### PR TITLE
Closes #12305

### DIFF
--- a/src/main/webapp/dataAdmin/admin_functions.xhtml
+++ b/src/main/webapp/dataAdmin/admin_functions.xhtml
@@ -51,13 +51,16 @@
                             <tbody>
                                 <tr>
                                     <td><strong>Correct Reference Bill in GRN Returns</strong></td>
-                                    <td>Correct Reference Bill in GRN Returns - description will come here</td>
+                                    <td>
+                                        This issue was caused by a bug where GRN Returns were recorded with incorrect references to the original Order Bills, leading to errors in calculating remaining quantities for subsequent GRNs. The bug has now been fixed and will not affect future records. This correction will update existing GRN Returns to point to the correct Order Bills, ensuring accurate remaining quantity calculations.
+                                    </td>
+
                                     <td>
                                         <h:form>
                                             <p:commandButton 
                                                 action="#{billController.fixReferancesInPharmacyGrnReturns()}"
                                                 ajax="false"
-                                                value="Correction Button will appear here"  />
+                                                value="Correct Reference Bill in GRN Returns"  />
                                         </h:form>
                                     </td>
                                     <td>


### PR DESCRIPTION
Closes #12305


<h3>🔍 GRN and Cancellation Investigation Report</h3>
<p>We identified <strong>two bugs</strong> affecting GRN workflows:</p>
<hr>
<h3>🐞 1. <strong>Bug in Remaining Quantity Calculation</strong></h3>
<p>A system logic error caused incorrect calculation of remaining items when proceeding to receive against previous orders.</p>
<p>✅ The bug has been identified and <strong>corrected</strong>. This issue <strong>will not affect future GRNs</strong>.</p>
<p>However, to <strong>fix already affected past data</strong>, please follow these steps:</p>
<blockquote>
<p><strong>Menu</strong> → <em>System Administration</em> → <em>Manage Metadata</em> → <em>System Administration Functions</em><br>
<strong>Click:</strong> <code inline="">Admin Functions</code><br>
<strong>Select Tab:</strong> <code inline="">Pharmacy</code><br>
<strong>Select Period</strong> → <em>relevant past timeframe</em><br>
<strong>Click Button:</strong> <code inline="">Correct Reference Bill in GRN Returns</code></p>
</blockquote>
<p>This action will ensure the <strong>"Remaining to Receive" quantities</strong> reflect correctly for historical orders.</p>
<hr>
<h3>🛑 2. <strong>Critical Bug in GRN Cancellations</strong></h3>
<p>Upon detailed checking, we found that <strong>GRN Return Bills</strong> (cancellations) duplicated entries for each item in the original GRN bill.</p>
<ul>
<li>
<p>❌ Ideally, there should be <strong>only one cancellation BillItem per GRN BillItem</strong>.</p>
</li>
<li>
<p>✅ Totals were calculated correctly <strong>ignoring duplicates</strong>.</p>
</li>
<li>
<p>❌ But <strong>duplicate item lines remained</strong>, which caused incorrect "Remaining" values and confusion.</p>
</li>
</ul>
<p>We attempted to replicate the issue but <strong>could not reproduce it</strong> with current workflows. Further investigation is required. If it reoccurs or is reproducible, a dedicated GitHub issue should be opened.</p>
<hr>
<h3>📦 GRN Cancellation Reconciliation Summary</h3>

Item | Ordered Qty | Ordered Free | Received Qty | Received Free | Cancelled Qty | Cancelled Free | Actual Remaining | Shown Remaining
-- | -- | -- | -- | -- | -- | -- | -- | --
Filgen Injection | 10 | 0 | 10 | 0 | 0 | 0 | 0 | 0
Almiral gel | 10 | 0 | 10 | 0 | 20 | 0 | 0 | 0
Ataline 2.5mg tablet | 1000 | 0 | 1000 | 0 | 2000 | 0 | 0 | 0
Medodermone 15g Cream | 30 | 0 | 30 | 0 | 0 | 0 | 0 | 0
Medodermone 15g ointment | 30 | 0 | 30 | 0 | 0 | 0 | 0 | 0
Betasone 15g Cream | 20 | 0 | 20 | 0 | 40 | 0 | 0 | 0
Disuf Cream | 10 | 0 | 10 | 0 | 20 | 0 | 0 | 0
INOX 100mg Capsule | 980 | 0 | 980 | 0 | 1960 | 0 | 0 | 0
Betahist 8mg Tablet | 500 | 0 | 0 | 0 | 0 | 0 | 500 | 500
Betahist Forte 16 mg | 500 | 0 | 500 | 100 | 1000 | 200 | 0 | 100
Diabetmin XR 500mg | 500 | 0 | 500 | 100 | 1000 | 200 | 0 | 100




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Updated the description for the "Correct Reference Bill in GRN Returns" task to provide a clearer explanation of the issue and its resolution.
  - Changed the button label to "Correct Reference Bill in GRN Returns" for better clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->