### PR TITLE
Navigate to search bht number page after checking one's bht issued drug list

### DIFF
--- a/src/main/java/com/divudi/bean/inward/InwardReportControllerBht.java
+++ b/src/main/java/com/divudi/bean/inward/InwardReportControllerBht.java
@@ -186,6 +186,11 @@ public class InwardReportControllerBht implements Serializable {
         //department = null;
         return "/inward/reports/inpatient_pharmacy_item_list?faces-redirect=true";
     }
+    
+    public String madeNull() {
+        patientEncounter = null;
+        return "/pharmacy/reports/inpatient_pharmacy_item_list.xhtml?faces-redirect=true";
+    }
 
     public String navigateToInpatientLabItemList() {
         System.out.println("navigateToInpatientLabItemList");

--- a/src/main/webapp/pharmacy/reports/inpatient_pharmacy_item_list.xhtml
+++ b/src/main/webapp/pharmacy/reports/inpatient_pharmacy_item_list.xhtml
@@ -93,6 +93,14 @@
                         rendered="false"
                         icon="fa fa-arrow-circle-left">
                     </p:commandButton>
+                    
+                    <p:commandButton 
+                        value="New Search" 
+                        action="#{inwardReportControllerBht.madeNull()}" 
+                        style="float: right;"
+                        class="ui-button-warning m-1"
+                        icon="fa fa-arrow-circle-left">
+                    </p:commandButton>
 
 
                 </f:facet>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a “New Search” button on the Inpatient Pharmacy Item List page. When clicked, it resets the current search state and navigates users to a refreshed report view.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->