### PR TITLE
11811 add 5x8inch bill format for inward billing

### DIFF
--- a/src/main/webapp/inward/inward_bill_service.xhtml
+++ b/src/main/webapp/inward/inward_bill_service.xhtml
@@ -530,6 +530,13 @@
                                                             <br/>
                                                         </ui:repeat>
                                                     </h:panelGroup>
+                                                    
+                                                    <h:panelGroup  rendered="#{configOptionApplicationController.getBooleanValueByKey('Inward Servise Bill size is 5x8 inch Paper')}" >
+                                                        <ui:repeat value="#{billBhtController.bills}" var="pp">
+                                                            <print:five_eight_opd_bill bill="#{pp}" duplicate="false" payments="#{billBhtController.bills.size()}"/>
+                                                            <br/>
+                                                        </ui:repeat>
+                                                    </h:panelGroup>
 
                                                 </h:panelGroup>
                                             </p:panel>

--- a/src/main/webapp/inward/inward_reprint_bill_service.xhtml
+++ b/src/main/webapp/inward/inward_reprint_bill_service.xhtml
@@ -25,66 +25,83 @@
                                     <h:outputLabel value="Service Reprint" />
                                 </div>
                                 <div >
-                                    
-                                     <p:commandButton 
-                                                        value="To Sample Management" 
-                                                        icon="fas fa-flask"
-                                                        class="ui-button-raised mx-1"
-                                                        action="#{patientInvestigationController.navigateToSampleManagementFromOPDBatchBillView(inwardSearch.bill)}"
-                                                        ajax="false">
-                                                    </p:commandButton>
 
-                                    <p:commandButton class="ui-button-info mx-2" icon="fas fa-print" value="Reprint" ajax="false" action="#"  >
+                                    <p:commandButton 
+                                        value="To Sample Management" 
+                                        icon="fas fa-flask"
+                                        class="ui-button-raised mx-1"
+                                        action="#{patientInvestigationController.navigateToSampleManagementFromOPDBatchBillView(inwardSearch.bill)}"
+                                        ajax="false">
+                                    </p:commandButton>
+
+                                    <p:commandButton 
+                                        class="ui-button-info mx-2" 
+                                        icon="fas fa-print" 
+                                        value="Reprint" 
+                                        ajax="false" 
+                                        action="#"  >
                                         <p:printer target="gpBillPreview" ></p:printer>
                                     </p:commandButton>
 
-                                    <p:commandButton class="ui-button-info" icon="fas fa-print" value="Reprint(Cancel/Refund)" ajax="false" action="#" rendered="#{inwardSearch.bill.refundBills.size()>0 or inwardSearch.bill.cancelled}" >
+                                    <p:commandButton 
+                                        class="ui-button-info" 
+                                        icon="fas fa-print" 
+                                        value="Reprint(Cancel/Refund)" 
+                                        ajax="false" 
+                                        action="#" 
+                                        rendered="#{inwardSearch.bill.refundBills.size()>0 or inwardSearch.bill.cancelled}" >
                                         <p:printer target="gpBillPreview2" ></p:printer>
                                     </p:commandButton>
 
-                                    <p:commandButton ajax="false" 
-                                                     value="Cancel" 
-                                                     icon="fa fa-ban"
-                                                     action="inward_cancel_bill_service?faces-redirect=true"
-                                                     disabled="#{inwardSearch.bill.cancelled or inwardSearch.bill.refunded }"  
-                                                     class="m-2 ui-button-danger">                           
+                                    <p:commandButton 
+                                        ajax="false" 
+                                        value="Cancel" 
+                                        icon="fa fa-ban"
+                                        action="inward_cancel_bill_service?faces-redirect=true"
+                                        disabled="#{inwardSearch.bill.cancelled or inwardSearch.bill.refunded }"  
+                                        class="m-2 ui-button-danger">                           
                                     </p:commandButton>
-                                    <p:commandButton ajax="false" 
-                                                     value="Return" 
-                                                     icon="fa fa-undo"
-                                                     actionListener="#{billSearch.recreateModel()}"
-                                                     action="inward_bill_service_refund?faces-redirect=true"
-                                                     disabled="#{inwardSearch.bill.cancelled}"
-                                                     class="m-2 "
-                                                     >    
+                                    <p:commandButton 
+                                        ajax="false" 
+                                        value="Return" 
+                                        icon="fa fa-undo"
+                                        actionListener="#{billSearch.recreateModel()}"
+                                        action="inward_bill_service_refund?faces-redirect=true"
+                                        disabled="#{inwardSearch.bill.cancelled}"
+                                        class="m-2 "
+                                        >    
                                         <f:setPropertyActionListener  
                                             value="#{inwardSearch.bill}" 
                                             target="#{billSearch.bill}"  />
                                     </p:commandButton>
 
