### PR TITLE
12630 pharmacy direct purchase with costing ensure accurate display and calculation of bill level financial values

### DIFF
--- a/src/main/java/com/divudi/bean/pharmacy/PharmacyDirectPurchaseController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacyDirectPurchaseController.java
@@ -236,6 +236,8 @@ public class PharmacyDirectPurchaseController implements Serializable {
             totalQtyInUnits = totalQty;
         }
 
+        f.setUnitsPerPack(unitsPerPack);
+        
         // 5. Record unit-based quantities in finance details
         f.setQuantityByUnits(qtyInUnits);
         f.setFreeQuantityByUnits(freeQtyInUnits);

--- a/src/main/java/com/divudi/bean/pharmacy/PharmacyDirectPurchaseController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacyDirectPurchaseController.java
@@ -1056,9 +1056,10 @@ public class PharmacyDirectPurchaseController implements Serializable {
             getBillItemFacade().edit(i);
             saveBillFee(i);
             ItemBatch itemBatch = getPharmacyBillBean().saveItemBatchWithCosting(i);
-            double addingQty = tmpPh.getQtyInUnit() + tmpPh.getFreeQtyInUnit();
-
+            
+            double addingQty = i.getBillItemFinanceDetails().getTotalQuantityByUnits().doubleValue();
             tmpPh.setItemBatch(itemBatch);
+            
             Stock stock = getPharmacyBean().addToStock(tmpPh, Math.abs(addingQty), getSessionController().getDepartment());
             tmpPh.setLastPurchaseRate(lastPurchaseRate);
             tmpPh.setStock(stock);
@@ -1066,10 +1067,12 @@ public class PharmacyDirectPurchaseController implements Serializable {
 
             getBill().getBillItems().add(i);
         }
-        if (billItemsTotalQty == 0.0) {
-            JsfUtil.addErrorMessage("Please Add Item Quantities To Bill");
-            return;
-        }
+
+//        This is already checked        
+//        if (billItemsTotalQty == 0.0) {
+//            JsfUtil.addErrorMessage("Please Add Item Quantities To Bill");
+//            return;
+//        }
 
         //check and calculate expenses separately
         if (billExpenses != null && !billExpenses.isEmpty()) {
@@ -1085,16 +1088,13 @@ public class PharmacyDirectPurchaseController implements Serializable {
         }
 
         getPharmacyBillBean().calculateRetailSaleValueAndFreeValueAtPurchaseRate(getBill());
-
         getBillFacade().edit(getBill());
 
-        WebUser wb = getCashTransactionBean().saveBillCashOutTransaction(getBill(), getSessionController().getLoggedUser());
-        getSessionController().setLoggedUser(wb);
+//        WebUser wb = getCashTransactionBean().saveBillCashOutTransaction(getBill(), getSessionController().getLoggedUser());
+//        getSessionController().setLoggedUser(wb);
 
-        JsfUtil.addSuccessMessage("Successfully Billed");
+        JsfUtil.addSuccessMessage("Direct Purchase Successfully Completed.");
         printPreview = true;
-        //   recreate();
-
     }
 
     public void removeItem(BillItem bi) {

--- a/src/main/java/com/divudi/core/entity/pharmacy/ItemBatch.java
+++ b/src/main/java/com/divudi/core/entity/pharmacy/ItemBatch.java
@@ -42,6 +42,7 @@ public class ItemBatch implements Serializable, RetirableEntity {
     double purcahseRate;
     double retailsaleRate;
     double wholesaleRate;
+    private Double costRate;
     @ManyToOne
     Category make;
     String modal;
@@ -334,5 +335,17 @@ public class ItemBatch implements Serializable, RetirableEntity {
         this.retireComments = retireComments;
     }
 
+    public Double getCostRate() {
+        if (costRate == null) {
+            if (purcahseRate != 0.0) {
+                costRate = purcahseRate;
+            }
+        }
+        return costRate;
+    }
+
+    public void setCostRate(Double costRate) {
+        this.costRate = costRate;
+    }
 
 }

--- a/src/main/java/com/divudi/ejb/PharmacyCalculation.java
+++ b/src/main/java/com/divudi/ejb/PharmacyCalculation.java
@@ -39,6 +39,7 @@ import java.math.RoundingMode;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Calendar;
+import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -707,72 +708,110 @@ public class PharmacyCalculation implements Serializable {
         return itemBatch;
     }
 
-    public ItemBatch saveItemBatchWithCosting(BillItem tmp) {
-        //System.err.println("Save Item Batch");
+    private ItemBatch fetchItemBatchWithCosting(Item item, double purchaseRate, double retailRate, double costRate, Date dateOfExpiry) {
+        String jpql = "SELECT p FROM ItemBatch p "
+                + "WHERE p.retired = false "
+                + "AND p.item = :itm "
+                + "AND p.dateOfExpire = :doe "
+                + "AND p.retailsaleRate = :ret "
+                + "AND p.costRate = :cr "
+                + "AND p.purcahseRate = :pur";
 
-        ItemBatch itemBatch = new ItemBatch();
-        Item itm = tmp.getItem();
-        if (itm instanceof Ampp) {
-            itm = ((Ampp) itm).getAmp();
+        Map<String, Object> params = new HashMap<>();
+        params.put("itm", item);
+        params.put("doe", dateOfExpiry);
+        params.put("ret", retailRate);
+        params.put("cr", costRate);
+        params.put("pur", purchaseRate);
+
+        return getItemBatchFacade().findFirstByJpql(jpql, params, TemporalType.TIMESTAMP);
+    }
+
+    private ItemBatch fetchItemBatchWithoutCosting(Item item, double purchaseRate, double retailRate, Date dateOfExpiry) {
+        String jpql = "SELECT p FROM ItemBatch p "
+                + "WHERE p.retired = false "
+                + "AND p.item = :itm "
+                + "AND p.dateOfExpire = :doe "
+                + "AND p.retailsaleRate = :ret "
+                + "AND p.purcahseRate = :pur";
+
+        Map<String, Object> params = new HashMap<>();
+        params.put("itm", item);
+        params.put("doe", dateOfExpiry);
+        params.put("ret", retailRate);
+        params.put("pur", purchaseRate);
+
+        return getItemBatchFacade().findFirstByJpql(jpql, params, TemporalType.TIMESTAMP);
+    }
+
+    /**
+     * Creates or fetches an existing ItemBatch based on costing and expiry
+     * logic. Ensures uniqueness based on AMP, purchaseRate, retailRate,
+     * costRate, and expiry. Additional fields like wholesaleRate, make, etc.,
+     * are set but not used for uniqueness.
+     */
+    public ItemBatch saveItemBatchWithCosting(BillItem inputBillItem) {
+        if (inputBillItem == null || inputBillItem.getItem() == null || inputBillItem.getPharmaceuticalBillItem() == null) {
+            return null;
         }
 
-        double purchase = 0d;
+        // Extract AMP (Actual Medicinal Product) even if input is AMPP (Pack)
+        Item amp = inputBillItem.getItem();
+        if (amp instanceof Ampp) {
+            amp = ((Ampp) amp).getAmp();
+        }
+
+        Date expiryDate = inputBillItem.getPharmaceuticalBillItem().getDoe();
+        if (expiryDate == null || amp == null) {
+            return null;
+        }
+
+        ItemBatch itemBatch = null;
+
+        double purchaseRatePerUnit;
+        double retailRatePerUnit;
+        double wholesaleRate = 0.0;
+        double costRatePerUnit = 0.0;
+
         boolean manageCosting = configOptionApplicationController.getBooleanValueByKey("Manage Cost", true);
+
         if (manageCosting) {
-            BigDecimal qty = Optional.ofNullable(tmp.getBillItemFinanceDetails().getQuantity())
-                    .filter(q -> q.compareTo(BigDecimal.ZERO) != 0)
-                    .orElse(BigDecimal.ONE); // Prevent divide by zero
+            // Use finance details when costing is enabled
+            if (inputBillItem.getBillItemFinanceDetails() == null) {
+                return null;
+            }
 
-            BigDecimal lineCost = Optional.ofNullable(tmp.getBillItemFinanceDetails().getLineCost())
-                    .orElse(BigDecimal.ZERO); // Prevent null
+            purchaseRatePerUnit = inputBillItem.getBillItemFinanceDetails().getLineGrossRate().doubleValue();
+            retailRatePerUnit = inputBillItem.getBillItemFinanceDetails().getRetailSaleRatePerUnit().doubleValue();
+            costRatePerUnit = inputBillItem.getBillItemFinanceDetails().getTotalCostRate().doubleValue();
 
-            purchase = lineCost.divide(qty, 6, RoundingMode.HALF_UP).doubleValue();
+            itemBatch = fetchItemBatchWithCosting(amp, purchaseRatePerUnit, retailRatePerUnit, costRatePerUnit, expiryDate);
         } else {
-            purchase = tmp.getPharmaceuticalBillItem().getPurchaseRateInUnit();
+            // Use values from PharmaceuticalBillItem when costing is not enabled
+            purchaseRatePerUnit = inputBillItem.getPharmaceuticalBillItem().getPurchaseRate();
+            retailRatePerUnit = inputBillItem.getPharmaceuticalBillItem().getRetailRateInUnit();
+            wholesaleRate = inputBillItem.getPharmaceuticalBillItem().getWholesaleRate();
+
+            itemBatch = fetchItemBatchWithoutCosting(amp, purchaseRatePerUnit, retailRatePerUnit, expiryDate);
         }
 
-        double retail = tmp.getPharmaceuticalBillItem().getRetailRateInUnit();
-        double wholesale = tmp.getPharmaceuticalBillItem().getWholesaleRate();
-        ////// // System.out.println("wholesale = " + wholesale);
-        itemBatch.setDateOfExpire(tmp.getPharmaceuticalBillItem().getDoe());
-        itemBatch.setBatchNo(tmp.getPharmaceuticalBillItem().getStringValue());
+        // If no matching batch found, create a new one
+        if (itemBatch == null) {
+            itemBatch = new ItemBatch();
+            itemBatch.setItem(amp);
+            itemBatch.setDateOfExpire(expiryDate);
+            itemBatch.setBatchNo(inputBillItem.getPharmaceuticalBillItem().getStringValue());
+            itemBatch.setPurcahseRate(purchaseRatePerUnit);
+            itemBatch.setRetailsaleRate(retailRatePerUnit);
+            itemBatch.setWholesaleRate(wholesaleRate);
+            itemBatch.setCostRate(costRatePerUnit);
+            itemBatch.setLastPurchaseBillItem(inputBillItem);
+            itemBatch.setMake(inputBillItem.getPharmaceuticalBillItem().getMake());
+            itemBatch.setModal(inputBillItem.getPharmaceuticalBillItem().getModel());
 
-        itemBatch.setPurcahseRate(purchase);
-        itemBatch.setRetailsaleRate(retail);
-        itemBatch.setWholesaleRate(wholesale);
-        itemBatch.setLastPurchaseBillItem(tmp);
-        HashMap hash = new HashMap();
-        String sql;
-
-        itemBatch.setItem(itm);
-        sql = "Select p from ItemBatch p where  p.item=:itm "
-                + " and p.dateOfExpire= :doe and p.retailsaleRate=:ret "
-                + " and p.purcahseRate=:pur";
-
-        hash.put("doe", itemBatch.getDateOfExpire());
-        hash.put("itm", itemBatch.getItem());
-        hash.put("ret", itemBatch.getRetailsaleRate());
-        hash.put("pur", itemBatch.getPurcahseRate());
-        List<ItemBatch> i = getItemBatchFacade().findByJpql(sql, hash, TemporalType.TIMESTAMP);
-        //System.err.println("Size " + i.size());
-        if (!i.isEmpty()) {
-//            //System.err.println("Edit");
-//            i.get(0).setBatchNo(i.get(0).getBatchNo());
-//            i.get(0).setDateOfExpire(i.get(0).getDateOfExpire());
-            itemBatch.setMake(tmp.getPharmaceuticalBillItem().getMake());
-            itemBatch.setModal(tmp.getPharmaceuticalBillItem().getModel());
-            ItemBatch ib = i.get(0);
-            ib.setWholesaleRate(wholesale);
-            getItemBatchFacade().edit(ib);
-            return ib;
-        } else {
-            //System.err.println("Create");
-            itemBatch.setMake(tmp.getPharmaceuticalBillItem().getMake());
-            itemBatch.setModal(tmp.getPharmaceuticalBillItem().getModel());
             getItemBatchFacade().create(itemBatch);
         }
 
-        //System.err.println("ItemBatc Id " + itemBatch.getId());
         return itemBatch;
     }
 

--- a/src/main/webapp/pharmacy/direct_purchase.xhtml
+++ b/src/main/webapp/pharmacy/direct_purchase.xhtml
@@ -524,7 +524,7 @@
                                             value="#{pharmacyDirectPurchaseController.bill.tax}">
                                             <p:ajax 
                                                 process="tx" 
-                                                update=":bill:panelBillDetails"
+                                                update=":bill:net :bill:billFinanceDetails"
                                                 event="blur"
                                                 listener="#{pharmacyDirectPurchaseController.billDiscountChangedByUser()}" />
                                         </p:inputText>
@@ -537,7 +537,7 @@
                                             value="#{pharmacyDirectPurchaseController.bill.discount}">
                                             <p:ajax 
                                                 process="@this" 
-                                                update=":bill:panelBillDetails"
+                                                update=":bill:net :bill:billFinanceDetails"
                                                 event="blur"
                                                 listener="#{pharmacyDirectPurchaseController.billDiscountChangedByUser()}" />
                                         </p:inputText>
@@ -563,7 +563,7 @@
                                 <!-- Detailed Finance Tab -->
                                 <p:tab title="Financial Summary">
                                     
-                                    <ph:bill_finance_details bill="#{pharmacyDirectPurchaseController.bill}" ></ph:bill_finance_details>
+                                    <ph:bill_finance_details id="billFinanceDetails" bill="#{pharmacyDirectPurchaseController.bill}" ></ph:bill_finance_details>
                                   
 
                                 </p:tab>

--- a/src/main/webapp/pharmacy/direct_purchase.xhtml
+++ b/src/main/webapp/pharmacy/direct_purchase.xhtml
@@ -500,84 +500,72 @@
                             </h:panelGrid>
                         </p:panel>
 
-                        <p:panel header="Bill details" class="m-1" >
+                        <p:panel id="panelBillDetails" header="Bill details" class="m-1" >
                             <f:facet name="header" >
                                 <h:outputText styleClass="fas fa-receipt"/>
                                 <h:outputText  class="mx-4" value="Bill Details" />
                             </f:facet>
-
-
                             <p:tabView id="tot">
-
                                 <!-- Legacy Summary -->
                                 <p:tab title="Bill Summary">
-                                    <p:panel header="Bill details" class="m-1">
-                                        <f:facet name="header">
-                                            <h:outputText styleClass="fas fa-receipt" />
-                                            <h:outputText class="mx-4" value="Bill Details" />
-                                        </f:facet>
+                                    <p:panelGrid columns="2" >
+                                        <p:outputLabel value="Gross Total" />
+                                        <p:outputLabel 
+                                            id="gro" 
+                                            value="#{pharmacyDirectPurchaseController.bill.total}" 
+                                            class="w-100 text-end ui-inputfield bg-secondary text-white"
+                                            />
 
-                                        <h:panelGrid columns="2" id="totGrid" style="min-width: 100%; font-weight: bolder">
-                                            <p:outputLabel value="Gross Total" />
-                                            <p:outputLabel id="gro" value="#{pharmacyDirectPurchaseController.bill.total}" />
+                                        <p:outputLabel value="Tax" />
+                                        <p:inputText 
+                                            autocomplete="off" 
+                                            id="tx" 
+                                            class="w-100 text-end"
+                                            value="#{pharmacyDirectPurchaseController.bill.tax}">
+                                            <p:ajax 
+                                                process="tx" 
+                                                update=":bill:panelBillDetails"
+                                                event="blur"
+                                                listener="#{pharmacyDirectPurchaseController.billDiscountChangedByUser()}" />
+                                        </p:inputText>
 
-                                            <p:outputLabel value="Tax" />
-                                            <p:inputText autocomplete="off" id="tx" value="#{pharmacyDirectPurchaseController.bill.tax}">
-                                                <p:ajax process="tx" update="gro tx net" event="keyup"
-                                                        listener="#{pharmacyDirectPurchaseController.billDiscountChangedByUser()}" />
-                                            </p:inputText>
+                                        <p:outputLabel value="Discount" />
+                                        <p:inputText 
+                                            class="w-100 text-end"
+                                            id="dis" 
+                                            autocomplete="off" 
+                                            value="#{pharmacyDirectPurchaseController.bill.discount}">
+                                            <p:ajax 
+                                                process="@this" 
+                                                update=":bill:panelBillDetails"
+                                                event="blur"
+                                                listener="#{pharmacyDirectPurchaseController.billDiscountChangedByUser()}" />
+                                        </p:inputText>
 
-                                            <p:outputLabel value="Discount" />
-                                            <p:inputText autocomplete="off" id="dis" value="#{pharmacyDirectPurchaseController.bill.discount}">
-                                                <p:ajax process="@this" update="gro tx net" event="keyup"
-                                                        listener="#{pharmacyDirectPurchaseController.billDiscountChangedByUser()}" />
-                                            </p:inputText>
+                                        <p:outputLabel value="Net Total" />
+                                        <h:outputLabel 
+                                            id="net"
+                                            class="w-100 text-end ui-inputfield bg-secondary text-white"
+                                            value="#{pharmacyDirectPurchaseController.bill.netTotal}">
+                                            <f:convertNumber pattern="#,##0.00" />
+                                        </h:outputLabel>
 
-                                            <p:outputLabel value="Net Total" />
-                                            <h:outputLabel id="net" value="#{pharmacyDirectPurchaseController.bill.netTotal}">
-                                                <f:convertNumber pattern="#,##0.00" />
-                                            </h:outputLabel>
-
-                                            <p:outputLabel value="Sale Value" />
-                                            <h:outputLabel id="saleValue" value="#{pharmacyDirectPurchaseController.bill.saleValue}">
-                                                <f:convertNumber pattern="#,##0.00" />
-                                            </h:outputLabel>
-                                        </h:panelGrid>
-                                    </p:panel>
+                                        <p:outputLabel value="Sale Value" />
+                                        <h:outputLabel 
+                                            id="saleValue"
+                                            class="w-100 text-end ui-inputfield bg-secondary text-white"
+                                            value="#{pharmacyDirectPurchaseController.bill.saleValue}">
+                                            <f:convertNumber pattern="#,##0.00" />
+                                        </h:outputLabel>
+                                    </p:panelGrid>
                                 </p:tab>
 
                                 <!-- Detailed Finance Tab -->
                                 <p:tab title="Financial Summary">
-                                    <p:panelGrid columns="2" layout="tabular" styleClass="w-100">
+                                    
+                                    <ph:bill_finance_details bill="#{pharmacyDirectPurchaseController.bill}" ></ph:bill_finance_details>
+                                  
 
-                                        <p:outputLabel value="Total Purchase Value" />
-                                        <p:outputLabel value="#{pharmacyDirectPurchaseController.bill.billFinanceDetails.totalPurchaseValue}" styleClass="text-end" />
-
-                                        <p:outputLabel value="Total Cost Value" />
-                                        <p:outputLabel value="#{pharmacyDirectPurchaseController.bill.billFinanceDetails.totalCostValue}" styleClass="text-end" />
-
-                                        <p:outputLabel value="Total Retail Sale Value" />
-                                        <p:outputLabel value="#{pharmacyDirectPurchaseController.bill.billFinanceDetails.totalRetailSaleValue}" styleClass="text-end" />
-
-                                        <p:outputLabel value="Total Tax Value" />
-                                        <p:outputLabel value="#{pharmacyDirectPurchaseController.bill.billFinanceDetails.totalTaxValue}" styleClass="text-end" />
-
-                                        <p:outputLabel value="Bill Discount" />
-                                        <p:outputLabel value="#{pharmacyDirectPurchaseController.bill.billFinanceDetails.billDiscount}" styleClass="text-end" />
-
-                                        <p:outputLabel value="Line Discounts Total" />
-                                        <p:outputLabel value="#{pharmacyDirectPurchaseController.bill.billFinanceDetails.lineDiscount}" styleClass="text-end" />
-
-                                        <p:outputLabel value="Total Discount" />
-                                        <p:outputLabel value="#{pharmacyDirectPurchaseController.bill.billFinanceDetails.totalDiscount}" styleClass="text-end" />
-
-                                        <p:outputLabel value="Total Expense" />
-                                        <p:outputLabel value="#{pharmacyDirectPurchaseController.bill.billFinanceDetails.totalExpense}" styleClass="text-end" />
-
-                                        <p:outputLabel value="Free Item Value" />
-                                        <p:outputLabel value="#{pharmacyDirectPurchaseController.bill.billFinanceDetails.totalOfFreeItemValues}" styleClass="text-end" />
-
-                                    </p:panelGrid>
                                 </p:tab>
 
                             </p:tabView>

--- a/src/main/webapp/resources/ezcomp/pharmacy/bill_finance_details.xhtml
+++ b/src/main/webapp/resources/ezcomp/pharmacy/bill_finance_details.xhtml
@@ -1,0 +1,74 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:cc="http://xmlns.jcp.org/jsf/composite"
+      xmlns:f="http://xmlns.jcp.org/jsf/core"
+      xmlns:p="http://primefaces.org/ui"
+      xmlns:h="http://xmlns.jcp.org/jsf/html">
+
+    <!-- INTERFACE -->
+    <cc:interface>
+        <cc:attribute name="bill" type="com.divudi.core.entity.Bill" />
+    </cc:interface>
+
+    <!-- IMPLEMENTATION -->
+    <cc:implementation>
+
+        <p:panelGrid columns="2" layout="tabular" styleClass="w-100 m-1">
+
+            <p:outputLabel value="Bill Discount" />
+            <p:outputLabel value="#{cc.attrs.bill.billFinanceDetails.billDiscount}" styleClass="text-end w-100" />
+
+            <p:outputLabel value="Sum of Line Discounts" />
+            <p:outputLabel value="#{cc.attrs.bill.billFinanceDetails.lineDiscount}" styleClass="text-end w-100" />
+
+            <p:outputLabel value="Total Discount" />
+            <p:outputLabel value="#{cc.attrs.bill.billFinanceDetails.totalDiscount}" styleClass="text-end w-100" />
+
+        </p:panelGrid>
+        <p:panelGrid columns="2" layout="tabular" styleClass="w-100 m-1">
+
+            <p:outputLabel value="Bill Expenses" />
+            <p:outputLabel value="#{cc.attrs.bill.billFinanceDetails.billExpense}" styleClass="text-end w-100" />
+
+            <p:outputLabel value="Sum of Line Expenses" />
+            <p:outputLabel value="#{cc.attrs.bill.billFinanceDetails.lineExpense}" styleClass="text-end w-100" />
+
+            <p:outputLabel value="Total Expense" />
+            <p:outputLabel value="#{cc.attrs.bill.billFinanceDetails.totalExpense}" styleClass="text-end w-100" />
+
+            <p:outputLabel value="Free Item Value" />
+            <p:outputLabel value="#{cc.attrs.bill.billFinanceDetails.totalOfFreeItemValues}" styleClass="text-end w-100" />
+
+        </p:panelGrid>
+        <p:panelGrid columns="2" layout="tabular" styleClass="w-100 m-1">
+
+            <p:outputLabel value="Bill Tax" />
+            <p:outputLabel value="#{cc.attrs.bill.billFinanceDetails.billTaxValue}" styleClass="text-end w-100" />
+
+            <p:outputLabel value="Sum of Line Taxes" />
+            <p:outputLabel value="#{cc.attrs.bill.billFinanceDetails.itemTaxValue}" styleClass="text-end w-100" />
+
+            <p:outputLabel value="Total Tax" />
+            <p:outputLabel value="#{cc.attrs.bill.billFinanceDetails.totalTaxValue}" styleClass="text-end w-100" />
+
+        </p:panelGrid>
+        <p:panelGrid columns="2" layout="tabular" styleClass="w-100 m-1">
+
+            <p:outputLabel value="Sum of Line Purchase Values" />
+            <p:outputLabel value="#{cc.attrs.bill.billFinanceDetails.totalPurchaseValue}" styleClass="text-end w-100" />
+
+            <p:outputLabel value="Net Total" />
+            <p:outputLabel value="#{cc.attrs.bill.billFinanceDetails.netTotal}" styleClass="text-end w-100" />
+
+            <p:outputLabel value="Total Cost" />
+            <p:outputLabel value="#{cc.attrs.bill.billFinanceDetails.totalCostValue}" styleClass="text-end w-100" />
+
+            <p:outputLabel value="Total Retail Sale Value" />
+            <p:outputLabel value="#{cc.attrs.bill.billFinanceDetails.totalRetailSaleValue}" styleClass="text-end w-100" />
+
+        </p:panelGrid>
+
+
+    </cc:implementation>
+</html>


### PR DESCRIPTION
**✅ PR Comment – Close Request: Pharmacy Direct Purchase – Final Bill-Level Calculations & Display**

This PR finalises the calculation and assignment of **bill-level financial values** in the Pharmacy Direct Purchase module, with the following key clarifications:

---

### 🧮 **Core Logic Implemented in `calculateBillTotalsFromItems()`**

This method computes **aggregate totals** based on the bill items, but does **not** modify or derive **user-entered bill-level fields** such as `billDiscount`, `billTax`, `billExpense`, or `billCost`. These are retained if already assigned, ensuring user control is respected.

### 🔢 **Key Financial Calculations**

* **Line-level aggregates:**

  * `lineDiscount`, `lineExpense`, `lineTax`, `lineCost` are calculated from item finance details.
* **Totals including bill-level values:**

  * `totalDiscount`, `totalExpense`, `totalCostValue`, `totalTaxValue` are computed by summing both bill-level (if any) and item-level contributions.
* **Quantities and rates:**

  * All quantities (`totalQty`, `freeQty`, `atomic units`) and financials like `totalRetailSaleValue`, `totalWholesaleValue` are accurately calculated from each item's finance detail (`BillItemFinanceDetails`).

### 📦 **Support for AMP/AMPP**

The method conditionally handles `Amp` and `Ampp` items to correctly assign quantities and rates:

```java
if (bi.getItem() instanceof Ampp) {
    bi.setQty(pbi.getQtyPacks());
    bi.setRate(pbi.getPurchaseRatePack());
}
```

### 📈 **Assigned Values to `BillFinanceDetails`**

All derived values are assigned to the associated `BillFinanceDetails`:

* Financial summaries: `totalDiscount`, `totalTaxValue`, etc.
* Quantity summaries: `totalQuantity`, `totalFreeQuantity`, etc.
* Value summaries: `grossTotal`, `netTotal`, `lineGrossTotal`, `lineNetTotal`.

---

### 🖥️ **UI Binding Compatibility**

All values are accessible via:

```xhtml
#{pharmacyDirectPurchaseController.bill.billFinanceDetails.[property]}
```

and now correctly support display in **Rates**, **Values**, and **Quantity** tabs without UI misalignment.

---

### 🛠️ Remaining Tasks (Out of Scope Here)

* Bill item recalculations are managed in a separate method and are not part of this logic.
* Future enhancements: show derived totals dynamically in the UI without refresh (optional).

---

**🔒 Closing this PR. The logic is working and values are now displayed correctly as expected.**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a reusable financial summary component for bills, providing a detailed breakdown of discounts, expenses, taxes, and purchase/sale values.
	- Added a new cost rate field to item batches for improved financial tracking.

- **Improvements**
	- Enhanced retail sale rate calculations and display to use per-unit values throughout the direct purchase interface.
	- Streamlined and restyled the bill summary and financial summary tabs for better usability and clarity.
	- Improved item batch handling to support costing management and more accurate batch matching.

- **Bug Fixes**
	- Ensured unit-per-pack and quantity calculations are consistently updated during direct purchase billing.

- **Chores**
	- Updated success messages and cleaned up redundant or commented-out code for improved maintainability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->