### PR TITLE
Signed-off-by: Pubudu-Piyankara <pubudupiyankara.me@gmail.com>

### DIFF
--- a/src/main/java/com/divudi/bean/pharmacy/PharmacyController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacyController.java
@@ -908,7 +908,6 @@ public class PharmacyController implements Serializable {
 
         String sql = "SELECT b FROM Bill b "
                 + " WHERE b.retired = false"
-                + " and b.cancelled = false"
                 + " and b.billTypeAtomic In :btas"
                 + " and b.createdAt between :fromDate and :toDate";
 

--- a/src/main/webapp/pharmacy/pharmacy_reprint_grn.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_reprint_grn.xhtml
@@ -19,7 +19,7 @@
                             <div class="d-flex justify-content-between">
                                 <h:outputLabel value="GRN Reprint" class="mt-2"></h:outputLabel>
                                 <div class="d-flex gap-2">
-                                    
+
                                     <p:commandButton 
                                         class="ui-button-warning"
                                         icon="fa fa-print"
@@ -30,7 +30,7 @@
                                             value="#{pharmacyBillSearch.bill}" 
                                             target="#{transferIssueController.requestedBill}" ></f:setPropertyActionListener>
                                     </p:commandButton>
-                                    
+
                                     <p:commandButton 
                                         class="ui-button-info"
                                         icon="fa fa-print"
@@ -45,7 +45,7 @@
                                         icon="fa fa-ban"
                                         action="pharmacy_cancel_grn" 
                                         disabled="#{pharmacyBillSearch.bill.cancelled}">                           
-                                    </p:commandButton>  
+                                    </p:commandButton>
                                 </div>
                             </div>              
                         </f:facet>


### PR DESCRIPTION
After cancellation, Net Purchase Value isn't updated in detail

After cancellation Net Sale Value isn't updated in detail

After cancellation in summary Purchase Value, Sale value isn't updated

Cheque, Slip & etc payment updated under Final Cash and Credit Total in summary

The unwanted line was displayed - Details Excel

Unwanted line was displayed - Return Excel

>>>> DONE
