### PR TITLE
Laboratory order report update

### DIFF
--- a/src/main/webapp/reportLab/lab_inward_order_report_print.xhtml
+++ b/src/main/webapp/reportLab/lab_inward_order_report_print.xhtml
@@ -14,7 +14,7 @@
                     <p:panel header="Test Wise Count Report Print" styleClass="w-100">
                         <f:facet name="header"  >
                             <div class="d-flex justify-content-between">
-                                <h:outputText value="Laboratory Order Report Print" class="mt-2"/>
+                                <h:outputText value="Test Wise Count Report Print" class="mt-2"/>
                                 <div class="d-flex gap-2">
                                     <p:commandButton 
                                         icon="fa-solid fa-print"
@@ -30,222 +30,283 @@
                                         style="width: 200px"
                                         icon="fa fa-arrow-left"
                                         class="ui-button-warning"
-                                        action="lab_inward_order_report?faces-redirect=true;" >
+                                        action="test_wise_count?faces-redirect=true;" >
                                     </p:commandButton>
                                 </div>
 
                             </div>
                         </f:facet>
 
+                        <style>
+
+                            @media screen{
+                                .paper{
+                                    position: static !important;
+                                    width: 210mm!important;
+                                    zoom: 2.0;
+                                }
+
+                                table {
+                                    border-collapse: collapse;
+                                    width: 100%;
+                                    font-size: 13px!important;
+                                    margin-top: 3mm!important;
+                                }
+
+                                th, td {
+                                    border: 1px solid #000;
+                                    padding: 0px!important;
+                                    margin: 2px!important;
+                                    text-align: left;
+                                    margin-left: 10mm!important;
+                                }
+                                
+                                .toinsdept{
+                                    font-size: 16px!important;
+                                }
+
+                            }
+
+
+                            @media print {
+                                @page {
+                                    @bottom-right {
+                                        content: "Page " counter(page) " of " counter(pages);
+                                        font-family: Arial, sans-serif;
+                                        font-size: 10pt;
+                                    }
+                                }
+
+                                body {
+                                    counter-reset: page;
+                                }
+
+                                .paper{
+                                    position: static !important;
+                                    width: 210mm!important;
+                                    size: A4 portrait!important;
+
+                                }
+
+                                .header{
+                                    line-height: 1.1;
+                                    margin: 0mm!important;
+                                }
+
+                                table {
+                                    border-collapse: collapse;
+                                    width: 99%;
+                                    font-size: 12px!important;
+                                    margin-top: 3mm!important;
+                                }
+
+                                th, td {
+                                    border: 1px solid #000;
+                                    padding: 0px!important;
+                                    margin: 2px!important;
+                                    text-align: left;
+                                    margin-left: 10mm!important;
+                                }
+
+                                th {
+
+                                }
+                                
+                                .toinsdept{
+                                    font-size: 14px!important;
+                                }
+
+                            }
+
+                        </style>
 
 
                         <h:panelGroup id="reportView" class="d-flex justify-content-center">
                             <div class="paper">
-                                <p:dataTable
-                                        id="tbl"
-                                        style="padding: 2px!important; margin-top: 10px!important; margin: 0px!important; font-size: 20px!important;"
-                                        styleClass="ui-datatable-borderless ui-datatable-sm compact-datatable"
-                                        value="#{laborataryReportController.bundle.rows}"
-                                        var="row"
-                                        paginator="true"
-                                        rowIndexVar="i"
-                                        rows="20"
-                                        rowsPerPageTemplate="20,50,100,500,1000,2000,5000,10000"
-                                        paginatorPosition="bottom">
-
-                                    <f:facet name="header"  >
-                                        <div style="padding: 3px!important; margin: 0px!important;">
-                                            <div class="d-flex justify-content-center text-5 gap-2" style="font-weight: 700; font-size: 24px;">
-                                                <h:outputText value="#{sessionController.institution.name}"/>
+                                <div class="header" >
+                                    <div class="d-flex justify-content-center text-5 gap-2" style="font-weight: 700; font-size: 22px;">
+                                        <h:outputText value="#{sessionController.institution.name}"/>
+                                    </div>
+                                    <div class="d-flex justify-content-center text-5 gap-2" style="font-weight: 700; font-size: 18px;">
+                                        <h:outputText value="Laboratary Test Count"/>
+                                        <h:panelGroup  rendered="#{laborataryReportController.department ne null}">
+                                            <div class="d-flex gap-2">
+                                                <h:outputText value="-" style="width: 1em!important;" class="text-center"/>
+                                                <h:outputText value="#{laborataryReportController.department.name}"/>
                                             </div>
