### PR TITLE
Manage the default service departments

### DIFF
--- a/src/main/java/com/divudi/bean/common/DefaultServiceDepartmentController.java
+++ b/src/main/java/com/divudi/bean/common/DefaultServiceDepartmentController.java
@@ -23,6 +23,7 @@ import javax.faces.component.UIComponent;
 import javax.faces.context.FacesContext;
 import javax.faces.convert.Converter;
 import javax.faces.convert.FacesConverter;
+import javax.inject.Inject;
 
 /**
  *
@@ -35,7 +36,10 @@ public class DefaultServiceDepartmentController implements Serializable {
     // <editor-fold defaultstate="collapsed" desc="EJBs">
     @EJB
     private DefaultServiceDepartmentFacade ejbFacade;
-    @EJB
+    // </editor-fold>
+
+    // <editor-fold defaultstate="collapsed" desc="Controllers">
+    @Inject
     private SessionController sessionController;
     // </editor-fold>
 
@@ -92,12 +96,12 @@ public class DefaultServiceDepartmentController implements Serializable {
             return null;
         }
         items = getDefaultServiceDepartments(orderingDepartment, serviceDepartment, category, item);
-        return navigateToEditDefaultServiceDepartment();
+        return navigateToListDefaultServiceDepartments();
     }
 
     public String saveExistingDefaultServiceDepartment() {
         if (current == null) {
-            JsfUtil.addErrorMessage("Must have an ordering department");
+            JsfUtil.addErrorMessage("No record selected");
             return null;
         }
         if (current.getBillingDepartment() == null) {
@@ -113,6 +117,10 @@ public class DefaultServiceDepartmentController implements Serializable {
     }
 
     public DefaultServiceDepartment getDefaultServiceDepartment(Department orderingDept, Department serviceDept, Category cat, Item itm) {
+        if (orderingDept == null || serviceDept == null) {
+            JsfUtil.addErrorMessage("Ordering and Service departments are required");
+            return null;
+        }
         String jpql = "select d "
                 + " from DefaultServiceDepartment d "
                 + " where d.retired=false "
@@ -198,12 +206,8 @@ public class DefaultServiceDepartmentController implements Serializable {
     }
 
     public List<DefaultServiceDepartment> getItems() {
-        if (items == null) {
-            items = getFacade().findAll();
-        }
         return items;
     }
-
 
     public Department getOrderingDepartment() {
         return orderingDepartment;
@@ -237,8 +241,6 @@ public class DefaultServiceDepartmentController implements Serializable {
         this.item = item;
     }
 
-    
-    
     public DefaultServiceDepartmentFacade getFacade() {
         return ejbFacade;
     }

--- a/src/main/java/com/divudi/bean/common/DefaultServiceDepartmentController.java
+++ b/src/main/java/com/divudi/bean/common/DefaultServiceDepartmentController.java
@@ -86,17 +86,16 @@ public class DefaultServiceDepartmentController implements Serializable {
         return navigateToEditDefaultServiceDepartment();
     }
 
-    public String listDefaultServiceDepartments() {
+    public void listDefaultServiceDepartments() {
         if (orderingDepartment == null) {
             JsfUtil.addErrorMessage("Must have an ordering department");
-            return null;
+            return;
         }
         if (serviceDepartment == null) {
             JsfUtil.addErrorMessage("Must have a service department");
-            return null;
+            return;
         }
         items = getDefaultServiceDepartments(orderingDepartment, serviceDepartment, category, item);
-        return navigateToListDefaultServiceDepartments();
     }
 
     public String saveExistingDefaultServiceDepartment() {

--- a/src/main/java/com/divudi/bean/common/DefaultServiceDepartmentController.java
+++ b/src/main/java/com/divudi/bean/common/DefaultServiceDepartmentController.java
@@ -1,0 +1,284 @@
+/*
+* Dr M H B Ariyaratne, Damith & ChatGPT contribution
+ */
+package com.divudi.bean.common;
+
+import com.divudi.core.entity.DefaultServiceDepartment;
+import com.divudi.core.facade.DefaultServiceDepartmentFacade;
+import com.divudi.bean.common.SessionController;
+import com.divudi.core.entity.Category;
+import com.divudi.core.entity.Department;
+import com.divudi.core.entity.Item;
+import com.divudi.core.util.JsfUtil;
+
+import javax.ejb.EJB;
+import javax.inject.Named;
+import javax.enterprise.context.SessionScoped;
+import java.io.Serializable;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import javax.faces.component.UIComponent;
+import javax.faces.context.FacesContext;
+import javax.faces.convert.Converter;
+import javax.faces.convert.FacesConverter;
+
+/**
+ *
+ * @author Buddhika, Damith & ChatGPT
+ */
+@Named
+@SessionScoped
+public class DefaultServiceDepartmentController implements Serializable {
+
+    // <editor-fold defaultstate="collapsed" desc="EJBs">
+    @EJB
+    private DefaultServiceDepartmentFacade ejbFacade;
+    @EJB
+    private SessionController sessionController;
+    // </editor-fold>
+
+    // <editor-fold defaultstate="collapsed" desc="Class Variables">
+    private DefaultServiceDepartment current;
+    private List<DefaultServiceDepartment> items;
+    Department orderingDepartment;
+    Department serviceDepartment;
+    Category category;
+    Item item;
+
+    // </editor-fold>
+    // <editor-fold defaultstate="collapsed" desc="Constructors">
+    public DefaultServiceDepartmentController() {
+    }
+    // </editor-fold>
+
+    // <editor-fold defaultstate="collapsed" desc="Navigation Functions">
+    public String navigateToAddNewDefaultServiceDepartment() {
+        return "/admin/items/add_default_service_department?faces-redirect=true";
+    }
+
+    public String navigateToEditDefaultServiceDepartment() {
+        return "/admin/items/edit_default_service_department?faces-redirect=true";
+    }
+
+    public String navigateToListDefaultServiceDepartments() {
+        items = null;
+        return "/admin/items/list_default_service_departments?faces-redirect=true";
+    }
+
+    // </editor-fold>
+    // <editor-fold defaultstate="collapsed" desc="Functions">
+    public String saveNewDefaultServiceDepartment() {
+        if (orderingDepartment == null) {
+            JsfUtil.addErrorMessage("Must have an ordering department");
+            return null;
+        }
+        if (serviceDepartment == null) {
+            JsfUtil.addErrorMessage("Must have a service department");
+            return null;
+        }
+        current = getDefaultServiceDepartment(orderingDepartment, serviceDepartment, category, item);
+        return navigateToEditDefaultServiceDepartment();
+    }
+
+    public String listDefaultServiceDepartments() {
+        if (orderingDepartment == null) {
+            JsfUtil.addErrorMessage("Must have an ordering department");
+            return null;
+        }
+        if (serviceDepartment == null) {
+            JsfUtil.addErrorMessage("Must have a service department");
+            return null;
+        }
+        items = getDefaultServiceDepartments(orderingDepartment, serviceDepartment, category, item);
+        return navigateToEditDefaultServiceDepartment();
+    }
+
+    public String saveExistingDefaultServiceDepartment() {
+        if (current == null) {
+            JsfUtil.addErrorMessage("Must have an ordering department");
+            return null;
+        }
+        if (current.getBillingDepartment() == null) {
+            JsfUtil.addErrorMessage("Must have an ordering department");
+            return null;
+        }
+        if (current.getPerformingDepartment() == null) {
+            JsfUtil.addErrorMessage("Must have a service department");
+            return null;
+        }
+        save();
+        return navigateToEditDefaultServiceDepartment();
+    }
+
+    public DefaultServiceDepartment getDefaultServiceDepartment(Department orderingDept, Department serviceDept, Category cat, Item itm) {
+        String jpql = "select d "
+                + " from DefaultServiceDepartment d "
+                + " where d.retired=false "
+                + " and d.billingDepartment=:bd "
+                + " and d.performingDepartment=:pd "
+                + " and d.category=:cat "
+                + " and d.item=:itm";
+        Map<String, Object> m = new HashMap<>();
+        m.put("bd", orderingDept);
+        m.put("pd", serviceDept);
+        m.put("cat", cat);
+        m.put("itm", itm);
+
+        DefaultServiceDepartment dsd = getFacade().findFirstByJpql(jpql, m);
+
+        if (dsd == null) {
+            dsd = new DefaultServiceDepartment();
+            dsd.setBillingDepartment(orderingDept);
+            dsd.setPerformingDepartment(serviceDept);
+            dsd.setCategory(cat);
+            dsd.setItem(itm);
+            dsd.setCreatedAt(new Date());
+            dsd.setCreatedBy(sessionController.getLoggedUser());
+            getFacade().create(dsd);
+        }
+
+        return dsd;
+    }
+
+    public List<DefaultServiceDepartment> getDefaultServiceDepartments(Department orderingDept, Department serviceDept, Category cat, Item itm) {
+        String jpql = "select d from DefaultServiceDepartment d where d.retired = false and d.billingDepartment = :bd and d.performingDepartment = :pd";
+        Map<String, Object> m = new HashMap<>();
+        m.put("bd", orderingDept);
+        m.put("pd", serviceDept);
+
+        if (cat != null) {
+            jpql += " and d.category = :cat";
+            m.put("cat", cat);
+        }
+
+        if (itm != null) {
+            jpql += " and d.item = :itm";
+            m.put("itm", itm);
+        }
+
+        jpql += " order by d.id";  // optional, ensures stable order
+
+        return getFacade().findByJpql(jpql, m);
+    }
+
+    public void save() {
+        save(current);
+    }
+
+    public void save(DefaultServiceDepartment saving) {
+        if (saving == null) {
+            JsfUtil.addErrorMessage("No record selected.");
+            return;
+        }
+
+        if (saving.getId() == null) {
+            saving.setCreatedAt(new Date());
+            saving.setCreatedBy(sessionController.getLoggedUser());
+            getFacade().create(saving);
+            JsfUtil.addSuccessMessage("Saved Successfully.");
+        } else {
+            getFacade().edit(saving);
+            JsfUtil.addSuccessMessage("Updated Successfully.");
+        }
+    }
+    // </editor-fold>
+
+    // <editor-fold defaultstate="collapsed" desc="Getters and Setters">
+    public DefaultServiceDepartment getCurrent() {
+        if (current == null) {
+            current = new DefaultServiceDepartment();
+        }
+        return current;
+    }
+
+    public void setCurrent(DefaultServiceDepartment current) {
+        this.current = current;
+    }
+
+    public List<DefaultServiceDepartment> getItems() {
+        if (items == null) {
+            items = getFacade().findAll();
+        }
+        return items;
+    }
+
+
+    public Department getOrderingDepartment() {
+        return orderingDepartment;
+    }
+
+    public void setOrderingDepartment(Department orderingDepartment) {
+        this.orderingDepartment = orderingDepartment;
+    }
+
+    public Department getServiceDepartment() {
+        return serviceDepartment;
+    }
+
+    public void setServiceDepartment(Department serviceDepartment) {
+        this.serviceDepartment = serviceDepartment;
+    }
+
+    public Category getCategory() {
+        return category;
+    }
+
+    public void setCategory(Category category) {
+        this.category = category;
+    }
+
+    public Item getItem() {
+        return item;
+    }
+
+    public void setItem(Item item) {
+        this.item = item;
+    }
+
+    
+    
+    public DefaultServiceDepartmentFacade getFacade() {
+        return ejbFacade;
+    }
+    // </editor-fold>
+
+    // <editor-fold defaultstate="collapsed" desc="Inner Classes Static Converter">
+    @FacesConverter(forClass = DefaultServiceDepartment.class)
+    public static class DefaultServiceDepartmentConverter implements Converter {
+
+        @Override
+        public Object getAsObject(FacesContext facesContext, UIComponent component, String value) {
+            if (value == null || value.isEmpty()) {
+                return null;
+            }
+            DefaultServiceDepartmentController controller = (DefaultServiceDepartmentController) facesContext.getApplication().getELResolver().
+                    getValue(facesContext.getELContext(), null, "defaultServiceDepartmentController");
+            return controller.getFacade().find(getKey(value));
+        }
+
+        Long getKey(String value) {
+            return Long.valueOf(value);
+        }
+
+        String getStringKey(Long value) {
+            return value.toString();
+        }
+
+        @Override
+        public String getAsString(FacesContext facesContext, UIComponent component, Object object) {
+            if (object == null) {
+                return null;
+            }
+            if (object instanceof DefaultServiceDepartment) {
+                DefaultServiceDepartment dsd = (DefaultServiceDepartment) object;
+                return getStringKey(dsd.getId());
+            } else {
+                throw new IllegalArgumentException("object " + object + " is of type " + object.getClass().getName()
+                        + "; expected type: " + DefaultServiceDepartment.class.getName());
+            }
+        }
+    }
+    // </editor-fold>
+}

