### PR TITLE
#10206_Disbursement_issue_cancellation

### DIFF
--- a/src/main/java/com/divudi/bean/pharmacy/PharmacyBillSearch.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacyBillSearch.java
@@ -1463,13 +1463,11 @@ public class PharmacyBillSearch implements Serializable {
             ph.copy(nB.getPharmaceuticalBillItem());
             ph.invertValue(nB.getPharmaceuticalBillItem());
 
-            if (ph.getId() == null) {
-                getPharmaceuticalBillItemFacade().create(ph);
-            }
-
             b.setPharmaceuticalBillItem(ph);
 
             if (b.getId() == null) {
+                getBillItemFacede().create(b);
+            }else{
                 getBillItemFacede().edit(b);
             }
 


### PR DESCRIPTION
When cancelling transfer issue bill, the bill item duplicates 5 times.
>>>> DONE

when billItem is created in pharmacy module, the phamaceuticalBillItem is auto created. there is no need to create manually by code. 