### PR TITLE
11525-hide-retail-sale-value-column-for-the-original-print-and-duplicate-print-in-direct-purchase

### DIFF
--- a/src/main/webapp/pharmacy/pharmacy_purchase.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_purchase.xhtml
@@ -608,6 +608,14 @@
                         .showProfit{
 
                         }
+                        
+                        .hideRetailValue{
+                            display: none!important;
+                        }
+
+                        .showRetailValue{
+
+                        }
 
                     }
 

--- a/src/main/webapp/pharmacy/pharmacy_reprint_purchase.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_reprint_purchase.xhtml
@@ -5,7 +5,7 @@
       xmlns:p="http://primefaces.org/ui"
       xmlns:h="http://xmlns.jcp.org/jsf/html"
       xmlns:f="http://xmlns.jcp.org/jsf/core"
-      xmlns:ph="http://xmlns.jcp.org/jsf/composite/pharmacy">
+      xmlns:pharmacy="http://xmlns.jcp.org/jsf/composite/pharmacy">
 
     <h:body>
 
@@ -58,54 +58,48 @@
                         </f:facet>
 
                         <style>
-                            @media print{
-                                .purhcaseBill{
-                                    width: 297mm!important;
-                                }
+                    @media print{
+                        .purhcaseBill{
+                            width: 297mm!important;
+                        }
 
-                                .hideProfit{
-                                    display: none!important;
-                                }
+                        .hideProfit{
+                            display: none!important;
+                        }
 
-                                .showProfit{
+                        .showProfit{
 
-                                }
-                                
-                                .hideRetailValue{
-                                    display: none!important;
-                                }
+                        }
+                        
+                        .hideRetailValue{
+                            display: none!important;
+                        }
 
-                                .showRetailValue{
+                        .showRetailValue{
 
-                                }
+                        }
 
-                            }
+                    }
 
-                            @media screen{
-                                .purhcaseBill{
-                                    width: 100%!important;
-                                }
+                    @media screen{
+                        .purhcaseBill{
+                            width: 100%!important;
+                        }
 
-                                .showProfit{
+                        .showProfit{
 
-                                }
-                                
-                                .showRetailValue{
+                        }
+                    }
 
-                                }
-                            }
+                </style>
 
-                        </style>
-
-                        <h:panelGroup id="gpBillPreview" >
-                            <div class="d-flex justify-content-between" style="width: 297mm;">
-                                <ph:purhcase 
-                                    bill="#{pharmacyBillSearch.bill}" 
-                                    ShowProfit="#{configOptionApplicationController.getBooleanValueByKey('Show Profit % in Direct Purchase Bill', true)}"
-                                    ShowRetailValue="#{configOptionApplicationController.getBooleanValueByKey('Show Retail Value in Direct Purchase Bill', true)}">
-                                </ph:purhcase>
-                            </div>
-                        </h:panelGroup>
+                <h:panelGroup id="gpBillPreview" >
+                    <pharmacy:purhcase
+                        bill="#{pharmacyPurchaseController.bill}"
+                        ShowProfit="#{configOptionApplicationController.getBooleanValueByKey('Show Profit % in Direct Purchase Bill', true)}"
+                        ShowRetailValue="#{configOptionApplicationController.getBooleanValueByKey('Show Retail Value in Direct Purchase Bill', true)}">
+                    </pharmacy:purhcase>
+                </h:panelGroup>
 
                     </p:panel>
 

--- a/src/main/webapp/resources/pharmacy/purhcase.xhtml
+++ b/src/main/webapp/resources/pharmacy/purhcase.xhtml
@@ -42,7 +42,7 @@
 
             <div style="text-align: center!important;
                  font-weight: bold!important;
-                 font-size: 15px!important;
+                 font-size: 18px!important;
                  font-weight: bold;">
                 <h:outputLabel value="PURCHASE BILL"   />                           
             </div>
@@ -95,14 +95,14 @@
                         </h:outputLabel>
                     </p:column>                                 
 
-                    <p:column style="padding: 4px; width: 3em;">
+                    <p:column style="padding: 4px; width: 3em;" class="text-end">
                         <f:facet name="header">QTY</f:facet>
                         <h:outputLabel value="#{bip.pharmaceuticalBillItem.qty}">
                             <f:convertNumber pattern="#,##0" />
                         </h:outputLabel>
                     </p:column>
 
