### PR TITLE
11920 pharmacy income report should have a view for inward type plus discount scheme

### DIFF
--- a/src/main/java/com/divudi/bean/pharmacy/PharmacySummaryReportController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacySummaryReportController.java
@@ -461,6 +461,9 @@ public class PharmacySummaryReportController implements Serializable {
             case BY_BILL_TYPE:
                 processPharmacyIncomeReportByBillType();
                 break;
+            case BY_DISCOUNT_TYPE_AND_ADMISSION_TYPE:
+                processPharmacyIncomeReportByDiscountTypeAndAdmissionType();
+                break;
             default:
                 JsfUtil.addErrorMessage("Unsupported report view type.");
                 break;
@@ -511,6 +514,53 @@ public class PharmacySummaryReportController implements Serializable {
         }, SummaryReports.PHARMACY_INCOME_REPORT, sessionController.getLoggedUser());
     }
 
+    public void processPharmacyIncomeReportByDiscountTypeAndAdmissionType() {
+        reportTimerController.trackReportExecution(() -> {
+            System.out.println("processPharmacyIncomeReportByBillType");
+            List<BillTypeAtomic> billTypeAtomics = new ArrayList<>();
+            billTypeAtomics.add(BillTypeAtomic.PHARMACY_RETAIL_SALE);
+            billTypeAtomics.add(BillTypeAtomic.PHARMACY_RETAIL_SALE_CANCELLED);
+            billTypeAtomics.add(BillTypeAtomic.PHARMACY_RETAIL_SALE_REFUND);
+            billTypeAtomics.add(BillTypeAtomic.PHARMACY_RETAIL_SALE_RETURN_ITEMS_AND_PAYMENTS);
+            billTypeAtomics.add(BillTypeAtomic.PHARMACY_RETAIL_SALE_PREBILL_SETTLED_AT_CASHIER);
+            billTypeAtomics.add(BillTypeAtomic.PHARMACY_RETAIL_SALE_RETURN_ITEMS_ONLY);
+            billTypeAtomics.add(BillTypeAtomic.PHARMACY_WHOLESALE);
+            billTypeAtomics.add(BillTypeAtomic.PHARMACY_WHOLESALE_CANCELLED);
+            billTypeAtomics.add(BillTypeAtomic.PHARMACY_WHOLESALE_PRE);
+            billTypeAtomics.add(BillTypeAtomic.PHARMACY_WHOLESALE_REFUND);
+            billTypeAtomics.add(BillTypeAtomic.DIRECT_ISSUE_INWARD_MEDICINE);
+            billTypeAtomics.add(BillTypeAtomic.DIRECT_ISSUE_INWARD_MEDICINE_CANCELLATION);
+            billTypeAtomics.add(BillTypeAtomic.DIRECT_ISSUE_INWARD_MEDICINE_RETURN);
+            billTypeAtomics.add(BillTypeAtomic.DIRECT_ISSUE_THEATRE_MEDICINE);
+            billTypeAtomics.add(BillTypeAtomic.DIRECT_ISSUE_THEATRE_MEDICINE_CANCELLATION);
+            billTypeAtomics.add(BillTypeAtomic.DIRECT_ISSUE_THEATRE_MEDICINE_RETURN);
+            billTypeAtomics.add(BillTypeAtomic.ISSUE_MEDICINE_ON_REQUEST_INWARD);
+            billTypeAtomics.add(BillTypeAtomic.ISSUE_MEDICINE_ON_REQUEST_INWARD_CANCELLATION);
+            billTypeAtomics.add(BillTypeAtomic.ISSUE_MEDICINE_ON_REQUEST_THEATRE);
+            billTypeAtomics.add(BillTypeAtomic.ISSUE_MEDICINE_ON_REQUEST_THEATRE_CANCELLATION);
+            billTypeAtomics.add(BillTypeAtomic.ACCEPT_RETURN_MEDICINE_INWARD);
+            billTypeAtomics.add(BillTypeAtomic.ACCEPT_RETURN_MEDICINE_THEATRE);
+
+            List<Bill> incomeBills = billService.fetchBills(fromDate, toDate, institution, site, department, webUser, billTypeAtomics, admissionType, paymentScheme);
+            bundle = new IncomeBundle(incomeBills);
+            for (IncomeRow r : bundle.getRows()) {
+                if (r.getBill() == null) {
+                    continue;
+                }
+                if (r.getBill().getPaymentMethod() == null) {
+                    continue;
+                }
+                if (r.getBill().getPaymentMethod().equals(PaymentMethod.MultiplePaymentMethods)) {
+                    r.setPayments(billService.fetchBillPayments(r.getBill()));
+                }
+                if (r.getBill().getPaymentMethod().equals(PaymentMethod.MultiplePaymentMethods)) {
+                    r.setPayments(billService.fetchBillPayments(r.getBill()));
+                }
+            }
+            bundle.generatePaymentDetailsGroupedDiscountSchemeAndAdmissionType();
+        }, SummaryReports.PHARMACY_INCOME_REPORT, sessionController.getLoggedUser());
+    }
+    
     public void processPharmacyIncomeReportByBill() {
         reportTimerController.trackReportExecution(() -> {
             System.out.println("processPharmacyIncomeReport");

--- a/src/main/java/com/divudi/core/data/IncomeBundle.java
+++ b/src/main/java/com/divudi/core/data/IncomeBundle.java
@@ -5,6 +5,24 @@ import static com.divudi.core.data.BillCategory.CANCELLATION;
 import static com.divudi.core.data.BillCategory.PAYMENTS;
 import static com.divudi.core.data.BillCategory.PREBILL;
 import static com.divudi.core.data.BillCategory.REFUND;
+import static com.divudi.core.data.PaymentMethod.Agent;
+import static com.divudi.core.data.PaymentMethod.Card;
+import static com.divudi.core.data.PaymentMethod.Cash;
+import static com.divudi.core.data.PaymentMethod.Cheque;
+import static com.divudi.core.data.PaymentMethod.Credit;
+import static com.divudi.core.data.PaymentMethod.IOU;
+import static com.divudi.core.data.PaymentMethod.MultiplePaymentMethods;
+import static com.divudi.core.data.PaymentMethod.None;
+import static com.divudi.core.data.PaymentMethod.OnCall;
+import static com.divudi.core.data.PaymentMethod.OnlineSettlement;
+import static com.divudi.core.data.PaymentMethod.PatientDeposit;
+import static com.divudi.core.data.PaymentMethod.PatientPoints;
+import static com.divudi.core.data.PaymentMethod.Slip;
+import static com.divudi.core.data.PaymentMethod.Staff;
+import static com.divudi.core.data.PaymentMethod.Staff_Welfare;
+import static com.divudi.core.data.PaymentMethod.Voucher;
+import static com.divudi.core.data.PaymentMethod.YouOweMe;
+import static com.divudi.core.data.PaymentMethod.ewallet;
 import com.divudi.core.entity.*;
 import com.divudi.core.entity.channel.SessionInstance;
 import com.divudi.core.entity.pharmacy.PharmaceuticalBillItem;
@@ -354,9 +372,10 @@ public class IncomeBundle implements Serializable {
 
             BillCategory bc = bta.getBillCategory();
             Double q = b.getQty();
-            Double rRate = bta == BillTypeAtomic.PHARMACY_RETAIL_SALE_RETURN_ITEMS_AND_PAYMENTS
-                    ? b.getBillItem().getNetRate()
-                    : b.getRetailRate();
+//            Double rRate = bta == BillTypeAtomic.PHARMACY_RETAIL_SALE_RETURN_ITEMS_AND_PAYMENTS
+//                    ? b.getBillItem().getNetRate()
+//                    : b.getRetailRate();
+            Double rRate = b.getRetailRate();
             Double pRate = b.getPurchaseRate();
 
             if (q == null || rRate == null || pRate == null) {
@@ -680,7 +699,164 @@ public class IncomeBundle implements Serializable {
 
         // Replace with grouped rows
         getRows().clear();
-        getRows().addAll(grouped.values());
+        grouped.values().stream()
+                .sorted(Comparator.comparing(IncomeRow::getBillTypeAtomic, Comparator.nullsLast(Comparator.naturalOrder())))
+                .forEachOrdered(getRows()::add);
+        populateSummaryRow();
+    }
+
+// Contribution by ChatGPT - adapted based on provided instructions
+    public void generatePaymentDetailsGroupedDiscountSchemeAndAdmissionType() {
+        Map<String, IncomeRow> grouped = new LinkedHashMap<>();
+
+        for (IncomeRow r : getRows()) {
+            Bill b = r.getBill();
+            if (b == null) {
+                continue;
+            }
+
+            // Standard processing from generatePaymentDetailsForBills()
+            r.setGrossTotal(b.getTotal());
+            r.setNetTotal(b.getNetTotal());
+            r.setDiscount(b.getDiscount());
+            r.setServiceCharge(b.getMargin());
+            r.setActualTotal(b.getTotal() - b.getServiceCharge());
+
+            if (b.getPaymentMethod() == null) {
+                r.setCreditValue(b.getNetTotal());
+                if (b.getPatientEncounter() != null) {
+                    r.setOpdCreditValue(0);
+                    r.setInpatientCreditValue(b.getNetTotal());
+                } else {
+                    r.setOpdCreditValue(0);
+                    r.setInpatientCreditValue(0);
+                    r.setNoneValue(b.getNetTotal());
+                }
+            } else {
+                switch (b.getPaymentMethod()) {
+                    case Agent:
+                        r.setAgentValue(b.getNetTotal());
+                        break;
+                    case Card:
+                        r.setCardValue(b.getNetTotal());
+                        break;
+                    case Cash:
+                        r.setCashValue(b.getNetTotal());
+                        break;
+                    case Cheque:
+                        r.setChequeValue(b.getNetTotal());
+                        break;
+                    case IOU:
+                        r.setIouValue(b.getNetTotal());
+                        break;
+                    case None:
+                        break;
+                    case OnCall:
+                        r.setOnCallValue(b.getNetTotal());
+                        break;
+                    case Credit:
+                        r.setCreditValue(b.getNetTotal());
+                        if (b.getPatientEncounter() != null) {
+                            r.setOpdCreditValue(0);
+                            r.setInpatientCreditValue(b.getNetTotal());
+                        } else {
+                            r.setOpdCreditValue(b.getNetTotal());
+                            r.setInpatientCreditValue(0);
+                        }
+                        break;
+                    case MultiplePaymentMethods:
+                        calculateBillPaymentValuesFromPayments(r);
+                        break;
+                    case OnlineSettlement:
+                        r.setOnlineSettlementValue(b.getNetTotal());
+                        break;
+                    case PatientDeposit:
+                        r.setPatientDepositValue(b.getNetTotal());
+                        break;
+                    case PatientPoints:
+                        r.setPatientPointsValue(b.getNetTotal());
+                        break;
+                    case Slip:
+                        r.setSlipValue(b.getNetTotal());
+                        break;
+                    case Staff:
+                        r.setStaffValue(b.getNetTotal());
+                        break;
+                    case Staff_Welfare:
+                        r.setStaffWelfareValue(b.getNetTotal());
+                        break;
+                    case Voucher:
+                        r.setVoucherValue(b.getNetTotal());
+                        break;
+                    case ewallet:
+                        r.setEwalletValue(b.getNetTotal());
+                        break;
+                    case YouOweMe:
+                        break;
+                }
+            }
+
+            String groupKey;
+            if (b.getPatientEncounter() != null) {
+                // Inpatient Sale
+                r.setAdmissionType(b.getPatientEncounter().getAdmissionType());
+                if (b.getPatientEncounter().getAdmissionType() == null) {
+                    r.setRowType("Inpatient Sale - No Admission Type");
+                    groupKey = "Inpatient Sale - No Admission Type";
+                } else {
+                    r.setRowType("Inpatient Sale - " + b.getPatientEncounter().getAdmissionType().getName());
+                    groupKey = "Inpatient Sale - " + b.getPatientEncounter().getAdmissionType().getName();
+                }
+            } else {
+                // Outpatient Sale
+                r.setPaymentScheme(b.getPaymentScheme());
+                if (b.getPaymentScheme() == null) {
+                    r.setRowType("Outpatient Sale - No Discount Scheme");
+                    groupKey = "Outpatient Sale - No Discount Scheme";
+                } else {
+                    r.setRowType("Outpatient Sale - " + b.getPaymentScheme().getName());
+                    groupKey = "Outpatient Sale - " + b.getPaymentScheme().getName();
+                }
+            }
+
+            IncomeRow groupRow = grouped.computeIfAbsent(groupKey, k -> {
+                IncomeRow ir = new IncomeRow();
+                ir.setRowType(k);
+                return ir;
+            });
+
+            groupRow.setNetTotal(groupRow.getNetTotal() + r.getNetTotal());
+            groupRow.setGrossTotal(groupRow.getGrossTotal() + r.getGrossTotal());
+            groupRow.setDiscount(groupRow.getDiscount() + r.getDiscount());
+            groupRow.setServiceCharge(groupRow.getServiceCharge() + r.getServiceCharge());
+            groupRow.setActualTotal(groupRow.getActualTotal() + r.getActualTotal());
+
+            groupRow.setCashValue(groupRow.getCashValue() + r.getCashValue());
+            groupRow.setCardValue(groupRow.getCardValue() + r.getCardValue());
+            groupRow.setChequeValue(groupRow.getChequeValue() + r.getChequeValue());
+            groupRow.setCreditValue(groupRow.getCreditValue() + r.getCreditValue());
+            groupRow.setOpdCreditValue(groupRow.getOpdCreditValue() + r.getOpdCreditValue());
+            groupRow.setInpatientCreditValue(groupRow.getInpatientCreditValue() + r.getInpatientCreditValue());
+            groupRow.setNoneValue(groupRow.getNoneValue() + r.getNoneValue());
+
+            groupRow.setAgentValue(groupRow.getAgentValue() + r.getAgentValue());
+            groupRow.setIouValue(groupRow.getIouValue() + r.getIouValue());
+            groupRow.setOnlineSettlementValue(groupRow.getOnlineSettlementValue() + r.getOnlineSettlementValue());
+            groupRow.setPatientDepositValue(groupRow.getPatientDepositValue() + r.getPatientDepositValue());
+            groupRow.setPatientPointsValue(groupRow.getPatientPointsValue() + r.getPatientPointsValue());
+            groupRow.setSlipValue(groupRow.getSlipValue() + r.getSlipValue());
+            groupRow.setStaffValue(groupRow.getStaffValue() + r.getStaffValue());
+            groupRow.setStaffWelfareValue(groupRow.getStaffWelfareValue() + r.getStaffWelfareValue());
+            groupRow.setVoucherValue(groupRow.getVoucherValue() + r.getVoucherValue());
+            groupRow.setEwalletValue(groupRow.getEwalletValue() + r.getEwalletValue());
+            groupRow.setOnCallValue(groupRow.getOnCallValue() + r.getOnCallValue());
+        }
+
+        // Replace with grouped rows
+        getRows().clear();
+        grouped.values().stream()
+                .sorted(Comparator.comparing(IncomeRow::getRowType, Comparator.nullsLast(String::compareToIgnoreCase)))
+                .forEachOrdered(getRows()::add);
         populateSummaryRow();
     }
 

--- a/src/main/java/com/divudi/core/data/IncomeRow.java
+++ b/src/main/java/com/divudi/core/data/IncomeRow.java
@@ -2,6 +2,7 @@ package com.divudi.core.data;
 
 import com.divudi.core.entity.*;
 import com.divudi.core.entity.channel.SessionInstance;
+import com.divudi.core.entity.inward.AdmissionType;
 import com.divudi.core.entity.lab.PatientInvestigation;
 import com.divudi.core.entity.pharmacy.PharmaceuticalBillItem;
 
@@ -23,6 +24,9 @@ public class IncomeRow implements Serializable {
     private Long counter;
     String rowType;
 
+    private PaymentScheme paymentScheme;
+    private AdmissionType admissionType;
+    
     private Category category;
     private Bill bill;
     private Bill batchBill;
@@ -1264,6 +1268,22 @@ public class IncomeRow implements Serializable {
 
     public void setGrossProfit(double grossProfit) {
         this.grossProfit = grossProfit;
+    }
+
+    public PaymentScheme getPaymentScheme() {
+        return paymentScheme;
+    }
+
+    public void setPaymentScheme(PaymentScheme paymentScheme) {
+        this.paymentScheme = paymentScheme;
+    }
+
+    public AdmissionType getAdmissionType() {
+        return admissionType;
+    }
+
+    public void setAdmissionType(AdmissionType admissionType) {
+        this.admissionType = admissionType;
     }
     
     

--- a/src/main/java/com/divudi/core/data/ReportViewType.java
+++ b/src/main/java/com/divudi/core/data/ReportViewType.java
@@ -14,6 +14,7 @@ public enum ReportViewType {
     BY_PAYMENT_METHOD("By Payment Method"),
     BY_INSTITUTION("By Institution"),
     BY_DEPARTMENT("By Department"),
+    BY_DISCOUNT_TYPE_AND_ADMISSION_TYPE("By Department"),
     BY_STAFF("By Staff"),
     BY_PATIENT_CATEGORY("By Patient Category"),
     BY_ITEM_CATEGORY("By Item Category"),

--- a/src/main/java/com/divudi/core/data/ReportViewType.java
+++ b/src/main/java/com/divudi/core/data/ReportViewType.java
@@ -14,7 +14,7 @@ public enum ReportViewType {
     BY_PAYMENT_METHOD("By Payment Method"),
     BY_INSTITUTION("By Institution"),
     BY_DEPARTMENT("By Department"),
-    BY_DISCOUNT_TYPE_AND_ADMISSION_TYPE("By Department"),
+    BY_DISCOUNT_TYPE_AND_ADMISSION_TYPE("By Discount Type and Admission Type"),
     BY_STAFF("By Staff"),
     BY_PATIENT_CATEGORY("By Patient Category"),
     BY_ITEM_CATEGORY("By Item Category"),

--- a/src/main/resources/META-INF/persistence.xml
+++ b/src/main/resources/META-INF/persistence.xml
@@ -2,7 +2,7 @@
 <persistence version="2.2" xmlns="http://java.sun.com/xml/ns/persistence" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/persistence http://xmlns.jcp.org/xml/ns/persistence/persistence_2_2.xsd">
     <persistence-unit name="hmisPU" transaction-type="JTA">
         <provider>org.eclipse.persistence.jpa.PersistenceProvider</provider>
-        <jta-data-source>jdbc/sl</jta-data-source>
+        <jta-data-source>jdbc/coop</jta-data-source>
         <exclude-unlisted-classes>false</exclude-unlisted-classes>
         <properties>
             <property name="eclipselink.logging.level.sql" value="SEVERE"/>

--- a/src/main/resources/META-INF/persistence.xml
+++ b/src/main/resources/META-INF/persistence.xml
@@ -2,17 +2,17 @@
 <persistence version="2.2" xmlns="http://java.sun.com/xml/ns/persistence" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/persistence http://xmlns.jcp.org/xml/ns/persistence/persistence_2_2.xsd">
     <persistence-unit name="hmisPU" transaction-type="JTA">
         <provider>org.eclipse.persistence.jpa.PersistenceProvider</provider>
-        <jta-data-source>jdbc/coop</jta-data-source>
+        <jta-data-source>${JDBC_DATASOURCE}</jta-data-source>
         <exclude-unlisted-classes>false</exclude-unlisted-classes>
         <properties>
-            <property name="eclipselink.logging.level.sql" value="SEVERE"/>
+            <property name="eclipselink.logging.level" value="SEVERE"/>
         </properties>
     </persistence-unit>
     <persistence-unit name="hmisAuditPU" transaction-type="JTA">
-        <jta-data-source>jdbc/ruhunuAudit</jta-data-source>
+        <jta-data-source>${JDBC_AUDIT_DATASOURCE}</jta-data-source>
         <exclude-unlisted-classes>false</exclude-unlisted-classes>
         <properties>
-            <property name="eclipselink.logging.level.sql" value="SEVERE"/>
+            <property name="eclipselink.logging.level" value="SEVERE"/>
         </properties>
     </persistence-unit>
 </persistence>

--- a/src/main/webapp/pharmacy/reports/summary_reports/pharmacy_income_report.xhtml
+++ b/src/main/webapp/pharmacy/reports/summary_reports/pharmacy_income_report.xhtml
@@ -172,7 +172,7 @@
                         </p:selectOneMenu>
 
                         <p:spacer></p:spacer>
-                        
+
                         <!-- Report View Type Filter -->
                         <h:panelGroup layout="block" styleClass="form-group">
                             <h:outputText value="&#xf080;" styleClass="fa mr-2" /> <!-- FontAwesome chart bar icon -->
@@ -251,11 +251,11 @@
                             <p:column headerText="Patient"  style="padding: 0px!important; margin: 0px!important;" >
                                 <h:outputText value="#{row.bill.patient.person.nameWithTitle}"  style="padding: 0px!important; margin: 0px!important;" />
                             </p:column>
-<p:column 
-    rendered="#{webUserController.hasPrivilege('Developers')}"
-    headerText="Bill Type"  style="padding: 0px!important; margin: 0px!important;" >
-    <h:outputText value="#{row.bill.billTypeAtomic}"  style="padding: 0px!important; margin: 0px!important;" />
-</p:column>
+                            <p:column 
+                                rendered="#{webUserController.hasPrivilege('Developers')}"
+                                headerText="Bill Type"  style="padding: 0px!important; margin: 0px!important;" >
+                                <h:outputText value="#{row.bill.billTypeAtomic}"  style="padding: 0px!important; margin: 0px!important;" />
+                            </p:column>
                             <p:column headerText="Date"   width="10em" >
                                 <h:outputText value="#{row.bill.createdAt}"  style="padding: 0px!important; margin: 0px!important;" >
                                     <f:convertDateTime pattern="#{sessionController.applicationPreference.shortDateTimeFormat}" />
@@ -437,6 +437,125 @@
 
                             <p:column headerText="Bill Type" width="18em">
                                 <h:outputText value="#{row.billTypeAtomic}" />
+                            </p:column>
+
+                            <p:column headerText="Net Total" width="10em" class="text-end">
+                                <h:outputText value="#{row.netTotal}">
+                                    <f:convertNumber pattern="#,##0.00" />
+                                </h:outputText>
+                            </p:column>
+
+                            <p:column headerText="Cash" width="10em" class="text-end">
+                                <h:outputText value="#{row.cashValue}">
+                                    <f:convertNumber pattern="#,##0.00" />
+                                </h:outputText>
+                            </p:column>
+
+                            <p:column headerText="Card" width="10em" class="text-end">
+                                <h:outputText value="#{row.cardValue}">
+                                    <f:convertNumber pattern="#,##0.00" />
+                                </h:outputText>
+                            </p:column>
+
+                            <p:column headerText="Cheque" width="10em" class="text-end">
+                                <h:outputText value="#{row.chequeValue}">
+                                    <f:convertNumber pattern="#,##0.00" />
+                                </h:outputText>
+                            </p:column>
+
+                            <p:column headerText="Inpatient Credit" width="10em" class="text-end">
+                                <h:outputText value="#{row.inpatientCreditValue}">
+                                    <f:convertNumber pattern="#,##0.00" />
+                                </h:outputText>
+                            </p:column>
+
+                            <p:column headerText="Outpatient Credit" width="10em" class="text-end">
+                                <h:outputText value="#{row.opdCreditValue}">
+                                    <f:convertNumber pattern="#,##0.00" />
+                                </h:outputText>
+                            </p:column>
+
+                            <p:column headerText="Staff Credit" width="10em" class="text-end">
+                                <h:outputText value="#{row.staffValue}">
+                                    <f:convertNumber pattern="#,##0.00" />
+                                </h:outputText>
+                            </p:column>
+
+                            <p:column headerText="Agent Credit" width="10em" class="text-end">
+                                <h:outputText value="#{row.agentValue}">
+                                    <f:convertNumber pattern="#,##0.00" />
+                                </h:outputText>
+                            </p:column>
+
+                            <p:column headerText="Total" width="10em" class="text-end">
+                                <h:outputText value="#{row.grossTotal}">
+                                    <f:convertNumber pattern="#,##0.00" />
+                                </h:outputText>
+                            </p:column>
+
+                            <p:column headerText="Discount" width="10em" class="text-end">
+                                <h:outputText value="#{row.discount}">
+                                    <f:convertNumber pattern="#,##0.00" />
+                                </h:outputText>
+                            </p:column>
+
+                            <p:column headerText="Service Charge" width="10em" class="text-end">
+                                <h:outputText value="#{row.serviceCharge}">
+                                    <f:convertNumber pattern="#,##0.00" />
+                                </h:outputText>
+                            </p:column>
+
+                            <p:column headerText="Actual Total" width="10em" class="text-end">
+                                <h:outputText value="#{row.actualTotal}">
+                                    <f:convertNumber pattern="#,##0.00" />
+                                </h:outputText>
+                            </p:column>
+
+                        </p:dataTable>
+                    </h:panelGroup>
+
+                    <h:panelGroup rendered="#{pharmacySummaryReportController.reportViewType eq 'BY_BILL_TYPE'}">
+
+                        <p:commandButton 
+                            value="Download" 
+                            ajax="false"
+                            styleClass="ui-button-info m-1"
+                            icon="pi pi-download">
+                            <p:dataExporter 
+                                type="xlsx" 
+                                target="tblBillType1"
+                                fileName="pharmacy_income_by_bill_type_#{pharmacySummaryReportController.fromDate}_to_#{pharmacySummaryReportController.toDate}" />
+                        </p:commandButton>
+
+                        <p:commandButton 
+                            value="Print" 
+                            ajax="false"
+                            styleClass="ui-button-warning m-1"
+                            icon="pi pi-print">
+                            <p:printer target="tblBillType1" />
+                        </p:commandButton>
+
+                        <p:dataTable
+                            id="tblBillType1"
+                            style="padding: 0px!important; margin: 0px!important; font-size: #{pharmacySummaryReportController.fontSizeForScreen}!important;" 
+                            styleClass="ui-datatable-borderless ui-datatable-sm compact-datatable"
+                            value="#{pharmacySummaryReportController.bundle.rows}" var="row"
+                            paginator="true"
+                            rows="#{pharmacySummaryReportController.rowsPerPageForScreen}" 
+                            rowsPerPageTemplate="#{pharmacySummaryReportController.rowsPerPageForScreen}, 5,10,15,50,100"
+                            paginatorPosition="bottom">
+
+                            <p:column headerText="Bill Type" width="18em">
+                                <h:outputText value="#{row.billTypeAtomic}" />
+                            </p:column>
+
+                            <p:column headerText="Admission" width="18em">
+                            </p:column>
+
+                            <p:column headerText="Discount Scheme" width="18em">
+                            </p:column>
+
+                            <p:column headerText="Bill Type" width="18em">
                             </p:column>
 
                             <p:column headerText="Net Total" width="10em" class="text-end">

--- a/src/main/webapp/pharmacy/reports/summary_reports/pharmacy_income_report.xhtml
+++ b/src/main/webapp/pharmacy/reports/summary_reports/pharmacy_income_report.xhtml
@@ -238,8 +238,6 @@
                                 <p:printer target="tbl" />
                             </p:commandButton>
 
-
-
                             <p:dataTable
                                 id="tbl"
                                 style="padding: 0px!important; margin: 0px!important; font-size: #{pharmacySummaryReportController.fontSizeForScreen}!important;" 
@@ -289,7 +287,6 @@
                                             <f:convertNumber pattern="#,##0.00" />
                                         </h:outputText>
                                     </f:facet>
-
                                 </p:column>
                                 <p:column headerText="Card"   width="10em" class="text-end" style="padding: 0px!important; margin: 0px!important;" >
                                     <h:outputText value="#{row.cardValue}">
@@ -448,81 +445,306 @@
                                     <h:outputText value="#{row.billTypeAtomic}" />
                                 </p:column>
 
+                                <p:column headerText="Net Total"  width="10em" class="text-end" style="padding: 0px!important; margin: 0px!important;" >
+                                    <h:outputText value="#{row.netTotal}">
+                                        <f:convertNumber pattern="#,##0.00" />
+                                    </h:outputText>
+                                    <f:facet name="footer" >
+                                        <h:outputText value="#{pharmacySummaryReportController.bundle.summaryRow.netTotal}" style="padding: 0px!important; margin: 0px!important; font-weight: bold" >
+                                            <f:convertNumber pattern="#,##0.00" />
+                                        </h:outputText>
+                                    </f:facet>
+                                </p:column>
+                                <p:column headerText="Cash"   width="10em"  class="text-end" style="padding: 0px!important; margin: 0px!important;" >
+                                    <h:outputText value="#{row.cashValue}">
+                                        <f:convertNumber pattern="#,##0.00" />
+                                    </h:outputText>
+                                    <f:facet name="footer" >
+                                        <h:outputText value="#{pharmacySummaryReportController.bundle.summaryRow.cashValue}" style="padding: 0px!important; margin: 0px!important; font-weight: bold" >
+                                            <f:convertNumber pattern="#,##0.00" />
+                                        </h:outputText>
+                                    </f:facet>
+                                </p:column>
+                                <p:column headerText="Card"   width="10em" class="text-end" style="padding: 0px!important; margin: 0px!important;" >
+                                    <h:outputText value="#{row.cardValue}">
+                                        <f:convertNumber pattern="#,##0.00" />
+                                    </h:outputText>
+                                    <f:facet name="footer" >
+                                        <h:outputText value="#{pharmacySummaryReportController.bundle.summaryRow.cardValue}" style="padding: 0px!important; margin: 0px!important; font-weight: bold" >
+                                            <f:convertNumber pattern="#,##0.00" />
+                                        </h:outputText>
+                                    </f:facet>
+
+                                </p:column>
+                                <p:column headerText="Cheque"   width="10em"  class="text-end" style="padding: 0px!important; margin: 0px!important;" >
+                                    <h:outputText value="#{row.chequeValue}">
+                                        <f:convertNumber pattern="#,##0.00" />
+                                    </h:outputText>
+                                    <f:facet name="footer" >
+                                        <h:outputText value="#{pharmacySummaryReportController.bundle.summaryRow.chequeValue}" style="padding: 0px!important; margin: 0px!important; font-weight: bold" >
+                                            <f:convertNumber pattern="#,##0.00" />
+                                        </h:outputText>
+                                    </f:facet>
+
+                                </p:column>
+                                <p:column headerText="Inpatient Credit"   width="10em" class="text-end light-grey-background"  style="padding: 0px!important; margin: 0px!important;" >
+                                    <h:outputText value="#{row.inpatientCreditValue}">
+                                        <f:convertNumber pattern="#,##0.00" />
+                                    </h:outputText>
+                                    <f:facet name="footer" >
+                                        <h:outputText value="#{pharmacySummaryReportController.bundle.summaryRow.inpatientCreditValue}" style="padding: 0px!important; margin: 0px!important; font-weight: bold" >
+                                            <f:convertNumber pattern="#,##0.00" />
+                                        </h:outputText>
+                                    </f:facet>
+
+                                </p:column>
+                                <p:column headerText="Outpatient Credit"   width="10em"  class="text-end light-grey-background" style="padding: 0px!important; margin: 0px!important;" >
+                                    <h:outputText value="#{row.opdCreditValue}">
+                                        <f:convertNumber pattern="#,##0.00" />
+                                    </h:outputText>
+                                    <f:facet name="footer" >
+                                        <h:outputText value="#{pharmacySummaryReportController.bundle.summaryRow.opdCreditValue}" style="padding: 0px!important; margin: 0px!important; font-weight: bold" >
+                                            <f:convertNumber pattern="#,##0.00" />
+                                        </h:outputText>
+                                    </f:facet>
+
+                                </p:column>
+                                <p:column headerText="Staff Credit"    width="10em"  class="text-end light-grey-background"  style="padding: 0px!important; margin: 0px!important;" >
+                                    <h:outputText value="#{row.staffValue}">
+                                        <f:convertNumber pattern="#,##0.00" />
+                                    </h:outputText>
+                                    <f:facet name="footer" >
+                                        <h:outputText value="#{pharmacySummaryReportController.bundle.summaryRow.staffValue}" style="padding: 0px!important; margin: 0px!important; font-weight: bold" >
+                                            <f:convertNumber pattern="#,##0.00" />
+                                        </h:outputText>
+                                    </f:facet>
+
+                                </p:column>
+                                <p:column headerText="Agent Credit"   width="10em"  class="text-end light-grey-background"  style="padding: 0px!important; margin: 0px!important;" >
+                                    <h:outputText value="#{row.agentValue}">
+                                        <f:convertNumber pattern="#,##0.00" />
+                                    </h:outputText>
+                                    <f:facet name="footer" >
+                                        <h:outputText value="#{pharmacySummaryReportController.bundle.summaryRow.agentValue}" style="padding: 0px!important; margin: 0px!important; font-weight: bold" >
+                                            <f:convertNumber pattern="#,##0.00" />
+                                        </h:outputText>
+                                    </f:facet>
+
+                                </p:column>
+                                <p:column headerText="Total"    width="10em" class="text-end" style="padding: 0px!important; margin: 0px!important;" >
+                                    <h:outputText value="#{row.grossTotal}" >
+                                        <f:convertNumber pattern="#,##0.00" ></f:convertNumber>
+                                    </h:outputText>
+                                    <f:facet name="footer" >
+                                        <h:outputText value="#{pharmacySummaryReportController.bundle.summaryRow.grossTotal}" style="padding: 0px!important; margin: 0px!important; font-weight: bold" >
+                                            <f:convertNumber pattern="#,##0.00" />
+                                        </h:outputText>
+                                    </f:facet>
+                                </p:column>
+                                <p:column headerText="Discount"   width="10em"  class="text-end" style="padding: 0px!important; margin: 0px!important;" >
+                                    <h:outputText value="#{row.discount}" >
+                                        <f:convertNumber pattern="#,##0.00" ></f:convertNumber>
+                                    </h:outputText>
+                                    <f:facet name="footer" >
+                                        <h:outputText value="#{pharmacySummaryReportController.bundle.summaryRow.discount}" style="padding: 0px!important; margin: 0px!important; font-weight: bold" >
+                                            <f:convertNumber pattern="#,##0.00" />
+                                        </h:outputText>
+                                    </f:facet>
+
+                                </p:column>
+                                <p:column headerText="Service Charge"  width="10em"   class="text-end"  style="padding: 0px!important; margin: 0px!important;" >
+                                    <h:outputText value="#{row.serviceCharge}" >
+                                        <f:convertNumber pattern="#,##0.00" ></f:convertNumber>
+                                    </h:outputText>
+                                    <f:facet name="footer" >
+                                        <h:outputText value="#{pharmacySummaryReportController.bundle.summaryRow.serviceCharge}" style="padding: 0px!important; margin: 0px!important; font-weight: bold" >
+                                            <f:convertNumber pattern="#,##0.00" />
+                                        </h:outputText>
+                                    </f:facet>
+
+                                </p:column>
+                                <p:column headerText="Actual Total"    width="10em" class="text-end" style="padding: 0px!important; margin: 0px!important;" >
+                                    <h:outputText value="#{row.netTotal}" >
+                                        <f:convertNumber pattern="#,##0.00" ></f:convertNumber>
+                                    </h:outputText>
+                                    <f:facet name="footer" >
+                                        <h:outputText value="#{pharmacySummaryReportController.bundle.summaryRow.netTotal}" style="padding: 0px!important; margin: 0px!important; font-weight: bold" >
+                                            <f:convertNumber pattern="#,##0.00" />
+                                        </h:outputText>
+                                    </f:facet>
+                                </p:column>
+
+                            </p:dataTable>
+                        </h:panelGroup>
+
+                        <h:panelGroup rendered="#{pharmacySummaryReportController.reportViewType eq 'BY_DISCOUNT_TYPE_AND_ADMISSION_TYPE'}">
+
+                            <p:commandButton 
+                                value="Download" 
+                                ajax="false"
+                                styleClass="ui-button-info m-1"
+                                icon="pi pi-download">
+                                <p:dataExporter 
+                                    type="xlsx" 
+                                    target="tblGroupedByDiscountAndAdmission"
+                                    fileName="pharmacy_income_by_discount_and_admission_#{pharmacySummaryReportController.fromDate}_to_#{pharmacySummaryReportController.toDate}" />
+                            </p:commandButton>
+
+                            <p:commandButton 
+                                value="Print" 
+                                ajax="false"
+                                styleClass="ui-button-warning m-1"
+                                icon="pi pi-print">
+                                <p:printer target="tblGroupedByDiscountAndAdmission" />
+                            </p:commandButton>
+
+                            <p:dataTable
+                                id="tblGroupedByDiscountAndAdmission"
+                                style="padding: 0px!important; margin: 0px!important; font-size: #{pharmacySummaryReportController.fontSizeForScreen}!important;" 
+                                styleClass="ui-datatable-borderless ui-datatable-sm compact-datatable"
+                                value="#{pharmacySummaryReportController.bundle.rows}" var="row"
+                                paginator="true"
+                                rows="#{pharmacySummaryReportController.rowsPerPageForScreen}" 
+                                rowsPerPageTemplate="#{pharmacySummaryReportController.rowsPerPageForScreen}, 5,10,15,50,100"
+                                paginatorPosition="bottom">
+
+                                <p:column headerText="Group" width="24em">
+                                    <h:outputText value="#{row.rowType}" />
+                                </p:column>
+
                                 <p:column headerText="Net Total" width="10em" class="text-end">
                                     <h:outputText value="#{row.netTotal}">
                                         <f:convertNumber pattern="#,##0.00" />
                                     </h:outputText>
+                                    <f:facet name="footer" >
+                                        <h:outputText value="#{pharmacySummaryReportController.bundle.summaryRow.netTotal}" style="padding: 0px!important; margin: 0px!important; font-weight: bold" >
+                                            <f:convertNumber pattern="#,##0.00" />
+                                        </h:outputText>
+                                    </f:facet>
                                 </p:column>
 
                                 <p:column headerText="Cash" width="10em" class="text-end">
                                     <h:outputText value="#{row.cashValue}">
                                         <f:convertNumber pattern="#,##0.00" />
                                     </h:outputText>
+                                    <f:facet name="footer" >
+                                        <h:outputText value="#{pharmacySummaryReportController.bundle.summaryRow.cashValue}" style="padding: 0px!important; margin: 0px!important; font-weight: bold" >
+                                            <f:convertNumber pattern="#,##0.00" />
+                                        </h:outputText>
+                                    </f:facet>
                                 </p:column>
 
                                 <p:column headerText="Card" width="10em" class="text-end">
                                     <h:outputText value="#{row.cardValue}">
                                         <f:convertNumber pattern="#,##0.00" />
                                     </h:outputText>
-                                </p:column>
+                                    <f:facet name="footer" >
+                                        <h:outputText value="#{pharmacySummaryReportController.bundle.summaryRow.cardValue}" style="padding: 0px!important; margin: 0px!important; font-weight: bold" >
+                                            <f:convertNumber pattern="#,##0.00" />
+                                        </h:outputText>
+                                    </f:facet>
 
-                                <p:column headerText="Cheque" width="10em" class="text-end">
+                                </p:column>
+                                <p:column headerText="Cheque"   width="10em"  class="text-end" style="padding: 0px!important; margin: 0px!important;" >
                                     <h:outputText value="#{row.chequeValue}">
                                         <f:convertNumber pattern="#,##0.00" />
                                     </h:outputText>
-                                </p:column>
+                                    <f:facet name="footer" >
+                                        <h:outputText value="#{pharmacySummaryReportController.bundle.summaryRow.chequeValue}" style="padding: 0px!important; margin: 0px!important; font-weight: bold" >
+                                            <f:convertNumber pattern="#,##0.00" />
+                                        </h:outputText>
+                                    </f:facet>
 
-                                <p:column headerText="Inpatient Credit" width="10em" class="text-end">
+                                </p:column>
+                                <p:column headerText="Inpatient Credit"   width="10em" class="text-end light-grey-background"  style="padding: 0px!important; margin: 0px!important;" >
                                     <h:outputText value="#{row.inpatientCreditValue}">
                                         <f:convertNumber pattern="#,##0.00" />
                                     </h:outputText>
-                                </p:column>
+                                    <f:facet name="footer" >
+                                        <h:outputText value="#{pharmacySummaryReportController.bundle.summaryRow.inpatientCreditValue}" style="padding: 0px!important; margin: 0px!important; font-weight: bold" >
+                                            <f:convertNumber pattern="#,##0.00" />
+                                        </h:outputText>
+                                    </f:facet>
 
-                                <p:column headerText="Outpatient Credit" width="10em" class="text-end">
+                                </p:column>
+                                <p:column headerText="Outpatient Credit"   width="10em"  class="text-end light-grey-background" style="padding: 0px!important; margin: 0px!important;" >
                                     <h:outputText value="#{row.opdCreditValue}">
                                         <f:convertNumber pattern="#,##0.00" />
                                     </h:outputText>
-                                </p:column>
+                                    <f:facet name="footer" >
+                                        <h:outputText value="#{pharmacySummaryReportController.bundle.summaryRow.opdCreditValue}" style="padding: 0px!important; margin: 0px!important; font-weight: bold" >
+                                            <f:convertNumber pattern="#,##0.00" />
+                                        </h:outputText>
+                                    </f:facet>
 
-                                <p:column headerText="Staff Credit" width="10em" class="text-end">
+                                </p:column>
+                                <p:column headerText="Staff Credit"    width="10em"  class="text-end light-grey-background"  style="padding: 0px!important; margin: 0px!important;" >
                                     <h:outputText value="#{row.staffValue}">
                                         <f:convertNumber pattern="#,##0.00" />
                                     </h:outputText>
-                                </p:column>
+                                    <f:facet name="footer" >
+                                        <h:outputText value="#{pharmacySummaryReportController.bundle.summaryRow.staffValue}" style="padding: 0px!important; margin: 0px!important; font-weight: bold" >
+                                            <f:convertNumber pattern="#,##0.00" />
+                                        </h:outputText>
+                                    </f:facet>
 
-                                <p:column headerText="Agent Credit" width="10em" class="text-end">
+                                </p:column>
+                                <p:column headerText="Agent Credit"   width="10em"  class="text-end light-grey-background"  style="padding: 0px!important; margin: 0px!important;" >
                                     <h:outputText value="#{row.agentValue}">
                                         <f:convertNumber pattern="#,##0.00" />
                                     </h:outputText>
-                                </p:column>
+                                    <f:facet name="footer" >
+                                        <h:outputText value="#{pharmacySummaryReportController.bundle.summaryRow.agentValue}" style="padding: 0px!important; margin: 0px!important; font-weight: bold" >
+                                            <f:convertNumber pattern="#,##0.00" />
+                                        </h:outputText>
+                                    </f:facet>
 
-                                <p:column headerText="Total" width="10em" class="text-end">
-                                    <h:outputText value="#{row.grossTotal}">
-                                        <f:convertNumber pattern="#,##0.00" />
-                                    </h:outputText>
                                 </p:column>
-
-                                <p:column headerText="Discount" width="10em" class="text-end">
-                                    <h:outputText value="#{row.discount}">
-                                        <f:convertNumber pattern="#,##0.00" />
+                                <p:column headerText="Total"    width="10em" class="text-end" style="padding: 0px!important; margin: 0px!important;" >
+                                    <h:outputText value="#{row.grossTotal}" >
+                                        <f:convertNumber pattern="#,##0.00" ></f:convertNumber>
                                     </h:outputText>
+                                    <f:facet name="footer" >
+                                        <h:outputText value="#{pharmacySummaryReportController.bundle.summaryRow.grossTotal}" style="padding: 0px!important; margin: 0px!important; font-weight: bold" >
+                                            <f:convertNumber pattern="#,##0.00" />
+                                        </h:outputText>
+                                    </f:facet>
                                 </p:column>
-
-                                <p:column headerText="Service Charge" width="10em" class="text-end">
-                                    <h:outputText value="#{row.serviceCharge}">
-                                        <f:convertNumber pattern="#,##0.00" />
+                                <p:column headerText="Discount"   width="10em"  class="text-end" style="padding: 0px!important; margin: 0px!important;" >
+                                    <h:outputText value="#{row.discount}" >
+                                        <f:convertNumber pattern="#,##0.00" ></f:convertNumber>
                                     </h:outputText>
+                                    <f:facet name="footer" >
+                                        <h:outputText value="#{pharmacySummaryReportController.bundle.summaryRow.discount}" style="padding: 0px!important; margin: 0px!important; font-weight: bold" >
+                                            <f:convertNumber pattern="#,##0.00" />
+                                        </h:outputText>
+                                    </f:facet>
+
                                 </p:column>
-
-                                <p:column headerText="Actual Total" width="10em" class="text-end">
-                                    <h:outputText value="#{row.actualTotal}">
-                                        <f:convertNumber pattern="#,##0.00" />
+                                <p:column headerText="Service Charge"  width="10em"   class="text-end"  style="padding: 0px!important; margin: 0px!important;" >
+                                    <h:outputText value="#{row.serviceCharge}" >
+                                        <f:convertNumber pattern="#,##0.00" ></f:convertNumber>
                                     </h:outputText>
+                                    <f:facet name="footer" >
+                                        <h:outputText value="#{pharmacySummaryReportController.bundle.summaryRow.serviceCharge}" style="padding: 0px!important; margin: 0px!important; font-weight: bold" >
+                                            <f:convertNumber pattern="#,##0.00" />
+                                        </h:outputText>
+                                    </f:facet>
+
+                                </p:column>
+                                <p:column headerText="Actual Total"    width="10em" class="text-end" style="padding: 0px!important; margin: 0px!important;" >
+                                    <h:outputText value="#{row.netTotal}" >
+                                        <f:convertNumber pattern="#,##0.00" ></f:convertNumber>
+                                    </h:outputText>
+                                    <f:facet name="footer" >
+                                        <h:outputText value="#{pharmacySummaryReportController.bundle.summaryRow.netTotal}" style="padding: 0px!important; margin: 0px!important; font-weight: bold" >
+                                            <f:convertNumber pattern="#,##0.00" />
+                                        </h:outputText>
+                                    </f:facet>
                                 </p:column>
 
                             </p:dataTable>
                         </h:panelGroup>
-
 
 
                     </h:form>


### PR DESCRIPTION
Closes #11920

---

✅ **Feature Verified: Grouped Pharmacy Income Report by Admission Type and Discount Scheme**

**Navigation Path:**
`Menu > Pharmacy > Analytics > Summary Reports > Income Report`

**Steps to Verify:**

1. Set the **Report View Type** to **"By Discount Type and Admission Type"**.
2. Set appropriate date range, institutions, departments, etc.
3. Click **Process**.

**Expected Behaviour:**
- Income rows are grouped by **Admission Type** (for inpatients) and **Discount Scheme** (for outpatients).
- Rows are sorted **alphabetically by group label (rowType)**.
- Aggregates such as **Net Total**, **Cash**, **Card**, **Inpatient Credit**, etc., are correctly calculated and displayed.
- Table supports **Print** and **Download (Excel)**.

📸 Attached screenshot shows correct grouping and totals.



![image](https://github.com/user-attachments/assets/294b9e40-041d-49f6-b5b9-720c604114bd)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a new pharmacy income report view that groups data by discount type and admission type.
  - Extended the report UI to display detailed summaries for the new grouping, including additional summary columns and footers.
- **Enhancements**
  - Improved report tables with consistent styling and added summary rows for clearer financial overviews.
- **User Interface**
  - Introduced new download and print options for the updated report view.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->