--- a/src/main/java/com/divudi/core/entity/DefaultServiceDepartment.java
+++ b/src/main/java/com/divudi/core/entity/DefaultServiceDepartment.java
@@ -1,0 +1,169 @@
+package com.divudi.core.entity;
+
+import java.io.Serializable;
+import java.util.Date;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.ManyToOne;
+import javax.persistence.Temporal;
+import javax.persistence.TemporalType;
+
+/**
+ *
+ * @author Buddhika & Damith
+ *
+ */
+@Entity
+public class DefaultServiceDepartment implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO)
+    private Long id;
+
+    @ManyToOne
+    private Department billingDepartment;  // Department raising the bill/order
+
+    @ManyToOne
+    private Category category;    // Optional: Category-level mapping
+
+    @ManyToOne
+    private Item item;                    // Optional: Item-level mapping
+
+    @ManyToOne
+    private Department performingDepartment; // Department where service/test is done
+
+    @ManyToOne
+    private WebUser createdBy;
+
+    @Temporal(TemporalType.TIMESTAMP)
+    private Date createdAt;
+
+    private boolean retired;
+
+    @ManyToOne
+    private WebUser retiredBy;
+
+    @Temporal(TemporalType.TIMESTAMP)
+    private Date retiredAt;
+
+    private String retireComments;
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    
+    
+    @Override
+    public int hashCode() {
+        int hash = 0;
+        hash += (id != null ? id.hashCode() : 0);
+        return hash;
+    }
+
+    @Override
+    public boolean equals(Object object) {
+        // TODO: Warning - this method won't work in the case the id fields are not set
+        if (!(object instanceof DefaultServiceDepartment)) {
+            return false;
+        }
+        DefaultServiceDepartment other = (DefaultServiceDepartment) object;
+        if ((this.id == null && other.id != null) || (this.id != null && !this.id.equals(other.id))) {
+            return false;
+        }
+        return true;
+    }
+
+    @Override
+    public String toString() {
+        return "com.divudi.core.entity.DefaultServiceDepartment[ id=" + id + " ]";
+    }
+
+    public Department getBillingDepartment() {
+        return billingDepartment;
+    }
+
+    public void setBillingDepartment(Department billingDepartment) {
+        this.billingDepartment = billingDepartment;
+    }
+
+    public Category getCategory() {
+        return category;
+    }
+
+    public void setCategory(Category category) {
+        this.category = category;
+    }
+
+    public Item getItem() {
+        return item;
+    }
+
+    public void setItem(Item item) {
+        this.item = item;
+    }
+
+    public Department getPerformingDepartment() {
+        return performingDepartment;
+    }
+
+    public void setPerformingDepartment(Department performingDepartment) {
+        this.performingDepartment = performingDepartment;
+    }
+
+    public WebUser getCreatedBy() {
+        return createdBy;
+    }
+
+    public void setCreatedBy(WebUser createdBy) {
+        this.createdBy = createdBy;
+    }
+
+    public Date getCreatedAt() {
+        return createdAt;
+    }
+
+    public void setCreatedAt(Date createdAt) {
+        this.createdAt = createdAt;
+    }
+
+    public boolean isRetired() {
+        return retired;
+    }
+
+    public void setRetired(boolean retired) {
+        this.retired = retired;
+    }
+
+    public WebUser getRetiredBy() {
+        return retiredBy;
+    }
+
+    public void setRetiredBy(WebUser retiredBy) {
+        this.retiredBy = retiredBy;
+    }
+
+    public Date getRetiredAt() {
+        return retiredAt;
+    }
+
+    public void setRetiredAt(Date retiredAt) {
+        this.retiredAt = retiredAt;
+    }
+
+    public String getRetireComments() {
+        return retireComments;
+    }
+
+    public void setRetireComments(String retireComments) {
+        this.retireComments = retireComments;
+    }
+
+}

