### PR TITLE
12473 when adding new fields by ddl script fields are not created for bigdecimals

### DIFF
--- a/src/main/java/com/divudi/bean/common/DataAdministrationController.java
+++ b/src/main/java/com/divudi/bean/common/DataAdministrationController.java
@@ -86,7 +86,6 @@ import com.divudi.core.facade.UserStockContainerFacade;
 import com.divudi.core.facade.UserStockFacade;
 import com.divudi.core.util.CommonFunctions;
 import com.divudi.service.LogFileService;
-import java.io.Serializable;
 import java.sql.SQLSyntaxErrorException;
 import java.text.DecimalFormat;
 import java.util.ArrayList;
@@ -100,11 +99,9 @@ import java.util.Map;
 import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-import javax.ejb.EJB;
 import javax.enterprise.context.SessionScoped;
 import javax.faces.context.FacesContext;
 import javax.inject.Inject;
-import javax.inject.Named;
 import javax.persistence.Entity;
 import javax.persistence.PersistenceException;
 import javax.persistence.TemporalType;
@@ -120,9 +117,7 @@ import java.io.Serializable;
 import java.nio.file.*;
 import java.time.*;
 import java.util.*;
-import javax.annotation.PostConstruct;
 import javax.ejb.EJB;
-import javax.faces.view.ViewScoped;
 import javax.inject.Named;
 import org.primefaces.model.StreamedContent;
 
