### PR TITLE
updated

### DIFF
--- a/src/main/webapp/resources/ezcomp/prints/five_five_paper_coustom_opd_refundBill.xhtml
+++ b/src/main/webapp/resources/ezcomp/prints/five_five_paper_coustom_opd_refundBill.xhtml
@@ -41,7 +41,7 @@
 
             <div class="headingBillFiveFive mt-2" style="text-align: center;font-weight: bold;">
                 <div class="d-flex align-items-center justify-content-center">
-                    <h:outputLabel value="OPD Refuned Receipt" />
+                    <h:outputLabel value="OPD Refund Receipt" />
                 </div>
                 <h:panelGroup  rendered="#{cc.attrs.duplicate eq true}"  >
                     <h:outputLabel value="**Duplicate**" />


### PR DESCRIPTION
Need OPD refund bill impovement
[#11348](https://github.com/hmislk/hmis/issues/11348)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected a typographical error in the refund receipt label. End-users will now see the proper text "OPD Refund Receipt" instead of the previous misspelling. This update enhances clarity and professionalism on printed receipts, ensuring that all displayed information is accurate and user-friendly for a better overall experience. Users will appreciate the improved presentation and consistent messaging on their documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->