### PR TITLE
12529 add email monitoring retry and manual sending UI

### DIFF
--- a/src/main/java/com/divudi/bean/common/ConfigOptionApplicationController.java
+++ b/src/main/java/com/divudi/bean/common/ConfigOptionApplicationController.java
@@ -68,6 +68,19 @@ public class ConfigOptionApplicationController implements Serializable {
             applicationOptions.put(option.getOptionKey(), option);
         }
 //        initializeDenominations();
+        loadEmailGatewayConfigurationDefaults();
+    }
+
+    private void loadEmailGatewayConfigurationDefaults() {
+        getIntegerValueByKey("Email Gateway - SMTP Port", 587);
+        getBooleanValueByKey("Email Gateway - SMTP Auth Enabled", true);
+        getBooleanValueByKey("Email Gateway - StartTLS Enabled", true);
+        getBooleanValueByKey("Email Gateway - SSL Enabled", false);
+        // DO NOT set defaults for these, just trigger their presence in DB:
+        getShortTextValueByKey("Email Gateway - Username", "");
+        getShortTextValueByKey("Email Gateway - Password", "");
+        getShortTextValueByKey("Email Gateway - SMTP Host", "");
+        getShortTextValueByKey("Email Gateway - URL", "");
     }
 
     public ConfigOption getApplicationOption(String key) {

--- a/src/main/java/com/divudi/bean/common/EmailController.java
+++ b/src/main/java/com/divudi/bean/common/EmailController.java
@@ -211,23 +211,11 @@ public class EmailController implements Serializable {
         return emailFacade;
     }
 
-    public void setEmailFacade(EmailFacade emailFacade) {
-        this.emailFacade = emailFacade;
-    }
-
     public EmailManagerEjb getEmailManager() {
         return emailManager;
     }
 
-    public void setEmailManager(EmailManagerEjb emailManager) {
-        this.emailManager = emailManager;
-    }
-
     public SessionController getSessionController() {
         return sessionController;
-    }
-
-    public void setSessionController(SessionController sessionController) {
-        this.sessionController = sessionController;
     }
 }

--- a/src/main/java/com/divudi/bean/common/EmailController.java
+++ b/src/main/java/com/divudi/bean/common/EmailController.java
@@ -99,8 +99,19 @@ public class EmailController implements Serializable {
         JsfUtil.addSuccessMessage(success ? "Resent Successfully" : "Resending failed");
     }
 
-    // ---------------- Getters & Setters ---------------- //
+    public String navigateToEmailList() {
+        return "/analytics/email_list?faces-redirect=true";
+    }
 
+    public String navigateToFailedEmailList() {
+        return "/analytics/email_failed_list?faces-redirect=true";
+    }
+
+    public String navigateToSendEmail() {
+        return "/analytics/email_send?faces-redirect=true";
+    }
+
+    // ---------------- Getters & Setters ---------------- //
     public List<AppEmail> getEmails() {
         return emails;
     }

