### PR TITLE
Fixed - create-new-stock-report-with-suppliers

### DIFF
--- a/src/main/java/com/divudi/bean/pharmacy/ReportsStock.java
+++ b/src/main/java/com/divudi/bean/pharmacy/ReportsStock.java
@@ -712,10 +712,6 @@ public class ReportsStock implements Serializable {
     }
 
     public String fillDistributorStocks() {
-        Date startTime = new Date();
-        Date fromDate = null;
-        Date toDate = null;
-
         if (department == null || institution == null) {
             JsfUtil.addErrorMessage("Please select a department && Dealor");
             return "";
@@ -747,7 +743,40 @@ public class ReportsStock implements Serializable {
 
         return "/pharmacy/pharmacy_report_supplier_stock_by_batch";
     }
-    
+
+    public String fillSupplierStocks() {
+        if (department == null) {
+            JsfUtil.addErrorMessage("Please select a department");
+            return "";
+        }
+        Map m;
+        String sql;
+        records = new ArrayList<>();
+
+        m = new HashMap();
+
+        m.put("dep", department);
+        m.put("st", 0.0);
+        sql = "select s "
+                + " from Stock s "
+                + " where s.department=:dep "
+                + " and s.stock > :st ";
+
+        if (institution != null) {
+            sql += "and s.itemBatch.lastPurchaseBillItem.bill.fromInstitution =:ins";
+            m.put("ins", institution);
+        }
+        stocks = getStockFacade().findByJpql(sql, m);
+        stockPurchaseValue = 0.0;
+        stockSaleValue = 0.0;
+        for (Stock ts : stocks) {
+            stockPurchaseValue = stockPurchaseValue + (ts.getItemBatch().getPurcahseRate() * ts.getStock());
+            stockSaleValue = stockSaleValue + (ts.getItemBatch().getRetailsaleRate() * ts.getStock());
+        }
+
+        return "/pharmacy/pharmacy_report_stock_report_with_supplier?faces-redirect=true";
+    }
+
     public void fillCategoryStocks() {
         Date startTime = new Date();
         Date fromDate = null;
@@ -961,14 +990,14 @@ public class ReportsStock implements Serializable {
         }
 
     }
-    
+
     public void fillAllSuppliersStocks() {
 
         if (department == null) {
             JsfUtil.addErrorMessage("Please select a department");
             return;
         }
-        
+
         Map m;
         String sql;
         records = new ArrayList<>();

--- a/src/main/webapp/pharmacy/pharmacy_analytics.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_analytics.xhtml
@@ -126,10 +126,9 @@
                                             </p:commandButton>   
 
                                             <p:commandButton 
-                                                class="w-100"
-                                                rendered="false"
-                                                value="Supplier Stock Report" 
-                                                action="pharmacy_report_supplier_stock_by_batch?faces-redirect=true" 
+                                                class="w-100 ui-button-warning"
+                                                value="Stock Report (with Suppliers)" 
+                                                action="pharmacy_report_stock_report_with_supplier?faces-redirect=true" 
                                                 ajax="false" >
                                             </p:commandButton>       
                                         </div>

--- a/src/main/webapp/pharmacy/pharmacy_report_stock_report_with_supplier.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_report_stock_report_with_supplier.xhtml
@@ -139,7 +139,6 @@
                                 <p:column 
                                     headerText="Expiry" 
                                     style=" width: 100px!important;"
-                                    sortBy="#{i.itemBatch.item.name}"
                                     styleClass="averageNumericColumn">
                                     <h:outputLabel value="#{i.itemBatch.dateOfExpire}"  >
                                         <f:convertDateTime pattern="dd MMM yy" ></f:convertDateTime>

--- a/src/main/webapp/pharmacy/pharmacy_report_stock_report_with_supplier.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_report_stock_report_with_supplier.xhtml
@@ -1,0 +1,207 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
+      xmlns:p="http://primefaces.org/ui"
+      xmlns:h="http://xmlns.jcp.org/jsf/html"
+      xmlns:f="http://xmlns.jcp.org/jsf/core"
+      >
+
+    <h:body>
+
+        <ui:composition template="/pharmacy/pharmacy_analytics.xhtml">
+
+            <ui:define name="subcontent">
+                <h:form>
+                    <p:panel header="Stock Report (with Suppliers)" >
+
+                        <h:panelGrid columns="8" class="my-2" >
+                            <h:outputLabel value="Department" ></h:outputLabel>
+                            <p:autoComplete 
+                                class="mx-2" 
+                                completeMethod="#{departmentController.completeDept}" 
+                                var="dept" 
+                                itemLabel="#{dept.name}" 
+                                itemValue="#{dept}" 
+                                maxResults="15"
+                                forceSelection="true" 
+                                value="#{reportsStock.department}"  >
+                                <p:column headerText="Code" style="padding: 5px; width: 6em;">
+                                    <h:outputText value="#{dept.code}" ></h:outputText>
+                                </p:column>
+                                <p:column headerText="Name" style="padding: 5px; min-width: 20em;">
+                                    <h:outputText value="#{dept.name}" ></h:outputText>
+                                </p:column>
+                            </p:autoComplete>
+
+                            <h:outputLabel value="Supplier" ></h:outputLabel>
+                            <p:autoComplete 
+                                class="mx-2"
+                                completeMethod="#{institutionController.completeSuppliers}" 
+                                var="dept" 
+                                maxResults="15"
+                                itemLabel="#{dept.name}" 
+                                itemValue="#{dept}" 
+                                forceSelection="true" 
+                                value="#{reportsStock.institution}" >
+                                <p:column headerText="Code" style="padding: 5px; width: 6em;">
+                                    <h:outputText value="#{dept.code}" ></h:outputText>
+                                </p:column>
+                                <p:column headerText="Name" style="padding: 5px; min-width: 20em;">
+                                    <h:outputText value="#{dept.name}" ></h:outputText>
+                                </p:column>
+                            </p:autoComplete>
+
+                            <p:commandButton 
+                                ajax="false" 
+                                value="Process" 
+                                class="ui-button-warning " 
+                                icon="fas fa-cogs" 
+                                action="#{reportsStock.fillSupplierStocks()}" >
+                            </p:commandButton>
+
+                            <p:commandButton 
+                                class="ui-button-info mx-2" 
+                                icon="fas fa-print" 
+                                value="Print" 
+                                ajax="false" >
+                                <p:printer target="gpBillPreview" ></p:printer>
+                            </p:commandButton>
+
+                            <p:commandButton 
+                                class="ui-button-success" 
+                                icon="fas fa-file-excel"  
+                                value="Excel"
+                                ajax="false">
+                                <p:dataExporter type="xlsx" target="tbl" fileName="Lab_Investigation_List"/>
+                            </p:commandButton>
+                        </h:panelGrid>
+
+                        <h:panelGroup styleClass="noBorder summeryBorder"  id="gpBillPreview">
+
+                            <p:dataTable 
+                                id="tbl" style="min-width: 100%;"  
+                                rowStyleClass="#{i.stock eq 0 ?'noDisplayRow' : ''}"
+                                value="#{reportsStock.stocks}" 
+                                var="i" 
+                                rowIndexVar="ii" 
+                                rows="20"
+                                paginator="true"
+                                paginatorPosition="bottom"
+                                paginatorTemplate="{CurrentPageReport}  {FirstPageLink} {PreviousPageLink} {PageLinks} {NextPageLink} {LastPageLink} {RowsPerPageDropdown}"
+                                rowsPerPageTemplate="20,50,1000">
+
+                                <f:facet name="header">
+                                    <h:outputLabel value="Department - #{reportsStock.department.name} "/>   <br/>                                 
+                                    <h:outputLabel value="Supplier - #{reportsStock.institution.name}"/>                                    
+                                </f:facet>
+
+                                <p:column width="40px;" headerText="No" sortBy="#{ii}">
+                                    <h:outputLabel value="#{ii+1}" />
+                                </p:column>
+
+                                <p:column 
+                                    headerText="Code" 
+                                    style="width: 80px!important;"
+                                    sortBy="#{i.itemBatch.item.code}" 
+                                    filterBy="#{i.itemBatch.item.code}" 
+                                    filterMatchMode="contains"
+                                    styleClass="averageNumericColumn">
+                                    <h:outputLabel value="#{i.itemBatch.item.code}" ></h:outputLabel>
+                                </p:column>
+
+                                <p:column 
+                                    headerText="Item" 
+                                    sortBy="#{i.itemBatch.item.name}" 
+                                    filterBy="#{i.itemBatch.item.name}" 
+                                    filterMatchMode="contains">                                   
+                                    <h:outputLabel value="#{i.itemBatch.item.name}" ></h:outputLabel>
+                                </p:column>
+
+                                <p:column 
+                                    headerText="Suppliers" 
+                                    sortBy="#{i.itemBatch.lastPurchaseBillItem.bill.fromInstitution.name}" 
+                                    filterBy="#{i.itemBatch.lastPurchaseBillItem.bill.fromInstitution.name}" 
+                                    filterMatchMode="contains">                                  
+                                    <h:outputLabel value="#{i.itemBatch.lastPurchaseBillItem.bill.fromInstitution.name}" ></h:outputLabel>
+                                </p:column>
+
+                                <p:column 
+                                    headerText="Stock Quantity"
+                                    styleClass="averageNumericColumn"
+                                    style=" width: 100px!important;"
+                                    sortBy="#{i.stock}">
+                                    <h:outputLabel value="#{i.stock}"  >
+                                        <f:convertNumber pattern="#,###" ></f:convertNumber>
+                                    </h:outputLabel>                                  
+                                </p:column>
+
+                                <p:column 
+                                    headerText="Expiry" 
+                                    style=" width: 100px!important;"
+                                    sortBy="#{i.itemBatch.item.name}"
+                                    styleClass="averageNumericColumn">
+                                    <h:outputLabel value="#{i.itemBatch.dateOfExpire}"  >
+                                        <f:convertDateTime pattern="dd MMM yy" ></f:convertDateTime>
+                                    </h:outputLabel>
+                                </p:column>
+
+                                <p:column 
+                                    headerText="Purchase Rate"
+                                    styleClass="averageNumericColumn"
+                                    sortBy="#{i.itemBatch.purcahseRate}"
+                                    style="text-align: right; width: 100px!important;">
+                                    <h:outputLabel value="#{i.itemBatch.purcahseRate}"  >
+                                        <f:convertNumber pattern="#,##0.00" ></f:convertNumber>
+                                    </h:outputLabel>
+                                </p:column>
+
+                                <p:column 
+                                    headerText="Purchase Value"
+                                    styleClass="averageNumericColumn"
+                                    sortBy="#{i.itemBatch.purcahseRate}" 
+                                    style="text-align: right; width: 100px!important;">
+                                    <h:outputLabel value="#{i.itemBatch.purcahseRate * i.stock}"  >
+                                        <f:convertNumber pattern="#,##0.00" ></f:convertNumber>
+                                    </h:outputLabel>
+                                    <f:facet name="footer" >
+                                        <h:outputLabel value="#{reportsStock.stockPurchaseValue}" >
+                                            <f:convertNumber h:pattern="#,##0.00" ></f:convertNumber>
+                                        </h:outputLabel>
+                                    </f:facet>
+                                </p:column>
+
+                                <p:column
+                                    headerText="Sale Rate" 
+                                    styleClass="averageNumericColumn"
+                                    sortBy="#{i.itemBatch.retailsaleRate}"
+                                    style="text-align: right; width: 100px!important;">
+                                    <h:outputLabel value="#{i.itemBatch.retailsaleRate}"  >
+                                        <f:convertNumber pattern="#,##0.00" ></f:convertNumber>
+                                    </h:outputLabel>
+                                </p:column>
+
+                                <p:column
+                                    headerText="Sale Value" 
+                                    styleClass="averageNumericColumn"
+                                    sortBy="#{i.itemBatch.retailsaleRate * i.stock}"
+                                    style="text-align: right; width: 100px!important;">
+                                    <h:outputLabel value="#{i.itemBatch.retailsaleRate * i.stock}"  >
+                                        <f:convertNumber pattern="#,##0.00" ></f:convertNumber>
+                                    </h:outputLabel>
+                                    <f:facet name="footer" >
+                                        <h:outputLabel value="#{reportsStock.stockSaleValue}" >
+                                            <f:convertNumber h:pattern="#,##0.00" ></f:convertNumber>
+                                        </h:outputLabel>
+                                    </f:facet>
+                                </p:column>
+
+                            </p:dataTable>
+                        </h:panelGroup>
+                    </p:panel>
+                </h:form>
+            </ui:define>
+        </ui:composition>
+
+    </h:body>
+</html>

--- a/src/main/webapp/pharmacy/pharmacy_stock_summary_with_supplier.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_stock_summary_with_supplier.xhtml
@@ -83,7 +83,7 @@
                                     filterMatchMode="contains">
                                     <p:commandLink 
                                         value="#{i.institution.name}"
-                                        action="#{reportsStock.fillDistributorStocks()}" 
+                                        action="#{reportsStock.fillSupplierStocks()}" 
                                         ajax="false" >
                                         <f:setPropertyActionListener target="#{reportsStock.institution}" value="#{i.institution}"/>
                                     </p:commandLink>


### PR DESCRIPTION
closes #11929
Signed-off-by: DamithDeshan <hkddrajapaksha@gmail.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new "Stock Report (with Suppliers)" page, allowing users to filter and view pharmacy stock by department and supplier, with options to print or export to Excel.
- **Improvements**
	- Updated navigation and button labeling for supplier stock reporting, making the feature more accessible and visually distinct.
	- Enhanced supplier stock summary interactions to use the new supplier-focused report.
- **Bug Fixes**
	- Removed unused variables and improved error handling when required selections are missing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->