### PR TITLE
Recreate the print view

### DIFF
--- a/src/main/webapp/pharmacy/reports/summary_reports/pharmacy_income_report.xhtml
+++ b/src/main/webapp/pharmacy/reports/summary_reports/pharmacy_income_report.xhtml
@@ -198,12 +198,11 @@
                         <p:printer target="tbl" />
                     </p:commandButton>
 
-                    <p:button 
+                    <p:commandButton
                         value="To Print" 
                         styleClass="ui-button-warning m-1"
                         icon="pi pi-print"
-                        outcome="pharmacy_income_report_print"
-                        target="_blank"/>
+                        action="pharmacy_income_report_print_view?faces-redirect=true;"/>
 
 
                     <p:dataTable

--- a/src/main/webapp/pharmacy/reports/summary_reports/pharmacy_income_report_print_view.xhtml
+++ b/src/main/webapp/pharmacy/reports/summary_reports/pharmacy_income_report_print_view.xhtml
@@ -1,0 +1,373 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
+      xmlns:h="http://xmlns.jcp.org/jsf/html"
+      xmlns:p="http://primefaces.org/ui"
+      xmlns:f="http://xmlns.jcp.org/jsf/core">
+
+    <h:body>
+        <ui:composition template="/resources/template/template.xhtml">
+            <ui:define name="content">
+
+                <h:form >
+                    <p:panel header="Pharmacy Income Report Print" styleClass="w-100">
+                        <f:facet name="header"  >
+                            <div class="d-flex justify-content-between">
+                                <h:outputText value="Pharmacy Income Report Print" class="mt-2"/>
+                                <div class="d-flex gap-2">
+                                    <p:commandButton
+                                        icon="fa-solid fa-print"
+                                        class="ui-button-info"
+                                        style="width: 150px"
+                                        ajax="false"
+                                        value="Print">
+                                        <p:printer target="reportView" />
+                                    </p:commandButton>
+                                    <p:commandButton
+                                        ajax="false"
+                                        value="Back to Report"
+                                        style="width: 200px"
+                                        icon="fa fa-arrow-left"
+                                        class="ui-button-warning"
+                                        action="pharmacy_income_report?faces-redirect=true;" >
+                                    </p:commandButton>
+                                </div>
+
+                            </div>
+                        </f:facet>
+
+                        <style>
+
+                            @media screen{
+                                .paper{
+                                    position: static !important;
+                                    width: 297mm!important;
+                                    zoom: 2.0;
+                                }
+
+                                table {
+                                    border-collapse: collapse;
+                                    width: 100%;
+                                    font-size: 12px!important;
+                                    margin-top: 1mm!important;
+                                }
+
+                                th, td {
+                                    border: 1px solid #000;
+                                    padding: 0px!important;
+                                    margin: 2px!important;
+                                    text-align: left;
+                                    margin-left: 10mm!important;
+                                }
+
+                                .header{
+                                    font-size: 16px!important;
+                                }
+
+                                tfoot{
+                                    font-weight: 700!important;
+                                    font-size: 11px!important;
+                                }
+                            }
+
+                            @media print {
+                                @page {
+                                    @bottom-right {
+                                        content: "Page " counter(page) " of " counter(pages);
+                                        font-family: Arial, sans-serif;
+                                        font-size: 10pt;
+                                    }
+                                }
+
+                                body {
+                                    counter-reset: page;
+                                }
+
+                                .paper{
+                                    position: static !important;
+                                    width: 297mm!important;
+                                    size: A4 landscape!important;
+
+                                }
+
+                                .header{
+                                    line-height: 1.1;
+                                    margin: 0mm!important;
+                                    font-size: 13px!important;
+                                }
+
+                                table {
+                                    border-collapse: collapse;
+                                    width: 99.9%;
+                                    font-size: 12px!important;
+                                    margin-top: 1mm!important;
+                                }
+                                th, td {
+                                    border: 1px solid #000;
+                                    padding: 0px!important;
+                                    margin: 2px!important;
+                                    text-align: left;
+                                    margin-left: 10mm!important;
+                                }
+                                th {
+
+                                }
+                                tfoot{
+                                    font-weight: 700!important;
+                                    font-size: 11px!important;
+                                }
+                            }
+                        </style>
+
+                        <h:panelGroup id="reportView" class="d-flex justify-content-center">
+                            <div class="paper">
+                                <div class="header" >
+                                    <div class="d-flex justify-content-center text-5 gap-2" style="font-weight: 700; font-size: 22px;">
+                                        <h:outputText value="#{sessionController.institution.name}"/>
+                                    </div>
+                                    <div class="d-flex justify-content-center text-5 gap-2" style="font-weight: 700; font-size: 18px;">
+                                        <h:outputText value="All Sales Report"/>
+                                        <h:panelGroup  rendered="#{pharmacySummaryReportController.department ne null}">
+                                            <div class="d-flex gap-2">
+                                                <h:outputText value="-" style="width: 1em!important;" class="text-center"/>
+                                                <h:outputText value="#{pharmacySummaryReportController.department.name}"/>
+                                            </div>
+                                        </h:panelGroup>
+                                    </div>
+                                    <div class="d-flex justify-content-center mt-2" style=" font-size: 12px;">
+                                        <div class="d-flex gap-3">
+                                            <h:outputText value="From Date" style="width: 5em!important; font-weight: 600;"/>
+                                            <h:outputText value="#{pharmacySummaryReportController.fromDate}">
+                                                <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateFormat}" />
+                                            </h:outputText>
+                                        </div>
+                                        <h:outputText value="" style="width: 15mm!important;"/>
+                                        <div class="d-flex gap-3">
+                                            <h:outputText value="To Date" style="width: 4em!important; font-weight: 600;"/>
+                                            <h:outputText value="#{pharmacySummaryReportController.toDate}">
+                                                <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateFormat}" />
+                                            </h:outputText>
+                                        </div>
+                                        <div></div>
+                                    </div>
+
+                                    <div class="d-flex justify-content-between mt-2 w-100 gap-2" style=" font-size: 16px;" id="toinsdept">
+                                        <div class="d-flex gap-2">
+                                            <h:outputText
+                                                rendered="#{pharmacySummaryReportController.toInstitution ne null}"
+                                                value="#{pharmacySummaryReportController.toInstitution.name}"
+                                                style="font-weight: 600;">
+                                            </h:outputText>
+                                            <h:outputText
+                                                value="-"
+                                                rendered="#{pharmacySummaryReportController.toInstitution ne null and pharmacySummaryReportController.toDepartment ne null}"
+                                                style="width: 2em!important; font-weight: 600; text-align: center;"/>
+                                            <h:outputText
+                                                rendered="#{pharmacySummaryReportController.toInstitution ne null and pharmacySummaryReportController.toDepartment ne null}"
+                                                value="#{pharmacySummaryReportController.toDepartment.name}"
+                                                style="font-weight: 600;">
+                                            </h:outputText>
+                                        </div>
+                                    </div>
+                                </div>
+
+                                <div>
+                                    <table>
+                                        <thead>
+                                            <tr>
+                                                <th style="width: 7mm; font-weight: 700;">
+                                                    <h:outputText value="No" style="margin-left: 1mm;"/>
+                                                </th>
+                                                <th style="width: 25mm;font-weight: 700;">
+                                                    <h:outputText value="OrderNo" style="margin-left: 1mm;"/>
+                                                </th>
+                                                <th style="width: 67mm; font-weight: 700; text-align: left;">
+                                                    <h:outputText value="Patient Name" style="margin-left:  1mm;"/>
+                                                </th>
+                                                <th style="width: 17mm; font-weight: 700; text-align: left;">
+                                                    <h:outputText value="Date" style="margin-left:  1mm;"/>
+                                                </th>
+                                                <th style="width: 17mm; font-weight: 700; text-align: right;">
+                                                    <h:outputText value="Net Total" style="margin-right: 1mm;"/>
+                                                </th>
+                                                <th style="width: 17mm; font-weight: 700; text-align: right;">
+                                                    <h:outputText value="Cash" style="margin-right: 1mm;"/>
+                                                </th>
+                                                <th style="width: 17mm; font-weight: 700; text-align: right;">
+                                                    <h:outputText value="Card" style="margin-right: 1mm;"/>
+                                                </th>
+                                                <th style="width: 10mm; font-weight: 700; text-align: center;">
+                                                    <h:outputText value="#" style="margin-right: 1mm;"/>
+                                                </th>
+                                                <th style="width: 17mm; font-weight: 700; text-align: right;">
+                                                    <h:outputText value="IP Credit" style="margin-right: 1mm;"/>
+                                                </th>
+                                                <th style="width: 17mm; font-weight: 700; text-align: right;">
+                                                    <h:outputText value="OP Credit" style="margin-right: 1mm;"/>
+                                                </th>
+                                                <th style="width: 17mm; font-weight: 700; text-align: center;">
+                                                    <h:outputText value="Staff Credit" style="margin-right: 1mm;"/>
+                                                </th>
+                                                <th style="width: 17mm; font-weight: 700; text-align: center;">
+                                                    <h:outputText value="Agent Credit" style="margin-right: 1mm;"/>
+                                                </th>
+                                                <th style="width: 17mm; font-weight: 700; text-align: right;">
+                                                    <h:outputText value="Discount" style="margin-right: 1mm;"/>
+                                                </th>
+                                                <th style="width: 17mm; font-weight: 700; text-align: center;">
+                                                    <h:outputText value="Service Charge" style="margin-right: 1mm;"/>
+                                                </th>
+                                                <th style="width: 17mm; font-weight: 700; text-align: center;">
+                                                    <h:outputText value="Actual Total" style="margin-right: 1mm;"/>
+                                                </th>
+                                            </tr>
+                                        </thead>
+                                        <tbody>
+                                            <ui:repeat value="#{pharmacySummaryReportController.bundle.rows}" var="row" varStatus="i">
+                                                <tr>
+                                                    <td style="width: 8mm;" >
+                                                        <h:outputText value="#{i.index +1}" style="margin-left: 1mm;"/>
+                                                    </td>
+                                                    <td style="width: 25mm; text-align: left;">
+                                                        <h:outputText value="#{row.bill.deptId}" style="margin-left: 1mm;"/>
+                                                    </td>
+                                                    <td style="width: 67mm; text-align: left;">
+                                                        <h:outputText value="#{row.bill.patient.person.nameWithTitle}" style="margin-left: 1mm;"></h:outputText>
+                                                    </td>
+                                                    <td style="width: 17mm; text-align: left;">
+                                                        <h:outputText value="#{row.bill.createdAt}" style="margin-left: 1mm;">
+                                                            <f:convertDateTime pattern="dd/MM/YY" />
+                                                        </h:outputText>
+                                                    </td>
+                                                    <td style="width: 17mm; text-align: right;">
+                                                        <h:outputText value="#{row.bill.netTotal}" style="margin-right: 1mm;">
+                                                            <f:convertNumber pattern="#,##0.00" />
+                                                        </h:outputText>
+                                                    </td>
+                                                    <td style="width: 17mm; text-align: right;">
+                                                        <h:outputText value="#{row.cashValue}" style="margin-right: 1mm;">
+                                                            <f:convertNumber pattern="#,##0.00" />
+                                                        </h:outputText>
+                                                    </td>
+                                                    <td style="width: 17mm; text-align: right;">
+                                                        <h:outputText value="#{row.cardValue}" style="margin-right: 1mm;">
+                                                            <f:convertNumber pattern="#,##0.00" />
+                                                        </h:outputText>
+                                                    </td>
+                                                    <td style="width: 10mm; text-align: center;">
+                                                        <h:outputText value="-" style="margin-right: 1mm;"></h:outputText>
+                                                    </td>
+                                                    <td style="width: 17mm; text-align: right;">
+                                                        <h:outputText value="#{row.inpatientCreditValue}" style="margin-right: 1mm;">
+                                                            <f:convertNumber pattern="#,##0.00" />
+                                                        </h:outputText>
+                                                    </td>
+                                                    <td style="width: 17mm; text-align: right;">
+                                                        <h:outputText value="#{row.opdCreditValue}" style="margin-right: 1mm;">
+                                                            <f:convertNumber pattern="#,##0.00" />
+                                                        </h:outputText>
+                                                    </td>
+                                                    <td style="width: 17mm; text-align: right;">
+                                                        <h:outputText value="#{row.staffValue}" style="margin-right: 1mm;">
+                                                            <f:convertNumber pattern="#,##0.00" />
+                                                        </h:outputText>
+                                                    </td>
+                                                    <td style="width: 17mm; text-align: right;">
+                                                        <h:outputText value="#{row.agentValue}" style="margin-right: 1mm;">
+                                                            <f:convertNumber pattern="#,##0.00" />
+                                                        </h:outputText>
+                                                    </td>
+                                                    <td style="width: 17mm; text-align: right;">
+                                                        <h:outputText value="#{row.discount}" style="margin-right: 1mm;">
+                                                            <f:convertNumber pattern="#,##0.00" />
+                                                        </h:outputText>
+                                                    </td>
+                                                    <td style="width: 17mm; text-align: right;">
+                                                        <h:outputText value="#{row.serviceCharge}" style="margin-right: 1mm;">
+                                                            <f:convertNumber pattern="#,##0.00" />
+                                                        </h:outputText>
+                                                    </td>
+                                                    <td style="width: 17mm; text-align: right;">
+                                                        <h:outputText value="#{row.netTotal}" style="margin-right: 1mm;">
+                                                            <f:convertNumber pattern="#,##0.00" />
+                                                        </h:outputText>
+                                                    </td>
+                                                </tr>
+                                            </ui:repeat>
+                                        </tbody>
+                                        <tfoot>
+                                            <tr>
+                                                <td style="width: 8mm;" ></td>
+                                                <td style="width: 25mm; text-align: left;"></td>
+                                                <td style="width: 67mm; text-align: left;"></td>
+                                                <td style="width: 17mm; text-align: left;"></td>
+                                                <td style="width: 17mm; text-align: right;">
+                                                    <h:outputText value="#{pharmacySummaryReportController.bundle.summaryRow.netTotal}" style="margin-right: 1mm;">
+                                                        <f:convertNumber pattern="#,##0.00" />
+                                                    </h:outputText>
+                                                </td>
+                                                <td style="width: 17mm; text-align: right;">
+                                                    <h:outputText value="#{pharmacySummaryReportController.bundle.summaryRow.cashValue}" style="margin-right: 1mm;">
+                                                        <f:convertNumber pattern="#,##0.00" />
+                                                    </h:outputText>
+                                                </td>
+                                                <td style="width: 17mm; text-align: right;">
+                                                    <h:outputText value="#{pharmacySummaryReportController.bundle.summaryRow.cardValue}" style="margin-right: 1mm;">
+                                                        <f:convertNumber pattern="#,##0.00" />
+                                                    </h:outputText>
+                                                </td>
+                                                <td style="width: 10mm; text-align: center;">
+                                                    <h:outputText value="-" style="margin-right: 1mm;"></h:outputText>
+                                                </td>
+                                                <td style="width: 17mm; text-align: right;">
+                                                    <h:outputText value="#{pharmacySummaryReportController.bundle.summaryRow.inpatientCreditValue}" style="margin-right: 1mm;">
+                                                        <f:convertNumber pattern="#,##0.00" />
+                                                    </h:outputText>
+                                                </td>
+                                                <td style="width: 17mm; text-align: right;">
+                                                    <h:outputText value="#{pharmacySummaryReportController.bundle.summaryRow.opdCreditValue}" style="margin-right: 1mm;">
+                                                        <f:convertNumber pattern="#,##0.00" />
+                                                    </h:outputText>
+                                                </td>
+                                                <td style="width: 17mm; text-align: right;">
+                                                    <h:outputText value="#{pharmacySummaryReportController.bundle.summaryRow.staffValue}" style="margin-right: 1mm;">
+                                                        <f:convertNumber pattern="#,##0.00" />
+                                                    </h:outputText>
+                                                </td>
+                                                <td style="width: 17mm; text-align: right;">
+                                                    <h:outputText value="#{pharmacySummaryReportController.bundle.summaryRow.agentValue}" style="margin-right: 1mm;">
+                                                        <f:convertNumber pattern="#,##0.00" />
+                                                    </h:outputText>
+                                                </td>
+                                                <td style="width: 17mm; text-align: right;">
+                                                    <h:outputText value="#{pharmacySummaryReportController.bundle.summaryRow.discount}" style="margin-right: 1mm;">
+                                                        <f:convertNumber pattern="#,##0.00" />
+                                                    </h:outputText>
+                                                </td>
+                                                <td style="width: 17mm; text-align: right;">
+                                                    <h:outputText value="#{pharmacySummaryReportController.bundle.summaryRow.serviceCharge}" style="margin-right: 1mm;">
+                                                        <f:convertNumber pattern="#,##0.00" />
+                                                    </h:outputText>
+                                                </td>
+                                                <td style="width: 17mm; text-align: right;">
+                                                    <h:outputText value="#{pharmacySummaryReportController.bundle.summaryRow.netTotal}" style="margin-right: 1mm;">
+                                                        <f:convertNumber pattern="#,##0.00" />
+                                                    </h:outputText>
+                                                </td>
+                                            </tr>
+                                        </tfoot>
+                                    </table>
+
+                                </div>
+
+                            </div>
+                        </h:panelGroup>
+
+                    </p:panel>
+                </h:form>
+            </ui:define>
+        </ui:composition>
+
+    </h:body>
+</html>


### PR DESCRIPTION
Print Improvements in Pharmacy Income Report
[#11845](https://github.com/hmislk/hmis/issues/11845)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a dedicated print view page for the Pharmacy Income Report with optimized layout and formatting for A4 landscape printing.
  - Added detailed sales data table with summary totals and improved print styling.

- **Changes**
  - Updated the "To Print" button to open the print view in the same window instead of a new tab.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->