### PR TITLE
11474 discount is not working when adding another drug items after applying the discount

### DIFF
--- a/src/main/java/com/divudi/bean/pharmacy/PharmacySaleController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacySaleController.java
@@ -1267,7 +1267,7 @@ public class PharmacySaleController implements Serializable, ControllerWithPatie
                 System.out.println("Set Rate from ItemBatch: " + bi.getRate());
             }
 
-            double discountPercent = calculateBillItemDiscountRate(bi);  // Now returns just 7.5 for 7.5%
+            double discountPercent = calculateBillItemDiscountRate(bi); // Now returns percentage (e.g., 7.5)
             bi.setDiscountRate(discountPercent);
             System.out.println("Discount Percent: " + discountPercent);
 
@@ -1283,8 +1283,9 @@ public class PharmacySaleController implements Serializable, ControllerWithPatie
             bi.setNetValue(netValue);
             System.out.println("Net Value (GrossValue - Discount): " + netValue);
 
-            bi.setNetRate(bi.getRate() - ((bi.getRate() * discountPercent) / 100));
-            System.out.println("Net Rate (Rate - DiscountPercent): " + bi.getNetRate());
+            double netRate = bi.getRate() * (1 - discountPercent / 100);
+            bi.setNetRate(netRate);
+            System.out.println("Net Rate (Rate * (1 - DiscountPercent / 100)): " + netRate);
         } else {
             System.out.println("PharmaceuticalBillItem or Stock or ItemBatch is NULL");
         }

--- a/src/main/resources/META-INF/persistence.xml
+++ b/src/main/resources/META-INF/persistence.xml
@@ -2,14 +2,14 @@
 <persistence version="2.2" xmlns="http://java.sun.com/xml/ns/persistence" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/persistence http://xmlns.jcp.org/xml/ns/persistence/persistence_2_2.xsd">
     <persistence-unit name="hmisPU" transaction-type="JTA">
         <provider>org.eclipse.persistence.jpa.PersistenceProvider</provider>
-        <jta-data-source>jdbc/ruhunu</jta-data-source>
+        <jta-data-source>jdbc/coop</jta-data-source>
         <exclude-unlisted-classes>false</exclude-unlisted-classes>
         <properties>
             <property name="eclipselink.logging.level" value="SEVERE"/>
         </properties>
     </persistence-unit>
     <persistence-unit name="hmisAuditPU" transaction-type="JTA">
-        <jta-data-source>jdbc/ruhunuaudit</jta-data-source>
+        <jta-data-source>jdbc/ruhunuAudit</jta-data-source>
         <exclude-unlisted-classes>false</exclude-unlisted-classes>
         <properties>
             <property name="eclipselink.logging.level" value="SEVERE"/>

--- a/src/main/resources/META-INF/persistence.xml
+++ b/src/main/resources/META-INF/persistence.xml
@@ -2,14 +2,14 @@
 <persistence version="2.2" xmlns="http://java.sun.com/xml/ns/persistence" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/persistence http://xmlns.jcp.org/xml/ns/persistence/persistence_2_2.xsd">
     <persistence-unit name="hmisPU" transaction-type="JTA">
         <provider>org.eclipse.persistence.jpa.PersistenceProvider</provider>
-        <jta-data-source>jdbc/coop</jta-data-source>
+        <jta-data-source>${JDBC_DATASOURCE}</jta-data-source>
         <exclude-unlisted-classes>false</exclude-unlisted-classes>
         <properties>
             <property name="eclipselink.logging.level" value="SEVERE"/>
         </properties>
     </persistence-unit>
     <persistence-unit name="hmisAuditPU" transaction-type="JTA">
-        <jta-data-source>jdbc/ruhunuAudit</jta-data-source>
+        <jta-data-source>${JDBC_AUDIT_DATASOURCE}</jta-data-source>
         <exclude-unlisted-classes>false</exclude-unlisted-classes>
         <properties>
             <property name="eclipselink.logging.level" value="SEVERE"/>

--- a/src/main/webapp/pharmacy/pharmacy_bill_retail_sale.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_bill_retail_sale.xhtml
@@ -1200,35 +1200,49 @@
                                                         <h:outputText styleClass="fas fa-list" />
                                                         <h:outputLabel value="Bill Details" class="mx-4"></h:outputLabel>
                                                     </f:facet>