@@ -425,7 +420,6 @@ public class DataAdministrationController implements Serializable {
     public void retireAllPharmacyRelatedData() {
         progress = 0;
         progressMessage = "Starting retirement process for pharmacy-related data...";
-        System.out.println(progressMessage);
 
         Date retiredAt = new Date(); // Common timestamp for all retire operations
         WebUser retirer = sessionController.getLoggedUser(); // The user performing the operation
@@ -447,7 +441,6 @@ public class DataAdministrationController implements Serializable {
         if (totalRecords == 0) {
             progress = 100;
             progressMessage = "No pharmacy-related records to retire.";
-            System.out.println(progressMessage);
             return;
         }
 
@@ -463,13 +456,11 @@ public class DataAdministrationController implements Serializable {
         // Completion message
         progress = 100;
         progressMessage = "Retirement process for pharmacy-related data completed.";
-        System.out.println(progressMessage);
     }
 
     public void retireAllBillRelatedData() {
         progress = 0;
         progressMessage = "Starting retirement process for bill-related data...";
-        System.out.println(progressMessage);
 
         Date retiredAt = new Date(); // Common timestamp for all retire operations
         WebUser retirer = sessionController.getLoggedUser(); // The user performing the operation
@@ -503,7 +494,6 @@ public class DataAdministrationController implements Serializable {
         if (totalRecords == 0) {
             progress = 100;
             progressMessage = "No bill-related records to retire.";
-            System.out.println(progressMessage);
             return;
         }
 
@@ -529,13 +519,11 @@ public class DataAdministrationController implements Serializable {
         // Completion message
         progress = 100;
         progressMessage = "Retirement process for bill-related data completed.";
-        System.out.println(progressMessage);
     }
 
     public void retireAllMembershipData() {
         progress = 0;
         progressMessage = "Starting retirement process...";
-        System.out.println(progressMessage);
         String jpql = "Select f from Family f where f.retired=:ret";
         Map params = new HashMap();
         params.put("ret", false);
@@ -590,7 +578,6 @@ public class DataAdministrationController implements Serializable {
     public void retireAllPatientInvestigationRelatedData() {
         progress = 0;
         progressMessage = "Starting retirement process...";
-        System.out.println(progressMessage);
 
         Date retiredAt = new Date(); // Common timestamp for all retire operations
         WebUser retirer = sessionController.getLoggedUser(); // The user performing the operation
@@ -624,7 +611,6 @@ public class DataAdministrationController implements Serializable {
         if (totalRecords == 0) {
             progress = 100;
             progressMessage = "No records to retire.";
-            System.out.println(progressMessage);
             return;
         }
 
@@ -646,7 +632,6 @@ public class DataAdministrationController implements Serializable {
         // Completion message
         progress = 100;
         progressMessage = "Retirement process completed.";
-        System.out.println(progressMessage);
     }
 
     private <T> int retireEntities(List<T> entities, Date retiredAt, WebUser retirer, String uuid, AbstractFacade<T> facade) {
@@ -663,8 +648,6 @@ public class DataAdministrationController implements Serializable {
                 retirable.setRetireComments(uuid);
                 facade.edit(entity); // Use the specific facade passed as a parameter
             } else {
-                System.out.println("Entity that does not implement retirable");
-                System.out.println("entity = " + entity);
             }
             processedRecords++;
             updateProgress();
@@ -678,7 +661,6 @@ public class DataAdministrationController implements Serializable {
 
     private void updateProgress() {
         progress = (processedRecords * 100) / totalRecords;
-        System.out.println("Progress: " + progress + "%");
     }
 
     public void detectWholeSaleBills() {
@@ -937,7 +919,6 @@ public class DataAdministrationController implements Serializable {
     public void createTablesAndFieldsForAllCreateStatements() {
         StringBuilder executionResults = new StringBuilder();
 
-        System.out.println("===== Starting CREATE TABLE execution and ALTER processing =====");
 
         String[] rawParts = allCreateStetements.split("(?i)CREATE TABLE");
         int counter = 0;
@@ -949,32 +930,25 @@ public class DataAdministrationController implements Serializable {
             }
 
             String createStatement = "CREATE TABLE " + part;
-            System.out.println("\n[INFO] Processing statement #" + (++counter));
-            System.out.println("Create SQL:\n" + createStatement);
 
             try {
                 // First execute the CREATE TABLE
                 try {
-                    System.out.println("[EXEC] Running CREATE TABLE SQL");
                     itemFacade.executeNativeSql(createStatement);
                     executionResults.append("<br/>Successfully executed: ").append(createStatement);
                 } catch (Exception e) {
-                    System.out.println("[WARNING] CREATE TABLE failed (might already exist): " + e.getMessage());
                     executionResults.append("<br/>CREATE TABLE failed (likely already exists): ").append(e.getMessage());
                 }
 
                 // Proceed with ALTER logic
                 String tableName = extractTableName(createStatement);
                 if (tableName == null || tableName.isEmpty()) {
-                    System.out.println("[WARNING] Skipping statement — table name not found.");
                     executionResults.append("<br/>Skipped malformed CREATE TABLE statement.");
                     continue;
                 }
 
-                System.out.println("[INFO] Extracted table name: " + tableName);
 
                 String alterSql = generateAlterStatements(createStatement);
-                System.out.println("[INFO] Generated ALTER statements:\n" + alterSql);
 
                 String[] sqlStatements = alterSql.split(";");
                 for (String sql : sqlStatements) {
@@ -985,22 +959,17 @@ public class DataAdministrationController implements Serializable {
 
                     try {
                         if (isValidSqlStatement(sql)) {
-                            System.out.println("[EXEC] Running SQL: " + sql);
                             itemFacade.executeNativeSql(sql);
                             executionResults.append("<br/>Successfully executed: ").append(sql);
                         } else {
-                            System.out.println("[ERROR] Potentially harmful SQL rejected: " + sql);
                             executionResults.append("<br/>Rejected potentially harmful SQL: ").append(sql);
                         }
                     } catch (Exception e) {
-                        System.out.println("[ERROR] SQL failed: " + sql);
-                        System.out.println("[ERROR] Exception: " + e.getMessage());
                         executionResults.append("<br/>Failed to execute: ").append(sql);
                         executionResults.append("<br/>Error: ").append(e.getMessage());
                     }
                 }
             } catch (Exception e) {
-                System.out.println("[ERROR] Unexpected error while processing create statement.");
                 e.printStackTrace();
                 executionResults.append("<br/>Error processing create statement: ").append(e.getMessage());
             }
@@ -1008,7 +977,6 @@ public class DataAdministrationController implements Serializable {
 
         executionFeedback = executionResults.toString();
 
-        System.out.println("===== All CREATE TABLE processing complete =====");
     }
 
     // Add this method to validate SQL statements

--- a/src/main/webapp/dataAdmin/admin_data_administration.xhtml
+++ b/src/main/webapp/dataAdmin/admin_data_administration.xhtml
@@ -228,7 +228,7 @@
                                         <p:commandButton
                                             ajax="false" 
                                             action="#{dataAdministrationController.navigateToCheckMissingFields()}" 
-                                            value="Check Missing Fields"  
+                                            value="Update Database Structure"  
                                             class="w-100 m-1"
                                             />
                                         

--- a/src/main/webapp/resources/ezcomp/midding_data_fields.xhtml
+++ b/src/main/webapp/resources/ezcomp/midding_data_fields.xhtml
@@ -25,27 +25,33 @@
                     <p:panelGrid columns="2" class="mt-1 w-100" style="border: 10px green;">
                         <f:facet name="header">
                             <i class="fa fa-search"/>
-                            <h:outputLabel value="Run SQL Commands" class="mx-2"/>
+                            <h:outputLabel value="Update Database by DDL File" class="mx-2"/>
                         </f:facet>
-                        <p:outputLabel value="All Create Statements in ddl file" ></p:outputLabel>
+
+                        <p:outputLabel value="Instructions" />
+                        <p:outputLabel value="To generate the DDL file, replace the contents of your persistence.xml with the configuration from persistence_for_database_generation_script.xml. Adjust the output file path accordingly. Run the application to generate the DDL file. Then copy its contents and paste into the field below. Click 'Update Database' to apply all missing tables and fields. The latest version of the DDL file is available at https://github.com/hmislk/hmis/wiki/Database-Schema-DDL-Generation-Guide" />
+
+                        <p:outputLabel value="DDL Content" />
                         <p:inputTextarea
                             rows="6"
                             autoResize="false"
                             value="#{dataAdministrationController.allCreateStetements}" 
-                            class="w-100"/>
-                        <p:spacer ></p:spacer>
-                        <p:commandButton 
-                            value="RUN SQL" 
-                            ajax="false" 
-                            action="#{dataAdministrationController.createTablesAndFieldsForAllCreateStatements}" ></p:commandButton>
+                            class="w-100" />
 
-                        <p:outputLabel value="Execution Feedback" ></p:outputLabel>
+                        <p:spacer />
+
+                        <p:commandButton 
+                            value="Update Database" 
+                            ajax="false" 
+                            action="#{dataAdministrationController.createTablesAndFieldsForAllCreateStatements}" />
+
+                        <p:outputLabel value="Execution Feedback" />
                         <p:inputTextarea
                             rows="6"
                             autoResize="false"
                             value="#{dataAdministrationController.executionFeedback}" 
                             readonly="true"
-                            class="w-100"/>
+                            class="w-100" />
                     </p:panelGrid>
 
                 </p:tab>

--- a/src/main/webapp/resources/ezcomp/midding_data_fields.xhtml
+++ b/src/main/webapp/resources/ezcomp/midding_data_fields.xhtml
@@ -46,16 +46,13 @@
                             action="#{dataAdministrationController.createTablesAndFieldsForAllCreateStatements}" />
 
                         <p:outputLabel value="Execution Feedback" />
-                        <p:inputTextarea
-                            rows="6"
-                            autoResize="false"
-                            value="#{dataAdministrationController.executionFeedback}" 
-                            readonly="true"
-                            class="w-100" />
+                        <p:outputPanel escape="false">
+                            <textarea readonly="readonly" rows="6" class="form-control w-100" style="resize: none;">#{dataAdministrationController.executionFeedback}</textarea>
+                        </p:outputPanel>
                     </p:panelGrid>
 
                 </p:tab>
-                <p:tab title="Add Missing Fields using individual create statements" >
+                <p:tab title="Check Missing Fields add individual tables" >
 
 
 
@@ -116,7 +113,7 @@
 
                 </p:tab>
 
-                <p:tab title="Run SQL Commands" >
+                <p:tab title="Run Custom SQL Commands" >
 
 
 


### PR DESCRIPTION
**Description:**

This PR fixes the issue where fields of type `BigDecimal` (defined as `DECIMAL(x,y)` in SQL) were not being created when using the "Add Missing Fields" functionality. The previous logic split column definitions by every comma, which broke complex types like `DECIMAL(18,4)` into invalid parts and led to SQL syntax errors.

### ✅ How to Verify

1. Go to **Administration > Manage Metadata > Updata Database Structure > Update Database by DDL file**.
2. Provide a DDL `CREATE TABLE` script that includes one or more fields with `DECIMAL(18,4)` (e.g., `BILLTOTAL DECIMAL(18,4)`).
3. Ensure the corresponding field is **missing** in the database table.
4. Paste the script and click **Update Database**.
5. Confirm that the missing `DECIMAL` field is created successfully without SQL errors.

The parsing now correctly handles all numeric types with parameters, such as `DECIMAL(18,4)`, `NUMERIC(10,2)`, etc.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced SQL parsing for database updates, improving robustness when handling complex column definitions.
	- Added validation to ensure only safe SQL statements are executed during database updates.

- **Refactor**
	- Improved feedback display for database update operations, preserving formatting and clarity.

- **Style**
	- Updated button and tab labels for greater clarity, including renaming actions and providing clearer instructions for updating the database.

- **Chores**
	- Removed debug and informational console output for cleaner logs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->