### PR TITLE
Fixed - create-new-supplier-stock-summary-report

### DIFF
--- a/src/main/webapp/pharmacy/pharmacy_analytics.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_analytics.xhtml
@@ -118,6 +118,20 @@
                                             <p:commandButton class="w-100" value="Stock Taking Report(New)" action="pharmacy_report_adjustment_bill_for_stock_taking?faces-redirect=true" ajax="false" ></p:commandButton>                            
                                             <p:commandButton class="w-100" value="Stock With Movement" action="pharmacy_report_item_stock_sale?faces-redirect=true" ajax="false" ></p:commandButton>                            
 
+                                            <p:commandButton 
+                                                class="w-100 ui-button-warning"
+                                                value="Stock Summary (with Suppliers)" 
+                                                action="pharmacy_stock_summary_with_supplier?faces-redirect=true" 
+                                                ajax="false" >
+                                            </p:commandButton>   
+
+                                            <p:commandButton 
+                                                class="w-100"
+                                                rendered="false"
+                                                value="Supplier Stock Report" 
+                                                action="pharmacy_report_supplier_stock_by_batch?faces-redirect=true" 
+                                                ajax="false" >
+                                            </p:commandButton>       
                                         </div>
                                     </p:tab>
 

--- a/src/main/webapp/pharmacy/pharmacy_stock_summary_with_supplier.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_stock_summary_with_supplier.xhtml
@@ -109,7 +109,7 @@
                                     </h:outputText>
                                     <f:facet name="footer" >
                                         <h:outputText value="#{reportsStock.stockPurchaseValue}" >
-                                            <f:convertNumber parent="#,##0.00" ></f:convertNumber>
+                                            <f:convertNumber pattern="#,##0.00" ></f:convertNumber>
                                         </h:outputText>
                                     </f:facet>
                                 </p:column>
@@ -124,7 +124,7 @@
                                     </h:outputText>
                                     <f:facet name="footer" >
                                         <h:outputText value="#{reportsStock.stockSaleValue}" >
-                                            <f:convertNumber parent="#,##0.00" />
+                                            <f:convertNumber pattern="#,##0.00" />
                                         </h:outputText>
                                     </f:facet>
                                 </p:column>

