### PR TITLE
Corrected the titles in Manage sites

### DIFF
--- a/src/main/webapp/admin/institutions/site_management.xhtml
+++ b/src/main/webapp/admin/institutions/site_management.xhtml
@@ -16,7 +16,7 @@
                 <p:focus id="selectFocus" for="lstSelect" />
                 <p:focus id="detailFocus" for="gpDetail" />
 
-                <p:panel header="Manage Departments">
+                <p:panel header="Site">
                     <div class="row">
                         <div class="col-md-5">
 
@@ -61,7 +61,7 @@
                         <div class="col-md-7">
                             <p:panel class="w-100" id="gpDetail" >
                                 <f:facet name="header" >
-                                    <h:outputLabel value="Details of the Department" class="mr-5"></h:outputLabel>
+                                    <h:outputLabel value="Details of the Site" class="mr-5"></h:outputLabel>
                                     <p:spacer width="50" ></p:spacer>
                                     <p:commandButton 
                                         id="btnSave" 


### PR DESCRIPTION
Manage site
[#12468](https://github.com/hmislk/hmis/issues/12468)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Updated interface text to use "Site" instead of "Department" in panel headers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->