-                                                    <h:panelGrid columns="2" columnClasses="numberCol, textCol"  >
-                                                        <h:outputLabel value="Total" ></h:outputLabel>
-                                                        <h:outputLabel class="mx-4 my-1" id="total" value="#{pharmacySaleController.preBill.total}" >
-                                                            <f:convertNumber pattern="#,##0.00" />
-                                                        </h:outputLabel>
-                                                        <h:outputLabel value="Discount" ></h:outputLabel>
-                                                        <h:outputLabel class="mx-4 my-1" id="dis" value="#{pharmacySaleController.preBill.discount}" >
-                                                            <f:convertNumber pattern="#,##0.00" />
-                                                            <p:ajax process="total dis netTotal paid" update="balance netTotal" event="blur"/>
-                                                        </h:outputLabel>
-                                                        <h:outputLabel value="Net Total" ></h:outputLabel>
-                                                        <h:outputLabel class="mx-4 my-1" id="netTotal" value="#{pharmacySaleController.preBill.netTotal}" >
-                                                            <f:convertNumber pattern="#,##0.00" />
-                                                        </h:outputLabel>
-                                                        <h:outputLabel  value="Tendered" ></h:outputLabel>
-                                                        <p:inputText
-                                                            class="mx-4 my-1"
-                                                            autocomplete="off"
-                                                            accesskey="t"
-                                                            id="paid"
-                                                            value="#{pharmacySaleController.cashPaid}"
-                                                            onfocus="this.select()">
-                                                            <p:ajax process="total dis netTotal paid" update="balance netTotal" event="keyup"/>
-                                                        </p:inputText>
-                                                        <h:outputLabel  value="Balance" ></h:outputLabel>
-                                                        <h:outputLabel class="mx-4 my-1" id="balance" value="#{pharmacySaleController.balance}" >
-                                                            <f:convertNumber pattern="#,##0.00" />
-                                                        </h:outputLabel>
+                                                    <h:panelGrid columns="2" columnClasses="numberCol, textCol">
+                                                        <h:outputLabel value="Total" />
+                                                        <h:panelGroup layout="block" class="text-end mx-4 my-1">
+                                                            <h:outputLabel id="total" value="#{pharmacySaleController.preBill.total}">
+                                                                <f:convertNumber pattern="#,##0.00" />
+                                                            </h:outputLabel>
+                                                        </h:panelGroup>
+
+                                                        <h:outputLabel value="Discount" />
+                                                        <h:panelGroup layout="block" class="text-end mx-4 my-1">
+                                                            <h:outputLabel id="dis" value="#{pharmacySaleController.preBill.discount}">
+                                                                <f:convertNumber pattern="#,##0.00" />
+                                                            </h:outputLabel>
+                                                        </h:panelGroup>
+
+                                                        <h:outputLabel value="Net Total" />
+                                                        <h:panelGroup layout="block" class="text-end mx-4 my-1">
+                                                            <h:outputLabel id="netTotal" value="#{pharmacySaleController.preBill.netTotal}">
+                                                                <f:convertNumber pattern="#,##0.00" />
+                                                            </h:outputLabel>
+                                                        </h:panelGroup>
+
+                                                        <h:outputLabel value="Tendered" />
+                                                        <h:panelGroup layout="block" class="text-end mx-4 my-1">
+                                                            <p:inputText
+                                                                id="paid"
+                                                                value="#{pharmacySaleController.cashPaid}"
+                                                                class="form-control text-end"
+                                                                autocomplete="off"
+                                                                accesskey="t"
+                                                                onfocus="this.select()">
+                                                                <p:ajax process="total dis netTotal paid" update="balance netTotal" event="keyup" />
+                                                            </p:inputText>
+                                                        </h:panelGroup>
+
+                                                        <h:outputLabel value="Balance" />
+                                                        <h:panelGroup layout="block" class="text-end mx-4 my-1">
+                                                            <h:outputLabel id="balance" value="#{pharmacySaleController.balance}">
+                                                                <f:convertNumber pattern="#,##0.00" />
+                                                            </h:outputLabel>
+                                                        </h:panelGroup>
                                                     </h:panelGrid>
+
 
                                                 </p:panel>
 

--- a/src/main/webapp/pharmacy/pharmacy_bill_retail_sale.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_bill_retail_sale.xhtml
@@ -182,7 +182,7 @@
                                                                 <f:convertDateTime pattern="#{sessionController.applicationPreference.shortDateFormat}" ></f:convertDateTime>
                                                             </h:outputLabel>
                                                         </p:column>