--- a/src/main/java/com/divudi/core/facade/DefaultServiceDepartmentFacade.java
+++ b/src/main/java/com/divudi/core/facade/DefaultServiceDepartmentFacade.java
@@ -1,0 +1,32 @@
+/*
+* Dr M H B Ariyaratne, Damith & ChatGPT contribution
+ */
+package com.divudi.core.facade;
+
+import com.divudi.core.entity.DefaultServiceDepartment;
+import javax.ejb.Stateless;
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+
+/**
+ *
+ * @author Buddhika, Damith & ChatGPT
+ */
+@Stateless
+public class DefaultServiceDepartmentFacade extends AbstractFacade<DefaultServiceDepartment> {
+
+    @PersistenceContext(unitName = "hmisPU")
+    private EntityManager em;
+
+    @Override
+    protected EntityManager getEntityManager() {
+        if (em == null) {
+        }
+        return em;
+    }
+
+    public DefaultServiceDepartmentFacade() {
+        super(DefaultServiceDepartment.class);
+    }
+
+}

--- a/src/main/resources/META-INF/persistence.xml
+++ b/src/main/resources/META-INF/persistence.xml
@@ -1,41 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<persistence version="2.2"
-    xmlns="http://java.sun.com/xml/ns/persistence"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="
-        http://xmlns.jcp.org/xml/ns/persistence
-        http://xmlns.jcp.org/xml/ns/persistence/persistence_2_2.xsd">
-
+<persistence version="2.2" xmlns="http://java.sun.com/xml/ns/persistence" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/persistence http://xmlns.jcp.org/xml/ns/persistence/persistence_2_2.xsd">
     <persistence-unit name="hmisPU" transaction-type="JTA">
         <provider>org.eclipse.persistence.jpa.PersistenceProvider</provider>