-                                    <p:commandButton ajax="false" 
-                                                     value="Mark As Checked"
-                                                     icon="fa fa-check-square"
-                                                     action="#{inwardSearch.markAsChecked()}"
-                                                     rendered="#{webUserController.hasPrivilege('InwardCheck')}"  
-                                                     class="m-2 ui-button-success"/>
-                                    <p:commandButton ajax="false" 
-                                                     value="Mark As Uncheck"
-                                                     icon="fa fa-square"
-                                                     action="#{inwardSearch.markAsUnChecked()}"
-                                                     rendered="#{webUserController.hasPrivilege('InwardUnCheck')}"  
-                                                     class="m-2 ui-button-warning"/>
-                                    <p:commandButton ajax="false" 
-                                                     value="Back To View" 
-                                                     icon="fa fa-backward"
-                                                     action="/inward/inward_edit_bill_item_view?faces-redirect=true"  
-                                                     class="m-2 "/>
-                                    <p:commandButton ajax="false" 
-                                                     value="Back To Interim" 
-                                                     icon="fa fa-arrow-circle-left"
-                                                     action="/inward/inward_bill_intrim?faces-redirect=true" 
-                                                     actionListener="#{bhtSummeryController.createTables()}"
-                                                     class="m-2 ui-button-warning"/>
+                                    <p:commandButton 
+                                        ajax="false" 
+                                        value="Mark As Checked"
+                                        icon="fa fa-check-square"
+                                        action="#{inwardSearch.markAsChecked()}"
+                                        rendered="#{webUserController.hasPrivilege('InwardCheck')}"  
+                                        class="m-2 ui-button-success"/>
+                                    <p:commandButton 
+                                        ajax="false" 
+                                        value="Mark As Uncheck"
+                                        icon="fa fa-square"
+                                        action="#{inwardSearch.markAsUnChecked()}"
+                                        rendered="#{webUserController.hasPrivilege('InwardUnCheck')}"  
+                                        class="m-2 ui-button-warning"/>
+                                    <p:commandButton 
+                                        ajax="false" 
+                                        value="Back To View" 
+                                        icon="fa fa-backward"
+                                        action="/inward/inward_edit_bill_item_view?faces-redirect=true"  
+                                        class="m-2 "/>
+                                    <p:commandButton 
+                                        ajax="false" 
+                                        value="Back To Interim" 
+                                        icon="fa fa-arrow-circle-left"
+                                        action="/inward/inward_bill_intrim?faces-redirect=true" 
+                                        actionListener="#{bhtSummeryController.createTables()}"
+                                        class="m-2 ui-button-warning"/>
                                 </div>
 
                             </div>
@@ -192,6 +209,13 @@
                             <h:panelGroup rendered="#{sessionController.departmentPreference.inwardServiceBillPaperType eq 'FiveFiveCustom3'}" >
                                 <ui:repeat value="#{inwardSearch.bill}" var="pp">
                                     <print:five_five_custom_3_inward bill="#{pp}" duplicate="true" payments="#{inwardSearch.bill.size()}"/>
+                                    <br/>
+                                </ui:repeat>
+                            </h:panelGroup>
+                            
+                            <h:panelGroup rendered="#{sessionController.departmentPreference.inwardServiceBillPaperType eq 'FiveEightInchPaper'}" >
+                                <ui:repeat value="#{inwardSearch.bill}" var="pp">
+                                    <print:five_eight_opd_bill bill="#{pp}" duplicate="true" payments="#{inwardSearch.bill.size()}"/>
                                     <br/>
                                 </ui:repeat>
                             </h:panelGroup>

--- a/src/main/webapp/opd/bill_reprint.xhtml
+++ b/src/main/webapp/opd/bill_reprint.xhtml
@@ -211,28 +211,34 @@
                                                         <prints:five_five_paper_with_headings bill="#{ffb}" duplicate="true"/>                        
                                                     </ui:repeat>
                                                 </h:panelGroup>
-                                                
+
                                                 <h:panelGroup rendered="#{configOptionApplicationController.getBooleanValueByKey('OPD Bill Paper Size is FiveFivePrintedPaper')}" >
                                                     <ui:repeat value="#{billSearch.bill}" var="ffpp">
                                                         <prints:five_five_paper_without_headings bill="#{ffpp}"  duplicate="true"/>
                                                     </ui:repeat>
                                                 </h:panelGroup>
-                                                
+
                                                 <h:panelGroup rendered="#{configOptionApplicationController.getBooleanValueByKey('OPD Bill Paper Size is PosPaper')}" >
                                                     <ui:repeat value="#{billSearch.bill}" var="pp">
                                                         <prints:posOpdBill bill="#{pp}" duplicate="true"/>                        
                                                     </ui:repeat>
                                                 </h:panelGroup>
-                                                
+
                                                 <h:panelGroup rendered="#{configOptionApplicationController.getBooleanValueByKey('OPD Bill Paper Size is FiveFivePaperCoustom1')}" >
                                                     <ui:repeat value="#{billSearch.bill}" var="ffb" >
                                                         <prints:five_five_paper_coustom_1 bill="#{ffb}" duplicate="true" payments="1"/>                        
                                                     </ui:repeat>
                                                 </h:panelGroup>
