### PR TITLE
11831 checque must be printed from the system not handwritten

### DIFF
--- a/src/main/java/com/divudi/bean/pharmacy/SupplierPaymentController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/SupplierPaymentController.java
@@ -147,6 +147,7 @@ public class SupplierPaymentController implements Serializable {
     private List<String> supplierPaymentStatusList;
     private String supplierPaymentStatus;
     boolean changed = false;
+    private boolean acPayeeOnly;
 
     // </editor-fold>
     // <editor-fold defaultstate="collapsed" desc="Constructors">
@@ -3121,6 +3122,10 @@ public class SupplierPaymentController implements Serializable {
             return s;
         }
     }
+    
+    public String convertToWord(Double d){
+        return CommonFunctions.convertToWord(d);
+    }
 
     public Payment findPaymentFromBill(Bill b){
         String jpql = "Select p From Payment p Where " +
@@ -3542,5 +3547,13 @@ public class SupplierPaymentController implements Serializable {
 
     public void setChanged(boolean changed) {
         this.changed = changed;
+    }
+
+    public boolean isAcPayeeOnly() {
+        return acPayeeOnly;
+    }
+
+    public void setAcPayeeOnly(boolean acPayeeOnly) {
+        this.acPayeeOnly = acPayeeOnly;
     }
 }

--- a/src/main/java/com/divudi/bean/pharmacy/SupplierPaymentController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/SupplierPaymentController.java
@@ -3107,7 +3107,7 @@ public class SupplierPaymentController implements Serializable {
             String filledFooter;
            
             String bankName = (p != null ? p.getBank().getName() : "");
-            String chequeDate = (p != null ? CommonFunctions.getDateFormat(p.getChequeDate(), sessionController.getApplicationPreference().getShortDateFormat()) : "");
+            String chequeDate = (p != null ? CommonFunctions.getDateFormat(p.getChequeDate(), sessionController.getApplicationPreference().getLongDateFormat()) : "");
             String chequeNo = (p != null ? p.getChequeRefNo() : "");
             Double amount = (p != null ? Math.abs(p.getPaidValue()) : 0.0);
 

--- a/src/main/webapp/dealerPayment/settle_approved_supplier_payment.xhtml
+++ b/src/main/webapp/dealerPayment/settle_approved_supplier_payment.xhtml
@@ -97,7 +97,7 @@
                                     <h:outputText value="Comments: " />
                                     <h:outputText value="#{supplierPaymentController.current.paymentGenerationComments}" />
                                 </h:panelGroup>
-                                
+
                                 <p:outputLabel value="Payment Checking"/>
                                 <h:panelGroup>
                                     <h:outputText value="Checked by " />
@@ -186,10 +186,21 @@
                             <p:commandButton value="Print" ajax="false" icon="pi pi-print" styleClass="ui-button-secondary m-1">
                                 <p:printer target="gpBillPreview"></p:printer>
                             </p:commandButton>
+                            <p:selectBooleanCheckbox value="#{supplierPaymentController.acPayeeOnly}"
+                                                     label="A/C Payee Only" itemLabel="A/C Payee Only"
+                                                     class="mx-2">
+                                <p:ajax process="@this" update="@all"/>
+                            </p:selectBooleanCheckbox>
+                            <p:commandButton value="Print Cheque" class="mx-2" icon="pi pi-print" ajax="false" action="#" >
+                                <p:printer target="gpBillPreview1" ></p:printer>
+                            </p:commandButton>
 
                             <p:panel id="gpBillPreview">
                                 <bi:grn_payment_with_pre_bill billItems="#{supplierPaymentController.current.billItems}" bill="#{supplierPaymentController.current}"/>
                             </p:panel>
+                            <h:panelGroup   id="gpBillPreview1" class="my-5">
+                                <bi:supplier_payment_cheque billItems="#{supplierPaymentController.current.billItems}" bill="#{supplierPaymentController.current}" acpayeeonly="#{supplierPaymentController.acPayeeOnly}" />
+                            </h:panelGroup>
                         </p:panel>
                     </h:form>
                 </h:panelGroup>

--- a/src/main/webapp/dealerPayment/settle_approved_supplier_payment.xhtml
+++ b/src/main/webapp/dealerPayment/settle_approved_supplier_payment.xhtml
@@ -199,7 +199,7 @@
                                 <bi:grn_payment_with_pre_bill billItems="#{supplierPaymentController.current.billItems}" bill="#{supplierPaymentController.current}"/>
                             </p:panel>
                             <h:panelGroup   id="gpBillPreview1" class="my-5">
-                                <bi:supplier_payment_cheque billItems="#{supplierPaymentController.current.billItems}" bill="#{supplierPaymentController.current}" acpayeeonly="#{supplierPaymentController.acPayeeOnly}" />
+                                <bi:supplier_payment_cheque billItems="#{supplierPaymentController.current.billItems}" bill="#{supplierPaymentController.current}" acPayeeOnly="#{supplierPaymentController.acPayeeOnly}" />
                             </h:panelGroup>
                         </p:panel>
                     </h:form>

--- a/src/main/webapp/dealerPayment/view_supplier_payment_voucher.xhtml
+++ b/src/main/webapp/dealerPayment/view_supplier_payment_voucher.xhtml
@@ -11,13 +11,26 @@
     <h:body>
         <ui:composition template="/dealerPayment/index.xhtml">
             <ui:define name="subcontent">
-
-                <p:commandButton value="Print" ajax="false" action="#" >
-                    <p:printer target="gpBillPreview" ></p:printer>
-                </p:commandButton>
-                <p:panel   id="gpBillPreview">
-                    <bi:grn_payment_with_pre_bill billItems="#{supplierPaymentController.current.billItems}" bill="#{supplierPaymentController.current}"/>
-                </p:panel>
+                <h:form>
+                    <p:commandButton value="Print" ajax="false" action="#" icon="pi pi-print"  styleClass="ui-button-secondary m-1" >
+                        <p:printer target="gpBillPreview" ></p:printer>
+                    </p:commandButton>
+                    <p:selectBooleanCheckbox value="#{supplierPaymentController.acPayeeOnly}"
+                                             label="A/C Payee Only" itemLabel="A/C Payee Only"
+                                             class="mx-2">
+                        <p:ajax process="@this" update="@all"/>
+                    </p:selectBooleanCheckbox>
+                    <p:commandButton value="Print Cheque" class="mx-2" ajax="false" action="#" icon="pi pi-print" >
+                        <p:printer target="gpBillPreview1" ></p:printer>
+                    </p:commandButton>
+                    <p:panel   id="gpBillPreview">
+                        <bi:grn_payment_with_pre_bill billItems="#{supplierPaymentController.current.billItems}" bill="#{supplierPaymentController.current}"/>
+                    </p:panel>
+                    #{supplierPaymentController.acPayeeOnly}
+                    <h:panelGroup   id="gpBillPreview1" class="my-5">
+                        <bi:supplier_payment_cheque billItems="#{supplierPaymentController.current.billItems}" bill="#{supplierPaymentController.current}" acpayeeonly="#{supplierPaymentController.acPayeeOnly}" />
+                    </h:panelGroup>
+                </h:form>
             </ui:define>
         </ui:composition>
     </h:body>

--- a/src/main/webapp/dealerPayment/view_supplier_payment_voucher.xhtml
+++ b/src/main/webapp/dealerPayment/view_supplier_payment_voucher.xhtml
@@ -28,7 +28,7 @@
                     </p:panel>
                     #{supplierPaymentController.acPayeeOnly}
                     <h:panelGroup   id="gpBillPreview1" class="my-5">
-                        <bi:supplier_payment_cheque billItems="#{supplierPaymentController.current.billItems}" bill="#{supplierPaymentController.current}" acpayeeonly="#{supplierPaymentController.acPayeeOnly}" />
+                        <bi:supplier_payment_cheque billItems="#{supplierPaymentController.current.billItems}" bill="#{supplierPaymentController.current}" acPayeeOnly="#{supplierPaymentController.acPayeeOnly}" />
                     </h:panelGroup>
                 </h:form>
             </ui:define>

--- a/src/main/webapp/dealerPayment/view_supplier_payment_voucher.xhtml
+++ b/src/main/webapp/dealerPayment/view_supplier_payment_voucher.xhtml
@@ -26,7 +26,7 @@
                     <p:panel   id="gpBillPreview">
                         <bi:grn_payment_with_pre_bill billItems="#{supplierPaymentController.current.billItems}" bill="#{supplierPaymentController.current}"/>
                     </p:panel>
-                    #{supplierPaymentController.acPayeeOnly}
+                    
                     <h:panelGroup   id="gpBillPreview1" class="my-5">
                         <bi:supplier_payment_cheque billItems="#{supplierPaymentController.current.billItems}" bill="#{supplierPaymentController.current}" acPayeeOnly="#{supplierPaymentController.acPayeeOnly}" />
                     </h:panelGroup>

--- a/src/main/webapp/resources/bill/grn_payment.xhtml
+++ b/src/main/webapp/resources/bill/grn_payment.xhtml
@@ -191,7 +191,7 @@
             </div>
 
             <div  style="#{configOptionApplicationController.getLongTextValueByKey('Supplier Payment Footer Header CSS')}" >
-                <h:outputText value="#{configOptionApplicationController.getLongTextValueByKey('Supplier Payment Voucher Footer Text')}" escape="false" ></h:outputText>
+                <h:outputText value="#{supplierPaymentController.fillFooterDataOfPaymentVoucher(configOptionApplicationController.getLongTextValueByKey('Supplier Payment Voucher Footer Text'), cc.attrs.bill)}" escape="false" ></h:outputText>
             </div>
         </div>
     </cc:implementation>

--- a/src/main/webapp/resources/bill/supplier_payment_cheque.xhtml
+++ b/src/main/webapp/resources/bill/supplier_payment_cheque.xhtml
@@ -1,0 +1,97 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:cc="http://xmlns.jcp.org/jsf/composite"
+      xmlns:h="http://xmlns.jcp.org/jsf/html"
+      xmlns:p="http://primefaces.org/ui"
+      xmlns:f="http://xmlns.jcp.org/jsf/core">
+
+    <!-- INTERFACE -->
+    <cc:interface>
+        <cc:attribute name="bill" type="com.divudi.core.entity.Bill"/>
+        <cc:attribute name="billItems" />
+        <cc:attribute name="acpayeeonly" />
+    </cc:interface>
+
+    <!-- IMPLEMENTATION -->
+    <cc:implementation>
+        <style>
+        .body {
+            font-family: "Arial";
+            margin: 0;
+            padding: 0;
+            width: 210mm;
+            height: 297mm;
+            font-size: 9pt;
+        }
+
+        .vertical-text {
+            position: absolute;
+            transform: rotate(270deg);
+            transform-origin: left top;
+        }
+
+        .vertical-text-boader {
+            position: absolute;
+            transform: rotate(270deg);
+            transform-origin: left top;
+            border-bottom: 1px solid;
+            border-top: 1px solid;
+        }
+
+        /* For screen only: rotate the whole layout 90 degrees */
+        @media screen {
+            .wrapper {
+                transform: rotate(90deg);
+                transform-origin: top left;
+                position: absolute;
+                top: 0;
+                left: 0;
+                width: 297mm;
+                height: 210mm;
+                overflow: auto;
+            }
+        }
+
+        /* For print: keep the original orientation */
+        @media print {
+            .wrapper {
+                transform: none !important;
+                width: 210mm;
+                height: 297mm;
+            }
+        }
+    </style>
+
+        <div class="wrapper">
+            <div class="vertical-text" style="left: 135mm; top: 56mm;  font-size: 10pt;">
+                <h:outputLabel value="#{sessionController.currentDate}" style="letter-spacing: 4.5mm;">
+                    <f:convertDateTime pattern="ddMMyyyy" />
+                </h:outputLabel>
+            </div>
+            <div class="vertical-text-boader" style="left: 135mm; top: 100mm; text-transform: uppercase !important;  font-size: 10pt;">
+                <h:outputLabel value="A/C PAYEE ONLY"  rendered="#{cc.attrs.acpayeeonly}"/>
+            </div>
+            <div class="vertical-text" style="left: 148mm; top: 158mm; text-transform: uppercase !important;  font-size: 10pt;">
+                <h:outputLabel value="#{cc.attrs.bill.toInstitution.name}" />
+            </div>
+            <div class="vertical-text" style="left: 158mm; top: 158mm; text-transform: uppercase !important;  font-size: 10pt; width: 84mm">
+                <h:outputLabel value="**#{supplierPaymentController.convertToWord(-cc.attrs.bill.netTotal)} ONLY**" />
+            </div>
+            <div class="vertical-text" style="left: 163mm; top: 54mm; text-transform: uppercase !important; font-weight: bold;  font-size: 10pt;">
+                <h:outputLabel value="#{-cc.attrs.bill.netTotal}">
+                    <f:convertNumber pattern="#,###,###.00" />
+                </h:outputLabel>
+            </div>
+            <div class="vertical-text" style="left: 174mm; top: 52mm; text-transform: uppercase !important; font-family: 'Times New Roman'; text-align: center; font-size: 8pt;">
+                <h:outputLabel value="GALLE CO-OPERATIVE  HOSPITAL LTD." />
+            </div>
+            <div class="vertical-text" style="left: 191mm; top: 68mm; text-transform: uppercase !important; font-size: 8pt;">
+                <h:outputLabel value="............................................................................................................." />
+            </div>
+            <div class="vertical-text" style="left: 197mm; top: 65mm; font-size: 8pt; font-family: 'Times New Roman'; width: 80mm">
+                <h:outputLabel value="Chairman   Vise Chairman   General Manager   Accuntant" />
+            </div>
+        </div>
+    </cc:implementation>
+</html>

--- a/src/main/webapp/resources/bill/supplier_payment_cheque.xhtml
+++ b/src/main/webapp/resources/bill/supplier_payment_cheque.xhtml
@@ -70,7 +70,7 @@
                 </h:outputLabel>
             </div>
             <div class="vertical-text-border" style="left: 135mm; top: 100mm; text-transform: uppercase !important;  font-size: 10pt;">
-                <h:outputLabel value="A/C PAYEE ONLY"  rendered="#{cc.attrs.acpayeeonly}"/>
+                <h:outputLabel value="A/C PAYEE ONLY"  rendered="#{cc.attrs.acPayeeOnly}"/>
             </div>
             <div class="vertical-text" style="left: 148mm; top: 158mm; text-transform: uppercase !important;  font-size: 10pt;">
                 <h:outputLabel value="#{cc.attrs.bill.toInstitution.name}" />

--- a/src/main/webapp/resources/bill/supplier_payment_cheque.xhtml
+++ b/src/main/webapp/resources/bill/supplier_payment_cheque.xhtml
@@ -10,7 +10,7 @@
     <cc:interface>
         <cc:attribute name="bill" type="com.divudi.core.entity.Bill"/>
         <cc:attribute name="billItems" />
-        <cc:attribute name="acpayeeonly" />
+        <cc:attribute name="acPayeeOnly" type="boolean" required="false"/>
     </cc:interface>
 
     <!-- IMPLEMENTATION -->
@@ -31,7 +31,7 @@
             transform-origin: left top;
         }
 
-        .vertical-text-boader {
+        .vertical-text-border {
             position: absolute;
             transform: rotate(270deg);
             transform-origin: left top;
@@ -69,7 +69,7 @@
                     <f:convertDateTime pattern="ddMMyyyy" />
                 </h:outputLabel>
             </div>
-            <div class="vertical-text-boader" style="left: 135mm; top: 100mm; text-transform: uppercase !important;  font-size: 10pt;">
+            <div class="vertical-text-border" style="left: 135mm; top: 100mm; text-transform: uppercase !important;  font-size: 10pt;">
                 <h:outputLabel value="A/C PAYEE ONLY"  rendered="#{cc.attrs.acpayeeonly}"/>
             </div>
             <div class="vertical-text" style="left: 148mm; top: 158mm; text-transform: uppercase !important;  font-size: 10pt;">
@@ -90,7 +90,7 @@
                 <h:outputLabel value="............................................................................................................." />
             </div>
             <div class="vertical-text" style="left: 197mm; top: 65mm; font-size: 8pt; font-family: 'Times New Roman'; width: 80mm">
-                <h:outputLabel value="Chairman   Vise Chairman   General Manager   Accuntant" />
+                <h:outputLabel value="Chairman   Vice Chairman   General Manager   Accountant" />
             </div>
         </div>
     </cc:implementation>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an "A/C Payee Only" checkbox to supplier payment settlement and voucher pages, allowing users to specify cheque payment type.
  - Introduced a "Print Cheque" button that generates a printable cheque layout for supplier payments, including payee details and amount in words.
- **Enhancements**
  - Cheque date formatting updated to use a long date format on payment vouchers.
  - Footer content in payment vouchers now dynamically incorporates bill data for improved clarity.
- **User Interface**
  - Improved print preview panels and button styling for better usability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->