### PR TITLE
Closes #10869

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -176,12 +176,13 @@
             <type>jar</type>
         </dependency>
 
-        <!-- MySQL Connector -->
+        <!-- https://mvnrepository.com/artifact/com.mysql/mysql-connector-j -->
         <dependency>
-            <groupId>mysql</groupId>
-            <artifactId>mysql-connector-java</artifactId>
-            <version>8.0.30</version>
+            <groupId>com.mysql</groupId>
+            <artifactId>mysql-connector-j</artifactId>
+            <version>8.4.0</version>
         </dependency>
+
 
         <!-- OpenPDF -->
         <dependency>


### PR DESCRIPTION
**Description:**

The project was using `mysql:mysql-connector-java:8.0.33`, which is affected by a known vulnerability in Oracle MySQL Connectors (CVE-2024-21096). This vulnerability impacts all versions up to 8.1.0, allowing unauthenticated attackers with network access to potentially compromise the connector, with the risk of broader system impact through user interaction.

As there are no further updates in the 8.0.x or 8.1.x lines, the dependency has been updated to the latest LTS version, `com.mysql:mysql-connector-j:8.4.0`, which contains security fixes and ongoing support.

This change ensures improved security while maintaining compatibility with the existing codebase. Full testing has been performed to confirm functionality after the update.

No other code changes were necessary.