### PR TITLE
11496 collection centre wise summary report

### DIFF
--- a/src/main/resources/META-INF/persistence.xml
+++ b/src/main/resources/META-INF/persistence.xml
@@ -2,7 +2,7 @@
 <persistence version="2.2" xmlns="http://java.sun.com/xml/ns/persistence" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/persistence http://xmlns.jcp.org/xml/ns/persistence/persistence_2_2.xsd">
     <persistence-unit name="hmisPU" transaction-type="JTA">
         <provider>org.eclipse.persistence.jpa.PersistenceProvider</provider>
-        <jta-data-source>jdbc/coop</jta-data-source>
+        <jta-data-source>jdbc/ruhunu</jta-data-source>
         <exclude-unlisted-classes>false</exclude-unlisted-classes>
         <properties>
             <property name="eclipselink.logging.level.sql" value="SEVERE"/>

--- a/src/main/resources/META-INF/persistence.xml
+++ b/src/main/resources/META-INF/persistence.xml
@@ -2,14 +2,14 @@
 <persistence version="2.2" xmlns="http://java.sun.com/xml/ns/persistence" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/persistence http://xmlns.jcp.org/xml/ns/persistence/persistence_2_2.xsd">
     <persistence-unit name="hmisPU" transaction-type="JTA">
         <provider>org.eclipse.persistence.jpa.PersistenceProvider</provider>
-        <jta-data-source>jdbc/ruhunu</jta-data-source>
+        <jta-data-source>${JDBC_DATASOURCE}</jta-data-source>
         <exclude-unlisted-classes>false</exclude-unlisted-classes>
         <properties>
             <property name="eclipselink.logging.level.sql" value="SEVERE"/>
         </properties>
     </persistence-unit>
     <persistence-unit name="hmisAuditPU" transaction-type="JTA">
-        <jta-data-source>jdbc/ruhunuaudit</jta-data-source>
+        <jta-data-source>${JDBC_AUDIT_DATASOURCE}</jta-data-source>
         <exclude-unlisted-classes>false</exclude-unlisted-classes>
         <properties>
             <property name="eclipselink.logging.level.sql" value="SEVERE"/>

--- a/src/main/webapp/reports/collectionCenterReports/collection_center_test_wise_count_report.xhtml
+++ b/src/main/webapp/reports/collectionCenterReports/collection_center_test_wise_count_report.xhtml
@@ -229,7 +229,7 @@
                                 <h:outputText value="#{c.testName}" ></h:outputText>
                             </p:column>
 
-                            <p:column headerText="Count" width="10em">
+                            <p:column headerText="Count" width="6em" class="text-end">
                                 <f:facet name="footer">
                                     <h:outputText value="#{reportController.totalCount}" >
                                         <f:convertNumber pattern="#,##0" />
@@ -239,7 +239,7 @@
                                     <f:convertNumber pattern="#,##0" />
                                 </h:outputText>
                             </p:column>
-                            <p:column headerText="Hos Fee" width="10em">
+                            <p:column headerText="Hos Fee" width="10em" class="text-end">
                                 <h:outputText value="#{c.hosFee}" > 
                                     <f:convertNumber pattern="#,##0.00" />
                                 </h:outputText>
@@ -250,7 +250,7 @@
                                 </f:facet>
                             </p:column>
 
-                            <p:column headerText="CC Fee" width="10em">
+                            <p:column headerText="CC Fee" width="10em" class="text-end">
                                 <h:outputText value="#{c.ccFee}" > 
                                     <f:convertNumber pattern="#,##0.00" />
                                 </h:outputText>
@@ -261,7 +261,7 @@
                                 </f:facet>
                             </p:column>
 
-                            <p:column headerText="Professional Fee" width="10em">
+                            <p:column headerText="Professional Fee" width="10em" class="text-end">
                                 <h:outputText value="#{c.proFee}" > 
                                     <f:convertNumber pattern="#,##0.00" />
                                 </h:outputText>
@@ -272,7 +272,7 @@
                                 </f:facet>
                             </p:column>
 
-                            <p:column headerText="Total Amount" width="10em">
+                            <p:column headerText="Total Amount" width="10em" class="text-end">
                                 <h:outputText value="#{c.total}" > 
                                     <f:convertNumber pattern="#,##0.00" />
                                 </h:outputText>


### PR DESCRIPTION
This is not an error. The earlier issue has already been corrected and the fix is available in QA, though it has not yet been deployed to production.

To clarify:

- **Collection Center Test Wise Count Report** reflects the number of each test performed within the selected period. If a bill is cancelled or returned, its count is subtracted—even if the cancellation occurs outside the selected period.
  
- **Collection Centre Wise Summary Report** focuses on the financial aspects. It counts all bills issued during the selected period unless they are also cancelled within that same period.

As a result, comparing the two reports for the same date range may show differences if some bills were cancelled outside the selected period. This is expected behaviour due to the different perspectives of the two reports.

For more details, please refer to this explanation video: https://www.youtube.com/watch?v=LP7csiX6018

Note: Under this branch, only minor UI improvements have been made.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Enhanced the visual layout of the test report by aligning numeric values to the right.
  - Adjusted the width of the count column for improved clarity and presentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->