### PR TITLE
Closes #11887

### DIFF
--- a/src/main/webapp/dataAdmin/bills_with_errors.xhtml
+++ b/src/main/webapp/dataAdmin/bills_with_errors.xhtml
@@ -126,7 +126,7 @@
                                 <f:selectItem itemLabel="All Types" ></f:selectItem>
                                 <f:selectItems 
                                     var="billTypeAtomic"
-                                    itemLabel="#{billTypeAtomic.label}"           
+                                    itemLabel="#{billTypeAtomic}"           
                                     itemValue="#{billTypeAtomic}" 
                                     value="#{enumController.billTypesAtomic}" ></f:selectItems>
                             </p:selectOneMenu>
@@ -166,13 +166,6 @@
                                 ajax="false" 
                                 value="List Bills with Errors" 
                                 action="#{searchController.findBillsWithErrors}"/>
-                            <p:commandButton 
-                                class="ui-button-success" 
-                                icon="fas fa-magnifying-glass" 
-                                id="btnSearch"
-                                ajax="false" 
-                                value="List All Bills" 
-                                action="#{searchController.listBills()}"/>
                             <p:commandButton class="ui-button-success mx-2" icon="fas fa-file-excel" id="btnExcel" ajax="false" value="Excel" >
                                 <p:dataExporter fileName="Bill With Errors" type="xlsx" target="tblBills" ></p:dataExporter>
                             </p:commandButton>
@@ -192,19 +185,14 @@
                                          rowsPerPageTemplate="5,10,15,50"
                                          >
 
-<!--                                <p:column rendered="#{webUserController.hasPrivilege('Developers')}" headerText="Bill ID" sortBy="#{bill.id}" filterBy="#{bill.id}" filterMatchMode="contains" >                                
-                                    <h:outputLabel value="#{bill.id}"/>
-                                </p:column>-->
+
                                 <p:column
                                     headerText="Bill No" sortBy="#{bill.deptId}" filterBy="#{bill.deptId}" 
                                     filterMatchMode="contains" >                                
                                     <h:outputLabel value="#{bill.deptId}"/>
                                 </p:column>
-<!--                                <p:column headerText="Bill Class" >                                
-                                    <h:outputLabel value="#{bill.billClass}"/>
-                                </p:column>-->
                                 <p:column headerText="Bill Type" >                                
-                                    <h:outputLabel value="#{bill.billTypeAtomic.label}"/>
+                                    <h:outputLabel value="#{bill.billTypeAtomic}"/>
                                 </p:column>
                                 <p:column headerText="Date/Time">
                                     <p:outputLabel value="#{bill.createdAt}" >


### PR DESCRIPTION
**✅ Closing Comment**

Issue reviewed and clarified.

Bills without Bill Items under Collecting Centre Bills were not listed in the **Bills with Errors** report found under:

`Administration > Metadata > Search & Lists > Bills with Errors` (*Note: “Manage Data, Workflows and Templates” was renamed to “Metadata”*)

🛠️ **Root Cause:**
If the **Settle** method is triggered twice—typically due to double-clicking during slow system performance—two bills are created:
- The first bill is valid and contains bill items.
- The second bill is a duplicate with matching totals but no bill items.

This bug was due to the absence of a mechanism to prevent repeated method execution.

🆕 A new issue will be created to address this **double-click vulnerability**, as the root cause has been confirmed.

📌 **Impact:**
- **Cashier Summaries** and related reports are unaffected.
- **Collecting Centre Statements** show incorrect balances from the point of the erroneous bills onward.
- Manual balance adjustments are required.
- Erroneous bills (without items) must be manually deleted.

Closing this issue. Further actions will be tracked under the new issue.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added validation to ensure credit card-related bills contain bill items and that their net totals match the sum of their bill items.
- **Bug Fixes**
  - Improved error detection and messaging for bills with inconsistencies.
- **Refactor**
  - Streamlined bill validation logic for better maintainability.
- **Style**
  - Updated bill type labels in the user interface for consistency.
- **Chores**
  - Removed the "List All Bills" button from the bills with errors page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->