-                                            <div class="d-flex justify-content-center text-5 gap-2" style="font-weight: 700; font-size: 18px;">
-                                                <h:outputText value="Laboratory Order Report"/>
-                                                <h:panelGroup  rendered="#{laborataryReportController.department ne null}">
-                                                    <div class="d-flex gap-2">
-                                                        <h:outputText value="-" style="width: 1em!important;" class="text-center"/>
-                                                        <h:outputText value="#{laborataryReportController.department.name}"/>
-                                                    </div>
-                                                </h:panelGroup>
-                                            </div>
-                                            <div class="d-flex justify-content-center mt-2" style=" font-size: 14px;">
-                                                <div class="d-flex gap-3">
-                                                    <h:outputText value="From Date" style="width: 6em!important; font-weight: 600;"/>
-                                                    <h:outputText value="#{laborataryReportController.fromDate}">
-                                                        <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateFormat}" />
-                                                    </h:outputText>
-                                                </div>
-                                                <p:spacer width="50" ></p:spacer>
-                                                <div class="d-flex gap-3">
-                                                    <h:outputText value="To Date" style="width: 4em!important; font-weight: 600;"/>
-                                                    <h:outputText value="#{laborataryReportController.toDate}">
-                                                        <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateFormat}" />
-                                                    </h:outputText>
-                                                </div>
-                                                <div></div>
-                                            </div>
-
-                                            <div class="d-flex justify-content-between mt-2 w-100 gap-2" style=" font-size: 16px;">
-                                                <div class="d-flex gap-2">
-                                                    <h:outputText
-                                                            rendered="#{laborataryReportController.toInstitution ne null}"
-                                                            value="#{laborataryReportController.toInstitution.name}"
-                                                            style="font-weight: 600;">
-                                                    </h:outputText>
-                                                    <h:outputText
-                                                            value="-"
-                                                            rendered="#{laborataryReportController.toInstitution ne null and laborataryReportController.toDepartment ne null}"
-                                                            style="width: 2em!important; font-weight: 600; text-align: center;"/>
-                                                    <h:outputText
-                                                            rendered="#{laborataryReportController.toInstitution ne null and laborataryReportController.toDepartment ne null}"
-                                                            value="#{laborataryReportController.toDepartment.name}"
-                                                            style="font-weight: 600;">
-                                                    </h:outputText>
-                                                </div>
-                                            </div>
+                                        </h:panelGroup>
+                                    </div>
+                                    <div class="d-flex justify-content-center mt-2" style=" font-size: 12px;">
+                                        <div class="d-flex gap-3">
+                                            <h:outputText value="From Date" style="width: 6em!important; font-weight: 600;"/>
+                                            <h:outputText value="#{laborataryReportController.fromDate}">
+                                                <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateFormat}" />
+                                            </h:outputText>
                                         </div>