--- a/src/main/java/com/divudi/bean/common/EmailController.java
+++ b/src/main/java/com/divudi/bean/common/EmailController.java
@@ -1,0 +1,205 @@
+/*
+ * Open Hospital Management Information System
+ * Dr M H B Ariyaratne
+ * buddhika.ari@gmail.com
+ */
+package com.divudi.bean.common;
+
+import com.divudi.core.entity.AppEmail;
+import com.divudi.core.facade.EmailFacade;
+import com.divudi.ejb.EmailManagerEjb;
+import com.divudi.core.util.JsfUtil;
+import com.divudi.core.util.CommonFunctions;
+
+import javax.inject.Named;
+import javax.enterprise.context.SessionScoped;
+import javax.ejb.EJB;
+import javax.inject.Inject;
+import javax.persistence.TemporalType;
+import java.io.Serializable;
+import java.util.*;
+
+@Named
+@SessionScoped
+public class EmailController implements Serializable {
+
+    @EJB
+    private EmailFacade emailFacade;
+
+    @Inject
+    private EmailManagerEjb emailManager;
+
+    @Inject
+    private SessionController sessionController;
+
+    private List<AppEmail> emails;
+    private List<AppEmail> failedEmails;
+
+    private AppEmail selectedEmail;
+
+    private String recipient;
+    private String subject;
+    private String body;
+    private String output;
+
+    private Date fromDate;
+    private Date toDate;
+
+    public void fillAllEmails() {
+        String j = "select e from AppEmail e where e.createdAt between :fd and :td";
+        Map<String, Object> m = new HashMap<>();
+        m.put("fd", getFromDate());
+        m.put("td", getToDate());
+        emails = emailFacade.findByJpql(j, m, TemporalType.TIMESTAMP);
+    }
+
+    public void fillFailedEmails() {
+        String j = "select e from AppEmail e where e.sentSuccessfully <> :suc and e.createdAt between :fd and :td";
+        Map<String, Object> m = new HashMap<>();
+        m.put("fd", getFromDate());
+        m.put("td", getToDate());
+        m.put("suc", true);
+        failedEmails = emailFacade.findByJpql(j, m, TemporalType.TIMESTAMP);
+    }
+
+    public void sendManualEmail() {
+        List<String> recipients = new ArrayList<>();
+        recipients.add(recipient);
+
+        boolean success = emailManager.sendEmail(recipients, body, subject, true);
+        output = success ? "Email sent successfully" : "Failed to send email";
+
+        if (success) {
+            AppEmail e = new AppEmail();
+            e.setReceipientEmail(recipient);
+            e.setMessageSubject(subject);
+            e.setMessageBody(body);
+            e.setSentSuccessfully(true);
+            e.setCreatedAt(new Date());
+            e.setCreater(sessionController.getLoggedUser());
+            emailFacade.create(e);
+        }
+    }
+
+    public void resendSelectedEmail() {
+        if (selectedEmail == null) {
+            JsfUtil.addErrorMessage("No Email selected");
+            return;
+        }
+
+        List<String> recipients = new ArrayList<>();
+        recipients.add(selectedEmail.getReceipientEmail());
+
+        boolean success = emailManager.sendEmail(recipients, selectedEmail.getMessageBody(), selectedEmail.getMessageSubject(), true);
+
+        selectedEmail.setSentSuccessfully(success);
+        selectedEmail.setSentAt(new Date());
+        emailFacade.edit(selectedEmail);
+
+        JsfUtil.addSuccessMessage(success ? "Resent Successfully" : "Resending failed");
+    }
+
+    // ---------------- Getters & Setters ---------------- //
+
+    public List<AppEmail> getEmails() {
+        return emails;
+    }
+
+    public void setEmails(List<AppEmail> emails) {
+        this.emails = emails;
+    }
+
+    public List<AppEmail> getFailedEmails() {
+        return failedEmails;
+    }
+
+    public void setFailedEmails(List<AppEmail> failedEmails) {
+        this.failedEmails = failedEmails;
+    }
+
+    public AppEmail getSelectedEmail() {
+        return selectedEmail;
+    }
+
+    public void setSelectedEmail(AppEmail selectedEmail) {
+        this.selectedEmail = selectedEmail;
+    }
+
+    public String getRecipient() {
+        return recipient;
+    }
+
+    public void setRecipient(String recipient) {
+        this.recipient = recipient;
+    }
+
+    public String getSubject() {
+        return subject;
+    }
+
+    public void setSubject(String subject) {
+        this.subject = subject;
+    }
+
+    public String getBody() {
+        return body;
+    }
+
+    public void setBody(String body) {
+        this.body = body;
+    }
+
+    public String getOutput() {
+        return output;
+    }
+
+    public void setOutput(String output) {
+        this.output = output;
+    }
+
+    public Date getFromDate() {
+        if (fromDate == null) {
+            fromDate = CommonFunctions.getStartOfDay();
+        }
+        return fromDate;
+    }
+
+    public void setFromDate(Date fromDate) {
+        this.fromDate = fromDate;
+    }
+
+    public Date getToDate() {
+        if (toDate == null) {
+            toDate = CommonFunctions.getEndOfDay();
+        }
+        return toDate;
+    }
+
+    public void setToDate(Date toDate) {
+        this.toDate = toDate;
+    }
+
+    public EmailFacade getEmailFacade() {
+        return emailFacade;
+    }
+
+    public void setEmailFacade(EmailFacade emailFacade) {
+        this.emailFacade = emailFacade;
+    }
+
+    public EmailManagerEjb getEmailManager() {
+        return emailManager;
+    }
+
+    public void setEmailManager(EmailManagerEjb emailManager) {
+        this.emailManager = emailManager;
+    }
+
+    public SessionController getSessionController() {
+        return sessionController;
+    }
+
+    public void setSessionController(SessionController sessionController) {
+        this.sessionController = sessionController;
+    }
+}

