### PR TITLE
11782 need a method in bill administration to fix wrongly assigned bills for bill items for cancellation bills

### DIFF
--- a/src/main/java/com/divudi/bean/common/BillController.java
+++ b/src/main/java/com/divudi/bean/common/BillController.java
@@ -129,8 +129,6 @@ public class BillController implements Serializable, ControllerWithMultiplePayme
     @EJB
     PaymentFacade paymentFacade;
     @EJB
-    BillItemFacade billItemFacede;
-    @EJB
     BillService billService;
     @EJB
     StaffService staffService;
@@ -2370,7 +2368,7 @@ public class BillController implements Serializable, ControllerWithMultiplePayme
             newBillItem.setCreater(getSessionController().getLoggedUser());
             newBillItem.setPaidForBillFee(originalBillItem.getPaidForBillFee());
             newBillItem.setReferanceBillItem(originalBillItem);
-            billItemFacede.create(newBillItem);
+            billItemFacade.create(newBillItem);
 
             cancelBillComponents(originalBill, cancellationBill, originalBillItem, newBillItem);
 

--- a/src/main/java/com/divudi/bean/common/BillItemController.java
+++ b/src/main/java/com/divudi/bean/common/BillItemController.java
@@ -9,7 +9,9 @@
 package com.divudi.bean.common;
 
 import com.divudi.core.entity.BillItem;
+import com.divudi.core.entity.pharmacy.PharmaceuticalBillItem;
 import com.divudi.core.facade.BillItemFacade;
+import com.divudi.core.facade.PharmaceuticalBillItemFacade;
 import java.io.Serializable;
 import java.util.Date;
 import java.util.List;
@@ -36,6 +38,8 @@ public class BillItemController implements Serializable {
 
     @EJB
     BillItemFacade billItemFacade;
+    @EJB
+    PharmaceuticalBillItemFacade pharmaceuticalBillItemFacade;
 
     @Inject
     SessionController sessionController;
@@ -68,11 +72,37 @@ public class BillItemController implements Serializable {
         }
     }
 
+    public void save(PharmaceuticalBillItem sbi) {
+        if (sbi == null) {
+            return;
+        }
+        if (sbi.getId() == null) {
+            if (sbi.getCreatedAt() == null) {
+                sbi.setCreatedAt(new Date());
+            }
+            if (sbi.getCreater() == null) {
+                sbi.setCreater(sessionController.getLoggedUser());
+            }
+            pharmaceuticalBillItemFacade.create(sbi);
+        } else {
+            pharmaceuticalBillItemFacade.edit(sbi);
+        }
+    }
+
     public void save(List<BillItem> billItems) {
         if (billItems == null || billItems.isEmpty()) {
             return;
         }
         for (BillItem sbi : billItems) {
+            save(sbi);
+        }
+    }
+
+    public void savePharmaceuticalItems(List<PharmaceuticalBillItem> pharmaceuticalBillItems) {
+        if (pharmaceuticalBillItems == null || pharmaceuticalBillItems.isEmpty()) {
+            return;
+        }
+        for (PharmaceuticalBillItem sbi : pharmaceuticalBillItems) {
             save(sbi);
         }
     }
