### PR TITLE
Closes #10889

### DIFF
--- a/src/main/webapp/resources/template/template.xhtml
+++ b/src/main/webapp/resources/template/template.xhtml
@@ -9,6 +9,19 @@
     <h:head >
         <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1"></meta>
+
+        <script async="async" src="https://www.googletagmanager.com/gtag/js?id=#{configOptionApplicationController.getShortTextValueByKey('Google Analytics Measurement ID', 'G-XXXXXXXXXX')}"></script>
+        <script>
+            window.dataLayer = window.dataLayer || [];
+            function gtag() {
+                dataLayer.push(arguments);
+            }
+            gtag('js', new Date());
+
+            gtag('config', '#{configOptionApplicationController.getShortTextValueByKey('Google Analytics Measurement ID', 'G-XXXXXXXXXX')}');
+        </script>
+
+
         <ui:insert name="title" >
             <title>
                 <h:panelGroup rendered="#{sessionController.logged}" >


### PR DESCRIPTION
### Closing Comment  

**Completed.**  
All systems must be configured with the Google Analytics Measurement ID via:  

**Administration menu → Manage Institution → Preferences → Application Options →**  
Search and select **"Google Analytics Measurement ID"** and insert the correct Measurement ID.  

Ensure the value is saved properly to enable tracking across all pages.

![image](https://github.com/user-attachments/assets/5083afd7-300c-4c37-83a2-69f527d255dd)
