### PR TITLE
Closes #11815

### DIFF
--- a/src/main/webapp/dataAdmin/admin_functions.xhtml
+++ b/src/main/webapp/dataAdmin/admin_functions.xhtml
@@ -25,6 +25,15 @@
                                 class="w-100 m-1"
                                 value="Add Bill Type Atomics"/>
                         </div>
+                        
+                         <div class="col-12 col-md-8 col-lg-6 p-1">
+                            <p:commandButton 
+                                ajax="false"
+                                disabled="false"
+                                action="#{billController.fixTotalInPHARMACY_RETAIL_SALE_RETURN_ITEMS_AND_PAYMENTS}"
+                                class="w-100 m-1"
+                                value="FIX Gross Total in PHARMACY_RETAIL_SALE_RETURN_ITEMS_AND_PAYMENTS Bills"/>
+                        </div>
 
 
                         <div class="col-12 col-md-4 col-lg-2 p-1" >

--- a/src/main/webapp/pharmacy/pharmacy_reprint_bill.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_reprint_bill.xhtml
@@ -17,13 +17,34 @@
                         <f:facet name="header" >
                             <h:outputLabel value="Reprint" ></h:outputLabel>
                             <hr/>
-                            <p:commandButton value="Reprint" ajax="false" >
-                                <p:printer target="gpBillPreview" ></p:printer>
+                            <p:commandButton
+                                class="m-1 ui-button-success"
+                                icon="fa fa-print"
+                                value="Reprint" 
+                                ajax="false">
+                                <p:printer target="gpBillPreview"/>
                             </p:commandButton>
-                            <p:commandButton ajax="false" value="Cancel" action="pharmacy_cancel_bill" disabled="#{pharmacyBillSearch.bill.cancelled}" 
-                                             rendered="#{webUserController.hasPrivilege('PharmacySaleCancel') or true}">                           
+
+                            <p:commandButton
+                                class="m-1 ui-button-danger"
+                                ajax="false" 
+                                value="Cancel" 
+                                icon="fa fa-times"
+                                action="pharmacy_cancel_bill" 
+                                disabled="#{pharmacyBillSearch.bill.cancelled}" 
+                                rendered="#{webUserController.hasPrivilege('PharmacySaleCancel') or true}">
                             </p:commandButton>
-                          
+
+                            <p:commandButton 
+                                title="Admin" 
+                                icon="fa fa-shield-alt" 
+                                class="m-1 ui-button-danger" 
+                                action="#{billSearch.navigateToAdminBillByAtomicBillType()}" 
+                                ajax="false" 
+                                rendered="#{webUserController.hasPrivilege('Developers')}">
+                                <f:setPropertyActionListener value="#{pharmacyBillSearch.bill}" target="#{billSearch.bill}" />
+                            </p:commandButton>
+
                         </f:facet>
                     </p:panel>
 


### PR DESCRIPTION
First check the Gross Total in PHARMACY_RETAIL_SALE_RETURN_ITEMS_AND_PAYMENTS Bills and also in Bill Items. Identify they are actually having net totals (which excluse the discount or service charge)

Menu > Admin Menu (can be identified from its icon of a database) > Manage Data, Workflows and Templates > Page
Select System Admin Functions

Under that look for the button with label FIX Gross Total in PHARMACY_RETAIL_SALE_RETURN_ITEMS_AND_PAYMENTS Bills
Click the button
then again check the above to see that they are fixed.

This function needs to be deleted once the past data is fixed in all instances.

Signed-off-by: Dr M H Buddhika Ariyaratne <buddhika.ari@gmail.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an admin function to fix gross totals in specific pharmacy retail sale return bills, accessible via a new button on the admin functions page.
  - Introduced an "Admin" button to the pharmacy bill reprint page, available only to users with "Developers" privilege.

- **Style**
  - Enhanced the appearance of "Reprint" and "Cancel" buttons on the pharmacy bill reprint page with improved styling and icons.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->