### PR TITLE
Closes #11474

### DIFF
--- a/src/main/java/com/divudi/bean/pharmacy/PharmacySaleController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacySaleController.java
@@ -3063,7 +3063,7 @@ public class PharmacySaleController implements Serializable, ControllerWithPatie
         stock = null;
         editingQty = null;
         errorMessage = "";
-        paymentMethod = PaymentMethod.Cash;
+        // paymentMethod = PaymentMethod.Cash; // Never do this. It shold be done in clear bill item
         paymentMethodData = null;
         setCashPaid(0.0);
         allergyListOfPatient = null;


### PR DESCRIPTION
✅ **Issue fixed:**  
The root cause was an unintended line in `clearBillItem()` that reset `paymentMethod` to `Cash` every time a bill item was cleared. This silently overrode the user's selection and disrupted discount logic.  

🚫 **Important:** Do **not** reset `paymentMethod` during bill item clearing. It should only be reset when the entire bill is reset.  

🔁 This issue consumed significant debugging time due to hidden state resets during Ajax operations and form updates.

🛠 **Fix implemented:**  
- Removed the unnecessary `paymentMethod = PaymentMethod.Cash;` line from `clearBillItem()`
- Added a clear in-code warning comment to prevent future regressions

✅ QA should **re-test the full retail pharmacy bill workflow end-to-end**,



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed an issue where the payment method was incorrectly reset to "Cash" when clearing bill items. The payment method now remains unchanged during this action.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->