### PR TITLE
The collection center cancel bill need cancel the header

### DIFF
--- a/src/main/webapp/collecting_centre/bill_cancel.xhtml
+++ b/src/main/webapp/collecting_centre/bill_cancel.xhtml
@@ -16,7 +16,15 @@
                     <h:panelGroup rendered="#{!billSearch.printPreview}" styleClass="alignTop">
                         <p:panel>
                             <f:facet name="header">
-                                <h:outputText value="Cancellation" class="mt-5"/>
+                                <h:panelGroup>
+                                    <h:outputText class="fa-solid fa-warehouse mt-2"  />
+                                    <h:outputLabel class="mx-2 mt-2">
+                                        <h:outputText value="Collecting Centre Bill"
+                                                      rendered="#{collectingCentreBillController.bill.billType eq 'CollectingCentreBill'}" />
+                                        <h:outputText value="OPD Bill"
+                                                      rendered="#{collectingCentreBillController.bill.billType eq 'OpdBill'}" />
+                                    </h:outputLabel>
+                                </h:panelGroup>
                                 <h:panelGrid columns="3" style="float: right" class="w-50">
                                     <p:selectOneMenu 
                                         id="commentsMenu" 

--- a/src/main/webapp/resources/bill/cc_bill/fiveFiveCCBill_Patient_Custom1.xhtml
+++ b/src/main/webapp/resources/bill/cc_bill/fiveFiveCCBill_Patient_Custom1.xhtml
@@ -38,11 +38,11 @@
                 </div>
             </div>
 
-            <div class="headingBillFiveFive" style="text-align: center;font-weight: bold;">   
-                <h:outputLabel value="Collection Center Invoice"   />    
-                <h:outputLabel value="**Duplicate**"  rendered="#{cc.attrs.duplicate eq true}" /> 
-                <h:outputLabel value="**Cancelled**"  rendered="#{cc.attrs.bill.cancelled eq true}" />  
-                <h:outputLabel value="**Refunded**"  rendered="#{cc.attrs.bill.refunded eq true}" /> 
+            <div class="headingBillFiveFive" style="text-align: center;font-weight: bold;">
+                <h:outputLabel value="Collection Center Invoice"   />
+                <h:outputLabel value="**Duplicate**"  rendered="#{cc.attrs.duplicate eq true}" />
+                <h:outputLabel value="**Cancelled**"  rendered="#{cc.attrs.bill.cancelled eq true}" />
+                <h:outputLabel value="**Refunded**"  rendered="#{cc.attrs.bill.refunded eq true}" />
             </div>
 
             <div>

--- a/src/main/webapp/resources/ezcomp/prints/five_five_paper_coustom_1.xhtml
+++ b/src/main/webapp/resources/ezcomp/prints/five_five_paper_coustom_1.xhtml
@@ -41,16 +41,16 @@
 
             <div class="headingBillFiveFive mt-2" style="text-align: center;font-weight: bold;">
                 <div class="d-flex align-items-center justify-content-center">
-                    <h:panelGroup >
-                        <h:outputLabel value="OPD" />
+                    <!-- Dynamic Header -->
+                    <h:panelGroup rendered="#{cc.attrs.bill.billType eq 'OpdBill'}">
+                        <h:outputLabel value="OPD Receipt" />
                     </h:panelGroup>
-
-                    <h:panelGroup>
-                        <h:outputLabel value="&nbsp;&nbsp;" />
-                        <h:outputLabel value=" Receipt"/>
+                    <h:panelGroup rendered="#{cc.attrs.bill.billType eq 'CollectingCentreBill'}">
+                        <h:outputLabel value="Collecting Centre Receipt" />
                     </h:panelGroup>
                 </div>
-                <h:panelGroup  rendered="#{cc.attrs.duplicate eq true}"  >
+                <!-- Duplicate Indicator -->
+                <h:panelGroup rendered="#{cc.attrs.duplicate}">
                     <h:outputLabel value="**Duplicate**" />
                 </h:panelGroup>
             </div>
@@ -139,25 +139,31 @@
                     </tr>
 
                     <!-- Only the modified section is shown -->
-                    <ui:repeat value="#{billController.billItemsOfBill(cc.attrs.bill)}" var="billItem">
+                    <ui:repeat value="#{billController.billItemsOfBill(cc.attrs.bill)}" var="billItem"   >
                         <tr class="billDetailsFiveFive">
-                            <td style="width:80%!important;">
-                                <h:outputLabel value="#{billItem.item.name}"></h:outputLabel>
-                                <h:outputLabel value=" (N)" rendered="#{billItem.item.special}"/>
+                            <td  style="width:80%!important;">
+                                <h:outputLabel value="#{billItem.item.printName}"></h:outputLabel>
+                                <h:outputLabel value="&nbsp;X #{billItem.qty}" rendered="#{configOptionApplicationController.getBooleanValueByKey('Show Quantity on OPD Bills') and billItem.item.requestForQuentity}">
+                                    <f:convertNumber pattern="0" />
+                                </h:outputLabel>
                             </td>
                             <td style="width:10%!important;">
-                                <h:panelGroup rendered="#{billItem.item.printSessionNumber}">
-                                    <h:panelGroup rendered="#{configOptionApplicationController.getBooleanValueByKey('Print Individual Bill Item Session Number in OPD Bills')}">
-                                        <h:outputLabel value="#{billItem.billSession.serialNo}"/>
+                                <h:panelGroup rendered="#{billItem.item.printSessionNumber}" >
+                                    <h:panelGroup rendered="#{configOptionApplicationController.getBooleanValueByKey('Print Individual Bill Item Session Number in OPD Bills')}" >
+                                        <td>
+                                            <h:outputLabel  value="#{billItem.billSession.serialNo}"    >
+                                            </h:outputLabel>
+                                        </td>
                                     </h:panelGroup>
                                 </h:panelGroup>
                             </td>
-                            <td style="width:10%!important;text-align: right;">
-                                <h:outputLabel value="#{billItem.netValue}" style="text-align: right;" class="w-100">
-                                    <f:convertNumber pattern="#,##0.00"/>
+                            <td   style="width:10%!important;text-align: right;">
+                                <h:outputLabel value="#{billItem.grossValue}" style="text-align: right;" class="w-100">
+                                    <f:convertNumber pattern="#,##0.00" />
                                 </h:outputLabel>
                             </td>
                         </tr>
+
                     </ui:repeat>
 
                     <tr class="totalsBlock mt-3" style="font-weight: 600" >


### PR DESCRIPTION
 the issue was fixed. issue 11315

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Receipt headers now dynamically display "OPD Receipt" or "Collecting Centre Receipt" based on bill type.
  - Bill cancellation panel header now shows an icon and dynamically displays the bill type ("Collecting Centre Bill" or "OPD Bill").

- **Enhancements**
  - Bill item listings now show item print names and, when configured, display item quantities on receipts.
  - Amounts in bill items now reflect gross value instead of net value.

- **Style**
  - Improved whitespace formatting for invoice status labels.
  - Updated markup for session number display and duplicate indicators.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->