### PR TITLE
Inward Servise Bill size is A4Printed Paper (header isn't displayed) issue fixed

### DIFF
--- a/src/main/webapp/inward/inward_cancel_bill_service.xhtml
+++ b/src/main/webapp/inward/inward_cancel_bill_service.xhtml
@@ -113,14 +113,14 @@
 
                                 <h:panelGroup rendered="#{configOptionApplicationController.getBooleanValueByKey('Inward Servise Bill size is POS Paper')}">
                                     <ui:repeat value="#{inwardSearch.bill.cancelledBill}" var="bill">
-                                        <bi:inwardBillPrintPos bill="#{bill}" duplicate="false"/>
+                                        <bi:inwardBillPrintPos bill="#{bill}" duplicate="false" cancelled="true"/>
                                     </ui:repeat>
                                 </h:panelGroup>
 
                                 <h:panelGroup rendered="#{configOptionApplicationController.getBooleanValueByKey('Inward Servise Bill size is FiveFive paper',true)}">
                                     <ui:repeat value="#{inwardSearch.bill.cancelledBill}" var="ffb">
                                         <div style="page-break-after: always;">
-                                            <print:five_five_paper_with_headings_inward_service bill="#{ffb}"/>
+                                            <print:five_five_paper_with_headings_inward_service bill="#{ffb}" cancelled="true"/>
                                         </div>
                                         <br/>
                                     </ui:repeat>
@@ -128,7 +128,7 @@
 
                                 <h:panelGroup rendered="#{configOptionApplicationController.getBooleanValueByKey('Inward Servise Bill size is FiveFiveCustom3 Paper')}">
                                     <ui:repeat value="#{inwardSearch.bill.cancelledBill}" var="pp">
-                                        <print:five_five_custom_3_inward bill="#{pp}" duplicate="false" payments="#{inwardSearch.bill.cancelledBil.size()}"/>
+                                        <print:five_five_custom_3_inward bill="#{pp}" duplicate="false" payments="#{inwardSearch.bill.cancelledBill.size()}" cancelled="true"/>
                                         <br/>
                                     </ui:repeat>
                                 </h:panelGroup>

--- a/src/main/webapp/inward/inward_cancel_bill_service.xhtml
+++ b/src/main/webapp/inward/inward_cancel_bill_service.xhtml
@@ -128,7 +128,7 @@
 
                                 <h:panelGroup rendered="#{configOptionApplicationController.getBooleanValueByKey('Inward Servise Bill size is FiveFiveCustom3 Paper')}">
                                     <ui:repeat value="#{inwardSearch.bill.cancelledBill}" var="pp">
-                                        <print:five_five_custom_3_inward bill="#{pp}" duplicate="false" payments="#{inwardSearch.bill.cancelledBill.size()}" cancelled="true"/>
+                                        <print:five_five_custom_3_inward bill="#{pp}" duplicate="false" payments="#{inwardSearch.bill.cancelledBil.size()}" cancelled="true"/>
                                         <br/>
                                     </ui:repeat>
                                 </h:panelGroup>

--- a/src/main/webapp/inward/inward_cancel_bill_service.xhtml
+++ b/src/main/webapp/inward/inward_cancel_bill_service.xhtml
@@ -128,7 +128,7 @@
 
                                 <h:panelGroup rendered="#{configOptionApplicationController.getBooleanValueByKey('Inward Servise Bill size is FiveFiveCustom3 Paper')}">
                                     <ui:repeat value="#{inwardSearch.bill.cancelledBill}" var="pp">
-                                        <print:five_five_custom_3_inward bill="#{pp}" duplicate="false" payments="#{inwardSearch.bill.cancelledBil.size()}" cancelled="true"/>
+                                        <print:five_five_custom_3_inward bill="#{pp}" duplicate="false" payments="#{inwardSearch.bill.cancelledBill.size()}" cancelled="true"/>
                                         <br/>
                                     </ui:repeat>
                                 </h:panelGroup>

--- a/src/main/webapp/resources/bill/inwardBillPrintPos.xhtml
+++ b/src/main/webapp/resources/bill/inwardBillPrintPos.xhtml
@@ -10,8 +10,9 @@
     <!-- INTERFACE -->
     <cc:interface>
         <cc:attribute name="bill" />
-        <cc:attribute name="duplicate" />
+        <cc:attribute name="duplicate" type="java.lang.Boolean" />
         <cc:attribute name="refunded" />
+        <cc:attribute name="cancelled" type="java.lang.Boolean"/>
     </cc:interface>
 
     <!-- IMPLEMENTATION -->
@@ -57,7 +58,7 @@
             <div class="headingBill">
                 <h:outputLabel value="INVOICE"   />    
                 <h:outputLabel value="**Duplicate**"  rendered="#{cc.attrs.duplicate eq true}" /> 
-                <h:outputLabel value="**Cancelled**"  rendered="#{cc.attrs.bill.cancelled eq true}" /> 
+                <h:outputLabel value="**Cancelled**"  rendered="#{cc.attrs.cancelled }" />
             </div>
 
             <div class="billline">

--- a/src/main/webapp/resources/ezcomp/prints/A4_paper_without_headings.xhtml
+++ b/src/main/webapp/resources/ezcomp/prints/A4_paper_without_headings.xhtml
@@ -20,7 +20,7 @@
         <h:outputStylesheet library="css" name="pharmacypos.css" ></h:outputStylesheet>
         <div class="a4bill" style="width: 210mm;" >
 
-            <div style="height: 55mm!important;"></div>
+            <div style="height: #{configOptionApplicationController.getShortTextValueByKey('Inward Servise Bill Header Height',55)}mm!important;"></div>
 
             <div class="billDetailsFiveFive" >
                 <table style="width: 99%!important;" >

--- a/src/main/webapp/resources/ezcomp/prints/five_five_custom_3_inward.xhtml
+++ b/src/main/webapp/resources/ezcomp/prints/five_five_custom_3_inward.xhtml
@@ -12,6 +12,7 @@
         <cc:attribute name="duplicate" type="java.lang.Boolean" default="false"/>
         <cc:attribute name="refunded" type="java.lang.Boolean" default="false"/>
         <cc:attribute name="payments" type="java.lang.Integer"></cc:attribute>
+        <cc:attribute name="cancelled" type="java.lang.Boolean"/>
     </cc:interface>
 
     <h:head>
@@ -25,6 +26,8 @@
             <!-- Attributes passed to the component -->
             <cc:attribute name="bill" required="true" />
             <cc:attribute name="duplicate" required="false" />
+            <cc:attribute name="cancelled" type="java.lang.Boolean"/>
+
         </cc:interface>
 
         <!-- Composite Component Implementation -->
@@ -63,7 +66,7 @@
                     <h:outputLabel value="#{cc.attrs.bill.department.name}"/>
                     <br/>
                     <h:outputLabel value="**Duplicate**"  rendered="#{cc.attrs.duplicate eq true}" />
-                    <h:outputLabel value="**Cancelled**"  rendered="#{cc.attrs.bill.cancelled eq true}" />
+                    <h:outputLabel value="**Cancelled**"  rendered="#{cc.attrs.cancelled}" />
                 </div>
 
                 <!-- Separator Line -->

--- a/src/main/webapp/resources/ezcomp/prints/five_five_paper_with_headings_inward_service.xhtml
+++ b/src/main/webapp/resources/ezcomp/prints/five_five_paper_with_headings_inward_service.xhtml
@@ -11,6 +11,7 @@
     <cc:interface>
         <cc:attribute name="bill" type="com.divudi.core.entity.Bill" />
         <cc:attribute name="duplicate" type="java.lang.Boolean"/>
+        <cc:attribute name="cancelled" type="java.lang.Boolean"/>
     </cc:interface>
 
     <!-- IMPLEMENTATION -->
@@ -43,7 +44,7 @@
                 <h:outputLabel value="RECEIPT"   />
 
                 <h:outputLabel value="**Duplicate**"  rendered="#{cc.attrs.duplicate eq true}" />
-                <h:outputLabel value="**Cancelled**"  rendered="#{cc.attrs.bill.cancelled eq true}" />
+                <h:outputLabel value="**Cancelled**"  rendered="#{cc.attrs.cancelled}" />
 
             </div>
 


### PR DESCRIPTION
Service Cancellation Bill PaperType Options POS paper, five five custom3, and five five paper were fixed

issue #11347

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved visibility of cancelled bills by explicitly displaying a "Cancelled" label in bill print previews and receipts.
  - The header height in A4 bill layouts is now configurable based on application settings.

- **Bug Fixes**
  - Corrected a typo in the expression that determines the size of cancelled bills, ensuring accurate display.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->