-                                                        <p:ajax event="focus" process="acStock :#{p:resolveFirstComponentWithId('cmbPs',view).clientId} :#{p:resolveFirstComponentWithId('cmbPaymentScheme',view).clientId}"  ></p:ajax>
+                                                        <p:ajax event="focus" process="acStock :#{p:resolveFirstComponentWithId('cmbPs',view).clientId}"  ></p:ajax>
                                                         <p:ajax event="itemSelect" listener="#{pharmacySaleController.handleSelect}" update="txtQty txtRate focusQty txtItemInstructions :#{p:resolveFirstComponentWithId('lstReplaceableBatch',view).clientId}" ></p:ajax>
                                                         <p:ajax event="query" update=":#{p:resolveFirstComponentWithId('tabI',view).clientId}" process="acStock"></p:ajax>
                                                     </p:autoComplete>
@@ -230,7 +230,7 @@
                                                                 <f:convertDateTime pattern="#{sessionController.applicationPreference.shortDateFormat}" ></f:convertDateTime>
                                                             </h:outputLabel>
                                                         </p:column>
-                                                        <p:ajax event="focus" process="acStock :#{p:resolveFirstComponentWithId('cmbPs',view).clientId} :#{p:resolveFirstComponentWithId('cmbPaymentScheme',view).clientId}"  ></p:ajax>
+                                                        <p:ajax event="focus" process="acStock :#{p:resolveFirstComponentWithId('cmbPs',view).clientId}"  ></p:ajax>
                                                         <p:ajax event="itemSelect" listener="#{pharmacySaleController.handleSelect}" update="txtQty txtRate focusQty txtItemInstructions :#{p:resolveFirstComponentWithId('lstReplaceableBatch',view).clientId}" ></p:ajax>
                                                         <p:ajax event="query" update=":#{p:resolveFirstComponentWithId('tabI',view).clientId}" process="acStock"></p:ajax>
                                                     </p:autoComplete>
@@ -249,8 +249,8 @@
                                                     class="w-100"
                                                     style="text-align: right;"
                                                     value="#{pharmacySaleController.intQty}">
-                                                    <p:ajax event="keyup" listener="#{pharmacySaleController.calculateBillItemListner}" process="acStock txtQty :#{p:resolveFirstComponentWithId('cmbPs',view).clientId} :#{p:resolveFirstComponentWithId('cmbPaymentScheme',view).clientId}" update="txtRate txtVal"></p:ajax>
-                                                    <p:ajax event="blur" listener="#{pharmacySaleController.calculateBillItemListner}" process="acStock txtQty :#{p:resolveFirstComponentWithId('cmbPs',view).clientId} :#{p:resolveFirstComponentWithId('cmbPaymentScheme',view).clientId}" update="txtRate txtVal"></p:ajax>
+                                                    <p:ajax event="keyup" listener="#{pharmacySaleController.calculateBillItemListner}" process="acStock txtQty :#{p:resolveFirstComponentWithId('cmbPs',view).clientId}" update="txtRate txtVal"></p:ajax>
+                                                    <p:ajax event="blur" listener="#{pharmacySaleController.calculateBillItemListner}" process="acStock txtQty :#{p:resolveFirstComponentWithId('cmbPs',view).clientId}" update="txtRate txtVal"></p:ajax>
                                                 </p:inputText>
 
                                             </div>
@@ -265,7 +265,7 @@
                                                             value="Add"
                                                             styleClass="ui-button-success"
                                                             action="#{pharmacySaleController.addBillItem()}"
-                                                            process="@this acStock txtQty :#{p:resolveFirstComponentWithId('cmbPs',view).clientId} :#{p:resolveFirstComponentWithId('cmbPaymentScheme',view).clientId} focusForAcIx"
+                                                            process="@this acStock txtQty :#{p:resolveFirstComponentWithId('cmbPs',view).clientId} focusForAcIx"
                                                             update=":#{p:resolveFirstComponentWithId('netTotal',view).clientId} :#{p:resolveFirstComponentWithId('dis',view).clientId} :#{p:resolveFirstComponentWithId('total',view).clientId} :#{p:resolveFirstComponentWithId('panelBillDetails',view).clientId} :#{p:resolveFirstComponentWithId('tblBillItem',view).clientId} txtRate txtQty acStock focusItem :#{p:resolveFirstComponentWithId('tabI',view).clientId} :#{p:resolveFirstComponentWithId('panelError',view).clientId} txtItemInstructions" >
                                                         </p:commandButton>
 
