### PR TITLE
12051 add validation to returning qty input in pharmacy bill return page

### DIFF
--- a/src/main/java/com/divudi/bean/common/SessionController.java
+++ b/src/main/java/com/divudi/bean/common/SessionController.java
@@ -894,11 +894,8 @@ public class SessionController implements Serializable, HttpSessionListener {
     }
 
     private boolean isFirstVisit() {
-        System.out.println("this = " + this);
-        System.out.println("isFirstVisit = ");
         String j = "Select w from WebUser w order by w.id";
         WebUser ws = getFacede().findFirstByJpql(j);
-        System.out.println("ws = " + ws);
         if (ws == null) {
             JsfUtil.addSuccessMessage("First Visit");
             return true;
@@ -1856,7 +1853,6 @@ public class SessionController implements Serializable, HttpSessionListener {
         }
         m.put("ret", true);
         m.put("wu", twu);
-        System.out.println("m = " + m);
         List<WebUserPrivilege> twups = getWebUserPrivilegeFacade().findByJpql(sql, m);
         return twups;
     }
@@ -1977,7 +1973,6 @@ public class SessionController implements Serializable, HttpSessionListener {
                 getLoginsFacade().create(thisLogin);
             } catch (Exception e) {
                 getLoginsFacade().edit(thisLogin);
-                System.err.println("e = " + e);
             }
 
         } else {
@@ -1988,7 +1983,6 @@ public class SessionController implements Serializable, HttpSessionListener {
 
     @PreDestroy
     private void recordLogout() {
-        System.out.println("Session destroyed: " + thisLogin);
 
         if (thisLogin == null) {
             return;
@@ -2006,10 +2000,8 @@ public class SessionController implements Serializable, HttpSessionListener {
                 managedLogin.setLogoutAt(thisLogin.getLogoutAt());
                 getLoginsFacade().edit(managedLogin);
             } else {
-                System.err.println("Error: Unable to find the Login entity with ID: " + thisLogin.getId());
             }
         } catch (Exception e) {
-            System.err.println("Error recording logout: " + e.getMessage());
             e.printStackTrace();
         }
     }

--- a/src/main/webapp/pharmacy/pharmacy_bill_return_retail.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_bill_return_retail.xhtml
@@ -78,11 +78,13 @@
 
 
                                 <p:column headerText="Returning Qty" class="text-end">                     
-                                    <p:inputText autocomplete="off" value="#{ph.qty}" onfocus="this.select();" class="text-end w-100">
+                                    <p:inputText
+                                        converter="javax.faces.Integer"
+                                        autocomplete="off" value="#{ph.qty}" onfocus="this.select();" class="text-end w-100">
                                         <f:ajax 
                                             event="blur"
                                             delay="500"
-                                            render="@this :#{p:resolveFirstComponentWithId('totalPanel',view).clientId}"  
+                                            render=":#{p:resolveFirstComponentWithId('totalPanel',view).clientId}"  
                                             execute="@this" 
                                             listener="#{saleReturnController.onEdit(ph)}" ></f:ajax>
                                             <f:validateDoubleRange minimum="0" maximum="#{ph.pharmaceuticalBillItem.qty}" />

--- a/src/main/webapp/pharmacy/pharmacy_bill_return_retail.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_bill_return_retail.xhtml
@@ -77,13 +77,15 @@
                                 </p:column>
 
 
-                                <p:column headerText="Returning Qty in Unit" class="text-end">                     
+                                <p:column headerText="Returning Qty" class="text-end">                     
                                     <p:inputText autocomplete="off" value="#{ph.qty}" onfocus="this.select();" class="text-end w-100">
                                         <f:ajax 
                                             event="blur"
+                                            delay="500"
                                             render="@this :#{p:resolveFirstComponentWithId('totalPanel',view).clientId}"  
                                             execute="@this" 
                                             listener="#{saleReturnController.onEdit(ph)}" ></f:ajax>
+                                            <f:validateDoubleRange minimum="0" maximum="#{ph.pharmaceuticalBillItem.qty}" />
                                     </p:inputText>
                                 </p:column>  
 


### PR DESCRIPTION
Done

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved validation and user input handling for the "Returning Qty" field in pharmacy bill returns, ensuring only valid integer values within the allowed range can be entered.
  - Enhanced interface responsiveness by adjusting event timing and updating only relevant UI components.

- **Chores**
  - Removed debug print statements from session management to streamline application logs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->