-                                    </f:facet>
-
-                                    <p:column
-                                            headerText="Investigation"
-                                            style="padding: 6px!important; margin: 2px!important;" >
-                                        <div class="d-flex gap-5">
-                                            <div class="d-flex" style="width: 230px;">
-                                                <h:outputText
-                                                        rendered="#{row.rowType eq 'Bill'}"
-                                                        value="OrderNo : "
-                                                        style="padding: 6px!important; margin: 2px!important;" >
-                                                </h:outputText>
-                                                <h:outputText
-                                                        rendered="#{row.rowType eq 'Bill'}"
-                                                        value="#{row.bill.deptId}"
-                                                        style="padding: 6px!important; margin: 2px!important; font-weight: 700;" >
-                                                </h:outputText>
-                                            </div>
-
-                                            <div class="d-flex gap-1" style="width: 250px;">
-                                                <h:outputText
-                                                        rendered="#{row.rowType eq 'Bill'}"
-                                                        value="Order Date : "
-                                                        style="padding: 6px!important; margin: 2px!important;" >
-                                                </h:outputText>
-                                                <h:outputText
-                                                        value="#{row.bill.createdAt}"
-                                                        rendered="#{row.rowType eq 'Bill'}"
-                                                        style="padding: 6px!important; margin: 2px!important; font-weight: 700;" >
-                                                    <f:convertDateTime pattern="d/MM/YYYY HH:mm" />
-                                                </h:outputText>
-                                            </div>
-                                            <h:panelGroup rendered="#{row.bill.patientEncounter ne null}">
-                                                <div class="d-flex" style="width: 150px;">
-                                                    <h:outputText
-                                                            rendered="#{row.rowType eq 'Bill'}"
-                                                            value="BHT No : "
-                                                            style="padding: 6px!important; margin: 2px!important;" >
-                                                    </h:outputText>
-                                                    <h:outputText
-                                                            rendered="#{row.rowType eq 'Bill'}"
-                                                            value="#{row.bill.patientEncounter.bhtNo}"
-                                                            style="padding: 6px!important; margin: 2px!important; font-weight: 700;" >
-                                                    </h:outputText>
-                                                </div>
-                                            </h:panelGroup>
+                                        <h:outputText value="" style="width: 5mm!important;"/>
+                                        <div class="d-flex gap-3">
+                                            <h:outputText value="To Date" style="width: 4em!important; font-weight: 600;"/>
+                                            <h:outputText value="#{laborataryReportController.toDate}">
+                                                <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateFormat}" />
+                                            </h:outputText>
                                         </div>
+                                        <div></div>
+                                    </div>
 
-                                        <h:outputText
-                                                value=""
-                                                rendered="#{row.rowType eq 'BillItem'}"
-                                                style="padding: 6px!important; margin: 2px!important; width: 5em;" >
-                                        </h:outputText>
-
-                                        <h:outputText
-                                                value="#{row.billItem.item.name}"
-                                                rendered="#{row.rowType eq 'BillItem'}"
-                                                style="padding: 6px!important; margin: 2px!important;" >
-                                        </h:outputText>
-
-                                    </p:column>
-
-                                    <p:column headerText="Hos. Fee" width="8em" class="text-end" style="padding: 6px!important; margin: 2px!important;" >
-                                        <h:outputText
-                                                rendered="#{row.rowType eq 'BillItem'}"
-                                                value="#{row.billItem.hospitalFee - (row.billItem.reagentFee + row.billItem.otherFee)}">
-                                            <f:convertNumber pattern="#,##0.00" />
-                                        </h:outputText>
-                                        <f:facet name="footer" >
-                                            <h:outputText value="#{laborataryReportController.totalHospitalFee}" style="padding: 6px!important; margin: 2px!important;" >
-                                                <f:convertNumber pattern="#,##0.00" />
+                                    <div class="d-flex justify-content-between mt-2 w-100 gap-2" style=" font-size: 16px;" id="toinsdept">
+                                        <div class="d-flex gap-2">
+                                            <h:outputText 
+                                                rendered="#{laborataryReportController.toInstitution ne null}"
+                                                value="#{laborataryReportController.toInstitution.name}" 
+                                                style="font-weight: 600;">
                                             </h:outputText>
