### PR TITLE
#10266_retail_sale_bill

### DIFF
--- a/src/main/webapp/pharmacy/pharmacy_bill_retail_sale.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_bill_retail_sale.xhtml
@@ -1058,16 +1058,17 @@
 
 
                         <h:panelGroup id="gpBillPreview" >
-                            <h:panelGroup   id="gpBillWithOutItem" rendered="#{configOptionApplicationController.getBooleanValueByKey('Pharmacy Retail Sale Bill is PosPaper',true)}">
-                                <div style="page-break-inside: avoid;">
-                                    <phi:saleBill_without_item bill="#{pharmacySaleController.printBill}"></phi:saleBill_without_item>                                        
-                                </div>
-                                <br/>
+                            <h:panelGroup   id="gpBillWithItem" rendered="#{configOptionApplicationController.getBooleanValueByKey('Pharmacy Retail Sale Bill is PosPaper',true)}">
                                 <div style="page-break-inside: avoid;">
                                     <phi:saleBill bill="#{pharmacySaleController.printBill}"></phi:saleBill>
                                 </div>
                             </h:panelGroup>
 
+                            <h:panelGroup id="gpBillWithOutItem" rendered="#{configOptionApplicationController.getBooleanValueByKey('Pharmacy Retail Sale Bill Without Item by POS Paper',true)}"> 
+                                <div style="page-break-inside: avoid;">
+                                    <phi:saleBill_without_item bill="#{pharmacySaleController.printBill}"></phi:saleBill_without_item>                                        
+                                </div>
+                            </h:panelGroup>
 
                             <h:panelGroup id="gpBillPreviewDouble" rendered="#{configOptionApplicationController.getBooleanValueByKey('Pharmacy Retail Sale Bill is PosPaper(prabodha)',true)}"> 
                                 <phi:saleBill_prabodha bill="#{pharmacySaleController.printBill}"></phi:saleBill_prabodha>


### PR DESCRIPTION
There is a new option for the bill called 'Pharmacy Retail Sale Bill Without Items,' which is printed on POS paper.