### PR TITLE
11535-when-an-item-is-refund-the-creation-of-the-associated-lab-report-should-be-blocked

### DIFF
--- a/src/main/webapp/lab/generate_barcode_p.xhtml
+++ b/src/main/webapp/lab/generate_barcode_p.xhtml
@@ -289,6 +289,23 @@
                                         <p:column headerText="Status" style="width: 7em; vertical-align: top;">
                                             <i class="fas fa-info-circle text-info"></i> <!-- Status Icon -->
                                             <h:outputLabel value="#{patientInvestigation.status}"/>
+                                            <br/>
+                                            <br/>
+                                            <p:badge 
+                                                value="Item Refunded" 
+                                                severity="info"
+                                                style="width: 200px;"
+                                                rendered="#{patientInvestigation.billItem.refunded}"
+                                                styleClass="ui-badge-warning" >
+                                            </p:badge>
+                                            
+                                                <p:badge 
+                                                    value="Bill Cancel" 
+                                                    severity="info"
+                                                    rendered="#{patientInvestigation.billItem.bill.cancelled}"
+                                                    style="width: 200px;"
+                                                    styleClass="ui-badge-danger" >
+                                                </p:badge>
                                         </p:column>
 
                                         <!-- Ordered Institution and Department Column with Icons -->
@@ -330,7 +347,7 @@
                                         <!-- Actions Column -->
                                         <p:column headerText="Actions" style="width: 6em; vertical-align: top;">
 
-                                            <h:panelGroup rendered="#{patientInvestigation.billItem.bill.cancelled ne true}">
+                                            <h:panelGroup rendered="#{patientInvestigation.billItem.bill.cancelled ne true and patientInvestigation.billItem.refunded ne true}">
                                                 <div class="row">
                                                     <p:commandButton 
                                                         icon="fa fa-file-text"
@@ -385,17 +402,84 @@
 
                                             </h:panelGroup>
 
-                                            <div class="d-flex justify-content-center mt-5">
+                                            <h:panelGroup rendered="#{patientInvestigation.billItem.bill.cancelled}" class="d-flex justify-content-center mt-5">
                                                 <p:badge 
                                                     value="Bill Cancel" 
                                                     severity="info"
                                                     size="large"
                                                     style="width: 200px;"
-                                                    styleClass="ui-badge-danger" 
-                                                    rendered="#{patientInvestigation.billItem.bill.cancelled}" >
+                                                    styleClass="ui-badge-danger" >
                                                 </p:badge>
-                                            </div>
+                                            </h:panelGroup>
 
+                                            <h:panelGroup rendered="#{patientInvestigation.billItem.refunded}">
+                                                <h:panelGroup rendered="#{configOptionApplicationController.getBooleanValueByKey('Creating a new laboratory patient report for a refunded BillItem.',true)}">
+                                                    <div class="row">
+                                                        <p:commandButton 
+                                                            icon="fa fa-file-text"
+                                                            value="To Worksheet" 
+                                                            class="ui-button-info"
+                                                            ajax="false" 
+                                                            id="btnPrintWorksheetsForRefund" 
+                                                            disabled="#{patientInvestigation.sampleAccepted ne true}" 
+                                                            action="/lab/single_worksheet?faces-redirect=true"
+                                                            >
+                                                            <f:setPropertyActionListener value="#{patientInvestigation}" target="#{patientInvestigationController.current}" ></f:setPropertyActionListener>
+                                                        </p:commandButton>
+                                                    </div>
+                                                    <div class="row">
+                                                        <p:commandButton 
+                                                            icon="fa fa-file-text"
+                                                            value="Create a New Report" 
+                                                            id="btnNewReportForRefund"
+                                                            disabled="#{!patientInvestigation.sampleAccepted}" 
+                                                            action="#{patientReportController.navigateToCreatedPatientReport(patientInvestigation)}"
+                                                            class="ui-button-danger mt-2"
+                                                            onclick="if (!confirm('Are you sure you want to New Patient Report?'))
+                                                                        return false;"
+                                                            ajax="false">
+                                                        </p:commandButton>
+                                                    </div>
+
+                                                    <div class="row ">
+                                                        <p:commandButton 
+                                                            icon="fa fa-file-text"
+                                                            value="Upload New Report" 
+                                                            id="btnNewUploadForRefund"
+                                                            rendered="#{patientInvestigation.billItem.item.canUploadPatinrtReport}"
+                                                            disabled="#{patientInvestigation.sampleSentAt eq null}"
+                                                            action="#{patientReportController.navigateToUploadNewPatientReport(patientInvestigation)}"
+                                                            class="ui-button-warning mt-2"
+                                                            onclick="if (!confirm('Are you sure you want to New Patient Report?'))
+                                                                        return false;"
+                                                            ajax="false">
+                                                        </p:commandButton>
+                                                    </div>
+
+                                                    <div class="row">
+                                                        <p:commandButton 
+                                                            icon="fa fa-file-text"
+                                                            value="To Reports" 
+                                                            class="ui-button-success mt-2"
+                                                            ajax="false" 
+                                                            action="#{patientInvestigationController.navigateToPatientReportsFromSelectedInvestigation(patientInvestigation)}" >
+                                                        </p:commandButton>
+                                                    </div>
+
+                                                </h:panelGroup>
+
+                                                <h:panelGroup rendered="#{!configOptionApplicationController.getBooleanValueByKey('Creating a new laboratory patient report for a refunded BillItem.',true)}">
+                                                    <div class="d-flex justify-content-center mt-5">
+                                                        <p:badge 
+                                                            value="Item Refunded" 
+                                                            severity="info"
+                                                            size="large"
+                                                            style="width: 200px;"
+                                                            styleClass="ui-badge-warning" >
+                                                        </p:badge>
+                                                    </div>
+                                                </h:panelGroup>
+                                            </h:panelGroup>
                                         </p:column>
                                     </p:dataTable>
 


### PR DESCRIPTION
Signed-off-by: DamithDeshan <hkddrajapaksha@gmail.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced visual indicators that show when an item is refunded or a bill is cancelled.
	- Refined action button display so that they appear only when items are active.
	- Added context-sensitive options for handling refunded items, including report creation, uploading, and navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->