### PR TITLE
recreate the print view

### DIFF
--- a/src/main/webapp/pharmacy/reports/summary_reports/pharmacy_income_report.xhtml
+++ b/src/main/webapp/pharmacy/reports/summary_reports/pharmacy_income_report.xhtml
@@ -223,12 +223,11 @@
                                     fileName="pharmacy_income_by_bill_#{pharmacySummaryReportController.fromDate}_to_#{pharmacySummaryReportController.toDate}" />
                             </p:commandButton>
 
-                            <p:button 
+                            <p:commandButton
                                 value="To Print" 
                                 styleClass="ui-button-warning m-1"
                                 icon="pi pi-print"
-                                outcome="pharmacy_income_report_print"
-                                target="_blank"/>
+                                action="pharmacy_income_report_print_view"/>
 
                             <p:commandButton 
                                 value="Print" 


### PR DESCRIPTION
Print Improvements in Pharmacy Income Report
[#11845](https://github.com/hmislk/hmis/issues/11845)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated the "To Print" button in the pharmacy income report to use a command button for navigation, changing how the print view is accessed. The print view now opens in the same tab instead of a new tab.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->