### PR TITLE
11817 need a method to manually fix wrong bill items and pharmaceutical returns on retail sale returns   items only

### DIFF
--- a/src/main/webapp/dataAdmin/admin_functions.xhtml
+++ b/src/main/webapp/dataAdmin/admin_functions.xhtml
@@ -35,14 +35,17 @@
                                 value="FIX Gross Total in PHARMACY_RETAIL_SALE_RETURN_ITEMS_AND_PAYMENTS Bills"/>
                         </div>
 
-                        <div class="col-12 col-md-8 col-lg-6 p-1">
-                            <p:commandButton 
-                                ajax="false"
-                                disabled="false"
-                                action="#{billController.fixTotalInPHARMACY_RETAIL_SALE_RETURN_ITEMS_ONLY}"
-                                class="w-100 m-1"
-                                value="FIX Gross Total in PHARMACY_RETAIL_SALE_RETURN_ITEMS_ONLY Bills"/>
-                        </div>
+<div class="col-12 col-md-8 col-lg-6 p-1">
+    <p:commandButton 
+        ajax="false"
+        disabled="false"
+        onclick="return confirm('This will modify billing data. Proceed?');"
+        rendered="#{webUserController.hasPrivilege('Developers')}"
+        action="#{billController.fixTotalInPHARMACY_RETAIL_SALE_RETURN_ITEMS_ONLY}"
+        update=":growl"
+        class="w-100 m-1"
+        value="FIX Gross Total in PHARMACY_RETAIL_SALE_RETURN_ITEMS_ONLY Bills"/>
+</div>
 
 
 


### PR DESCRIPTION
**Fix Gross Total in PHARMACY_RETAIL_SALE_RETURN_ITEMS_ONLY Bills**

This utility addresses incorrect gross totals in bills of type `PHARMACY_RETAIL_SALE_RETURN_ITEMS_ONLY`, where bill-level and item-level totals do not match expected values, although the net total (excluding discounts or service charges) may appear correct.

> ⚠️ **Do not run this function until the bill item values have been corrected first.**  
> A separate admin method must be developed and executed to fix the `rate` and `netRate` of the `BillItem`s.

---

**Step-by-step (to be followed in order):**

1. **[Pending]** Run a new admin function to update `BillItem.rate` and `BillItem.netRate` to negative values.  
   This is necessary because in this bill type, positive values were mistakenly stored. This correction should happen at the time of item return entry, not post-hoc.

2. Once item values are corrected, proceed with this function to fix the overall gross total of the bill:

   Go to  
   **Menu > Admin Menu** (icon: database) → **Manage Data, Workflows and Templates** → **Page**  
   Select **System Admin Functions**

   Click the button labeled:  
   **FIX Gross Total in PHARMACY_RETAIL_SALE_RETURN_ITEMS_ONLY Bills**

   Then re-check the affected bills to ensure they are consistent and correct.

---

**Final Notes:**

- This script is intended as a **temporary, one-time fix** for legacy data. It should be removed once cleanup is completed.
- A **permanent fix** is required in the return workflow logic to ensure negative `rate` and `netRate` are correctly saved at the time of return item entry—preventing this issue from reoccurring.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a new admin button for users with "Developers" privilege to trigger a billing data modification, with confirmation dialog and responsive styling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->