### PR TITLE
12364 identify and reverse incorrect grn reference updates caused by returns

### DIFF
--- a/src/main/java/com/divudi/bean/common/BillController.java
+++ b/src/main/java/com/divudi/bean/common/BillController.java
@@ -595,22 +595,27 @@ public class BillController implements Serializable, ControllerWithMultiplePayme
                 continue;
             }
 
-            Bill correctReferenceBill = null;
+            Bill correctReferenceOfPoBill = null;
             for (BillItem returnItem : returnItems) {
                 BillItem refItem = returnItem.getReferanceBillItem();
                 if (refItem == null || refItem.getBill() == null) {
                     continue;
                 }
                 if (refItem.getBill().getBillTypeAtomic() == BillTypeAtomic.PHARMACY_GRN) {
-                    correctReferenceBill = refItem.getBill();
+                    correctReferenceOfPoBill = refItem.getBill();
                     break;
                 }
             }
 
-            if (correctReferenceBill != null) {
-                grnReturnBill.setReferenceBill(correctReferenceBill);
+            if (correctReferenceOfPoBill != null) {
+                grnReturnBill.setReferenceBill(correctReferenceOfPoBill);
                 billFacade.edit(grnReturnBill);
-                output += "Fixed: GRN Return #" + grnReturnBill.getDeptId() + " reference updated to PO #" + correctReferenceBill.getDeptId() + ".\n";
+                
+                grnBill.setReferenceBill(correctReferenceOfPoBill);
+                billFacade.edit(grnBill);
+                
+                output += "Fixed: GRN Return #" + grnReturnBill.getDeptId() + " reference updated to PO #" + correctReferenceOfPoBill.getDeptId() + ".\n";
+                output += "Fixed: GRN #" + grnBill.getDeptId() + " reference updated to PO #" + correctReferenceOfPoBill.getDeptId() + ".\n";
                 fixedCount++;
             } else {
                 output += "Failed to find correct PO for GRN Return #" + grnReturnBill.getDeptId() + ".\n";

--- a/src/main/webapp/dataAdmin/admin_functions.xhtml
+++ b/src/main/webapp/dataAdmin/admin_functions.xhtml
@@ -5,18 +5,16 @@
       xmlns:h="http://xmlns.jcp.org/jsf/html"
       xmlns:p="http://primefaces.org/ui"
       xmlns:f="http://xmlns.jcp.org/jsf/core">
-
     <body>
-
         <ui:composition template="/dataAdmin/admin_data_administration.xhtml">
-
             <ui:define name="subcontent">
-
-                <h:form >
-
-                    <div class='row' >
-                        <div class="col-12 col-md-12 col-lg-12 p-1">
-                            <h:form>
+                <div class='row' >
+                    <div class="col-12 col-md-12 col-lg-12 p-1">
+                        <h:form>
+                            <p:panelGrid layout="tabular" columns="5" class="w-100">
+                                <f:facet name="header" >
+                                    <h:outputText value="Period for Adjustments" ></h:outputText>
+                                </f:facet>
                                 <h:outputLabel value="From Date" />
                                 <p:calendar id="calFrom" 
                                             navigator="false" pattern="#{sessionController.applicationPreference.longDateTimeFormat}"
@@ -32,312 +30,370 @@
                                             value="#{billController.toDate}">
                                     <p:ajax event="dateSelect" process="calTo" />
                                 </p:calendar>
-                            </h:form>
-                        </div>
+                            </p:panelGrid>
 
-
-                        <div class="col-12 col-md-4 col-lg-2 p-1">
-                            <p:commandButton 
-                                ajax="false"
-                                disabled="false"
-                                action="#{billController.addMissingBillTypeAtomics}"
-                                class="w-100 m-1"
-                                value="Add Bill Type Atomics"/>
-                        </div>
-
-                        <div class="col-12 col-md-8 col-lg-6 p-1">
-                            <p:commandButton 
-                                ajax="false"
-                                disabled="false"
-                                action="#{billController.fixTotalInPHARMACY_RETAIL_SALE_RETURN_ITEMS_AND_PAYMENTS}"
-                                class="w-100 m-1"
-                                value="FIX Gross Total in PHARMACY_RETAIL_SALE_RETURN_ITEMS_AND_PAYMENTS Bills"/>
-                        </div>
-
-
-                        <div class="col-12 col-md-8 col-lg-6 p-1">
-                            <!--THis function is called done by admin. Have to do hundreds of time. So confirmation is a real headache. removing the confirmation-->
-                            <p:commandButton 
-                                ajax="false"
-                                disabled="false"
-                                rendered="#{webUserController.hasPrivilege('Developers')}"
-                                action="#{billController.fixTotalInPHARMACY_RETAIL_SALE_RETURN_ITEMS_ONLY}"
-                                update=":growl"
-                                class="w-100 m-1"
-                                value="FIX Gross Total in PHARMACY_RETAIL_SALE_RETURN_ITEMS_ONLY Bills"/>
-                        </div>
-
-                        <div class="col-12 col-md-8 col-lg-6 p-1">
-                            <p:commandButton 
-                                ajax="false"
-                                disabled="false"
-                                action="#{billController.correctBillItemRatesInPHARMACY_RETAIL_SALE_RETURN_ITEMS_ONLY}"
-                                class="w-100 m-1"
-                                value="Correct Bill Item Rates in PHARMACY_RETAIL_SALE_RETURN_ITEMS_ONLY Bills"/>
-                        </div>
-
-
-                        <div class="col-12 col-md-8 col-lg-6 p-1">
-                            <p:commandButton 
-                                ajax="false"
-                                disabled="false"
-                                action="#{billController.fixTotalInPHARMACY_RETAIL_SALE_RETURN_ITEMS_ONLY}"
-                                class="w-100 m-1"
-                                value="FIX Gross Total in PHARMACY_RETAIL_SALE_RETURN_ITEMS_ONLY Bills"/>
-                        </div>
-
-                        <div class="col-12 col-md-8 col-lg-6 p-1">
-                            <p:commandButton 
-                                ajax="false"
-                                disabled="false"
-                                action="#{billController.convertPharmaceuticalBillItemReferanceFromErronouslyRecordedPharmacyRetailSaleCancellationPreBillToPharmacyRetailSalePreBillForAllBills}"
-                                class="w-100 m-1"
-                                value="Fix All Pharmaceutical BillItem Reference for All PHARMACY_RETAIL_SALE_CANCELLED Bills"/>
-                        </div>
-
-
-
-
-                        <div class="col-12 col-md-8 col-lg-6 p-1">
-                            <p:commandButton 
-                                ajax="false"
-                                disabled="false"
-                                action="#{billController.correctBillItemRatesInDIRECT_ISSUE_INWARD_MEDICINE_RETURN}"
-                                class="w-100 m-1"
-                                value="Correct Bill Item Rates in DIRECT_ISSUE_INWARD_MEDICINE_RETURN Bills"/>
-                        </div>
-
-
-
-
-
-
-                        <div class="col-12 col-md-4 col-lg-2 p-1" >
-                            <p:commandButton 
-                                class="w-100"
-                                disabled="false"
-                                value="Fix Missing Bill Time Data" 
-                                action="#{financialTransactionController.addMissingBillTimeData}" 
-                                ajax="false">
-                            </p:commandButton>
-                        </div>
-                        <div class="col-12 col-md-4 col-lg-2 p-1" >
-                            <p:commandButton 
-                                class="w-100"
-                                disabled="false"
-                                value="Add Handover Accept Bill Referance to Handover Create Bill" 
-                                action="#{financialTransactionController.addMissingBackwordReferancesForShiftStartBills}" 
-                                ajax="false">
-                            </p:commandButton>
-                        </div>
-                        <div class="col-12 col-md-4 col-lg-2 p-1" >
-                            <p:commandButton 
-                                class="w-100"
-                                disabled="true"
-                                value="Delete All Memberships" 
-                                action="#{dataAdministrationController.retireAllMembershipData()}" 
-                                ajax="false">
-                            </p:commandButton>
-                        </div>
-                        <div class="col-12 col-md-4 col-lg-2 p-1" >
-                            <p:commandButton 
-                                disabled="true"
-                                value="Delete All Patient Investigation Related Data" 
-                                action="#{dataAdministrationController.retireAllMembershipData}" 
-                                ajax="false">
-                            </p:commandButton>
-                        </div>
-                        <div class="col-12 col-md-4 col-lg-2 p-1" >
-                            <p:commandButton 
-                                disabled="true"
-                                value="Delete All Bill Related Data" 
-                                action="#{dataAdministrationController.retireAllBillRelatedData}" 
-                                ajax="false">
-                            </p:commandButton>
-                        </div>
-                        <div class="col-12 col-md-4 col-lg-2 p-1" >
-                            <p:commandButton 
-                                disabled="true"
-                                value="Delete All Pharmacy Related Data" 
-                                action="#{dataAdministrationController.retireAllPharmacyRelatedData}" 
-                                ajax="false">
-                            </p:commandButton>
-                        </div>
-
-
-                        <div class="col-12 col-md-4 col-lg-2 p-1">
-                            <p:commandButton 
-                                disabled="true"
-                                value="Delete All Pharmacy Related Data" 
-                                action="#{dataAdministrationController.retireAllPharmacyRelatedData}" 
-                                ajax="false">
-                            </p:commandButton>
-                        </div>
-
-                        <div class="col-12 col-md-4 col-lg-2 p-1">
-                            <p:commandButton
-                                ajax="false" 
-                                disabled="true"
-                                action="#{dataAdministrationController.navigateToListOpdBillsAndBillItemsFields()}" 
-                                value="Missing Bill Items"  
-                                class="w-100 m-1"/>
-                        </div>
-
-                        <div class="col-12 col-md-4 col-lg-2 p-1">
-                            <p:commandButton
-                                ajax="false" 
-                                disabled="true"
-                                action="retire_payments_for_individual_opd_bills" 
-                                value="Retire Payments for Individual OPD Bills"  
-                                class="w-100 m-1"/>
-                        </div>
-
-                        <div class="col-12 col-md-4 col-lg-2 p-1">
-                            <p:commandButton 
-                                ajax="false"
-                                disabled="true"
-                                action="#{itemController.makeAllItemsToAllowDiscounts()}"
-                                class="w-100 m-1"
-                                value="Make All OPD Services and Investigations to Allow Discounts"/>
-                        </div>
-
-
-
-                        <div class="col-12 col-md-4 col-lg-2 p-1">
-                            <p:commandButton 
-                                ajax="false"
-                                disabled="true"
-                                action="#{paymentController.addMissingPaymentDates()}"
-                                class="w-100 m-1"
-                                value="Add Missing Payment Dates"/>
-                        </div>
-
-                        <div class="col-12 col-md-4 col-lg-2 p-1">
-                            <p:commandButton 
-                                ajax="false"
-                                disabled="true"
-                                action="#{billController.addMissingRefundStatusForCcRefunds()}"
-                                class="w-100 m-1"
-                                value="Add Missing Refund Status to CC Bills"/>
-                        </div>
-
-                        <div class="col-12 col-md-4 col-lg-2 p-1">
-                            <p:commandButton 
-                                ajax="false"
-                                disabled="true"
-                                action="#{billController.addMissingValuesForCcCancellationBillItems()}"
-                                class="w-100 m-1"
-                                value="Add Missing CC Fees Bills"/>
-                        </div>
-
-                        <div class="col-12 col-md-4 col-lg-2 p-1">
-                            <p:commandButton
-                                ajax="false" 
-                                disabled="true"
-                                action="#{dataAdministrationController.navigateToListMissingBillDeptNumber()}" 
-                                value="Missing Bill Number (Dept Bill Number)"  
-                                class="w-100 m-1"/>
-                        </div>
-
-                        <div class="col-12 col-md-4 col-lg-2 p-1">
-                            <p:commandButton 
-                                ajax="false" 
-                                disabled="true"
-                                action="#{dataAdministrationController.addBillFeesToProfessionalCancelBills()}" 
-                                value="1. Add bill fees to professional fee cancel bills"/>
-                        </div>
-
-                        <div class="col-12 col-md-4 col-lg-2 p-1">
-                            <p:commandButton 
-                                ajax="false" 
-                                disabled="true"
-                                action="#{dataAdministrationController.removeAllBillsAndBillItems()}" 
-                                value="2. Remove All Bills with Bill Items"/>
-                        </div>
-
-                        <div class="col-12 col-md-4 col-lg-2 p-1">
-                            <p:commandButton 
-                                ajax="false" 
-                                disabled="true"
-                                action="#{dataAdministrationController.restBillNumber()}" 
-                                value="3. Reset Bill Number"/>
-                        </div>
-
-                        <div class="col-12 col-md-4 col-lg-2 p-1">
-                            <p:commandButton 
-                                ajax="false" 
-                                disabled="true"
-                                action="#{dataAdministrationController.makeRateFromPurchaseRateToSaleInTransferBills()}" 
-                                value="4. Make Rate From Purchase Rate To Sale In Transfer Bills"/>
-                        </div>
-
-                        <div class="col-12 col-md-4 col-lg-2 p-1">
-                            <p:commandButton 
-                                ajax="false" 
-                                disabled="true"
-                                action="#{dataAdministrationController.removeUnsedPharmaceuticalCategories()}" 
-                                value="5. Remove Unused Pharmaceutical Categories"/>
-                        </div>
-
-                        <div class="col-12 col-md-4 col-lg-2 p-1">
-                            <p:commandButton 
-                                ajax="false" 
-                                disabled="true"
-                                action="/dataAdmin/change_categories" 
-                                value="6. Change Categories of Items"/>
-                        </div>
-
-                        <div class="col-12 col-md-4 col-lg-2 p-1">
-                            <p:commandButton 
-                                ajax="false" 
-                                disabled="true"
-                                action="#{dataAdministrationController.addWholesalePrices()}" 
-                                value="7. Add Wholesale Prices"/>
-                        </div>
-
-                        <div class="col-12 col-md-4 col-lg-2 p-1">
-                            <p:commandButton 
-                                ajax="false" 
-                                disabled="true"
-                                action="#{dataAdministrationController.detectWholeSaleBills}" 
-                                value="8. Convert Sale Bills to Wholesale Bills"/>
-                        </div>
-
-                        <div class="col-12 col-md-4 col-lg-2 p-1">
-                            <p:commandButton 
-                                ajax="false" 
-                                disabled="true"
-                                action="/channel/channel_report_agent_referece_book_bulk_delete" 
-                                value="9. Channel Book Bulk Delete"/>
-                        </div>
-
-                        <div class="col-12 col-md-4 col-lg-2 p-1">
-                            <p:commandButton 
-                                ajax="false" 
-                                disabled="true"
-                                action="/dataAdmin/inward_search_service_with_payment_methord" 
-                                value="10. Update Inward Service bill Payment Method"/>
-                        </div>
-
-                        <div class="col-12 col-md-4 col-lg-2 p-1">
-                            <p:commandButton 
-                                ajax="false" 
-                                disabled="true"
-                                action="#{dataAdministrationController.addInstitutionToInvestigationsWithoutInstitution}" 
-                                value="11. Add Institutions to Investigations without Institution"/>
-                        </div>
-
-                        <div class="col-12 col-md-4 col-lg-2 p-1">
-                            <p:commandButton 
-                                ajax="false" 
-                                disabled="true"
-                                action="#{staffShiftController.updateStaffShiftWithoutRoster()}" 
-                                value="12. Update Staff Shift Without Roster"/>
-                        </div>
-
+                        </h:form>
                     </div>
+                </div>
 
-                </h:form>
+                <p:accordionPanel >
+
+                    <p:tab title="Pharmacy" >
+                        <table class="table table-sm table-bordered w-100">
+                            <thead class="table-light">
+                                <tr>
+                                    <th style="width: 30%;">Name</th>
+                                    <th style="width: 50%;">Description</th>
+                                    <th style="width: 20%;">Action</th>
+                                    <th style="width: 20%;">Output</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td><strong>Correct Reference Bill in GRN Returns</strong></td>
+                                    <td>Correct Reference Bill in GRN Returns - description will come here</td>
+                                    <td>
+                                        <h:form>
+                                            <p:commandButton 
+                                                action="#{billController.fixReferancesInPharmacyGrnReturns}"
+                                                ajax="false"
+                                                value="Correction Button will appear here"  />
+                                        </h:form>
+                                    </td>
+                                    <td>
+                                        #{billController.output}
+                                    </td>
+                                </tr>
+                                <!--                                <tr>
+                                                                    <td><strong>Another Correction Task</strong></td>
+                                                                    <td>Description for another correction goes here</td>
+                                                                    <td>
+                                                                        <p:commandButton value="Do This Fix"  />
+                                                                    </td>
+                                                                    <td>
+                                #{financialTransactionController.output}
+                            </td>
+                        </tr>-->
+                            </tbody>
+                        </table>
+
+
+
+                    </p:tab>
+                    <p:tab title="Unclassified" >
+                        <div class='row' >
+                            <div class="col-12 col-md-12 col-lg-12 p-1">
+
+                            </div>
+
+
+                            <div class="col-12 col-md-4 col-lg-2 p-1">
+                                <p:commandButton 
+                                    ajax="false"
+                                    disabled="false"
+                                    action="#{billController.addMissingBillTypeAtomics}"
+                                    class="w-100 m-1"
+                                    value="Add Bill Type Atomics"/>
+                            </div>
+
+                            <div class="col-12 col-md-8 col-lg-6 p-1">
+                                <p:commandButton 
+                                    ajax="false"
+                                    disabled="false"
+                                    action="#{billController.fixTotalInPHARMACY_RETAIL_SALE_RETURN_ITEMS_AND_PAYMENTS}"
+                                    class="w-100 m-1"
+                                    value="FIX Gross Total in PHARMACY_RETAIL_SALE_RETURN_ITEMS_AND_PAYMENTS Bills"/>
+                            </div>
+
+
+                            <div class="col-12 col-md-8 col-lg-6 p-1">
+                                <!--THis function is called done by admin. Have to do hundreds of time. So confirmation is a real headache. removing the confirmation-->
+                                <p:commandButton 
+                                    ajax="false"
+                                    disabled="false"
+                                    rendered="#{webUserController.hasPrivilege('Developers')}"
+                                    action="#{billController.fixTotalInPHARMACY_RETAIL_SALE_RETURN_ITEMS_ONLY}"
+                                    update=":growl"
+                                    class="w-100 m-1"
+                                    value="FIX Gross Total in PHARMACY_RETAIL_SALE_RETURN_ITEMS_ONLY Bills"/>
+                            </div>
+
+                            <div class="col-12 col-md-8 col-lg-6 p-1">
+                                <p:commandButton 
+                                    ajax="false"
+                                    disabled="false"
+                                    action="#{billController.correctBillItemRatesInPHARMACY_RETAIL_SALE_RETURN_ITEMS_ONLY}"
+                                    class="w-100 m-1"
+                                    value="Correct Bill Item Rates in PHARMACY_RETAIL_SALE_RETURN_ITEMS_ONLY Bills"/>
+                            </div>
+
+
+                            <div class="col-12 col-md-8 col-lg-6 p-1">
+                                <p:commandButton 
+                                    ajax="false"
+                                    disabled="false"
+                                    action="#{billController.fixTotalInPHARMACY_RETAIL_SALE_RETURN_ITEMS_ONLY}"
+                                    class="w-100 m-1"
+                                    value="FIX Gross Total in PHARMACY_RETAIL_SALE_RETURN_ITEMS_ONLY Bills"/>
+                            </div>
+
+                            <div class="col-12 col-md-8 col-lg-6 p-1">
+                                <p:commandButton 
+                                    ajax="false"
+                                    disabled="false"
+                                    action="#{billController.convertPharmaceuticalBillItemReferanceFromErronouslyRecordedPharmacyRetailSaleCancellationPreBillToPharmacyRetailSalePreBillForAllBills}"
+                                    class="w-100 m-1"
+                                    value="Fix All Pharmaceutical BillItem Reference for All PHARMACY_RETAIL_SALE_CANCELLED Bills"/>
+                            </div>
+
+
+
+
+                            <div class="col-12 col-md-8 col-lg-6 p-1">
+                                <p:commandButton 
+                                    ajax="false"
+                                    disabled="false"
+                                    action="#{billController.correctBillItemRatesInDIRECT_ISSUE_INWARD_MEDICINE_RETURN}"
+                                    class="w-100 m-1"
+                                    value="Correct Bill Item Rates in DIRECT_ISSUE_INWARD_MEDICINE_RETURN Bills"/>
+                            </div>
+
+
+
+
+
+
+                            <div class="col-12 col-md-4 col-lg-2 p-1" >
+                                <p:commandButton 
+                                    class="w-100"
+                                    disabled="false"
+                                    value="Fix Missing Bill Time Data" 
+                                    action="#{financialTransactionController.addMissingBillTimeData}" 
+                                    ajax="false">
+                                </p:commandButton>
+                            </div>
+                            <div class="col-12 col-md-4 col-lg-2 p-1" >
+                                <p:commandButton 
+                                    class="w-100"
+                                    disabled="false"
+                                    value="Add Handover Accept Bill Referance to Handover Create Bill" 
+                                    action="#{financialTransactionController.addMissingBackwordReferancesForShiftStartBills}" 
+                                    ajax="false">
+                                </p:commandButton>
+                            </div>
+                            <div class="col-12 col-md-4 col-lg-2 p-1" >
+                                <p:commandButton 
+                                    class="w-100"
+                                    disabled="true"
+                                    value="Delete All Memberships" 
+                                    action="#{dataAdministrationController.retireAllMembershipData()}" 
+                                    ajax="false">
+                                </p:commandButton>
+                            </div>
+                            <div class="col-12 col-md-4 col-lg-2 p-1" >
+                                <p:commandButton 
+                                    disabled="true"
+                                    value="Delete All Patient Investigation Related Data" 
+                                    action="#{dataAdministrationController.retireAllMembershipData}" 
+                                    ajax="false">
+                                </p:commandButton>
+                            </div>
+                            <div class="col-12 col-md-4 col-lg-2 p-1" >
+                                <p:commandButton 
+                                    disabled="true"
+                                    value="Delete All Bill Related Data" 
+                                    action="#{dataAdministrationController.retireAllBillRelatedData}" 
+                                    ajax="false">
+                                </p:commandButton>
+                            </div>
+                            <div class="col-12 col-md-4 col-lg-2 p-1" >
+                                <p:commandButton 
+                                    disabled="true"
+                                    value="Delete All Pharmacy Related Data" 
+                                    action="#{dataAdministrationController.retireAllPharmacyRelatedData}" 
+                                    ajax="false">
+                                </p:commandButton>
+                            </div>
+
+
+                            <div class="col-12 col-md-4 col-lg-2 p-1">
+                                <p:commandButton 
+                                    disabled="true"
+                                    value="Delete All Pharmacy Related Data" 
+                                    action="#{dataAdministrationController.retireAllPharmacyRelatedData}" 
+                                    ajax="false">
+                                </p:commandButton>
+                            </div>
+
+                            <div class="col-12 col-md-4 col-lg-2 p-1">
+                                <p:commandButton
+                                    ajax="false" 
+                                    disabled="true"
+                                    action="#{dataAdministrationController.navigateToListOpdBillsAndBillItemsFields()}" 
+                                    value="Missing Bill Items"  
+                                    class="w-100 m-1"/>
+                            </div>
+
+                            <div class="col-12 col-md-4 col-lg-2 p-1">
+                                <p:commandButton
+                                    ajax="false" 
+                                    disabled="true"
+                                    action="retire_payments_for_individual_opd_bills" 
+                                    value="Retire Payments for Individual OPD Bills"  
+                                    class="w-100 m-1"/>
+                            </div>
+
+                            <div class="col-12 col-md-4 col-lg-2 p-1">
+                                <p:commandButton 
+                                    ajax="false"
+                                    disabled="true"
+                                    action="#{itemController.makeAllItemsToAllowDiscounts()}"
+                                    class="w-100 m-1"
+                                    value="Make All OPD Services and Investigations to Allow Discounts"/>
+                            </div>
+
+
+
+                            <div class="col-12 col-md-4 col-lg-2 p-1">
+                                <p:commandButton 
+                                    ajax="false"
+                                    disabled="true"
+                                    action="#{paymentController.addMissingPaymentDates()}"
+                                    class="w-100 m-1"
+                                    value="Add Missing Payment Dates"/>
+                            </div>
+
+                            <div class="col-12 col-md-4 col-lg-2 p-1">
+                                <p:commandButton 
+                                    ajax="false"
+                                    disabled="true"
+                                    action="#{billController.addMissingRefundStatusForCcRefunds()}"
+                                    class="w-100 m-1"
+                                    value="Add Missing Refund Status to CC Bills"/>
+                            </div>
+
+                            <div class="col-12 col-md-4 col-lg-2 p-1">
+                                <p:commandButton 
+                                    ajax="false"
+                                    disabled="true"
+                                    action="#{billController.addMissingValuesForCcCancellationBillItems()}"
+                                    class="w-100 m-1"
+                                    value="Add Missing CC Fees Bills"/>
+                            </div>
+
+                            <div class="col-12 col-md-4 col-lg-2 p-1">
+                                <p:commandButton
+                                    ajax="false" 
+                                    disabled="true"
+                                    action="#{dataAdministrationController.navigateToListMissingBillDeptNumber()}" 
+                                    value="Missing Bill Number (Dept Bill Number)"  
+                                    class="w-100 m-1"/>
+                            </div>
+
+                            <div class="col-12 col-md-4 col-lg-2 p-1">
+                                <p:commandButton 
+                                    ajax="false" 
+                                    disabled="true"
+                                    action="#{dataAdministrationController.addBillFeesToProfessionalCancelBills()}" 
+                                    value="1. Add bill fees to professional fee cancel bills"/>
+                            </div>
+
+                            <div class="col-12 col-md-4 col-lg-2 p-1">
+                                <p:commandButton 
+                                    ajax="false" 
+                                    disabled="true"
+                                    action="#{dataAdministrationController.removeAllBillsAndBillItems()}" 
+                                    value="2. Remove All Bills with Bill Items"/>
+                            </div>
+
+                            <div class="col-12 col-md-4 col-lg-2 p-1">
+                                <p:commandButton 
+                                    ajax="false" 
+                                    disabled="true"
+                                    action="#{dataAdministrationController.restBillNumber()}" 
+                                    value="3. Reset Bill Number"/>
+                            </div>
+
+                            <div class="col-12 col-md-4 col-lg-2 p-1">
+                                <p:commandButton 
+                                    ajax="false" 
+                                    disabled="true"
+                                    action="#{dataAdministrationController.makeRateFromPurchaseRateToSaleInTransferBills()}" 
+                                    value="4. Make Rate From Purchase Rate To Sale In Transfer Bills"/>
+                            </div>
+
+                            <div class="col-12 col-md-4 col-lg-2 p-1">
+                                <p:commandButton 
+                                    ajax="false" 
+                                    disabled="true"
+                                    action="#{dataAdministrationController.removeUnsedPharmaceuticalCategories()}" 
+                                    value="5. Remove Unused Pharmaceutical Categories"/>
+                            </div>
+
+                            <div class="col-12 col-md-4 col-lg-2 p-1">
+                                <p:commandButton 
+                                    ajax="false" 
+                                    disabled="true"
+                                    action="/dataAdmin/change_categories" 
+                                    value="6. Change Categories of Items"/>
+                            </div>
+
+                            <div class="col-12 col-md-4 col-lg-2 p-1">
+                                <p:commandButton 
+                                    ajax="false" 
+                                    disabled="true"
+                                    action="#{dataAdministrationController.addWholesalePrices()}" 
+                                    value="7. Add Wholesale Prices"/>
+                            </div>
+
+                            <div class="col-12 col-md-4 col-lg-2 p-1">
+                                <p:commandButton 
+                                    ajax="false" 
+                                    disabled="true"
+                                    action="#{dataAdministrationController.detectWholeSaleBills}" 
+                                    value="8. Convert Sale Bills to Wholesale Bills"/>
+                            </div>
+
+                            <div class="col-12 col-md-4 col-lg-2 p-1">
+                                <p:commandButton 
+                                    ajax="false" 
+                                    disabled="true"
+                                    action="/channel/channel_report_agent_referece_book_bulk_delete" 
+                                    value="9. Channel Book Bulk Delete"/>
+                            </div>
+
+                            <div class="col-12 col-md-4 col-lg-2 p-1">
+                                <p:commandButton 
+                                    ajax="false" 
+                                    disabled="true"
+                                    action="/dataAdmin/inward_search_service_with_payment_methord" 
+                                    value="10. Update Inward Service bill Payment Method"/>
+                            </div>
+
+                            <div class="col-12 col-md-4 col-lg-2 p-1">
+                                <p:commandButton 
+                                    ajax="false" 
+                                    disabled="true"
+                                    action="#{dataAdministrationController.addInstitutionToInvestigationsWithoutInstitution}" 
+                                    value="11. Add Institutions to Investigations without Institution"/>
+                            </div>
+
+                            <div class="col-12 col-md-4 col-lg-2 p-1">
+                                <p:commandButton 
+                                    ajax="false" 
+                                    disabled="true"
+                                    action="#{staffShiftController.updateStaffShiftWithoutRoster()}" 
+                                    value="12. Update Staff Shift Without Roster"/>
+                            </div>
+
+                        </div>
+                    </p:tab>
+
+                </p:accordionPanel>
+
+
+
+
 
             </ui:define>
 

--- a/src/main/webapp/dataAdmin/admin_functions.xhtml
+++ b/src/main/webapp/dataAdmin/admin_functions.xhtml
@@ -55,7 +55,7 @@
                                     <td>
                                         <h:form>
                                             <p:commandButton 
-                                                action="#{billController.fixReferancesInPharmacyGrnReturns}"
+                                                action="#{billController.fixReferencesInPharmacyGrnReturns}"
                                                 ajax="false"
                                                 value="Correction Button will appear here"  />
                                         </h:form>

--- a/src/main/webapp/dataAdmin/admin_functions.xhtml
+++ b/src/main/webapp/dataAdmin/admin_functions.xhtml
@@ -216,14 +216,6 @@
                             </div>
 
 
-                            <div class="col-12 col-md-4 col-lg-2 p-1">
-                                <p:commandButton 
-                                    disabled="true"
-                                    value="Delete All Pharmacy Related Data" 
-                                    action="#{dataAdministrationController.retireAllPharmacyRelatedData}" 
-                                    ajax="false">
-                                </p:commandButton>
-                            </div>
 
                             <div class="col-12 col-md-4 col-lg-2 p-1">
                                 <p:commandButton

--- a/src/main/webapp/dataAdmin/admin_functions.xhtml
+++ b/src/main/webapp/dataAdmin/admin_functions.xhtml
@@ -42,10 +42,10 @@
                         <table class="table table-sm table-bordered w-100">
                             <thead class="table-light">
                                 <tr>
-                                    <th style="width: 30%;">Name</th>
-                                    <th style="width: 50%;">Description</th>
-                                    <th style="width: 20%;">Action</th>
-                                    <th style="width: 20%;">Output</th>
+                                    <th style="width: 15%;">Name</th>
+                                    <th style="width: 30%;">Description</th>
+                                    <th style="width: 10%;">Action</th>
+                                    <th style="width: 45%;">Output</th>
                                 </tr>
                             </thead>
                             <tbody>
@@ -55,7 +55,7 @@
                                     <td>
                                         <h:form>
                                             <p:commandButton 
-                                                action="#{billController.fixReferencesInPharmacyGrnReturns}"
+                                                action="#{billController.fixReferancesInPharmacyGrnReturns()}"
                                                 ajax="false"
                                                 value="Correction Button will appear here"  />
                                         </h:form>


### PR DESCRIPTION
### ✅ Issue #12364 Closed: Incorrect Reference Bill in Pharmacy GRN Returns

Closes #12364

The issue with incorrect reference bills being assigned to **Pharmacy GRN Return** and **Refund** bills has now been resolved.

#### 🔍 Problem Summary

When a GRN was returned, the system mistakenly replaced the reference of the **original GRN** (which should point to a Pharmacy Purchase Order) with the **GRN Return** bill itself. This caused:

* Broken linkage between GRNs and Purchase Orders
* Missing GRNs from PO-based listings
* Difficulty tracking the original procurement flow

#### 🧪 How QA Can Test

1. Navigate to:
   **Menu > Administration > Manage Metadata > Admin Functions**

2. In the **Pharmacy** section:

   * Select a time range using the **From Date** and **To Date** calendars
   * Click the button **“Correction Button will appear here”** next to **“Correct Reference Bill in GRN Returns”**

3. Once triggered:

   * The system will process all Pharmacy GRN Returns and Refunds within the selected period
   * It will detect original GRNs with incorrect references and restore the correct link to the Pharmacy PO
   * The result will appear in the **Output** column with detailed logs per correction

4. Confirm by checking the GRN under:

   * **PO listing views**
   * **Pharmacy GRN module** — confirm `referenceBill` correctly points to the **PO**, not the GRN Return

---

#### 💻 Developer Notes (What Was Done)

* A new method `fixReferancesInPharmacyGrnReturns()` was implemented in `BillController`
* The logic:

  * Loads all Pharmacy GRN Return and Refund bills for the selected date range
  * For each return:

    * Reloads associated GRN via `billedBill`
    * Checks if its reference points incorrectly to a GRN Return
    * Deduces the correct PO by analyzing `referanceBillItem` on GRN Return bill items
    * Updates the reference to the correct PO, if found
* Logging:

  * Each step (skipped, fixed, failed) is appended to a `String output` variable
  * Output is displayed in the UI table under the “Output” column
* All database edits are committed using `billFacade.edit(...)`
* The method is triggered via a `p:commandButton` in `admin_functions.xhtml` inside the **Pharmacy** tab

---

#### 📌 Example Output

```
Fixed: GRN Return #MP/GRNRET/4 reference updated to PO #MP/GRN/25/018452.
Skipped: GRN Return #MP/GRNRET/2 has no billed bill.
Correction completed. Total GRN Returns fixed: 4.
```

![Image](https://github.com/user-attachments/assets/5abd72dc-8bca-4eb4-9d32-ccc05d7d074f)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a correction tool for pharmacy GRN return bill references, accessible from the admin interface, with results displayed in the UI.

- **Style**
  - Improved the admin functions page layout by introducing tabbed sections for better organization and clarity, and enhanced the presentation of date range inputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->