@@ -977,23 +977,38 @@
                                                     </f:facet>
                                                     <div class="row" >
                                                         <div class="col-md-5" >
+                                                            <p:outputLabel value="Payment Method" for="pay" ></p:outputLabel>
                                                             <p:selectOneMenu   id="pay"
                                                                                value="#{pharmacySaleController.paymentMethod}">
                                                                 <f:selectItems value="#{enumController.paymentMethodsForPharmacyBilling}" var="p" itemLabel="#{p.label}"
                                                                                itemValue="#{p}"/>
-                                                                <p:ajax process="@this cmbPs cmbPaymentScheme"
+                                                                <p:ajax process="pay"
                                                                         update="panelBillDetails panelPaymentDetails"
                                                                         event="change"
                                                                         listener="#{pharmacySaleController.listnerForPaymentMethodChange()}"/>
                                                             </p:selectOneMenu>
 
+<!--                                                            <p:outputLabel value="Payment Scheme" for="cmbPaymentScheme" ></p:outputLabel>
                                                             <p:selectOneMenu   id="cmbPaymentScheme" value="#{pharmacySaleController.paymentScheme}" rendered="#{sessionController.loggedPreference.checkPaymentSchemeValidation eq true}">
                                                                 <f:selectItems value="#{paymentSchemeController.items}" var="i" itemLabel="#{i.name}" itemValue="#{i}"/>
-                                                                <p:ajax process="@this pay "
+                                                                <p:ajax process="cmbPaymentScheme"
+                                                                        update="panelBillDetails panelPaymentDetails"
+                                                                        event="change"
+                                                                        listener="#{pharmacySaleController.listnerForPaymentMethodChange()}"/>
+                                                            </p:selectOneMenu>-->
+
+
+                                                            <p:outputLabel value="Discount Scheme" for="cmbPs" ></p:outputLabel>
+                                                            <p:selectOneMenu   id="cmbPs" value="#{pharmacySaleController.paymentScheme}" rendered="#{sessionController.loggedPreference.checkPaymentSchemeValidation eq false}" class="my-1">
+                                                                <f:selectItem itemLabel="Discount Scheme"/>
+                                                                <f:selectItems value="#{paymentSchemeController.paymentSchemesForPharmacy}" var="i" itemLabel="#{i.name}" itemValue="#{i}"/>
+                                                                <p:ajax process="cmbPs"
                                                                         update="panelBillDetails panelPaymentDetails"
                                                                         event="change"
                                                                         listener="#{pharmacySaleController.listnerForPaymentMethodChange()}"/>
                                                             </p:selectOneMenu>
+
+
                                                         </div>
                                                     </div>
                                                     <div class="row" >
@@ -1166,16 +1181,7 @@
                                                         </div>
                                                     </div>
 
-                                                    <div class="col-5">
-                                                        <p:selectOneMenu   id="cmbPs" value="#{pharmacySaleController.paymentScheme}" rendered="#{sessionController.loggedPreference.checkPaymentSchemeValidation eq false}" class="my-1">
-                                                            <f:selectItem itemLabel="Discount Scheme"/>
-                                                            <f:selectItems value="#{paymentSchemeController.paymentSchemesForPharmacy}" var="i" itemLabel="#{i.name}" itemValue="#{i}"/>
-                                                            <p:ajax process="@this pay "
-                                                                    update="panelBillDetails panelPaymentDetails"
-                                                                    event="change"
-                                                                    listener="#{pharmacySaleController.listnerForPaymentMethodChange()}"/>
-                                                        </p:selectOneMenu>
-                                                    </div>
+
 
                                                     <h:panelGrid columns="2" class="my-2">
                                                         <p:outputLabel value="Referring Doctor" ></p:outputLabel>

--- a/src/main/webapp/pharmacy/pharmacy_bill_retail_sale.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_bill_retail_sale.xhtml
@@ -979,24 +979,15 @@
                                                         <div class="col-md-5" >
                                                             <p:outputLabel value="Payment Method" for="pay" ></p:outputLabel>
                                                             <p:selectOneMenu   id="pay"
+                                                                               required="true"
                                                                                value="#{pharmacySaleController.paymentMethod}">
                                                                 <f:selectItems value="#{enumController.paymentMethodsForPharmacyBilling}" var="p" itemLabel="#{p.label}"
                                                                                itemValue="#{p}"/>
                                                                 <p:ajax process="pay"
                                                                         update="panelBillDetails panelPaymentDetails"