@@ -162,7 +192,6 @@ public class BillItemController implements Serializable {
 //        }
 //
 //    }
-
     @FacesConverter(forClass = BillItem.class)
     public static class BillItemControllerConverter implements Converter {
 

--- a/src/main/java/com/divudi/bean/common/BillSearch.java
+++ b/src/main/java/com/divudi/bean/common/BillSearch.java
@@ -278,6 +278,7 @@ public class BillSearch implements Serializable {
     private List<Bill> viewingRefundBills;
     private List<Bill> viewingReferanceBills;
     private List<BillItem> viewingBillItems;
+    private List<PharmaceuticalBillItem> viewingPharmaceuticalBillItems;
     private List<BillFee> viewingBillFees;
     private List<BillComponent> viewingBillComponents;
     private List<Payment> viewingBillPayments;
@@ -1807,6 +1808,7 @@ public class BillSearch implements Serializable {
     public void saveViewingBillData() {
         billController.save(viewingBill);
         billItemController.save(viewingBillItems);
+        billItemController.savePharmaceuticalItems(viewingPharmaceuticalBillItems);
         billFeeController.save(viewingBillFees);
         paymentController.save(viewingBillPayments);
     }
@@ -5240,9 +5242,8 @@ public class BillSearch implements Serializable {
         viewingIndividualBillsOfBatchBill = billBean.fetchIndividualBillsOfBatchBill(bill);
         viewingRefundBills = billBean.fetchRefundBillsOfBilledBill(bill);
         viewingBillItems = billService.fetchBillItems(bill);
-//        System.out.println("viewingBillItems = " + viewingBillItems);
+        viewingPharmaceuticalBillItems = billService.fetchPharmaceuticalBillItems(bill);
         viewingBillFees = billService.fetchBillFees(bill);
-//        System.out.println("viewingBillFees = " + viewingBillFees);
         viewingBillComponents = billBean.fetchBillComponents(bill);
         viewingBillPayments = billBean.fetchBillPayments(bill);
         viewingReferanceBills = billService.fetchAllReferanceBills(bill);
@@ -5263,6 +5264,8 @@ public class BillSearch implements Serializable {
     public void setViewingBillItems(List<BillItem> viewingBillItems) {
         this.viewingBillItems = viewingBillItems;
     }
+    
+    
 
     public List<BillFee> getViewingBillFees() {
         return viewingBillFees;
@@ -5334,6 +5337,14 @@ public class BillSearch implements Serializable {
 
     public void setViewingReferanceBills(List<Bill> viewingReferanceBills) {
         this.viewingReferanceBills = viewingReferanceBills;
+    }
+
+    public List<PharmaceuticalBillItem> getViewingPharmaceuticalBillItems() {
+        return viewingPharmaceuticalBillItems;
+    }
+
+    public void setViewingPharmaceuticalBillItems(List<PharmaceuticalBillItem> viewingPharmaceuticalBillItems) {
+        this.viewingPharmaceuticalBillItems = viewingPharmaceuticalBillItems;
     }
 
     public class PaymentSummary {

--- a/src/main/java/com/divudi/core/data/BillTypeAtomic.java
+++ b/src/main/java/com/divudi/core/data/BillTypeAtomic.java
@@ -370,6 +370,9 @@ public enum BillTypeAtomic {
     private final PaymentCategory paymentCategory;
 
     public static BillTypeAtomic getBillTypeAtomic(BillType billType, BillClassType billClassType) {
+        System.out.println("getBillTypeAtomic");
+        System.out.println("billClassType = " + billClassType);
+        System.out.println("billType = " + billType);
         switch (billClassType) {
             case Bill:
                 switch (billType) {

--- a/src/main/java/com/divudi/core/data/BillTypeAtomic.java
+++ b/src/main/java/com/divudi/core/data/BillTypeAtomic.java
@@ -407,6 +407,8 @@ public enum BillTypeAtomic {
                         return BillTypeAtomic.PHARMACY_WHOLESALE_GRN_BILL_CANCELLED;
                     case PharmacyPurchaseBill:
                         return BillTypeAtomic.PHARMACY_DIRECT_PURCHASE_CANCELLED;
+                    case PharmacyPre:
+                        return BillTypeAtomic.PHARMACY_RETAIL_SALE_CANCELLED_PRE;
                 }
                 return null;
             case RefundBill:

--- a/src/main/java/com/divudi/core/entity/BillItem.java
+++ b/src/main/java/com/divudi/core/entity/BillItem.java
@@ -113,6 +113,7 @@ public class BillItem implements Serializable, RetirableEntity {
     WebUser retirer;
     @Temporal(javax.persistence.TemporalType.TIMESTAMP)
     Date retiredAt;
+    @Lob
     String retireComments;
     String insId;
     String deptId;

--- a/src/main/java/com/divudi/core/entity/pharmacy/PharmaceuticalBillItem.java
+++ b/src/main/java/com/divudi/core/entity/pharmacy/PharmaceuticalBillItem.java
@@ -7,6 +7,7 @@ package com.divudi.core.entity.pharmacy;
 import com.divudi.core.entity.BillItem;
 import com.divudi.core.entity.Category;
 import com.divudi.core.entity.Institution;
+import com.divudi.core.entity.WebUser;
 import java.io.Serializable;
 import java.util.Date;
 import javax.persistence.Entity;
@@ -107,6 +108,20 @@ public class PharmaceuticalBillItem implements Serializable {
 
     @ManyToOne
     private Institution manufacturer;
+
+    //Created Properties
+    @ManyToOne
+    private WebUser creater;
+    @Temporal(javax.persistence.TemporalType.TIMESTAMP)
+    private Date createdAt;
+    //Retairing properties
+    private boolean retired;
+    @ManyToOne
+    private WebUser retirer;
+    @Temporal(javax.persistence.TemporalType.TIMESTAMP)
+    private Date retiredAt;
+    @Lob
+    private String retireComments;
 
     @Transient
     private double transQtyPlusFreeQty;
@@ -368,7 +383,6 @@ public class PharmaceuticalBillItem implements Serializable {
 //        }
         return qty;
     }
-
 
     public void setQty(double qty) {
 //        if (getBillItem() != null && getBillItem().getItem() instanceof Ampp || getBillItem() != null && getBillItem().getItem() instanceof Vmpp) {
@@ -721,7 +735,53 @@ public class PharmaceuticalBillItem implements Serializable {
         this.afterAdjustmentExpiry = afterAdjustmentExpiry;
     }
 
+    public WebUser getCreater() {
+        return creater;
+    }
 
+    public void setCreater(WebUser creater) {
+        this.creater = creater;
+    }
 
+    public Date getCreatedAt() {
+        return createdAt;
+    }
+
+    public void setCreatedAt(Date createdAt) {
+        this.createdAt = createdAt;
+    }
+
+    public boolean isRetired() {
+        return retired;
+    }
+
+    public void setRetired(boolean retired) {
+        this.retired = retired;
+    }
+
+    public WebUser getRetirer() {
+        return retirer;
+    }
+
+    public void setRetirer(WebUser retirer) {
+        this.retirer = retirer;
+    }
+
+    public Date getRetiredAt() {
+        return retiredAt;
+    }
+
+    public void setRetiredAt(Date retiredAt) {
+        this.retiredAt = retiredAt;
+    }
+
+    public String getRetireComments() {
+        return retireComments;
+    }
+
+    public void setRetireComments(String retireComments) {
+        this.retireComments = retireComments;
+    }
+    
 
 }

--- a/src/main/java/com/divudi/service/BillService.java
+++ b/src/main/java/com/divudi/service/BillService.java
@@ -465,6 +465,17 @@ public class BillService {
         return billItemFacade.findByJpql(jpql, params);
     }
 
+    public List<PharmaceuticalBillItem> fetchPharmaceuticalBillItems(Bill b) {
+        String jpql;
+        HashMap params = new HashMap();
+        jpql = "SELECT pbi "
+                + " FROM PharmaceuticalBillItem pbi "
+                + " WHERE pbi.billItem.bill=:bl "
+                + " order by pbi.id";
+        params.put("bl", b);
+        return pharmaceuticalBillItemFacade.findByJpql(jpql, params);
+    }
+
     public Long fetchBillItemCount(Bill b) {
         String jpql;
         HashMap params = new HashMap();
@@ -524,7 +535,7 @@ public class BillService {
                 + "order by p.id";
         if (batchBill != null) {
             params.put("bill", batchBill);
-        }else{
+        } else {
             params.put("bill", bill);
         }
         fetchingBillComponents = paymentFacade.findByJpql(jpql, params);
@@ -786,7 +797,7 @@ public class BillService {
         List<Bill> fetchedBills = billFacade.findByJpql(jpql, params, TemporalType.TIMESTAMP);
         return fetchedBills;
     }
-    
+
     public List<BillItem> fetchBillItems(Date fromDate,
             Date toDate,
             Institution institution,
@@ -803,7 +814,7 @@ public class BillService {
                 + " from BillItem bi "
                 + " join bi.bill b "
                 + " where (b.retired=false or b.retired is null) "
-                 + " and (bi.retired=false or bi.retired is null) "
+                + " and (bi.retired=false or bi.retired is null) "
                 + " and b.billTypeAtomic in :billTypesAtomics "
                 + " and b.createdAt between :fromDate and :toDate ";
 
@@ -845,7 +856,7 @@ public class BillService {
         List<BillItem> fetchedBillItems = billItemFacade.findByJpql(jpql, params, TemporalType.TIMESTAMP);
         return fetchedBillItems;
     }
-    
+
     public List<PharmaceuticalBillItem> fetchPharmaceuticalBillItems(Date fromDate,
             Date toDate,
             Institution institution,
@@ -863,7 +874,7 @@ public class BillService {
                 + " join pbi.billItem bi "
                 + " join bi.bill b "
                 + " where (b.retired=false or b.retired is null) "
-                 + " and (bi.retired=false or bi.retired is null) "
+                + " and (bi.retired=false or bi.retired is null) "
                 + " and b.billTypeAtomic in :billTypesAtomics "
                 + " and b.createdAt between :fromDate and :toDate ";
 

--- a/src/main/resources/META-INF/persistence.xml
+++ b/src/main/resources/META-INF/persistence.xml
@@ -2,17 +2,17 @@
 <persistence version="2.2" xmlns="http://java.sun.com/xml/ns/persistence" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/persistence http://xmlns.jcp.org/xml/ns/persistence/persistence_2_2.xsd">
     <persistence-unit name="hmisPU" transaction-type="JTA">
         <provider>org.eclipse.persistence.jpa.PersistenceProvider</provider>
-        <jta-data-source>${JDBC_DATASOURCE}</jta-data-source>
+        <jta-data-source>jdbc/sl</jta-data-source>
         <exclude-unlisted-classes>false</exclude-unlisted-classes>
         <properties>
-            <property name="eclipselink.logging.level" value="SEVERE"/>
+            <property name="eclipselink.logging.level.sql" value="SEVERE"/>
         </properties>
     </persistence-unit>
     <persistence-unit name="hmisAuditPU" transaction-type="JTA">
-        <jta-data-source>${JDBC_AUDIT_DATASOURCE}</jta-data-source>
+        <jta-data-source>jdbc/ruhunuAudit</jta-data-source>
         <exclude-unlisted-classes>false</exclude-unlisted-classes>
         <properties>
-            <property name="eclipselink.logging.level" value="SEVERE"/>
+            <property name="eclipselink.logging.level.sql" value="SEVERE"/>
         </properties>
     </persistence-unit>
 </persistence>

--- a/src/main/resources/META-INF/persistence.xml
+++ b/src/main/resources/META-INF/persistence.xml
@@ -2,17 +2,17 @@
 <persistence version="2.2" xmlns="http://java.sun.com/xml/ns/persistence" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/persistence http://xmlns.jcp.org/xml/ns/persistence/persistence_2_2.xsd">
     <persistence-unit name="hmisPU" transaction-type="JTA">
         <provider>org.eclipse.persistence.jpa.PersistenceProvider</provider>
-        <jta-data-source>jdbc/sl</jta-data-source>
+        <jta-data-source>${JDBC_DATASOURCE}</jta-data-source>
         <exclude-unlisted-classes>false</exclude-unlisted-classes>
         <properties>
-            <property name="eclipselink.logging.level.sql" value="SEVERE"/>
+            <property name="eclipselink.logging.level" value="SEVERE"/>
         </properties>
     </persistence-unit>
     <persistence-unit name="hmisAuditPU" transaction-type="JTA">
-        <jta-data-source>jdbc/ruhunuAudit</jta-data-source>
+        <jta-data-source>${JDBC_AUDIT_DATASOURCE}</jta-data-source>
         <exclude-unlisted-classes>false</exclude-unlisted-classes>
         <properties>
-            <property name="eclipselink.logging.level.sql" value="SEVERE"/>
+            <property name="eclipselink.logging.level" value="SEVERE"/>
         </properties>
     </persistence-unit>
 </persistence>

--- a/src/main/webapp/analytics/bill_types.xhtml
+++ b/src/main/webapp/analytics/bill_types.xhtml
@@ -159,8 +159,8 @@
                                 <p:column headerText="Bill Class" >                                
                                     <h:outputLabel value="#{row.billClassType}"/>
                                 </p:column>
-                                <p:column headerText="Bill Type (Atomic)" >                                
-                                    <h:outputLabel value="#{row.billTypeAtomic.label}"/>
+                                <p:column headerText="Bill Type (Atomic)" sortBy="#{row.billTypeAtomic}" filterBy="#{row.billTypeAtomic}" filterMatchMode="contains">                                
+                                    <h:outputLabel value="#{row.billTypeAtomic}"/>
                                 </p:column>
                                  <p:column headerText="Bill Type (Atomic)" >                                
                                      <h:outputLabel value="#{row.billTypeAtomic.billFinanceType}"/>

--- a/src/main/webapp/dataAdmin/admin_functions.xhtml
+++ b/src/main/webapp/dataAdmin/admin_functions.xhtml
@@ -15,6 +15,18 @@
                 <h:form >
 
                     <div class='row' >
+
+
+                        <div class="col-12 col-md-4 col-lg-2 p-1">
+                            <p:commandButton 
+                                ajax="false"
+                                disabled="false"
+                                action="#{billController.addMissingBillTypeAtomics}"
+                                class="w-100 m-1"
+                                value="Add Bill Type Atomics"/>
+                        </div>
+
+
                         <div class="col-12 col-md-4 col-lg-2 p-1" >
                             <p:commandButton 
                                 class="w-100"
@@ -104,14 +116,7 @@
                                 value="Make All OPD Services and Investigations to Allow Discounts"/>
                         </div>
 
-                        <div class="col-12 col-md-4 col-lg-2 p-1">
-                            <p:commandButton 
-                                ajax="false"
-                                disabled="false"
-                                action="#{billController.addMissingBillTypeAtomics}"
-                                class="w-100 m-1"
-                                value="Add Bill Type Atomics"/>
-                        </div>
+
 
                         <div class="col-12 col-md-4 col-lg-2 p-1">
                             <p:commandButton 

--- a/src/main/webapp/opd/view/bill_admin.xhtml
+++ b/src/main/webapp/opd/view/bill_admin.xhtml
@@ -42,7 +42,7 @@
                                     <p:tab title="Bill Items" >
                                         <view:bill_item_list_edit editable="true" billItems="#{billSearch.viewingBillItems}"/>
                                         
-                                        <view:pharmaceutical_bill_item_list_edit editable="true" billItems="#{billSearch.viewingPharmaceuticalBillItems}"/>
+                                        <!--<view:pharmaceutical_bill_item_list_edit editable="true" pharmaceuticalBillItems="#{billSearch.viewingPharmaceuticalBillItems}"/>-->
                                         
                                     </p:tab>
                                     <p:tab title="Bill Fees" >

--- a/src/main/webapp/opd/view/bill_admin.xhtml
+++ b/src/main/webapp/opd/view/bill_admin.xhtml
@@ -41,6 +41,9 @@
                                     </p:tab>
                                     <p:tab title="Bill Items" >
                                         <view:bill_item_list_edit editable="true" billItems="#{billSearch.viewingBillItems}"/>
+                                        
+                                        <view:pharmaceutical_bill_item_list_edit editable="true" billItems="#{billSearch.viewingPharmaceuticalBillItems}"/>
+                                        
                                     </p:tab>
                                     <p:tab title="Bill Fees" >
                                         <view:bill_fee_list_edit editable="true" billFees="#{billSearch.viewingBillFees}" ></view:bill_fee_list_edit>

--- a/src/main/webapp/opd/view/bill_admin.xhtml
+++ b/src/main/webapp/opd/view/bill_admin.xhtml
@@ -42,7 +42,7 @@
                                     <p:tab title="Bill Items" >
                                         <view:bill_item_list_edit editable="true" billItems="#{billSearch.viewingBillItems}"/>
                                         
-                                        <!--<view:pharmaceutical_bill_item_list_edit editable="true" pharmaceuticalBillItems="#{billSearch.viewingPharmaceuticalBillItems}"/>-->
+                                        <view:pharmaceutical_bill_item_list_edit editable="true" pharmaceuticalBillItems="#{billSearch.viewingPharmaceuticalBillItems}"/>
                                         
                                     </p:tab>
                                     <p:tab title="Bill Fees" >
@@ -179,9 +179,9 @@
                                             rowsPerPageTemplate="5,10,15,50"
                                             >
 
-<!--                                            <p:column rendered="#{webUserController.hasPrivilege('Developers')}" headerText="Bill ID" sortBy="#{bill.id}" filterBy="#{bill.id}" filterMatchMode="contains" >                                
+                                            <p:column headerText="Bill ID" sortBy="#{bill.id}" filterBy="#{bill.id}" filterMatchMode="contains" >                                
                                                 <h:outputLabel value="#{bill.id}"/>
-                                            </p:column>-->
+                                            </p:column>
             <!--                                <p:column rendered="#{webUserController.hasPrivilege('Developers')}" headerText="Ins ID" sortBy="#{bill.insId}" filterBy="#{bill.insId}" filterMatchMode="contains" >                                
                                                 <h:outputLabel value="#{bill.insId}"/>
                                             </p:column>-->

--- a/src/main/webapp/resources/ezcomp/view/bill_item_list_edit.xhtml
+++ b/src/main/webapp/resources/ezcomp/view/bill_item_list_edit.xhtml
@@ -25,11 +25,17 @@
             <f:facet name="header" >
                 <h:outputText value="Bill Items" ></h:outputText>
             </f:facet>
-            <!--            <p:column >
-                            <h:outputText value="#{bi.id}" class="w-100 m-1"></h:outputText>
-                        </p:column>-->
-            <p:column >
+            <p:column headerText="Item" >
+                <h:outputText value="#{bi.id}" class="w-100 m-1"></h:outputText>
+            </p:column>
+            <p:column headerText="Item Name">
                 <h:outputText value="#{bi.item.name}" ></h:outputText>
+            </p:column>
+            <p:column headerText="Referance Bill Item ID">
+                <h:outputText value="#{bi.referanceBillItem.id}" ></h:outputText>
+            </p:column>
+            <p:column headerText="Pharmaceutical Bill Item ID">
+                <h:outputText value="#{bi.pharmaceuticalBillItem.id}" ></h:outputText>
             </p:column>
             <p:column headerText="Quantity" class="text-end">
                 <p:inputText value="#{bi.qty}" rendered="#{cc.attrs.editable}" class="w-100 m-1 text-end" />

--- a/src/main/webapp/resources/ezcomp/view/pharmaceutical_bill_item_list_edit.xhtml
+++ b/src/main/webapp/resources/ezcomp/view/pharmaceutical_bill_item_list_edit.xhtml
@@ -28,61 +28,7 @@
             <p:column headerText="ID">
                 <h:outputText value="#{bi.id}" class="w-100 m-1"></h:outputText>
             </p:column>
-            <p:column headerText="Bill Item ID">
-                <h:outputText value="#{bi.billItem.item.name}" ></h:outputText>
-            </p:column>
-            <p:column headerText="Item Name">
-                <h:outputText value="#{bi.billItem.item.name}" ></h:outputText>
-            </p:column>
-            <p:column headerText="Quantity" class="text-end">
-                <p:inputText value="#{bi.qty}" rendered="#{cc.attrs.editable}" class="w-100 m-1 text-end" />
-                <p:outputLabel value="#{bi.qty}" rendered="#{!cc.attrs.editable}" class="text-end" />
-            </p:column>
-            <p:column headerText="Rate" class="text-end">
-                <p:inputText value="#{bi.netRate}" rendered="#{cc.attrs.editable}" class="w-100 m-1 text-end" />
-                <p:outputLabel value="#{bi.netRate}" rendered="#{!cc.attrs.editable}" class="text-end" />
-            </p:column>
-             <p:column headerText="Margin Rate" class="text-end">
-                <p:inputText value="#{bi.marginRate}" rendered="#{cc.attrs.editable}" class="w-100 m-1 text-end" />
-                <p:outputLabel value="#{bi.marginRate}" rendered="#{!cc.attrs.editable}" class="text-end" />
-            </p:column>
-            <p:column headerText="Hospital Fee" class="text-end">
-                <p:inputText value="#{bi.hospitalFee}" rendered="#{cc.attrs.editable}" class="w-100 m-1 text-end" />
-                <h:outputText value="#{bi.hospitalFee}" rendered="#{!cc.attrs.editable}" class="text-end" />
-            </p:column>
-            <p:column headerText="Staff Fee" class="text-end">
-                <p:inputText value="#{bi.staffFee}" rendered="#{cc.attrs.editable}" class="w-100 m-1 text-end" />
-                <h:outputText value="#{bi.staffFee}" rendered="#{!cc.attrs.editable}" class="text-end" />
-            </p:column>
-            <p:column headerText="Collecting Centre Fee" class="text-end">
-                <p:inputText value="#{bi.collectingCentreFee}" rendered="#{cc.attrs.editable}" class="w-100 m-1 text-end" />
-                <h:outputText value="#{bi.collectingCentreFee}" rendered="#{!cc.attrs.editable}" class="text-end" />
-            </p:column>
-            <p:column headerText="Other Fee" class="text-end">
-                <p:inputText value="#{bi.otherFee}" rendered="#{cc.attrs.editable}" class="w-100 m-1 text-end" />
-                <h:outputText value="#{bi.otherFee}" rendered="#{!cc.attrs.editable}" class="text-end" />
-            </p:column>
-            <p:column headerText="Gross Value" class="text-end">
-                <p:inputText value="#{bi.grossValue}" rendered="#{cc.attrs.editable}" class="w-100 m-1 text-end" />
-                <h:outputText value="#{bi.grossValue}" rendered="#{!cc.attrs.editable}" class="text-end" />
-            </p:column>
-            <p:column headerText="Discount" class="text-end">
-                <p:inputText value="#{bi.discount}" rendered="#{cc.attrs.editable}" class="w-100 m-1 text-end" />
-                <h:outputText value="#{bi.discount}" rendered="#{!cc.attrs.editable}" class="text-end" />
-            </p:column>
-              <p:column headerText="Service Charge" class="text-end">
-                <p:inputText value="#{bi.marginValue}" rendered="#{cc.attrs.editable}" class="w-100 m-1 text-end" />
-                <h:outputText value="#{bi.marginValue}" rendered="#{!cc.attrs.editable}" class="text-end" />
-            </p:column>
-            <p:column headerText="Net Value" class="text-end">
-                <p:inputText value="#{bi.netValue}" rendered="#{cc.attrs.editable}" class="w-100 m-1 text-end" />
-                <h:outputText value="#{bi.netValue}" rendered="#{!cc.attrs.editable}" class="text-end" />
-            </p:column>
-            <p:column headerText="Retired" class="text-end">
-                <p:selectBooleanCheckbox value="#{bi.retired}" rendered="#{cc.attrs.editable}" class="text-end" />
-                <p:outputLabel value="#{bi.retired ? 'Yes' : 'No'}" rendered="#{!cc.attrs.editable}" class="text-end" />
-            </p:column>
-
+          
         </p:dataTable>
 
     </cc:implementation>

--- a/src/main/webapp/resources/ezcomp/view/pharmaceutical_bill_item_list_edit.xhtml
+++ b/src/main/webapp/resources/ezcomp/view/pharmaceutical_bill_item_list_edit.xhtml
@@ -1,0 +1,89 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:cc="http://xmlns.jcp.org/jsf/composite"
+      xmlns:p="http://primefaces.org/ui"
+      xmlns:h="http://xmlns.jcp.org/jsf/html"
+      xmlns:f="http://xmlns.jcp.org/jsf/core">
+
+    <!-- INTERFACE -->
+    <cc:interface>
+        <cc:attribute name="pharmaceuticalBillItems" type="com.divudi.core.entity.pharmacy.PharmaceuticalBillItem"/>
+        <cc:attribute name="editable" type="java.lang.Boolean" />
+    </cc:interface>
+
+    <!-- IMPLEMENTATION -->
+    <cc:implementation>
+
+        <p:commandButton value="Download" ajax="false">
+            <p:dataExporter fileName="bill_items" target="tblBillItems" type="xlsx" ></p:dataExporter>
+        </p:commandButton>
+
+        <p:dataTable 
+            id="tblBillItems"
+            value="#{cc.attrs.pharmaceuticalBillItems}" var="bi" rowKey="#{bi.id}" >
+            <f:facet name="header" >
+                <h:outputText value="Bill Items" ></h:outputText>
+            </f:facet>
+            <p:column headerText="ID">
+                <h:outputText value="#{bi.id}" class="w-100 m-1"></h:outputText>
+            </p:column>
+            <p:column headerText="Bill Item ID">
+                <h:outputText value="#{bi.billItem.item.name}" ></h:outputText>
+            </p:column>
+            <p:column headerText="Item Name">
+                <h:outputText value="#{bi.billItem.item.name}" ></h:outputText>
+            </p:column>
+            <p:column headerText="Quantity" class="text-end">
+                <p:inputText value="#{bi.qty}" rendered="#{cc.attrs.editable}" class="w-100 m-1 text-end" />
+                <p:outputLabel value="#{bi.qty}" rendered="#{!cc.attrs.editable}" class="text-end" />
+            </p:column>
+            <p:column headerText="Rate" class="text-end">
+                <p:inputText value="#{bi.netRate}" rendered="#{cc.attrs.editable}" class="w-100 m-1 text-end" />
+                <p:outputLabel value="#{bi.netRate}" rendered="#{!cc.attrs.editable}" class="text-end" />
+            </p:column>
+             <p:column headerText="Margin Rate" class="text-end">
+                <p:inputText value="#{bi.marginRate}" rendered="#{cc.attrs.editable}" class="w-100 m-1 text-end" />
+                <p:outputLabel value="#{bi.marginRate}" rendered="#{!cc.attrs.editable}" class="text-end" />
+            </p:column>
+            <p:column headerText="Hospital Fee" class="text-end">
+                <p:inputText value="#{bi.hospitalFee}" rendered="#{cc.attrs.editable}" class="w-100 m-1 text-end" />
+                <h:outputText value="#{bi.hospitalFee}" rendered="#{!cc.attrs.editable}" class="text-end" />
+            </p:column>
+            <p:column headerText="Staff Fee" class="text-end">
+                <p:inputText value="#{bi.staffFee}" rendered="#{cc.attrs.editable}" class="w-100 m-1 text-end" />
+                <h:outputText value="#{bi.staffFee}" rendered="#{!cc.attrs.editable}" class="text-end" />
+            </p:column>
+            <p:column headerText="Collecting Centre Fee" class="text-end">
+                <p:inputText value="#{bi.collectingCentreFee}" rendered="#{cc.attrs.editable}" class="w-100 m-1 text-end" />
+                <h:outputText value="#{bi.collectingCentreFee}" rendered="#{!cc.attrs.editable}" class="text-end" />
+            </p:column>
+            <p:column headerText="Other Fee" class="text-end">
+                <p:inputText value="#{bi.otherFee}" rendered="#{cc.attrs.editable}" class="w-100 m-1 text-end" />
+                <h:outputText value="#{bi.otherFee}" rendered="#{!cc.attrs.editable}" class="text-end" />
+            </p:column>
+            <p:column headerText="Gross Value" class="text-end">
+                <p:inputText value="#{bi.grossValue}" rendered="#{cc.attrs.editable}" class="w-100 m-1 text-end" />
+                <h:outputText value="#{bi.grossValue}" rendered="#{!cc.attrs.editable}" class="text-end" />
+            </p:column>
+            <p:column headerText="Discount" class="text-end">
+                <p:inputText value="#{bi.discount}" rendered="#{cc.attrs.editable}" class="w-100 m-1 text-end" />
+                <h:outputText value="#{bi.discount}" rendered="#{!cc.attrs.editable}" class="text-end" />
+            </p:column>
+              <p:column headerText="Service Charge" class="text-end">
+                <p:inputText value="#{bi.marginValue}" rendered="#{cc.attrs.editable}" class="w-100 m-1 text-end" />
+                <h:outputText value="#{bi.marginValue}" rendered="#{!cc.attrs.editable}" class="text-end" />
+            </p:column>
+            <p:column headerText="Net Value" class="text-end">
+                <p:inputText value="#{bi.netValue}" rendered="#{cc.attrs.editable}" class="w-100 m-1 text-end" />
+                <h:outputText value="#{bi.netValue}" rendered="#{!cc.attrs.editable}" class="text-end" />
+            </p:column>
+            <p:column headerText="Retired" class="text-end">
+                <p:selectBooleanCheckbox value="#{bi.retired}" rendered="#{cc.attrs.editable}" class="text-end" />
+                <p:outputLabel value="#{bi.retired ? 'Yes' : 'No'}" rendered="#{!cc.attrs.editable}" class="text-end" />
+            </p:column>
+
+        </p:dataTable>
+
+    </cc:implementation>
+</html>

--- a/src/main/webapp/resources/ezcomp/view/pharmaceutical_bill_item_list_edit.xhtml
+++ b/src/main/webapp/resources/ezcomp/view/pharmaceutical_bill_item_list_edit.xhtml
@@ -64,6 +64,13 @@
                     <f:convertNumber pattern="#,##0.00" />
                 </h:outputText>
             </p:column>
+            <p:column headerText="Actions">
+                <p:commandButton 
+                    value="Fix" 
+                    action="#{billController.convertPharmaceuticalBillItemReferanceFromErronouslyRecordedPharmacyRetailSaleCancellationPreBillToPharmacyRetailSalePreBill(bi)}" 
+                    ajax="false"
+                    ></p:commandButton>
+            </p:column>
 
 
         </p:dataTable>

--- a/src/main/webapp/resources/ezcomp/view/pharmaceutical_bill_item_list_edit.xhtml
+++ b/src/main/webapp/resources/ezcomp/view/pharmaceutical_bill_item_list_edit.xhtml
@@ -8,7 +8,7 @@
 
     <!-- INTERFACE -->
     <cc:interface>
-        <cc:attribute name="pharmaceuticalBillItems" type="com.divudi.core.entity.pharmacy.PharmaceuticalBillItem"/>
+        <cc:attribute name="pharmaceuticalBillItems" />
         <cc:attribute name="editable" type="java.lang.Boolean" />
     </cc:interface>
 
@@ -23,12 +23,49 @@
             id="tblBillItems"
             value="#{cc.attrs.pharmaceuticalBillItems}" var="bi" rowKey="#{bi.id}" >
             <f:facet name="header" >
-                <h:outputText value="Bill Items" ></h:outputText>
+                <h:outputText value="Pharmaceutical Bill Items" ></h:outputText>
             </f:facet>
             <p:column headerText="ID">
                 <h:outputText value="#{bi.id}" class="w-100 m-1"></h:outputText>
             </p:column>
-          
+            <p:column headerText="Bill Item ID">
+                <h:outputText value="#{bi.billItem.id}" class="w-100 m-1"></h:outputText>
+            </p:column>
+            <p:column headerText="Item">
+                <h:outputText value="#{bi.itemBatch.item.name}" class="w-100 m-1"></h:outputText>
+            </p:column>
+            <p:column headerText="Qty">
+                <h:outputText value="#{bi.qty}" class="w-100 m-1">
+                    <f:convertNumber pattern="#,##0.00" />
+                </h:outputText>
+            </p:column>
+            <p:column headerText="Fee Qty">
+                <h:outputText value="#{bi.freeQty}" class="w-100 m-1">
+                    <f:convertNumber pattern="#,##0.00" />
+                </h:outputText>
+            </p:column>
+            <p:column headerText="Retail Rate">
+                <h:outputText value="#{bi.retailRate}" class="w-100 m-1">
+                    <f:convertNumber pattern="#,##0.00" />
+                </h:outputText>
+            </p:column>
+            <p:column headerText="Retail Value">
+                <h:outputText value="#{bi.retailValue}" class="w-100 m-1">
+                    <f:convertNumber pattern="#,##0.00" />
+                </h:outputText>
+            </p:column>
+            <p:column headerText="Purchase Rate">
+                <h:outputText value="#{bi.purchaseRate}" class="w-100 m-1">
+                    <f:convertNumber pattern="#,##0.00" />
+                </h:outputText>
+            </p:column>
+            <p:column headerText="Purchase Value">
+                <h:outputText value="#{bi.purchaseValue}" class="w-100 m-1">
+                    <f:convertNumber pattern="#,##0.00" />
+                </h:outputText>
+            </p:column>
+
+
         </p:dataTable>
 
     </cc:implementation>

--- a/src/main/webapp/resources/ezcomp/view/pharmaceutical_bill_item_list_edit.xhtml
+++ b/src/main/webapp/resources/ezcomp/view/pharmaceutical_bill_item_list_edit.xhtml
@@ -67,9 +67,12 @@
             <p:column headerText="Actions">
                 <p:commandButton 
                     value="Fix" 
-                    action="#{billController.convertPharmaceuticalBillItemReferanceFromErronouslyRecordedPharmacyRetailSaleCancellationPreBillToPharmacyRetailSalePreBill(bi)}" 
+                    action="#{billController.convertPharmaceuticalBillItemReferenceFromErroneouslyRecordedPharmacyRetailSaleCancellationPreBillToPharmacyRetailSalePreBill(bi)}" 
                     ajax="false"
-                    ></p:commandButton>
+                    onclick="return confirm('Are you sure you want to fix this pharmaceutical bill item? This action cannot be undone.');"
+                    styleClass="ui-button-warning"
+                    rendered="#{cc.attrs.editable}">
+                </p:commandButton>
             </p:column>
 
 


### PR DESCRIPTION
Closes #11782
Signed-off-by: Dr M H Buddhika Ariyaratne <buddhika.ari@gmail.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added the ability to view and edit pharmaceutical bill items alongside regular bill items in bill administration screens.
  - Introduced a new component for displaying and managing pharmaceutical bill items, including export to XLSX and a "Fix" action for correcting references.
  - Pharmaceutical bill items now track creation and retirement metadata for improved auditing.
  - Added functionality to correct erroneous pharmaceutical bill item references related to pharmacy retail sale cancellation pre-bills.

- **Improvements**
  - Enhanced bill type analytics with sortable and filterable columns.
  - Bill item lists now display additional reference information for better clarity.
  - Relocated and deduplicated the "Add Bill Type Atomics" button for easier access.
  - Improved data loading and saving to include pharmaceutical bill items in bill views.

- **Bug Fixes**
  - Made previously hidden columns (such as Bill ID) visible in relevant admin views.

- **Documentation**
  - Added headers and clarified columns in bill item tables for improved usability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->