### PR TITLE
11780 no bill type atomic for pre bill created during cancellation

### DIFF
--- a/src/main/java/com/divudi/bean/pharmacy/PharmacyBillSearch.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacyBillSearch.java
@@ -1300,6 +1300,28 @@ public class PharmacyBillSearch implements Serializable {
         return cb;
     }
 
+    private CancelledBill createPharmacyRetailSaleCancellationBill(Bill originalBill) {
+        CancelledBill cb = new CancelledBill();
+
+        cb.setBilledBill(originalBill);
+        cb.copy(originalBill);
+        cb.setReferenceBill(originalBill.getReferenceBill());
+        cb.invertAndAssignValuesFromOtherBill(originalBill);
+
+        cb.setPaymentScheme(originalBill.getPaymentScheme());
+        cb.setBalance(0.0);
+        cb.setCreatedAt(new Date());
+        cb.setCreater(getSessionController().getLoggedUser());
+
+        cb.setDepartment(getSessionController().getLoggedUser().getDepartment());
+        cb.setInstitution(getSessionController().getInstitution());
+
+        cb.setComments(getComment());
+        cb.setBillTypeAtomic(BillTypeAtomic.PHARMACY_RETAIL_SALE_CANCELLED);
+
+        return cb;
+    }
+
     private RefundBill pharmacyCreateRefundCancelBill() {
         RefundBill cb = new RefundBill();
         cb.invertQty();
@@ -1728,21 +1750,18 @@ public class PharmacyBillSearch implements Serializable {
 //            }
             newlyCreatedReturningItem.setPharmaceuticalBillItem(newlyCreatedReturningPharmaceuticalBillItem);
             newlyCreatedReturningPharmaceuticalBillItem.setBillItem(newlyCreatedReturningItem);
-            
-            getBillItemFacede().create(newlyCreatedReturningItem);
 
+            getBillItemFacede().create(newlyCreatedReturningItem);
 
             //get billfees from using cancel billItem  >> This feature of BillFee for Bill Items is NOT used in pharmacy related transactions
 //            String sql = "Select bf From BillFee bf where bf.retired=false and bf.billItem.id=" + originalBillItem.getId();
 //            List<BillFee> tmp = getBillFeeFacade().findByJpql(sql);
 //            cancelBillFee(can, newlyCreatedReturningItem, tmp);
-
             //create BillFeePayments For cancel >> This feature of BillFee for Bill Items is NOT used in pharmacy related transactions
 //            sql = "Select bf From BillFee bf where bf.retired=false and bf.billItem.id=" + newlyCreatedReturningItem.getId();
 //            List<BillFee> tmpC = getBillFeeFacade().findByJpql(sql);
 //            calculateBillfeePaymentsForCancelRefundBill(tmpC, p);
             //
-
             newlyCreatedCancellingBill.getBillItems().add(newlyCreatedReturningItem);
 
         }
@@ -2079,57 +2098,43 @@ public class PharmacyBillSearch implements Serializable {
                 return;
             }
 
-//            if (calculateNumberOfBillsPerOrder(getBill().getReferenceBill())) {
-//                return;
-//            } before
-            ////System.out.println("getBill().getReferenceBill().getDepartment() = " + getBill().getReferenceBill().getDepartment().getName());
-            ////System.out.println("bill.getDepartment() = " + getBill().getDepartment().getName());
-            ////System.out.println("getSessionController().getDepartment() = " + getSessionController().getDepartment().getName());
             if (checkDepartment(getBill())) {
                 return;
             }
 
-            Bill preBill = getPharmacyBean().reAddToStock(getBill().getReferenceBill(), getSessionController().getLoggedUser(), getSessionController().getDepartment(), BillNumberSuffix.PRECAN);
-            CancelledBill cb = pharmacyCreateCancelBill();
+            Bill newlyCreatedRetailSaleCancellationBillPre = getPharmacyBean().createPreBillForRetailSaleCancellation(getBill().getReferenceBill(), getSessionController().getLoggedUser(), getSessionController().getDepartment());
+
+            CancelledBill newlyCreatedRetailSaleCancellationBill = createPharmacyRetailSaleCancellationBill(getBill());
 
             String deptId = getBillNumberBean().departmentBillNumberGeneratorYearly(getSessionController().getDepartment(), BillTypeAtomic.PHARMACY_RETAIL_SALE_CANCELLED);
 
-            cb.setDeptId(deptId);
-            cb.setInsId(deptId);
+            newlyCreatedRetailSaleCancellationBill.setDeptId(deptId);
+            newlyCreatedRetailSaleCancellationBill.setInsId(deptId);
 
-            if (cb.getId() == null) {
-                getBillFacade().create(cb);
+            if (newlyCreatedRetailSaleCancellationBill.getId() == null) {
+                getBillFacade().create(newlyCreatedRetailSaleCancellationBill);
             }
 
             //for Payment,billFee and BillFeepayment
-            List<Payment> newlyCreatedCancellationPayments = pharmacySaleController.createPaymentForRetailSaleCancellation(cb, paymentMethod);
+            List<Payment> newlyCreatedCancellationPayments = pharmacySaleController.createPaymentForRetailSaleCancellation(newlyCreatedRetailSaleCancellationBill, paymentMethod);
             drawerController.updateDrawerForOuts(newlyCreatedCancellationPayments);
-            pharmacyCancelBillItems(cb, newlyCreatedCancellationPayments);
+            pharmacyCancelBillItems(newlyCreatedRetailSaleCancellationBill, newlyCreatedCancellationPayments);
 
             getBill().setCancelled(true);
-            getBill().setCancelledBill(cb);
+            getBill().setCancelledBill(newlyCreatedRetailSaleCancellationBill);
             getBillFacade().edit(getBill());
 
-            preBill.setBackwardReferenceBill(getBill());
-            preBill.setForwardReferenceBill(cb);
-            getBillFacade().edit(preBill);
+            newlyCreatedRetailSaleCancellationBillPre.setBackwardReferenceBill(getBill());
+            newlyCreatedRetailSaleCancellationBillPre.setForwardReferenceBill(newlyCreatedRetailSaleCancellationBill);
+            getBillFacade().edit(newlyCreatedRetailSaleCancellationBillPre);
 
-//            if (getBill().getReferenceBill() != null) {
-//                getBill().getReferenceBill().setReferenceBill(null);
-//                getBillFacade().edit(getBill().getReferenceBill());
-//            }
-//            getCashTransactionBean().saveBillCashOutTransaction(cb, getSessionController().getLoggedUser());
             JsfUtil.addSuccessMessage("Cancelled");
-            //   ////System.out.println("going to cancel staff payments");
             if (getBill().getPaymentMethod() == PaymentMethod.Credit) {
-                //   ////System.out.println("getBill().getPaymentMethod() = " + getBill().getPaymentMethod());
-                //   ////System.out.println("getBill().getToStaff() = " + getBill().getToStaff());
                 if (getBill().getToStaff() != null) {
-                    //   ////System.out.println("getBill().getNetTotal() = " + getBill().getNetTotal());
                     getStaffBean().updateStaffCredit(getBill().getToStaff(), 0 - getBill().getNetTotal());
                     JsfUtil.addSuccessMessage("Staff Credit Updated");
-                    cb.setFromStaff(getBill().getToStaff());
-                    getBillFacade().edit(cb);
+                    newlyCreatedRetailSaleCancellationBill.setFromStaff(getBill().getToStaff());
+                    getBillFacade().edit(newlyCreatedRetailSaleCancellationBill);
                 }
             }
 

--- a/src/main/java/com/divudi/core/data/BillTypeAtomic.java
+++ b/src/main/java/com/divudi/core/data/BillTypeAtomic.java
@@ -122,6 +122,8 @@ public enum BillTypeAtomic {
             PaymentCategory.NO_PAYMENT),
     PHARMACY_RETAIL_SALE_CANCELLED("Pharmacy Retail Sale Cancelled", BillCategory.CANCELLATION, ServiceType.PHARMACY, BillFinanceType.CASH_OUT, CountedServiceType.PHARMACY,
             PaymentCategory.NON_CREDIT_COLLECTION),
+    PHARMACY_RETAIL_SALE_CANCELLED_PRE("Pharmacy Retail Sale Cancelled - Pre Bill", BillCategory.CANCELLATION, ServiceType.PHARMACY, BillFinanceType.NO_FINANCE_TRANSACTIONS, CountedServiceType.PHARMACY,
+            PaymentCategory.NO_PAYMENT),
     PHARMACY_RETAIL_SALE_REFUND("Pharmacy Retail Sale Refund", BillCategory.REFUND, ServiceType.PHARMACY, BillFinanceType.CASH_OUT, CountedServiceType.PHARMACY,
             PaymentCategory.NON_CREDIT_COLLECTION),
     PHARMACY_RETAIL_SALE_RETURN_ITEMS_ONLY("Pharmacy Retail Sale Return Items Only", BillCategory.REFUND, ServiceType.PHARMACY, BillFinanceType.NO_FINANCE_TRANSACTIONS, CountedServiceType.PHARMACY,

--- a/src/main/java/com/divudi/ejb/PharmacyBean.java
+++ b/src/main/java/com/divudi/ejb/PharmacyBean.java
@@ -7,6 +7,7 @@ package com.divudi.ejb;
 import com.divudi.core.data.BillClassType;
 import com.divudi.core.data.BillNumberSuffix;
 import com.divudi.core.data.BillType;
+import com.divudi.core.data.BillTypeAtomic;
 import com.divudi.core.data.DepartmentType;
 import com.divudi.core.data.ItemBatchQty;
 import com.divudi.core.data.StockQty;
@@ -239,6 +240,51 @@ public class PharmacyBean {
 
     }
 
+    
+    
+    private List<BillItem> createBillItemsForPharmacyRetailSaleCancellationPreBillWithStockReturn(Bill originalBill, Bill cancellationPreBill, WebUser user, Department department) {
+
+        List<BillItem> billItems = new ArrayList<>();
+
+        if (originalBill == null) {
+            return billItems;
+        }
+
+        if (originalBill.getBillItems() == null) {
+            return billItems;
+        }
+
+        for (BillItem existingBillItemFromOriginalBill : originalBill.getBillItems()) {
+            BillItem newlyCreatedBillItemForCancellationPrebill = new BillItem();
+            newlyCreatedBillItemForCancellationPrebill.copy(existingBillItemFromOriginalBill);
+            newlyCreatedBillItemForCancellationPrebill.invertValue(existingBillItemFromOriginalBill);
+            newlyCreatedBillItemForCancellationPrebill.setBill(cancellationPreBill);
+            newlyCreatedBillItemForCancellationPrebill.setReferanceBillItem(existingBillItemFromOriginalBill);
+            newlyCreatedBillItemForCancellationPrebill.setCreatedAt(new Date());
+            newlyCreatedBillItemForCancellationPrebill.setCreater(user);
+
+            PharmaceuticalBillItem newlyCreatedPharmaceuticalBillItem = new PharmaceuticalBillItem();
+            newlyCreatedPharmaceuticalBillItem.copy(existingBillItemFromOriginalBill.getPharmaceuticalBillItem());
+            newlyCreatedPharmaceuticalBillItem.invertValue(existingBillItemFromOriginalBill.getPharmaceuticalBillItem());
+            newlyCreatedPharmaceuticalBillItem.setBillItem(newlyCreatedBillItemForCancellationPrebill);
+            newlyCreatedBillItemForCancellationPrebill.setPharmaceuticalBillItem(newlyCreatedPharmaceuticalBillItem);
+
+            getBillItemFacade().create(newlyCreatedBillItemForCancellationPrebill);
+
+            double qty = 0;
+            if (existingBillItemFromOriginalBill.getQty() != null) {
+                qty = Math.abs(existingBillItemFromOriginalBill.getQty());
+            }
+
+            addToStock(newlyCreatedPharmaceuticalBillItem.getStock(), qty, newlyCreatedPharmaceuticalBillItem, department);
+            billItems.add(newlyCreatedBillItemForCancellationPrebill);
+
+        }
+
+        return billItems;
+
+    }
+    
     public Bill reAddToStock(Bill bill, WebUser user, Department department, BillNumberSuffix billNumberSuffix) {
 //        if (bill.isCancelled()) {
 //            JsfUtil.addErrorMessage("Bill Already Cancelled");
@@ -254,6 +300,36 @@ public class PharmacyBean {
         getBillFacade().edit(preBill);
 
         return preBill;
+    }
+
+    public Bill createPreBillForRetailSaleCancellation(Bill originalBill, WebUser user, Department department) {
+        Bill newCancellationPreBillCreated = new PreBill();
+        // This is not needed as invertAndAssignValuesFromOtherBill do both the following actions
+//        newPre.copy(originalBill);
+//        newPre.invertQty();
+
+        newCancellationPreBillCreated.invertAndAssignValuesFromOtherBill(originalBill);
+        newCancellationPreBillCreated.setBilledBill(originalBill);
+        String commonDeptAndInsId = getBillNumberBean().departmentBillNumberGeneratorYearly(department, BillTypeAtomic.PHARMACY_RETAIL_SALE_CANCELLED_PRE);
+        newCancellationPreBillCreated.setDeptId(commonDeptAndInsId);
+        newCancellationPreBillCreated.setInsId(commonDeptAndInsId);
+        newCancellationPreBillCreated.setDepartment(department);
+        newCancellationPreBillCreated.setInstitution(department.getInstitution());
+        newCancellationPreBillCreated.setCreatedAt(new Date());
+        newCancellationPreBillCreated.setCreater(user);
+        newCancellationPreBillCreated.setBackwardReferenceBill(originalBill);
+
+        getBillFacade().create(newCancellationPreBillCreated);
+
+        List<BillItem> listOfNewlyCreatedBillItemsForPharmacyRetailSaleCancellationPreBill = createBillItemsForPharmacyRetailSaleCancellationPreBillWithStockReturn(originalBill, newCancellationPreBillCreated, user, department);
+
+        originalBill.setForwardReferenceBill(newCancellationPreBillCreated);
+        getBillFacade().edit(originalBill);
+
+        newCancellationPreBillCreated.setBillItems(listOfNewlyCreatedBillItemsForPharmacyRetailSaleCancellationPreBill);
+        getBillFacade().edit(newCancellationPreBillCreated);
+
+        return newCancellationPreBillCreated;
     }
 
     public Bill readdStockForIssueBills(PreBill bill, WebUser user, Department department, BillNumberSuffix billNumberSuffix) {

--- a/src/main/java/com/divudi/ejb/PharmacyBean.java
+++ b/src/main/java/com/divudi/ejb/PharmacyBean.java
@@ -310,6 +310,7 @@ public class PharmacyBean {
 
         newCancellationPreBillCreated.invertAndAssignValuesFromOtherBill(originalBill);
         newCancellationPreBillCreated.setBilledBill(originalBill);
+        newCancellationPreBillCreated.setBillTypeAtomic(BillTypeAtomic.PHARMACY_RETAIL_SALE_CANCELLED_PRE);
         String commonDeptAndInsId = getBillNumberBean().departmentBillNumberGeneratorYearly(department, BillTypeAtomic.PHARMACY_RETAIL_SALE_CANCELLED_PRE);
         newCancellationPreBillCreated.setDeptId(commonDeptAndInsId);
         newCancellationPreBillCreated.setInsId(commonDeptAndInsId);

--- a/src/main/resources/META-INF/persistence.xml
+++ b/src/main/resources/META-INF/persistence.xml
@@ -2,17 +2,17 @@
 <persistence version="2.2" xmlns="http://java.sun.com/xml/ns/persistence" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/persistence http://xmlns.jcp.org/xml/ns/persistence/persistence_2_2.xsd">
     <persistence-unit name="hmisPU" transaction-type="JTA">
         <provider>org.eclipse.persistence.jpa.PersistenceProvider</provider>
-        <jta-data-source>${JDBC_DATASOURCE}</jta-data-source>
+        <jta-data-source>jdbc/sl</jta-data-source>
         <exclude-unlisted-classes>false</exclude-unlisted-classes>
         <properties>
-            <property name="eclipselink.logging.level" value="SEVERE"/>
+            <property name="eclipselink.logging.level.sql" value="SEVERE"/>
         </properties>
     </persistence-unit>
     <persistence-unit name="hmisAuditPU" transaction-type="JTA">
-        <jta-data-source>${JDBC_AUDIT_DATASOURCE}</jta-data-source>
+        <jta-data-source>jdbc/ruhunuAudit</jta-data-source>
         <exclude-unlisted-classes>false</exclude-unlisted-classes>
         <properties>
-            <property name="eclipselink.logging.level" value="SEVERE"/>
+            <property name="eclipselink.logging.level.sql" value="SEVERE"/>
         </properties>
     </persistence-unit>
 </persistence>

--- a/src/main/resources/META-INF/persistence.xml
+++ b/src/main/resources/META-INF/persistence.xml
@@ -2,17 +2,17 @@
 <persistence version="2.2" xmlns="http://java.sun.com/xml/ns/persistence" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/persistence http://xmlns.jcp.org/xml/ns/persistence/persistence_2_2.xsd">
     <persistence-unit name="hmisPU" transaction-type="JTA">
         <provider>org.eclipse.persistence.jpa.PersistenceProvider</provider>
-        <jta-data-source>jdbc/sl</jta-data-source>
+        <jta-data-source>${JDBC_DATASOURCE}</jta-data-source>
         <exclude-unlisted-classes>false</exclude-unlisted-classes>
         <properties>
-            <property name="eclipselink.logging.level.sql" value="SEVERE"/>
+            <property name="eclipselink.logging.level" value="SEVERE"/>
         </properties>
     </persistence-unit>
     <persistence-unit name="hmisAuditPU" transaction-type="JTA">
-        <jta-data-source>jdbc/ruhunuAudit</jta-data-source>
+        <jta-data-source>${JDBC_AUDIT_DATASOURCE}</jta-data-source>
         <exclude-unlisted-classes>false</exclude-unlisted-classes>
         <properties>
-            <property name="eclipselink.logging.level.sql" value="SEVERE"/>
+            <property name="eclipselink.logging.level" value="SEVERE"/>
         </properties>
     </persistence-unit>
 </persistence>

--- a/src/main/webapp/analytics/bills.xhtml
+++ b/src/main/webapp/analytics/bills.xhtml
@@ -197,24 +197,24 @@
                                     <h:outputLabel value="#{bill.deptId}"/>
                                 </p:column>
                                 <p:column headerText="Bill Class" >                                
-                                    <h:outputLabel value="#{bill.billClass}"/>
+                                    <p:inputText readonly="true" value="#{bill.billClass}"/>
                                 </p:column>
                                 <p:column headerText="Bill Type" >                                
-                                    <h:outputLabel value="#{bill.billTypeAtomic.label}"/>
+                                    <p:inputText readonly="true"  value="#{bill.billTypeAtomic.label}"/>
                                 </p:column>
                                 <p:column headerText="Payment Method" >                                
-                                    <h:outputLabel value="#{bill.paymentMethod}"/>
+                                    <p:inputText readonly="true"  value="#{bill.paymentMethod}"/>
                                 </p:column>
                                 <p:column headerText="Name" sortBy="#{bill.patient.person.nameWithTitle}" filterBy="#{bill.patient.person.nameWithTitle}" filterMatchMode="contains">                                
-                                    <h:outputLabel value="#{bill.patient.person.nameWithTitle}"/>
+                                    <p:inputText readonly="true"  value="#{bill.patient.person.nameWithTitle}"/>
                                 </p:column>
                                 <p:column headerText="Date/Time">
-                                    <p:outputLabel value="#{bill.createdAt}" >
+                                    <p:inputText readonly="true"  value="#{bill.createdAt}" >
                                         <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateTimeFormat}" ></f:convertDateTime>
-                                    </p:outputLabel>
+                                    </p:inputText>
                                 </p:column>
                                 <p:column headerText="User">
-                                    <h:outputText value="#{bill.creater.name}" ></h:outputText>
+                                    <p:inputText readonly="true"  value="#{bill.creater.name}" ></p:inputText>
                                 </p:column>
                                 <p:column headerText="Status" exportable="false">
                                     <h:panelGroup>
@@ -225,9 +225,9 @@
                                 </p:column>
 
                                 <p:column headerText="Gross Value" styleClass="averageNumericColumn">
-                                    <h:outputLabel value="#{bill.total}">
+                                    <p:inputText readonly="true"   value="#{bill.total}">
                                         <f:convertNumber pattern="#,##0.00"/>
-                                    </h:outputLabel>
+                                    </p:inputText>
                                     <f:facet name="footer">
                                         <h:outputText value="#{searchController.total}">
                                             <f:convertNumber pattern="#,##0.00"/>
@@ -235,9 +235,9 @@
                                     </f:facet>
                                 </p:column>
                                 <p:column headerText="Discount" styleClass="averageNumericColumn">
-                                    <h:outputLabel value="#{bill.discount}">
+                                    <p:inputText readonly="true"   value="#{bill.discount}">
                                         <f:convertNumber pattern="#,##0.00"/>
-                                    </h:outputLabel>
+                                    </p:inputText>
                                     <f:facet name="footer">
                                         <h:outputText value="#{searchController.discount}">
                                             <f:convertNumber pattern="#,##0.00"/>
@@ -245,9 +245,9 @@
                                     </f:facet>
                                 </p:column>
                                 <p:column headerText="Net Value" styleClass="averageNumericColumn">
-                                    <h:outputLabel value="#{bill.netTotal}">
+                                    <p:inputText readonly="true"   value="#{bill.netTotal}">
                                         <f:convertNumber pattern="#,##0.00"/>
-                                    </h:outputLabel>
+                                    </p:inputText>
                                     <f:facet name="footer">
                                         <h:outputText value="#{searchController.netTotal}">
                                             <f:convertNumber pattern="#,##0.00"/>
@@ -255,32 +255,29 @@
                                     </f:facet>
                                 </p:column>
 
-                                <p:column headerText="No" exportable="false" styleClass="alignTop">
+                                <p:column headerText="Actions" exportable="false" width="9em">
                                     <p:commandButton 
-                                        value="View" 
+                                        title="View" 
                                         icon="fa fa-eye" 
                                         class="m-1 ui-button-info"
-                                        style="width: 100px;"
                                         action="#{billSearch.navigateToViewBillByAtomicBillType()}" 
                                         ajax="false">
                                         <f:setPropertyActionListener value="#{bill}" target="#{billSearch.bill}" />
                                     </p:commandButton>
 
                                     <p:commandButton 
-                                        value="Manage" 
+                                        title="Manage" 
                                         icon="fa fa-tools" 
                                         class="m-1 ui-button-warning" 
-                                        style="width: 100px;"
                                         action="#{billSearch.navigateToManageBillByAtomicBillType()}" 
                                         ajax="false">
                                         <f:setPropertyActionListener value="#{bill}" target="#{billSearch.bill}" />
                                     </p:commandButton>
 
                                     <p:commandButton 
-                                        value="Admin" 
+                                        title="Admin" 
                                         icon="fa fa-shield-alt" 
                                         class="m-1 ui-button-danger" 
-                                        style="width: 100px;"
                                         action="#{billSearch.navigateToAdminBillByAtomicBillType()}" 
                                         ajax="false" 
                                         rendered="#{webUserController.hasPrivilege('Developers')}">


### PR DESCRIPTION
Now bill type atomic is created for Retail Sale Cancellation Pre Bill
![image](https://github.com/user-attachments/assets/77252a88-e806-42d3-97d8-f9c80731b656)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced enhanced handling for pharmacy retail sale cancellations, including pre-bill creation and improved stock management during cancellation.
  - Added a new bill type for pharmacy retail sale cancellation pre-bills.

- **Refactor**
  - Updated the pharmacy retail sale cancellation workflow to streamline references, payment handling, and bill linking.

- **Style**
  - Improved the readability of bill data in analytics tables by using consistent read-only input fields and updated column headers for clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->