-                                        </f:facet>
-                                    </p:column>
-
-                                    <p:column headerText="Reagent Fee" width="8em" class="text-end" style="padding: 6px!important; margin: 2px!important;" >
-                                        <h:outputText
-                                                rendered="#{row.rowType eq 'BillItem'}"
-                                                value="#{row.billItem.reagentFee}">
-                                            <f:convertNumber pattern="#,##0.00" />
-                                        </h:outputText>
-                                        <f:facet name="footer" >
-                                            <h:outputText value="#{laborataryReportController.totalReagentFee}" style="padding: 6px!important; margin: 2px!important;" >
-                                                <f:convertNumber pattern="#,##0.00" />
+                                            <h:outputText 
+                                                value="-" 
+                                                rendered="#{laborataryReportController.toInstitution ne null and laborataryReportController.toDepartment ne null}"
+                                                style="width: 1em!important; font-weight: 600; text-align: center;"/>
+                                            <h:outputText 
+                                                rendered="#{laborataryReportController.toInstitution ne null and laborataryReportController.toDepartment ne null}"
+                                                value="#{laborataryReportController.toDepartment.name}" 
+                                                style="font-weight: 600;">
                                             </h:outputText>
-                                        </f:facet>
-                                    </p:column>
+                                        </div>
+                                    </div>
+                                </div>
 
-                                    <p:column headerText="Other Fee" width="8em" class="text-end" style="padding: 6px!important; margin: 2px!important;" >
-                                        <h:outputText
-                                                rendered="#{row.rowType eq 'BillItem'}"
-                                                value="#{row.billItem.otherFee}">
-                                            <f:convertNumber pattern="#,##0.00" />
-                                        </h:outputText>
-                                        <f:facet name="footer" >
-                                            <h:outputText value="#{laborataryReportController.totalOtherFee}" style="padding: 6px!important; margin: 2px!important;" >
-                                                <f:convertNumber pattern="#,##0.00" />
-                                            </h:outputText>
-                                        </f:facet>
-                                    </p:column>
+                                <div>
+                                    <table id="tbl">
+                                        <thead>
+                                            <tr>
+                                                <th style=" margin-left: 2mm;">
+                                                    <h:outputText value="Investigation"/>
+                                                </th>
+                                                <th style="text-align: center; width: 23mm!important;">
+                                                    <h:outputText value="Hos. Fee"/>
+                                                </th>
+                                                <th style="text-align: center; width: 19mm!important;">
+                                                    <h:outputText value="Reagent Fee"/>
+                                                </th>
+                                                <th style="text-align: center; width: 19mm!important;">
+                                                    <h:outputText value="Other Fee"/>
+                                                </th>
+                                                <th style="text-align: center; width: 23mm!important;">
+                                                    <h:outputText value="Net Total"/>
+                                                </th>
+                                                <th style="text-align: center; width: 19mm!important;">
+                                                    <h:outputText value="Discount"/>
+                                                </th>
+                                                <th style="text-align: center; width: 19mm!important;">
+                                                    <h:outputText value="Service Charge"/>
+                                                </th>
+                                            </tr>
+                                        </thead>
+                                        <tbody> 
+                                            <ui:repeat value="#{laborataryReportController.bundle.rows}" var="row">
+                                                <tr>
+                                                    <h:panelGroup rendered="#{row.rowType eq 'Bill'}">
+                                                        <td colspan="5" >
+                                                            <div class="d-flex gap-3">
+                                                                <div class="d-flex">
+                                                                    <h:outputText value="OrderNo  " style="font-size: 12px!important; width: 5em; margin-left: 2mm;"/>
+                                                                    <h:outputText value="#{row.bill.deptId}" style=" font-weight: 700; font-size: 12px!important;"/>
+                                                                </div>
+                                                                <div class="d-flex gap-1" >
+                                                                    <h:outputText value="Order Date " style="font-size: 12px!important; width: 5em;"/>
+                                                                    <h:outputText value="#{row.bill.createdAt}" style="font-weight: 700; font-size: 12px!important;">
+                                                                        <f:convertDateTime pattern="dd/MM/YYYY"/>
+                                                                    </h:outputText>
+                                                                </div>
+                                                                <h:panelGroup rendered="#{row.bill.patientEncounter ne null}">
+                                                                    <div class="d-flex">
+                                                                        <h:outputText value="BHT No " style="font-size: 12px!important; width: 5em;"/>
+                                                                        <h:outputText value="#{row.bill.patientEncounter.bhtNo}" style="font-weight: 700; font-size: 12px!important;"/>
+                                                                    </div>
+                                                                </h:panelGroup>
+                                                            </div>
+                                                        </td>
+                                                        <td style="text-align: right; width: 19mm!important;">
+                                                            <h:outputText rendered="#{row.rowType eq 'Bill'}" value="#{row.bill.discount}" style="margin-right: 3mm!important;">
+                                                                <f:convertNumber pattern="#,##0.00"/>
+                                                            </h:outputText>
+                                                        </td>
+                                                        <td style="text-align: right; width: 19mm!important;">
+                                                            <h:outputText rendered="#{row.rowType eq 'Bill'}" value="#{row.bill.serviceCharge}" style="margin-right: 3mm!important;">
+                                                                <f:convertNumber pattern="#,##0.00"/>
+                                                            </h:outputText>
+                                                        </td>
+                                                    </h:panelGroup>
 