-        <jta-data-source>jdbc/ruhunu</jta-data-source>
+        <jta-data-source>${JDBC_DATASOURCE}</jta-data-source>
         <exclude-unlisted-classes>false</exclude-unlisted-classes>
         <properties>
-            <property name="eclipselink.logging.level" value="FINEST"/>
-            <property name="eclipselink.logging.parameters" value="true"/>
-            <!-- Generate DDL scripts without applying them -->
-            <property name="eclipselink.ddl-generation" value="create-or-extend-tables"/>
-            <property name="eclipselink.ddl-generation.output-mode" value="sql-script"/>
-            <!-- Use a relative path for the application location -->
-            <property name="eclipselink.application-location" value="c:/tmp/"/>
-            <!-- After generation, set ddl-generation to 'none' -->
-            <!-- <property name="eclipselink.ddl-generation" value="none"/> -->
-
+            <property name="eclipselink.logging.level" value="SEVERE"/>
         </properties>
     </persistence-unit>
     <persistence-unit name="hmisAuditPU" transaction-type="JTA">
-        <jta-data-source>jdbc/ruhunuAudit</jta-data-source>
+        <jta-data-source>${JDBC_AUDIT_DATASOURCE}</jta-data-source>
         <exclude-unlisted-classes>false</exclude-unlisted-classes>
         <properties>
