### PR TITLE
12232 need to show that comment for pharmacy staff when issuing items for that request

### DIFF
--- a/src/main/java/com/divudi/bean/pharmacy/PharmacySaleBhtController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacySaleBhtController.java
@@ -1494,7 +1494,7 @@ public class PharmacySaleBhtController implements Serializable {
             return "";
         }
         generateIssueBillComponentsForBhtRequest(bhtRequestBill);
-        return "/ward/ward_pharmacy_bht_issue";
+        return "/ward/ward_pharmacy_bht_issue?faces-redirect=true;";
     }
 
     public void generateIssueBillComponentsForBhtRequest(Bill b) {

--- a/src/main/webapp/ward/ward_pharmacy_bht_issue.xhtml
+++ b/src/main/webapp/ward/ward_pharmacy_bht_issue.xhtml
@@ -42,9 +42,9 @@
                                     <p:autoComplete accesskey="i"    id="acStock"
                                                     value="#{pharmacySaleBhtController.tmpStock}"
                                                     completeMethod="#{stockController.completeAvailableStocks}"
-                                                    var="i" itemLabel="#{i.itemBatch.item.name}" itemValue="#{i}" maxResults="20"
+                                                    var="i" itemLabel="#{i.itemBatch.item.name}" itemValue="#{i}" maxResults="10" size="100"
                                                     >
-                                        <p:column headerText="Item" styleClass="#{commonFunctionsProxy.currentDateTime > i.itemBatch.dateOfExpire ?'ui-messages-fatal': commonFunctionsProxy.dateAfterThreeMonthsCurrentDateTime > i.itemBatch.dateOfExpire ?'ui-messages-warn':''}">
+                                        <p:column headerText="Item" style="padding: 4px" styleClass="#{commonFunctionsProxy.currentDateTime > i.itemBatch.dateOfExpire ?'ui-messages-fatal': commonFunctionsProxy.dateAfterThreeMonthsCurrentDateTime > i.itemBatch.dateOfExpire ?'ui-messages-warn':''}">
                                             <h:outputLabel value="#{i.itemBatch.item.name}"  style="width: 300px!important;">
                                                 &nbsp;<p:tag rendered="#{commonFunctionsProxy.currentDateTime > i.itemBatch.dateOfExpire ?'true': commonFunctionsProxy.dateAfterThreeMonthsCurrentDateTime > i.itemBatch.dateOfExpire ?'true':'false'}" value="#{commonFunctionsProxy.currentDateTime > i.itemBatch.dateOfExpire ?'Expired ':
                                                                          commonFunctionsProxy.dateAfterThreeMonthsCurrentDateTime > i.itemBatch.dateOfExpire ?'Expired Soon':''}"
@@ -52,27 +52,27 @@
                                             </h:outputLabel>
                                         </p:column>
 
-                                        <p:column headerText="Code" styleClass="#{commonFunctionsProxy.currentDateTime > i.itemBatch.dateOfExpire ?'ui-messages-fatal':
+                                        <p:column headerText="Code" style="padding: 4px" styleClass="#{commonFunctionsProxy.currentDateTime > i.itemBatch.dateOfExpire ?'ui-messages-fatal':
                                                                                   commonFunctionsProxy.dateAfterThreeMonthsCurrentDateTime > i.itemBatch.dateOfExpire ?'ui-messages-warn':''}">
                                             <h:outputLabel value="#{i.itemBatch.item.code}" style="width: 50px!important;"></h:outputLabel>
                                         </p:column>
-                                        <p:column headerText="Generic" styleClass="#{commonFunctionsProxy.currentDateTime > i.itemBatch.dateOfExpire ?'ui-messages-fatal':
+                                        <p:column headerText="Generic" style="padding: 4px" styleClass="#{commonFunctionsProxy.currentDateTime > i.itemBatch.dateOfExpire ?'ui-messages-fatal':
                                                                                      commonFunctionsProxy.dateAfterThreeMonthsCurrentDateTime > i.itemBatch.dateOfExpire ?'ui-messages-warn':''}">
                                             <h:outputLabel value="#{i.itemBatch.item.vmp.name}" style="width: 150px!important;"></h:outputLabel>
                                         </p:column>