-                                    <p:column headerText="Net Total" width="8em" class="text-end" style="padding: 6px!important; margin: 2px!important;" >
-                                        <h:outputText
-                                                rendered="#{row.rowType eq 'BillItem'}"
-                                                value="#{row.billItem.netValue}">
-                                            <f:convertNumber pattern="#,##0.00" />
-                                        </h:outputText>
-                                        <f:facet name="footer" >
-                                            <h:outputText value="#{laborataryReportController.totalNetTotal}" style="padding: 6px!important; margin: 2px!important;" >
-                                                <f:convertNumber pattern="#,##0.00" />
-                                            </h:outputText>
-                                        </f:facet>
-                                    </p:column>
+                                                    <h:panelGroup rendered="#{row.rowType eq 'BillItem'}">
+                                                        <td>
+                                                            <h:outputText value="#{row.billItem.item.name}" style="margin-left: 5mm!important;"/>
+                                                        </td>
+                                                        <td style="text-align: right; width: 23mm!important;">
+                                                            <h:outputText value="#{row.billItem.hospitalFee - (row.billItem.reagentFee + row.billItem.otherFee)}" style="margin-right: 1mm!important;">
+                                                                <f:convertNumber pattern="#,##0.00"/>
+                                                            </h:outputText>
+                                                        </td>
+                                                        <td style="text-align: right; width: 19mm!important;">
+                                                            <h:outputText value="#{row.billItem.reagentFee}" style="margin-right: 1mm!important;">
+                                                                <f:convertNumber pattern="#,##0.00"/>
+                                                            </h:outputText>
+                                                        </td>
+                                                        <td style="text-align: right; width: 19mm!important;">
+                                                            <h:outputText value="#{row.billItem.otherFee}" style="margin-right: 1mm!important;">
+                                                                <f:convertNumber pattern="#,##0.00"/>
+                                                            </h:outputText>
+                                                        </td>
+                                                        <td style="text-align: right; width: 23mm!important;">
+                                                            <h:outputText value="#{row.billItem.netValue}" style="margin-right: 1mm!important;">
+                                                                <f:convertNumber pattern="#,##0.00"/>
+                                                            </h:outputText>
+                                                        </td>
+                                                        <td style="text-align: right; width: 19mm!important;"></td>
+                                                        <td style="text-align: right; width: 19mm!important;"></td>
+                                                    </h:panelGroup>
 