-                    <p:column style="padding: 4px; width: 3em;">
+                    <p:column style="padding: 4px; width: 3em;" class="text-end">
                         <f:facet name="header">Free</f:facet>
                         <h:outputLabel value="#{bip.pharmaceuticalBillItem.freeQty}">
                             <f:convertNumber pattern="#,##0" />
@@ -110,28 +110,28 @@
 
                     </p:column>
 
-                    <p:column style="padding: 4px; width: 5em;">
+                    <p:column style="padding: 4px; width: 5em;" class="text-end">
                         <f:facet name="header">P. Rate</f:facet>
                         <h:outputLabel value="#{bip.pharmaceuticalBillItem.purchaseRate}">
                             <f:convertNumber pattern="#,##0.00" />
                         </h:outputLabel>
                     </p:column>
 
-                    <p:column style="padding: 4px; width: 5em;" >
+                    <p:column style="padding: 4px; width: 5em;" class="text-end">
                         <f:facet name="header">Last P.R.</f:facet>
                         <h:outputLabel value="#{bip.pharmaceuticalBillItem.lastPurchaseRate}">
                             <f:convertNumber pattern="#,##0.00" />
                         </h:outputLabel>
                     </p:column>
 
-                    <p:column style="padding: 4px; width: 5em;">
+                    <p:column style="padding: 4px; width: 6em;" class="text-end">
                         <f:facet name="header">P. Value</f:facet>
                         <h:outputLabel value="#{bip.pharmaceuticalBillItem.purchaseRate*bip.pharmaceuticalBillItem.qty}">
                             <f:convertNumber pattern="#,##0.00" />
                         </h:outputLabel>
                     </p:column>
 
-                    <p:column style="padding: 4px; width: 5em;">
+                    <p:column style="padding: 4px; width: 5em;" class="text-end">
                         <f:facet name="header">Re. Rate</f:facet>
                         <h:outputLabel value="#{bip.pharmaceuticalBillItem.retailRate}">
                             <f:convertNumber pattern="#,##0.00" />
@@ -139,8 +139,8 @@
                     </p:column>
 
                     <p:column  
-                        style="padding: 4px; width: 5em;" 
-                        class="#{configOptionApplicationController.getBooleanValueByKey('Print RetailValue in Direct Purchase Bill', true) ? 'showRetailValue' : 'hideRetailValue' }"
+                        style="padding: 4px; width: 6em;" 
+                        class="text-end #{configOptionApplicationController.getBooleanValueByKey('Print RetailValue in Direct Purchase Bill', true) ? 'showRetailValue' : 'hideRetailValue' }"
                         rendered="#{cc.attrs.ShowRetailValue}">
                         <f:facet name="header" >Re. Value</f:facet>
 
@@ -152,7 +152,7 @@
                     <p:column  
                         rendered="#{cc.attrs.ShowProfit}"
                         style="padding: 4px; width: 4em;" 
-                        class="#{configOptionApplicationController.getBooleanValueByKey('Print Profit % in Direct Purchase Bill', true) ? 'showProfit' : 'hideProfit' }">
+                        class="text-end #{configOptionApplicationController.getBooleanValueByKey('Print Profit % in Direct Purchase Bill', true) ? 'showProfit' : 'hideProfit' }">
                         <f:facet name="header">Profit %</f:facet>
                         <h:outputText id="profMargin" value="#{((bip.pharmaceuticalBillItem.retailRate - bip.pharmaceuticalBillItem.purchaseRate ) / bip.pharmaceuticalBillItem.purchaseRate)*100}" >
                             <f:convertNumber pattern="0.0" ></f:convertNumber>
@@ -162,7 +162,7 @@
                     <p:columnGroup type="footer">
                         <p:row style="padding: 4px; width: 8em;">
                             <p:column style="padding: 4px; width: 6em;" colspan="6" footerText="Total"/>
-                            <p:column style="padding: 4px; width: 6em;" footerText="#{0-cc.attrs.bill.total}" >
+                            <p:column style="padding: 4px; width: 6em;" footerText="#{0-cc.attrs.bill.total}"  class="text-end">
                                 <f:facet name="footer">
                                     <h:outputLabel value="#{0-cc.attrs.bill.total}">
                                         <f:convertNumber pattern="#,##0.00" />
