### PR TITLE
11774 wrong pharmacy retail bill cancellation   a pharmaceutical bill item is created in cancellation with the bill item reference from the billed bill instead of the cancelled bill

### DIFF
--- a/src/main/resources/META-INF/persistence.xml
+++ b/src/main/resources/META-INF/persistence.xml
@@ -2,17 +2,17 @@
 <persistence version="2.2" xmlns="http://java.sun.com/xml/ns/persistence" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/persistence http://xmlns.jcp.org/xml/ns/persistence/persistence_2_2.xsd">
     <persistence-unit name="hmisPU" transaction-type="JTA">
         <provider>org.eclipse.persistence.jpa.PersistenceProvider</provider>
-        <jta-data-source>${JDBC_DATASOURCE}</jta-data-source>
+        <jta-data-source>jdbc/sl</jta-data-source>
         <exclude-unlisted-classes>false</exclude-unlisted-classes>
         <properties>
-            <property name="eclipselink.logging.level" value="SEVERE"/>
+            <property name="eclipselink.logging.level.sql" value="SEVERE"/>
         </properties>
     </persistence-unit>
     <persistence-unit name="hmisAuditPU" transaction-type="JTA">
-        <jta-data-source>${JDBC_AUDIT_DATASOURCE}</jta-data-source>
+        <jta-data-source>jdbc/ruhunuAudit</jta-data-source>
         <exclude-unlisted-classes>false</exclude-unlisted-classes>
         <properties>
-            <property name="eclipselink.logging.level" value="SEVERE"/>
+            <property name="eclipselink.logging.level.sql" value="SEVERE"/>
         </properties>
     </persistence-unit>
 </persistence>

--- a/src/main/resources/META-INF/persistence.xml
+++ b/src/main/resources/META-INF/persistence.xml
@@ -2,17 +2,17 @@
 <persistence version="2.2" xmlns="http://java.sun.com/xml/ns/persistence" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/persistence http://xmlns.jcp.org/xml/ns/persistence/persistence_2_2.xsd">
     <persistence-unit name="hmisPU" transaction-type="JTA">
         <provider>org.eclipse.persistence.jpa.PersistenceProvider</provider>
-        <jta-data-source>jdbc/sl</jta-data-source>
+        <jta-data-source>${JDBC_DATASOURCE}</jta-data-source>
         <exclude-unlisted-classes>false</exclude-unlisted-classes>
         <properties>
-            <property name="eclipselink.logging.level.sql" value="SEVERE"/>
+            <property name="eclipselink.logging.level" value="SEVERE"/>
         </properties>
     </persistence-unit>
     <persistence-unit name="hmisAuditPU" transaction-type="JTA">
-        <jta-data-source>jdbc/ruhunuAudit</jta-data-source>
+        <jta-data-source>${JDBC_AUDIT_DATASOURCE}</jta-data-source>
         <exclude-unlisted-classes>false</exclude-unlisted-classes>
         <properties>
-            <property name="eclipselink.logging.level.sql" value="SEVERE"/>
+            <property name="eclipselink.logging.level" value="SEVERE"/>
         </properties>
     </persistence-unit>
 </persistence>

--- a/src/main/webapp/pharmacy/reports/summary_reports/pharmacy_income_and_cost_report.xhtml
+++ b/src/main/webapp/pharmacy/reports/summary_reports/pharmacy_income_and_cost_report.xhtml
@@ -219,7 +219,6 @@
                             <h:outputText value="#{row.pharmaceuticalBillItem.billItem.bill.deptId}"  style="padding: 0px!important; margin: 0px!important;" />
                             <f:facet name="footer" >
                                 <h:outputText value="Total Amounts" style="padding: 0px!important; margin: 0px!important; font-weight: bold" >
-
                                 </h:outputText>
                             </f:facet>
                         </p:column>
@@ -227,8 +226,6 @@
                             headerText="Bill Type"  style="padding: 0px!important; margin: 0px!important;" >
                             <h:outputText value="#{row.pharmaceuticalBillItem.billItem.bill.billTypeAtomic}"  style="padding: 0px!important; margin: 0px!important;" />
                         </p:column>
-                        </p:column>
-
                         <p:column headerText="Patient"  style="padding: 0px!important; margin: 0px!important;" >
                             <h:outputText value="#{row.pharmaceuticalBillItem.billItem.bill.patient.person.nameWithTitle}"  style="padding: 0px!important; margin: 0px!important;" />
                         </p:column>
@@ -299,25 +296,6 @@
                                 ajax="false">
                                 <f:setPropertyActionListener value="#{row.pharmaceuticalBillItem.billItem.bill}" target="#{billSearch.bill}" />
                             </p:commandLink>
-
-                            <!--                            <p:commandLink 
-                                                            value="Manage" 
-                                                            style="font-size: #{pharmacySummaryReportController.fontSizeForScreen}!important;" 
-                                                            class="mx-1"
-                                                            action="#{billSearch.navigateToManageBillByAtomicBillType()}" 
-                                                            ajax="false">
-                                                            <f:setPropertyActionListener value="#{row.pharmaceuticalBillItem.billItem.bill}" target="#{billSearch.bill}" />
-                                                        </p:commandLink>-->
-
-                            <!--                            <p:commandLink 
-                                                            value="Admin" 
-                                                            style="font-size: #{pharmacySummaryReportController.fontSizeForScreen}!important;" 
-                                                            class="mx-1"
-                                                            action="#{billSearch.navigateToAdminBillByAtomicBillType()}" 
-                                                            ajax="false" 
-                                                            rendered="#{webUserController.hasPrivilege('Developers')}">
-                                                            <f:setPropertyActionListener value="#{row.pharmaceuticalBillItem.billItem.bill}" target="#{billSearch.bill}" />
-                                                        </p:commandLink>-->
                         </p:column>
 
 


### PR DESCRIPTION
Done.
Now, the cancellation bill creation is working fine.
Cancel a pharmacy retail bill
Please check the cancellations against the Pharmacy > Analytics > Summary > Pharmacy Income and Cost [Report]