--- a/src/main/java/com/divudi/bean/common/EmailController.java
+++ b/src/main/java/com/divudi/bean/common/EmailController.java
@@ -62,37 +62,43 @@ public class EmailController implements Serializable {
         failedEmails = emailFacade.findByJpql(j, m, TemporalType.TIMESTAMP);
     }
 
-    public void sendManualEmail() {
-        if (recipient == null || recipient.trim().isEmpty()) {
-            JsfUtil.addErrorMessage("Recipient email is required.");
-            return;
-        }
-
-        List<String> recipients = new ArrayList<>();
-        recipients.add(recipient.trim());
-
-        boolean success = emailManager.sendEmail(recipients, body, subject, true);
-
-        if (success) {
-            JsfUtil.addSuccessMessage("Email sent successfully");
-
-            AppEmail e = new AppEmail();
-            e.setReceipientEmail(recipient.trim());
-            e.setMessageSubject(subject);
-            e.setMessageBody(body);
-            e.setSentSuccessfully(true);
-            e.setCreatedAt(new Date());
-            e.setCreater(sessionController.getLoggedUser());
-            emailFacade.create(e);
-
-            // Clear form
-            recipient = null;
-            subject = null;
-            body = null;
-        } else {
-            JsfUtil.addErrorMessage("Failed to send email");
-        }
+public void sendManualEmail() {
+    if (recipient == null || recipient.trim().isEmpty()) {
+        JsfUtil.addErrorMessage("Recipient email is required.");
+        return;
     }
+
+    List<String> recipients = new ArrayList<>();
+    recipients.add(recipient.trim());
+
+    boolean success = false;
+    try {
+        success = emailManager.sendEmail(recipients, body, subject, true);
+    } catch (Exception e) {
+        JsfUtil.addErrorMessage("An error occurred while sending the email: " + e.getMessage());
+        return;
+    }
+
+    if (success) {
+        JsfUtil.addSuccessMessage("Email sent successfully");
+
+        AppEmail e = new AppEmail();
+        e.setReceipientEmail(recipient.trim());
+        e.setMessageSubject(subject);
+        e.setMessageBody(body);
+        e.setSentSuccessfully(true);
+        e.setCreatedAt(new Date());
+        e.setCreater(sessionController.getLoggedUser());
+        emailFacade.create(e);
+
+        // Clear form
+        recipient = null;
+        subject = null;
+        body = null;
+    } else {
+        JsfUtil.addErrorMessage("Failed to send email");
+    }
+}
 
     public void resendSelectedEmail() {
         if (selectedEmail == null) {

--- a/src/main/java/com/divudi/bean/common/EmailController.java
+++ b/src/main/java/com/divudi/bean/common/EmailController.java
@@ -63,21 +63,34 @@ public class EmailController implements Serializable {
     }
 
     public void sendManualEmail() {
+        if (recipient == null || recipient.trim().isEmpty()) {
+            JsfUtil.addErrorMessage("Recipient email is required.");
+            return;
+        }
+
         List<String> recipients = new ArrayList<>();
-        recipients.add(recipient);
+        recipients.add(recipient.trim());
 
         boolean success = emailManager.sendEmail(recipients, body, subject, true);
-        output = success ? "Email sent successfully" : "Failed to send email";
 
         if (success) {
+            JsfUtil.addSuccessMessage("Email sent successfully");
+
             AppEmail e = new AppEmail();
-            e.setReceipientEmail(recipient);
+            e.setReceipientEmail(recipient.trim());
             e.setMessageSubject(subject);
             e.setMessageBody(body);
             e.setSentSuccessfully(true);
             e.setCreatedAt(new Date());
             e.setCreater(sessionController.getLoggedUser());
             emailFacade.create(e);
+
+            // Clear form
+            recipient = null;
+            subject = null;
+            body = null;
+        } else {
+            JsfUtil.addErrorMessage("Failed to send email");
         }
     }
 
@@ -96,7 +109,11 @@ public class EmailController implements Serializable {
         selectedEmail.setSentAt(new Date());
         emailFacade.edit(selectedEmail);
 
-        JsfUtil.addSuccessMessage(success ? "Resent Successfully" : "Resending failed");
+        if (success) {
+            JsfUtil.addSuccessMessage("Email resent successfully");
+        } else {
+            JsfUtil.addErrorMessage("Failed to resend email");
+        }
     }
 
     public String navigateToEmailList() {

--- a/src/main/java/com/divudi/ejb/EmailManagerEjb.java
+++ b/src/main/java/com/divudi/ejb/EmailManagerEjb.java
@@ -57,11 +57,76 @@ public class EmailManagerEjb {
 
     }
 
+    private boolean sendEmailViaRestGateway(String subject, String body, List<String> recipients, boolean isHtml) {
+        String messengerServiceURL = configOptionApplicationController.getShortTextValueByKey("Email Gateway - URL", "");
+
+        if (messengerServiceURL == null || messengerServiceURL.trim().isEmpty()) {
+            Logger.getLogger(EmailManagerEjb.class.getName()).log(Level.SEVERE, "Email Gateway URL is not configured.");
+            return false;
+        }
+
+        try {
+            JSONObject payload = buildEmailJsonPayload(subject, body, recipients, isHtml);
+
+            URL url = new URL(messengerServiceURL);
+            HttpsURLConnection connection = (HttpsURLConnection) url.openConnection();
+            connection.setDoOutput(true);
+            connection.setRequestMethod("POST");
+            connection.setRequestProperty("Content-Type", "application/json");
+
+            try (OutputStream os = connection.getOutputStream()) {
+                os.write(payload.toString().getBytes("UTF-8"));
+                os.flush();
+            }
+
+            int responseCode = connection.getResponseCode();
+            if (responseCode == 200) {
+                return true;
+            } else {
+                Logger.getLogger(EmailManagerEjb.class.getName()).log(Level.SEVERE, "Email sending failed with response code: " + responseCode);
+                return false;
+            }
+        } catch (Exception e) {
+            Logger.getLogger(EmailManagerEjb.class.getName()).log(Level.SEVERE, "Exception in sendEmailViaRestGateway: " + e.getMessage(), e);
+            return false;
+        }
+    }
+
+    private JSONObject buildEmailJsonPayload(String subject, String body, List<String> recipients, boolean isHtml) {
+        final String username = configOptionApplicationController.getShortTextValueByKey("Email Gateway - Username", "");
+        final String password = configOptionApplicationController.getShortTextValueByKey("Email Gateway - Password", "");
+        final String smtpHost = configOptionApplicationController.getShortTextValueByKey("Email Gateway - SMTP Host", "");
+
+        JSONObject payload = new JSONObject();
+        payload.put("subject", subject);
+        payload.put("body", body);
+        payload.put("isHtml", isHtml);
+
+        JSONArray recipientArray = new JSONArray();
+        for (String recipient : recipients) {
+            recipientArray.put(recipient);
+        }
+        payload.put("recipients", recipientArray);
+
+        JSONObject smtpConfig = new JSONObject();
+        smtpConfig.put("username", username);
+        smtpConfig.put("password", password);
+        smtpConfig.put("smtpHost", smtpHost);
+        smtpConfig.put("smtpPort", configOptionApplicationController.getIntegerValueByKey("Email Gateway - SMTP Port", 587));
+        smtpConfig.put("smtpAuth", configOptionApplicationController.getBooleanValueByKey("Email Gateway - SMTP Auth Enabled", true));
+        smtpConfig.put("smtpStarttlsEnable", configOptionApplicationController.getBooleanValueByKey("Email Gateway - StartTLS Enabled", true));
+        smtpConfig.put("smtpSslEnable", configOptionApplicationController.getBooleanValueByKey("Email Gateway - SSL Enabled", false));
+
+        payload.put("smtpConfig", smtpConfig);
+
+        return payload;
+    }
+
     private void sendReportApprovalEmails() {
         String j = "Select e from AppEmail e where e.sentSuccessfully=:ret and e.retired=false";
         Map m = new HashMap();
         m.put("ret", false);
-        List<AppEmail> emails = getEmailFacade().findByJpql(j,m);
+        List<AppEmail> emails = getEmailFacade().findByJpql(j, m);
         for (AppEmail e : emails) {
             e.setSentSuccessfully(Boolean.TRUE);
             getEmailFacade().edit(e);
@@ -85,6 +150,37 @@ public class EmailManagerEjb {
             String subject,
             String messageHtml,
             String attachmentFile1Path) {
+
+        try {
+            List<String> recipients = new ArrayList<>();
+            recipients.add(receipientEmail);
+
+            // Optional: Warn if attachment path is not null
+            if (attachmentFile1Path != null && !attachmentFile1Path.trim().isEmpty()) {
+                Logger.getLogger(EmailManagerEjb.class.getName()).log(
+                        Level.WARNING,
+                        "Attachments are not supported in REST-based email API. Skipping attachment: " + attachmentFile1Path
+                );
+            }
+
+            return sendEmailViaRestGateway(subject, messageHtml, recipients, true);
+        } catch (Exception e) {
+            Logger.getLogger(EmailManagerEjb.class.getName()).log(Level.SEVERE, "Legacy sendEmail() failed: " + e.getMessage(), e);
+            return false;
+        }
+    }
+
+    
+    @Deprecated // Will be remove soon
+    public boolean sendEmail(
+            final String senderUsername,
+            final String senderPassword,
+            String sendingEmail,
+            String receipientEmail,
+            String subject,
+            String messageHtml,
+            String attachmentFile1Path,
+            boolean legacyMethod) {
         Properties props = new Properties();
         props.put("mail.smtp.starttls.enable", "true");
         props.put("mail.smtp.auth", "true");
@@ -135,6 +231,16 @@ public class EmailManagerEjb {
 
     // Latest Email Sender
     public boolean sendEmail(final List<String> recipients, final String body, final String subject, final boolean isHtml) {
+        try {
+            return sendEmailViaRestGateway(subject, body, recipients, isHtml);
+        } catch (Exception e) {
+            Logger.getLogger(EmailManagerEjb.class.getName()).log(Level.SEVERE, "Failed to send email: " + e.getMessage(), e);
+            return false;
+        }
+    }
+
+    @Deprecated // Will be remove soon
+    public boolean sendEmail(final List<String> recipients, final String body, final String subject, final boolean isHtml, boolean legacyMethod) {
         final String username = configOptionApplicationController.getShortTextValueByKey("Email Gateway - Username", "");
         final String password = configOptionApplicationController.getShortTextValueByKey("Email Gateway - Password", "");
         final String smtpHost = configOptionApplicationController.getShortTextValueByKey("Email Gateway - SMTP Host", "");
@@ -177,7 +283,7 @@ public class EmailManagerEjb {
             return connection.getResponseCode() == 200;
         } catch (Exception e) {
             Logger.getLogger(EmailManagerEjb.class.getName()).log(
-                   Level.SEVERE, "Failed to send email: " + e.getMessage(), e);
+                    Level.SEVERE, "Failed to send email: " + e.getMessage(), e);
             return false;
         }
     }

--- a/src/main/webapp/analytics/email_failed_list.xhtml
+++ b/src/main/webapp/analytics/email_failed_list.xhtml
@@ -1,0 +1,72 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
+      xmlns:p="http://primefaces.org/ui"
+      xmlns:h="http://xmlns.jcp.org/jsf/html"
+      xmlns:f="http://xmlns.jcp.org/jsf/core">
+    <h:body>
+        <ui:composition template="/analytics/index.xhtml">
+            <ui:define name="report">
+                <h:form>
+                    <p:panel header="Failed Email List" styleClass="p-3">
+                        <p:panelGrid columns="4" styleClass="w-100 mb-3">
+                            <h:outputLabel value="From Date:" />
+                            <p:calendar value="#{emailController.fromDate}" pattern="yyyy-MM-dd" />
+
+                            <h:outputLabel value="To Date:" />
+                            <p:calendar value="#{emailController.toDate}" pattern="yyyy-MM-dd" />
+
+                            <p:spacer />
+                            <p:commandButton
+                                value="Search"
+                                icon="pi pi-search"
+                                styleClass="ui-button-warning"
+                                action="#{emailController.fillFailedEmails}"
+                                ajax="false" />
+                        </p:panelGrid>
+
+                        <p:dataTable value="#{emailController.failedEmails}" var="e" paginator="true" rows="20" styleClass="w-100" selectionMode="single" selection="#{emailController.selectedEmail}" rowKey="#{e.id}">
+                            <p:column headerText="Date" sortBy="#{e.createdAt}">
+                                <h:outputText value="#{e.createdAt}">
+                                    <f:convertDateTime pattern="yyyy-MM-dd HH:mm" />
+                                </h:outputText>
+                            </p:column>
+
+                            <p:column headerText="Recipient">
+                                <h:outputText value="#{e.receipientEmail}" />
+                            </p:column>
+
+                            <p:column headerText="Subject">
+                                <h:outputText value="#{e.messageSubject}" />
+                            </p:column>
+
+                            <p:column headerText="Error">
+                                <h:outputText value="#{e.receivedMessage}" />
+                            </p:column>
+
+                            <p:column headerText="Retry">
+                                <p:column headerText="Retry">
+                                    <p:commandButton
+                                        icon="pi pi-replay"
+                                        styleClass="ui-button-secondary"
+                                        value="Retry"
+                                        action="#{emailController.resendSelectedEmail}"
+                                        update=":form:msgs"
+                                        process="@this"
+                                        ajax="true" />
+                                </p:column>
+
+                            </p:column>
+                        </p:dataTable>
+                    </p:panel>
+                    <p:growl id="msgs" showDetail="true" life="5000" />
+
+
+                </h:form>
+
+            </ui:define>
+
+        </ui:composition>
+    </h:body>
+</html>

--- a/src/main/webapp/analytics/email_failed_list.xhtml
+++ b/src/main/webapp/analytics/email_failed_list.xhtml
@@ -45,19 +45,16 @@
                                 <h:outputText value="#{e.receivedMessage}" />
                             </p:column>
 
-                            <p:column headerText="Retry">
-                                <p:column headerText="Retry">
-                                    <p:commandButton
-                                        icon="pi pi-replay"
-                                        styleClass="ui-button-secondary"
-                                        value="Retry"
-                                        action="#{emailController.resendSelectedEmail}"
-                                        update=":form:msgs"
-                                        process="@this"
-                                        ajax="true" />
-                                </p:column>
-
-                            </p:column>
+<p:column headerText="Retry">
+    <p:commandButton
+        icon="pi pi-replay"
+        styleClass="ui-button-secondary"
+        value="Retry"
+        action="#{emailController.resendSelectedEmail}"
+        update=":form:msgs"
+        process="@this"
+        ajax="true" />
+</p:column>
                         </p:dataTable>
                     </p:panel>
                     <p:growl id="msgs" showDetail="true" life="5000" />

--- a/src/main/webapp/analytics/email_list.xhtml
+++ b/src/main/webapp/analytics/email_list.xhtml
@@ -1,0 +1,64 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
+      xmlns:p="http://primefaces.org/ui"
+      xmlns:h="http://xmlns.jcp.org/jsf/html"
+      xmlns:f="http://xmlns.jcp.org/jsf/core">
+    <h:body>
+        <ui:composition template="/analytics/index.xhtml">
+            <ui:define name="report">
+                <h:form>
+                    <p:panel header="Sent Email List" styleClass="p-3">
+                        <p:panelGrid columns="4" styleClass="w-100 mb-3">
+                            <h:outputLabel value="From Date:" />
+                            <p:calendar value="#{emailController.fromDate}" pattern="yyyy-MM-dd" />
+
+                            <h:outputLabel value="To Date:" />
+                            <p:calendar value="#{emailController.toDate}" pattern="yyyy-MM-dd" />
+
+                            <p:spacer />
+                            <p:commandButton
+                                value="Search"
+                                icon="pi pi-search"
+                                styleClass="ui-button-info"
+                                action="#{emailController.fillAllEmails}"
+                                ajax="false" />
+                        </p:panelGrid>
+
+                        <p:dataTable value="#{emailController.emails}" var="e" paginator="true" rows="20" styleClass="w-100">
+
+                            <p:column headerText="Date" sortBy="#{e.createdAt}">
+                                <h:outputText value="#{e.createdAt}">
+                                    <f:convertDateTime pattern="yyyy-MM-dd HH:mm" />
+                                </h:outputText>
+                            </p:column>
+
+                            <p:column headerText="Recipient">
+                                <h:outputText value="#{e.receipientEmail}" />
+                            </p:column>
+
+                            <p:column headerText="Subject">
+                                <h:outputText value="#{e.messageSubject}" />
+                            </p:column>
+
+                            <p:column headerText="Success">
+                                <h:outputText value="#{e.sentSuccessfully ? 'Yes' : 'No'}" />
+                            </p:column>
+
+                            <p:column headerText="Created By">
+                                <h:outputText value="#{e.creater.webUserPerson.name}" />
+                            </p:column>
+
+                        </p:dataTable>
+                    </p:panel>
+
+                </h:form>
+
+
+
+            </ui:define>
+
+        </ui:composition>
+    </h:body>
+</html>

--- a/src/main/webapp/analytics/email_send.xhtml
+++ b/src/main/webapp/analytics/email_send.xhtml
@@ -1,0 +1,43 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
+      xmlns:p="http://primefaces.org/ui"
+      xmlns:h="http://xmlns.jcp.org/jsf/html"
+      xmlns:f="http://xmlns.jcp.org/jsf/core">
+    <h:body>
+        <ui:composition template="/analytics/index.xhtml">
+            <ui:define name="report">
+                <h:form>
+                    <p:panel header="Send Test Email" styleClass="p-3">
+                        <p:panelGrid columns="2" styleClass="w-100">
+
+                            <h:outputLabel for="recipient" value="Recipient Email:" />
+                            <p:inputText id="recipient" value="#{emailController.recipient}" styleClass="w-100" />
+
+                            <h:outputLabel for="subject" value="Subject:" />
+                            <p:inputText id="subject" value="#{emailController.subject}" styleClass="w-100" />
+
+                            <h:outputLabel for="body" value="Body:" />
+                            <p:inputTextarea id="body" value="#{emailController.body}" rows="6" autoResize="true" styleClass="w-100" />
+
+                            <p:spacer />
+                            <p:commandButton
+                                value="Send Email"
+                                icon="pi pi-send"
+                                styleClass="ui-button-success"
+                                ajax="false"
+                                action="#{emailController.sendManualEmail}" />
+                        </p:panelGrid>
+
+                        <p:outputLabel value="#{emailController.output}" styleClass="text-success mt-3" />
+                    </p:panel>
+                </h:form>
+
+
+
+            </ui:define>
+
+        </ui:composition>
+    </h:body>
+</html>

--- a/src/main/webapp/analytics/email_send.xhtml
+++ b/src/main/webapp/analytics/email_send.xhtml
@@ -15,13 +15,30 @@
                         <p:panelGrid columns="2" styleClass="w-100">
 
                             <h:outputLabel for="recipient" value="Recipient Email:" />
-                            <p:inputText id="recipient" value="#{emailController.recipient}" styleClass="w-100" />
+                            <p:inputText id="recipient" 
+                                value="#{emailController.recipient}" 
+                                styleClass="w-100"
+                                required="true"
+                                requiredMessage="Recipient email is required"
+                                validatorMessage="Please enter a valid email address">
+                                <f:validateRegex pattern="^[A-Za-z0-9+_.-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}$" />
+                            </p:inputText>
 
                             <h:outputLabel for="subject" value="Subject:" />
-                            <p:inputText id="subject" value="#{emailController.subject}" styleClass="w-100" />
+                            <p:inputText id="subject" 
+                                value="#{emailController.subject}" 
+                                styleClass="w-100"
+                                required="true"
+                                requiredMessage="Subject is required" />
 
                             <h:outputLabel for="body" value="Body:" />
-                            <p:inputTextarea id="body" value="#{emailController.body}" rows="6" autoResize="true" styleClass="w-100" />
+                            <p:inputTextarea id="body" 
+                                value="#{emailController.body}" 
+                                rows="6" 
+                                autoResize="true" 
+                                styleClass="w-100"
+                                required="true"
+                                requiredMessage="Email body is required" />
 
                             <p:spacer />
                             <p:commandButton

--- a/src/main/webapp/analytics/email_send.xhtml
+++ b/src/main/webapp/analytics/email_send.xhtml
@@ -9,6 +9,8 @@
         <ui:composition template="/analytics/index.xhtml">
             <ui:define name="report">
                 <h:form>
+                    <p:growl id="msgs" showDetail="true" life="5000" />
+
                     <p:panel header="Send Test Email" styleClass="p-3">
                         <p:panelGrid columns="2" styleClass="w-100">
 
@@ -28,6 +30,7 @@
                                 styleClass="ui-button-success"
                                 ajax="false"
                                 action="#{emailController.sendManualEmail}" />
+
                         </p:panelGrid>
 
                         <p:outputLabel value="#{emailController.output}" styleClass="text-success mt-3" />

--- a/src/main/webapp/analytics/index.xhtml
+++ b/src/main/webapp/analytics/index.xhtml
@@ -93,9 +93,9 @@
                                         </div>
 
                                     </p:tab>
-                                    
-                                    
-                                     <p:tab title="Additional Lists">
+
+
+                                    <p:tab title="Additional Lists">
                                         <div class="d-grid gap-2">
                                             <p:commandButton 
                                                 ajax="false" 
@@ -103,15 +103,15 @@
                                                 action="#{searchController.navigateToCancellationBillList}"
                                                 class="w-100">
                                             </p:commandButton>
-                                             <p:commandButton 
+                                            <p:commandButton 
                                                 ajax="false" 
                                                 value="Return Bill List" 
                                                 action="#{searchController.navigateToReturnBillList()}"
                                                 class="w-100">
                                             </p:commandButton>
                                         </div>
-                                     </p:tab>
-                                    
+                                    </p:tab>
+
                                     <p:tab title="Downloads">
                                         <div class="d-grid gap-2">
 
@@ -233,7 +233,7 @@
                                                 value="OPD Summary by Item"
                                                 action="#{searchController.navigateToOpdSummaryByItem()}">
                                             </p:commandButton>
-                                            
+
 
                                         </div>
                                     </p:tab>
@@ -300,6 +300,31 @@
                                             <p:commandButton ajax="false" value="Sent SMS" action="#{searchController.navigateToSendSms()}"  ></p:commandButton>
                                         </div>
                                     </p:tab>  
+                                    <p:tab title="Email">
+                                        <div class="d-grid gap-2">
+                                            <p:commandButton 
+                                                ajax="false" 
+                                                icon="pi pi-list" 
+                                                value="Email List" 
+                                                styleClass="ui-button-info" 
+                                                action="#{emailController.navigateToEmailList()}" />
+
+                                            <p:commandButton 
+                                                ajax="false" 
+                                                icon="pi pi-times-circle" 
+                                                value="Failed Emails" 
+                                                styleClass="ui-button-danger" 
+                                                action="#{emailController.navigateToFailedEmailList()}" />
+
+                                            <p:commandButton 
+                                                ajax="false" 
+                                                icon="pi pi-send" 
+                                                value="Send Email" 
+                                                styleClass="ui-button-success" 
+                                                action="#{emailController.navigateToSendEmail()}" />
+                                        </div>
+                                    </p:tab>
+
                                     <p:tab title="Audit Reports">
                                         <div class="d-grid gap-2">
                                             <p:commandButton 

--- a/src/main/webapp/analytics/index.xhtml
+++ b/src/main/webapp/analytics/index.xhtml
@@ -293,7 +293,7 @@
                                             <p:commandButton ajax="false" value="Referral Test List" action="#"  ></p:commandButton>
                                         </div>
                                     </p:tab>
-                                    <p:tab title="SMS Reports">
+                                    <p:tab title="SMS">
                                         <div class="d-grid gap-2">
                                             <p:commandButton ajax="false" value="SMS List" action="#{searchController.navigateToSmsList()}"></p:commandButton>
                                             <p:commandButton ajax="false" value="SMS Failed List" action="#{searchController.navigateToFailedSmsList()}"  ></p:commandButton>


### PR DESCRIPTION
### ✅ PR Comment for Closing Issue `#12529`

**Closes #12529 – Implement Email Monitoring and Manual Retry Features**

This PR introduces UI and backend support for monitoring and retrying sent emails:

* ✅ `EmailController` added with methods to list sent and failed emails, and to manually send or retry failed ones
* ✅ Navigation methods:

  * `navigateToEmailList()`
  * `navigateToFailedEmailList()`
  * `navigateToSendEmail()`
* ✅ Three JSF pages:

  * `email_list.xhtml` – shows all sent emails
  * `email_failed_list.xhtml` – shows failed emails with retry button
  * `email_send.xhtml` – form to send a test email manually
* ✅ Integrated PrimeFaces Growl messages for user feedback
* ✅ Input validation and form clearing on successful send
* ✅ Added buttons under `<p:tab title="Email">` in `/analytics/index.xhtml`

These features mirror the structure of the existing SMS system for consistency.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced an email management interface with pages to view sent emails, failed emails, and send emails manually.
  - Added date range filtering and retry capability for failed emails within the interface.
  - Added a new "Email" tab in the analytics dashboard for streamlined access to email functions.

- **Enhancements**
  - Implemented a REST-based email sending mechanism for improved reliability and external gateway integration.
  - Automatically initialize default email gateway configuration options.

- **User Interface**
  - Enhanced analytics dashboard navigation with new tabs and updated labels for better organization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->