-                                                                        event="change"
+                                                                        event="blur"
                                                                         listener="#{pharmacySaleController.listnerForPaymentMethodChange()}"/>
                                                             </p:selectOneMenu>
-
-<!--                                                            <p:outputLabel value="Payment Scheme" for="cmbPaymentScheme" ></p:outputLabel>
-                                                            <p:selectOneMenu   id="cmbPaymentScheme" value="#{pharmacySaleController.paymentScheme}" rendered="#{sessionController.loggedPreference.checkPaymentSchemeValidation eq true}">
-                                                                <f:selectItems value="#{paymentSchemeController.items}" var="i" itemLabel="#{i.name}" itemValue="#{i}"/>
-                                                                <p:ajax process="cmbPaymentScheme"
-                                                                        update="panelBillDetails panelPaymentDetails"
-                                                                        event="change"
-                                                                        listener="#{pharmacySaleController.listnerForPaymentMethodChange()}"/>
-                                                            </p:selectOneMenu>-->
-
 
                                                             <p:outputLabel value="Discount Scheme" for="cmbPs" ></p:outputLabel>
                                                             <p:selectOneMenu   id="cmbPs" value="#{pharmacySaleController.paymentScheme}" rendered="#{sessionController.loggedPreference.checkPaymentSchemeValidation eq false}" class="my-1">

--- a/src/main/webapp/pharmacy/pharmacy_bill_retail_sale.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_bill_retail_sale.xhtml
@@ -977,16 +977,17 @@
                                                     </f:facet>
                                                     <div class="row" >
                                                         <div class="col-md-5" >
-                                                            <p:outputLabel value="Payment Method" for="pay" ></p:outputLabel>
-                                                            <p:selectOneMenu   id="pay"
-                                                                               required="true"
-                                                                               value="#{pharmacySaleController.paymentMethod}">
-                                                                <f:selectItems value="#{enumController.paymentMethodsForPharmacyBilling}" var="p" itemLabel="#{p.label}"
-                                                                               itemValue="#{p}"/>
-                                                                <p:ajax process="pay"
+                                                            <p:outputLabel value="Payment Method" for="cmbPaymentMethod" ></p:outputLabel>
+                                                            <p:selectOneMenu id="cmbPaymentMethod" value="#{pharmacySaleController.paymentMethod}" required="true">
+                                                                <p:ajax event="valueChange" 
+                                                                        listener="#{pharmacySaleController.listnerForPaymentMethodChange}" 
                                                                         update="panelBillDetails panelPaymentDetails"
-                                                                        event="blur"
-                                                                        listener="#{pharmacySaleController.listnerForPaymentMethodChange()}"/>
+                                                                        process="@this" 
+                                                                        partialSubmit="true"/>
+                                                                <f:selectItems value="#{enumController.paymentMethodsWithoutCredit}" 
+                                                                               var="pmt" 
+                                                                               itemLabel="#{pmt.label}" 
+                                                                               itemValue="#{pmt}" />
                                                             </p:selectOneMenu>
 
                                                             <p:outputLabel value="Discount Scheme" for="cmbPs" ></p:outputLabel>


### PR DESCRIPTION
✅ **Issue fixed:**  
The root cause was an unintended line in `clearBillItem()` that reset `paymentMethod` to `Cash` every time a bill item was cleared. This silently overrode the user's selection and disrupted discount logic.  

🚫 **Important:** Do **not** reset `paymentMethod` during bill item clearing. It should only be reset when the entire bill is reset.  

🔁 This issue consumed significant debugging time due to hidden state resets during Ajax operations and form updates.

🛠 **Fix implemented:**  
- Removed the unnecessary `paymentMethod = PaymentMethod.Cash;` line from `clearBillItem()`
- Added a clear in-code warning comment to prevent future regressions

✅ QA should **re-test the full retail pharmacy bill workflow end-to-end**, as several optimizations and safety improvements were made during debugging.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added new columns to bill item reports for displaying Bill Item ID and Bill ID, visible to users with "Developers" privileges.
  - Introduced a new "Ref Bill Nos" column in agent history reports to display reference bill numbers and status badges.

- **Improvements**
  - Enhanced billing calculations with more robust handling of discounts and improved error messages.
  - Refined payment method selection in the pharmacy sale interface, simplifying options and validation.
  - Updated agent history reports for clearer navigation and status display.

- **Bug Fixes**
  - Improved handling of null and zero values in billing processes to prevent errors.

- **Style**
  - Minor whitespace and UI adjustments for better readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->