### PR TITLE
Gross Amount & Net Amount are corrected

### DIFF
--- a/src/main/webapp/reportInstitution/report_opd_pharmacy_staff_welfare.xhtml
+++ b/src/main/webapp/reportInstitution/report_opd_pharmacy_staff_welfare.xhtml
@@ -116,7 +116,7 @@
                             <f:convertNumber pattern="#,##0.00"/>
                         </p:outputLabel>
                         <f:facet name="footer">
-                            <h:outputLabel value="#{serviceSummery.totalBill+serviceSummery.discountBill}">
+                            <h:outputLabel value="#{serviceSummery.totalBill}">
                                 <f:convertNumber pattern="#,##0.00"/>
                             </h:outputLabel>
                         </f:facet>
@@ -143,7 +143,7 @@
                             <f:convertNumber pattern="#,##0.00"/>
                         </p:outputLabel>
                         <f:facet name="footer">
-                            <h:outputLabel value="#{serviceSummery.totalBill}">
+                            <h:outputLabel value="#{serviceSummery.totalBill-serviceSummery.discountBill}">
                                 <f:convertNumber pattern="#,##0.00"/>
                             </h:outputLabel>
                         </f:facet>


### PR DESCRIPTION
Gross Amount & Net Amount are incorrect in Staff Welfare Report
[#12390](https://github.com/hmislk/hmis/issues/12390)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected the calculation and display of "Gross Amount" and "Net Amount" footer values in the OPD Pharmacy Staff Welfare report to ensure accurate totals.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->