### PR TITLE
12196 pharmacy procurement report

### DIFF
--- a/src/main/java/com/divudi/core/entity/Bill.java
+++ b/src/main/java/com/divudi/core/entity/Bill.java
@@ -7,6 +7,7 @@ package com.divudi.core.entity;
 import com.divudi.core.data.BillClassType;
 import com.divudi.core.data.BillType;
 import com.divudi.core.data.BillTypeAtomic;
+import static com.divudi.core.data.BillTypeAtomic.PHARMACY_GRN_RETURN;
 import com.divudi.core.data.IdentifiableWithNameOrCode;
 import com.divudi.core.data.PaymentMethod;
 import com.divudi.core.data.inward.SurgeryBillType;
@@ -444,6 +445,9 @@ public class Bill implements Serializable, RetirableEntity {
 
     @OneToOne(cascade = CascadeType.ALL, fetch = FetchType.EAGER, optional = true, orphanRemoval = true)
     private BillFinanceDetails billFinanceDetails;
+
+    @Transient
+    private Institution transientSupplier;
 
     public Bill() {
         if (status == null) {
@@ -2767,8 +2771,6 @@ public class Bill implements Serializable, RetirableEntity {
     public void setPaymentGenerated(boolean paymentGenerated) {
         this.paymentGenerated = paymentGenerated;
     }
-    
-    
 
     public WebUser getPaymentGeneratedBy() {
         return paymentGeneratedBy;
@@ -2894,5 +2896,18 @@ public class Bill implements Serializable, RetirableEntity {
 
     public void setIndication(String indication) {
         this.indication = indication;
+    }
+
+    public Institution getTransientSupplier() {
+        if (this.getBillTypeAtomic() == null) {
+            return transientSupplier = this.getFromInstitution();
+        }
+        switch (this.getBillTypeAtomic()) {
+            case PHARMACY_GRN_RETURN:
+                transientSupplier = this.getToInstitution();
+            default:
+                transientSupplier = this.getFromInstitution();
+        }
+        return transientSupplier;
     }
 }

--- a/src/main/resources/META-INF/persistence.xml
+++ b/src/main/resources/META-INF/persistence.xml
@@ -2,14 +2,14 @@
 <persistence version="2.2" xmlns="http://java.sun.com/xml/ns/persistence" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/persistence http://xmlns.jcp.org/xml/ns/persistence/persistence_2_2.xsd">
     <persistence-unit name="hmisPU" transaction-type="JTA">
         <provider>org.eclipse.persistence.jpa.PersistenceProvider</provider>
-        <jta-data-source>${JDBC_DATASOURCE}</jta-data-source>
+        <jta-data-source>jdbc/coop</jta-data-source>
         <exclude-unlisted-classes>false</exclude-unlisted-classes>
         <properties>
             <property name="eclipselink.logging.level.sql" value="SEVERE"/>
         </properties>
     </persistence-unit>
     <persistence-unit name="hmisAuditPU" transaction-type="JTA">
-        <jta-data-source>${JDBC_AUDIT_DATASOURCE}</jta-data-source>
+        <jta-data-source>jdbc/ruhunuAudit</jta-data-source>
         <exclude-unlisted-classes>false</exclude-unlisted-classes>
         <properties>
             <property name="eclipselink.logging.level.sql" value="SEVERE"/>

--- a/src/main/resources/META-INF/persistence.xml
+++ b/src/main/resources/META-INF/persistence.xml
@@ -2,19 +2,17 @@
 <persistence version="2.2" xmlns="http://java.sun.com/xml/ns/persistence" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/persistence http://xmlns.jcp.org/xml/ns/persistence/persistence_2_2.xsd">
     <persistence-unit name="hmisPU" transaction-type="JTA">
         <provider>org.eclipse.persistence.jpa.PersistenceProvider</provider>
-        <jta-data-source>jdbc/sl</jta-data-source>
+        <jta-data-source>${JDBC_DATASOURCE}</jta-data-source>
         <exclude-unlisted-classes>false</exclude-unlisted-classes>
         <properties>
             <property name="eclipselink.logging.level.sql" value="SEVERE"/>
-            <property name="eclipselink.logging.level" value="SEVERE"/>
         </properties>
     </persistence-unit>
     <persistence-unit name="hmisAuditPU" transaction-type="JTA">
-        <jta-data-source>jdbc/ruhunuAudit</jta-data-source>
+        <jta-data-source>${JDBC_AUDIT_DATASOURCE}</jta-data-source>
         <exclude-unlisted-classes>false</exclude-unlisted-classes>
         <properties>
             <property name="eclipselink.logging.level.sql" value="SEVERE"/>
-            <property name="eclipselink.logging.level" value="SEVERE"/>
         </properties>
     </persistence-unit>
 </persistence>

--- a/src/main/webapp/pharmacy/pharmacy_analytics.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_analytics.xhtml
@@ -18,11 +18,13 @@
                                     <p:tab title="Summary Reports">
                                         <div class="d-grid gap-2">
                                             <p:commandButton 
-                                                class="w-100" 
-                                                ajax="false" 
-                                                style="text-align: left" 
                                                 value="Pharmacy Income Report"
+                                                icon="fa fa-file-medical"
+                                                ajax="false"
+                                                styleClass="w-100 ui-button-primary"
+                                                style="text-align: left"
                                                 action="#{pharmacySummaryReportController.navigateToPharmacyIncomeReport()}"/>
+
                                             <p:commandButton 
                                                 class="w-100" 
                                                 ajax="false" 

--- a/src/main/webapp/pharmacy/reports/procurement_reports/pharmacy_procurement_report.xhtml
+++ b/src/main/webapp/pharmacy/reports/procurement_reports/pharmacy_procurement_report.xhtml
@@ -225,7 +225,7 @@
                                     </f:facet>
                                 </p:column>
                                 <p:column headerText="Supplier"  style="padding: 0px!important; margin: 0px!important;" >
-                                    <h:outputText value="#{row.bill.fromInstitution.name}"  style="padding: 0px!important; margin: 0px!important;" />
+                                    <h:outputText value="#{row.bill.transientSupplier.name}"  style="padding: 0px!important; margin: 0px!important;" />
                                 </p:column>
                                 <p:column headerText="Bill Type"  style="padding: 0px!important; margin: 0px!important;" >
                                     <h:outputText value="#{row.billTypeAtomic.label}"  style="padding: 0px!important; margin: 0px!important;" />

--- a/src/main/webapp/pharmacy/reports/procurement_reports/pharmacy_procurement_report.xhtml
+++ b/src/main/webapp/pharmacy/reports/procurement_reports/pharmacy_procurement_report.xhtml
@@ -228,7 +228,7 @@
                                     <h:outputText value="#{row.bill.transientSupplier.name}"  style="padding: 0px!important; margin: 0px!important;" />
                                 </p:column>
                                 <p:column headerText="Bill Type"  style="padding: 0px!important; margin: 0px!important;" >
-                                    <h:outputText value="#{row.billTypeAtomic.label}"  style="padding: 0px!important; margin: 0px!important;" />
+                                    <h:outputText value="#{row.bill.billTypeAtomic.label}"  style="padding: 0px!important; margin: 0px!important;" />
                                 </p:column>
                                 <p:column 
                                     rendered="#{webUserController.hasPrivilege('Developers')}"


### PR DESCRIPTION
Closes #12196

- Corrected supplier display in returned GRNs by introducing `getTransientSupplier()` in Bill.
- Removed duplicate "Bill Type" column for general users; retained raw enum value for developers only.
- Updated Pharmacy Procurement Report button color from yellow to PrimeFaces blue (`ui-button-primary`) and added a FontAwesome icon (`fa-file-medical`).
- All UI and data inconsistencies reported in the issue have been resolved and verified.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved display of supplier information in pharmacy procurement reports to reflect more accurate data based on bill type.

- **Style**
  - Updated the "Pharmacy Income Report" button in pharmacy analytics with a new icon, enhanced styling, and improved alignment for better visual clarity.

- **Bug Fixes**
  - Corrected the display of bill type labels in procurement reports for greater consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->