-            <property name="eclipselink.logging.level" value="FINEST"/>
-            <property name="eclipselink.logging.parameters" value="true"/>
-            <!-- Generate DDL scripts without applying them -->
-            <property name="eclipselink.ddl-generation" value="create-or-extend-tables"/>
-            <property name="eclipselink.ddl-generation.output-mode" value="sql-script"/>
-            <!-- Use a relative path for the application location -->
-            <property name="eclipselink.application-location" value="c:/tmp/"/>
-            <!-- After generation, set ddl-generation to 'none' -->
-            <!-- <property name="eclipselink.ddl-generation" value="none"/> -->
+            <property name="eclipselink.logging.level" value="SEVERE"/>
         </properties>
     </persistence-unit>
 </persistence>

--- a/src/main/resources/META-INF/persistence.xml
+++ b/src/main/resources/META-INF/persistence.xml
@@ -1,18 +1,41 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<persistence version="2.2" xmlns="http://java.sun.com/xml/ns/persistence" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/persistence http://xmlns.jcp.org/xml/ns/persistence/persistence_2_2.xsd">
+<persistence version="2.2"
+    xmlns="http://java.sun.com/xml/ns/persistence"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="
+        http://xmlns.jcp.org/xml/ns/persistence
+        http://xmlns.jcp.org/xml/ns/persistence/persistence_2_2.xsd">
+
     <persistence-unit name="hmisPU" transaction-type="JTA">
         <provider>org.eclipse.persistence.jpa.PersistenceProvider</provider>
-        <jta-data-source>${JDBC_DATASOURCE}</jta-data-source>
+        <jta-data-source>jdbc/ruhunu</jta-data-source>
         <exclude-unlisted-classes>false</exclude-unlisted-classes>
         <properties>
-            <property name="eclipselink.logging.level" value="SEVERE"/>
+            <property name="eclipselink.logging.level" value="FINEST"/>
+            <property name="eclipselink.logging.parameters" value="true"/>
+            <!-- Generate DDL scripts without applying them -->
+            <property name="eclipselink.ddl-generation" value="create-or-extend-tables"/>
+            <property name="eclipselink.ddl-generation.output-mode" value="sql-script"/>
+            <!-- Use a relative path for the application location -->
+            <property name="eclipselink.application-location" value="c:/tmp/"/>
+            <!-- After generation, set ddl-generation to 'none' -->
+            <!-- <property name="eclipselink.ddl-generation" value="none"/> -->
+
         </properties>
     </persistence-unit>
     <persistence-unit name="hmisAuditPU" transaction-type="JTA">
-        <jta-data-source>${JDBC_AUDIT_DATASOURCE}</jta-data-source>
+        <jta-data-source>jdbc/ruhunuAudit</jta-data-source>
         <exclude-unlisted-classes>false</exclude-unlisted-classes>
         <properties>
-            <property name="eclipselink.logging.level" value="SEVERE"/>
+            <property name="eclipselink.logging.level" value="FINEST"/>
+            <property name="eclipselink.logging.parameters" value="true"/>
+            <!-- Generate DDL scripts without applying them -->
+            <property name="eclipselink.ddl-generation" value="create-or-extend-tables"/>
+            <property name="eclipselink.ddl-generation.output-mode" value="sql-script"/>
+            <!-- Use a relative path for the application location -->
+            <property name="eclipselink.application-location" value="c:/tmp/"/>
+            <!-- After generation, set ddl-generation to 'none' -->
+            <!-- <property name="eclipselink.ddl-generation" value="none"/> -->
         </properties>
     </persistence-unit>
 </persistence>

--- a/src/main/webapp/admin/items/add_default_service_department.xhtml
+++ b/src/main/webapp/admin/items/add_default_service_department.xhtml
@@ -3,7 +3,6 @@
 <ui:composition xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
                 template="/admin/items/index.xhtml"
                 xmlns:h="http://xmlns.jcp.org/jsf/html"
-                xmlns:f="http://xmlns.jcp.org/jsf/core"
                 xmlns="http://www.w3.org/1999/xhtml"
                 xmlns:p="http://primefaces.org/ui">
 