--- a/src/main/webapp/pharmacy/pharmacy_stock_summary_with_supplier.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_stock_summary_with_supplier.xhtml
@@ -1,0 +1,139 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
+      xmlns:p="http://primefaces.org/ui"
+      xmlns:h="http://xmlns.jcp.org/jsf/html"
+      xmlns:f="http://xmlns.jcp.org/jsf/core"
+      >
+    <h:body>
+        <ui:composition template="/pharmacy/pharmacy_analytics.xhtml">
+            <ui:define name="subcontent">
+                <h:form>
+                    <p:panel header="Stock Summary (with Suppliers)" >
+                        <h:panelGrid columns="8" class="my-2" >
+
+                            <h:outputText value="Department" ></h:outputText>
+                            <p:autoComplete 
+                                class="mx-2" 
+                                completeMethod="#{departmentController.completeDept}" 
+                                var="dept" 
+                                itemLabel="#{dept.name}" 
+                                itemValue="#{dept}" 
+                                forceSelection="true" 
+                                maxlength="15"
+                                value="#{reportsStock.department}"  >
+                                <p:column headerText="Code" style="padding: 5px; width: 6em;">
+                                    <h:outputText value="#{dept.code}" ></h:outputText>
+                                </p:column>
+                                <p:column headerText="Name" style="padding: 5px; min-width: 20em;">
+                                    <h:outputText value="#{dept.name}" ></h:outputText>
+                                </p:column>
+                            </p:autoComplete>
+
+                            <p:commandButton 
+                                class="ui-button-warning " 
+                                icon="fas fa-cogs"  
+                                ajax="false" 
+                                value="Process" 
+                                action="#{reportsStock.fillAllSuppliersStocks()}" >
+                            </p:commandButton>
+
+                            <p:commandButton 
+                                class="ui-button-info mx-2" 
+                                icon="fas fa-print"  
+                                value="Print" 
+                                ajax="false" >
+                                <p:printer target="gpBillPreview" ></p:printer>
+                            </p:commandButton>
+
+                            <p:commandButton 
+                                class="ui-button-success" 
+                                icon="fas fa-file-excel"  
+                                ajax="false" value="Excel" 
+                                styleClass="noPrintButton" >
+                                <p:dataExporter type="xlsx" target="tbl" fileName="Category_report"/>
+                            </p:commandButton>
+                        </h:panelGrid>
+
+                        <h:panelGroup id="gpBillPreview">
+                            <p:dataTable 
+                                id="tbl" 
+                                value="#{reportsStock.records}" 
+                                var="i"
+                                rowIndexVar="ii"
+                                rows="20"
+                                paginator="true"
+                                paginatorPosition="bottom"
+                                paginatorTemplate="{CurrentPageReport}  {FirstPageLink} {PreviousPageLink} {PageLinks} {NextPageLink} {LastPageLink} {RowsPerPageDropdown}"
+                                rowsPerPageTemplate="20, 50, 100" 
+                                >
+                                <f:facet name="header">
+                                    <h:outputText value="Supplier Stock Summary - #{reportsStock.department.name}"/>  
+                                </f:facet>
+
+                                <p:column headerText="No." style="width: 40px;">
+                                    <h:outputText value="#{ii+1}" ></h:outputText>
+                                </p:column>
+
+                                <p:column
+                                    headerText="Supplier" 
+                                    sortBy="#{i.institution.name}"
+                                    filterBy="#{i.institution.name}"
+                                    filterMatchMode="contains">
+                                    <p:commandLink 
+                                        value="#{i.institution.name}"
+                                        action="#{reportsStock.fillDistributorStocks()}" 
+                                        ajax="false" >
+                                        <f:setPropertyActionListener target="#{reportsStock.institution}" value="#{i.institution}"/>
+                                    </p:commandLink>
+                                </p:column>
+
+                                <p:column 
+                                    headerText="Stock" 
+                                    sortBy="#{i.qty}"
+                                    style="width: 12em;"
+                                    styleClass="averageNumericColumn">
+                                    <h:outputText value="#{i.qty}"  >
+                                        <f:convertNumber pattern="#,###" ></f:convertNumber>
+                                    </h:outputText>
+                                </p:column>
+
+                                <p:column 
+                                    headerText="Purchase Value" 
+                                    styleClass="averageNumericColumn"
+                                    style="text-align: right; width: 12em;"
+                                    sortBy="#{i.purchaseValue}">
+                                    <h:outputText value="#{i.purchaseValue}"  >
+                                        <f:convertNumber pattern="#,##0.00" ></f:convertNumber>
+                                    </h:outputText>
+                                    <f:facet name="footer" >
+                                        <h:outputText value="#{reportsStock.stockPurchaseValue}" >
+                                            <f:convertNumber parent="#,##0.00" ></f:convertNumber>
+                                        </h:outputText>
+                                    </f:facet>
+                                </p:column>
+
+                                <p:column 
+                                    headerText="Sale Value"
+                                    styleClass="averageNumericColumn"
+                                    style="text-align: right; width: 12em;"
+                                    sortBy="#{i.retailsaleValue}">
+                                    <h:outputText value="#{i.retailsaleValue}"  >
+                                        <f:convertNumber pattern="#,##0.00" ></f:convertNumber>
+                                    </h:outputText>
+                                    <f:facet name="footer" >
+                                        <h:outputText value="#{reportsStock.stockSaleValue}" >
+                                            <f:convertNumber parent="#,##0.00" />
+                                        </h:outputText>
+                                    </f:facet>
+                                </p:column>
+
+                            </p:dataTable>
+                        </h:panelGroup>
+                    </p:panel>
+                </h:form>
+            </ui:define>
+        </ui:composition>
+    </h:body>
+</html>


### PR DESCRIPTION
closes #11880
Signed-off-by: DamithDeshan <hkddrajapaksha@gmail.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a "Stock Summary (with Suppliers)" report accessible from the pharmacy analytics section, allowing users to view and analyze stock quantities, purchase values, and sale values grouped by supplier for a selected department.
  - Added interactive filtering, sorting, pagination, and export/print options to the supplier stock summary report.

- **User Interface**
  - Added a new button in the Stock Reports tab to access the supplier-based stock summary.
  - Enhanced the report page with department selection, drill-down links, and data export capabilities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->