### PR TITLE
site_

### DIFF
--- a/src/main/webapp/admin/institutions/site_management.xhtml
+++ b/src/main/webapp/admin/institutions/site_management.xhtml
@@ -16,7 +16,7 @@
                 <p:focus id="selectFocus" for="lstSelect" />
                 <p:focus id="detailFocus" for="gpDetail" />
 
-                <p:panel header="Site">
+                <p:panel header="Manage Site">
                     <div class="row">
                         <div class="col-md-5">
 


### PR DESCRIPTION
Header site should be Manage Site
[#12507](https://github.com/hmislk/hmis/issues/12507)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Updated the main panel header text in the site management interface from "Site" to "Manage Site".

<!-- end of auto-generated comment: release notes by coderabbit.ai -->