--- a/src/main/webapp/admin/items/add_default_service_department.xhtml
+++ b/src/main/webapp/admin/items/add_default_service_department.xhtml
@@ -1,0 +1,86 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<!DOCTYPE composition PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<ui:composition xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
+                template="/admin/items/index.xhtml"
+                xmlns:h="http://xmlns.jcp.org/jsf/html"
+                xmlns:f="http://xmlns.jcp.org/jsf/core"
+                xmlns="http://www.w3.org/1999/xhtml"
+                xmlns:p="http://primefaces.org/ui">
+
+    <ui:define name="item">
+
+        <h:form>
+            <p:growl />
+
+            <p:panel header="Add Default Service Department">
+
+                <p:panelGrid columns="2" columnClasses="label, value">
+
+                    <p:outputLabel value="Ordering Department" />
+                    <p:autoComplete 
+                        value="#{defaultServiceDepartmentController.orderingDepartment}" 
+                        completeMethod="#{departmentController.completeDept}"
+                        var="d"
+                        itemLabel="#{d.name}"
+                        itemValue="#{d}"
+                        forceSelection="true">
+                        <p:column>
+                            <h:outputText value="#{d.institution.name}" />
+                        </p:column>
+                        <p:column>
+                            <h:outputText value="#{d.name}" />
+                        </p:column>
+                    </p:autoComplete>
+
+                    <p:outputLabel value="Service Department" />
+                    <p:autoComplete 
+                        value="#{defaultServiceDepartmentController.serviceDepartment}" 
+                        completeMethod="#{departmentController.completeDept}"
+                        var="d"
+                        itemLabel="#{d.name}"
+                        itemValue="#{d}"
+                        forceSelection="true">
+                        <p:column>
+                            <h:outputText value="#{d.institution.name}" />
+                        </p:column>
+                        <p:column>
+                            <h:outputText value="#{d.name}" />
+                        </p:column>
+                    </p:autoComplete>
+
+                    <p:outputLabel value="Category" />
+                    <p:autoComplete 
+                        value="#{defaultServiceDepartmentController.category}" 
+                        completeMethod="#{categoryController.completeCategory}"
+                        var="c"
+                        itemLabel="#{c.name}"
+                        itemValue="#{c}"
+                        forceSelection="true" />
+
+                    <p:outputLabel value="Item" />
+                    <p:autoComplete 
+                        value="#{defaultServiceDepartmentController.item}" 
+                        completeMethod="#{itemController.completeServicesPlusInvestigationsAll}"
+                        var="i"
+                        itemLabel="#{i.name}"
+                        itemValue="#{i}"
+                        forceSelection="true" />
+
+                </p:panelGrid>
+
+                <p:separator />
+
+                <p:commandButton 
+                    value="Add" 
+                    ajax="false"
+                    class="ui-button-success"
+                    icon="fas fa-plus"
+                    action="#{defaultServiceDepartmentController.saveNewDefaultServiceDepartment}" />
+
+            </p:panel>
+
+        </h:form>
+
+    </ui:define>
+
+</ui:composition>

--- a/src/main/webapp/admin/items/edit_default_service_department.xhtml
+++ b/src/main/webapp/admin/items/edit_default_service_department.xhtml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8' ?>
-<!DOCTYPE composition PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//DTD/xhtml1-transitional.dtd">
+<!DOCTYPE composition PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <ui:composition xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
                 template="/admin/items/index.xhtml"
                 xmlns:h="http://xmlns.jcp.org/jsf/html"

--- a/src/main/webapp/admin/items/edit_default_service_department.xhtml
+++ b/src/main/webapp/admin/items/edit_default_service_department.xhtml
@@ -1,0 +1,86 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<!DOCTYPE composition PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//DTD/xhtml1-transitional.dtd">
+<ui:composition xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
+                template="/admin/items/index.xhtml"
+                xmlns:h="http://xmlns.jcp.org/jsf/html"
+                xmlns:f="http://xmlns.jcp.org/jsf/core"
+                xmlns="http://www.w3.org/1999/xhtml"
+                xmlns:p="http://primefaces.org/ui">
+
+    <ui:define name="item">
+
+        <h:form>
+            <p:growl />
+
+            <p:panel header="Edit Default Service Department">
+
+                <p:panelGrid columns="2" columnClasses="label, value">
+
+                    <p:outputLabel value="Ordering Department" />
+                    <p:autoComplete 
+                        value="#{defaultServiceDepartmentController.current.billingDepartment}" 
+                        completeMethod="#{departmentController.completeDept}"
+                        var="d"
+                        itemLabel="#{d.name}"
+                        itemValue="#{d}"
+                        forceSelection="true">
+                        <p:column>
+                            <h:outputText value="#{d.institution.name}" />
+                        </p:column>
+                        <p:column>
+                            <h:outputText value="#{d.name}" />
+                        </p:column>
+                    </p:autoComplete>
+
+                    <p:outputLabel value="Service Department" />
+                    <p:autoComplete 
+                        value="#{defaultServiceDepartmentController.current.performingDepartment}" 
+                        completeMethod="#{departmentController.completeDept}"
+                        var="d"
+                        itemLabel="#{d.name}"
+                        itemValue="#{d}"
+                        forceSelection="true">
+                        <p:column>
+                            <h:outputText value="#{d.institution.name}" />
+                        </p:column>
+                        <p:column>
+                            <h:outputText value="#{d.name}" />
+                        </p:column>
+                    </p:autoComplete>
+
+                    <p:outputLabel value="Category" />
+                    <p:autoComplete 
+                        value="#{defaultServiceDepartmentController.current.category}" 
+                        completeMethod="#{categoryController.completeCategory}"
+                        var="c"
+                        itemLabel="#{c.name}"
+                        itemValue="#{c}"
+                        forceSelection="true" />
+
+                    <p:outputLabel value="Item" />
+                    <p:autoComplete 
+                        value="#{defaultServiceDepartmentController.current.item}" 
+                        completeMethod="#{itemController.completeServicesPlusInvestigationsAll}"
+                        var="i"
+                        itemLabel="#{i.name}"
+                        itemValue="#{i}"
+                        forceSelection="true" />
+
+                </p:panelGrid>
+
+                <p:separator />
+
+                <p:commandButton 
+                    value="Save" 
+                    ajax="false"
+                    class="ui-button-success"
+                    icon="fas fa-save"
+                    action="#{defaultServiceDepartmentController.saveExistingDefaultServiceDepartment}" />
+
+            </p:panel>
+
+        </h:form>
+
+    </ui:define>
+
+</ui:composition>

