### PR TITLE
12649 last purchase tracking for ampp not preserved itembatch needs last purchase billitem for ampp

### DIFF
--- a/src/main/java/com/divudi/bean/pharmacy/PharmacyDirectPurchaseController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacyDirectPurchaseController.java
@@ -556,8 +556,16 @@ public class PharmacyDirectPurchaseController implements Serializable {
             return;
         }
         Item item = getCurrentBillItem().getItem();
+        BillItem lastPurchasedBillItem = getPharmacyBean().getLastPurchaseItem(getCurrentBillItem().getItem(), getSessionController().getDepartment());
+        
+        //this is the old way of getting last prices. have to remove them
         double pr = getPharmacyBean().getLastPurchaseRate(getCurrentBillItem().getItem(), getSessionController().getDepartment());
         double rr = getPharmacyBean().getLastRetailRate(getCurrentBillItem().getItem(), getSessionController().getDepartment());
+        
+        
+        pr = lastPurchasedBillItem.getBillItemFinanceDetails().getLineGrossRate().doubleValue();
+        rr = lastPurchasedBillItem.getBillItemFinanceDetails().getRetailSaleRatePerUnit().doubleValue();
+        
         // Keep these for backword compatibility - Start
         getCurrentBillItem().getPharmaceuticalBillItem().setPurchaseRate(pr);
         getCurrentBillItem().getPharmaceuticalBillItem().setRetailRate(rr);

