### PR TITLE
11819 correct bill item rates in pharmacy retail sale return items only bills

### DIFF
--- a/src/main/java/com/divudi/bean/common/BillController.java
+++ b/src/main/java/com/divudi/bean/common/BillController.java
@@ -3258,7 +3258,8 @@ public class BillController implements Serializable, ControllerWithMultiplePayme
         return count != null && count > 1;
     }
 
-    public void convertPharmaceuticalBillItemReferanceFromErronouslyRecordedPharmacyRetailSaleCancellationPreBillToPharmacyRetailSalePreBill(PharmaceuticalBillItem pbi) {
+    public void convertPharmaceuticalBillItemReferenceFromErroneouslyRecordedPharmacyRetailSaleCancellationPreBillToPharmacyRetailSalePreBill
+        (PharmaceuticalBillItem pbi) {
         Bill originalBill = null;
         Bill cancelledBill = null;
         BillItem originalBillItemNowWonglyAssignedToCancelledBill = null;

--- a/src/main/java/com/divudi/bean/common/BillController.java
+++ b/src/main/java/com/divudi/bean/common/BillController.java
@@ -3138,9 +3138,11 @@ public class BillController implements Serializable, ControllerWithMultiplePayme
                         pbiUpdated = true;
                     }
 
-                    double purchaseValue = Math.abs(pbi.getPurchaseRate() * pbi.getQty());
-                    pbi.setPurchaseValue(-purchaseValue);
-                    pbiUpdated = true;
+                    if (pbi.getPurchaseValue() == 0) {
+                        double value = Math.abs(pbi.getPurchaseRate() * pbi.getQty());
+                        pbi.setPurchaseValue(-value);
+                        pbiUpdated = true;
+                    }
 
                     if (pbiUpdated) {
                         pharmaceuticalBillItemFacade.edit(pbi);

--- a/src/main/java/com/divudi/bean/common/BillController.java
+++ b/src/main/java/com/divudi/bean/common/BillController.java
@@ -2953,7 +2953,6 @@ public class BillController implements Serializable, ControllerWithMultiplePayme
      *
      * @param billTypeAtomic the atomic bill type to filter and process
      */
-    @javax.transaction.Transactional
     public void fixTotalsInBillsByAtomicType(BillTypeAtomic billTypeAtomic) {
         System.out.println("Starting temporary fix for bill type: " + billTypeAtomic);
 
@@ -2961,8 +2960,7 @@ public class BillController implements Serializable, ControllerWithMultiplePayme
         Map<String, Object> params = new HashMap<>();
         params.put("bta", billTypeAtomic);
 
-        // Process in smaller batches for better memory management
-        List<Bill> bills = getFacade().findByJpql(jpql, params, 500);
+        List<Bill> bills = getFacade().findByJpql(jpql, params, 1000);
 
         if (bills == null || bills.isEmpty()) {
             System.out.println("No matching bills found for type: " + billTypeAtomic);
@@ -2971,14 +2969,8 @@ public class BillController implements Serializable, ControllerWithMultiplePayme
 
         System.out.println("Found " + bills.size() + " bills to process.");
 
-        int processed = 0;
-        int updated = 0;
-        int skipped = 0;
-        int batchCounter = 0;
-
         for (Bill b : bills) {
-            processed++;
-            System.out.println("Processing bill ID: " + b.getId() + " (" + processed + "/" + bills.size() + ")");
+            System.out.println("Processing bill ID: " + b.getId());
 
             double total = 0.0;
             double netTotal = 0.0;
@@ -2990,12 +2982,6 @@ public class BillController implements Serializable, ControllerWithMultiplePayme
                 bi.setGrossValue(grossValue);
                 billItemFacade.edit(bi);
 
-                batchCounter++;
-                // Flush periodically to manage memory and reduce lock contention
-                if (batchCounter % 100 == 0) {
-                    billItemFacade.flush();
-                }
-
                 total += grossValue;
                 netTotal += bi.getNetValue();
             }
@@ -3004,40 +2990,15 @@ public class BillController implements Serializable, ControllerWithMultiplePayme
             System.out.println("Calculated Net Total: " + netTotal + " | Existing: " + b.getNetTotal());
 
             if (Math.abs(b.getNetTotal() - netTotal) >= 1.0) {
-                System.out.println("WARNING: Skipping bill ID: " + b.getId()
-                    + ". Net total mismatch suggests deeper issue. "
-                    + "Expected: " + netTotal + ", Actual: " + b.getNetTotal()
-                    + ", Difference: " + Math.abs(b.getNetTotal() - netTotal));
-                skipped++;
+                System.out.println("Skipping bill ID: " + b.getId() + ". Net total mismatch suggests deeper issue.");
             } else {
                 System.out.println("Updating gross total for bill ID: " + b.getId());
                 b.setTotal(total);
-                // Update other relevant bill total fields for consistency
-                if (b.getGrantTotal() != null) {
-                    b.setGrantTotal(total);
-                }
-                // If VAT is present, update VAT-related totals
-                if (b.getVat() > 0) {
-                    b.setVatPlusNetTotal(b.getNetTotal() + b.getVat());
-                }
                 getFacade().edit(b);
-                updated++;
-                // Flush periodically
-                if (updated % 50 == 0) {
-                    getFacade().flush();
-                }
             }
         }
 
-        // Provide a summary report for easy verification
-        System.out.println("\n===== SUMMARY =====");
-        System.out.println("Bill type: " + billTypeAtomic);
-        System.out.println("Total bills processed: " + processed);
-        System.out.println("Bills updated: " + updated);
-        System.out.println("Bills skipped due to discrepancies: " + skipped);
-        System.out.println("==================\n");
-        // Final flush to ensure all changes are persisted
-        getFacade().flush();
+        System.out.println("Completed processing for bill type: " + billTypeAtomic);
     }
 
     /**

--- a/src/main/java/com/divudi/bean/report/PharmacyReportController.java
+++ b/src/main/java/com/divudi/bean/report/PharmacyReportController.java
@@ -2178,9 +2178,9 @@ public class PharmacyReportController implements Serializable {
         response.reset();
         response.setContentType("application/pdf");
         response.setHeader("Content-Disposition", "attachment; filename=Stock_Ledger_Report.pdf");
-
+        Document document = null;
         try (OutputStream out = response.getOutputStream()) {
-            Document document = new Document(PageSize.A4.rotate());
+            document = new Document(PageSize.A4.rotate());
             PdfWriter.getInstance(document, out);
             document.open();
 
@@ -2278,6 +2278,10 @@ public class PharmacyReportController implements Serializable {
             context.responseComplete();
         } catch (Exception e) {
             e.printStackTrace();
+        } finally {
+            if (document != null && document.isOpen()) {
+                document.close();
+            }
         }
     }
 

--- a/src/main/resources/META-INF/persistence.xml
+++ b/src/main/resources/META-INF/persistence.xml
@@ -1,41 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<persistence version="2.2"
-    xmlns="http://java.sun.com/xml/ns/persistence"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="
-        http://xmlns.jcp.org/xml/ns/persistence
-        http://xmlns.jcp.org/xml/ns/persistence/persistence_2_2.xsd">
-
+<persistence version="2.2" xmlns="http://java.sun.com/xml/ns/persistence" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/persistence http://xmlns.jcp.org/xml/ns/persistence/persistence_2_2.xsd">
     <persistence-unit name="hmisPU" transaction-type="JTA">
         <provider>org.eclipse.persistence.jpa.PersistenceProvider</provider>
-        <jta-data-source>jdbc/ruhunu</jta-data-source>
+        <jta-data-source>${JDBC_DATASOURCE}</jta-data-source>
         <exclude-unlisted-classes>false</exclude-unlisted-classes>
         <properties>
-            <property name="eclipselink.logging.level" value="FINEST"/>
-            <property name="eclipselink.logging.parameters" value="true"/>
-            <!-- Generate DDL scripts without applying them -->
-            <property name="eclipselink.ddl-generation" value="create-or-extend-tables"/>
-            <property name="eclipselink.ddl-generation.output-mode" value="sql-script"/>
-            <!-- Use a relative path for the application location -->
-            <property name="eclipselink.application-location" value="c:/tmp/"/>
-            <!-- After generation, set ddl-generation to 'none' -->
-            <!-- <property name="eclipselink.ddl-generation" value="none"/> -->
-
+            <property name="eclipselink.logging.level" value="SEVERE"/>
         </properties>
     </persistence-unit>
     <persistence-unit name="hmisAuditPU" transaction-type="JTA">
-        <jta-data-source>jdbc/ruhunuAudit</jta-data-source>
+        <jta-data-source>${JDBC_AUDIT_DATASOURCE}</jta-data-source>
         <exclude-unlisted-classes>false</exclude-unlisted-classes>
         <properties>
-            <property name="eclipselink.logging.level" value="FINEST"/>
-            <property name="eclipselink.logging.parameters" value="true"/>
-            <!-- Generate DDL scripts without applying them -->
-            <property name="eclipselink.ddl-generation" value="create-or-extend-tables"/>
-            <property name="eclipselink.ddl-generation.output-mode" value="sql-script"/>
-            <!-- Use a relative path for the application location -->
-            <property name="eclipselink.application-location" value="c:/tmp/"/>
-            <!-- After generation, set ddl-generation to 'none' -->
-            <!-- <property name="eclipselink.ddl-generation" value="none"/> -->
+            <property name="eclipselink.logging.level" value="SEVERE"/>
         </properties>
     </persistence-unit>
 </persistence>

--- a/src/main/resources/META-INF/persistence.xml
+++ b/src/main/resources/META-INF/persistence.xml
@@ -2,17 +2,17 @@
 <persistence version="2.2" xmlns="http://java.sun.com/xml/ns/persistence" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/persistence http://xmlns.jcp.org/xml/ns/persistence/persistence_2_2.xsd">
     <persistence-unit name="hmisPU" transaction-type="JTA">
         <provider>org.eclipse.persistence.jpa.PersistenceProvider</provider>
-        <jta-data-source>${JDBC_DATASOURCE}</jta-data-source>
+        <jta-data-source>jdbc/sl</jta-data-source>
         <exclude-unlisted-classes>false</exclude-unlisted-classes>
         <properties>
-            <property name="eclipselink.logging.level" value="SEVERE"/>
+            <property name="eclipselink.logging.level.sql" value="SEVERE"/>
         </properties>
     </persistence-unit>
     <persistence-unit name="hmisAuditPU" transaction-type="JTA">
-        <jta-data-source>${JDBC_AUDIT_DATASOURCE}</jta-data-source>
+        <jta-data-source>jdbc/ruhunuAudit</jta-data-source>
         <exclude-unlisted-classes>false</exclude-unlisted-classes>
         <properties>
-            <property name="eclipselink.logging.level" value="SEVERE"/>
+            <property name="eclipselink.logging.level.sql" value="SEVERE"/>
         </properties>
     </persistence-unit>
 </persistence>

--- a/src/main/resources/META-INF/persistence.xml
+++ b/src/main/resources/META-INF/persistence.xml
@@ -2,17 +2,17 @@
 <persistence version="2.2" xmlns="http://java.sun.com/xml/ns/persistence" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/persistence http://xmlns.jcp.org/xml/ns/persistence/persistence_2_2.xsd">
     <persistence-unit name="hmisPU" transaction-type="JTA">
         <provider>org.eclipse.persistence.jpa.PersistenceProvider</provider>
-        <jta-data-source>jdbc/sl</jta-data-source>
+        <jta-data-source>${JDBC_DATASOURCE}</jta-data-source>
         <exclude-unlisted-classes>false</exclude-unlisted-classes>
         <properties>
-            <property name="eclipselink.logging.level.sql" value="SEVERE"/>
+            <property name="eclipselink.logging.level" value="SEVERE"/>
         </properties>
     </persistence-unit>
     <persistence-unit name="hmisAuditPU" transaction-type="JTA">
-        <jta-data-source>jdbc/ruhunuAudit</jta-data-source>
+        <jta-data-source>${JDBC_AUDIT_DATASOURCE}</jta-data-source>
         <exclude-unlisted-classes>false</exclude-unlisted-classes>
         <properties>
-            <property name="eclipselink.logging.level.sql" value="SEVERE"/>
+            <property name="eclipselink.logging.level" value="SEVERE"/>
         </properties>
     </persistence-unit>
 </persistence>

--- a/src/main/webapp/dataAdmin/admin_functions.xhtml
+++ b/src/main/webapp/dataAdmin/admin_functions.xhtml
@@ -15,6 +15,25 @@
                 <h:form >
 
                     <div class='row' >
+                        <div class="col-12 col-md-12 col-lg-12 p-1">
+                            <h:form>
+                                <h:outputLabel value="From Date" />
+                                <p:calendar id="calFrom" 
+                                            navigator="false" pattern="#{sessionController.applicationPreference.longDateTimeFormat}"
+                                            value="#{billController.fromDate}">
+                                    <p:ajax event="dateSelect" process="calFrom" />
+                                </p:calendar>
+
+                                <p:spacer width="10em" />
+
+                                <h:outputLabel value="To Date" />
+                                <p:calendar id="calTo"
+                                            navigator="false" pattern="#{sessionController.applicationPreference.longDateTimeFormat}"
+                                            value="#{billController.toDate}">
+                                    <p:ajax event="dateSelect" process="calTo" />
+                                </p:calendar>
+                            </h:form>
+                        </div>
 
 
                         <div class="col-12 col-md-4 col-lg-2 p-1">
@@ -36,17 +55,17 @@
                         </div>
 
 
-<div class="col-12 col-md-8 col-lg-6 p-1">
-    <p:commandButton 
-        ajax="false"
-        disabled="false"
-        onclick="return confirm('This will modify billing data. Proceed?');"
-        rendered="#{webUserController.hasPrivilege('Developers')}"
-        action="#{billController.fixTotalInPHARMACY_RETAIL_SALE_RETURN_ITEMS_ONLY}"
-        update=":growl"
-        class="w-100 m-1"
-        value="FIX Gross Total in PHARMACY_RETAIL_SALE_RETURN_ITEMS_ONLY Bills"/>
-</div>
+                        <div class="col-12 col-md-8 col-lg-6 p-1">
+                            <p:commandButton 
+                                ajax="false"
+                                disabled="false"
+                                onclick="return confirm('This will modify billing data. Proceed?');"
+                                rendered="#{webUserController.hasPrivilege('Developers')}"
+                                action="#{billController.fixTotalInPHARMACY_RETAIL_SALE_RETURN_ITEMS_ONLY}"
+                                update=":growl"
+                                class="w-100 m-1"
+                                value="FIX Gross Total in PHARMACY_RETAIL_SALE_RETURN_ITEMS_ONLY Bills"/>
+                        </div>
 
                         <div class="col-12 col-md-8 col-lg-6 p-1">
                             <p:commandButton 
@@ -66,6 +85,16 @@
                                 class="w-100 m-1"
                                 value="FIX Gross Total in PHARMACY_RETAIL_SALE_RETURN_ITEMS_ONLY Bills"/>
                         </div>
+
+<!--                        <div class="col-12 col-md-8 col-lg-6 p-1">
+                            <p:commandButton 
+                                ajax="false"
+                                disabled="false"
+                                action="#{billController.convertPharmaceuticalBillItemReferanceFromErronouslyRecordedPharmacyRetailSaleCancellationPreBillToPharmacyRetailSalePreBillForAllBills}"
+                                class="w-100 m-1"
+                                value="Fix Pharmaceutical BillItem Reference for All PHARMACY_RETAIL_SALE_CANCELLED Bills"/>
+                        </div>-->
+
 
 
 

--- a/src/main/webapp/pharmacy/reports/summary_reports/pharmacy_income_and_cost_report.xhtml
+++ b/src/main/webapp/pharmacy/reports/summary_reports/pharmacy_income_and_cost_report.xhtml
@@ -186,8 +186,12 @@
                         ajax="false"
                         styleClass="ui-button-info m-1"
                         icon="pi pi-download">
-                        <p:dataExporter fileName="pharmacy_income_report.xlsx" target="tbl" type="xlsx" />
+                        <p:dataExporter 
+                            type="xlsx" 
+                            target="tbl"
+                            fileName="pharmacy_income_and_cost_bill_item_report_#{pharmacySummaryReportController.fromDate}_to_#{pharmacySummaryReportController.toDate}" />
                     </p:commandButton>
+
 
                     <p:commandButton 
                         value="Print" 

--- a/src/main/webapp/pharmacy/reports/summary_reports/pharmacy_income_report.xhtml
+++ b/src/main/webapp/pharmacy/reports/summary_reports/pharmacy_income_report.xhtml
@@ -186,8 +186,13 @@
                         ajax="false"
                         styleClass="ui-button-info m-1"
                         icon="pi pi-download">
-                        <p:dataExporter fileName="pharmacy_income_report.xlsx" target="tbl" type="xlsx" />
+
+                        <p:dataExporter 
+                            type="xlsx" 
+                            target="tbl"
+                            fileName="pharmacy_income_#{pharmacySummaryReportController.fromDate}_to_#{pharmacySummaryReportController.toDate}" />
                     </p:commandButton>
+
 
                     <p:commandButton 
                         value="Print" 
@@ -219,7 +224,7 @@
                             <h:outputText value="#{row.bill.deptId}"  style="padding: 0px!important; margin: 0px!important;" />
                             <f:facet name="footer" >
                                 <h:outputText value="Total Amounts" style="padding: 0px!important; margin: 0px!important; font-weight: bold" >
-                                    
+
                                 </h:outputText>
                             </f:facet>
                         </p:column>

--- a/src/main/webapp/resources/ezcomp/view/pharmaceutical_bill_item_list_edit.xhtml
+++ b/src/main/webapp/resources/ezcomp/view/pharmaceutical_bill_item_list_edit.xhtml
@@ -14,56 +14,72 @@
 
     <!-- IMPLEMENTATION -->
     <cc:implementation>
-
         <p:commandButton value="Download" ajax="false">
-            <p:dataExporter fileName="bill_items" target="tblBillItems" type="xlsx" ></p:dataExporter>
+            <p:dataExporter 
+                fileName="pharmaceutical_bill_items" 
+                target="tblBillItems" 
+                type="xlsx" />
         </p:commandButton>
 
         <p:dataTable 
             id="tblBillItems"
-            value="#{cc.attrs.pharmaceuticalBillItems}" var="bi" rowKey="#{bi.id}" >
-            <f:facet name="header" >
-                <h:outputText value="Pharmaceutical Bill Items" ></h:outputText>
+            value="#{cc.attrs.pharmaceuticalBillItems}" 
+            var="bi" 
+            rowKey="#{bi.id}" 
+            editable="true">
+
+            <f:facet name="header">
+                <h:outputText value="Pharmaceutical Bill Items" />
             </f:facet>
+
             <p:column headerText="ID">
-                <h:outputText value="#{bi.id}" class="w-100 m-1"></h:outputText>
+                <h:outputText value="#{bi.id}" class="w-100 m-1" />
             </p:column>
+
             <p:column headerText="Bill Item ID">
-                <h:outputText value="#{bi.billItem.id}" class="w-100 m-1"></h:outputText>
+                <h:outputText value="#{bi.billItem.id}" class="w-100 m-1" />
             </p:column>
+
             <p:column headerText="Item">
-                <h:outputText value="#{bi.itemBatch.item.name}" class="w-100 m-1"></h:outputText>
+                <h:outputText value="#{bi.itemBatch.item.name}" class="w-100 m-1" />
             </p:column>
+
             <p:column headerText="Qty">
-                <h:outputText value="#{bi.qty}" class="w-100 m-1">
+                <p:inputText value="#{bi.qty}" styleClass="text-end w-100 m-1">
                     <f:convertNumber pattern="#,##0.00" />
-                </h:outputText>
+                </p:inputText>
             </p:column>
-            <p:column headerText="Fee Qty">
-                <h:outputText value="#{bi.freeQty}" class="w-100 m-1">
+
+            <p:column headerText="Free Qty">
+                <p:inputText value="#{bi.freeQty}" styleClass="text-end w-100 m-1">
                     <f:convertNumber pattern="#,##0.00" />
-                </h:outputText>
+                </p:inputText>
             </p:column>
+
             <p:column headerText="Retail Rate">
-                <h:outputText value="#{bi.retailRate}" class="w-100 m-1">
+                <p:inputText value="#{bi.retailRate}" styleClass="text-end w-100 m-1">
                     <f:convertNumber pattern="#,##0.00" />
-                </h:outputText>
+                </p:inputText>
             </p:column>
+
             <p:column headerText="Retail Value">
-                <h:outputText value="#{bi.retailValue}" class="w-100 m-1">
+                <p:inputText value="#{bi.retailValue}" styleClass="text-end w-100 m-1">
                     <f:convertNumber pattern="#,##0.00" />
-                </h:outputText>
+                </p:inputText>
             </p:column>
+
             <p:column headerText="Purchase Rate">
-                <h:outputText value="#{bi.purchaseRate}" class="w-100 m-1">
+                <p:inputText value="#{bi.purchaseRate}" styleClass="text-end w-100 m-1">
                     <f:convertNumber pattern="#,##0.00" />
-                </h:outputText>
+                </p:inputText>
             </p:column>
+
             <p:column headerText="Purchase Value">
-                <h:outputText value="#{bi.purchaseValue}" class="w-100 m-1">
+                <p:inputText value="#{bi.purchaseValue}" styleClass="text-end w-100 m-1">
                     <f:convertNumber pattern="#,##0.00" />
-                </h:outputText>
+                </p:inputText>
             </p:column>
+
             <p:column headerText="Actions">
                 <p:commandButton 
                     value="Fix" 
@@ -75,8 +91,8 @@
                 </p:commandButton>
             </p:column>
 
-
         </p:dataTable>
+
 
     </cc:implementation>
 </html>

--- a/src/main/webapp/resources/ezcomp/view/pharmaceutical_bill_item_list_edit.xhtml
+++ b/src/main/webapp/resources/ezcomp/view/pharmaceutical_bill_item_list_edit.xhtml
@@ -83,7 +83,7 @@
             <p:column headerText="Actions">
                 <p:commandButton 
                     value="Fix" 
-                    action="#{billController.convertPharmaceuticalBillItemReferanceFromErronouslyRecordedPharmacyRetailSaleCancellationPreBillToPharmacyRetailSalePreBill(bi)}" 
+                    action="#{billController.convertPharmaceuticalBillItemReferenceFromErroneouslyRecordedPharmacyRetailSaleCancellationPreBillToPharmacyRetailSalePreBill(bi)}" 
                     ajax="false"
                     onclick="return confirm('Are you sure you want to fix this pharmaceutical bill item? This action cannot be undone.');"
                     styleClass="ui-button-warning"

--- a/src/main/webapp/resources/ezcomp/view/pharmaceutical_bill_item_list_edit.xhtml
+++ b/src/main/webapp/resources/ezcomp/view/pharmaceutical_bill_item_list_edit.xhtml
@@ -83,7 +83,7 @@
             <p:column headerText="Actions">
                 <p:commandButton 
                     value="Fix" 
-                    action="#{billController.convertPharmaceuticalBillItemReferenceFromErroneouslyRecordedPharmacyRetailSaleCancellationPreBillToPharmacyRetailSalePreBill(bi)}" 
+                    action="#{billController.convertPharmaceuticalBillItemReferanceFromErronouslyRecordedPharmacyRetailSaleCancellationPreBillToPharmacyRetailSalePreBill(bi)}" 
                     ajax="false"
                     onclick="return confirm('Are you sure you want to fix this pharmaceutical bill item? This action cannot be undone.');"
                     styleClass="ui-button-warning"


### PR DESCRIPTION
✅ **Fixed: Incorrect BillItem Rates in PHARMACY_RETAIL_SALE_RETURN_ITEMS_ONLY Bills**

This introduces a temporary admin method to correct historical data inconsistencies where `BillItem.rate`, `BillItem.netRate`, `BillItem.grossValue`, and `BillItem.netValue` were mistakenly recorded as positive in return-type bills (`PHARMACY_RETAIL_SALE_RETURN_ITEMS_ONLY`).

📌 **Admin Function Added:**  
**Correct Bill Item Rates in PHARMACY_RETAIL_SALE_RETURN_ITEMS_ONLY Bills**  
Accessible via:  
**Admin Menu → Manage Data, Workflows and Templates → System Admin Functions**

🔧 **What It Does:**  
- Identifies affected bills of the specified type  
- Updates each `BillItem` where values are incorrectly positive  
- Ensures all relevant fields reflect a return (negative values)  
- Does **not** alter the bill-level net total, as it is already correctly negative

🚨 **Important:**  
This fix must be executed **before** running the gross total correction function for these bills.

🗂️ Closes: #11819



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added date range selection to the admin functions interface for enhanced filtering.
	- Enabled inline editing of pharmaceutical bill item quantities and rates in the item list view.

- **Bug Fixes**
	- Ensured correct handling of negative values for return transactions in bill item corrections.
	- Corrected header label from "Fee Qty" to "Free Qty" in the pharmaceutical bill item list.

- **Refactor**
	- Improved consistency and formatting in pharmacy stock ledger PDF exports.
	- Enhanced resource management and formatting for exported reports.

- **Style**
	- Updated exported filenames for pharmacy income reports to include the selected date range.
	- Renamed exported file for pharmaceutical bill items for clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->