--- a/src/main/webapp/admin/items/index.xhtml
+++ b/src/main/webapp/admin/items/index.xhtml
@@ -31,6 +31,23 @@
                                 </div>
 
                             </p:tab>
+                            <p:tab title="Default Service Department">
+                                <div class="d-grid gap-2">
+                                    <!-- Button to navigate to Add Default Service Department -->
+                                    <p:commandButton 
+                                        class="w-100"  
+                                        ajax="false" 
+                                        value="Add Default Service Department" 
+                                        action="#{defaultServiceDepartmentController.navigateToAddNewDefaultServiceDepartment}" />
+
+                                    <!-- Button to navigate to List Default Service Departments -->
+                                    <p:commandButton 
+                                        class="w-100"  
+                                        ajax="false" 
+                                        value="List Default Service Departments" 
+                                        action="#{defaultServiceDepartmentController.navigateToListDefaultServiceDepartments}" />
+                                </div>
+                            </p:tab>
                             <p:tab title="Manage Services">
                                 <div class="d-grid gap-2">
                                     <p:commandButton   
@@ -84,7 +101,7 @@
                                         ajax="false" 
                                         value="Theatre Service" 
                                         action="#{investigationCategoryController.navigateToTheatreService()}" />
-                                    
+
                                     <p:commandButton   
                                         class="w-100"  
                                         ajax="false" 
@@ -200,8 +217,8 @@
                                         ajax="false" 
                                         value="Item &amp; Hospital Fee Upload" 
                                         action="#{dataUploadController.navigateToUploadOpdItemsAndHospitalFees()}" />
-                                    
-                                     <p:commandButton   
+
+                                    <p:commandButton   
                                         class="w-100"  
                                         ajax="false" 
                                         value="Item Upload to Correct Code" 
@@ -225,14 +242,14 @@
                                         ajax="false" 
                                         value="Item &amp; Fee Upload for Collecting Centres" 
                                         action="#{dataUploadController.navigateToUploadCollectingCentreFees()}" />
-                                    
+
                                     <p:commandButton   
                                         class="w-100 ui-button-warning"  
                                         ajax="false"
                                         icon="fa fa-upload"
                                         value="Item &amp; Fees Upload " 
                                         action="#{dataUploadController.navigateToUploadItemAndFees()}" />
-                                    
+
                                     <p:commandButton   
                                         class="w-100 ui-button-warning"  
                                         ajax="false"
@@ -276,7 +293,7 @@
                                         ajax="false" 
                                         value="Bulk Delete of Investigations" 
                                         action="#{investigationCategoryController.navigateToInvestigationListToRemove()}" />
-                                    
+
                                     <p:commandButton   
                                         class="w-100"  
                                         ajax="false" 
@@ -288,7 +305,7 @@
                                         ajax="false" 
                                         value="Bulk Delete of Services" 
                                         action="#{investigationCategoryController.navigateToOpdListToRemove()}" />
-                                    
+
                                     <p:commandButton   
                                         class="w-100"  
                                         ajax="false" 
@@ -299,7 +316,7 @@
                                         ajax="false" 
                                         value="Bulk Delete of Investigations" 
                                         action="#{investigationCategoryController.navigateToInvestigationListToRemove()}" />
-                                    
+
                                     <p:commandButton   
                                         class="w-100"  
                                         ajax="false" 

--- a/src/main/webapp/admin/items/list_default_service_departments.xhtml
+++ b/src/main/webapp/admin/items/list_default_service_departments.xhtml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8' ?>
-<!DOCTYPE composition PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//DTD/xhtml1-transitional.dtd">
+<!DOCTYPE composition PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <ui:composition xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
                 template="/admin/items/index.xhtml"
                 xmlns:h="http://xmlns.jcp.org/jsf/html"

