### PR TITLE
fix-view-bill-page-navigation-error-in-inward-intrin-bill

### DIFF
--- a/src/main/java/com/divudi/bean/inward/BillBhtController.java
+++ b/src/main/java/com/divudi/bean/inward/BillBhtController.java
@@ -176,11 +176,7 @@ public class BillBhtController implements Serializable {
     }
 
     public String navigateToSampleManegmentFromInwardIntrimBill(Bill b) {
-        List<Bill> newBills = new ArrayList<>();
-        newBills.add(b);
-        patientInvestigationController.setBills(newBills);
-        patientInvestigationController.searchBillsWithoutSampleId();
-        return "/lab/generate_barcode_p?faces-redirect=true";
+        return patientInvestigationController.navigateToSampleManagementFromOPDBatchBillView(b);
     }
 
     public String navigateToNewBillFromPrintLabelsForInvestigations() {

--- a/src/main/webapp/inward/inward_edit_bill_item_view.xhtml
+++ b/src/main/webapp/inward/inward_edit_bill_item_view.xhtml
@@ -10,12 +10,24 @@
 
     <ui:define name="content">
 
-        <h:panelGroup >
+        <p:panel >
+            <f:facet name="header">
+                <h:outputLabel value="BillItem Details" class="mt-2"/>
+                <p:commandButton 
+                    ajax="false" 
+                    style="float: right;"
+                    icon="fa fa-arrow-left"
+                    class="ui-button-warning"
+                    value="Back to Interim"
+                    action="/inward/inward_bill_intrim?faces-redirect=true"/>
+            </f:facet>
             <h:form  >
-                <p:commandButton ajax="false" value="Back to Interim"
-                                 action="/inward/inward_bill_intrim" />
-                <p:dataTable value="#{bhtSummeryController.billItems}" var="ser"
-                             rowStyleClass="#{(ser.bill.billClass eq 'class com.divudi.core.entity.BilledBill')? '':'noDisplayRow'}">
+
+                <p:dataTable 
+                    value="#{bhtSummeryController.billItems}" 
+                    var="ser"
+                    rowStyleClass="#{(ser.bill.billClass eq 'class com.divudi.core.entity.BilledBill')? '':'noDisplayRow'}">
+
                     <p:column headerText="Services Name">
                         #{ser.item.name}
                     </p:column>
@@ -93,61 +105,38 @@
                     </p:column>
                     <p:column headerText="Description">
                         #{ser.descreption}
-                    </p:column>
-                    <p:column headerText="Billed Id" rendered="false">
-                        #{ser.bill.id}
-                    </p:column>
-                    <p:column headerText="Cancelled Id" rendered="false">
-                        #{ser.bill.cancelledBill.id}
-                    </p:column>
-                    <p:column>
-                        <p:commandButton ajax="false" action="inward_edit_bill_item"  value="View Bill Fee Break Down"  >
-                            <f:setPropertyActionListener value="#{ser}" target="#{serviceFeeEdit.billItem}"/>
-                        </p:commandButton>
-                    </p:column>
-                    <p:column>
-                        <p:commandButton ajax="false" action="inward_reprint_bill_service"
-                                         value="View Bill"
-                                         actionListener="#{inwardSearch.selectBillItem(ser)}" >
-                        </p:commandButton>
-             
-                        <p:commandButton
-                                ajax="false"
-                                value="Cancel (POS)"
-                                action="#{bhtSummeryController.cancelBillWithPaperType(ser.bill, 'POS')}"
-                                rendered="#{!ser.bill.cancelled}"
-                                styleClass="ui-button-danger"/>
-                        <p:commandButton
-                                ajax="false"
-                                value="Cancel (FiveFive)"
-                                action="#{bhtSummeryController.cancelBillWithPaperType(ser.bill, 'FiveFive')}"
-                                rendered="#{!ser.bill.cancelled}"
-                                styleClass="ui-button-danger"/>
-                        <p:commandButton
-                                ajax="false"
-                                value="Cancel (FiveFiveCustom3)"
-                                action="#{bhtSummeryController.cancelBillWithPaperType(ser.bill, 'FiveFiveCustom3')}"
-                                rendered="#{!ser.bill.cancelled}"
-                                styleClass="ui-button-danger"/>
+                    </p:column> 
+                    <p:column width="20em">
+                        <div class="d-flex gap-2">
+                            <p:commandButton 
+                                ajax="false" 
+                                action="inward_edit_bill_item?faces-redirect=true"  
+                                value="View Bill Fee Break Down"  >
+                                <f:setPropertyActionListener value="#{ser}" target="#{serviceFeeEdit.billItem}"/>
+                            </p:commandButton>
+                            
+                            <p:commandButton 
+                                ajax="false" 
+                                action="inward_reprint_bill_service?faces-redirect=true"
+                                value="View Bill"
+                                actionListener="#{inwardSearch.selectBillItem(ser)}" >
+                            </p:commandButton>
 
-                                        actionListener="#{inwardSearch.selectBillItem(ser)}" >
-                        </p:commandButton>
-                        <p:commandButton
-                                                    value="To Manage Samples"
-                                                    class="ui-button-warning"
-                                                    ajax="false"
-                                                    action="#{billBhtController.navigateToSampleManegmentFromInwardIntrimBill(ser.bill)}" icon="fa-solid fa-cogs"
-                                                    rendered="#{configOptionApplicationController.getBooleanValueByKey('Use Sample Management for Inward Service and Investigations')}"
-                                                    >
-                                                </p:commandButton>
+                            <p:commandButton
+                                title="To Manage Samples"
+                                class="ui-button-warning"
+                                ajax="false"
+                                action="#{billBhtController.navigateToSampleManegmentFromInwardIntrimBill(ser.bill)}" 
+                                icon="fa fa-flask"
+                                rendered="#{configOptionApplicationController.getBooleanValueByKey('Use Sample Management for Inward Service and Investigations')}">
+                            </p:commandButton>
+                        </div>
+
 
                     </p:column>
 
                 </p:dataTable>
             </h:form>
-
-        </h:panelGroup>
-
+        </p:panel>
     </ui:define>
-
 </ui:composition>


### PR DESCRIPTION
closes #11660
Signed-off-by: DamithDeshan <hkddrajapaksha@gmail.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Streamlined bill management navigation for a smoother user experience.
  - Updated the bill editing interface with a refreshed header that offers improved back navigation and a full page refresh.
  - Introduced new buttons for viewing fee breakdowns, reprinting bills, and managing samples while removing some redundant options for a cleaner workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->