### PR TITLE
Fixed - list-inward-items-by-department-in-inward-biling

### DIFF
--- a/src/main/java/com/divudi/bean/inward/BillBhtController.java
+++ b/src/main/java/com/divudi/bean/inward/BillBhtController.java
@@ -11,6 +11,8 @@ package com.divudi.bean.inward;
 import com.divudi.bean.common.BillBeanController;
 import com.divudi.bean.common.BillController;
 import com.divudi.bean.common.BillSearch;
+import com.divudi.bean.common.ConfigOptionApplicationController;
+import com.divudi.bean.common.DepartmentController;
 import com.divudi.bean.common.ItemApplicationController;
 import com.divudi.bean.common.ItemController;
 import com.divudi.bean.common.ItemFeeManager;
@@ -56,6 +58,7 @@ import com.divudi.core.util.JsfUtil;
 import com.divudi.bean.lab.PatientInvestigationController;
 import com.divudi.core.data.BillTypeAtomic;
 import com.divudi.core.data.ItemLight;
+import static com.divudi.core.data.ItemListingStrategy.*;
 import com.divudi.core.data.lab.InvestigationTubeSticker;
 import com.divudi.core.entity.UserPreference;
 import com.divudi.ws.lims.Lims;
@@ -94,6 +97,10 @@ public class BillBhtController implements Serializable {
     PatientInvestigationController patientInvestigationController;
     @Inject
     ItemFeeManager itemFeeManager;
+    @Inject
+    DepartmentController departmentController;
+    @Inject
+    ConfigOptionApplicationController configOptionApplicationController;
     /////////////////
     @EJB
     private ItemFeeFacade itemFeeFacade;
@@ -157,6 +164,11 @@ public class BillBhtController implements Serializable {
     private ItemLight itemLight;
 
     private int entriesIndex;
+    
+    private List<ItemLight> departmentInwardItems;
+    private Department selectedInwardItemDepartment;
+    private List<Department> inwardItemDepartments;
+    private List<ItemLight> inwardItem;
 
     public String navigateToAddServiceFromMenu() {
         resetBillData();
@@ -976,6 +988,81 @@ public class BillBhtController implements Serializable {
         lstBillComponents = getBillBean().billComponentsFromBillEntries(lstBillEntries);
         lstBillFees = getBillBean().billFeesFromBillEntries(lstBillEntries);
     }
+    
+    public List<ItemLight> fillInwardItem() {
+        UserPreference up = sessionController.getDepartmentPreference();
+        List<ItemLight> temItems;
+        switch (up.getInwardItemListingStrategy()) {
+            case ALL_ITEMS:
+                temItems = itemApplicationController.getInvestigationsAndServices();
+                break;
+            case ITEMS_MAPPED_TO_LOGGED_DEPARTMENT:
+                temItems = itemMappingController.fillItemLightByDepartment(sessionController.getDepartment());
+                break;
+            case ITEMS_MAPPED_TO_LOGGED_INSTITUTION:
+                temItems = itemMappingController.fillItemLightByInstitution(sessionController.getInstitution());
+                break;
+            case ITEMS_OF_LOGGED_DEPARTMENT:
+                temItems = itemController.getDepartmentItems();
+                break;
+            case ITEMS_OF_LOGGED_INSTITUTION:
+                temItems = itemController.getInstitutionItems();
+                break;
+            case SITE_FEE_ITEMS:
+                temItems = itemFeeManager.fillItemLightsForSite(sessionController.getDepartment().getSite());
+                break;
+            default:
+                temItems = itemApplicationController.getInvestigationsAndServices();
+                break;
+        }
+        boolean listItemsByDepartment = configOptionApplicationController.getBooleanValueByKey("List Inward Items by Department", false);
+        if (listItemsByDepartment) {
+            fillInwardItemDepartments(temItems);
+        } else {
+            inwardItemDepartments = null;
+        }
+        if (getSelectedInwardItemDepartment() != null) {
+            departmentInwardItems = filterItemLightesByDepartment(temItems, getSelectedInwardItemDepartment());
+        }
+
+        return temItems;
+    }
+    
+    private List<ItemLight> filterItemLightesByDepartment(List<ItemLight> ils, Department dept) {
+        boolean listItemsByDepartment = configOptionApplicationController.getBooleanValueByKey("List Inward Items by Department", false);
+        if (!listItemsByDepartment || dept == null || dept.getId() == null) {
+            return ils;
+        }
+        List<ItemLight> tils = new ArrayList<>();
+        for (ItemLight il : ils) {
+            if (il.getDepartmentId() != null && il.getDepartmentId().equals(dept.getId())) {
+                tils.add(il);
+            }
+        }
+        return tils;
+    }
+    
+    public void fillInwardItemDepartments(List<ItemLight> itemLightsToAddDepartments) {
+        inwardItemDepartments = new ArrayList<>();
+        Set<Long> uniqueDeptIds = new HashSet<>();
+        for (ItemLight il : itemLightsToAddDepartments) {
+            if (il.getDepartmentId() != null) {
+                uniqueDeptIds.add(il.getDepartmentId());
+            }
+        }
+        for (Long deptId : uniqueDeptIds) {
+            Department d = departmentController.findDepartment(deptId);
+            inwardItemDepartments.add(d);
+        }
+    }
+    
+    public void departmentChanged() {
+        if (selectedInwardItemDepartment == null) {
+            departmentInwardItems = getInwardItem();
+        } else {
+            departmentInwardItems = filterItemLightesByDepartment(getInwardItem(), getSelectedInwardItemDepartment());
+        }
+    }
 
     public BillFacade getEjbFacade() {
         return billFacade;
@@ -1356,6 +1443,51 @@ public class BillBhtController implements Serializable {
 
     public void setEntriesIndex(int entriesIndex) {
         this.entriesIndex = entriesIndex;
+    }
+    
+    public List<ItemLight> getInwardItem() {
+        if (inwardItem == null) {
+            inwardItem = fillInwardItem();
+        }
+        return inwardItem;
+    }
+    
+    public void setInwardItem(List<ItemLight> inwardItem) {
+        this.inwardItem = inwardItem;
+    }
+
+    public List<ItemLight> getDepartmentInwardItems() {
+        getInwardItem();
+        departmentInwardItems = filterItemLightesByDepartment(getInwardItem(), getSelectedInwardItemDepartment());
+        return departmentInwardItems;
+    }
+
+    public void setDepartmentInwardItems(List<ItemLight> departmentInwardItems) {
+        this.departmentInwardItems = departmentInwardItems;
+    }
+
+    public Department getSelectedInwardItemDepartment() {
+        if (selectedInwardItemDepartment == null) {
+            if (inwardItemDepartments != null && !inwardItemDepartments.isEmpty()) {
+                selectedInwardItemDepartment = inwardItemDepartments.get(0);
+            }
+        }
+        return selectedInwardItemDepartment;
+    }
+
+    public void setSelectedInwardItemDepartment(Department selectedInwardItemDepartment) {
+        this.selectedInwardItemDepartment = selectedInwardItemDepartment;
+    }
+
+    public List<Department> getInwardItemDepartments() {
+        if (inwardItemDepartments == null) {
+            getInwardItem();
+        }
+        return inwardItemDepartments;
+    }
+
+    public void setInwardItemDepartments(List<Department> inwardItemDepartments) {
+        this.inwardItemDepartments = inwardItemDepartments;
     }
 
 }

--- a/src/main/webapp/inward/inward_bill_service.xhtml
+++ b/src/main/webapp/inward/inward_bill_service.xhtml
@@ -216,8 +216,32 @@
                                                         </div>
                                                     </div>
                                                 </f:facet>
+                                                
                                                 <div class="row">
 
+                                                    <h:panelGroup  rendered="#{billBhtController.inwardItemDepartments ne null}" id="departments">
+                                                        <div class="row mt-1 mb-2 mx-1">
+                                                            <div class="col-3"></div>
+                                                            <div class="col-9">
+                                                                <div class="row" >
+                                                                    <div class="col-md-12" >
+                                                                        <ui:repeat  value="#{billBhtController.inwardItemDepartments}" var="dept">
+                                                                            <p:commandButton 
+                                                                                value="#{dept.name}"
+                                                                                process="@this"
+                                                                                update=":#{p:resolveFirstComponentWithId('itm',view).clientId} :#{p:resolveFirstComponentWithId('departments',view).clientId}"
+                                                                                action="#{billBhtController.departmentChanged}"
+                                                                                class="m-1 #{dept eq billBhtController.selectedInwardItemDepartment ? 'ui-button-success' : 'ui-button-primary'}">
+                                                                                <f:setPropertyActionListener value="#{dept}" target="#{billBhtController.selectedInwardItemDepartment}"></f:setPropertyActionListener>
+                                                                            </p:commandButton>
+                                                                        </ui:repeat>
+                                                                    </div>
+                                                                </div>
+
+                                                            </div>
+                                                        </div>
+                                                    </h:panelGroup>
+                                                    
                                                     <div class="row mt-1 mb-2 mx-1">
                                                         <div class="col-3">
                                                             <h:outputLabel value="Investigation or Service"/>
@@ -231,7 +255,7 @@
                                                                 filterMatchMode="contains"
                                                                 class="w-100"
                                                                 converter="itemLightConverter">
-                                                                <f:selectItems value="#{billBhtController.inwardItems}" var="ix" itemLabel="#{ix.name}" itemValue="#{ix}" />
+                                                                <f:selectItems value="#{billBhtController.departmentInwardItems}" var="ix" itemLabel="#{ix.name}" itemValue="#{ix}" />
                                                                 <p:column>
                                                                     <h:outputLabel value="#{t.name}"/>
                                                                 </p:column>
@@ -530,7 +554,7 @@
                                                             <br/>
                                                         </ui:repeat>
                                                     </h:panelGroup>
-                                                    
+
                                                     <h:panelGroup  rendered="#{configOptionApplicationController.getBooleanValueByKey('Inward Servise Bill size is 5x8 inch Paper')}" >
                                                         <ui:repeat value="#{billBhtController.bills}" var="pp">
                                                             <print:five_eight_opd_bill bill="#{pp}" duplicate="false" payments="#{billBhtController.bills.size()}"/>


### PR DESCRIPTION
closes #12139
Signed-off-by: DamithDeshan <hkddrajapaksha@gmail.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added the ability to filter inward items by department, allowing users to view items specific to a selected department.
  - Introduced dynamic department selection buttons in the UI for easier navigation and filtering.
  - The item list now updates automatically based on the chosen department, streamlining the selection process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->