@@ -170,9 +170,9 @@
                                 </f:facet>
                             </p:column>
                             <p:column style="padding: 4px; width: 6em;" ></p:column>
-                            <p:column style="padding: 4px; width: 6em;" footerText="#{0-cc.attrs.bill.saleValue}" rendered="#{cc.attrs.ShowRetailValue}">
+                            <p:column style="padding: 4px; width: 6em;" footerText="#{0-cc.attrs.bill.saleValue}"  class="text-end #{configOptionApplicationController.getBooleanValueByKey('Print RetailValue in Direct Purchase Bill', true) ? 'showRetailValue' : 'hideRetailValue' }">
                                 <f:facet name="footer">
-                                    <h:outputLabel value="#{cc.attrs.bill.saleValue}" class="#{configOptionApplicationController.getBooleanValueByKey('Print RetailValue in Direct Purchase Bill', true) ? 'showRetailValue' : 'hideRetailValue' }">
+                                    <h:outputLabel value="#{cc.attrs.bill.saleValue}">
                                         <f:convertNumber pattern="#,##0.00" />
                                     </h:outputLabel>
                                 </f:facet>
@@ -181,7 +181,7 @@
 
                         <p:row rendered="#{cc.attrs.bill.expenseTotal ne null and cc.attrs.bill.expenseTotal != 0}">
                             <p:column style="padding: 4px; width: 6em;" colspan="6" footerText="Expense Total"/>
-                            <p:column style="padding: 4px; width: 6em;" footerText="#{0-cc.attrs.bill.total}" rendered="#{cc.attrs.ShowRetailValue}" >
+                            <p:column style="padding: 4px; width: 6em;" footerText="#{0-cc.attrs.bill.total}" class="text-end">
                                 <f:facet name="footer">
                                     <h:outputLabel value="#{0-cc.attrs.bill.expenseTotal}">
                                         <f:convertNumber pattern="#,##0.00" />
@@ -193,7 +193,7 @@
 
                         <p:row rendered="#{cc.attrs.bill.tax!=0}">
                             <p:column  style="padding: 4px; width: 6em;" colspan="6" footerText="Tax"/>
-                            <p:column style="padding: 4px; width: 6em;" footerText="#{cc.attrs.bill.tax}" rendered="#{cc.attrs.ShowRetailValue}">
+                            <p:column style="padding: 4px; width: 6em;" footerText="#{cc.attrs.bill.tax}" class="text-end">
                                 <f:facet name="footer">
                                     <h:outputLabel value="#{cc.attrs.bill.tax}">
                                         <f:convertNumber pattern="#,##0.00" />
@@ -204,7 +204,7 @@
                         </p:row>
                         <p:row rendered="#{cc.attrs.bill.discount!=0}">
                             <p:column style="padding: 4px; width: 6em;" colspan="6" footerText="Discount"/>
-                            <p:column style="padding: 4px; width: 6em;" footerText="#{0-cc.attrs.bill.discount}" rendered="#{cc.attrs.ShowRetailValue}">
+                            <p:column style="padding: 4px; width: 6em;" footerText="#{0-cc.attrs.bill.discount}" class="text-end">
                                 <f:facet name="footer">
                                     <h:outputLabel value="#{0-cc.attrs.bill.discount}">
                                         <f:convertNumber pattern="#,##0.00" />
@@ -215,7 +215,7 @@
                         </p:row>
                         <p:row rendered="#{cc.attrs.bill.total!=cc.attrs.bill.netTotal}">
                             <p:column style="padding: 4px; width: 6em;" colspan="6" footerText="Net Total"/>
-                            <p:column style="padding: 4px; width: 6em;" footerText="#{0-cc.attrs.bill.netTotal}" rendered="#{cc.attrs.ShowRetailValue}">
+                            <p:column style="padding: 4px; width: 6em;" footerText="#{0-cc.attrs.bill.netTotal}" class="text-end">
                                 <f:facet name="footer">
                                     <h:outputLabel value="#{0-cc.attrs.bill.netTotal}">
                                         <f:convertNumber pattern="#,##0.00" />


### PR DESCRIPTION
**Use following Options**
> - Show Profit % in Direct Purchase Bill
> - Show Retail Value in Direct Purchase Bill
> - Print RetailValue in Direct Purchase Bill
> - Print Profit % in Direct Purchase Bill