### PR TITLE
fix: migrate legacy email sending to REST API via configurable gateway

### DIFF
--- a/src/main/java/com/divudi/bean/common/ConfigOptionApplicationController.java
+++ b/src/main/java/com/divudi/bean/common/ConfigOptionApplicationController.java
@@ -68,6 +68,19 @@ public class ConfigOptionApplicationController implements Serializable {
             applicationOptions.put(option.getOptionKey(), option);
         }
 //        initializeDenominations();
+        loadEmailGatewayConfigurationDefaults();
+    }
+
+    private void loadEmailGatewayConfigurationDefaults() {
+        getIntegerValueByKey("Email Gateway - SMTP Port", 587);
+        getBooleanValueByKey("Email Gateway - SMTP Auth Enabled", true);
+        getBooleanValueByKey("Email Gateway - StartTLS Enabled", true);
+        getBooleanValueByKey("Email Gateway - SSL Enabled", false);
+        // DO NOT set defaults for these, just trigger their presence in DB:
+        getShortTextValueByKey("Email Gateway - Username", "");
+        getShortTextValueByKey("Email Gateway - Password", "");
+        getShortTextValueByKey("Email Gateway - SMTP Host", "");
+        getShortTextValueByKey("Email Gateway - URL", "");
     }
 
     public ConfigOption getApplicationOption(String key) {

--- a/src/main/java/com/divudi/ejb/EmailManagerEjb.java
+++ b/src/main/java/com/divudi/ejb/EmailManagerEjb.java
@@ -57,11 +57,76 @@ public class EmailManagerEjb {
 
     }
 
+    private boolean sendEmailViaRestGateway(String subject, String body, List<String> recipients, boolean isHtml) {
+        String messengerServiceURL = configOptionApplicationController.getShortTextValueByKey("Email Gateway - URL", "");
+
+        if (messengerServiceURL == null || messengerServiceURL.trim().isEmpty()) {
+            Logger.getLogger(EmailManagerEjb.class.getName()).log(Level.SEVERE, "Email Gateway URL is not configured.");
+            return false;
+        }
+
+        try {
+            JSONObject payload = buildEmailJsonPayload(subject, body, recipients, isHtml);
+
+            URL url = new URL(messengerServiceURL);
+            HttpsURLConnection connection = (HttpsURLConnection) url.openConnection();
+            connection.setDoOutput(true);
+            connection.setRequestMethod("POST");
+            connection.setRequestProperty("Content-Type", "application/json");
+
+            try (OutputStream os = connection.getOutputStream()) {
+                os.write(payload.toString().getBytes("UTF-8"));
+                os.flush();
+            }
+
+            int responseCode = connection.getResponseCode();
+            if (responseCode == 200) {
+                return true;
+            } else {
+                Logger.getLogger(EmailManagerEjb.class.getName()).log(Level.SEVERE, "Email sending failed with response code: " + responseCode);
+                return false;
+            }
+        } catch (Exception e) {
+            Logger.getLogger(EmailManagerEjb.class.getName()).log(Level.SEVERE, "Exception in sendEmailViaRestGateway: " + e.getMessage(), e);
+            return false;
+        }
+    }
+
+    private JSONObject buildEmailJsonPayload(String subject, String body, List<String> recipients, boolean isHtml) {
+        final String username = configOptionApplicationController.getShortTextValueByKey("Email Gateway - Username", "");
+        final String password = configOptionApplicationController.getShortTextValueByKey("Email Gateway - Password", "");
+        final String smtpHost = configOptionApplicationController.getShortTextValueByKey("Email Gateway - SMTP Host", "");
+
+        JSONObject payload = new JSONObject();
+        payload.put("subject", subject);
+        payload.put("body", body);
+        payload.put("isHtml", isHtml);
+
+        JSONArray recipientArray = new JSONArray();
+        for (String recipient : recipients) {
+            recipientArray.put(recipient);
+        }
+        payload.put("recipients", recipientArray);
+
+        JSONObject smtpConfig = new JSONObject();
+        smtpConfig.put("username", username);
+        smtpConfig.put("password", password);
+        smtpConfig.put("smtpHost", smtpHost);
+        smtpConfig.put("smtpPort", configOptionApplicationController.getIntegerValueByKey("Email Gateway - SMTP Port", 587));
+        smtpConfig.put("smtpAuth", configOptionApplicationController.getBooleanValueByKey("Email Gateway - SMTP Auth Enabled", true));
+        smtpConfig.put("smtpStarttlsEnable", configOptionApplicationController.getBooleanValueByKey("Email Gateway - StartTLS Enabled", true));
+        smtpConfig.put("smtpSslEnable", configOptionApplicationController.getBooleanValueByKey("Email Gateway - SSL Enabled", false));
+
+        payload.put("smtpConfig", smtpConfig);
+
+        return payload;
+    }
+
     private void sendReportApprovalEmails() {
         String j = "Select e from AppEmail e where e.sentSuccessfully=:ret and e.retired=false";
         Map m = new HashMap();
         m.put("ret", false);
-        List<AppEmail> emails = getEmailFacade().findByJpql(j,m);
+        List<AppEmail> emails = getEmailFacade().findByJpql(j, m);
         for (AppEmail e : emails) {
             e.setSentSuccessfully(Boolean.TRUE);
             getEmailFacade().edit(e);
@@ -85,6 +150,37 @@ public class EmailManagerEjb {
             String subject,
             String messageHtml,
             String attachmentFile1Path) {
+
+        try {
+            List<String> recipients = new ArrayList<>();
+            recipients.add(receipientEmail);
+
+            // Optional: Warn if attachment path is not null
+            if (attachmentFile1Path != null && !attachmentFile1Path.trim().isEmpty()) {
+                Logger.getLogger(EmailManagerEjb.class.getName()).log(
+                        Level.WARNING,
+                        "Attachments are not supported in REST-based email API. Skipping attachment: " + attachmentFile1Path
+                );
+            }
+
+            return sendEmailViaRestGateway(subject, messageHtml, recipients, true);
+        } catch (Exception e) {
+            Logger.getLogger(EmailManagerEjb.class.getName()).log(Level.SEVERE, "Legacy sendEmail() failed: " + e.getMessage(), e);
+            return false;
+        }
+    }
+
+    
+    @Deprecated // Will be remove soon
+    public boolean sendEmail(
+            final String senderUsername,
+            final String senderPassword,
+            String sendingEmail,
+            String receipientEmail,
+            String subject,
+            String messageHtml,
+            String attachmentFile1Path,
+            boolean legacyMethod) {
         Properties props = new Properties();
         props.put("mail.smtp.starttls.enable", "true");
         props.put("mail.smtp.auth", "true");
@@ -135,6 +231,16 @@ public class EmailManagerEjb {
 
     // Latest Email Sender
     public boolean sendEmail(final List<String> recipients, final String body, final String subject, final boolean isHtml) {
+        try {
+            return sendEmailViaRestGateway(subject, body, recipients, isHtml);
+        } catch (Exception e) {
+            Logger.getLogger(EmailManagerEjb.class.getName()).log(Level.SEVERE, "Failed to send email: " + e.getMessage(), e);
+            return false;
+        }
+    }
+
+    @Deprecated // Will be remove soon
+    public boolean sendEmail(final List<String> recipients, final String body, final String subject, final boolean isHtml, boolean legacyMethod) {
         final String username = configOptionApplicationController.getShortTextValueByKey("Email Gateway - Username", "");
         final String password = configOptionApplicationController.getShortTextValueByKey("Email Gateway - Password", "");
         final String smtpHost = configOptionApplicationController.getShortTextValueByKey("Email Gateway - SMTP Host", "");
@@ -177,7 +283,7 @@ public class EmailManagerEjb {
             return connection.getResponseCode() == 200;
         } catch (Exception e) {
             Logger.getLogger(EmailManagerEjb.class.getName()).log(
-                   Level.SEVERE, "Failed to send email: " + e.getMessage(), e);
+                    Level.SEVERE, "Failed to send email: " + e.getMessage(), e);
             return false;
         }
     }

--- a/src/main/webapp/analytics/index.xhtml
+++ b/src/main/webapp/analytics/index.xhtml
@@ -293,7 +293,7 @@
                                             <p:commandButton ajax="false" value="Referral Test List" action="#"  ></p:commandButton>
                                         </div>
                                     </p:tab>
-                                    <p:tab title="SMS Reports">
+                                    <p:tab title="SMS">
                                         <div class="d-grid gap-2">
                                             <p:commandButton ajax="false" value="SMS List" action="#{searchController.navigateToSmsList()}"></p:commandButton>
                                             <p:commandButton ajax="false" value="SMS Failed List" action="#{searchController.navigateToFailedSmsList()}"  ></p:commandButton>


### PR DESCRIPTION
### ✅ **Pull Request Description :**

This PR addresses issue **#12527** by replacing direct SMTP email sending with a REST-based gateway approach using `messenger.carecode.org`. Key changes include:

* Introduced `sendEmailViaRestGateway()` and `buildEmailJsonPayload()` to send emails via REST.
* All configuration values (SMTP credentials, host, port, and REST URL) are now read from `ConfigOptionApplicationController`, with non-sensitive defaults applied.
* Existing `sendEmail(...)` methods are preserved with the same signatures for full backward compatibility.
* Deprecated original SMTP methods, which will be removed later.
* Added warnings for unsupported features (e.g., attachments via REST).
* Ensured `ConfigOptionApplicationController` initialises the necessary keys on startup.

This implementation allows secure, pluggable email delivery while maintaining legacy compatibility for dependent modules.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added the ability to send emails via a REST email gateway, supporting multiple recipients and HTML content.
- **Bug Fixes**
  - Improved handling of email configuration defaults to ensure reliable email gateway setup.
- **Other Changes**
  - Deprecated older SMTP-based email sending methods, but retained them for backward compatibility.
  - Updated the SMS reports tab title to "SMS" for clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->