--- a/src/main/java/com/divudi/bean/pharmacy/PharmacyDirectPurchaseController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacyDirectPurchaseController.java
@@ -567,6 +567,7 @@ public class PharmacyDirectPurchaseController implements Serializable {
         if (lastPurchasedBillItem != null && lastPurchasedBillItem.getBillItemFinanceDetails() != null) {
             pr = lastPurchasedBillItem.getBillItemFinanceDetails().getLineGrossRate().doubleValue();
             rr = lastPurchasedBillItem.getBillItemFinanceDetails().getRetailSaleRatePerUnit().doubleValue();
+
         }
 
         // Fallback to old methods if pr or rr is 0.0
@@ -580,14 +581,13 @@ public class PharmacyDirectPurchaseController implements Serializable {
         getCurrentBillItem().getPharmaceuticalBillItem().setRetailRate(rr);
         // Keep these for backward compatibility - End
 
+        getCurrentBillItem().getBillItemFinanceDetails().setLineGrossRate(BigDecimal.valueOf(pr));
+        getCurrentBillItem().getBillItemFinanceDetails().setRetailSaleRatePerUnit(BigDecimal.valueOf(rr));
+
         if (item instanceof Ampp) {
             getCurrentBillItem().getBillItemFinanceDetails().setUnitsPerPack(BigDecimal.valueOf(item.getDblValue()));
-            getCurrentBillItem().getBillItemFinanceDetails().setLineGrossRate(BigDecimal.valueOf(pr).multiply(getCurrentBillItem().getBillItemFinanceDetails().getUnitsPerPack()));
-            getCurrentBillItem().getBillItemFinanceDetails().setRetailSaleRatePerUnit(BigDecimal.valueOf(rr));
         } else {
             getCurrentBillItem().getBillItemFinanceDetails().setUnitsPerPack(BigDecimal.ONE);
-            getCurrentBillItem().getBillItemFinanceDetails().setLineGrossRate(BigDecimal.valueOf(pr));
-            getCurrentBillItem().getBillItemFinanceDetails().setRetailSaleRatePerUnit(BigDecimal.valueOf(rr));
         }
 
         recalculateFinancialsBeforeAddingBillItem(getCurrentBillItem().getBillItemFinanceDetails());

--- a/src/main/java/com/divudi/bean/pharmacy/PharmacyDirectPurchaseController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacyDirectPurchaseController.java
@@ -565,9 +565,11 @@ public class PharmacyDirectPurchaseController implements Serializable {
         BillItem lastPurchasedBillItem = getPharmacyBean().getLastPurchaseItem(item, dept);
 
         if (lastPurchasedBillItem != null && lastPurchasedBillItem.getBillItemFinanceDetails() != null) {
-            pr = lastPurchasedBillItem.getBillItemFinanceDetails().getLineGrossRate().doubleValue();
-            rr = lastPurchasedBillItem.getBillItemFinanceDetails().getRetailSaleRatePerUnit().doubleValue();
+            BigDecimal lineGrossRate = lastPurchasedBillItem.getBillItemFinanceDetails().getLineGrossRate();
+            BigDecimal retailRate = lastPurchasedBillItem.getBillItemFinanceDetails().getRetailSaleRatePerUnit();
 
+            pr = (lineGrossRate != null) ? lineGrossRate.doubleValue() : 0.0;
+            rr = (retailRate != null) ? retailRate.doubleValue() : 0.0;
         }
 
         // Fallback to old methods if pr or rr is 0.0

--- a/src/main/java/com/divudi/ejb/PharmacyBean.java
+++ b/src/main/java/com/divudi/ejb/PharmacyBean.java
@@ -1528,6 +1528,57 @@ public class PharmacyBean {
         this.VtmFacade = VtmFacade;
     }
 
+    public BillItem getLastPurchaseItem(Item item, Department dept) {
+        if (item == null || dept == null) {
+            return null;
+        }
+
+        Map<String, Object> params = new HashMap<>();
+        String jpql = "SELECT bi "
+                + "FROM BillItem bi "
+                + "WHERE bi.retired = false "
+                + "AND bi.bill.cancelled = false "
+                + "AND bi.item = :i "
+                + "AND bi.bill.department = :d "
+                + "AND (bi.bill.billType = :t OR bi.bill.billType = :t1) "
+                + "ORDER BY bi.id DESC";
+
+        params.put("i", item);
+        params.put("d", dept);
+        params.put("t", BillType.PharmacyGrnBill);
+        params.put("t1", BillType.PharmacyPurchaseBill);
+
+        BillItem bi = getBillItemFacade().findFirstByJpql(jpql, params);
+
+        // If not found, fallback to search without department
+        if (bi == null) {
+            bi = getLastPurchaseItem(item); // call overload
+        }
+
+        return bi;
+    }
+
+    public BillItem getLastPurchaseItem(Item item) {
+        if (item == null) {
+            return null;
+        }
+
+        Map<String, Object> params = new HashMap<>();
+        String jpql = "SELECT bi "
+                + "FROM BillItem bi "
+                + "WHERE bi.retired = false "
+                + "AND bi.bill.cancelled = false "
+                + "AND bi.item = :i "
+                + "AND (bi.bill.billType = :t OR bi.bill.billType = :t1) "
+                + "ORDER BY bi.id DESC";
+
+        params.put("i", item);
+        params.put("t", BillType.PharmacyGrnBill);
+        params.put("t1", BillType.PharmacyPurchaseBill);
+
+        return getBillItemFacade().findFirstByJpql(jpql, params);
+    }
+
     public double getLastPurchaseRate(Item item, Department dept) {
         if (item instanceof Ampp) {
             item = ((Ampp) item).getAmp();

--- a/src/main/resources/META-INF/persistence.xml
+++ b/src/main/resources/META-INF/persistence.xml
@@ -2,17 +2,19 @@
 <persistence version="2.2" xmlns="http://java.sun.com/xml/ns/persistence" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/persistence http://xmlns.jcp.org/xml/ns/persistence/persistence_2_2.xsd">
     <persistence-unit name="hmisPU" transaction-type="JTA">
         <provider>org.eclipse.persistence.jpa.PersistenceProvider</provider>
-        <jta-data-source>${JDBC_DATASOURCE}</jta-data-source>
+        <jta-data-source>jdbc/sl</jta-data-source>
         <exclude-unlisted-classes>false</exclude-unlisted-classes>
         <properties>
             <property name="eclipselink.logging.level.sql" value="SEVERE"/>
+            <property name="eclipselink.logging.level" value="SEVERE"/>
         </properties>
     </persistence-unit>
     <persistence-unit name="hmisAuditPU" transaction-type="JTA">
-        <jta-data-source>${JDBC_AUDIT_DATASOURCE}</jta-data-source>
+        <jta-data-source>jdbc/ruhunuAudit</jta-data-source>
         <exclude-unlisted-classes>false</exclude-unlisted-classes>
         <properties>
             <property name="eclipselink.logging.level.sql" value="SEVERE"/>
+            <property name="eclipselink.logging.level" value="SEVERE"/>
         </properties>
     </persistence-unit>
 </persistence>

--- a/src/main/resources/META-INF/persistence.xml
+++ b/src/main/resources/META-INF/persistence.xml
@@ -2,19 +2,17 @@
 <persistence version="2.2" xmlns="http://java.sun.com/xml/ns/persistence" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/persistence http://xmlns.jcp.org/xml/ns/persistence/persistence_2_2.xsd">
     <persistence-unit name="hmisPU" transaction-type="JTA">
         <provider>org.eclipse.persistence.jpa.PersistenceProvider</provider>
-        <jta-data-source>jdbc/sl</jta-data-source>
+        <jta-data-source>${JDBC_DATASOURCE}</jta-data-source>
         <exclude-unlisted-classes>false</exclude-unlisted-classes>
         <properties>
             <property name="eclipselink.logging.level.sql" value="SEVERE"/>
-            <property name="eclipselink.logging.level" value="SEVERE"/>
         </properties>
     </persistence-unit>
     <persistence-unit name="hmisAuditPU" transaction-type="JTA">
-        <jta-data-source>jdbc/ruhunuAudit</jta-data-source>
+        <jta-data-source>${JDBC_AUDIT_DATASOURCE}</jta-data-source>
         <exclude-unlisted-classes>false</exclude-unlisted-classes>
         <properties>
             <property name="eclipselink.logging.level.sql" value="SEVERE"/>
-            <property name="eclipselink.logging.level" value="SEVERE"/>
         </properties>
     </persistence-unit>
 </persistence>


### PR DESCRIPTION
### ✅ Purpose of This PR

This PR addresses a critical gap in recording and retrieving **last purchase prices** when pharmaceutical items are purchased via **AMPPs (Actual Medicinal Product Packs)**. The initial design assumed purchases would always be at the AMP level. However, now that the system supports purchases via AMPPs, it became evident that the old `getLastPurchaseRate()` and `getLastRetailRate()` methods were insufficient.

---

### 🧭 Original Approach (Now Revised)

Previously, both of these methods were implemented as:

```java
public double getLastPurchaseRate(Item item, Department dept) {
    if (item instanceof Ampp) {
        item = ((Ampp) item).getAmp();
    }
    // Then fetch ItemBatch and read its purchase rate.
}
```

This worked **only for AMP-level transactions**, and effectively ignored the unique identity and pricing of the AMPP. When AMPPs were used in purchases, the system:

* Stored the item batch against AMP (`itemBatch.setItem(amp);`)
* Overwrote last purchase reference (`itemBatch.setLastPurchaseBillItem(...)`) at the AMP level
* Resulted in **missing or incorrect last purchase data for AMPPs**

---

### 🔁 New Approach Adopted

Instead of retrofitting the existing methods (`getLastPurchaseRate`, `getLastRetailRate`), we introduced a **direct and explicit method** to retrieve the full `BillItem` for the last purchase:

```java
public BillItem getLastPurchaseItem(Item item, Department dept);
```

This method:

* Preserves the exact `BillItem` (and `BillItemFinanceDetails`) used in the last purchase.
* Avoids ambiguity between AMP and AMPP.
* Enables fetching accurate purchase rate and retail rate:

  * `lineGrossRate()` (which may include cost/discount adjustments)
  * `retailSaleRatePerUnit()` (unit-based retail price)
* Can be called with or without a `Department` fallback.

The actual logic to set purchase rate and retail rate now lives in the `onItemSelect()` method, ensuring consistency when selecting either AMP or AMPP for direct purchase.

---

### 📌 Transitional Handling

In the `onItemSelect()` method:

* If a valid `BillItem` is found with non-zero rates, those are used.
* If rates are zero, it **falls back** to the old `getLastPurchaseRate()` and `getLastRetailRate()` for backward compatibility.
* The `PharmaceuticalBillItem.setPurchaseRate()` and `setRetailRate()` are still assigned for existing code paths to work without change.
* Eventually, these fallback lines will be marked for removal once production data is normalized and stable.

---

### 🔮 Future Implications

The revised `getLastPurchaseItem()` must be **used in all modules** where:

* Last purchase rate or retail rate is used
* Stock valuation, item cost comparisons, profit margin, or pricing logic depend on accurate past purchase records

This includes:

* **GRN workflows**
* **Item price auto-fill**
* **Stock reporting modules**
* **Any financial comparison tools relying on purchase history**

It is also recommended to replace direct `ItemBatch.getPurchaseRate()` and `.getRetailSaleRate()` calls with ones sourced from the last `BillItemFinanceDetails`, wherever AMPPs might be involved.

---

### ✅ Summary of Fix

* Fixed the issue where last purchase of AMPPs was not recorded distinctly.
* Introduced a reliable, extensible way to retrieve accurate last purchase values.
* Ensured compatibility with existing AMP-based workflows.
* Prepared the system for future AMPP-based features and modules like GRN.

---

**Labels:** `refactor`, `ampp`, `purchase`, `finance`, `stock`, `backward-compatible`

Closes #12649

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved retrieval of last purchase and retail rates for selected pharmacy items, enhancing rate accuracy during direct purchase operations.

- **Bug Fixes**
  - Ensured fallback mechanisms for rate retrieval if recent purchase data is unavailable, reducing potential errors in rate assignment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->