-                                    <p:column headerText="Discount" width="8em" class="text-end" style="padding: 6px!important; margin: 2px!important;" >
-                                        <h:outputText
-                                                rendered="#{row.rowType eq 'Bill'}"
-                                                value="#{row.bill.discount}" >
-                                            <f:convertNumber pattern="#,##0.00" ></f:convertNumber>
-                                        </h:outputText>
-                                        <f:facet name="footer" >
-                                            <h:outputText value="#{laborataryReportController.totalDiscount}" style="padding: 6px!important; margin: 2px!important;" >
-                                                <f:convertNumber pattern="#,##0.00" />
-                                            </h:outputText>
-                                        </f:facet>
-                                    </p:column>
-
-                                    <p:column headerText="Service Charge" width="8em" class="text-end"  style="padding: 6px!important; margin: 2px!important;" >
-                                        <h:outputText
-                                                rendered="#{row.rowType eq 'Bill'}"
-                                                value="#{row.bill.serviceCharge}" >
-                                            <f:convertNumber pattern="#,##0.00" ></f:convertNumber>
-                                        </h:outputText>
-                                        <f:facet name="footer" >
-                                            <h:outputText value="#{laborataryReportController.totalServiceCharge}" style="padding: 6px!important; margin: 2px!important;" >
-                                                <f:convertNumber pattern="#,##0.00" />
-                                            </h:outputText>
-                                        </f:facet>
-                                    </p:column>
-
-                                </p:dataTable>
-
-
+                                                </tr>
+                                            </ui:repeat>
+                                        </tbody>
+                                        <tfoot>
+                                            <tr>
+                                                <td style="font-weight: bold; margin-left: 2mm;"> 
+                                                    <h:outputText value="Total" style="margin-left: 2mm!important;"/>
+                                                </td>
+                                                <td style="text-align: right; font-weight: bold; width: 19mm!important;">
+                                                    <h:outputText value="#{laborataryReportController.totalHospitalFee}" style="margin-right: 1mm!important;">
+                                                        <f:convertNumber pattern="#,##0.00"/>
+                                                    </h:outputText>
+                                                </td>
+                                                <td style="text-align: right; font-weight: bold; width: 19mm!important;">
+                                                    <h:outputText value="#{laborataryReportController.totalReagentFee}" style="margin-right: 1mm!important;">
+                                                        <f:convertNumber pattern="#,##0.00"/>
+                                                    </h:outputText>
+                                                </td>
+                                                <td style="text-align: right; font-weight: bold; width: 19mm!important;">
+                                                    <h:outputText value="#{laborataryReportController.totalOtherFee}" style="margin-right: 1mm!important;">
+                                                        <f:convertNumber pattern="#,##0.00"/>
+                                                    </h:outputText>
+                                                </td>
+                                                <td style="text-align: right; font-weight: bold; width: 25mm!important;">
+                                                    <h:outputText value="#{laborataryReportController.totalNetTotal}" style="margin-right: 1mm!important;">
+                                                        <f:convertNumber pattern="#,##0.00"/>
+                                                    </h:outputText>
+                                                </td>
+                                                <td style="text-align: right; font-weight: bold; width: 19mm!important;">
+                                                    <h:outputText value="#{laborataryReportController.totalDiscount}" style="margin-right: 1mm!important;">
+                                                        <f:convertNumber pattern="#,##0.00"/>
+                                                    </h:outputText>
+                                                </td>
+                                                <td style="text-align: right; font-weight: bold; width: 19mm!important;">
+                                                    <h:outputText value="#{laborataryReportController.totalServiceCharge}" style="margin-right: 1mm!important;">
+                                                        <f:convertNumber pattern="#,##0.00"/>
+                                                    </h:outputText>
+                                                </td>
+                                            </tr>
+                                        </tfoot>
+                                    </table>
+                                    
+                                </div>
                             </div>
                         </h:panelGroup>
                         

