### PR TITLE
11807 create new paper type for opd billing

### DIFF
--- a/src/main/java/com/divudi/core/data/PaperType.java
+++ b/src/main/java/com/divudi/core/data/PaperType.java
@@ -16,7 +16,8 @@ public enum PaperType {
     PosPrintedBatchPaper("POS Printed Batch Bill"),
     PosHeaderPaper("POS Bill with Header"),
     FiveFIvePaperCustom2("5 inch to 5 inch Paper with out heading Coustom 2"),
-    FiveFiveCustom3("5 inch to 5 inch Paper with out heading Custom 3");
+    FiveFiveCustom3("5 inch to 5 inch Paper with out heading Custom 3"),
+    FiveEightInchPaper("5x8 inch Paper");
 
     private String label;
 

--- a/src/main/webapp/opd/opd_batch_bill_print.xhtml
+++ b/src/main/webapp/opd/opd_batch_bill_print.xhtml
@@ -177,6 +177,13 @@
                                                     <prints:five_five_custom_3 bill="#{ffb}" duplicate="#{opdBillController.duplicatePrint}" payments="#{opdBillController.bills.size()}"/>                        
                                                 </ui:repeat>
                                             </h:panelGroup>
+                                            
+                                            <h:panelGroup rendered="#{sessionController.departmentPreference.opdBillPaperType eq 'FiveEightInchPaper'}" >
+                                                <ui:repeat value="#{opdBillController.bills}" var="ffb" >
+                                                    <prints:five_eight_opd_bill bill="#{ffb}" duplicate="#{opdBillController.duplicatePrint}" payments="#{opdBillController.bills.size()}"/>                        
+                                                </ui:repeat>
+                                            </h:panelGroup>
+                                            
                                         </ui:repeat>
                                     </h:panelGroup>
 

--- a/src/main/webapp/resources/css/five_eight_bill.css
+++ b/src/main/webapp/resources/css/five_eight_bill.css
@@ -1,0 +1,167 @@
+/* General Container */
+.receipt-container {
+    font-family: "Courier New", "Liberation Mono", monospace;
+    font-size: 12px;
+    line-height: 1.2;
+    width: 11cm;
+    height: 14cm;
+    margin: auto;
+    padding: 2px;
+    box-sizing: border-box;
+    border: 1px solid #000;
+}
+
+/* Header */
+.hospital-name {
+    font-family: sans-serif !important;
+    text-align: center!important;
+    font-weight: normal!important;
+    font-size: 16px!important; /* Larger font for hospital name */
+    text-transform: uppercase!important;
+}
+
+.hospital-details {
+    text-align: center;
+    font-size: 12px;
+    font-family: sans-serif !important;
+    line-height: 1.2;
+}
+
+/* Line Separator */
+.separator {
+    border-top: 1px solid #000;
+    margin: 2px 0;
+}
+
+/* Patient and Bill Info Table */
+.info-table {
+    width: 100%;
+    border-collapse: collapse;
+    margin-bottom: 2px;
+}
+
+.info-table td {
+    font-size: 12px;
+    padding: 5px;
+}
+
+.info-table .label {
+    font-weight: normal!important;
+    text-align: left;
+}
+
+.info-table .value {
+    text-align: left;
+}
+
+.info-table .spacer {
+    width: 10px; /* Adds space between the two columns */
+}
+
+/* Item Table */
+.receipt-table {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: 12px;
+    margin-bottom: 2px;
+}
+
+.receipt-table th,
+.receipt-table td {
+    text-align: left;
+    padding: 2px;
+    font-family: sans-serif !important;
+    line-height: 1.2;
+    /*    border-bottom: 1px solid #000;*/
+}
+
+.receipt-table th {
+    font-weight: normal!important;
+    text-transform: uppercase;
+    font-family: sans-serif !important;
+    line-height: 1.2;
+}
+
+/* Total Section Table */
+.total-table {
+    width: 100%;
+    border-collapse: collapse;
+    margin-top: 2px;
+    font-size: 15px;
+    font-family: sans-serif !important;
+    line-height: 1.2;
+}
+
+.total-table td {
+    padding: 2px;
+    font-family: sans-serif !important;
+    line-height: 1.2;
+}
+
+.total-table .label {
+    font-weight: normal!important;
+    text-align: left;
+    font-family: sans-serif !important;
+    line-height: 1.2;
+}
+
+.total-table .value {
+    text-align: right;
+    font-weight: normal!important;
+    font-family: sans-serif !important;
+    line-height: 1.2;
+}
+
+/* Footer */
+.receipt-footer {
+    text-align: center;
+    font-size: 12px;
+    margin-top: 20px;
+    font-style: italic;
+    font-family: sans-serif !important;
+    line-height: 1.2;
+}
+
+/* Print Styles */
+@media print {
+    .receipt-container {
+        border: none;
+        width: 10cm!important;
+        height: 9.5cm!important;
+        margin-left: 0cm!important;
+        margin-right: 2.5cm!important;
+        margin-bottom: 1.0cm!important;
+        margin-top: 2.5cm!important;
+        font-family: sans-serif !important;
+        padding-left: 0.25cm;
+        /*        font-family: sans-serif !important;
+                border: none;
+                width: 11cm!important;
+                height: 14cm!important;
+                margin-left: 0cm!important;
+                margin-right: 1.5cm!important;
+                margin-top: 1cm!important;
+                margin-bottom: 0cm!important;
+                padding: 2px!important;
+                line-height: 1.2!important;*/
+    }
+
+    .hospital-name {
+        font-size: 12px;
+        font-family: sans-serif !important;
+        line-height: 1.2;
+    }
+
+    .receipt-table th,
+    .receipt-table td {
+        padding: 2px;
+        font-family: sans-serif !important;
+        line-height: 1.2;
+    }
+
+    .separator {
+        margin: 2px;
+        font-family: sans-serif !important;
+        line-height: 1.2;
+    }
+}

--- a/src/main/webapp/resources/css/five_eight_bill_without_header.css
+++ b/src/main/webapp/resources/css/five_eight_bill_without_header.css
@@ -1,0 +1,160 @@
+/* General Container */
+.receipt-container {
+    font-family: "Courier New", "Liberation Mono", monospace;
+    font-size: 12px;
+    line-height: 1.2;
+    width: 5.0in;
+    height: 8.0in;
+    margin: auto;
+    padding: 2px;
+    box-sizing: border-box;
+    border: 1px solid #000;
+}
+
+/* Header */
+.hospital-name {
+    font-family: sans-serif !important;
+    text-align: center!important;
+    font-weight: normal!important;
+    font-size: 16px!important; /* Larger font for hospital name */
+    text-transform: uppercase!important;
+}
+
+.hospital-details {
+    text-align: center;
+    font-size: 12px;
+    font-family: sans-serif !important;
+    line-height: 1.2;
+}
+
+/* Line Separator */
+.separator {
+    border-top: 1px solid #000;
+    margin: 2px 0;
+}
+
+/* Patient and Bill Info Table */
+.info-table {
+    width: 100%;
+    border-collapse: collapse;
+    margin-bottom: 2px;
+}
+
+.info-table td {
+    font-size: 12px;
+    padding: 5px;
+}
+
+.info-table .label {
+    font-weight: normal!important;
+    text-align: left;
+}
+
+.info-table .value {
+    text-align: left;
+}
+
+.info-table .spacer {
+    width: 10px; /* Adds space between the two columns */
+}
+
+/* Item Table */
+.receipt-table {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: 12px;
+    margin-bottom: 2px;
+}
+
+.receipt-table th,
+.receipt-table td {
+    text-align: left;
+    padding: 2px;
+    font-family: sans-serif !important;
+    line-height: 1.1;
+    /*    border-bottom: 1px solid #000;*/
+}
+
+.receipt-table th {
+    font-weight: normal!important;
+    text-transform: uppercase;
+    font-family: sans-serif !important;
+    line-height: 1.1;
+}
+
+/* Total Section Table */
+.total-table {
+    width: 100%;
+    border-collapse: collapse;
+    margin-top: 2px;
+    font-size: 15px;
+    font-family: sans-serif !important;
+    line-height: 1.2;
+}
+
+.total-table td {
+    padding: 2px;
+    font-family: sans-serif !important;
+    line-height: 1.2;
+}
+
+.total-table .label {
+    font-weight: normal!important;
+    text-align: left;
+    font-family: sans-serif !important;
+    line-height: 1.2;
+}
+
+.total-table .value {
+    text-align: right;
+    font-weight: normal!important;
+    font-family: sans-serif !important;
+    line-height: 1.2;
+}
+
+/* Footer */
+.receipt-footer {
+    text-align: center;
+    font-size: 12px;
+    margin-top: 20px;
+    font-style: italic;
+    font-family: sans-serif !important;
+    line-height: 1.2;
+}
+
+/* Print Styles */
+@media print {
+    .receipt-container {
+        border: none;
+        width: 5.0in!important;
+        height: 6.85in!important;
+        margin-left: 0cm!important;
+        margin-right: 0cm!important;
+        margin-bottom: 3cm!important;
+        margin-top: 1.0in!important;
+        font-family: sans-serif !important;
+        padding-left: 0.25cm!important;
+        padding-right: 0.25cm!important;
+
+    }
+
+    .hospital-name {
+        font-size: 12px;
+        font-family: sans-serif !important;
+        line-height: 1.2;
+    }
+
+    .receipt-table th,
+    .receipt-table td {
+        padding: 2px;
+        font-family: sans-serif !important;
+        line-height: 1.1;
+    }
+
+    .separator {
+        margin: 2px;
+        font-family: sans-serif !important;
+        line-height: 1.1;
+    }
+
+}

--- a/src/main/webapp/resources/ezcomp/prints/five_eight_opd_bill.xhtml
+++ b/src/main/webapp/resources/ezcomp/prints/five_eight_opd_bill.xhtml
@@ -43,7 +43,7 @@
                             <h:outputLabel value="#{cc.attrs.bill.department.address}"/>
                         </div>
                         <div >
-                            <h:outputLabel value="#{cc.attrs.bill.department.telephone2} / #{cc.attrs.bill.department.telephone2}"/>
+                            <h:outputLabel value="#{cc.attrs.bill.department.telephone1} / #{cc.attrs.bill.department.telephone2}"/>
                             <!--                    <h:outputLabel value="/" style="width: 10px; text-align: center;"/>
                                                 <h:outputLabel value="#{cc.attrs.bill.department.telephone2}"/>-->
                         </div>
@@ -82,9 +82,7 @@
                         <td style="padding: 2px;" class="spacer"></td>
                         <td style="padding: 2px;">Mobile</td>
                         <td style="padding: 2px;">
-                            <h:outputLabel value="#{cc.attrs.bill.patient.person.phone}" >
-                                <f:convertDateTime pattern="HH:mm a" />
-                            </h:outputLabel>
+                            <h:outputLabel value="#{cc.attrs.bill.patient.person.phone}" ></h:outputLabel>
                         </td>
                     </tr>
 

--- a/src/main/webapp/resources/ezcomp/prints/five_eight_opd_bill.xhtml
+++ b/src/main/webapp/resources/ezcomp/prints/five_eight_opd_bill.xhtml
@@ -15,14 +15,11 @@
     </cc:interface>
 
     <h:head>
-        <!-- Include the custom CSS for styling -->
         <h:outputStylesheet library="css" name="five_eight_bill.css" />
     </h:head>
 
     <h:body>
-        <!-- Composite Component Interface -->
         <cc:interface>
-            <!-- Attributes passed to the component -->
             <cc:attribute name="bill" required="true" />
             <cc:attribute name="duplicate" required="false" />
         </cc:interface>

--- a/src/main/webapp/resources/ezcomp/prints/five_eight_opd_bill.xhtml
+++ b/src/main/webapp/resources/ezcomp/prints/five_eight_opd_bill.xhtml
@@ -1,0 +1,295 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:cc="http://xmlns.jcp.org/jsf/composite"
+      xmlns:f="http://xmlns.jcp.org/jsf/core"
+      xmlns:h="http://xmlns.jcp.org/jsf/html"
+      xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
+      xmlns:p="http://primefaces.org/ui">
+
+    <cc:interface>
+        <cc:attribute name="bill" type="com.divudi.core.entity.Bill" />
+        <cc:attribute name="duplicate" type="java.lang.Boolean" default="false"/>
+        <cc:attribute name="refunded" type="java.lang.Boolean" default="false"/>
+        <cc:attribute name="payments" type="java.lang.Integer"></cc:attribute>
+    </cc:interface>
+
+    <h:head>
+        <!-- Include the custom CSS for styling -->
+        <h:outputStylesheet library="css" name="five_eight_bill.css" />
+    </h:head>
+
+    <h:body>
+        <!-- Composite Component Interface -->
+        <cc:interface>
+            <!-- Attributes passed to the component -->
+            <cc:attribute name="bill" required="true" />
+            <cc:attribute name="duplicate" required="false" />
+        </cc:interface>
+
+        <!-- Composite Component Implementation -->
+        <cc:implementation>
+            <h:panelGroup rendered="#{!configOptionApplicationController.getBooleanValueByKey('Enable OPD 5x8 Bill Header',false)}" >
+                <h:outputStylesheet library="css" name="five_eight_bill.css" />
+            </h:panelGroup>
+            <h:panelGroup rendered="#{configOptionApplicationController.getBooleanValueByKey('Enable OPD 5x8 Bill Header')}" >
+                <h:outputStylesheet library="css" name="five_eight_bill_without_header.css" />
+            </h:panelGroup>
+
+            <div class="receipt-container">
+                <h:panelGroup rendered="#{configOptionApplicationController.getBooleanValueByKey('Enable OPD 5x8 Bill Header')}">
+                    <div class="hospital-name" >
+                        <h:outputLabel value="#{cc.attrs.bill.institution.name}" />
+                    </div>
+                    <div class="hospital-details" >
+                        <div>
+                            <h:outputLabel value="#{cc.attrs.bill.department.address}"/>
+                        </div>
+                        <div >
+                            <h:outputLabel value="#{cc.attrs.bill.department.telephone2} / #{cc.attrs.bill.department.telephone2}"/>
+                            <!--                    <h:outputLabel value="/" style="width: 10px; text-align: center;"/>
+                                                <h:outputLabel value="#{cc.attrs.bill.department.telephone2}"/>-->
+                        </div>
+                        <div >
+                            <h:outputLabel value="#{cc.attrs.bill.department.email}" />
+                        </div>
+                    </div>
+                    <div class="separator"></div>
+                </h:panelGroup>
+                <!-- Header Section -->
+                <div class="hospital-name">
+                    <h:outputLabel value="#{cc.attrs.bill.department.printingName}"/>
+                    <br/>
+                    <h:outputLabel value="**Duplicate**"  rendered="#{cc.attrs.duplicate eq true}" />
+                    <h:outputLabel value="**Cancelled**"  rendered="#{cc.attrs.bill.cancelled eq true}" />
+                </div>
+
+                <!-- Patient and Bill Information Table -->
+                <table class="info-table mt-2">
+                    <h:panelGroup rendered="#{cc.attrs.bill.patient ne null}" >
+                        <tr>
+                            <td style="padding: 2px;">Name </td>
+                            <td style="padding: 2px; font-weight: 700;" colspan="4">
+                                <h:outputLabel value="#{cc.attrs.bill.patient.person.nameWithTitle}"/>
+                            </td>
+                        </tr>
+                    </h:panelGroup>
+
+                    <tr>
+                        <h:panelGroup rendered="#{cc.attrs.bill.patient.person.ageAsShortString ne null}" >
+                            <td  style="padding: 2px;">Age/Sex </td>
+                            <td style="padding: 2px;" >
+                                <h:outputLabel value="#{cc.attrs.bill.patient.person.ageAsShortString} / #{cc.attrs.bill.patient.person.sex.label}"/>
+                            </td>
+                        </h:panelGroup>
+                        <td style="padding: 2px;" class="spacer"></td>
+                        <td style="padding: 2px;">Mobile</td>
+                        <td style="padding: 2px;">
+                            <h:outputLabel value="#{cc.attrs.bill.patient.person.phone}" >
+                                <f:convertDateTime pattern="HH:mm a" />
+                            </h:outputLabel>
+                        </td>
+                    </tr>
+
+                    <tr>
+                        <td  style="padding: 2px;">Bill Date</td>
+                        <td  style="padding: 2px;">
+                            <h:outputLabel value="#{cc.attrs.bill.createdAt}" >
+                                <f:convertDateTime pattern="yyyy-MM-dd" />
+                            </h:outputLabel>
+                        </td>
+                        <td style="padding: 2px;" class="spacer"></td>
+                        <td style="padding: 2px;">Bill Time</td>
+                        <td style="padding: 2px;">
+                            <h:outputLabel value="#{cc.attrs.bill.createdAt}" >
+                                <f:convertDateTime pattern="HH:mm a" />
+                            </h:outputLabel>
+                        </td>
+                    </tr>
+
+                    <tr>
+                        <td style="padding: 2px;">Bill No</td>
+                        <td style="padding: 2px; font-weight: 700;">#{cc.attrs.bill.deptId}</td>
+                        <td style="padding: 2px;" class="spacer"></td>
+                        <h:panelGroup rendered="#{cc.attrs.bill.patientEncounter eq null}" >
+                            <td style="padding: 2px;">Payment </td>
+                            <td style="padding: 2px;" colspan="4">
+                                <h:outputLabel value="#{cc.attrs.bill.paymentMethod}"/>
+                            </td>
+                        </h:panelGroup>
+                        <h:panelGroup rendered="#{cc.attrs.bill.patientEncounter ne null}" >
+                            <td style="padding: 2px;">BHT No  </td>
+                            <td style="padding: 2px;" colspan="4">
+                                <h:outputLabel value="#{cc.attrs.bill.patientEncounter.bhtNo}"/>
+                            </td>
+                        </h:panelGroup>
+                    </tr>
+
+                    <tr>
+                        <td style="padding: 2px;">To Department </td>
+                        <td style="padding: 2px;" colspan="4">
+                            <h:outputLabel value="#{cc.attrs.bill.toDepartment.name}"/>
+                        </td>
+                    </tr>
+
+                    <h:panelGroup rendered="#{cc.attrs.bill.referredBy ne null}" >
+                        <tr>
+                            <td style="padding: 2px;">Ref. Doctor </td>
+                            <td style="padding: 2px;" colspan="4">
+                                <h:outputLabel value="#{cc.attrs.bill.referredBy.person.nameWithTitle}"/>
+                            </td>
+                        </tr>
+                    </h:panelGroup>
+
+                </table>
+
+                <!-- Separator Line -->
+                <div class="separator"></div>
+
+                <!-- Item Table -->
+                <table class="receipt-table">
+                    <thead>
+                        <tr>
+                            <th>No</th>
+                            <th>Particular</th>
+                            <th style="text-align: right">Amount</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <ui:repeat value="#{billBeanController.fetchBillItems(cc.attrs.bill)}" var="item" varStatus="s">
+                            <tr>
+                                <!-- Display the item number across all items -->
+                                <td>#{s.index +1}</td> <!-- status.index starts from 0, so add 1 for a human-readable count -->
+                                <td>#{item.item.name}</td>
+                                <td style="text-align: right">
+                                    <h:outputLabel value="#{item.grossValue}">
+                                        <f:convertNumber pattern="#,##0.00" />
+                                    </h:outputLabel>
+                                </td>
+                            </tr>
+                        </ui:repeat>
+                    </tbody>
+                </table>
+
+                <!-- Separator Line -->
+                <div class="separator"></div>
+
+                <div class="d-flex">
+                    <div>
+                        <table >
+                            <thead>
+                                <tr>
+                                    <td>Pay Type</td>
+                                    <td style="text-align: end"> Amount</td>
+                                    <td></td>
+                                </tr>
+                            </thead>
+                            <ui:repeat value="#{billSearch.fetchBillPayments(cc.attrs.bill.backwardReferenceBill)}" var="ps">
+                                <tr>
+                                    <td style="width: 4cm;">
+                                        <h:outputText style="font-size: 8pt;"  value="#{ps.paymentMethod}"/>
+                                        <h:outputText style="font-size: 8pt; width: 2cm;"  value=" (#{ps.creditCardRefNo})" rendered="#{ps.paymentMethod eq 'Card'}"/>
+                                    </td>
+                                    <td style="width: 3cm; text-align: end">
+                                        <h:outputText style="font-size: 8pt; width: 2cm;"  value="#{ps.paidValue}">
+                                            <f:convertNumber pattern="#,##0.00" />
+                                        </h:outputText>
+                                    </td>
+                                    <td style="width: 1cm;">
+
+                                    </td>
+                                </tr>
+                            </ui:repeat>
+                        </table>
+                    </div>
+                    <div class="w-100">
+                        <table class="total-table">
+                            <tr>
+                                <td >Total Amount</td>
+                                <td  style="text-align: right;">
+                                    <h:outputLabel value="#{cc.attrs.bill.total}" >
+                                        <f:convertNumber pattern="#,##0.00" />
+                                    </h:outputLabel>
+                                </td>
+                            </tr>
+
+                            <tr>
+                                <td >Discount</td>
+                                <td  style="text-align: right;">
+                                    <h:outputLabel  value="#{- cc.attrs.bill.discount}">
+                                        <f:convertNumber pattern="#,##0.00" />
+                                    </h:outputLabel>
+                                </td>
+                            </tr>
+                            <tr>
+                                <td >Net Amount</td>
+                                <td style="text-align: right;">
+                                    <h:outputLabel value="#{cc.attrs.bill.netTotal}">
+                                        <f:convertNumber pattern="#,##0.00" />
+                                    </h:outputLabel>
+                                </td>
+                            </tr>
+                            <h:panelGroup rendered="#{cc.attrs.bill.paymentMethod ne 'MultiplePaymentMethods'}">
+                                <tr>
+                                    <td >Tendered Amount</td>
+                                    <td style="text-align: right;">
+                                        <h:outputLabel value="#{cc.attrs.bill.backwardReferenceBill.tenderedAmount}">
+                                            <f:convertNumber pattern="#,##0.00" />
+                                        </h:outputLabel>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td >Balance</td>
+                                    <td style="text-align: right;">
+                                        <h:outputLabel value="#{cc.attrs.bill.backwardReferenceBill.balance}">
+                                            <f:convertNumber pattern="#,##0.00" />
+                                        </h:outputLabel>
+                                    </td>
+                                </tr>
+                            </h:panelGroup>
+
+                        </table>
+                    </div>
+                </div>
+
+                <table  style="font-size: 8pt;">
+                    <tr>
+                        <td style="width: 4cm; vertical-align: top;">
+                            <h:outputLabel value="Billed By :"/>
+                            <h:outputLabel value="#{cc.attrs.bill.creater.name}"/>
+                        </td>
+                        <td style="width: 2cm;"></td>
+                        <td style=" vertical-align: top;">
+
+                        </td>
+                    </tr>
+                    <h:panelGroup rendered="#{cc.attrs.duplicate}">
+                        <tr>
+                            <td style="vertical-align: top;" colspan="3">
+                                <div class="d-flex gap-2">
+                                    <h:outputLabel value="Printerd By "/>
+                                    <h:outputLabel value="#{sessionController.loggedUser.name}"/>
+                                    <h:outputLabel value=" - "/>
+                                    <h:outputLabel value="#{sessionController.currentDate}">
+                                        <f:convertDateTime pattern="yyyy-MM-dd hh:mm a"/>
+                                    </h:outputLabel>
+                                </div>
+
+                            </td>
+                        </tr>
+                    </h:panelGroup>
+                </table>
+
+                <div class="d-flex justify-content-center mt-2">
+                    <h:outputLabel value="#{configOptionApplicationController.getLongTextValueByKey('Footer Massage of 5x8 inch Paper','Please receive your report within 3 months.')}"/>
+                </div>
+
+                <div class="d-flex justify-content-center mt-3" style="font-size: 10px;">
+                    <h:outputLabel value="Softwere by Carecode Solutions"/>
+                </div>
+            </div>
+
+        </cc:implementation>
+
+    </h:body>
+</html>

--- a/src/main/webapp/resources/ezcomp/view/out.xhtml
+++ b/src/main/webapp/resources/ezcomp/view/out.xhtml
@@ -78,11 +78,35 @@
                     <p:inputText  class="text-end  text-white bg-warning" value="#{cc.attrs.bill.invoiceNumber}" ></p:inputText>
 
                     <h:outputLabel value="Credit Company" ></h:outputLabel>
-                    <p:autoComplete value="#{cc.attrs.bill.creditCompany}" completeMethod="#{institutionController.completeIns}" var="i" itemLabel="#{i.name}"
-                                    itemValue="#{i}" rendered="false"></p:autoComplete><h:outputLabel value="#{cc.attrs.bill.creditCompany.name}" rendered="true"></h:outputLabel>
+                    <p:autoComplete 
+                        value="#{cc.attrs.bill.creditCompany}" 
+                        completeMethod="#{institutionController.completeIns}" 
+                        var="i" 
+                        inputStyleClass="form-control"
+                        class="w-75"
+                        itemLabel="#{i.name}"
+                        itemValue="#{i}">
+                    </p:autoComplete>
 
                     <h:outputLabel value="Referred By" ></h:outputLabel>
-                    <h:outputLabel value="#{cc.attrs.bill.referredBy.person.nameWithTitle}" ></h:outputLabel>
+                    <p:autoComplete 
+                        forceSelection="true" 
+                        value="#{cc.attrs.bill.referredBy}" 
+                        completeMethod="#{doctorController.completeDoctor}" 
+                        var="ix" 
+                        itemLabel="#{ix.person.nameWithTitle}" 
+                        itemValue="#{ix}" 
+                        inputStyleClass="form-control"
+                        class="w-75" 
+                        scrollHeight="500">
+                        <p:column headerText="Name" style="padding: 2px;">
+                            <h:outputText value="#{ix.person.nameWithTitle}" ></h:outputText>
+                        </p:column>
+                        <p:column headerText="Code" style="padding: 2px;">
+                            <h:outputText value="#{ix.code}" ></h:outputText>
+                        </p:column>
+                    </p:autoComplete>
+
 
                     <h:outputLabel value="Referring Institution" ></h:outputLabel>
                     <h:outputLabel value="#{cc.attrs.bill.referenceInstitution.name}" ></h:outputLabel>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for a new 5x8 inch paper type for bill printing.
  - Introduced a new bill print layout specifically designed for 5x8 inch paper, including a dedicated print component.
  - Added new CSS stylesheets to ensure proper formatting and appearance for 5x8 inch bill prints, both with and without headers.

- **Enhancements**
  - Updated the batch bill print interface to support the new 5x8 inch paper type.
  - Improved user interaction by replacing static labels with auto-complete fields for "Credit Company" and "Referred By" selections.

- **Style**
  - Enhanced bill print appearance and print optimization with new CSS for better readability and layout consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->