--- a/src/main/webapp/admin/items/list_default_service_departments.xhtml
+++ b/src/main/webapp/admin/items/list_default_service_departments.xhtml
@@ -1,0 +1,131 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<!DOCTYPE composition PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//DTD/xhtml1-transitional.dtd">
+<ui:composition xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
+                template="/admin/items/index.xhtml"
+                xmlns:h="http://xmlns.jcp.org/jsf/html"
+                xmlns:f="http://xmlns.jcp.org/jsf/core"
+                xmlns="http://www.w3.org/1999/xhtml"
+                xmlns:p="http://primefaces.org/ui">
+
+    <ui:define name="item">
+
+        <h:form>
+            <p:growl />
+
+            <p:panel header="Default Service Department List">
+
+                <p:panelGrid columns="2" columnClasses="label, value">
+
+                    <p:outputLabel value="Ordering Department" />
+                    <p:autoComplete 
+                        value="#{defaultServiceDepartmentController.orderingDepartment}" 
+                        completeMethod="#{departmentController.completeDept}"
+                        var="d"
+                        itemLabel="#{d.name}"
+                        itemValue="#{d}"
+                        forceSelection="true">
+                        <p:column>
+                            <h:outputText value="#{d.institution.name}" />
+                        </p:column>
+                        <p:column>
+                            <h:outputText value="#{d.name}" />
+                        </p:column>
+                    </p:autoComplete>
+
+                    <p:outputLabel value="Service Department" />
+                    <p:autoComplete 
+                        value="#{defaultServiceDepartmentController.serviceDepartment}" 
+                        completeMethod="#{departmentController.completeDept}"
+                        var="d"
+                        itemLabel="#{d.name}"
+                        itemValue="#{d}"
+                        forceSelection="true">
+                        <p:column>
+                            <h:outputText value="#{d.institution.name}" />
+                        </p:column>
+                        <p:column>
+                            <h:outputText value="#{d.name}" />
+                        </p:column>
+                    </p:autoComplete>
+
+                    <p:outputLabel value="Category" />
+                    <p:autoComplete 
+                        value="#{defaultServiceDepartmentController.category}" 
+                        completeMethod="#{categoryController.completeCategory}"
+                        var="c"
+                        itemLabel="#{c.name}"
+                        itemValue="#{c}"
+                        forceSelection="true" />
+
+                    <p:outputLabel value="Item" />
+                    <p:autoComplete 
+                        value="#{defaultServiceDepartmentController.item}" 
+                        completeMethod="#{itemController.completeServicesPlusInvestigationsAll}"
+                        var="i"
+                        itemLabel="#{i.name}"
+                        itemValue="#{i}"
+                        forceSelection="true" />
+
+                </p:panelGrid>
+
+                <p:separator />
+
+                <p:commandButton 
+                    value="List Items" 
+                    ajax="false"
+                    class="ui-button-primary"
+                    icon="fas fa-search"
+                    action="#{defaultServiceDepartmentController.listDefaultServiceDepartments}" />
+
+                <p:separator />
+
+                <p:dataTable 
+                    value="#{defaultServiceDepartmentController.items}" 
+                    var="dsd"
+                    paginator="true"
+                    rows="10"
+                    rowsPerPageTemplate="10,20,50"
+                    filterEvent="enter"
+                    sortMode="multiple">
+
+                    <p:column headerText="ID" sortBy="#{dsd.id}" filterBy="#{dsd.id}">
+                        <h:outputText value="#{dsd.id}" />
+                    </p:column>
+
+                    <p:column headerText="Ordering Department" sortBy="#{dsd.billingDepartment.name}" filterBy="#{dsd.billingDepartment.name}">
+                        <h:outputText value="#{dsd.billingDepartment.name}" />
+                    </p:column>
+
+                    <p:column headerText="Service Department" sortBy="#{dsd.performingDepartment.name}" filterBy="#{dsd.performingDepartment.name}">
+                        <h:outputText value="#{dsd.performingDepartment.name}" />
+                    </p:column>
+
+                    <p:column headerText="Category" sortBy="#{dsd.category.name}" filterBy="#{dsd.category.name}">
+                        <h:outputText value="#{dsd.category != null ? dsd.category.name : '-'}" />
+                    </p:column>
+
+                    <p:column headerText="Item" sortBy="#{dsd.item.name}" filterBy="#{dsd.item.name}">
+                        <h:outputText value="#{dsd.item != null ? dsd.item.name : '-'}" />
+                    </p:column>
+
+                    <p:column headerText="Actions">
+                        <p:commandButton 
+                            value="Edit"
+                            icon="fas fa-edit"
+                            ajax="false"
+                            action="#{defaultServiceDepartmentController.navigateToEditDefaultServiceDepartment}">
+                            <f:setPropertyActionListener 
+                                target="#{defaultServiceDepartmentController.current}" 
+                                value="#{dsd}" />
+                        </p:commandButton>
+                    </p:column>
+
+                </p:dataTable>
+
+            </p:panel>
+
+        </h:form>
+
+    </ui:define>
+
+</ui:composition>


### PR DESCRIPTION
Completed. Now can manage the default service departments

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced management for Default Service Departments, allowing administrators to add, edit, and list mappings between ordering and service departments, with optional category and item filters.
  - Added user interface pages for adding, editing, and listing Default Service Departments, including advanced filtering and search options.
  - Integrated auto-complete fields for streamlined selection of departments, categories, and items in the admin interface.
  - Provided in-app notifications for user actions and feedback during management tasks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->