### PR TITLE
11822 temporary administrative method to rectify historical gross total discrepancies in inward medicine returns

### DIFF
--- a/src/main/java/com/divudi/bean/common/BillController.java
+++ b/src/main/java/com/divudi/bean/common/BillController.java
@@ -3063,6 +3063,67 @@ public class BillController implements Serializable, ControllerWithMultiplePayme
         System.out.println("Completed correction of BillItem values.");
     }
 
+    /**
+     * Temporary admin method to correct BillItem rate, netRate, grossValue, and
+     * netValue for DIRECT_ISSUE_INWARD_MEDICINE_RETURN bills. These values
+     * should be negative to reflect a return transaction.
+     *
+     * Note: This method does not alter Bill-level totals.
+     *
+     * ChatGPT contributed - 2025-04
+     */
+    public void correctBillItemRatesInDIRECT_ISSUE_INWARD_MEDICINE_RETURN() {
+        System.out.println("Starting BillItem correction for DIRECT_ISSUE_INWARD_MEDICINE_RETURN");
+
+        String jpql = "SELECT b FROM Bill b WHERE b.retired = false AND b.billTypeAtomic = :bta";
+        Map<String, Object> params = new HashMap<>();
+        params.put("bta", BillTypeAtomic.DIRECT_ISSUE_INWARD_MEDICINE_RETURN);
+
+        List<Bill> bills = getFacade().findByJpql(jpql, params, 1000);
+        if (bills == null || bills.isEmpty()) {
+            System.out.println("No matching bills found.");
+            return;
+        }
+
+        System.out.println("Number of bills found: " + bills.size());
+
+        for (Bill bill : bills) {
+            System.out.println("Processing bill ID: " + bill.getId());
+            for (BillItem bi : bill.getBillItems()) {
+                boolean updated = false;
+
+                if (bi.getRate() > 0) {
+                    bi.setRate(-bi.getRate());
+                    updated = true;
+                }
+
+                if (bi.getNetRate() > 0) {
+                    bi.setNetRate(-bi.getNetRate());
+                    updated = true;
+                }
+
+                if (bi.getGrossValue() > 0) {
+                    bi.setGrossValue(-bi.getGrossValue());
+                    updated = true;
+                }
+
+                if (bi.getNetValue() > 0) {
+                    bi.setNetValue(-bi.getNetValue());
+                    updated = true;
+                }
+
+                if (updated) {
+                    billItemFacade.edit(bi);
+                    System.out.println("Updated BillItem ID: " + bi.getId());
+                } else {
+                    System.out.println("No update needed for BillItem ID: " + bi.getId());
+                }
+            }
+        }
+
+        System.out.println("Completed correction of BillItem values.");
+    }
+
     public void addMissingBillTypeAtomics() {
         System.out.println("addMissingBillTypeAtomics");
         String jpql = "select b "

--- a/src/main/resources/META-INF/persistence.xml
+++ b/src/main/resources/META-INF/persistence.xml
@@ -2,17 +2,17 @@
 <persistence version="2.2" xmlns="http://java.sun.com/xml/ns/persistence" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/persistence http://xmlns.jcp.org/xml/ns/persistence/persistence_2_2.xsd">
     <persistence-unit name="hmisPU" transaction-type="JTA">
         <provider>org.eclipse.persistence.jpa.PersistenceProvider</provider>
-        <jta-data-source>${JDBC_DATASOURCE}</jta-data-source>
+        <jta-data-source>jdbc/sl</jta-data-source>
         <exclude-unlisted-classes>false</exclude-unlisted-classes>
         <properties>
-            <property name="eclipselink.logging.level" value="SEVERE"/>
+            <property name="eclipselink.logging.level.sql" value="SEVERE"/>
         </properties>
     </persistence-unit>
     <persistence-unit name="hmisAuditPU" transaction-type="JTA">
-        <jta-data-source>${JDBC_AUDIT_DATASOURCE}</jta-data-source>
+        <jta-data-source>jdbc/ruhunuAudit</jta-data-source>
         <exclude-unlisted-classes>false</exclude-unlisted-classes>
         <properties>
-            <property name="eclipselink.logging.level" value="SEVERE"/>
+            <property name="eclipselink.logging.level.sql" value="SEVERE"/>
         </properties>
     </persistence-unit>
 </persistence>

--- a/src/main/resources/META-INF/persistence.xml
+++ b/src/main/resources/META-INF/persistence.xml
@@ -2,17 +2,17 @@
 <persistence version="2.2" xmlns="http://java.sun.com/xml/ns/persistence" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/persistence http://xmlns.jcp.org/xml/ns/persistence/persistence_2_2.xsd">
     <persistence-unit name="hmisPU" transaction-type="JTA">
         <provider>org.eclipse.persistence.jpa.PersistenceProvider</provider>
-        <jta-data-source>jdbc/sl</jta-data-source>
+        <jta-data-source>${JDBC_DATASOURCE}</jta-data-source>
         <exclude-unlisted-classes>false</exclude-unlisted-classes>
         <properties>
-            <property name="eclipselink.logging.level.sql" value="SEVERE"/>
+            <property name="eclipselink.logging.level" value="SEVERE"/>
         </properties>
     </persistence-unit>
     <persistence-unit name="hmisAuditPU" transaction-type="JTA">
-        <jta-data-source>jdbc/ruhunuAudit</jta-data-source>
+        <jta-data-source>${JDBC_AUDIT_DATASOURCE}</jta-data-source>
         <exclude-unlisted-classes>false</exclude-unlisted-classes>
         <properties>
-            <property name="eclipselink.logging.level.sql" value="SEVERE"/>
+            <property name="eclipselink.logging.level" value="SEVERE"/>
         </properties>
     </persistence-unit>
 </persistence>

--- a/src/main/webapp/dataAdmin/admin_functions.xhtml
+++ b/src/main/webapp/dataAdmin/admin_functions.xhtml
@@ -55,6 +55,19 @@
                         </div>
 
 
+                        <div class="col-12 col-md-8 col-lg-6 p-1">
+                            <p:commandButton 
+                                ajax="false"
+                                disabled="false"
+                                action="#{billController.correctBillItemRatesInDIRECT_ISSUE_INWARD_MEDICINE_RETURN}"
+                                class="w-100 m-1"
+                                value="Correct Bill Item Rates in DIRECT_ISSUE_INWARD_MEDICINE_RETURN Bills"/>
+                        </div>
+
+
+
+
+
 
                         <div class="col-12 col-md-4 col-lg-2 p-1" >
                             <p:commandButton 

--- a/src/main/webapp/dataAdmin/admin_functions.xhtml
+++ b/src/main/webapp/dataAdmin/admin_functions.xhtml
@@ -39,6 +39,16 @@
                             <p:commandButton 
                                 ajax="false"
                                 disabled="false"
+                                action="#{billController.correctBillItemRatesInPHARMACY_RETAIL_SALE_RETURN_ITEMS_ONLY}"
+                                class="w-100 m-1"
+                                value="Correct Bill Item Rates in PHARMACY_RETAIL_SALE_RETURN_ITEMS_ONLY Bills"/>
+                        </div>
+
+
+                        <div class="col-12 col-md-8 col-lg-6 p-1">
+                            <p:commandButton 
+                                ajax="false"
+                                disabled="false"
                                 action="#{billController.fixTotalInPHARMACY_RETAIL_SALE_RETURN_ITEMS_ONLY}"
                                 class="w-100 m-1"
                                 value="FIX Gross Total in PHARMACY_RETAIL_SALE_RETURN_ITEMS_ONLY Bills"/>

--- a/src/main/webapp/dataAdmin/search_bill.xhtml
+++ b/src/main/webapp/dataAdmin/search_bill.xhtml
@@ -123,7 +123,11 @@
                                 <h:outputLabel  value="#{bill.billClassType}" ></h:outputLabel>
                             </p:column>
 
-                            <p:column headerText="Atomic Type">
+                            <p:column 
+                                headerText="Atomic Type"
+                                sortBy="#{bill.billTypeAtomic}"
+                                filterBy="#{bill.billTypeAtomic}"
+                                filterMatchMode="contains">
                                 <h:outputLabel  value="#{bill.billTypeAtomic}" ></h:outputLabel>
                             </p:column>
 

--- a/src/main/webapp/pharmacy/pharmacy_reprint_bill.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_reprint_bill.xhtml
@@ -32,7 +32,7 @@
                                 icon="fa fa-times"
                                 action="pharmacy_cancel_bill" 
                                 disabled="#{pharmacyBillSearch.bill.cancelled}" 
-                                rendered="#{webUserController.hasPrivilege('PharmacySaleCancel') or true}">
+                                rendered="#{webUserController.hasPrivilege('PharmacySaleCancel')}">
                             </p:commandButton>
 
                             <p:commandButton 


### PR DESCRIPTION
✅ Issue resolved via temporary admin method: `correctBillItemRatesInDIRECT_ISSUE_INWARD_MEDICINE_RETURN()`.

The problem was isolated to incorrect positive values in `BillItem` fields (`rate`, `netRate`, `grossValue`, `netValue`) under `DIRECT_ISSUE_INWARD_MEDICINE_RETURN` bills. The parent `Bill` totals were already correct, so no changes were made to bill-level data.

This method safely negates the relevant fields in affected `BillItem`s to reflect proper return semantics.

✅ A JSF command button was also added to trigger this correction manually.

No further action needed on this data set. Permanent fix to the return generation logic will be addressed separately. Closing this issue.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added new administrative actions for correcting and fixing bill data, accessible via additional buttons in the admin interface.
  - Introduced an "Admin" button in the pharmacy reprint bill page for users with developer privileges, enabling direct navigation to advanced bill management.

- **Enhancements**
  - Improved the "Atomic Type" column in bill search with sorting and filtering capabilities.
  - Updated styling and icons for action buttons in the pharmacy reprint bill page for better clarity and user experience.

- **Access Control**
  - Refined visibility of the "Cancel" and "Admin" buttons based on user privileges.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->