--- a/src/main/webapp/reportLab/lab_inward_order_report_print.xhtml
+++ b/src/main/webapp/reportLab/lab_inward_order_report_print.xhtml
@@ -43,9 +43,9 @@
                                 .paper{
                                     position: static !important;
                                     width: 210mm!important;
-                                    zoom: 2.0;
-                                    margin: 10px;
-                                    margin-top: 20px;
+                                    transform: scale(1.5);
+                                    transform-origin:center;
+                                    margin-top: 50px;
                                 }
 
                                 table {
@@ -108,10 +108,6 @@
                                     margin: 2px!important;
                                     text-align: left;
                                     margin-left: 10mm!important;
-                                }
-
-                                th {
-
                                 }
                                 
                                 .toinsdept{

--- a/src/main/webapp/reportLab/lab_inward_order_report_print.xhtml
+++ b/src/main/webapp/reportLab/lab_inward_order_report_print.xhtml
@@ -11,10 +11,10 @@
             <ui:define name="content">
 
                 <h:form >
-                    <p:panel header="Test Wise Count Report Print" styleClass="w-100">
+                    <p:panel header="Laboratory Order Report Print" styleClass="w-100">
                         <f:facet name="header"  >
                             <div class="d-flex justify-content-between">
-                                <h:outputText value="Test Wise Count Report Print" class="mt-2"/>
+                                <h:outputText value="Laboratory Order Report Print" class="mt-2"/>
                                 <div class="d-flex gap-2">
                                     <p:commandButton 
                                         icon="fa-solid fa-print"
@@ -30,7 +30,7 @@
                                         style="width: 200px"
                                         icon="fa fa-arrow-left"
                                         class="ui-button-warning"
-                                        action="test_wise_count?faces-redirect=true;" >
+                                        action="lab_inward_order_report?faces-redirect=true;" >
                                     </p:commandButton>
                                 </div>
 
@@ -44,6 +44,8 @@
                                     position: static !important;
                                     width: 210mm!important;
                                     zoom: 2.0;
+                                    margin: 10px;
+                                    margin-top: 20px;
                                 }
 
                                 table {
@@ -122,13 +124,13 @@
 
 
                         <h:panelGroup id="reportView" class="d-flex justify-content-center">
-                            <div class="paper">
+                            <div class="paper" >
                                 <div class="header" >
-                                    <div class="d-flex justify-content-center text-5 gap-2" style="font-weight: 700; font-size: 22px;">
+                                    <div class="d-flex justify-content-center text-5 gap-2" style="font-weight: 700; font-size: 24px;">
                                         <h:outputText value="#{sessionController.institution.name}"/>
                                     </div>
-                                    <div class="d-flex justify-content-center text-5 gap-2" style="font-weight: 700; font-size: 18px;">
-                                        <h:outputText value="Laboratary Test Count"/>
+                                    <div class="d-flex justify-content-center text-5 gap-2" style="font-weight: 700; font-size: 18px;margin-top: 5px">
+                                        <h:outputText value="Laboratory Order Report"/>
                                         <h:panelGroup  rendered="#{laborataryReportController.department ne null}">
                                             <div class="d-flex gap-2">
                                                 <h:outputText value="-" style="width: 1em!important;" class="text-center"/>
@@ -138,14 +140,14 @@
                                     </div>
                                     <div class="d-flex justify-content-center mt-2" style=" font-size: 12px;">
                                         <div class="d-flex gap-3">
-                                            <h:outputText value="From Date" style="width: 6em!important; font-weight: 600;"/>
+                                            <h:outputText value="From Date:" style="width: 6em!important; font-weight: 600;"/>
                                             <h:outputText value="#{laborataryReportController.fromDate}">
                                                 <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateFormat}" />
                                             </h:outputText>
                                         </div>
                                         <h:outputText value="" style="width: 5mm!important;"/>
                                         <div class="d-flex gap-3">
-                                            <h:outputText value="To Date" style="width: 4em!important; font-weight: 600;"/>
+                                            <h:outputText value="To Date:" style="width: 4em!important; font-weight: 600;"/>
                                             <h:outputText value="#{laborataryReportController.toDate}">
                                                 <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateFormat}" />
                                             </h:outputText>
@@ -177,7 +179,7 @@
                                     <table id="tbl">
                                         <thead>
                                             <tr>
-                                                <th style=" margin-left: 2mm;">
+                                                <th style="text-align: center">
                                                     <h:outputText value="Investigation"/>
                                                 </th>
                                                 <th style="text-align: center; width: 23mm!important;">


### PR DESCRIPTION
The Laboratory Order Report's print view size differs from Laboratory Test Wise Count Report
[#11654](https://github.com/hmislk/hmis/issues/11654)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- The report header has been updated to "Laboratory Order Report Print" with an improved layout.
	- A custom table structure now presents report data with enhanced column formatting.

- **Style**
	- Added refined styling for both screen and print views, ensuring a consistent and polished appearance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->