### PR TITLE
11093 my handovers needs to be viewed and printed later

### DIFF
--- a/src/main/java/com/divudi/bean/cashTransaction/FinancialTransactionController.java
+++ b/src/main/java/com/divudi/bean/cashTransaction/FinancialTransactionController.java
@@ -1769,6 +1769,7 @@ public class FinancialTransactionController implements Serializable {
         resetClassVariablesForAcceptHandoverBill();
         bundle = new ReportTemplateRowBundle();
         bundle.setUser(selectedBill.getFromWebUser());
+        bundle.setToUser(selectedBill.getToWebUser());
         bundle.setStartBill(selectedBill.getReferenceBill());
         if (selectedBill.getReferenceBill() != null) {
             bundle.setEndBill(selectedBill.getReferenceBill().getReferenceBill());

--- a/src/main/java/com/divudi/core/data/ReportTemplateRowBundle.java
+++ b/src/main/java/com/divudi/core/data/ReportTemplateRowBundle.java
@@ -19,6 +19,7 @@ import java.util.UUID;
 import java.time.LocalDate;
 import java.time.ZoneId;
 import java.util.*;
+import java.util.stream.Collectors;
 
 /**
  * @author buddhika
@@ -1070,8 +1071,8 @@ public class ReportTemplateRowBundle implements Serializable {
                 if (row.getBill() == null) {
                     continue;
                 }
-                double amount = isOutpatient ? row.getBill().getNetTotal() : row.getBill().getBillClassType().equals(BillClassType.CancelledBill) ?
-                        row.getBill().getNetTotal() : row.getBill().getPatientEncounter().getFinalBill().getNetTotal();
+                double amount = isOutpatient ? row.getBill().getNetTotal() : row.getBill().getBillClassType().equals(BillClassType.CancelledBill)
+                        ? row.getBill().getNetTotal() : row.getBill().getPatientEncounter().getFinalBill().getNetTotal();
                 total += amount;
             }
         }
@@ -1112,8 +1113,8 @@ public class ReportTemplateRowBundle implements Serializable {
                     continue;
                 }
 
-                double amount = isOutpatient ? row.getBill().getSettledAmountByPatient() : row.getBill().getBillClassType().equals(BillClassType.CancelledBill) ?
-                        row.getBill().getSettledAmountByPatient() : row.getBill().getPatientEncounter().getFinalBill().getSettledAmountByPatient();
+                double amount = isOutpatient ? row.getBill().getSettledAmountByPatient() : row.getBill().getBillClassType().equals(BillClassType.CancelledBill)
+                        ? row.getBill().getSettledAmountByPatient() : row.getBill().getPatientEncounter().getFinalBill().getSettledAmountByPatient();
 
                 settledAmountByPatientsTotal += amount;
             }
@@ -1127,8 +1128,8 @@ public class ReportTemplateRowBundle implements Serializable {
                 if (row.getBill() == null) {
                     continue;
                 }
-                double amount = isOutpatient ? row.getBill().getSettledAmountBySponsor() : row.getBill().getBillClassType().equals(BillClassType.CancelledBill) ?
-                        row.getBill().getSettledAmountBySponsor() : row.getBill().getPatientEncounter().getFinalBill().getSettledAmountBySponsor();
+                double amount = isOutpatient ? row.getBill().getSettledAmountBySponsor() : row.getBill().getBillClassType().equals(BillClassType.CancelledBill)
+                        ? row.getBill().getSettledAmountBySponsor() : row.getBill().getPatientEncounter().getFinalBill().getSettledAmountBySponsor();
 
                 settledAmountBySponsorsTotal += amount;
             }
@@ -1143,11 +1144,11 @@ public class ReportTemplateRowBundle implements Serializable {
                     continue;
                 }
 
-                double amount = isOutpatient ? row.getBill().getNetTotal() - row.getBill().getSettledAmountBySponsor() - row.getBill().getSettledAmountByPatient() :
-                        row.getBill().getBillClassType().equals(BillClassType.CancelledBill) ?
-                                row.getBill().getNetTotal() - row.getBill().getSettledAmountBySponsor() - row.getBill().getSettledAmountByPatient() :
-                                row.getBill().getPatientEncounter().getFinalBill().getNetTotal() - row.getBill().getPatientEncounter().getFinalBill().getSettledAmountBySponsor() -
-                                        row.getBill().getPatientEncounter().getFinalBill().getSettledAmountByPatient();
+                double amount = isOutpatient ? row.getBill().getNetTotal() - row.getBill().getSettledAmountBySponsor() - row.getBill().getSettledAmountByPatient()
+                        : row.getBill().getBillClassType().equals(BillClassType.CancelledBill)
+                        ? row.getBill().getNetTotal() - row.getBill().getSettledAmountBySponsor() - row.getBill().getSettledAmountByPatient()
+                        : row.getBill().getPatientEncounter().getFinalBill().getNetTotal() - row.getBill().getPatientEncounter().getFinalBill().getSettledAmountBySponsor()
+                        - row.getBill().getPatientEncounter().getFinalBill().getSettledAmountByPatient();
 
                 totalBalance += amount;
             }
@@ -2850,6 +2851,13 @@ public class ReportTemplateRowBundle implements Serializable {
 //    }
     public List<DenominationTransaction> getDenominationTransactions() {
         return denominationTransactions;
+    }
+
+    public List<DenominationTransaction> getFilteredDenominationTransactions() {
+        return getDenominationTransactions()
+                .stream()
+                .filter(t -> t.getDenominationQty() != 0 || t.getDenominationValue() != 0)
+                .collect(Collectors.toList());
     }
 
     public void setDenominationTransactions(List<DenominationTransaction> denominationTransactions) {

--- a/src/main/resources/META-INF/persistence.xml
+++ b/src/main/resources/META-INF/persistence.xml
@@ -2,14 +2,14 @@
 <persistence version="2.2" xmlns="http://java.sun.com/xml/ns/persistence" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/persistence http://xmlns.jcp.org/xml/ns/persistence/persistence_2_2.xsd">
     <persistence-unit name="hmisPU" transaction-type="JTA">
         <provider>org.eclipse.persistence.jpa.PersistenceProvider</provider>
-        <jta-data-source>jdbc/ruhunu</jta-data-source>
+        <jta-data-source>${JDBC_DATASOURCE}</jta-data-source>
         <exclude-unlisted-classes>false</exclude-unlisted-classes>
         <properties>
             <property name="eclipselink.logging.level" value="SEVERE"/>
         </properties>
     </persistence-unit>
     <persistence-unit name="hmisAuditPU" transaction-type="JTA">
-        <jta-data-source>jdbc/ruhunuAudit</jta-data-source>
+        <jta-data-source>${JDBC_AUDIT_DATASOURCE}</jta-data-source>
         <exclude-unlisted-classes>false</exclude-unlisted-classes>
         <properties>
             <property name="eclipselink.logging.level" value="SEVERE"/>

--- a/src/main/resources/META-INF/persistence.xml
+++ b/src/main/resources/META-INF/persistence.xml
@@ -2,14 +2,14 @@
 <persistence version="2.2" xmlns="http://java.sun.com/xml/ns/persistence" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/persistence http://xmlns.jcp.org/xml/ns/persistence/persistence_2_2.xsd">
     <persistence-unit name="hmisPU" transaction-type="JTA">
         <provider>org.eclipse.persistence.jpa.PersistenceProvider</provider>
-        <jta-data-source>${JDBC_DATASOURCE}</jta-data-source>
+        <jta-data-source>jdbc/ruhunu</jta-data-source>
         <exclude-unlisted-classes>false</exclude-unlisted-classes>
         <properties>
             <property name="eclipselink.logging.level" value="SEVERE"/>
         </properties>
     </persistence-unit>
     <persistence-unit name="hmisAuditPU" transaction-type="JTA">
-        <jta-data-source>${JDBC_AUDIT_DATASOURCE}</jta-data-source>
+        <jta-data-source>jdbc/ruhunuAudit</jta-data-source>
         <exclude-unlisted-classes>false</exclude-unlisted-classes>
         <properties>
             <property name="eclipselink.logging.level" value="SEVERE"/>

--- a/src/main/webapp/cashier/handover_preview.xhtml
+++ b/src/main/webapp/cashier/handover_preview.xhtml
@@ -7,77 +7,102 @@
       xmlns:f="http://xmlns.jcp.org/jsf/core">
 
     <h:body>
-
         <ui:composition template="/cashier/index.xhtml">
-
             <ui:define name="subcontent">
-
-
                 <h:form>
-                    <p:panel  class="m-1 p-1 container-flex">
+                    <p:panel  class="w-100 m-1">
                         <f:facet name="header">
-                            <p:outputLabel value="Accept Handovers" />
+                            <p:outputLabel value="Reprint Handovers" />
+                            <p:commandButton 
+                                value="To Print" 
+                                styleClass="ui-button-success mx-1" 
+                                icon="pi pi-check-circle" 
+                                ajax="false" 
+                                style="float: right;"
+                                action="#{financialTransactionController.navigateToHandoverReprint()}">
+                            </p:commandButton>
                         </f:facet>
 
-                        <h:panelGroup id="gpPrint" >
-                            <div class="row mx-2" >
-                                <div class="col-7">
-                                    <p:panelGrid layout="tabular" columns="2" class="w-100" >
-                                        <f:facet name="header" >
-                                            <p:outputLabel value="Shift" class="font-weight-bold" ></p:outputLabel>
-                                        </f:facet>
+
+                        <div class="row" >
+                            <div class="col-7">
+                                <p:panel >
+                                    <f:facet name="header" >
+                                        <p:outputLabel value="Shift" class="font-weight-bold" ></p:outputLabel>
+                                    </f:facet>
+
+
+
+
+                                    <h:panelGrid columns="2" class="w-100" >
+
                                         <!-- User with Icon -->
                                         <h:panelGroup>
                                             <i class="pi pi-user" style="margin-right:5px; color: #007bff;"></i>
-                                            <p:outputLabel value="User" />
+                                            <p:outputLabel value="From User" />
                                         </h:panelGroup>
-                                        <p:badge value="#{financialTransactionController.bundle.user.webUserPerson.nameWithTitle}" styleClass="ui-badge-primary"></p:badge>
+                                        <p:outputLabel value="#{financialTransactionController.bundle.user.webUserPerson.nameWithTitle}" styleClass="ui-badge-primary"></p:outputLabel>
 
-                                        <!-- Shift Start with Icon -->
+                                        <!-- User with Icon -->
                                         <h:panelGroup>
-                                            <i class="pi pi-clock" style="margin-right:5px; color: #28a745;"></i>
-                                            <p:outputLabel value="Shift Start" />
+                                            <i class="pi pi-user" style="margin-right:5px; color: #007bff;"></i>
+                                            <p:outputLabel value="To User" />
                                         </h:panelGroup>
+                                        <p:outputLabel value="#{financialTransactionController.bundle.toUser.webUserPerson.nameWithTitle}" styleClass="ui-badge-primary"></p:outputLabel>
+
                                         <h:panelGroup>
-                                            <p:panelGrid columns="2">
-                                                <h:panelGroup>
-                                                    <i class="pi pi-list" style="margin-right:5px; color: #17a2b8;"></i>
-                                                    <p:outputLabel value="Shift Start Bill ID" />
-                                                </h:panelGroup>
-                                                <h:panelGroup >
-                                                    <p:outputLabel value="#{financialTransactionController.bundle.startBill.deptId}" rendered="#{financialTransactionController.bundle.startBill ne null}" />
-                                                    <p:outputLabel value="#{financialTransactionController.bundle.startBill.id}" rendered="#{financialTransactionController.bundle.startBill.deptId eq null}" />
-                                                </h:panelGroup>
+                                            <i class="pi pi-calendar-plus" style="margin-right:5px; color: #ffc107;"></i>
+                                            <p:outputLabel value="Shift Started At" />
+                                        </h:panelGroup>
+                                        <p:outputLabel value="#{financialTransactionController.bundle.startBill.createdAt}">
+                                            <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateTimeFormat}" />
+                                        </p:outputLabel>
 
-                                                <h:panelGroup>
-                                                    <i class="pi pi-calendar-plus" style="margin-right:5px; color: #ffc107;"></i>
-                                                    <p:outputLabel value="Shift Started At" />
-                                                </h:panelGroup>
-                                                <p:outputLabel value="#{financialTransactionController.bundle.startBill.createdAt}">
-                                                    <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateTimeFormat}" />
-                                                </p:outputLabel>
-                                            </p:panelGrid>
+                                        <h:panelGroup>
+                                            <i class="pi pi-list" style="margin-right:5px; color: #17a2b8;"></i>
+                                            <p:outputLabel value="Shift Start Number" />
+                                        </h:panelGroup>
+                                        <h:panelGroup >
+                                            <p:outputLabel value="#{financialTransactionController.bundle.startBill.deptId}" rendered="#{financialTransactionController.bundle.startBill ne null}" />
+                                            <p:outputLabel value="#{financialTransactionController.bundle.startBill.id}" rendered="#{financialTransactionController.bundle.startBill.deptId eq null}" />
                                         </h:panelGroup>
 
-                                        <!-- Shift End with Icon -->
+                                        <h:panelGroup  rendered="#{financialTransactionController.bundle.endBill eq null}" >
+                                            <i class="pi pi-clock" style="margin-right:5px; color: #dc3545;"></i>
+                                            <p:outputLabel value="Shift End" />
+                                        </h:panelGroup>
+
+                                        <h:panelGroup  rendered="#{financialTransactionController.bundle.endBill ne null}" >
+                                            <i class="pi pi-clock" style="margin-right:5px; color: #dc3545;"></i>
+                                            <p:outputLabel value="Shift Ended At" />
+                                        </h:panelGroup>
+
+                                        <h:panelGroup rendered="#{financialTransactionController.bundle.endBill eq null}" >
+                                            <p:outputLabel value="Shift Not Yet Ended" />
+                                        </h:panelGroup>
+
+
+                                        <h:panelGroup  rendered="#{financialTransactionController.bundle.endBill ne null}">
+                                            <p:outputLabel value="#{financialTransactionController.bundle.endBill.createdAt}">
+                                                <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateTimeFormat}" />
+                                            </p:outputLabel>
+                                        </h:panelGroup>
+
+
+                                        <p:panelGrid columns="2" rendered="#{financialTransactionController.bundle.endBill ne null}">
+                                            <i class="pi pi-list" style="margin-right:5px; color: #17a2b8;"></i>
+                                            <p:outputLabel value="Shift End Bill ID" />
+                                        </p:panelGrid>
+
+                                        <p:panelGrid columns="2" rendered="#{financialTransactionController.bundle.endBill ne null}">
+                                            <p:outputLabel value="#{financialTransactionController.bundle.endBill.deptId}" />
+                                        </p:panelGrid>
+
+
                                         <h:panelGroup rendered="#{financialTransactionController.bundle.endBill ne null}" >
                                             <i class="pi pi-clock" style="margin-right:5px; color: #dc3545;"></i>
                                             <p:outputLabel value="Shift End" />
                                         </h:panelGroup>
-                                        <p:panelGrid columns="2" rendered="#{financialTransactionController.bundle.endBill ne null}">
-                                            <h:panelGroup>
-                                                <i class="pi pi-list" style="margin-right:5px; color: #17a2b8;"></i>
-                                                <p:outputLabel value="Shift End Bill ID" />
-                                            </h:panelGroup>
-                                            <p:outputLabel value="#{financialTransactionController.bundle.endBill.deptId}" />
-                                            <h:panelGroup>
-                                                <i class="pi pi-calendar-minus" style="margin-right:5px; color: #ffc107;"></i>
-                                                <p:outputLabel value="Shift Ended At" />
-                                            </h:panelGroup>
-                                            <p:outputLabel value="#{financialTransactionController.bundle.endBill.createdAt}">
-                                                <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateTimeFormat}" />
-                                            </p:outputLabel>
-                                        </p:panelGrid>
 
                                         <!-- Total Handover Value with Icon -->
                                         <h:panelGroup>
@@ -87,677 +112,673 @@
                                         <p:outputLabel value="#{financialTransactionController.bundle.total}">
                                             <f:convertNumber pattern="#,##0.00" />
                                         </p:outputLabel>
-                                    </p:panelGrid>
-                                    <p:panel class="w-100 m-1" >
-                                        <f:facet name="header" >
-                                            <div class="row align-items-center my-2">
-                                                <!-- Header Label -->
-                                                <div class="col-md-4">
-                                                    <span class="font-weight-bold">Accept</span>
-                                                </div>
-                                                <div class="col-md-8 text-right">
-                                                    <p:commandButton 
-                                                        value="Reprint" 
-                                                        styleClass="ui-button-success mx-1" 
-                                                        icon="pi pi-check-circle" 
-                                                        ajax="false" 
-                                                        action="#{financialTransactionController.navigateToHandoverReprint()}">
-                                                    </p:commandButton>
-                                                </div>
-                                            </div>
-                                        </f:facet>
+                                    </h:panelGrid>
 
-                                        <table class="table table-bordered table-hover w-100">
-                                            <!-- Table Header -->
-                                            <thead class="thead-dark">
+                                </p:panel>
+                                <p:panel class="my-1">
+                                    <f:facet name="header" >
+                                        <p:outputLabel value="Payments" class="font-weight-bold" ></p:outputLabel>
+                                    </f:facet>
+                                    <table class="table table-bordered table-hover w-100 m-1">
+                                        <!-- Table Header -->
+                                        <thead class="thead-dark">
+                                            <tr>
+                                                <th class="text-center">Payment Method</th>
+                                                <th class="text-center">Collected</th>
+                                                <th class="text-center">Handed Over</th>
+                                                <th class="text-center">Difference</th>
+                                            </tr>
+                                        </thead>
+                                        <!-- Table Body -->
+                                        <tbody>
+                                            <!-- Cash Row -->
+                                            <ui:fragment rendered="#{financialTransactionController.bundle.hasCashTransaction}">
                                                 <tr>
-                                                    <th class="text-center">Payment Method</th>
-                                                    <th class="text-center">Collected</th>
-                                                    <th class="text-center">Handed Over</th>
-                                                    <th class="text-center">Difference</th>
+                                                    <td>Cash</td>
+                                                    <td class="text-end">
+                                                        <h:outputText value="#{financialTransactionController.bundle.cashValue}">
+                                                            <f:convertNumber pattern="#,##0.00" />
+                                                        </h:outputText>
+                                                    </td>
+                                                    <td class="text-end">
+                                                        <h:outputText value="#{financialTransactionController.bundle.cashHandoverValue}">
+                                                            <f:convertNumber pattern="#,##0.00" />
+                                                        </h:outputText>
+                                                    </td>
+                                                    <td class="text-end">
+                                                        <h:outputText value="#{financialTransactionController.bundle.cashValue - financialTransactionController.bundle.cashHandoverValue}">
+                                                            <f:convertNumber pattern="#,##0.00" />
+                                                        </h:outputText>
+                                                    </td>
                                                 </tr>
-                                            </thead>
-                                            <!-- Table Body -->
-                                            <tbody>
-                                                <!-- Cash Row -->
-                                                <ui:fragment rendered="#{financialTransactionController.bundle.hasCashTransaction}">
-                                                    <tr>
-                                                        <td>Cash</td>
-                                                        <td class="text-end">
-                                                            <h:outputText value="#{financialTransactionController.bundle.cashValue}">
-                                                                <f:convertNumber pattern="#,##0.00" />
-                                                            </h:outputText>
-                                                        </td>
-                                                        <td class="text-end">
-                                                            <h:outputText value="#{financialTransactionController.bundle.cashHandoverValue}">
-                                                                <f:convertNumber pattern="#,##0.00" />
-                                                            </h:outputText>
-                                                        </td>
-                                                        <td class="text-end">
-                                                            <h:outputText value="#{financialTransactionController.bundle.cashValue - financialTransactionController.bundle.cashHandoverValue}">
-                                                                <f:convertNumber pattern="#,##0.00" />
-                                                            </h:outputText>
-                                                        </td>
-                                                    </tr>
-                                                </ui:fragment>
+                                            </ui:fragment>
 
-                                                <!-- Card Row -->
-                                                <ui:fragment rendered="#{financialTransactionController.bundle.hasCardTransaction}">
-                                                    <tr>
-                                                        <td>Card</td>
-                                                        <td class="text-end">
-                                                            <h:outputText value="#{financialTransactionController.bundle.cardValue}">
-                                                                <f:convertNumber pattern="#,##0.00" />
-                                                            </h:outputText>
-                                                        </td>
-                                                        <td class="text-end">
-                                                            <h:outputText value="#{financialTransactionController.bundle.cardHandoverValue}">
-                                                                <f:convertNumber pattern="#,##0.00" />
-                                                            </h:outputText>
-                                                        </td>
-                                                        <td class="text-end">
-                                                            <h:outputText value="#{financialTransactionController.bundle.cardValue - financialTransactionController.bundle.cardHandoverValue}">
-                                                                <f:convertNumber pattern="#,##0.00" />
-                                                            </h:outputText>
-                                                        </td>
-                                                    </tr>
-                                                </ui:fragment>
-                                                <!-- Cheque Row -->
-                                                <ui:fragment rendered="#{financialTransactionController.bundle.hasChequeTransaction}">
-                                                    <tr>
-                                                        <td>Cheque</td>
-                                                        <td class="text-end">
-                                                            <h:outputText value="#{financialTransactionController.bundle.chequeValue}">
-                                                                <f:convertNumber pattern="#,##0.00" />
-                                                            </h:outputText>
-                                                        </td>
-                                                        <td class="text-end">
-                                                            <h:outputText value="#{financialTransactionController.bundle.chequeHandoverValue}">
-                                                                <f:convertNumber pattern="#,##0.00" />
-                                                            </h:outputText>
-                                                        </td>
-                                                        <td class="text-end">
-                                                            <h:outputText value="#{financialTransactionController.bundle.chequeValue - financialTransactionController.bundle.chequeHandoverValue}">
-                                                                <f:convertNumber pattern="#,##0.00" />
-                                                            </h:outputText>
-                                                        </td>
-                                                    </tr>
-                                                </ui:fragment>
+                                            <!-- Card Row -->
+                                            <ui:fragment rendered="#{financialTransactionController.bundle.hasCardTransaction}">
+                                                <tr>
+                                                    <td>Card</td>
+                                                    <td class="text-end">
+                                                        <h:outputText value="#{financialTransactionController.bundle.cardValue}">
+                                                            <f:convertNumber pattern="#,##0.00" />
+                                                        </h:outputText>
+                                                    </td>
+                                                    <td class="text-end">
+                                                        <h:outputText value="#{financialTransactionController.bundle.cardHandoverValue}">
+                                                            <f:convertNumber pattern="#,##0.00" />
+                                                        </h:outputText>
+                                                    </td>
+                                                    <td class="text-end">
+                                                        <h:outputText value="#{financialTransactionController.bundle.cardValue - financialTransactionController.bundle.cardHandoverValue}">
+                                                            <f:convertNumber pattern="#,##0.00" />
+                                                        </h:outputText>
+                                                    </td>
+                                                </tr>
+                                            </ui:fragment>
+                                            <!-- Cheque Row -->
+                                            <ui:fragment rendered="#{financialTransactionController.bundle.hasChequeTransaction}">
+                                                <tr>
+                                                    <td>Cheque</td>
+                                                    <td class="text-end">
+                                                        <h:outputText value="#{financialTransactionController.bundle.chequeValue}">
+                                                            <f:convertNumber pattern="#,##0.00" />
+                                                        </h:outputText>
+                                                    </td>
+                                                    <td class="text-end">
+                                                        <h:outputText value="#{financialTransactionController.bundle.chequeHandoverValue}">
+                                                            <f:convertNumber pattern="#,##0.00" />
+                                                        </h:outputText>
+                                                    </td>
+                                                    <td class="text-end">
+                                                        <h:outputText value="#{financialTransactionController.bundle.chequeValue - financialTransactionController.bundle.chequeHandoverValue}">
+                                                            <f:convertNumber pattern="#,##0.00" />
+                                                        </h:outputText>
+                                                    </td>
+                                                </tr>
+                                            </ui:fragment>
 
-                                                <!-- Slip Payment Row -->
-                                                <ui:fragment rendered="#{financialTransactionController.bundle.hasSlipTransaction}">
-                                                    <tr>
-                                                        <td>Slip Payment</td>
-                                                        <td class="text-end">
-                                                            <h:outputText value="#{financialTransactionController.bundle.slipValue}">
-                                                                <f:convertNumber pattern="#,##0.00" />
-                                                            </h:outputText>
-                                                        </td>
-                                                        <td class="text-end">
-                                                            <h:outputText value="#{financialTransactionController.bundle.slipHandoverValue}">
-                                                                <f:convertNumber pattern="#,##0.00" />
-                                                            </h:outputText>
-                                                        </td>
-                                                        <td class="text-end">
-                                                            <h:outputText value="#{financialTransactionController.bundle.slipValue - financialTransactionController.bundle.slipHandoverValue}">
-                                                                <f:convertNumber pattern="#,##0.00" />
-                                                            </h:outputText>
-                                                        </td>
-                                                    </tr>
-                                                </ui:fragment>
+                                            <!-- Slip Payment Row -->
+                                            <ui:fragment rendered="#{financialTransactionController.bundle.hasSlipTransaction}">
+                                                <tr>
+                                                    <td>Slip Payment</td>
+                                                    <td class="text-end">
+                                                        <h:outputText value="#{financialTransactionController.bundle.slipValue}">
+                                                            <f:convertNumber pattern="#,##0.00" />
+                                                        </h:outputText>
+                                                    </td>
+                                                    <td class="text-end">
+                                                        <h:outputText value="#{financialTransactionController.bundle.slipHandoverValue}">
+                                                            <f:convertNumber pattern="#,##0.00" />
+                                                        </h:outputText>
+                                                    </td>
+                                                    <td class="text-end">
+                                                        <h:outputText value="#{financialTransactionController.bundle.slipValue - financialTransactionController.bundle.slipHandoverValue}">
+                                                            <f:convertNumber pattern="#,##0.00" />
+                                                        </h:outputText>
+                                                    </td>
+                                                </tr>
+                                            </ui:fragment>
 
-                                                <!-- e-Wallet Payment Row -->
-                                                <ui:fragment rendered="#{financialTransactionController.bundle.hasEWalletTransaction}">
-                                                    <tr>
-                                                        <td>e-Wallet Payment</td>
-                                                        <td class="text-end">
-                                                            <h:outputText value="#{financialTransactionController.bundle.ewalletValue}">
-                                                                <f:convertNumber pattern="#,##0.00" />
-                                                            </h:outputText>
-                                                        </td>
-                                                        <td class="text-end">
-                                                            <h:outputText value="#{financialTransactionController.bundle.ewalletHandoverValue}">
-                                                                <f:convertNumber pattern="#,##0.00" />
-                                                            </h:outputText>
-                                                        </td>
-                                                        <td class="text-end">
-                                                            <h:outputText value="#{financialTransactionController.bundle.ewalletValue - financialTransactionController.bundle.ewalletHandoverValue}">
-                                                                <f:convertNumber pattern="#,##0.00" />
-                                                            </h:outputText>
-                                                        </td>
-                                                    </tr>
-                                                </ui:fragment>
+                                            <!-- e-Wallet Payment Row -->
+                                            <ui:fragment rendered="#{financialTransactionController.bundle.hasEWalletTransaction}">
+                                                <tr>
+                                                    <td>e-Wallet Payment</td>
+                                                    <td class="text-end">
+                                                        <h:outputText value="#{financialTransactionController.bundle.ewalletValue}">
+                                                            <f:convertNumber pattern="#,##0.00" />
+                                                        </h:outputText>
+                                                    </td>
+                                                    <td class="text-end">
+                                                        <h:outputText value="#{financialTransactionController.bundle.ewalletHandoverValue}">
+                                                            <f:convertNumber pattern="#,##0.00" />
+                                                        </h:outputText>
+                                                    </td>
+                                                    <td class="text-end">
+                                                        <h:outputText value="#{financialTransactionController.bundle.ewalletValue - financialTransactionController.bundle.ewalletHandoverValue}">
+                                                            <f:convertNumber pattern="#,##0.00" />
+                                                        </h:outputText>
+                                                    </td>
+                                                </tr>
+                                            </ui:fragment>
 
-                                                <!-- Patient Deposit Row -->
-                                                <ui:fragment rendered="#{financialTransactionController.bundle.hasPatientDepositTransaction}">
-                                                    <tr>
-                                                        <td>Patient Deposit</td>
-                                                        <td class="text-end">
-                                                            <h:outputText value="#{financialTransactionController.bundle.patientDepositValue}">
-                                                                <f:convertNumber pattern="#,##0.00" />
-                                                            </h:outputText>
-                                                        </td>
-                                                        <td class="text-end">
-                                                            <h:outputText value="#{financialTransactionController.bundle.patientDepositHandoverValue}">
-                                                                <f:convertNumber pattern="#,##0.00" />
-                                                            </h:outputText>
-                                                        </td>
-                                                        <td class="text-end">
-                                                            <h:outputText value="#{financialTransactionController.bundle.patientDepositValue - financialTransactionController.bundle.patientDepositHandoverValue}">
-                                                                <f:convertNumber pattern="#,##0.00" />
-                                                            </h:outputText>
-                                                        </td>
-                                                    </tr>
-                                                </ui:fragment>
+                                            <!-- Patient Deposit Row -->
+                                            <ui:fragment rendered="#{financialTransactionController.bundle.hasPatientDepositTransaction}">
+                                                <tr>
+                                                    <td>Patient Deposit</td>
+                                                    <td class="text-end">
+                                                        <h:outputText value="#{financialTransactionController.bundle.patientDepositValue}">
+                                                            <f:convertNumber pattern="#,##0.00" />
+                                                        </h:outputText>
+                                                    </td>
+                                                    <td class="text-end">
+                                                        <h:outputText value="#{financialTransactionController.bundle.patientDepositHandoverValue}">
+                                                            <f:convertNumber pattern="#,##0.00" />
+                                                        </h:outputText>
+                                                    </td>
+                                                    <td class="text-end">
+                                                        <h:outputText value="#{financialTransactionController.bundle.patientDepositValue - financialTransactionController.bundle.patientDepositHandoverValue}">
+                                                            <f:convertNumber pattern="#,##0.00" />
+                                                        </h:outputText>
+                                                    </td>
+                                                </tr>
+                                            </ui:fragment>
 
-                                                <!-- On Call Row -->
-                                                <ui:fragment rendered="#{financialTransactionController.bundle.hasOnCallTransaction}">
-                                                    <tr>
-                                                        <td>On Call</td>
-                                                        <td class="text-end">
-                                                            <h:outputText value="#{financialTransactionController.bundle.onCallValue}">
-                                                                <f:convertNumber pattern="#,##0.00" />
-                                                            </h:outputText>
-                                                        </td>
-                                                        <td class="text-end">
-                                                            <h:outputText value="#{financialTransactionController.bundle.onCallHandoverValue}">
-                                                                <f:convertNumber pattern="#,##0.00" />
-                                                            </h:outputText>
-                                                        </td>
-                                                        <td class="text-end">
-                                                            <h:outputText value="#{financialTransactionController.bundle.onCallValue - financialTransactionController.bundle.onCallHandoverValue}">
-                                                                <f:convertNumber pattern="#,##0.00" />
-                                                            </h:outputText>
-                                                        </td>
-                                                    </tr>
-                                                </ui:fragment>
+                                            <!-- On Call Row -->
+                                            <ui:fragment rendered="#{financialTransactionController.bundle.hasOnCallTransaction}">
+                                                <tr>
+                                                    <td>On Call</td>
+                                                    <td class="text-end">
+                                                        <h:outputText value="#{financialTransactionController.bundle.onCallValue}">
+                                                            <f:convertNumber pattern="#,##0.00" />
+                                                        </h:outputText>
+                                                    </td>
+                                                    <td class="text-end">
+                                                        <h:outputText value="#{financialTransactionController.bundle.onCallHandoverValue}">
+                                                            <f:convertNumber pattern="#,##0.00" />
+                                                        </h:outputText>
+                                                    </td>
+                                                    <td class="text-end">
+                                                        <h:outputText value="#{financialTransactionController.bundle.onCallValue - financialTransactionController.bundle.onCallHandoverValue}">
+                                                            <f:convertNumber pattern="#,##0.00" />
+                                                        </h:outputText>
+                                                    </td>
+                                                </tr>
+                                            </ui:fragment>
 
-                                                <!-- Multiple Payment Methods Row -->
-                                                <ui:fragment rendered="#{financialTransactionController.bundle.hasMultiplePaymentMethodsTransaction}">
-                                                    <tr>
-                                                        <td>Multiple Payment Methods</td>
-                                                        <td class="text-end">
-                                                            <h:outputText value="#{financialTransactionController.bundle.multiplePaymentMethodsValue}">
-                                                                <f:convertNumber pattern="#,##0.00" />
-                                                            </h:outputText>
-                                                        </td>
-                                                        <td class="text-end">
-                                                            <h:outputText value="#{financialTransactionController.bundle.multiplePaymentMethodsHandoverValue}">
-                                                                <f:convertNumber pattern="#,##0.00" />
-                                                            </h:outputText>
-                                                        </td>
-                                                        <td class="text-end">
-                                                            <h:outputText value="#{financialTransactionController.bundle.multiplePaymentMethodsValue - financialTransactionController.bundle.multiplePaymentMethodsHandoverValue}">
-                                                                <f:convertNumber pattern="#,##0.00" />
-                                                            </h:outputText>
-                                                        </td>
-                                                    </tr>
-                                                </ui:fragment>
+                                            <!-- Multiple Payment Methods Row -->
+                                            <ui:fragment rendered="#{financialTransactionController.bundle.hasMultiplePaymentMethodsTransaction}">
+                                                <tr>
+                                                    <td>Multiple Payment Methods</td>
+                                                    <td class="text-end">
+                                                        <h:outputText value="#{financialTransactionController.bundle.multiplePaymentMethodsValue}">
+                                                            <f:convertNumber pattern="#,##0.00" />
+                                                        </h:outputText>
+                                                    </td>
+                                                    <td class="text-end">
+                                                        <h:outputText value="#{financialTransactionController.bundle.multiplePaymentMethodsHandoverValue}">
+                                                            <f:convertNumber pattern="#,##0.00" />
+                                                        </h:outputText>
+                                                    </td>
+                                                    <td class="text-end">
+                                                        <h:outputText value="#{financialTransactionController.bundle.multiplePaymentMethodsValue - financialTransactionController.bundle.multiplePaymentMethodsHandoverValue}">
+                                                            <f:convertNumber pattern="#,##0.00" />
+                                                        </h:outputText>
+                                                    </td>
+                                                </tr>
+                                            </ui:fragment>
 
-                                                <!-- Staff Credit Row -->
-                                                <ui:fragment rendered="#{financialTransactionController.bundle.hasStaffTransaction}">
-                                                    <tr>
-                                                        <td>Staff Credit</td>
-                                                        <td class="text-end">
-                                                            <h:outputText value="#{financialTransactionController.bundle.staffValue}">
-                                                                <f:convertNumber pattern="#,##0.00" />
-                                                            </h:outputText>
-                                                        </td>
-                                                        <td class="text-end">
-                                                            <h:outputText value="#{financialTransactionController.bundle.staffHandoverValue}">
-                                                                <f:convertNumber pattern="#,##0.00" />
-                                                            </h:outputText>
-                                                        </td>
-                                                        <td class="text-end">
-                                                            <h:outputText value="#{financialTransactionController.bundle.staffValue - financialTransactionController.bundle.staffHandoverValue}">
-                                                                <f:convertNumber pattern="#,##0.00" />
-                                                            </h:outputText>
-                                                        </td>
-                                                    </tr>
-                                                </ui:fragment>
+                                            <!-- Staff Credit Row -->
+                                            <ui:fragment rendered="#{financialTransactionController.bundle.hasStaffTransaction}">
+                                                <tr>
+                                                    <td>Staff Credit</td>
+                                                    <td class="text-end">
+                                                        <h:outputText value="#{financialTransactionController.bundle.staffValue}">
+                                                            <f:convertNumber pattern="#,##0.00" />
+                                                        </h:outputText>
+                                                    </td>
+                                                    <td class="text-end">
+                                                        <h:outputText value="#{financialTransactionController.bundle.staffHandoverValue}">
+                                                            <f:convertNumber pattern="#,##0.00" />
+                                                        </h:outputText>
+                                                    </td>
+                                                    <td class="text-end">
+                                                        <h:outputText value="#{financialTransactionController.bundle.staffValue - financialTransactionController.bundle.staffHandoverValue}">
+                                                            <f:convertNumber pattern="#,##0.00" />
+                                                        </h:outputText>
+                                                    </td>
+                                                </tr>
+                                            </ui:fragment>
 
-                                                <!-- Credit Row -->
-                                                <ui:fragment rendered="#{financialTransactionController.bundle.hasCreditTransaction}">
-                                                    <tr>
-                                                        <td>Credit</td>
-                                                        <td class="text-end">
-                                                            <h:outputText value="#{financialTransactionController.bundle.creditValue}">
-                                                                <f:convertNumber pattern="#,##0.00" />
-                                                            </h:outputText>
-                                                        </td>
-                                                        <td class="text-end">
-                                                            <h:outputText value="#{financialTransactionController.bundle.creditHandoverValue}">
-                                                                <f:convertNumber pattern="#,##0.00" />
-                                                            </h:outputText>
-                                                        </td>
-                                                        <td class="text-end">
-                                                            <h:outputText value="#{financialTransactionController.bundle.creditValue - financialTransactionController.bundle.creditHandoverValue}">
-                                                                <f:convertNumber pattern="#,##0.00" />
-                                                            </h:outputText>
-                                                        </td>
-                                                    </tr>
-                                                </ui:fragment>
+                                            <!-- Credit Row -->
+                                            <ui:fragment rendered="#{financialTransactionController.bundle.hasCreditTransaction}">
+                                                <tr>
+                                                    <td>Credit</td>
+                                                    <td class="text-end">
+                                                        <h:outputText value="#{financialTransactionController.bundle.creditValue}">
+                                                            <f:convertNumber pattern="#,##0.00" />
+                                                        </h:outputText>
+                                                    </td>
+                                                    <td class="text-end">
+                                                        <h:outputText value="#{financialTransactionController.bundle.creditHandoverValue}">
+                                                            <f:convertNumber pattern="#,##0.00" />
+                                                        </h:outputText>
+                                                    </td>
+                                                    <td class="text-end">
+                                                        <h:outputText value="#{financialTransactionController.bundle.creditValue - financialTransactionController.bundle.creditHandoverValue}">
+                                                            <f:convertNumber pattern="#,##0.00" />
+                                                        </h:outputText>
+                                                    </td>
+                                                </tr>
+                                            </ui:fragment>
 
-                                                <!-- Staff Welfare Row -->
-                                                <ui:fragment rendered="#{financialTransactionController.bundle.hasStaffWelfareTransaction}">
-                                                    <tr>
-                                                        <td>Staff Welfare</td>
-                                                        <td class="text-end">
-                                                            <h:outputText value="#{financialTransactionController.bundle.staffWelfareValue}">
-                                                                <f:convertNumber pattern="#,##0.00" />
-                                                            </h:outputText>
-                                                        </td>
-                                                        <td class="text-end">
-                                                            <h:outputText value="#{financialTransactionController.bundle.staffWelfareHandoverValue}">
-                                                                <f:convertNumber pattern="#,##0.00" />
-                                                            </h:outputText>
-                                                        </td>
-                                                        <td class="text-end">
-                                                            <h:outputText value="#{financialTransactionController.bundle.staffWelfareValue - financialTransactionController.bundle.staffWelfareHandoverValue}">
-                                                                <f:convertNumber pattern="#,##0.00" />
-                                                            </h:outputText>
-                                                        </td>
-                                                    </tr>
-                                                </ui:fragment>
+                                            <!-- Staff Welfare Row -->
+                                            <ui:fragment rendered="#{financialTransactionController.bundle.hasStaffWelfareTransaction}">
+                                                <tr>
+                                                    <td>Staff Welfare</td>
+                                                    <td class="text-end">
+                                                        <h:outputText value="#{financialTransactionController.bundle.staffWelfareValue}">
+                                                            <f:convertNumber pattern="#,##0.00" />
+                                                        </h:outputText>
+                                                    </td>
+                                                    <td class="text-end">
+                                                        <h:outputText value="#{financialTransactionController.bundle.staffWelfareHandoverValue}">
+                                                            <f:convertNumber pattern="#,##0.00" />
+                                                        </h:outputText>
+                                                    </td>
+                                                    <td class="text-end">
+                                                        <h:outputText value="#{financialTransactionController.bundle.staffWelfareValue - financialTransactionController.bundle.staffWelfareHandoverValue}">
+                                                            <f:convertNumber pattern="#,##0.00" />
+                                                        </h:outputText>
+                                                    </td>
+                                                </tr>
+                                            </ui:fragment>
 
-                                                <!-- Voucher Row -->
-                                                <ui:fragment rendered="#{financialTransactionController.bundle.hasVoucherTransaction}">
-                                                    <tr>
-                                                        <td>Voucher</td>
-                                                        <td class="text-end">
-                                                            <h:outputText value="#{financialTransactionController.bundle.voucherValue}">
-                                                                <f:convertNumber pattern="#,##0.00" />
-                                                            </h:outputText>
-                                                        </td>
-                                                        <td class="text-end">
-                                                            <h:outputText value="#{financialTransactionController.bundle.voucherHandoverValue}">
-                                                                <f:convertNumber pattern="#,##0.00" />
-                                                            </h:outputText>
-                                                        </td>
-                                                        <td class="text-end">
-                                                            <h:outputText value="#{financialTransactionController.bundle.voucherValue - financialTransactionController.bundle.voucherHandoverValue}">
-                                                                <f:convertNumber pattern="#,##0.00" />
-                                                            </h:outputText>
-                                                        </td>
-                                                    </tr>
-                                                </ui:fragment>
+                                            <!-- Voucher Row -->
+                                            <ui:fragment rendered="#{financialTransactionController.bundle.hasVoucherTransaction}">
+                                                <tr>
+                                                    <td>Voucher</td>
+                                                    <td class="text-end">
+                                                        <h:outputText value="#{financialTransactionController.bundle.voucherValue}">
+                                                            <f:convertNumber pattern="#,##0.00" />
+                                                        </h:outputText>
+                                                    </td>
+                                                    <td class="text-end">
+                                                        <h:outputText value="#{financialTransactionController.bundle.voucherHandoverValue}">
+                                                            <f:convertNumber pattern="#,##0.00" />
+                                                        </h:outputText>
+                                                    </td>
+                                                    <td class="text-end">
+                                                        <h:outputText value="#{financialTransactionController.bundle.voucherValue - financialTransactionController.bundle.voucherHandoverValue}">
+                                                            <f:convertNumber pattern="#,##0.00" />
+                                                        </h:outputText>
+                                                    </td>
+                                                </tr>
+                                            </ui:fragment>
 
-                                                <!-- IOU Row -->
-                                                <ui:fragment rendered="#{financialTransactionController.bundle.hasIouTransaction}">
-                                                    <tr>
-                                                        <td>IOU</td>
-                                                        <td class="text-end">
-                                                            <h:outputText value="#{financialTransactionController.bundle.iouValue}">
-                                                                <f:convertNumber pattern="#,##0.00" />
-                                                            </h:outputText>
-                                                        </td>
-                                                        <td class="text-end">
-                                                            <h:outputText value="#{financialTransactionController.bundle.iouHandoverValue}">
-                                                                <f:convertNumber pattern="#,##0.00" />
-                                                            </h:outputText>
-                                                        </td>
-                                                        <td class="text-end">
-                                                            <h:outputText value="#{financialTransactionController.bundle.iouValue - financialTransactionController.bundle.iouHandoverValue}">
-                                                                <f:convertNumber pattern="#,##0.00" />
-                                                            </h:outputText>
-                                                        </td>
-                                                    </tr>
-                                                </ui:fragment>
+                                            <!-- IOU Row -->
+                                            <ui:fragment rendered="#{financialTransactionController.bundle.hasIouTransaction}">
+                                                <tr>
+                                                    <td>IOU</td>
+                                                    <td class="text-end">
+                                                        <h:outputText value="#{financialTransactionController.bundle.iouValue}">
+                                                            <f:convertNumber pattern="#,##0.00" />
+                                                        </h:outputText>
+                                                    </td>
+                                                    <td class="text-end">
+                                                        <h:outputText value="#{financialTransactionController.bundle.iouHandoverValue}">
+                                                            <f:convertNumber pattern="#,##0.00" />
+                                                        </h:outputText>
+                                                    </td>
+                                                    <td class="text-end">
+                                                        <h:outputText value="#{financialTransactionController.bundle.iouValue - financialTransactionController.bundle.iouHandoverValue}">
+                                                            <f:convertNumber pattern="#,##0.00" />
+                                                        </h:outputText>
+                                                    </td>
+                                                </tr>
+                                            </ui:fragment>
 
-                                                <!-- Agent Payment Row -->
-                                                <ui:fragment rendered="#{financialTransactionController.bundle.hasAgentTransaction}">
-                                                    <tr>
-                                                        <td>Agent Payment</td>
-                                                        <td class="text-end">
-                                                            <h:outputText value="#{financialTransactionController.bundle.agentValue}">
-                                                                <f:convertNumber pattern="#,##0.00" />
-                                                            </h:outputText>
-                                                        </td>
-                                                        <td class="text-end">
-                                                            <h:outputText value="#{financialTransactionController.bundle.agentHandoverValue}">
-                                                                <f:convertNumber pattern="#,##0.00" />
-                                                            </h:outputText>
-                                                        </td>
-                                                        <td class="text-end">
-                                                            <h:outputText value="#{financialTransactionController.bundle.agentValue - financialTransactionController.bundle.agentHandoverValue}">
-                                                                <f:convertNumber pattern="#,##0.00" />
-                                                            </h:outputText>
-                                                        </td>
-                                                    </tr>
-                                                </ui:fragment>
+                                            <!-- Agent Payment Row -->
+                                            <ui:fragment rendered="#{financialTransactionController.bundle.hasAgentTransaction}">
+                                                <tr>
+                                                    <td>Agent Payment</td>
+                                                    <td class="text-end">
+                                                        <h:outputText value="#{financialTransactionController.bundle.agentValue}">
+                                                            <f:convertNumber pattern="#,##0.00" />
+                                                        </h:outputText>
+                                                    </td>
+                                                    <td class="text-end">
+                                                        <h:outputText value="#{financialTransactionController.bundle.agentHandoverValue}">
+                                                            <f:convertNumber pattern="#,##0.00" />
+                                                        </h:outputText>
+                                                    </td>
+                                                    <td class="text-end">
+                                                        <h:outputText value="#{financialTransactionController.bundle.agentValue - financialTransactionController.bundle.agentHandoverValue}">
+                                                            <f:convertNumber pattern="#,##0.00" />
+                                                        </h:outputText>
+                                                    </td>
+                                                </tr>
+                                            </ui:fragment>
 
-                                                <!-- Patient Points Row -->
-                                                <ui:fragment rendered="#{financialTransactionController.bundle.hasPatientPointsTransaction}">
-                                                    <tr>
-                                                        <td>Patient Points</td>
-                                                        <td class="text-end">
-                                                            <h:outputText value="#{financialTransactionController.bundle.patientPointsValue}">
-                                                                <f:convertNumber pattern="#,##0.00" />
-                                                            </h:outputText>
-                                                        </td>
-                                                        <td class="text-end">
-                                                            <h:outputText value="#{financialTransactionController.bundle.patientPointsHandoverValue}">
-                                                                <f:convertNumber pattern="#,##0.00" />
-                                                            </h:outputText>
-                                                        </td>
-                                                        <td class="text-end">
-                                                            <h:outputText value="#{financialTransactionController.bundle.patientPointsValue - financialTransactionController.bundle.patientPointsHandoverValue}">
-                                                                <f:convertNumber pattern="#,##0.00" />
-                                                            </h:outputText>
-                                                        </td>
-                                                    </tr>
-                                                </ui:fragment>
+                                            <!-- Patient Points Row -->
+                                            <ui:fragment rendered="#{financialTransactionController.bundle.hasPatientPointsTransaction}">
+                                                <tr>
+                                                    <td>Patient Points</td>
+                                                    <td class="text-end">
+                                                        <h:outputText value="#{financialTransactionController.bundle.patientPointsValue}">
+                                                            <f:convertNumber pattern="#,##0.00" />
+                                                        </h:outputText>
+                                                    </td>
+                                                    <td class="text-end">
+                                                        <h:outputText value="#{financialTransactionController.bundle.patientPointsHandoverValue}">
+                                                            <f:convertNumber pattern="#,##0.00" />
+                                                        </h:outputText>
+                                                    </td>
+                                                    <td class="text-end">
+                                                        <h:outputText value="#{financialTransactionController.bundle.patientPointsValue - financialTransactionController.bundle.patientPointsHandoverValue}">
+                                                            <f:convertNumber pattern="#,##0.00" />
+                                                        </h:outputText>
+                                                    </td>
+                                                </tr>
+                                            </ui:fragment>
 
-                                                <!-- Online Settlement Row -->
-                                                <ui:fragment rendered="#{financialTransactionController.bundle.hasOnlineSettlementTransaction}">
-                                                    <tr>
-                                                        <td>Online Settlement</td>
-                                                        <td class="text-end">
-                                                            <h:outputText value="#{financialTransactionController.bundle.onlineSettlementValue}">
-                                                                <f:convertNumber pattern="#,##0.00" />
-                                                            </h:outputText>
-                                                        </td>
-                                                        <td class="text-end">
-                                                            <h:outputText value="#{financialTransactionController.bundle.onlineSettlementHandoverValue}">
-                                                                <f:convertNumber pattern="#,##0.00" />
-                                                            </h:outputText>
-                                                        </td>
-                                                        <td class="text-end">
-                                                            <h:outputText value="#{financialTransactionController.bundle.onlineSettlementValue - financialTransactionController.bundle.onlineSettlementHandoverValue}">
-                                                                <f:convertNumber pattern="#,##0.00" />
-                                                            </h:outputText>
-                                                        </td>
-                                                    </tr>
-                                                </ui:fragment>
+                                            <!-- Online Settlement Row -->
+                                            <ui:fragment rendered="#{financialTransactionController.bundle.hasOnlineSettlementTransaction}">
+                                                <tr>
+                                                    <td>Online Settlement</td>
+                                                    <td class="text-end">
+                                                        <h:outputText value="#{financialTransactionController.bundle.onlineSettlementValue}">
+                                                            <f:convertNumber pattern="#,##0.00" />
+                                                        </h:outputText>
+                                                    </td>
+                                                    <td class="text-end">
+                                                        <h:outputText value="#{financialTransactionController.bundle.onlineSettlementHandoverValue}">
+                                                            <f:convertNumber pattern="#,##0.00" />
+                                                        </h:outputText>
+                                                    </td>
+                                                    <td class="text-end">
+                                                        <h:outputText value="#{financialTransactionController.bundle.onlineSettlementValue - financialTransactionController.bundle.onlineSettlementHandoverValue}">
+                                                            <f:convertNumber pattern="#,##0.00" />
+                                                        </h:outputText>
+                                                    </td>
+                                                </tr>
+                                            </ui:fragment>
 
-                                            </tbody>
-                                        </table>
-
-                                    </p:panel>
-                                </div>
-                                <div class="col-5" >
-                                    <h:panelGroup id="gpDenominations" >
-                                        <p:dataTable   value="#{financialTransactionController.bundle.denominationTransactions}" var="deno"  >
-                                            <p:column title="Denomination">
-                                                <p:outputLabel value="#{deno.denomination.displayName}" ></p:outputLabel>
-                                            </p:column>
-                                            <p:column  title="Denomination">
-                                                <p:outputLabel 
-                                                    class="text-end w-100" 
-                                                    id="txtDenoQtyHandover"
-                                                    value="#{deno.denominationQty}" 
-                                                    style="width: 100%;">
-                                                    <f:convertNumber integerOnly="true" />
-                                                </p:outputLabel>  
-                                            </p:column>
-                                            <p:column >
-                                                <p:outputLabel
-                                                    class="text-end w-100"
-                                                    id="txtDenoVal" value="#{deno.denominationValue}" >
-                                                    <f:convertNumber pattern="#,##0.00" />
-                                                </p:outputLabel>
-                                            </p:column>
-                                        </p:dataTable>
-                                    </h:panelGroup>
-                                </div>
+                                        </tbody>
+                                    </table>
+                                </p:panel>
                             </div>
-                            <div class="row mx-2" >
-                                <p:dataTable 
-                                    emptyMessage="No Financial Transactions to Handover"
-                                    paginatorAlwaysVisible="false"
-                                    value="#{financialTransactionController.bundle.bundles}" 
-                                    var="summary"
-                                    paginator="true" rows="10" id="tblCashier"
-                                    paginatorTemplate="{CurrentPageReport}  {FirstPageLink} {PreviousPageLink} {PageLinks} {NextPageLink} {LastPageLink}"
-                                    currentPageReportTemplate="(Page {currentPage} of {totalPages})"
-                                    paginatorPosition="top">
-
-                                    <p:column headerText="Institution" >
-                                        <h:outputText value="#{summary.department.institution.name}" />
-                                    </p:column>
-
-                                    <p:column headerText="Site"  rendered="#{configOptionApplicationController.getBooleanValueByKey('Sites are Managed',true)}" >
-                                        <h:outputText value="#{summary.department.site.name}" />
-                                    </p:column>
-
-                                    <p:column headerText="Department" >
-                                        <h:outputText value="#{summary.department.name}" />
-                                    </p:column>
-
-                                    <p:column headerText="Date" >
-                                        <h:outputText value="#{summary.date}">
-                                            <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateFormat}" />
-                                        </h:outputText>
-                                    </p:column>
-
-                                    <p:column headerText="Cash" 
-                                              class="text-end"
-                                              rendered="#{financialTransactionController.bundle.hasCashTransaction}" >
-                                        <h:outputText value="#{summary.cashValue}"  style="text-align: right;">
-                                            <f:convertNumber pattern="#,##0.00" ></f:convertNumber>
-                                        </h:outputText>
-                                        <f:facet name="footer" >
-                                            <p:outputLabel value="#{financialTransactionController.bundle.cashValue}" >
-                                                <f:convertNumber pattern="#,##0.00" ></f:convertNumber>
+                            <div class="col-5" >
+                                <h:panelGroup id="gpDenominations" >
+                                    <p:dataTable   
+                                        value="#{financialTransactionController.bundle.filteredDenominationTransactions}"
+                                        var="deno"  >
+                                        <p:column 
+                                            headerText="Denomination"
+                                            title="Denomination">
+                                            <p:outputLabel value="#{deno.denomination.displayName}" ></p:outputLabel>
+                                        </p:column>
+                                        <p:column  
+                                            title="Quantity"
+                                            class="text-end"
+                                            headerText="Quantity">
+                                            <p:outputLabel 
+                                                class="text-end w-100" 
+                                                id="txtDenoQtyHandover"
+                                                value="#{deno.denominationQty}" 
+                                                style="width: 100%;">
+                                                <f:convertNumber integerOnly="true" />
+                                            </p:outputLabel>  
+                                        </p:column>
+                                        <p:column 
+                                            title="Value"
+                                            class="text-end"
+                                            headerText="Value">
+                                            <p:outputLabel
+                                                class="text-end w-100"
+                                                id="txtDenoVal" value="#{deno.denominationValue}" >
+                                                <f:convertNumber pattern="#,##0.00" />
                                             </p:outputLabel>
-                                        </f:facet>
+                                        </p:column>
+                                    </p:dataTable>
+                                </h:panelGroup>
+                            </div>
+                        </div>
+                        <div class="row" >
+                            <p:dataTable 
+                                emptyMessage="No Financial Transactions to Handover"
+                                paginatorAlwaysVisible="false"
+                                value="#{financialTransactionController.bundle.bundles}" 
+                                var="summary"
+                                paginator="true" rows="10" id="tblCashier"
+                                paginatorTemplate="{CurrentPageReport}  {FirstPageLink} {PreviousPageLink} {PageLinks} {NextPageLink} {LastPageLink}"
+                                currentPageReportTemplate="(Page {currentPage} of {totalPages})"
+                                paginatorPosition="top">
 
-                                    </p:column>
+                                <p:column headerText="Institution" >
+                                    <h:outputText value="#{summary.department.institution.name}" />
+                                </p:column>
 
-                                    <p:column 
-                                        class="text-end"
-                                        headerText="Card" 
-                                        rendered="#{financialTransactionController.bundle.hasCardTransaction}" >
-                                        <h:outputText value="#{summary.cardValue}" >
+                                <p:column headerText="Site"  rendered="#{configOptionApplicationController.getBooleanValueByKey('Sites are Managed',true)}" >
+                                    <h:outputText value="#{summary.department.site.name}" />
+                                </p:column>
+
+                                <p:column headerText="Department" >
+                                    <h:outputText value="#{summary.department.name}" />
+                                </p:column>
+
+                                <p:column headerText="Date" >
+                                    <h:outputText value="#{summary.date}">
+                                        <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateFormat}" />
+                                    </h:outputText>
+                                </p:column>
+
+                                <p:column headerText="Cash" 
+                                          class="text-end"
+                                          rendered="#{financialTransactionController.bundle.hasCashTransaction}" >
+                                    <h:outputText value="#{summary.cashValue}"  style="text-align: right;">
+                                        <f:convertNumber pattern="#,##0.00" ></f:convertNumber>
+                                    </h:outputText>
+                                    <f:facet name="footer" >
+                                        <p:outputLabel value="#{financialTransactionController.bundle.cashValue}" >
                                             <f:convertNumber pattern="#,##0.00" ></f:convertNumber>
-                                        </h:outputText>
-                                        <f:facet name="footer">
-                                            <h:outputText value="#{financialTransactionController.bundle.cardValue}">
-                                                <f:convertNumber pattern="#,##0.00" />
-                                            </h:outputText>
-                                        </f:facet>
-                                    </p:column>
+                                        </p:outputLabel>
+                                    </f:facet>
 
-                                    <p:column headerText="Multiple Payment Methods" 
-                                              rendered="#{financialTransactionController.bundle.hasMultiplePaymentMethodsTransaction}" >
-                                        <h:outputText value="#{summary.multiplePaymentMethodsValue}" >
-                                            <f:convertNumber pattern="#,##0.00" ></f:convertNumber>
-                                        </h:outputText>
-                                        <f:facet name="footer">
-                                            <h:outputText value="#{financialTransactionController.bundle.multiplePaymentMethodsValue}">
-                                                <f:convertNumber pattern="#,##0.00" />
-                                            </h:outputText>
-                                        </f:facet>
-                                    </p:column>
+                                </p:column>
 
-                                    <p:column headerText="Credit" 
-                                              class="text-end"
-                                              rendered="#{financialTransactionController.bundle.hasCreditTransaction}" >
-                                        <h:outputText value="#{summary.creditValue}" >
-                                            <f:convertNumber pattern="#,##0.00" ></f:convertNumber>
-                                        </h:outputText>
-                                        <f:facet name="footer">
-                                            <h:outputText value="#{financialTransactionController.bundle.creditValue}">
-                                                <f:convertNumber pattern="#,##0.00" />
-                                            </h:outputText>
-                                        </f:facet>
-                                    </p:column>
-
-                                    <!-- Continuing from Credit -->
-                                    <p:column 
-                                        headerText="Staff Welfare" 
-                                        class="text-end"
-                                        rendered="#{financialTransactionController.bundle.hasStaffWelfareTransaction}" >
-                                        <h:outputText value="#{summary.staffWelfareValue}" >
-                                            <f:convertNumber pattern="#,##0.00" ></f:convertNumber>
-                                        </h:outputText>
-                                        <f:facet name="footer">
-                                            <h:outputText value="#{financialTransactionController.bundle.staffWelfareValue}">
-                                                <f:convertNumber pattern="#,##0.00" />
-                                            </h:outputText>
-                                        </f:facet>
-                                    </p:column>
-
-                                    <p:column 
-                                        headerText="Staff" 
-                                        class="text-end"
-                                        rendered="#{financialTransactionController.bundle.hasStaffTransaction}" >
-                                        <h:outputText value="#{summary.staffValue}" >
-                                            <f:convertNumber pattern="#,##0.00" ></f:convertNumber>
-                                        </h:outputText>
-                                        <f:facet name="footer">
-                                            <h:outputText value="#{financialTransactionController.bundle.staffValue}">
-                                                <f:convertNumber pattern="#,##0.00" />
-                                            </h:outputText>
-                                        </f:facet>
-                                    </p:column>
-
-                                    <p:column 
-                                        headerText="Voucher" 
-                                        class="text-end"
-                                        rendered="#{financialTransactionController.bundle.hasVoucherTransaction}" >
-                                        <h:outputText value="#{summary.voucherValue}" >
-                                            <f:convertNumber pattern="#,##0.00" ></f:convertNumber>
-                                        </h:outputText>
-                                        <f:facet name="footer">
-                                            <h:outputText value="#{financialTransactionController.bundle.voucherValue}">
-                                                <f:convertNumber pattern="#,##0.00" />
-                                            </h:outputText>
-                                        </f:facet>
-                                    </p:column>
-
-                                    <p:column 
-                                        headerText="IOU" 
-                                        class="text-end"
-                                        rendered="#{financialTransactionController.bundle.hasIouTransaction}" >
-                                        <h:outputText value="#{summary.iouValue}" >
-                                            <f:convertNumber pattern="#,##0.00" ></f:convertNumber>
-                                        </h:outputText>
-                                        <f:facet name="footer">
-                                            <h:outputText value="#{financialTransactionController.bundle.iouValue}">
-                                                <f:convertNumber pattern="#,##0.00" />
-                                            </h:outputText>
-                                        </f:facet>
-                                    </p:column>
-
-                                    <p:column 
-                                        headerText="Agent"
-                                        class="text-end"
-                                        rendered="#{financialTransactionController.bundle.hasAgentTransaction}" >
-                                        <h:outputText value="#{summary.agentValue}" >
-                                            <f:convertNumber pattern="#,##0.00" ></f:convertNumber>
-                                        </h:outputText>
-                                        <f:facet name="footer">
-                                            <h:outputText value="#{financialTransactionController.bundle.agentValue}">
-                                                <f:convertNumber pattern="#,##0.00" />
-                                            </h:outputText>
-                                        </f:facet>
-                                    </p:column>
-
-                                    <p:column 
-                                        headerText="Cheque" 
-                                        class="text-end"
-                                        rendered="#{financialTransactionController.bundle.hasChequeTransaction}" >
-                                        <h:outputText value="#{summary.chequeValue}" >
-                                            <f:convertNumber pattern="#,##0.00" ></f:convertNumber>
-                                        </h:outputText>
-                                        <f:facet name="footer">
-                                            <h:outputText value="#{financialTransactionController.bundle.chequeValue}">
-                                                <f:convertNumber pattern="#,##0.00" />
-                                            </h:outputText>
-                                        </f:facet>
-                                    </p:column>
-
-                                    <p:column 
-                                        headerText="Slip"
-                                        class="text-end"
-                                        rendered="#{financialTransactionController.bundle.hasSlipTransaction}" >
-                                        <h:outputText value="#{summary.slipValue}" >
-                                            <f:convertNumber pattern="#,##0.00" ></f:convertNumber>
-                                        </h:outputText>
-                                        <f:facet name="footer">
-                                            <h:outputText value="#{financialTransactionController.bundle.slipValue}">
-                                                <f:convertNumber pattern="#,##0.00" />
-                                            </h:outputText>
-                                        </f:facet>
-                                    </p:column>
-
-                                    <p:column 
-                                        headerText="eWallet" 
-                                        class="text-end"
-                                        rendered="#{financialTransactionController.bundle.hasEWalletTransaction}" >
-                                        <h:outputText value="#{summary.ewalletValue}" >
-                                            <f:convertNumber pattern="#,##0.00" ></f:convertNumber>
-                                        </h:outputText>
-                                        <f:facet name="footer">
-                                            <h:outputText value="#{financialTransactionController.bundle.ewalletValue}">
-                                                <f:convertNumber pattern="#,##0.00" />
-                                            </h:outputText>
-                                        </f:facet>
-                                    </p:column>
-
-                                    <p:column 
-                                        headerText="Patient Deposit" 
-                                        class="text-end"
-                                        rendered="#{financialTransactionController.bundle.hasPatientDepositTransaction}" >
-                                        <h:outputText value="#{summary.patientDepositValue}" >
-                                            <f:convertNumber pattern="#,##0.00" ></f:convertNumber>
-                                        </h:outputText>
-                                        <f:facet name="footer">
-                                            <h:outputText value="#{financialTransactionController.bundle.patientDepositValue}">
-                                                <f:convertNumber pattern="#,##0.00" />
-                                            </h:outputText>
-                                        </f:facet>
-                                    </p:column>
-
-                                    <p:column 
-                                        headerText="Patient Points" 
-                                        class="text-end"
-                                        rendered="#{financialTransactionController.bundle.hasPatientPointsTransaction}" >
-                                        <h:outputText value="#{summary.patientPointsValue}" >
-                                            <f:convertNumber pattern="#,##0.00" ></f:convertNumber>
-                                        </h:outputText>
-                                        <f:facet name="footer">
-                                            <h:outputText value="#{financialTransactionController.bundle.patientPointsValue}">
-                                                <f:convertNumber pattern="#,##0.00" />
-                                            </h:outputText>
-                                        </f:facet>
-                                    </p:column>
-
-                                    <p:column 
-                                        headerText="Online Settlement" 
-                                        class="text-end"
-                                        rendered="#{financialTransactionController.bundle.hasOnlineSettlementTransaction}" >
-                                        <h:outputText value="#{summary.onlineSettlementValue}" >
-                                            <f:convertNumber pattern="#,##0.00" ></f:convertNumber>
-                                        </h:outputText>
-                                        <f:facet name="footer">
-                                            <h:outputText value="#{financialTransactionController.bundle.onlineSettlementValue}">
-                                                <f:convertNumber pattern="#,##0.00" />
-                                            </h:outputText>
-                                        </f:facet>
-                                    </p:column>
-
-                                    <p:column headerText="Total"
-                                              class="text-end">
-                                        <h:outputText value="#{summary.total}">
+                                <p:column 
+                                    class="text-end"
+                                    headerText="Card" 
+                                    rendered="#{financialTransactionController.bundle.hasCardTransaction}" >
+                                    <h:outputText value="#{summary.cardValue}" >
+                                        <f:convertNumber pattern="#,##0.00" ></f:convertNumber>
+                                    </h:outputText>
+                                    <f:facet name="footer">
+                                        <h:outputText value="#{financialTransactionController.bundle.cardValue}">
                                             <f:convertNumber pattern="#,##0.00" />
                                         </h:outputText>
-                                        <f:facet name="footer">
-                                            <h:outputText value="#{financialTransactionController.bundle.cashValue + financialTransactionController.bundle.cardValue + financialTransactionController.bundle.multiplePaymentMethodsValue + 
-                                                                   financialTransactionController.bundle.creditValue + financialTransactionController.bundle.staffWelfareValue + financialTransactionController.bundle.staffValue + financialTransactionController.bundle.voucherValue + 
-                                                                   financialTransactionController.bundle.iouValue + financialTransactionController.bundle.agentValue + financialTransactionController.bundle.chequeValue + financialTransactionController.bundle.slipValue + 
-                                                                   financialTransactionController.bundle.ewalletValue + financialTransactionController.bundle.patientDepositValue + financialTransactionController.bundle.patientPointsValue + financialTransactionController.bundle.onlineSettlementValue}" 
-                                                          style="text-align: right;">
-                                                <f:convertNumber pattern="#,##0.00" />
-                                            </h:outputText>
-                                        </f:facet>
-                                    </p:column>
+                                    </f:facet>
+                                </p:column>
+
+                                <p:column headerText="Multiple Payment Methods" 
+                                          rendered="#{financialTransactionController.bundle.hasMultiplePaymentMethodsTransaction}" >
+                                    <h:outputText value="#{summary.multiplePaymentMethodsValue}" >
+                                        <f:convertNumber pattern="#,##0.00" ></f:convertNumber>
+                                    </h:outputText>
+                                    <f:facet name="footer">
+                                        <h:outputText value="#{financialTransactionController.bundle.multiplePaymentMethodsValue}">
+                                            <f:convertNumber pattern="#,##0.00" />
+                                        </h:outputText>
+                                    </f:facet>
+                                </p:column>
+
+                                <p:column headerText="Credit" 
+                                          class="text-end"
+                                          rendered="#{financialTransactionController.bundle.hasCreditTransaction}" >
+                                    <h:outputText value="#{summary.creditValue}" >
+                                        <f:convertNumber pattern="#,##0.00" ></f:convertNumber>
+                                    </h:outputText>
+                                    <f:facet name="footer">
+                                        <h:outputText value="#{financialTransactionController.bundle.creditValue}">
+                                            <f:convertNumber pattern="#,##0.00" />
+                                        </h:outputText>
+                                    </f:facet>
+                                </p:column>
+
+                                <!-- Continuing from Credit -->
+                                <p:column 
+                                    headerText="Staff Welfare" 
+                                    class="text-end"
+                                    rendered="#{financialTransactionController.bundle.hasStaffWelfareTransaction}" >
+                                    <h:outputText value="#{summary.staffWelfareValue}" >
+                                        <f:convertNumber pattern="#,##0.00" ></f:convertNumber>
+                                    </h:outputText>
+                                    <f:facet name="footer">
+                                        <h:outputText value="#{financialTransactionController.bundle.staffWelfareValue}">
+                                            <f:convertNumber pattern="#,##0.00" />
+                                        </h:outputText>
+                                    </f:facet>
+                                </p:column>
+
+                                <p:column 
+                                    headerText="Staff" 
+                                    class="text-end"
+                                    rendered="#{financialTransactionController.bundle.hasStaffTransaction}" >
+                                    <h:outputText value="#{summary.staffValue}" >
+                                        <f:convertNumber pattern="#,##0.00" ></f:convertNumber>
+                                    </h:outputText>
+                                    <f:facet name="footer">
+                                        <h:outputText value="#{financialTransactionController.bundle.staffValue}">
+                                            <f:convertNumber pattern="#,##0.00" />
+                                        </h:outputText>
+                                    </f:facet>
+                                </p:column>
+
+                                <p:column 
+                                    headerText="Voucher" 
+                                    class="text-end"
+                                    rendered="#{financialTransactionController.bundle.hasVoucherTransaction}" >
+                                    <h:outputText value="#{summary.voucherValue}" >
+                                        <f:convertNumber pattern="#,##0.00" ></f:convertNumber>
+                                    </h:outputText>
+                                    <f:facet name="footer">
+                                        <h:outputText value="#{financialTransactionController.bundle.voucherValue}">
+                                            <f:convertNumber pattern="#,##0.00" />
+                                        </h:outputText>
+                                    </f:facet>
+                                </p:column>
+
+                                <p:column 
+                                    headerText="IOU" 
+                                    class="text-end"
+                                    rendered="#{financialTransactionController.bundle.hasIouTransaction}" >
+                                    <h:outputText value="#{summary.iouValue}" >
+                                        <f:convertNumber pattern="#,##0.00" ></f:convertNumber>
+                                    </h:outputText>
+                                    <f:facet name="footer">
+                                        <h:outputText value="#{financialTransactionController.bundle.iouValue}">
+                                            <f:convertNumber pattern="#,##0.00" />
+                                        </h:outputText>
+                                    </f:facet>
+                                </p:column>
+
+                                <p:column 
+                                    headerText="Agent"
+                                    class="text-end"
+                                    rendered="#{financialTransactionController.bundle.hasAgentTransaction}" >
+                                    <h:outputText value="#{summary.agentValue}" >
+                                        <f:convertNumber pattern="#,##0.00" ></f:convertNumber>
+                                    </h:outputText>
+                                    <f:facet name="footer">
+                                        <h:outputText value="#{financialTransactionController.bundle.agentValue}">
+                                            <f:convertNumber pattern="#,##0.00" />
+                                        </h:outputText>
+                                    </f:facet>
+                                </p:column>
+
+                                <p:column 
+                                    headerText="Cheque" 
+                                    class="text-end"
+                                    rendered="#{financialTransactionController.bundle.hasChequeTransaction}" >
+                                    <h:outputText value="#{summary.chequeValue}" >
+                                        <f:convertNumber pattern="#,##0.00" ></f:convertNumber>
+                                    </h:outputText>
+                                    <f:facet name="footer">
+                                        <h:outputText value="#{financialTransactionController.bundle.chequeValue}">
+                                            <f:convertNumber pattern="#,##0.00" />
+                                        </h:outputText>
+                                    </f:facet>
+                                </p:column>
+
+                                <p:column 
+                                    headerText="Slip"
+                                    class="text-end"
+                                    rendered="#{financialTransactionController.bundle.hasSlipTransaction}" >
+                                    <h:outputText value="#{summary.slipValue}" >
+                                        <f:convertNumber pattern="#,##0.00" ></f:convertNumber>
+                                    </h:outputText>
+                                    <f:facet name="footer">
+                                        <h:outputText value="#{financialTransactionController.bundle.slipValue}">
+                                            <f:convertNumber pattern="#,##0.00" />
+                                        </h:outputText>
+                                    </f:facet>
+                                </p:column>
+
+                                <p:column 
+                                    headerText="eWallet" 
+                                    class="text-end"
+                                    rendered="#{financialTransactionController.bundle.hasEWalletTransaction}" >
+                                    <h:outputText value="#{summary.ewalletValue}" >
+                                        <f:convertNumber pattern="#,##0.00" ></f:convertNumber>
+                                    </h:outputText>
+                                    <f:facet name="footer">
+                                        <h:outputText value="#{financialTransactionController.bundle.ewalletValue}">
+                                            <f:convertNumber pattern="#,##0.00" />
+                                        </h:outputText>
+                                    </f:facet>
+                                </p:column>
+
+                                <p:column 
+                                    headerText="Patient Deposit" 
+                                    class="text-end"
+                                    rendered="#{financialTransactionController.bundle.hasPatientDepositTransaction}" >
+                                    <h:outputText value="#{summary.patientDepositValue}" >
+                                        <f:convertNumber pattern="#,##0.00" ></f:convertNumber>
+                                    </h:outputText>
+                                    <f:facet name="footer">
+                                        <h:outputText value="#{financialTransactionController.bundle.patientDepositValue}">
+                                            <f:convertNumber pattern="#,##0.00" />
+                                        </h:outputText>
+                                    </f:facet>
+                                </p:column>
+
+                                <p:column 
+                                    headerText="Patient Points" 
+                                    class="text-end"
+                                    rendered="#{financialTransactionController.bundle.hasPatientPointsTransaction}" >
+                                    <h:outputText value="#{summary.patientPointsValue}" >
+                                        <f:convertNumber pattern="#,##0.00" ></f:convertNumber>
+                                    </h:outputText>
+                                    <f:facet name="footer">
+                                        <h:outputText value="#{financialTransactionController.bundle.patientPointsValue}">
+                                            <f:convertNumber pattern="#,##0.00" />
+                                        </h:outputText>
+                                    </f:facet>
+                                </p:column>
+
+                                <p:column 
+                                    headerText="Online Settlement" 
+                                    class="text-end"
+                                    rendered="#{financialTransactionController.bundle.hasOnlineSettlementTransaction}" >
+                                    <h:outputText value="#{summary.onlineSettlementValue}" >
+                                        <f:convertNumber pattern="#,##0.00" ></f:convertNumber>
+                                    </h:outputText>
+                                    <f:facet name="footer">
+                                        <h:outputText value="#{financialTransactionController.bundle.onlineSettlementValue}">
+                                            <f:convertNumber pattern="#,##0.00" />
+                                        </h:outputText>
+                                    </f:facet>
+                                </p:column>
+
+                                <p:column headerText="Total"
+                                          class="text-end">
+                                    <h:outputText value="#{summary.total}">
+                                        <f:convertNumber pattern="#,##0.00" />
+                                    </h:outputText>
+                                    <f:facet name="footer">
+                                        <h:outputText value="#{financialTransactionController.bundle.cashValue + financialTransactionController.bundle.cardValue + financialTransactionController.bundle.multiplePaymentMethodsValue + 
+                                                               financialTransactionController.bundle.creditValue + financialTransactionController.bundle.staffWelfareValue + financialTransactionController.bundle.staffValue + financialTransactionController.bundle.voucherValue + 
+                                                               financialTransactionController.bundle.iouValue + financialTransactionController.bundle.agentValue + financialTransactionController.bundle.chequeValue + financialTransactionController.bundle.slipValue + 
+                                                               financialTransactionController.bundle.ewalletValue + financialTransactionController.bundle.patientDepositValue + financialTransactionController.bundle.patientPointsValue + financialTransactionController.bundle.onlineSettlementValue}" 
+                                                      style="text-align: right;">
+                                            <f:convertNumber pattern="#,##0.00" />
+                                        </h:outputText>
+                                    </f:facet>
+                                </p:column>
 
 
-                                </p:dataTable>
-                            </div>
-                        </h:panelGroup>
+                            </p:dataTable>
+                        </div>
+
 
                     </p:panel>
 

--- a/src/main/webapp/cashier/handover_preview.xhtml
+++ b/src/main/webapp/cashier/handover_preview.xhtml
@@ -551,13 +551,6 @@
                                         <h:outputText value="#{summary.cardValue}" >
                                             <f:convertNumber pattern="#,##0.00" ></f:convertNumber>
                                         </h:outputText>
-                                        <p:commandButton 
-                                            icon="pi pi-refresh" 
-                                            title="Change Handover Value" 
-                                            ajax="false" 
-                                            styleClass="ui-button-warning m-1 mx-2" 
-                                            action="#{financialTransactionController.navigateToSelectPaymentsForHandoverAccept(summary, 'Card')}" >
-                                        </p:commandButton>
                                         <f:facet name="footer">
                                             <h:outputText value="#{financialTransactionController.bundle.cardValue}">
                                                 <f:convertNumber pattern="#,##0.00" />
@@ -761,16 +754,6 @@
                                         </f:facet>
                                     </p:column>
 
-                                    <p:column headerText="Actions" class="text-center">
-                                        <p:commandButton 
-                                            class="m-1 ui-button-success" 
-                                            value="View Details" 
-                                            icon="pi pi-eye"  
-                                            action="#{financialTransactionController.navigateToViewIndividualShiftForHandover}">
-                                             <f:setPropertyActionListener value="#{summary}" target="#{financialTransactionController.selectedBundle}"></f:setPropertyActionListener>
-                                        </p:commandButton>
-
-                                    </p:column>
 
                                 </p:dataTable>
                             </div>

--- a/src/main/webapp/resources/ezcomp/prints/five_five_paper_with_headings_for_handover.xhtml
+++ b/src/main/webapp/resources/ezcomp/prints/five_five_paper_with_headings_for_handover.xhtml
@@ -167,51 +167,420 @@
             <!-- Bill Body -->
             <div class="billBody">
 
-                <h:panelGrid columns="2" styleClass="handover-grid" columnClasses="labelColumn,valueColumn">
+                <div class="row" >
+
+                    <div class="col-6" >
+                        <h:panelGrid columns="2" styleClass="handover-grid" columnClasses="labelColumn,valueColumn">
 
 
-                    <h:outputText value="User:" styleClass="handover-label" style="font-weight: normal"/>
-                    <h:outputText value="#{cc.attrs.bundle.user.webUserPerson.nameWithTitle}" styleClass="handover-value" />
+                            <h:outputText value="From User:" styleClass="handover-label" style="font-weight: normal"/>
+                            <h:outputText value="#{cc.attrs.bundle.user.webUserPerson.nameWithTitle}" styleClass="handover-value" />
 
-                    <h:outputText value="Shift Start Bill ID:" styleClass="handover-label" style="font-weight: normal"/>
-                    <h:outputText value="#{cc.attrs.bundle.startBill.deptId}" styleClass="handover-value" />
-
-                    <h:outputText value="Shift Started At:" styleClass="handover-label" style="font-weight: normal" />
-                    <h:outputText value="#{cc.attrs.bundle.startBill.createdAt}">
-                        <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateTimeFormat}" />
-                    </h:outputText>
-
-                    <h:outputText value="Handover Bill ID:" styleClass="handover-label" style="font-weight: normal"/>
-                    <h:outputText value="#{cc.attrs.bundle.handoverBill.deptId}" styleClass="handover-value" />
-
-                    <h:outputText value="Handover At:" styleClass="handover-label" style="font-weight: normal" />
-                    <h:outputText value="#{cc.attrs.bundle.handoverBill.createdAt}">
-                        <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateTimeFormat}" />
-                    </h:outputText>
+                            <h:outputText value="To User:" styleClass="handover-label" style="font-weight: normal"/>
+                            <h:outputText value="#{cc.attrs.bundle.toUser.webUserPerson.nameWithTitle}" styleClass="handover-value" />
 
 
-                    <h:outputText  rendered="#{cc.attrs.bundle.endBill ne null}" value="Shift End Bill ID:" styleClass="handover-label" />
-                    <h:outputText  rendered="#{cc.attrs.bundle.endBill ne null}" value="#{cc.attrs.bundle.endBill.deptId}" styleClass="handover-value" />
+                            <h:outputText value="Shift Start Bill ID:" styleClass="handover-label" style="font-weight: normal"/>
+                            <h:outputText value="#{cc.attrs.bundle.startBill.deptId}" styleClass="handover-value" />
 
-                    <h:outputText  rendered="#{cc.attrs.bundle.endBill ne null}" value="Shift Ended At:" styleClass="handover-label" />
-                    <h:outputText  rendered="#{cc.attrs.bundle.endBill ne null}" value="#{cc.attrs.bundle.endBill.createdAt}">
-                        <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateTimeFormat}" />
-                    </h:outputText>
+                            <h:outputText value="Shift Started At:" styleClass="handover-label" style="font-weight: normal" />
+                            <h:outputText value="#{cc.attrs.bundle.startBill.createdAt}">
+                                <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateTimeFormat}" />
+                            </h:outputText>
 
-                    <h:outputText value="Total Due Handover Value:" styleClass="handover-label" style="font-weight: normal"/>
-                    <h:outputText value="#{cc.attrs.bundle.total}">
-                        <f:convertNumber pattern="#,##0.00" />
-                    </h:outputText>
+                            <h:outputText value="Handover Bill ID:" styleClass="handover-label" style="font-weight: normal"/>
+                            <h:outputText value="#{cc.attrs.bundle.handoverBill.deptId}" styleClass="handover-value" />
 
-                    <h:outputText value="Handingover Value:" styleClass="handover-label" style="font-weight: normal"/>
-                    <h:outputText value="#{cc.attrs.bundle.totalOut}">
-                        <f:convertNumber pattern="#,##0.00" />
-                    </h:outputText>
+                            <h:outputText value="Handover At:" styleClass="handover-label" style="font-weight: normal" />
+                            <h:outputText value="#{cc.attrs.bundle.handoverBill.createdAt}">
+                                <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateTimeFormat}" />
+                            </h:outputText>
 
-                    <h:outputText value="Handover To:" styleClass="handover-label" style="font-weight: normal"/>
-                    <h:outputText value="#{cc.attrs.bundle.toUser.webUserPerson.nameWithTitle}" styleClass="handover-value" />
 
-                </h:panelGrid>
+                            <h:outputText  rendered="#{cc.attrs.bundle.endBill ne null}" value="Shift End Bill ID:" styleClass="handover-label" />
+                            <h:outputText  rendered="#{cc.attrs.bundle.endBill ne null}" value="#{cc.attrs.bundle.endBill.deptId}" styleClass="handover-value" />
+
+                            <h:outputText  rendered="#{cc.attrs.bundle.endBill ne null}" value="Shift Ended At:" styleClass="handover-label" />
+                            <h:outputText  rendered="#{cc.attrs.bundle.endBill ne null}" value="#{cc.attrs.bundle.endBill.createdAt}">
+                                <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateTimeFormat}" />
+                            </h:outputText>
+
+                            <h:outputText value="Total Due Handover Value:" styleClass="handover-label" style="font-weight: normal"/>
+                            <h:outputText value="#{cc.attrs.bundle.total}">
+                                <f:convertNumber pattern="#,##0.00" />
+                            </h:outputText>
+
+                            <h:outputText value="Handingover Value:" styleClass="handover-label" style="font-weight: normal"/>
+                            <h:outputText value="#{cc.attrs.bundle.totalOut}">
+                                <f:convertNumber pattern="#,##0.00" />
+                            </h:outputText>
+
+                            <h:outputText value="Handover To:" styleClass="handover-label" style="font-weight: normal"/>
+                            <h:outputText value="#{cc.attrs.bundle.toUser.webUserPerson.nameWithTitle}" styleClass="handover-value" />
+
+                        </h:panelGrid>
+                    </div>
+                    <div class="col-6" >
+                        <h:panelGroup >
+
+                            <div class="col-12">
+                                <div class="row">
+                                    <div class="col-3"><p:outputLabel value="Payement Method"></p:outputLabel></div>
+                                    <div class="col-3"><p:outputLabel value="Collected"></p:outputLabel></div>
+                                    <div class="col-3"><p:outputLabel value="Handing Over"></p:outputLabel></div>
+                                    <div class="col-3"><p:outputLabel value="Difference"></p:outputLabel></div>
+                                </div>
+
+                                <h:panelGroup rendered="#{cc.attrs.bundle.hasCashTransaction}">
+                                    <div class="row my-3" >
+                                        <div class="col-3" >
+                                            <p:outputLabel value="Cash"></p:outputLabel>
+                                        </div>
+                                        <div class="col-3">
+                                            <h:outputText value="#{cc.attrs.bundle.cashValue}">
+                                                <f:convertNumber pattern="#,##0.00" />
+                                            </h:outputText>
+                                        </div>
+                                        <div class="col-3">
+                                            <h:outputText value="#{cc.attrs.bundle.denominatorValue}">
+                                                <f:convertNumber pattern="#,##0.00" />
+                                            </h:outputText>
+                                        </div>
+                                        <div class="col-3">
+                                            <h:outputText value="#{cc.attrs.bundle.cashValue - cc.attrs.bundle.denominatorValue}">
+                                                <f:convertNumber pattern="#,##0.00" />
+                                            </h:outputText>
+                                        </div>
+
+                                    </div>
+                                </h:panelGroup>
+
+
+                                <h:panelGroup rendered="#{cc.attrs.bundle.hasCardTransaction}">
+
+                                    <div class="row my-3" >
+                                        <div class="col-3" >
+                                            <p:outputLabel value="Card"></p:outputLabel>
+                                        </div>
+                                        <div class="col-3">
+                                            <h:outputText value="#{cc.attrs.bundle.cardValue}">
+                                                <f:convertNumber pattern="#,##0.00" />
+                                            </h:outputText>
+                                        </div>
+                                        <div class="col-3">
+                                            <h:outputText value="#{cc.attrs.bundle.cardHandoverValue}">
+                                                <f:convertNumber pattern="#,##0.00" />
+                                            </h:outputText>
+                                        </div>
+                                        <div class="col-3">
+                                            <h:outputText value="#{cc.attrs.bundle.cardValue - cc.attrs.bundle.cardHandoverValue}">
+                                                <f:convertNumber pattern="#,##0.00" />
+                                            </h:outputText>
+                                        </div>
+
+                                    </div>
+                                </h:panelGroup>
+
+                                <h:panelGroup rendered="#{cc.attrs.bundle.hasChequeTransaction}">
+                                    <div class="row my-3" >
+                                        <div class="col-3" >
+                                            <p:outputLabel value="Cheque"></p:outputLabel>
+                                        </div>
+                                        <div class="col-3">
+                                            <h:outputText value="#{cc.attrs.bundle.chequeValue}">
+                                                <f:convertNumber pattern="#,##0.00" />
+                                            </h:outputText>
+                                        </div>
+                                        <div class="col-3">
+                                            <h:outputText value="#{cc.attrs.bundle.chequeHandoverValue}">
+                                                <f:convertNumber pattern="#,##0.00" />
+                                            </h:outputText>
+                                        </div>
+                                        <div class="col-3">
+                                            <h:outputText value="#{cc.attrs.bundle.chequeValue - cc.attrs.bundle.chequeHandoverValue}">
+                                                <f:convertNumber pattern="#,##0.00" />
+                                            </h:outputText>
+                                        </div>
+
+                                    </div>
+
+
+                                </h:panelGroup>
+
+
+                                <h:panelGroup rendered="#{cc.attrs.bundle.hasVoucherTransaction}">
+                                    <div class="row my-3">
+                                        <div class="col-3" >
+                                            <p:outputLabel value="Voucher"></p:outputLabel>
+                                        </div>
+                                        <div class="col-3">
+                                            <h:outputText value="#{cc.attrs.bundle.voucherValue}">
+                                                <f:convertNumber pattern="#,##0.00" />
+                                            </h:outputText>
+                                        </div>
+                                        <div class="col-3">
+                                            <h:outputText value="#{cc.attrs.bundle.voucherHandoverValue}">
+                                                <f:convertNumber pattern="#,##0.00" />
+                                            </h:outputText>
+                                        </div>
+                                        <div class="col-3">
+                                            <h:outputText value="#{cc.attrs.bundle.voucherValue - cc.attrs.bundle.voucherHandoverValue}">
+                                                <f:convertNumber pattern="#,##0.00" />
+                                            </h:outputText>
+                                        </div>
+
+                                    </div>
+
+                                </h:panelGroup>
+
+                                <h:panelGroup rendered="#{cc.attrs.bundle.hasIouTransaction}">
+                                    <div class="row my-3">
+                                        <div class="col-3" >
+                                            <p:outputLabel value="IOU"></p:outputLabel>
+                                        </div>
+                                        <div class="col-3">
+                                            <h:outputText value="#{cc.attrs.bundle.iouValue}">
+                                                <f:convertNumber pattern="#,##0.00" />
+                                            </h:outputText>
+                                        </div>
+                                        <div class="col-3">
+                                            <h:outputText value="#{cc.attrs.bundle.iouHandoverValue}">
+                                                <f:convertNumber pattern="#,##0.00" />
+                                            </h:outputText>
+                                        </div>
+                                        <div class="col-3">
+                                            <h:outputText value="#{cc.attrs.bundle.iouValue - cc.attrs.bundle.iouHandoverValue}">
+                                                <f:convertNumber pattern="#,##0.00" />
+                                            </h:outputText>
+                                        </div>
+
+                                    </div>
+                                </h:panelGroup>
+
+                                <h:panelGroup rendered="#{cc.attrs.bundle.hasEWalletTransaction}">
+                                    <div class="row my-3" >
+                                        <div class="col-3" >
+                                            <p:outputLabel value="eWallet"></p:outputLabel>
+                                        </div>
+                                        <div class="col-3">
+                                            <h:outputText value="#{cc.attrs.bundle.ewalletValue}">
+                                                <f:convertNumber pattern="#,##0.00" />
+                                            </h:outputText>
+                                        </div>
+                                        <div class="col-3">
+                                            <h:outputText value="#{cc.attrs.bundle.ewalletHandoverValue}">
+                                                <f:convertNumber pattern="#,##0.00" />
+                                            </h:outputText>
+                                        </div>
+                                        <div class="col-3">
+                                            <h:outputText value="#{cc.attrs.bundle.voucherValue - cc.attrs.bundle.ewalletHandoverValue}">
+                                                <f:convertNumber pattern="#,##0.00" />
+                                            </h:outputText>
+                                        </div>
+
+                                    </div>
+                                </h:panelGroup>
+
+                                <h:panelGroup rendered="#{cc.attrs.bundle.hasStaffWelfareTransaction}">
+                                    <div class="row my-3" >
+                                        <div class="col-3" >
+                                            <p:outputLabel value="Staff Welfare"></p:outputLabel>
+                                        </div>
+                                        <div class="col-3">
+                                            <h:outputText value="#{cc.attrs.bundle.staffWelfareValue}">
+                                                <f:convertNumber pattern="#,##0.00" />
+                                            </h:outputText>
+                                        </div>
+                                        <div class="col-3">
+                                            <h:outputText value="#{cc.attrs.bundle.staffWelfareHandoverValue}">
+                                                <f:convertNumber pattern="#,##0.00" />
+                                            </h:outputText>
+                                        </div>
+                                        <div class="col-3">
+                                            <h:outputText value="#{cc.attrs.bundle.staffWelfareValue - cc.attrs.bundle.staffWelfareHandoverValue}">
+                                                <f:convertNumber pattern="#,##0.00" />
+                                            </h:outputText>
+                                        </div>
+
+                                    </div>
+                                </h:panelGroup>
+
+                                <h:panelGroup rendered="#{cc.attrs.bundle.hasPatientPointsTransaction}">
+                                    <div class="row my-3" >
+                                        <div class="col-3" >
+                                            <p:outputLabel value="Patient Points"></p:outputLabel>
+                                        </div>
+                                        <div class="col-3">
+                                            <h:outputText value="#{cc.attrs.bundle.patientPointsValue}">
+                                                <f:convertNumber pattern="#,##0.00" />
+                                            </h:outputText>
+                                        </div>
+                                        <div class="col-3">
+                                            <h:outputText value="#{cc.attrs.bundle.patientPointsHandoverValue}">
+                                                <f:convertNumber pattern="#,##0.00" />
+                                            </h:outputText>
+                                        </div>
+                                        <div class="col-3">
+                                            <h:outputText value="#{cc.attrs.bundle.patientPointsValue - cc.attrs.bundle.patientPointsHandoverValue}">
+                                                <f:convertNumber pattern="#,##0.00" />
+                                            </h:outputText>
+                                        </div>
+
+                                    </div>
+                                </h:panelGroup>
+
+                                <h:panelGroup rendered="#{cc.attrs.bundle.hasOnlineSettlementTransaction}">
+                                    <div class="row my-3" >
+                                        <div class="col-3" >
+                                            <p:outputLabel value="Online Settlement"></p:outputLabel>
+                                        </div>
+                                        <div class="col-3">
+                                            <h:outputText value="#{cc.attrs.bundle.onlineSettlementValue}">
+                                                <f:convertNumber pattern="#,##0.00" />
+                                            </h:outputText>
+                                        </div>
+                                        <div class="col-3">
+                                            <h:outputText value="#{cc.attrs.bundle.onlineSettlementHandoverValue}">
+                                                <f:convertNumber pattern="#,##0.00" />
+                                            </h:outputText>
+                                        </div>
+                                        <div class="col-3">
+                                            <h:outputText value="#{cc.attrs.bundle.onlineSettlementValue - cc.attrs.bundle.onlineSettlementHandoverValue}">
+                                                <f:convertNumber pattern="#,##0.00" />
+                                            </h:outputText>
+                                        </div>
+
+                                    </div>
+                                </h:panelGroup>
+
+                                <h:panelGroup rendered="#{cc.attrs.bundle.hasOnCallTransaction}">
+                                    <div class="row my-3" >
+                                        <div class="col-3" >
+                                            <p:outputLabel value="On Call"></p:outputLabel>
+                                        </div>
+                                        <div class="col-3">
+                                            <h:outputText value="#{cc.attrs.bundle.onCallValue}">
+                                                <f:convertNumber pattern="#,##0.00" />
+                                            </h:outputText>
+                                        </div>
+                                        <div class="col-3">
+                                            <h:outputText value="#{cc.attrs.bundle.onCallHandoverValue}">
+                                                <f:convertNumber pattern="#,##0.00" />
+                                            </h:outputText>
+                                        </div>
+                                        <div class="col-3">
+                                            <h:outputText value="#{cc.attrs.bundle.onCallValue - cc.attrs.bundle.onCallHandoverValue}">
+                                                <f:convertNumber pattern="#,##0.00" />
+                                            </h:outputText>
+                                        </div>
+
+                                    </div>
+                                </h:panelGroup>
+
+                                <h:panelGroup rendered="#{cc.attrs.bundle.hasSlipTransaction}">
+                                    <div class="row my-3" >
+                                        <div class="col-3" >
+                                            <p:outputLabel value="SLIP"></p:outputLabel>
+                                        </div>
+                                        <div class="col-3">
+                                            <h:outputText value="#{cc.attrs.bundle.slipValue}">
+                                                <f:convertNumber pattern="#,##0.00" />
+                                            </h:outputText>
+                                        </div>
+                                        <div class="col-3">
+                                            <h:outputText value="#{cc.attrs.bundle.slipHandoverValue}">
+                                                <f:convertNumber pattern="#,##0.00" />
+                                            </h:outputText>
+                                        </div>
+                                        <div class="col-3">
+                                            <h:outputText value="#{cc.attrs.bundle.slipValue - cc.attrs.bundle.slipHandoverValue}">
+                                                <f:convertNumber pattern="#,##0.00" />
+                                            </h:outputText>
+                                        </div>
+
+                                    </div>
+                                </h:panelGroup>
+
+                                <h:panelGroup rendered="#{cc.attrs.bundle.hasAgentTransaction}">
+                                    <div class="row my-3" >
+                                        <div class="col-3" >
+                                            <p:outputLabel value="Agent Value"></p:outputLabel>
+                                        </div>
+                                        <div class="col-3">
+                                            <h:outputText value="#{cc.attrs.bundle.agentValue}">
+                                                <f:convertNumber pattern="#,##0.00" />
+                                            </h:outputText>
+                                        </div>
+                                        <div class="col-3">
+                                            <h:outputText value="#{cc.attrs.bundle.agentHandoverValue}">
+                                                <f:convertNumber pattern="#,##0.00" />
+                                            </h:outputText>
+                                        </div>
+                                        <div class="col-3">
+                                            <h:outputText value="#{cc.attrs.bundle.agentValue - cc.attrs.bundle.agentHandoverValue}">
+                                                <f:convertNumber pattern="#,##0.00" />
+                                            </h:outputText>
+                                        </div>
+
+                                    </div>
+                                </h:panelGroup>
+
+                                <h:panelGroup rendered="#{cc.attrs.bundle.hasCreditTransaction}">
+                                    <div class="row my-3" >
+                                        <div class="col-3" >
+                                            <p:outputLabel value="Credit Value"></p:outputLabel>
+                                        </div>
+                                        <div class="col-3">
+                                            <h:outputText value="#{cc.attrs.bundle.creditValue}">
+                                                <f:convertNumber pattern="#,##0.00" />
+                                            </h:outputText>
+                                        </div>
+                                        <div class="col-3">
+                                            <h:outputText value="#{cc.attrs.bundle.creditHandoverValue}">
+                                                <f:convertNumber pattern="#,##0.00" />
+                                            </h:outputText>
+                                        </div>
+                                        <div class="col-3">
+                                            <h:outputText value="#{cc.attrs.bundle.creditValue - cc.attrs.bundle.creditHandoverValue}">
+                                                <f:convertNumber pattern="#,##0.00" />
+                                            </h:outputText>
+                                        </div>
+
+                                    </div>
+                                </h:panelGroup>
+
+                                <h:panelGroup rendered="#{cc.attrs.bundle.hasStaffTransaction}">
+                                    <div class="row my-3" >
+                                        <div class="col-3" >
+                                            <p:outputLabel value="Staff Value"></p:outputLabel>
+                                        </div>
+                                        <div class="col-3">
+                                            <h:outputText value="#{cc.attrs.bundle.staffValue}">
+                                                <f:convertNumber pattern="#,##0.00" />
+                                            </h:outputText>
+                                        </div>
+                                        <div class="col-3">
+                                            <h:outputText value="#{cc.attrs.bundle.staffHandoverValue}">
+                                                <f:convertNumber pattern="#,##0.00" />
+                                            </h:outputText>
+                                        </div>
+                                        <div class="col-3">
+                                            <h:outputText value="#{cc.attrs.bundle.staffValue - cc.attrs.bundle.staffHandoverValue}">
+                                                <f:convertNumber pattern="#,##0.00" />
+                                            </h:outputText>
+                                        </div>
+
+                                    </div>
+                                </h:panelGroup>
+
+                            </div>
+
+                        </h:panelGroup>
+                    </div>
+
+                </div>
+
+
 
                 <hr></hr>
 
@@ -220,361 +589,7 @@
                     <!-- Existing content ... -->
 
                     <!-- Payment Details Table -->
-                    <h:panelGroup >
 
-                        <div class="col-12">
-                            <div class="row">
-                                <div class="col-3"><p:outputLabel value="Payement Method"></p:outputLabel></div>
-                                <div class="col-3"><p:outputLabel value="Collected"></p:outputLabel></div>
-                                <div class="col-3"><p:outputLabel value="Handing Over"></p:outputLabel></div>
-                                <div class="col-3"><p:outputLabel value="Difference"></p:outputLabel></div>
-                            </div>
-
-                            <h:panelGroup rendered="#{cc.attrs.bundle.hasCashTransaction}">
-                                <div class="row my-3" >
-                                    <div class="col-3" >
-                                        <p:outputLabel value="Cash"></p:outputLabel>
-                                    </div>
-                                    <div class="col-3">
-                                        <h:outputText value="#{cc.attrs.bundle.cashValue}">
-                                            <f:convertNumber pattern="#,##0.00" />
-                                        </h:outputText>
-                                    </div>
-                                    <div class="col-3">
-                                        <h:outputText value="#{cc.attrs.bundle.denominatorValue}">
-                                            <f:convertNumber pattern="#,##0.00" />
-                                        </h:outputText>
-                                    </div>
-                                    <div class="col-3">
-                                        <h:outputText value="#{cc.attrs.bundle.cashValue - cc.attrs.bundle.denominatorValue}">
-                                            <f:convertNumber pattern="#,##0.00" />
-                                        </h:outputText>
-                                    </div>
-
-                                </div>
-                            </h:panelGroup>
-
-
-                            <h:panelGroup rendered="#{cc.attrs.bundle.hasCardTransaction}">
-
-                                <div class="row my-3" >
-                                    <div class="col-3" >
-                                        <p:outputLabel value="Card"></p:outputLabel>
-                                    </div>
-                                    <div class="col-3">
-                                        <h:outputText value="#{cc.attrs.bundle.cardValue}">
-                                            <f:convertNumber pattern="#,##0.00" />
-                                        </h:outputText>
-                                    </div>
-                                    <div class="col-3">
-                                        <h:outputText value="#{cc.attrs.bundle.cardHandoverValue}">
-                                            <f:convertNumber pattern="#,##0.00" />
-                                        </h:outputText>
-                                    </div>
-                                    <div class="col-3">
-                                        <h:outputText value="#{cc.attrs.bundle.cardValue - cc.attrs.bundle.cardHandoverValue}">
-                                            <f:convertNumber pattern="#,##0.00" />
-                                        </h:outputText>
-                                    </div>
-
-                                </div>
-                            </h:panelGroup>
-
-                            <h:panelGroup rendered="#{cc.attrs.bundle.hasChequeTransaction}">
-                                <div class="row my-3" >
-                                    <div class="col-3" >
-                                        <p:outputLabel value="Cheque"></p:outputLabel>
-                                    </div>
-                                    <div class="col-3">
-                                        <h:outputText value="#{cc.attrs.bundle.chequeValue}">
-                                            <f:convertNumber pattern="#,##0.00" />
-                                        </h:outputText>
-                                    </div>
-                                    <div class="col-3">
-                                        <h:outputText value="#{cc.attrs.bundle.chequeHandoverValue}">
-                                            <f:convertNumber pattern="#,##0.00" />
-                                        </h:outputText>
-                                    </div>
-                                    <div class="col-3">
-                                        <h:outputText value="#{cc.attrs.bundle.chequeValue - cc.attrs.bundle.chequeHandoverValue}">
-                                            <f:convertNumber pattern="#,##0.00" />
-                                        </h:outputText>
-                                    </div>
-
-                                </div>
-
-
-                            </h:panelGroup>
-
-
-                            <h:panelGroup rendered="#{cc.attrs.bundle.hasVoucherTransaction}">
-                                <div class="row my-3">
-                                    <div class="col-3" >
-                                        <p:outputLabel value="Voucher"></p:outputLabel>
-                                    </div>
-                                    <div class="col-3">
-                                        <h:outputText value="#{cc.attrs.bundle.voucherValue}">
-                                            <f:convertNumber pattern="#,##0.00" />
-                                        </h:outputText>
-                                    </div>
-                                    <div class="col-3">
-                                        <h:outputText value="#{cc.attrs.bundle.voucherHandoverValue}">
-                                            <f:convertNumber pattern="#,##0.00" />
-                                        </h:outputText>
-                                    </div>
-                                    <div class="col-3">
-                                        <h:outputText value="#{cc.attrs.bundle.voucherValue - cc.attrs.bundle.voucherHandoverValue}">
-                                            <f:convertNumber pattern="#,##0.00" />
-                                        </h:outputText>
-                                    </div>
-
-                                </div>
-
-                            </h:panelGroup>
-
-                            <h:panelGroup rendered="#{cc.attrs.bundle.hasIouTransaction}">
-                                <div class="row my-3">
-                                    <div class="col-3" >
-                                        <p:outputLabel value="IOU"></p:outputLabel>
-                                    </div>
-                                    <div class="col-3">
-                                        <h:outputText value="#{cc.attrs.bundle.iouValue}">
-                                            <f:convertNumber pattern="#,##0.00" />
-                                        </h:outputText>
-                                    </div>
-                                    <div class="col-3">
-                                        <h:outputText value="#{cc.attrs.bundle.iouHandoverValue}">
-                                            <f:convertNumber pattern="#,##0.00" />
-                                        </h:outputText>
-                                    </div>
-                                    <div class="col-3">
-                                        <h:outputText value="#{cc.attrs.bundle.iouValue - cc.attrs.bundle.iouHandoverValue}">
-                                            <f:convertNumber pattern="#,##0.00" />
-                                        </h:outputText>
-                                    </div>
-
-                                </div>
-                            </h:panelGroup>
-
-                            <h:panelGroup rendered="#{cc.attrs.bundle.hasEWalletTransaction}">
-                                <div class="row my-3" >
-                                    <div class="col-3" >
-                                        <p:outputLabel value="eWallet"></p:outputLabel>
-                                    </div>
-                                    <div class="col-3">
-                                        <h:outputText value="#{cc.attrs.bundle.ewalletValue}">
-                                            <f:convertNumber pattern="#,##0.00" />
-                                        </h:outputText>
-                                    </div>
-                                    <div class="col-3">
-                                        <h:outputText value="#{cc.attrs.bundle.ewalletHandoverValue}">
-                                            <f:convertNumber pattern="#,##0.00" />
-                                        </h:outputText>
-                                    </div>
-                                    <div class="col-3">
-                                        <h:outputText value="#{cc.attrs.bundle.voucherValue - cc.attrs.bundle.ewalletHandoverValue}">
-                                            <f:convertNumber pattern="#,##0.00" />
-                                        </h:outputText>
-                                    </div>
-
-                                </div>
-                            </h:panelGroup>
-
-                            <h:panelGroup rendered="#{cc.attrs.bundle.hasStaffWelfareTransaction}">
-                                <div class="row my-3" >
-                                    <div class="col-3" >
-                                        <p:outputLabel value="Staff Welfare"></p:outputLabel>
-                                    </div>
-                                    <div class="col-3">
-                                        <h:outputText value="#{cc.attrs.bundle.staffWelfareValue}">
-                                            <f:convertNumber pattern="#,##0.00" />
-                                        </h:outputText>
-                                    </div>
-                                    <div class="col-3">
-                                        <h:outputText value="#{cc.attrs.bundle.staffWelfareHandoverValue}">
-                                            <f:convertNumber pattern="#,##0.00" />
-                                        </h:outputText>
-                                    </div>
-                                    <div class="col-3">
-                                        <h:outputText value="#{cc.attrs.bundle.staffWelfareValue - cc.attrs.bundle.staffWelfareHandoverValue}">
-                                            <f:convertNumber pattern="#,##0.00" />
-                                        </h:outputText>
-                                    </div>
-
-                                </div>
-                            </h:panelGroup>
-
-                            <h:panelGroup rendered="#{cc.attrs.bundle.hasPatientPointsTransaction}">
-                                <div class="row my-3" >
-                                    <div class="col-3" >
-                                        <p:outputLabel value="Patient Points"></p:outputLabel>
-                                    </div>
-                                    <div class="col-3">
-                                        <h:outputText value="#{cc.attrs.bundle.patientPointsValue}">
-                                            <f:convertNumber pattern="#,##0.00" />
-                                        </h:outputText>
-                                    </div>
-                                    <div class="col-3">
-                                        <h:outputText value="#{cc.attrs.bundle.patientPointsHandoverValue}">
-                                            <f:convertNumber pattern="#,##0.00" />
-                                        </h:outputText>
-                                    </div>
-                                    <div class="col-3">
-                                        <h:outputText value="#{cc.attrs.bundle.patientPointsValue - cc.attrs.bundle.patientPointsHandoverValue}">
-                                            <f:convertNumber pattern="#,##0.00" />
-                                        </h:outputText>
-                                    </div>
-
-                                </div>
-                            </h:panelGroup>
-
-                            <h:panelGroup rendered="#{cc.attrs.bundle.hasOnlineSettlementTransaction}">
-                                <div class="row my-3" >
-                                    <div class="col-3" >
-                                        <p:outputLabel value="Online Settlement"></p:outputLabel>
-                                    </div>
-                                    <div class="col-3">
-                                        <h:outputText value="#{cc.attrs.bundle.onlineSettlementValue}">
-                                            <f:convertNumber pattern="#,##0.00" />
-                                        </h:outputText>
-                                    </div>
-                                    <div class="col-3">
-                                        <h:outputText value="#{cc.attrs.bundle.onlineSettlementHandoverValue}">
-                                            <f:convertNumber pattern="#,##0.00" />
-                                        </h:outputText>
-                                    </div>
-                                    <div class="col-3">
-                                        <h:outputText value="#{cc.attrs.bundle.onlineSettlementValue - cc.attrs.bundle.onlineSettlementHandoverValue}">
-                                            <f:convertNumber pattern="#,##0.00" />
-                                        </h:outputText>
-                                    </div>
-
-                                </div>
-                            </h:panelGroup>
-
-                            <h:panelGroup rendered="#{cc.attrs.bundle.hasOnCallTransaction}">
-                                <div class="row my-3" >
-                                    <div class="col-3" >
-                                        <p:outputLabel value="On Call"></p:outputLabel>
-                                    </div>
-                                    <div class="col-3">
-                                        <h:outputText value="#{cc.attrs.bundle.onCallValue}">
-                                            <f:convertNumber pattern="#,##0.00" />
-                                        </h:outputText>
-                                    </div>
-                                    <div class="col-3">
-                                        <h:outputText value="#{cc.attrs.bundle.onCallHandoverValue}">
-                                            <f:convertNumber pattern="#,##0.00" />
-                                        </h:outputText>
-                                    </div>
-                                    <div class="col-3">
-                                        <h:outputText value="#{cc.attrs.bundle.onCallValue - cc.attrs.bundle.onCallHandoverValue}">
-                                            <f:convertNumber pattern="#,##0.00" />
-                                        </h:outputText>
-                                    </div>
-
-                                </div>
-                            </h:panelGroup>
-
-                            <h:panelGroup rendered="#{cc.attrs.bundle.hasSlipTransaction}">
-                                <div class="row my-3" >
-                                    <div class="col-3" >
-                                        <p:outputLabel value="SLIP"></p:outputLabel>
-                                    </div>
-                                    <div class="col-3">
-                                        <h:outputText value="#{cc.attrs.bundle.slipValue}">
-                                            <f:convertNumber pattern="#,##0.00" />
-                                        </h:outputText>
-                                    </div>
-                                    <div class="col-3">
-                                        <h:outputText value="#{cc.attrs.bundle.slipHandoverValue}">
-                                            <f:convertNumber pattern="#,##0.00" />
-                                        </h:outputText>
-                                    </div>
-                                    <div class="col-3">
-                                        <h:outputText value="#{cc.attrs.bundle.slipValue - cc.attrs.bundle.slipHandoverValue}">
-                                            <f:convertNumber pattern="#,##0.00" />
-                                        </h:outputText>
-                                    </div>
-
-                                </div>
-                            </h:panelGroup>
-
-                            <h:panelGroup rendered="#{cc.attrs.bundle.hasAgentTransaction}">
-                                <div class="row my-3" >
-                                    <div class="col-3" >
-                                        <p:outputLabel value="Agent Value"></p:outputLabel>
-                                    </div>
-                                    <div class="col-3">
-                                        <h:outputText value="#{cc.attrs.bundle.agentValue}">
-                                            <f:convertNumber pattern="#,##0.00" />
-                                        </h:outputText>
-                                    </div>
-                                    <div class="col-3">
-                                        <h:outputText value="#{cc.attrs.bundle.agentHandoverValue}">
-                                            <f:convertNumber pattern="#,##0.00" />
-                                        </h:outputText>
-                                    </div>
-                                    <div class="col-3">
-                                        <h:outputText value="#{cc.attrs.bundle.agentValue - cc.attrs.bundle.agentHandoverValue}">
-                                            <f:convertNumber pattern="#,##0.00" />
-                                        </h:outputText>
-                                    </div>
-
-                                </div>
-                            </h:panelGroup>
-
-                            <h:panelGroup rendered="#{cc.attrs.bundle.hasCreditTransaction}">
-                                <div class="row my-3" >
-                                    <div class="col-3" >
-                                        <p:outputLabel value="Credit Value"></p:outputLabel>
-                                    </div>
-                                    <div class="col-3">
-                                        <h:outputText value="#{cc.attrs.bundle.creditValue}">
-                                            <f:convertNumber pattern="#,##0.00" />
-                                        </h:outputText>
-                                    </div>
-                                    <div class="col-3">
-                                        <h:outputText value="#{cc.attrs.bundle.creditHandoverValue}">
-                                            <f:convertNumber pattern="#,##0.00" />
-                                        </h:outputText>
-                                    </div>
-                                    <div class="col-3">
-                                        <h:outputText value="#{cc.attrs.bundle.creditValue - cc.attrs.bundle.creditHandoverValue}">
-                                            <f:convertNumber pattern="#,##0.00" />
-                                        </h:outputText>
-                                    </div>
-
-                                </div>
-                            </h:panelGroup>
-
-                            <h:panelGroup rendered="#{cc.attrs.bundle.hasStaffTransaction}">
-                                <div class="row my-3" >
-                                    <div class="col-3" >
-                                        <p:outputLabel value="Staff Value"></p:outputLabel>
-                                    </div>
-                                    <div class="col-3">
-                                        <h:outputText value="#{cc.attrs.bundle.staffValue}">
-                                            <f:convertNumber pattern="#,##0.00" />
-                                        </h:outputText>
-                                    </div>
-                                    <div class="col-3">
-                                        <h:outputText value="#{cc.attrs.bundle.staffHandoverValue}">
-                                            <f:convertNumber pattern="#,##0.00" />
-                                        </h:outputText>
-                                    </div>
-                                    <div class="col-3">
-                                        <h:outputText value="#{cc.attrs.bundle.staffValue - cc.attrs.bundle.staffHandoverValue}">
-                                            <f:convertNumber pattern="#,##0.00" />
-                                        </h:outputText>
-                                    </div>
-
-                                </div>
-                            </h:panelGroup>
-
-                        </div>
-
-                    </h:panelGroup>
 
                     <!-- Additional contents ... -->
                 </div>

--- a/src/main/webapp/resources/ezcomp/prints/five_five_paper_with_headings_for_handover.xhtml
+++ b/src/main/webapp/resources/ezcomp/prints/five_five_paper_with_headings_for_handover.xhtml
@@ -223,357 +223,133 @@
                     <div class="col-6" >
                         <h:panelGroup >
 
-                            <div class="col-12">
-                                <div class="row">
-                                    <div class="col-3"><p:outputLabel value="Payement Method"></p:outputLabel></div>
-                                    <div class="col-3"><p:outputLabel value="Collected"></p:outputLabel></div>
-                                    <div class="col-3"><p:outputLabel value="Handing Over"></p:outputLabel></div>
-                                    <div class="col-3"><p:outputLabel value="Difference"></p:outputLabel></div>
-                                </div>
+                            <h:panelGroup>
+                                <table class="table table-bordered">
+                                    <thead>
+                                        <tr>
+                                            <th>Payment Method</th>
+                                            <th class="text-end">Collected</th>
+                                            <th class="text-end">Handing Over</th>
+                                            <th class="text-end">Difference</th>
+                                        </tr>
+                                    </thead>
+                                    <tbody>
+                                        <h:panelGroup rendered="#{cc.attrs.bundle.hasCashTransaction}">
+                                            <tr>
+                                                <td>Cash</td>
+                                                <td class="text-end"><h:outputText value="#{cc.attrs.bundle.cashValue}"><f:convertNumber pattern="#,##0.00"/></h:outputText></td>
+                                                <td class="text-end"><h:outputText value="#{cc.attrs.bundle.denominatorValue}"><f:convertNumber pattern="#,##0.00"/></h:outputText></td>
+                                                <td class="text-end"><h:outputText value="#{cc.attrs.bundle.cashValue - cc.attrs.bundle.denominatorValue}"><f:convertNumber pattern="#,##0.00"/></h:outputText></td>
+                                            </tr>
+                                        </h:panelGroup>
+                                        <h:panelGroup rendered="#{cc.attrs.bundle.hasCardTransaction}">
+                                            <tr>
+                                                <td>Card</td>
+                                                <td class="text-end"><h:outputText value="#{cc.attrs.bundle.cardValue}"><f:convertNumber pattern="#,##0.00"/></h:outputText></td>
+                                                <td class="text-end"><h:outputText value="#{cc.attrs.bundle.cardHandoverValue}"><f:convertNumber pattern="#,##0.00"/></h:outputText></td>
+                                                <td class="text-end"><h:outputText value="#{cc.attrs.bundle.cardValue - cc.attrs.bundle.cardHandoverValue}"><f:convertNumber pattern="#,##0.00"/></h:outputText></td>
+                                            </tr>
+                                        </h:panelGroup>
+                                        <h:panelGroup rendered="#{cc.attrs.bundle.hasChequeTransaction}">
+                                            <tr>
+                                                <td>Cheque</td>
+                                                <td class="text-end"><h:outputText value="#{cc.attrs.bundle.chequeValue}"><f:convertNumber pattern="#,##0.00"/></h:outputText></td>
+                                                <td class="text-end"><h:outputText value="#{cc.attrs.bundle.chequeHandoverValue}"><f:convertNumber pattern="#,##0.00"/></h:outputText></td>
+                                                <td class="text-end"><h:outputText value="#{cc.attrs.bundle.chequeValue - cc.attrs.bundle.chequeHandoverValue}"><f:convertNumber pattern="#,##0.00"/></h:outputText></td>
+                                            </tr>
+                                        </h:panelGroup>
+                                        <h:panelGroup rendered="#{cc.attrs.bundle.hasVoucherTransaction}">
+                                            <tr>
+                                                <td>Voucher</td>
+                                                <td class="text-end"><h:outputText value="#{cc.attrs.bundle.voucherValue}"><f:convertNumber pattern="#,##0.00"/></h:outputText></td>
+                                                <td class="text-end"><h:outputText value="#{cc.attrs.bundle.voucherHandoverValue}"><f:convertNumber pattern="#,##0.00"/></h:outputText></td>
+                                                <td class="text-end"><h:outputText value="#{cc.attrs.bundle.voucherValue - cc.attrs.bundle.voucherHandoverValue}"><f:convertNumber pattern="#,##0.00"/></h:outputText></td>
+                                            </tr>
+                                        </h:panelGroup>
+                                        <h:panelGroup rendered="#{cc.attrs.bundle.hasIouTransaction}">
+                                            <tr>
+                                                <td>IOU</td>
+                                                <td class="text-end"><h:outputText value="#{cc.attrs.bundle.iouValue}"><f:convertNumber pattern="#,##0.00"/></h:outputText></td>
+                                                <td class="text-end"><h:outputText value="#{cc.attrs.bundle.iouHandoverValue}"><f:convertNumber pattern="#,##0.00"/></h:outputText></td>
+                                                <td class="text-end"><h:outputText value="#{cc.attrs.bundle.iouValue - cc.attrs.bundle.iouHandoverValue}"><f:convertNumber pattern="#,##0.00"/></h:outputText></td>
+                                            </tr>
+                                        </h:panelGroup>
+                                        <h:panelGroup rendered="#{cc.attrs.bundle.hasEWalletTransaction}">
+                                            <tr>
+                                                <td>eWallet</td>
+                                                <td class="text-end"><h:outputText value="#{cc.attrs.bundle.ewalletValue}"><f:convertNumber pattern="#,##0.00"/></h:outputText></td>
+                                                <td class="text-end"><h:outputText value="#{cc.attrs.bundle.ewalletHandoverValue}"><f:convertNumber pattern="#,##0.00"/></h:outputText></td>
+                                                <td class="text-end"><h:outputText value="#{cc.attrs.bundle.ewalletValue - cc.attrs.bundle.ewalletHandoverValue}"><f:convertNumber pattern="#,##0.00"/></h:outputText></td>
+                                            </tr>
+                                        </h:panelGroup>
+                                        <h:panelGroup rendered="#{cc.attrs.bundle.hasStaffWelfareTransaction}">
+                                            <tr>
+                                                <td>Staff Welfare</td>
+                                                <td class="text-end"><h:outputText value="#{cc.attrs.bundle.staffWelfareValue}"><f:convertNumber pattern="#,##0.00"/></h:outputText></td>
+                                                <td class="text-end"><h:outputText value="#{cc.attrs.bundle.staffWelfareHandoverValue}"><f:convertNumber pattern="#,##0.00"/></h:outputText></td>
+                                                <td class="text-end"><h:outputText value="#{cc.attrs.bundle.staffWelfareValue - cc.attrs.bundle.staffWelfareHandoverValue}"><f:convertNumber pattern="#,##0.00"/></h:outputText></td>
+                                            </tr>
+                                        </h:panelGroup>
+                                        <h:panelGroup rendered="#{cc.attrs.bundle.hasPatientPointsTransaction}">
+                                            <tr>
+                                                <td>Patient Points</td>
+                                                <td class="text-end"><h:outputText value="#{cc.attrs.bundle.patientPointsValue}"><f:convertNumber pattern="#,##0.00"/></h:outputText></td>
+                                                <td class="text-end"><h:outputText value="#{cc.attrs.bundle.patientPointsHandoverValue}"><f:convertNumber pattern="#,##0.00"/></h:outputText></td>
+                                                <td class="text-end"><h:outputText value="#{cc.attrs.bundle.patientPointsValue - cc.attrs.bundle.patientPointsHandoverValue}"><f:convertNumber pattern="#,##0.00"/></h:outputText></td>
+                                            </tr>
+                                        </h:panelGroup>
+                                        <h:panelGroup rendered="#{cc.attrs.bundle.hasOnlineSettlementTransaction}">
+                                            <tr>
+                                                <td>Online Settlement</td>
+                                                <td class="text-end"><h:outputText value="#{cc.attrs.bundle.onlineSettlementValue}"><f:convertNumber pattern="#,##0.00"/></h:outputText></td>
+                                                <td class="text-end"><h:outputText value="#{cc.attrs.bundle.onlineSettlementHandoverValue}"><f:convertNumber pattern="#,##0.00"/></h:outputText></td>
+                                                <td class="text-end"><h:outputText value="#{cc.attrs.bundle.onlineSettlementValue - cc.attrs.bundle.onlineSettlementHandoverValue}"><f:convertNumber pattern="#,##0.00"/></h:outputText></td>
+                                            </tr>
+                                        </h:panelGroup>
+                                        <h:panelGroup rendered="#{cc.attrs.bundle.hasOnCallTransaction}">
+                                            <tr>
+                                                <td>On Call</td>
+                                                <td class="text-end"><h:outputText value="#{cc.attrs.bundle.onCallValue}"><f:convertNumber pattern="#,##0.00"/></h:outputText></td>
+                                                <td class="text-end"><h:outputText value="#{cc.attrs.bundle.onCallHandoverValue}"><f:convertNumber pattern="#,##0.00"/></h:outputText></td>
+                                                <td class="text-end"><h:outputText value="#{cc.attrs.bundle.onCallValue - cc.attrs.bundle.onCallHandoverValue}"><f:convertNumber pattern="#,##0.00"/></h:outputText></td>
+                                            </tr>
+                                        </h:panelGroup>
+                                        <h:panelGroup rendered="#{cc.attrs.bundle.hasSlipTransaction}">
+                                            <tr>
+                                                <td>SLIP</td>
+                                                <td class="text-end"><h:outputText value="#{cc.attrs.bundle.slipValue}"><f:convertNumber pattern="#,##0.00"/></h:outputText></td>
+                                                <td class="text-end"><h:outputText value="#{cc.attrs.bundle.slipHandoverValue}"><f:convertNumber pattern="#,##0.00"/></h:outputText></td>
+                                                <td class="text-end"><h:outputText value="#{cc.attrs.bundle.slipValue - cc.attrs.bundle.slipHandoverValue}"><f:convertNumber pattern="#,##0.00"/></h:outputText></td>
+                                            </tr>
+                                        </h:panelGroup>
+                                        <h:panelGroup rendered="#{cc.attrs.bundle.hasAgentTransaction}">
+                                            <tr>
+                                                <td>Agent Value</td>
+                                                <td class="text-end"><h:outputText value="#{cc.attrs.bundle.agentValue}"><f:convertNumber pattern="#,##0.00"/></h:outputText></td>
+                                                <td class="text-end"><h:outputText value="#{cc.attrs.bundle.agentHandoverValue}"><f:convertNumber pattern="#,##0.00"/></h:outputText></td>
+                                                <td class="text-end"><h:outputText value="#{cc.attrs.bundle.agentValue - cc.attrs.bundle.agentHandoverValue}"><f:convertNumber pattern="#,##0.00"/></h:outputText></td>
+                                            </tr>
+                                        </h:panelGroup>
+                                        <h:panelGroup rendered="#{cc.attrs.bundle.hasCreditTransaction}">
+                                            <tr>
+                                                <td>Credit Value</td>
+                                                <td class="text-end"><h:outputText value="#{cc.attrs.bundle.creditValue}"><f:convertNumber pattern="#,##0.00"/></h:outputText></td>
+                                                <td class="text-end"><h:outputText value="#{cc.attrs.bundle.creditHandoverValue}"><f:convertNumber pattern="#,##0.00"/></h:outputText></td>
+                                                <td class="text-end"><h:outputText value="#{cc.attrs.bundle.creditValue - cc.attrs.bundle.creditHandoverValue}"><f:convertNumber pattern="#,##0.00"/></h:outputText></td>
+                                            </tr>
+                                        </h:panelGroup>
+                                        <h:panelGroup rendered="#{cc.attrs.bundle.hasStaffTransaction}">
+                                            <tr>
+                                                <td>Staff Value</td>
+                                                <td class="text-end"><h:outputText value="#{cc.attrs.bundle.staffValue}"><f:convertNumber pattern="#,##0.00"/></h:outputText></td>
+                                                <td class="text-end"><h:outputText value="#{cc.attrs.bundle.staffHandoverValue}"><f:convertNumber pattern="#,##0.00"/></h:outputText></td>
+                                                <td class="text-end"><h:outputText value="#{cc.attrs.bundle.staffValue - cc.attrs.bundle.staffHandoverValue}"><f:convertNumber pattern="#,##0.00"/></h:outputText></td>
+                                            </tr>
+                                        </h:panelGroup>
+                                    </tbody>
+                                </table>
+                            </h:panelGroup>
 
-                                <h:panelGroup rendered="#{cc.attrs.bundle.hasCashTransaction}">
-                                    <div class="row my-3" >
-                                        <div class="col-3" >
-                                            <p:outputLabel value="Cash"></p:outputLabel>
-                                        </div>
-                                        <div class="col-3">
-                                            <h:outputText value="#{cc.attrs.bundle.cashValue}">
-                                                <f:convertNumber pattern="#,##0.00" />
-                                            </h:outputText>
-                                        </div>
-                                        <div class="col-3">
-                                            <h:outputText value="#{cc.attrs.bundle.denominatorValue}">
-                                                <f:convertNumber pattern="#,##0.00" />
-                                            </h:outputText>
-                                        </div>
-                                        <div class="col-3">
-                                            <h:outputText value="#{cc.attrs.bundle.cashValue - cc.attrs.bundle.denominatorValue}">
-                                                <f:convertNumber pattern="#,##0.00" />
-                                            </h:outputText>
-                                        </div>
-
-                                    </div>
-                                </h:panelGroup>
-
-
-                                <h:panelGroup rendered="#{cc.attrs.bundle.hasCardTransaction}">
-
-                                    <div class="row my-3" >
-                                        <div class="col-3" >
-                                            <p:outputLabel value="Card"></p:outputLabel>
-                                        </div>
-                                        <div class="col-3">
-                                            <h:outputText value="#{cc.attrs.bundle.cardValue}">
-                                                <f:convertNumber pattern="#,##0.00" />
-                                            </h:outputText>
-                                        </div>
-                                        <div class="col-3">
-                                            <h:outputText value="#{cc.attrs.bundle.cardHandoverValue}">
-                                                <f:convertNumber pattern="#,##0.00" />
-                                            </h:outputText>
-                                        </div>
-                                        <div class="col-3">
-                                            <h:outputText value="#{cc.attrs.bundle.cardValue - cc.attrs.bundle.cardHandoverValue}">
-                                                <f:convertNumber pattern="#,##0.00" />
-                                            </h:outputText>
-                                        </div>
-
-                                    </div>
-                                </h:panelGroup>
-
-                                <h:panelGroup rendered="#{cc.attrs.bundle.hasChequeTransaction}">
-                                    <div class="row my-3" >
-                                        <div class="col-3" >
-                                            <p:outputLabel value="Cheque"></p:outputLabel>
-                                        </div>
-                                        <div class="col-3">
-                                            <h:outputText value="#{cc.attrs.bundle.chequeValue}">
-                                                <f:convertNumber pattern="#,##0.00" />
-                                            </h:outputText>
-                                        </div>
-                                        <div class="col-3">
-                                            <h:outputText value="#{cc.attrs.bundle.chequeHandoverValue}">
-                                                <f:convertNumber pattern="#,##0.00" />
-                                            </h:outputText>
-                                        </div>
-                                        <div class="col-3">
-                                            <h:outputText value="#{cc.attrs.bundle.chequeValue - cc.attrs.bundle.chequeHandoverValue}">
-                                                <f:convertNumber pattern="#,##0.00" />
-                                            </h:outputText>
-                                        </div>
-
-                                    </div>
-
-
-                                </h:panelGroup>
-
-
-                                <h:panelGroup rendered="#{cc.attrs.bundle.hasVoucherTransaction}">
-                                    <div class="row my-3">
-                                        <div class="col-3" >
-                                            <p:outputLabel value="Voucher"></p:outputLabel>
-                                        </div>
-                                        <div class="col-3">
-                                            <h:outputText value="#{cc.attrs.bundle.voucherValue}">
-                                                <f:convertNumber pattern="#,##0.00" />
-                                            </h:outputText>
-                                        </div>
-                                        <div class="col-3">
-                                            <h:outputText value="#{cc.attrs.bundle.voucherHandoverValue}">
-                                                <f:convertNumber pattern="#,##0.00" />
-                                            </h:outputText>
-                                        </div>
-                                        <div class="col-3">
-                                            <h:outputText value="#{cc.attrs.bundle.voucherValue - cc.attrs.bundle.voucherHandoverValue}">
-                                                <f:convertNumber pattern="#,##0.00" />
-                                            </h:outputText>
-                                        </div>
-
-                                    </div>
-
-                                </h:panelGroup>
-
-                                <h:panelGroup rendered="#{cc.attrs.bundle.hasIouTransaction}">
-                                    <div class="row my-3">
-                                        <div class="col-3" >
-                                            <p:outputLabel value="IOU"></p:outputLabel>
-                                        </div>
-                                        <div class="col-3">
-                                            <h:outputText value="#{cc.attrs.bundle.iouValue}">
-                                                <f:convertNumber pattern="#,##0.00" />
-                                            </h:outputText>
-                                        </div>
-                                        <div class="col-3">
-                                            <h:outputText value="#{cc.attrs.bundle.iouHandoverValue}">
-                                                <f:convertNumber pattern="#,##0.00" />
-                                            </h:outputText>
-                                        </div>
-                                        <div class="col-3">
-                                            <h:outputText value="#{cc.attrs.bundle.iouValue - cc.attrs.bundle.iouHandoverValue}">
-                                                <f:convertNumber pattern="#,##0.00" />
-                                            </h:outputText>
-                                        </div>
-
-                                    </div>
-                                </h:panelGroup>
-
-                                <h:panelGroup rendered="#{cc.attrs.bundle.hasEWalletTransaction}">
-                                    <div class="row my-3" >
-                                        <div class="col-3" >
-                                            <p:outputLabel value="eWallet"></p:outputLabel>
-                                        </div>
-                                        <div class="col-3">
-                                            <h:outputText value="#{cc.attrs.bundle.ewalletValue}">
-                                                <f:convertNumber pattern="#,##0.00" />
-                                            </h:outputText>
-                                        </div>
-                                        <div class="col-3">
-                                            <h:outputText value="#{cc.attrs.bundle.ewalletHandoverValue}">
-                                                <f:convertNumber pattern="#,##0.00" />
-                                            </h:outputText>
-                                        </div>
-                                        <div class="col-3">
-                                            <h:outputText value="#{cc.attrs.bundle.voucherValue - cc.attrs.bundle.ewalletHandoverValue}">
-                                                <f:convertNumber pattern="#,##0.00" />
-                                            </h:outputText>
-                                        </div>
-
-                                    </div>
-                                </h:panelGroup>
-
-                                <h:panelGroup rendered="#{cc.attrs.bundle.hasStaffWelfareTransaction}">
-                                    <div class="row my-3" >
-                                        <div class="col-3" >
-                                            <p:outputLabel value="Staff Welfare"></p:outputLabel>
-                                        </div>
-                                        <div class="col-3">
-                                            <h:outputText value="#{cc.attrs.bundle.staffWelfareValue}">
-                                                <f:convertNumber pattern="#,##0.00" />
-                                            </h:outputText>
-                                        </div>
-                                        <div class="col-3">
-                                            <h:outputText value="#{cc.attrs.bundle.staffWelfareHandoverValue}">
-                                                <f:convertNumber pattern="#,##0.00" />
-                                            </h:outputText>
-                                        </div>
-                                        <div class="col-3">
-                                            <h:outputText value="#{cc.attrs.bundle.staffWelfareValue - cc.attrs.bundle.staffWelfareHandoverValue}">
-                                                <f:convertNumber pattern="#,##0.00" />
-                                            </h:outputText>
-                                        </div>
-
-                                    </div>
-                                </h:panelGroup>
-
-                                <h:panelGroup rendered="#{cc.attrs.bundle.hasPatientPointsTransaction}">
-                                    <div class="row my-3" >
-                                        <div class="col-3" >
-                                            <p:outputLabel value="Patient Points"></p:outputLabel>
-                                        </div>
-                                        <div class="col-3">
-                                            <h:outputText value="#{cc.attrs.bundle.patientPointsValue}">
-                                                <f:convertNumber pattern="#,##0.00" />
-                                            </h:outputText>
-                                        </div>
-                                        <div class="col-3">
-                                            <h:outputText value="#{cc.attrs.bundle.patientPointsHandoverValue}">
-                                                <f:convertNumber pattern="#,##0.00" />
-                                            </h:outputText>
-                                        </div>
-                                        <div class="col-3">
-                                            <h:outputText value="#{cc.attrs.bundle.patientPointsValue - cc.attrs.bundle.patientPointsHandoverValue}">
-                                                <f:convertNumber pattern="#,##0.00" />
-                                            </h:outputText>
-                                        </div>
-
-                                    </div>
-                                </h:panelGroup>
-
-                                <h:panelGroup rendered="#{cc.attrs.bundle.hasOnlineSettlementTransaction}">
-                                    <div class="row my-3" >
-                                        <div class="col-3" >
-                                            <p:outputLabel value="Online Settlement"></p:outputLabel>
-                                        </div>
-                                        <div class="col-3">
-                                            <h:outputText value="#{cc.attrs.bundle.onlineSettlementValue}">
-                                                <f:convertNumber pattern="#,##0.00" />
-                                            </h:outputText>
-                                        </div>
-                                        <div class="col-3">
-                                            <h:outputText value="#{cc.attrs.bundle.onlineSettlementHandoverValue}">
-                                                <f:convertNumber pattern="#,##0.00" />
-                                            </h:outputText>
-                                        </div>
-                                        <div class="col-3">
-                                            <h:outputText value="#{cc.attrs.bundle.onlineSettlementValue - cc.attrs.bundle.onlineSettlementHandoverValue}">
-                                                <f:convertNumber pattern="#,##0.00" />
-                                            </h:outputText>
-                                        </div>
-
-                                    </div>
-                                </h:panelGroup>
-
-                                <h:panelGroup rendered="#{cc.attrs.bundle.hasOnCallTransaction}">
-                                    <div class="row my-3" >
-                                        <div class="col-3" >
-                                            <p:outputLabel value="On Call"></p:outputLabel>
-                                        </div>
-                                        <div class="col-3">
-                                            <h:outputText value="#{cc.attrs.bundle.onCallValue}">
-                                                <f:convertNumber pattern="#,##0.00" />
-                                            </h:outputText>
-                                        </div>
-                                        <div class="col-3">
-                                            <h:outputText value="#{cc.attrs.bundle.onCallHandoverValue}">
-                                                <f:convertNumber pattern="#,##0.00" />
-                                            </h:outputText>
-                                        </div>
-                                        <div class="col-3">
-                                            <h:outputText value="#{cc.attrs.bundle.onCallValue - cc.attrs.bundle.onCallHandoverValue}">
-                                                <f:convertNumber pattern="#,##0.00" />
-                                            </h:outputText>
-                                        </div>
-
-                                    </div>
-                                </h:panelGroup>
-
-                                <h:panelGroup rendered="#{cc.attrs.bundle.hasSlipTransaction}">
-                                    <div class="row my-3" >
-                                        <div class="col-3" >
-                                            <p:outputLabel value="SLIP"></p:outputLabel>
-                                        </div>
-                                        <div class="col-3">
-                                            <h:outputText value="#{cc.attrs.bundle.slipValue}">
-                                                <f:convertNumber pattern="#,##0.00" />
-                                            </h:outputText>
-                                        </div>
-                                        <div class="col-3">
-                                            <h:outputText value="#{cc.attrs.bundle.slipHandoverValue}">
-                                                <f:convertNumber pattern="#,##0.00" />
-                                            </h:outputText>
-                                        </div>
-                                        <div class="col-3">
-                                            <h:outputText value="#{cc.attrs.bundle.slipValue - cc.attrs.bundle.slipHandoverValue}">
-                                                <f:convertNumber pattern="#,##0.00" />
-                                            </h:outputText>
-                                        </div>
-
-                                    </div>
-                                </h:panelGroup>
-
-                                <h:panelGroup rendered="#{cc.attrs.bundle.hasAgentTransaction}">
-                                    <div class="row my-3" >
-                                        <div class="col-3" >
-                                            <p:outputLabel value="Agent Value"></p:outputLabel>
-                                        </div>
-                                        <div class="col-3">
-                                            <h:outputText value="#{cc.attrs.bundle.agentValue}">
-                                                <f:convertNumber pattern="#,##0.00" />
-                                            </h:outputText>
-                                        </div>
-                                        <div class="col-3">
-                                            <h:outputText value="#{cc.attrs.bundle.agentHandoverValue}">
-                                                <f:convertNumber pattern="#,##0.00" />
-                                            </h:outputText>
-                                        </div>
-                                        <div class="col-3">
-                                            <h:outputText value="#{cc.attrs.bundle.agentValue - cc.attrs.bundle.agentHandoverValue}">
-                                                <f:convertNumber pattern="#,##0.00" />
-                                            </h:outputText>
-                                        </div>
-
-                                    </div>
-                                </h:panelGroup>
-
-                                <h:panelGroup rendered="#{cc.attrs.bundle.hasCreditTransaction}">
-                                    <div class="row my-3" >
-                                        <div class="col-3" >
-                                            <p:outputLabel value="Credit Value"></p:outputLabel>
-                                        </div>
-                                        <div class="col-3">
-                                            <h:outputText value="#{cc.attrs.bundle.creditValue}">
-                                                <f:convertNumber pattern="#,##0.00" />
-                                            </h:outputText>
-                                        </div>
-                                        <div class="col-3">
-                                            <h:outputText value="#{cc.attrs.bundle.creditHandoverValue}">
-                                                <f:convertNumber pattern="#,##0.00" />
-                                            </h:outputText>
-                                        </div>
-                                        <div class="col-3">
-                                            <h:outputText value="#{cc.attrs.bundle.creditValue - cc.attrs.bundle.creditHandoverValue}">
-                                                <f:convertNumber pattern="#,##0.00" />
-                                            </h:outputText>
-                                        </div>
-
-                                    </div>
-                                </h:panelGroup>
-
-                                <h:panelGroup rendered="#{cc.attrs.bundle.hasStaffTransaction}">
-                                    <div class="row my-3" >
-                                        <div class="col-3" >
-                                            <p:outputLabel value="Staff Value"></p:outputLabel>
-                                        </div>
-                                        <div class="col-3">
-                                            <h:outputText value="#{cc.attrs.bundle.staffValue}">
-                                                <f:convertNumber pattern="#,##0.00" />
-                                            </h:outputText>
-                                        </div>
-                                        <div class="col-3">
-                                            <h:outputText value="#{cc.attrs.bundle.staffHandoverValue}">
-                                                <f:convertNumber pattern="#,##0.00" />
-                                            </h:outputText>
-                                        </div>
-                                        <div class="col-3">
-                                            <h:outputText value="#{cc.attrs.bundle.staffValue - cc.attrs.bundle.staffHandoverValue}">
-                                                <f:convertNumber pattern="#,##0.00" />
-                                            </h:outputText>
-                                        </div>
-
-                                    </div>
-                                </h:panelGroup>
-
-                            </div>
 
                         </h:panelGroup>
                     </div>


### PR DESCRIPTION
Navigate to Menu > Financial Transaction Manager
Selecy Handover Tab
Select my handovers
Select a period and click list
then you can click on the required handover
then click to Print button
you will be directed to a page with a print button
this page is currently set of A4
may need to adjust to different page sizes depending on the requests
Signed-off-by: Dr M H Buddhika Ariyaratne <buddhika.ari@gmail.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced the handover transaction view to clearly display both sender and recipient details.
  - Added a filter to showcase only denomination entries with valid amounts.
  - Redesigned the bill layout with updated labels and a streamlined payment details table for improved readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->