-                                        <p:column headerText="Rate" styleClass="#{commonFunctionsProxy.currentDateTime > i.itemBatch.dateOfExpire ?'ui-messages-fatal':
+                                        <p:column headerText="Rate" style="padding: 4px" styleClass="#{commonFunctionsProxy.currentDateTime > i.itemBatch.dateOfExpire ?'ui-messages-fatal':
                                                                                   commonFunctionsProxy.dateAfterThreeMonthsCurrentDateTime > i.itemBatch.dateOfExpire ?'ui-messages-warn':''}">
                                             <h:outputLabel value="#{i.itemBatch.retailsaleRate}" >
                                                 <f:convertNumber pattern="#,##0.00" ></f:convertNumber>
                                             </h:outputLabel>
                                         </p:column>
-                                        <p:column headerText="Stocks" styleClass="#{commonFunctionsProxy.currentDateTime > i.itemBatch.dateOfExpire ?'ui-messages-fatal':
+                                        <p:column headerText="Stocks" style="padding: 4px" styleClass="#{commonFunctionsProxy.currentDateTime > i.itemBatch.dateOfExpire ?'ui-messages-fatal':
                                                                                     commonFunctionsProxy.dateAfterThreeMonthsCurrentDateTime > i.itemBatch.dateOfExpire ?'ui-messages-warn':''}">
                                             <h:outputLabel value="#{i.stock}" >
                                                 <f:convertNumber pattern="#,###" ></f:convertNumber>
                                             </h:outputLabel>
                                         </p:column>
-                                        <p:column headerText="Expiry" class="w-100" styleClass="#{commonFunctionsProxy.currentDateTime > i.itemBatch.dateOfExpire ?'ui-messages-fatal':
+                                        <p:column headerText="Expiry" style="padding: 4px" class="w-100" styleClass="#{commonFunctionsProxy.currentDateTime > i.itemBatch.dateOfExpire ?'ui-messages-fatal':
                                                                                                   commonFunctionsProxy.dateAfterThreeMonthsCurrentDateTime > i.itemBatch.dateOfExpire ?'ui-messages-warn':''}">
                                             <h:outputLabel value="#{i.itemBatch.dateOfExpire}"
                                                            style="width: 100px!important;" >
@@ -96,12 +96,12 @@
                                 </h:panelGrid>
 
                                 <h:panelGrid columns="1" class="w-100" >
-                                    <p:outputLabel value="" ></p:outputLabel>
+                                    <p:outputLabel value="&nbsp;" ></p:outputLabel>
                                     <p:commandButton  accesskey="a"
                                                       id="btnAdd"
                                                       icon="fa fa-plus"
                                                       value="Add"
-                                                      class="ui-button-success mt-2"
+                                                      class="ui-button-success mx-1"
                                                       action="#{pharmacySaleBhtController.addBillItemNew}"
                                                       ajax="false"
                                                       style="float: right;"
@@ -138,6 +138,9 @@
                                 <p:outputLabel value="Net Total" ></p:outputLabel>
                                 <p:outputLabel value=":" ></p:outputLabel>
                                 <p:outputLabel value="#{pharmacySaleBhtController.bhtRequestBill.netTotal}" ><f:convertNumber pattern="#,##0.00" /></p:outputLabel>
+                                <p:outputLabel value="Comment" ></p:outputLabel>
+                                <p:outputLabel value=":" ></p:outputLabel>
+                                <p:outputLabel value="#{pharmacySaleBhtController.bhtRequestBill.comments}" ><f:convertNumber pattern="#,##0.00" /></p:outputLabel>
                             </h:panelGrid>
                         </p:panel>
 

--- a/src/main/webapp/ward/ward_pharmacy_reprint_bht_issue_request.xhtml
+++ b/src/main/webapp/ward/ward_pharmacy_reprint_bht_issue_request.xhtml
@@ -85,7 +85,7 @@
                                     <p:outputLabel value="#{pharmacyBillSearch.bill.discount}" ><f:convertNumber pattern="#,##0.00" /></p:outputLabel>
                                     <p:outputLabel value="Net Total" ></p:outputLabel>
                                     <p:outputLabel value=":" ></p:outputLabel>
-                                    <p:outputLabel value="#{pharmacyBillSearch.bill.netTotal}" ><f:convertNumber pattern="#,##0.00" /></p:outputLabel>
+                                    <p:outputLabel value="#{pharmacyBillSearch.bill.netTotal}" ></p:outputLabel>
                                 </h:panelGrid>
                             </p:panel>
                         </div>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Navigation to the BHT pharmacy issue page now explicitly triggers a redirect for smoother transitions.
  - The autocomplete for stock selection now displays a maximum of 10 results (previously 20) and improved spacing for dropdown items.
  - The "Add" button spacing has been adjusted for a cleaner layout.
  - Bill details now display a "Comment" field with improved formatting.
  - Minor layout enhancements for better consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->