-                                                
+
                                                 <h:panelGroup rendered="#{configOptionApplicationController.getBooleanValueByKey('OPD Bill Paper Size is FiveFiveCustom3')}" >
                                                     <ui:repeat value="#{billSearch.bill}" var="pp">
                                                         <prints:five_five_custom_3 bill="#{pp}" duplicate="true"/>                        
+                                                    </ui:repeat>
+                                                </h:panelGroup>
+
+                                                <h:panelGroup rendered="#{configOptionApplicationController.getBooleanValueByKey('OPD Bill Paper Size is 5x8 inch Paper')}" >
+                                                    <ui:repeat value="#{billSearch.bill}" var="pp">
+                                                        <prints:five_eight_opd_bill bill="#{pp}" duplicate="true"/>                        
                                                     </ui:repeat>
                                                 </h:panelGroup>
                                             </h:panelGroup>
@@ -271,7 +277,14 @@
                                                             <p:spacer />
                                                             <p:spacer />
                                                         </ui:repeat>
+                                                    </h:panelGroup>
 
+                                                    <h:panelGroup rendered="#{configOptionApplicationController.getBooleanValueByKey('OPD Bill Paper Size is 5x8 inch Paper')}" >
+                                                        <ui:repeat value="#{billSearch.refuendedBills}" var="pp">
+                                                            <prints:five_eight_opd_bill bill="#{pp}" duplicate="true"/>   
+                                                            <p:spacer />
+                                                            <p:spacer />
+                                                        </ui:repeat>
                                                     </h:panelGroup>
                                                 </h:panelGroup>
                                             </h:panelGroup>

--- a/src/main/webapp/resources/ezcomp/prints/five_eight_opd_bill.xhtml
+++ b/src/main/webapp/resources/ezcomp/prints/five_eight_opd_bill.xhtml
@@ -171,31 +171,33 @@
 
                 <div class="d-flex">
                     <div>
-                        <table >
-                            <thead>
-                                <tr>
-                                    <td>Pay Type</td>
-                                    <td style="text-align: end"> Amount</td>
-                                    <td></td>
-                                </tr>
-                            </thead>
-                            <ui:repeat value="#{billSearch.fetchBillPayments(cc.attrs.bill.backwardReferenceBill)}" var="ps">
-                                <tr>
-                                    <td style="width: 4cm;">
-                                        <h:outputText style="font-size: 8pt;"  value="#{ps.paymentMethod}"/>
-                                        <h:outputText style="font-size: 8pt; width: 2cm;"  value=" (#{ps.creditCardRefNo})" rendered="#{ps.paymentMethod eq 'Card'}"/>
-                                    </td>
-                                    <td style="width: 3cm; text-align: end">
-                                        <h:outputText style="font-size: 8pt; width: 2cm;"  value="#{ps.paidValue}">
-                                            <f:convertNumber pattern="#,##0.00" />
-                                        </h:outputText>
-                                    </td>
-                                    <td style="width: 1cm;">
+                        <h:panelGroup rendered="#{cc.attrs.bill.patientEncounter eq null}">
+                            <table >
+                                <thead>
+                                    <tr>
+                                        <td>Pay Type</td>
+                                        <td style="text-align: end"> Amount</td>
+                                        <td></td>
+                                    </tr>
+                                </thead>
+                                <ui:repeat value="#{billSearch.fetchBillPayments(cc.attrs.bill.backwardReferenceBill)}" var="ps">
+                                    <tr>
+                                        <td style="width: 4cm;">
+                                            <h:outputText style="font-size: 8pt;"  value="#{ps.paymentMethod}"/>
+                                            <h:outputText style="font-size: 8pt; width: 2cm;"  value=" (#{ps.creditCardRefNo})" rendered="#{ps.paymentMethod eq 'Card'}"/>
+                                        </td>
+                                        <td style="width: 3cm; text-align: end">
+                                            <h:outputText style="font-size: 8pt; width: 2cm;"  value="#{ps.paidValue}">
+                                                <f:convertNumber pattern="#,##0.00" />
+                                            </h:outputText>
+                                        </td>
+                                        <td style="width: 1cm;">
 
-                                    </td>
-                                </tr>
-                            </ui:repeat>
-                        </table>
+                                        </td>
+                                    </tr>
+                                </ui:repeat>
+                            </table>
+                        </h:panelGroup>
                     </div>
                     <div class="w-100">
                         <table class="total-table">
@@ -224,7 +226,7 @@
                                     </h:outputLabel>
                                 </td>
                             </tr>
-                            <h:panelGroup rendered="#{cc.attrs.bill.paymentMethod ne 'MultiplePaymentMethods'}">
+                            <h:panelGroup rendered="#{cc.attrs.bill.paymentMethod ne 'MultiplePaymentMethods' and cc.attrs.bill.patientEncounter eq null}">
                                 <tr>
                                     <td >Tendered Amount</td>
                                     <td style="text-align: right;">


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for printing bills in a new 5x8 inch paper format across inward and OPD bill sections, including both original and reprint views.
- **Bug Fixes**
  - Improved bill printouts by conditionally hiding payment details and tendered/balance amounts for bills associated with a patient encounter.
- **Style**
  - Reformatted button markup for improved readability in the service bill reprint view.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->