### PR TITLE
Closes #12612

### DIFF
--- a/src/main/java/com/divudi/bean/pharmacy/PharmacySimpleRetailSaleController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacySimpleRetailSaleController.java
@@ -110,7 +110,7 @@ import org.primefaces.event.TabChangeEvent;
  */
 @Named
 @SessionScoped
-@Deprecated
+@Deprecated // Simple Sale feature removed. Use PharmacyRetailSaleController for retail sales.
 public class PharmacySimpleRetailSaleController implements Serializable, ControllerWithPatient, ControllerWithMultiplePayments {
 
     // <editor-fold defaultstate="collapsed" desc="EJBs">

--- a/src/main/java/com/divudi/bean/pharmacy/PharmacySimpleRetailSaleController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacySimpleRetailSaleController.java
@@ -110,6 +110,7 @@ import org.primefaces.event.TabChangeEvent;
  */
 @Named
 @SessionScoped
+@Deprecated
 public class PharmacySimpleRetailSaleController implements Serializable, ControllerWithPatient, ControllerWithMultiplePayments {
 
     // <editor-fold defaultstate="collapsed" desc="EJBs">

--- a/src/main/java/com/divudi/core/entity/pharmacy/Stock.java
+++ b/src/main/java/com/divudi/core/entity/pharmacy/Stock.java
@@ -15,9 +15,7 @@ import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
-import javax.persistence.Index;
 import javax.persistence.ManyToOne;
-import javax.persistence.Table;
 import javax.persistence.Temporal;
 import javax.persistence.Transient;
 
@@ -26,30 +24,25 @@ import javax.persistence.Transient;
  * @author safrin
  */
 @Entity
-@Table(name = "stock",
-        indexes = {
-            @Index(name = "idx_dept_stock_itemname", columnList = "DEPARTMENT_ID, STOCK, ITEMNAME"),
-            @Index(name = "idx_dept_stock_code", columnList = "DEPARTMENT_ID, STOCK, CODE"),
-            @Index(name = "idx_dept_stock_barcode", columnList = "DEPARTMENT_ID, STOCK, BARCODE"),
-            @Index(name = "idx_dept_stock_longcode", columnList = "DEPARTMENT_ID, STOCK, LONGCODE")
-        }
-)
 public class Stock implements Serializable, RetirableEntity {
 
     private static final long serialVersionUID = 1L;
     @Id
     @GeneratedValue(strategy = GenerationType.AUTO)
     private Long id;
-    // ChatGPT contributed - 2025-05
+    @Deprecated // Use Item Batch > Item > barcode
     @Column(name = "ITEMNAME", length = 100)
     private String itemName;
 
+    @Deprecated // Use Item Batch > Item > barcode
     @Column(name = "BARCODE", length = 30)
     private String barcode;
 
+    @Deprecated // Use Item Batch > Item
     @Column(name = "LONGCODE")
     private Long longCode;
 
+    @Deprecated // Use Item Batch > DOE
     @Temporal(javax.persistence.TemporalType.DATE)
     private Date dateOfExpire;
 
@@ -67,6 +60,7 @@ public class Stock implements Serializable, RetirableEntity {
     String code;
     private Long startBarcode;
     private Long endBarcode;
+    @Deprecated // Use Item Stock > Retail Sale
     private double retailsaleRate;
 
     private boolean retired;
@@ -228,42 +222,52 @@ public class Stock implements Serializable, RetirableEntity {
         this.stockLocator = stockLocator;
     }
 
+    @Deprecated
     public String getItemName() {
         return itemName;
     }
 
+    @Deprecated
     public void setItemName(String itemName) {
         this.itemName = itemName;
     }
 
+    @Deprecated
     public String getBarcode() {
         return barcode;
     }
 
+    @Deprecated
     public void setBarcode(String barcode) {
         this.barcode = barcode;
     }
 
+    @Deprecated
     public Long getLongCode() {
         return longCode;
     }
 
+    @Deprecated
     public void setLongCode(Long longCode) {
         this.longCode = longCode;
     }
 
+    @Deprecated
     public Date getDateOfExpire() {
         return dateOfExpire;
     }
 
+    @Deprecated
     public void setDateOfExpire(Date dateOfExpire) {
         this.dateOfExpire = dateOfExpire;
     }
 
+    @Deprecated
     public double getRetailsaleRate() {
         return retailsaleRate;
     }
 
+    @Deprecated
     public void setRetailsaleRate(double retailsaleRate) {
         this.retailsaleRate = retailsaleRate;
     }

--- a/src/main/webapp/pharmacy/pharmacy_simple_retail_sale.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_simple_retail_sale.xhtml
@@ -5,983 +5,988 @@
       xmlns:h="http://xmlns.jcp.org/jsf/html"
       xmlns:p="http://primefaces.org/ui"
       xmlns:f="http://xmlns.jcp.org/jsf/core"
-      xmlns:bil="http://xmlns.jcp.org/jsf/composite/bill"
       xmlns:phi="http://xmlns.jcp.org/jsf/composite/pharmacy"
-      xmlns:pa="http://xmlns.jcp.org/jsf/composite/paymentMethod"
-      xmlns:pat="http://xmlns.jcp.org/jsf/composite/patient"
-      xmlns:common="http://xmlns.jcp.org/jsf/composite/ezcomp/common">
+      xmlns:pa="http://xmlns.jcp.org/jsf/composite/paymentMethod">
     <h:body>
         <ui:composition template="/resources/template/template.xhtml">
             <ui:define name="content">
-                <h:form id="bill" >
-                    <script>
-                        window.onload = function () {
-                            document.getElementById("acStock").focus();
-                        };
-                    </script>
-                    <p:growl id="panelError" />
-                    <p:defaultCommand  target="btnAdd" />
-                    <p:panel rendered="#{!pharmacySimpleRetailSaleController.billPreview}">
-                        <p:panel class="w-100">
-                            <f:facet name="header" >
-                                <h:outputText styleClass="fas fa-mortar-pestle" />
-                                <h:outputLabel value="Pharmacy Retail Bill (Sale 1)" class="mx-4"></h:outputLabel>
-                                <p:commandButton
-                                    accesskey="n"
-                                    icon="fa fa-plus"
-                                    value="New Bill"
-                                    style="float: right;"
-                                    ajax="false" 
-                                    class="mx-1 ui-button-warning"
-                                    action="#{pharmacySimpleRetailSaleController.navigateToPharmacySimpleRetailSale()}"  >
-                                </p:commandButton>
-                                <p:commandButton
-                                    ajax="false"
-                                    accesskey="s"
-                                    value="Settle"
-                                    icon="fa fa-check"
-                                    style="float: right;"
-                                    class="ui-button-success mx-1"
-                                    action="#{pharmacySimpleRetailSaleController.settleBillWithPay}" >
-                                </p:commandButton>
-                            </f:facet>
+                
+                <h:panelGroup rendered="true" >
+                    <h1> This page is not available. Please use Pharmacy > Retail Sale
+                </h:panelGroup>
 
-                            <div class="row">
-                                <div class="col-md-7" >
-                                    <p:panel>
-                                        <f:facet name="header" >
-                                            <h:outputText styleClass="fa-solid fa-circle-plus" />
-                                            <h:outputText value="Add New Items" class="mx-4"></h:outputText>
-                                        </f:facet>
-                                        <div class="row w-100 m-1 p-1 boder-1">
-                                            <div class="col-md-5">
-                                                <p:focus id="focusForAcIx" for="acStock" ></p:focus>
-                                                <p:outputLabel
-                                                    class="w-100"
-                                                    for="acStock">Medicines or Devices</p:outputLabel>
-                                                <h:panelGroup id="acStock" >
-                                                    <p:autoComplete
-                                                        accesskey="i"
-                                                        id="acStockWithoutTotalStock"
-                                                        inputStyleClass="w-100"
-                                                        minQueryLength="4"
-                                                        queryDelay="500"
-                                                        converter="stockLightConverter"
-                                                        maxResults="10"
+                <h:panelGroup rendered="false" >
+                    <h:form id="bill" >
+                        <script>
+                            window.onload = function () {
+                                document.getElementById("acStock").focus();
+                            };
+                        </script>
+                        <p:growl id="panelError" />
+                        <p:defaultCommand  target="btnAdd" />
+                        <p:panel rendered="#{!pharmacySimpleRetailSaleController.billPreview}">
+                            <p:panel class="w-100">
+                                <f:facet name="header" >
+                                    <h:outputText styleClass="fas fa-mortar-pestle" />
+                                    <h:outputLabel value="Pharmacy Retail Bill (Sale 1)" class="mx-4"></h:outputLabel>
+                                    <p:commandButton
+                                        accesskey="n"
+                                        icon="fa fa-plus"
+                                        value="New Bill"
+                                        style="float: right;"
+                                        ajax="false" 
+                                        class="mx-1 ui-button-warning"
+                                        action="#{pharmacySimpleRetailSaleController.navigateToPharmacySimpleRetailSale()}"  >
+                                    </p:commandButton>
+                                    <p:commandButton
+                                        ajax="false"
+                                        accesskey="s"
+                                        value="Settle"
+                                        icon="fa fa-check"
+                                        style="float: right;"
+                                        class="ui-button-success mx-1"
+                                        action="#{pharmacySimpleRetailSaleController.settleBillWithPay}" >
+                                    </p:commandButton>
+                                </f:facet>
+
+                                <div class="row">
+                                    <div class="col-md-7" >
+                                        <p:panel>
+                                            <f:facet name="header" >
+                                                <h:outputText styleClass="fa-solid fa-circle-plus" />
+                                                <h:outputText value="Add New Items" class="mx-4"></h:outputText>
+                                            </f:facet>
+                                            <div class="row w-100 m-1 p-1 boder-1">
+                                                <div class="col-md-5">
+                                                    <p:focus id="focusForAcIx" for="acStock" ></p:focus>
+                                                    <p:outputLabel
                                                         class="w-100"
-                                                        forceSelection="true"
-                                                        value="#{pharmacySimpleRetailSaleController.stockLight}"
-                                                        completeMethod="#{pharmacySimpleRetailSaleController.completeStockLights}"
-                                                        var="i"
-                                                        itemLabel="#{i.itemName}"
-                                                        itemValue="#{i}">
+                                                        for="acStock">Medicines or Devices</p:outputLabel>
+                                                    <h:panelGroup id="acStock" >
+                                                        <p:autoComplete
+                                                            accesskey="i"
+                                                            id="acStockWithoutTotalStock"
+                                                            inputStyleClass="w-100"
+                                                            minQueryLength="4"
+                                                            queryDelay="500"
+                                                            converter="stockLightConverter"
+                                                            maxResults="10"
+                                                            class="w-100"
+                                                            forceSelection="true"
+                                                            value="#{pharmacySimpleRetailSaleController.stockLight}"
+                                                            completeMethod="#{pharmacySimpleRetailSaleController.completeStockLights}"
+                                                            var="i"
+                                                            itemLabel="#{i.itemName}"
+                                                            itemValue="#{i}">
 
-                                                        <p:column headerText="Item" style="padding: 8px;">
-                                                            <h:outputText value="#{i.itemName}" />
-                                                            <p:tag rendered="#{commonFunctionsProxy.currentDateTime gt i.dateOfExpire or commonFunctionsProxy.dateAfterThreeMonthsCurrentDateTime gt i.dateOfExpire}"
-                                                                   value="#{commonFunctionsProxy.currentDateTime gt i.dateOfExpire ? 'Expired' : 'Expiring Soon'}"
-                                                                   severity="#{commonFunctionsProxy.currentDateTime gt i.dateOfExpire ? 'danger' : 'warning'}" />
-                                                        </p:column>
-                                                        <p:column headerText="Code" style="padding: 8px;">
-                                                            <h:outputText value="#{i.code}" />
-                                                        </p:column>
+                                                            <p:column headerText="Item" style="padding: 8px;">
+                                                                <h:outputText value="#{i.itemName}" />
+                                                                <p:tag rendered="#{commonFunctionsProxy.currentDateTime gt i.dateOfExpire or commonFunctionsProxy.dateAfterThreeMonthsCurrentDateTime gt i.dateOfExpire}"
+                                                                       value="#{commonFunctionsProxy.currentDateTime gt i.dateOfExpire ? 'Expired' : 'Expiring Soon'}"
+                                                                       severity="#{commonFunctionsProxy.currentDateTime gt i.dateOfExpire ? 'danger' : 'warning'}" />
+                                                            </p:column>
+                                                            <p:column headerText="Code" style="padding: 8px;">
+                                                                <h:outputText value="#{i.code}" />
+                                                            </p:column>
 
-                                                        <p:column headerText="Rate" style="padding: 8px;" styleClass="text-end">
-                                                            <h:outputLabel value="#{i.retailsaleRate}">
+                                                            <p:column headerText="Rate" style="padding: 8px;" styleClass="text-end">
+                                                                <h:outputLabel value="#{i.retailsaleRate}">
+                                                                    <f:convertNumber pattern="#,##0.00" />
+                                                                </h:outputLabel>
+                                                            </p:column>
+
+                                                            <p:column headerText="Stocks" style="padding: 8px;" styleClass="text-end">
+                                                                <h:outputLabel value="#{i.stockQty}">
+                                                                    <f:convertNumber pattern="#,###" />
+                                                                </h:outputLabel>
+                                                            </p:column>
+
+                                                            <p:column headerText="Expiry" style="padding: 8px;" class="w-100" styleClass="text-end">
+                                                                <h:outputLabel value="#{i.dateOfExpire}">
+                                                                    <f:convertDateTime pattern="#{sessionController.applicationPreference.shortDateFormat}" />
+                                                                </h:outputLabel>
+                                                            </p:column>
+
+                                                            <p:ajax event="itemSelect" listener="#{pharmacySimpleRetailSaleController.handleSelect}" update="txtQty txtRate focusQty" />
+                                                        </p:autoComplete>
+
+                                                    </h:panelGroup>
+
+
+                                                </div>
+                                                <div class="col-md-2">
+                                                    <p:outputLabel
+                                                        class="w-100"
+                                                        for="txtQty">Quantity</p:outputLabel>
+                                                    <p:inputText
+                                                        id="txtQty"
+                                                        accesskey="q"
+                                                        autocomplete="off"
+                                                        class="w-100"
+                                                        style="text-align: right;"
+                                                        value="#{pharmacySimpleRetailSaleController.intQty}">
+                                                        <p:ajax event="keyup" listener="#{pharmacySimpleRetailSaleController.calculateBillItemListner}" process="txtQty" update="txtRate txtVal"></p:ajax>
+                                                        <p:ajax event="blur" listener="#{pharmacySimpleRetailSaleController.calculateBillItemListner}" process="txtQty" update="txtRate txtVal"></p:ajax>
+                                                    </p:inputText>
+
+                                                </div>
+                                                <div class="col-md-5">
+                                                    <div class="row" >
+                                                        <div class="col-md-4">
+                                                            <p:outputLabel value="&nbsp;" class="w-100" ></p:outputLabel>
+                                                            <p:commandButton
+                                                                id="btnAdd"
+                                                                accesskey="a"
+                                                                icon="fa fa-plus"
+                                                                value="Add"
+                                                                styleClass="ui-button-success"
+                                                                action="#{pharmacySimpleRetailSaleController.addBillItem()}"
+                                                                process="@this"
+                                                                update=":#{p:resolveFirstComponentWithId('netTotal',view).clientId} :#{p:resolveFirstComponentWithId('dis',view).clientId} :#{p:resolveFirstComponentWithId('total',view).clientId} :#{p:resolveFirstComponentWithId('panelBillDetails',view).clientId} :#{p:resolveFirstComponentWithId('tblBillItem',view).clientId} txtRate txtQty acStock focusItem :#{p:resolveFirstComponentWithId('panelError',view).clientId}" >
+                                                            </p:commandButton>
+
+                                                        </div>
+                                                        <div class="col-md-4">
+                                                            <p:outputLabel class="w-100" for="txtRate">Rate</p:outputLabel>
+                                                            <p:inputText
+                                                                id="txtRate"
+                                                                style="text-align: right;"
+                                                                class="w-100"
+                                                                readonly="true"
+                                                                value="#{pharmacySimpleRetailSaleController.billItem.netRate}">
                                                                 <f:convertNumber pattern="#,##0.00" />
-                                                            </h:outputLabel>
-                                                        </p:column>
-
-                                                        <p:column headerText="Stocks" style="padding: 8px;" styleClass="text-end">
-                                                            <h:outputLabel value="#{i.stockQty}">
-                                                                <f:convertNumber pattern="#,###" />
-                                                            </h:outputLabel>
-                                                        </p:column>
-
-                                                        <p:column headerText="Expiry" style="padding: 8px;" class="w-100" styleClass="text-end">
-                                                            <h:outputLabel value="#{i.dateOfExpire}">
-                                                                <f:convertDateTime pattern="#{sessionController.applicationPreference.shortDateFormat}" />
-                                                            </h:outputLabel>
-                                                        </p:column>
-
-                                                        <p:ajax event="itemSelect" listener="#{pharmacySimpleRetailSaleController.handleSelect}" update="txtQty txtRate focusQty" />
-                                                    </p:autoComplete>
-
-                                                </h:panelGroup>
-
-
-                                            </div>
-                                            <div class="col-md-2">
-                                                <p:outputLabel
-                                                    class="w-100"
-                                                    for="txtQty">Quantity</p:outputLabel>
-                                                <p:inputText
-                                                    id="txtQty"
-                                                    accesskey="q"
-                                                    autocomplete="off"
-                                                    class="w-100"
-                                                    style="text-align: right;"
-                                                    value="#{pharmacySimpleRetailSaleController.intQty}">
-                                                    <p:ajax event="keyup" listener="#{pharmacySimpleRetailSaleController.calculateBillItemListner}" process="txtQty" update="txtRate txtVal"></p:ajax>
-                                                    <p:ajax event="blur" listener="#{pharmacySimpleRetailSaleController.calculateBillItemListner}" process="txtQty" update="txtRate txtVal"></p:ajax>
-                                                </p:inputText>
-
-                                            </div>
-                                            <div class="col-md-5">
-                                                <div class="row" >
-                                                    <div class="col-md-4">
-                                                        <p:outputLabel value="&nbsp;" class="w-100" ></p:outputLabel>
-                                                        <p:commandButton
-                                                            id="btnAdd"
-                                                            accesskey="a"
-                                                            icon="fa fa-plus"
-                                                            value="Add"
-                                                            styleClass="ui-button-success"
-                                                            action="#{pharmacySimpleRetailSaleController.addBillItem()}"
-                                                            process="@this"
-                                                            update=":#{p:resolveFirstComponentWithId('netTotal',view).clientId} :#{p:resolveFirstComponentWithId('dis',view).clientId} :#{p:resolveFirstComponentWithId('total',view).clientId} :#{p:resolveFirstComponentWithId('panelBillDetails',view).clientId} :#{p:resolveFirstComponentWithId('tblBillItem',view).clientId} txtRate txtQty acStock focusItem :#{p:resolveFirstComponentWithId('panelError',view).clientId}" >
-                                                        </p:commandButton>
-
-                                                    </div>
-                                                    <div class="col-md-4">
-                                                        <p:outputLabel class="w-100" for="txtRate">Rate</p:outputLabel>
-                                                        <p:inputText
-                                                            id="txtRate"
-                                                            style="text-align: right;"
-                                                            class="w-100"
-                                                            readonly="true"
-                                                            value="#{pharmacySimpleRetailSaleController.billItem.netRate}">
-                                                            <f:convertNumber pattern="#,##0.00" />
-                                                        </p:inputText>
-                                                    </div>
-                                                    <div class="col-md-4">
-                                                        <p:outputLabel
-                                                            class="w-100"
-                                                            value="Value"
-                                                            for="txtVal">
-                                                        </p:outputLabel>
-                                                        <p:inputText
-                                                            readonly="true"
-                                                            id="txtVal"
-                                                            class="w-100"
-                                                            style="text-align: right;"
-                                                            value="#{pharmacySimpleRetailSaleController.billItem.netValue}">
-                                                            <f:convertNumber pattern="#,##0.00" />
-                                                        </p:inputText>
+                                                            </p:inputText>
+                                                        </div>
+                                                        <div class="col-md-4">
+                                                            <p:outputLabel
+                                                                class="w-100"
+                                                                value="Value"
+                                                                for="txtVal">
+                                                            </p:outputLabel>
+                                                            <p:inputText
+                                                                readonly="true"
+                                                                id="txtVal"
+                                                                class="w-100"
+                                                                style="text-align: right;"
+                                                                value="#{pharmacySimpleRetailSaleController.billItem.netValue}">
+                                                                <f:convertNumber pattern="#,##0.00" />
+                                                            </p:inputText>
+                                                        </div>
                                                     </div>
                                                 </div>
                                             </div>
-                                        </div>
-                                        <p:focus id="focusQty" for="txtQty"></p:focus>
-                                        <p:focus id="focusItem" for="acStock"></p:focus>
-                                    </p:panel>
+                                            <p:focus id="focusQty" for="txtQty"></p:focus>
+                                            <p:focus id="focusItem" for="acStock"></p:focus>
+                                        </p:panel>
 
-                                    <p:panel id="pBis">
-                                        <f:facet name="header" >
-                                            <h:outputText styleClass="fas fa-money-bill" />
-                                            <h:outputLabel value="Bill Items" class="mx-4"></h:outputLabel>
-                                        </f:facet>
+                                        <p:panel id="pBis">
+                                            <f:facet name="header" >
+                                                <h:outputText styleClass="fas fa-money-bill" />
+                                                <h:outputLabel value="Bill Items" class="mx-4"></h:outputLabel>
+                                            </f:facet>
 
-                                        <p:dataTable id="tblBillItem" value="#{pharmacySimpleRetailSaleController.preBill.billItems}"
-                                                     var="bi" rowIndexVar="s" editable="true" sortBy="#{bi.searialNo}" class="w-100">
+                                            <p:dataTable id="tblBillItem" value="#{pharmacySimpleRetailSaleController.preBill.billItems}"
+                                                         var="bi" rowIndexVar="s" editable="true" sortBy="#{bi.searialNo}" class="w-100">
 
-                                            <p:ajax event="rowEdit" listener="#{pharmacySimpleRetailSaleController.onEdit}" update="@this gros :#{p:resolveFirstComponentWithId('panelBillDetails',view).clientId}" />
-                                            <p:ajax event="rowEditCancel" listener="#{pharmacySimpleRetailSaleController.onEdit}" update="@this gros :#{p:resolveFirstComponentWithId('panelBillDetails',view).clientId}" />
+                                                <p:ajax event="rowEdit" listener="#{pharmacySimpleRetailSaleController.onEdit}" update="@this gros :#{p:resolveFirstComponentWithId('panelBillDetails',view).clientId}" />
+                                                <p:ajax event="rowEditCancel" listener="#{pharmacySimpleRetailSaleController.onEdit}" update="@this gros :#{p:resolveFirstComponentWithId('panelBillDetails',view).clientId}" />
 
-                                            <p:column headerText="No" style="width: 2em; padding: 6px;">
-                                                <h:outputLabel value="#{s+1}" >
-                                                    <f:convertNumber pattern="#,##0" />
-                                                </h:outputLabel>
-                                            </p:column>
+                                                <p:column headerText="No" style="width: 2em; padding: 6px;">
+                                                    <h:outputLabel value="#{s+1}" >
+                                                        <f:convertNumber pattern="#,##0" />
+                                                    </h:outputLabel>
+                                                </p:column>
 
-                                            <p:column headerText="Item" style="padding: 6px;">
-                                                <h:outputLabel value="#{bi.pharmaceuticalBillItem.itemBatch.item.name}" />
-                                            </p:column>
+                                                <p:column headerText="Item" style="padding: 6px;">
+                                                    <h:outputLabel value="#{bi.pharmaceuticalBillItem.itemBatch.item.name}" />
+                                                </p:column>
 
-                                            <p:column headerText="Rate" style="width: 5em; padding: 6px;">
-                                                <h:outputLabel id="rate" value="#{bi.rate}" >
-                                                    <f:convertNumber pattern="#,##0.00" />
-                                                </h:outputLabel>
-                                            </p:column>
-                                            <p:column headerText="Value" style="width: 5em; padding: 6px;">
-                                                <h:outputLabel value="#{bi.grossValue}" id="gros">
-                                                    <f:convertNumber pattern="#,##0.00" />
-                                                </h:outputLabel>
-                                            </p:column>
-                                            <p:column headerText="Expiry" style="width: 7em; padding: 6px;">
-                                                <h:outputLabel value="#{bi.pharmaceuticalBillItem.itemBatch.dateOfExpire}" >
-                                                    <f:convertDateTime  timeZone="Asia/Colombo" pattern="#{sessionController.applicationPreference.shortDateFormat}"  ></f:convertDateTime>
-                                                </h:outputLabel>
+                                                <p:column headerText="Rate" style="width: 5em; padding: 6px;">
+                                                    <h:outputLabel id="rate" value="#{bi.rate}" >
+                                                        <f:convertNumber pattern="#,##0.00" />
+                                                    </h:outputLabel>
+                                                </p:column>
+                                                <p:column headerText="Value" style="width: 5em; padding: 6px;">
+                                                    <h:outputLabel value="#{bi.grossValue}" id="gros">
+                                                        <f:convertNumber pattern="#,##0.00" />
+                                                    </h:outputLabel>
+                                                </p:column>
+                                                <p:column headerText="Expiry" style="width: 7em; padding: 6px;">
+                                                    <h:outputLabel value="#{bi.pharmaceuticalBillItem.itemBatch.dateOfExpire}" >
+                                                        <f:convertDateTime  timeZone="Asia/Colombo" pattern="#{sessionController.applicationPreference.shortDateFormat}"  ></f:convertDateTime>
+                                                    </h:outputLabel>
 
-                                            </p:column>
-                                            <p:column headerText="Qty" style="width: 3em; padding: 6px;">
-                                                <p:cellEditor>
-                                                    <f:facet name="output">
-                                                        <h:outputText value="#{bi.qty}">
-                                                            <f:convertNumber integerOnly="true" pattern="#,##0"/>
-                                                        </h:outputText>
-                                                    </f:facet>
-                                                    <f:facet name="input">
-                                                        <p:inputText
-                                                            autocomplete="off"
-                                                            id="ipTblQty"
-                                                            value="#{bi.qty}"
-                                                            style="width:96%"
-                                                            converterMessage="Please enter a valid integer value.">
-                                                            <f:convertNumber integerOnly="true" pattern="#,##0"/>
-                                                        </p:inputText>
-                                                    </f:facet>
-                                                </p:cellEditor>
-                                            </p:column>
-
-
-                                            <p:column style="width: 10em; padding: 6px;">
-                                                <p:rowEditor style="display: inline-block; margin-right: 10px;"/>
-                                                <p:commandButton
-                                                    id="btnDelete"
-                                                    icon="fas fa-trash"
-                                                    action="#{pharmacySimpleRetailSaleController.removeBillItem(bi)}"
-                                                    class="ui-button-danger"
-                                                    process="btnDelete"
-                                                    update="tblBillItem :#{p:resolveFirstComponentWithId('panelBillDetails',view).clientId} :#{p:resolveFirstComponentWithId('panelPayment',view).clientId}"
-                                                    style="display: inline-block;">
-                                                </p:commandButton>
-                                            </p:column>
-
-
-                                        </p:dataTable>
-                                    </p:panel>
-                                </div>
-                                <div class="col-md-5"  >
-                                    <h:panelGrid id="sale" columns="1" class="alignTop w-100"  >
-                                        <p:panel id="panelPatient">
-                                            <p:growl id="msg"/>
-                                            <f:facet name="header">
-                                                <h:panelGroup layout="block" styleClass="d-flex justify-content-between align-items-center">
-                                                    <h:panelGroup id="headerFacet">
-                                                        <h:outputText value="Select a Patient" rendered="#{pharmacySimpleRetailSaleController.patient eq null}"></h:outputText>
-                                                        <h:outputText styleClass="fas fa-user" />
-                                                        <h:panelGroup
-                                                            rendered="#{patientController.quickSearchPatientList eq null or empty patientController.quickSearchPatientList}">
-                                                            <h:outputText
-                                                                rendered="#{pharmacySimpleRetailSaleController.patient.id eq null}"
-                                                                value="Patient"
-                                                                class="mx-4"
-                                                                >
+                                                </p:column>
+                                                <p:column headerText="Qty" style="width: 3em; padding: 6px;">
+                                                    <p:cellEditor>
+                                                        <f:facet name="output">
+                                                            <h:outputText value="#{bi.qty}">
+                                                                <f:convertNumber integerOnly="true" pattern="#,##0"/>
                                                             </h:outputText>
-                                                            <h:outputText
-                                                                rendered="#{pharmacySimpleRetailSaleController.patient.id ne null}"
-                                                                value="Searched Patient Details"
-                                                                class="mx-2"
-                                                                ></h:outputText>
-                                                            <h:panelGroup rendered="#{cc.attrs.editable}" id="edit" >
-                                                                <p:selectBooleanButton
-                                                                    value="#{pharmacySimpleRetailSaleController.patientDetailsEditable}"
-                                                                    offIcon="pi pi-pencil"
-                                                                    onIcon="pi pi-eye"
-                                                                    class="mx-2"
-                                                                    >
-                                                                    <p:ajax
-                                                                        process="@this"
-                                                                        update="viewPatient editPatient btnDone edit" />
-                                                                </p:selectBooleanButton>
-                                                                <p:commandButton id="btnDone" alt="Save Patient Details" class="ui-button-success" icon="fas fa-check" action="#{patientController.saveSelected(pharmacySimpleRetailSaleController.patient)}" rendered="#{pharmacySimpleRetailSaleController.patientDetailsEditable}" update=":#{p:resolveFirstComponentWithId('panelPatient',view).clientId} " />
-                                                            </h:panelGroup>
-
-                                                        </h:panelGroup>
-                                                    </h:panelGroup>
-                                                    <h:panelGroup id="quickSearch" >
-                                                        <h:panelGroup layout="block"  styleClass="form-inline">
+                                                        </f:facet>
+                                                        <f:facet name="input">
                                                             <p:inputText
                                                                 autocomplete="off"
-                                                                id="txtQuickSearchPhoneNumber"
-                                                                value="#{patientController.quickSearchPhoneNumber}"
-                                                                placeholder="Phone Number"
-                                                                class="form-control-sm mx-1"
-                                                                onfocus="this.select()"
-                                                                />
-                                                            <p:commandButton
-                                                                id="btnSearchbyPhoneNo"
-                                                                icon="fa fa-search"
-                                                                title="Quick Search from Phone Number"
-                                                                action="#{patientController.quickSearchPatientLongPhoneNumber(pharmacySimpleRetailSaleController)}"
-                                                                process="btnSearchbyPhoneNo txtQuickSearchPhoneNumber panelPayment"
-                                                                update="panelPatient selectPatient editPatient viewPatient panelPayment panelBillDetails"
-                                                                styleClass="btn-sm mx-1"/>
-                                                            <p:defaultCommand target="btnSearchbyPhoneNo"> </p:defaultCommand>
-                                                            <p:commandButton
-                                                                id="btnAddNewPatient"
-                                                                icon="fa fa-plus-circle"
-                                                                title="Add New Patient"
-                                                                action="#{patientController.quickSearchNewPatient(pharmacySimpleRetailSaleController)}"
-                                                                process="btnAddNewPatient"
-                                                                update="panelPatient selectPatient editPatient viewPatient panelPayment panelBillDetails"
-                                                                styleClass="btn-sm mx-1"/>
+                                                                id="ipTblQty"
+                                                                value="#{bi.qty}"
+                                                                style="width:96%"
+                                                                converterMessage="Please enter a valid integer value.">
+                                                                <f:convertNumber integerOnly="true" pattern="#,##0"/>
+                                                            </p:inputText>
+                                                        </f:facet>
+                                                    </p:cellEditor>
+                                                </p:column>
+
+
+                                                <p:column style="width: 10em; padding: 6px;">
+                                                    <p:rowEditor style="display: inline-block; margin-right: 10px;"/>
+                                                    <p:commandButton
+                                                        id="btnDelete"
+                                                        icon="fas fa-trash"
+                                                        action="#{pharmacySimpleRetailSaleController.removeBillItem(bi)}"
+                                                        class="ui-button-danger"
+                                                        process="btnDelete"
+                                                        update="tblBillItem :#{p:resolveFirstComponentWithId('panelBillDetails',view).clientId} :#{p:resolveFirstComponentWithId('panelPayment',view).clientId}"
+                                                        style="display: inline-block;">
+                                                    </p:commandButton>
+                                                </p:column>
+
+
+                                            </p:dataTable>
+                                        </p:panel>
+                                    </div>
+                                    <div class="col-md-5"  >
+                                        <h:panelGrid id="sale" columns="1" class="alignTop w-100"  >
+                                            <p:panel id="panelPatient">
+                                                <p:growl id="msg"/>
+                                                <f:facet name="header">
+                                                    <h:panelGroup layout="block" styleClass="d-flex justify-content-between align-items-center">
+                                                        <h:panelGroup id="headerFacet">
+                                                            <h:outputText value="Select a Patient" rendered="#{pharmacySimpleRetailSaleController.patient eq null}"></h:outputText>
+                                                            <h:outputText styleClass="fas fa-user" />
+                                                            <h:panelGroup
+                                                                rendered="#{patientController.quickSearchPatientList eq null or empty patientController.quickSearchPatientList}">
+                                                                <h:outputText
+                                                                    rendered="#{pharmacySimpleRetailSaleController.patient.id eq null}"
+                                                                    value="Patient"
+                                                                    class="mx-4"
+                                                                    >
+                                                                </h:outputText>
+                                                                <h:outputText
+                                                                    rendered="#{pharmacySimpleRetailSaleController.patient.id ne null}"
+                                                                    value="Searched Patient Details"
+                                                                    class="mx-2"
+                                                                    ></h:outputText>
+                                                                <h:panelGroup rendered="#{cc.attrs.editable}" id="edit" >
+                                                                    <p:selectBooleanButton
+                                                                        value="#{pharmacySimpleRetailSaleController.patientDetailsEditable}"
+                                                                        offIcon="pi pi-pencil"
+                                                                        onIcon="pi pi-eye"
+                                                                        class="mx-2"
+                                                                        >
+                                                                        <p:ajax
+                                                                            process="@this"
+                                                                            update="viewPatient editPatient btnDone edit" />
+                                                                    </p:selectBooleanButton>
+                                                                    <p:commandButton id="btnDone" alt="Save Patient Details" class="ui-button-success" icon="fas fa-check" action="#{patientController.saveSelected(pharmacySimpleRetailSaleController.patient)}" rendered="#{pharmacySimpleRetailSaleController.patientDetailsEditable}" update=":#{p:resolveFirstComponentWithId('panelPatient',view).clientId} " />
+                                                                </h:panelGroup>
+
+                                                            </h:panelGroup>
+                                                        </h:panelGroup>
+                                                        <h:panelGroup id="quickSearch" >
+                                                            <h:panelGroup layout="block"  styleClass="form-inline">
+                                                                <p:inputText
+                                                                    autocomplete="off"
+                                                                    id="txtQuickSearchPhoneNumber"
+                                                                    value="#{patientController.quickSearchPhoneNumber}"
+                                                                    placeholder="Phone Number"
+                                                                    class="form-control-sm mx-1"
+                                                                    onfocus="this.select()"
+                                                                    />
+                                                                <p:commandButton
+                                                                    id="btnSearchbyPhoneNo"
+                                                                    icon="fa fa-search"
+                                                                    title="Quick Search from Phone Number"
+                                                                    action="#{patientController.quickSearchPatientLongPhoneNumber(pharmacySimpleRetailSaleController)}"
+                                                                    process="btnSearchbyPhoneNo txtQuickSearchPhoneNumber panelPayment"
+                                                                    update="panelPatient selectPatient editPatient viewPatient panelPayment panelBillDetails"
+                                                                    styleClass="btn-sm mx-1"/>
+                                                                <p:defaultCommand target="btnSearchbyPhoneNo"> </p:defaultCommand>
+                                                                <p:commandButton
+                                                                    id="btnAddNewPatient"
+                                                                    icon="fa fa-plus-circle"
+                                                                    title="Add New Patient"
+                                                                    action="#{patientController.quickSearchNewPatient(pharmacySimpleRetailSaleController)}"
+                                                                    process="btnAddNewPatient"
+                                                                    update="panelPatient selectPatient editPatient viewPatient panelPayment panelBillDetails"
+                                                                    styleClass="btn-sm mx-1"/>
+                                                            </h:panelGroup>
                                                         </h:panelGroup>
                                                     </h:panelGroup>
+                                                </f:facet>
+                                                <h:panelGroup id="selectPatient" >
+                                                    <h:panelGroup rendered="#{patientController.quickSearchPatientList ne null and not empty patientController.quickSearchPatientList}">
+                                                        <p:dataTable id="tblPatients" value="#{patientController.quickSearchPatientList}" var="ps">
+                                                            <p:column headerText="Name">
+                                                                #{ps.person.name}
+                                                            </p:column>
+                                                            <p:column headerText="Phone Number">
+                                                                #{ps.person.phone}
+                                                            </p:column>
+                                                            <p:column headerText="Mobile Number">
+                                                                #{ps.person.mobile}
+                                                            </p:column>
+                                                            <p:column>
+                                                                <p:commandButton
+                                                                    action="#{patientController.selectQuickOneFromQuickSearchPatient(pharmacySimpleRetailSaleController)}"
+                                                                    id="btnSelectPt"
+                                                                    process="btnSelectPt panelPayment"
+                                                                    update=":#{p:resolveFirstComponentWithId('panelPatient',view).clientId} :#{p:resolveFirstComponentWithId('panelPayment',view).clientId} :#{p:resolveFirstComponentWithId('panelBillDetails',view).clientId}"
+                                                                    value="Select">
+                                                                    <f:setPropertyActionListener value="#{ps}" target="#{patientController.current}" />
+                                                                </p:commandButton>
+                                                            </p:column>
+                                                        </p:dataTable>
+                                                    </h:panelGroup>
                                                 </h:panelGroup>
-                                            </f:facet>
-                                            <h:panelGroup id="selectPatient" >
-                                                <h:panelGroup rendered="#{patientController.quickSearchPatientList ne null and not empty patientController.quickSearchPatientList}">
-                                                    <p:dataTable id="tblPatients" value="#{patientController.quickSearchPatientList}" var="ps">
-                                                        <p:column headerText="Name">
-                                                            #{ps.person.name}
-                                                        </p:column>
-                                                        <p:column headerText="Phone Number">
-                                                            #{ps.person.phone}
-                                                        </p:column>
-                                                        <p:column headerText="Mobile Number">
-                                                            #{ps.person.mobile}
-                                                        </p:column>
-                                                        <p:column>
-                                                            <p:commandButton
-                                                                action="#{patientController.selectQuickOneFromQuickSearchPatient(pharmacySimpleRetailSaleController)}"
-                                                                id="btnSelectPt"
-                                                                process="btnSelectPt panelPayment"
-                                                                update=":#{p:resolveFirstComponentWithId('panelPatient',view).clientId} :#{p:resolveFirstComponentWithId('panelPayment',view).clientId} :#{p:resolveFirstComponentWithId('panelBillDetails',view).clientId}"
-                                                                value="Select">
-                                                                <f:setPropertyActionListener value="#{ps}" target="#{patientController.current}" />
-                                                            </p:commandButton>
-                                                        </p:column>
-                                                    </p:dataTable>
-                                                </h:panelGroup>
-                                            </h:panelGroup>
-                                            <h:panelGroup id="editPatient" >
-                                                <h:panelGroup rendered="#{pharmacySimpleRetailSaleController.patientDetailsEditable}" >
-                                                    <h:panelGroup rendered="#{patientController.quickSearchPatientList eq null or empty patientController.quickSearchPatientList}">
-                                                        <h:panelGroup class="mb-1 w-100" id="panelPatientEdit" >
-                                                            <h:panelGroup id="gpPatient" >
-                                                                <div class="row">
-                                                                    <div class="col-md-3 p-1">
-                                                                        <p:selectOneMenu
-                                                                            id="cmbTitle"
-                                                                            class="form-control w-100"
-                                                                            value="#{pharmacySimpleRetailSaleController.patient.person.title}">
-                                                                            <f:selectItem itemLabel="Select Title" />
-                                                                            <f:selectItems value="#{opdBillController.title}" var="i"
-                                                                                           itemLabel="#{i.label}" itemValue="#{i}"/>
-                                                                            <p:ajax event="change" process="cmbTitle" update="cmbSex" ></p:ajax>
-                                                                        </p:selectOneMenu>
+                                                <h:panelGroup id="editPatient" >
+                                                    <h:panelGroup rendered="#{pharmacySimpleRetailSaleController.patientDetailsEditable}" >
+                                                        <h:panelGroup rendered="#{patientController.quickSearchPatientList eq null or empty patientController.quickSearchPatientList}">
+                                                            <h:panelGroup class="mb-1 w-100" id="panelPatientEdit" >
+                                                                <h:panelGroup id="gpPatient" >
+                                                                    <div class="row">
+                                                                        <div class="col-md-3 p-1">
+                                                                            <p:selectOneMenu
+                                                                                id="cmbTitle"
+                                                                                class="form-control w-100"
+                                                                                value="#{pharmacySimpleRetailSaleController.patient.person.title}">
+                                                                                <f:selectItem itemLabel="Select Title" />
+                                                                                <f:selectItems value="#{opdBillController.title}" var="i"
+                                                                                               itemLabel="#{i.label}" itemValue="#{i}"/>
+                                                                                <p:ajax event="change" process="cmbTitle" update="cmbSex" ></p:ajax>
+                                                                            </p:selectOneMenu>
+                                                                        </div>
+                                                                        <div class="col-md-9 p-1">
+                                                                            <p:inputText
+                                                                                autocomplete="off"
+                                                                                id="txtNewPtName"
+                                                                                placeholder="Enter the Name of the patient"
+                                                                                value="#{pharmacySimpleRetailSaleController.patient.person.name}"
+                                                                                validatorMessage="Please enter only letters and spaces."
+                                                                                class="form-control" >
+                                                                            </p:inputText>
+                                                                        </div>
                                                                     </div>
-                                                                    <div class="col-md-9 p-1">
-                                                                        <p:inputText
-                                                                            autocomplete="off"
-                                                                            id="txtNewPtName"
-                                                                            placeholder="Enter the Name of the patient"
-                                                                            value="#{pharmacySimpleRetailSaleController.patient.person.name}"
-                                                                            validatorMessage="Please enter only letters and spaces."
-                                                                            class="form-control" >
-                                                                        </p:inputText>
-                                                                    </div>
-                                                                </div>
 
-                                                                <div class="row">
-                                                                    <div class="col-md-3 p-1">
-                                                                        <p:selectOneMenu
-                                                                            id="cmbSex"
-                                                                            value="#{pharmacySimpleRetailSaleController.patient.person.sex}"
-                                                                            class="form-control w-100">
-                                                                            <f:selectItem itemLabel="Select Gender"/>
-                                                                            <f:selectItems value="#{opdBillController.sex}"/>
-                                                                        </p:selectOneMenu>
-                                                                    </div>
-                                                                    <div class="col-md-9 p-1">
-                                                                        <div class="row">
-                                                                            <div class="col-md-2">
-                                                                                <p:inputText
-                                                                                    autocomplete="off"
-                                                                                    id="year"
-                                                                                    placeholder="Years"
+                                                                    <div class="row">
+                                                                        <div class="col-md-3 p-1">
+                                                                            <p:selectOneMenu
+                                                                                id="cmbSex"
+                                                                                value="#{pharmacySimpleRetailSaleController.patient.person.sex}"
+                                                                                class="form-control w-100">
+                                                                                <f:selectItem itemLabel="Select Gender"/>
+                                                                                <f:selectItems value="#{opdBillController.sex}"/>
+                                                                            </p:selectOneMenu>
+                                                                        </div>
+                                                                        <div class="col-md-9 p-1">
+                                                                            <div class="row">
+                                                                                <div class="col-md-2">
+                                                                                    <p:inputText
+                                                                                        autocomplete="off"
+                                                                                        id="year"
+                                                                                        placeholder="Years"
 
-                                                                                    value="#{pharmacySimpleRetailSaleController.patient.person.ageYearsComponent}"
-                                                                                    class="form-control">
-                                                                                    <f:ajax event="keyup" execute="@this" render="dpDob" />
-                                                                                </p:inputText>
-                                                                            </div>
-                                                                            <div class="col-md-2">
-                                                                                <p:inputText
+                                                                                        value="#{pharmacySimpleRetailSaleController.patient.person.ageYearsComponent}"
+                                                                                        class="form-control">
+                                                                                        <f:ajax event="keyup" execute="@this" render="dpDob" />
+                                                                                    </p:inputText>
+                                                                                </div>
+                                                                                <div class="col-md-2">
+                                                                                    <p:inputText
 
-                                                                                    autocomplete="off" id="month" placeholder="Months"
-                                                                                    value="#{pharmacySimpleRetailSaleController.patient.person.ageMonthsComponent}"
-                                                                                    class="form-control">
-                                                                                    <f:ajax event="keyup" execute="@this"  render="dpDob"  />
-                                                                                </p:inputText>
-                                                                            </div>
-                                                                            <div class="col-md-2">
-                                                                                <p:inputText
+                                                                                        autocomplete="off" id="month" placeholder="Months"
+                                                                                        value="#{pharmacySimpleRetailSaleController.patient.person.ageMonthsComponent}"
+                                                                                        class="form-control">
+                                                                                        <f:ajax event="keyup" execute="@this"  render="dpDob"  />
+                                                                                    </p:inputText>
+                                                                                </div>
+                                                                                <div class="col-md-2">
+                                                                                    <p:inputText
 
-                                                                                    autocomplete="off" id="day" placeholder="Days"
-                                                                                    value="#{pharmacySimpleRetailSaleController.patient.person.ageDaysComponent}"
-                                                                                    class="form-control">
-                                                                                    <f:ajax event="keyup" execute="@this"  render="dpDob" />
-                                                                                </p:inputText>
-                                                                            </div>
-                                                                            <div class="col-md-6">
-                                                                                <p:datePicker
-                                                                                    value="#{pharmacySimpleRetailSaleController.patient.person.dob}"
-                                                                                    id="dpDob"
-                                                                                    class="w-100"
-                                                                                    yearNavigator="true"
-                                                                                    monthNavigator="true"
-                                                                                    inputStyleClass="form-control"
-                                                                                    pattern="#{sessionController.applicationPreference.longDateFormat}"
-                                                                                    placeholder="Date of Birth (dd/mm/yyyy)"
-                                                                                    >
-                                                                                    <p:ajax event="dateSelect" process="@this" update="year month day" />
-                                                                                </p:datePicker>
+                                                                                        autocomplete="off" id="day" placeholder="Days"
+                                                                                        value="#{pharmacySimpleRetailSaleController.patient.person.ageDaysComponent}"
+                                                                                        class="form-control">
+                                                                                        <f:ajax event="keyup" execute="@this"  render="dpDob" />
+                                                                                    </p:inputText>
+                                                                                </div>
+                                                                                <div class="col-md-6">
+                                                                                    <p:datePicker
+                                                                                        value="#{pharmacySimpleRetailSaleController.patient.person.dob}"
+                                                                                        id="dpDob"
+                                                                                        class="w-100"
+                                                                                        yearNavigator="true"
+                                                                                        monthNavigator="true"
+                                                                                        inputStyleClass="form-control"
+                                                                                        pattern="#{sessionController.applicationPreference.longDateFormat}"
+                                                                                        placeholder="Date of Birth (dd/mm/yyyy)"
+                                                                                        >
+                                                                                        <p:ajax event="dateSelect" process="@this" update="year month day" />
+                                                                                    </p:datePicker>
+                                                                                </div>
                                                                             </div>
                                                                         </div>
                                                                     </div>
-                                                                </div>
 
-                                                                <div class="row">
-                                                                    <div class="col-md-3 p-1">
-                                                                        <p:inputText
-                                                                            id="txtMobile"
-                                                                            autocomplete="off"
-                                                                            placeholder="Mobile Number"
-                                                                            value="#{pharmacySimpleRetailSaleController.patient.mobileNumberStringTransient}"
-                                                                            class="form-control"
-                                                                            validatorMessage="Please enter valid Number">
-                                                                        </p:inputText>
+                                                                    <div class="row">
+                                                                        <div class="col-md-3 p-1">
+                                                                            <p:inputText
+                                                                                id="txtMobile"
+                                                                                autocomplete="off"
+                                                                                placeholder="Mobile Number"
+                                                                                value="#{pharmacySimpleRetailSaleController.patient.mobileNumberStringTransient}"
+                                                                                class="form-control"
+                                                                                validatorMessage="Please enter valid Number">
+                                                                            </p:inputText>
+                                                                        </div>
+                                                                        <div class="col-md-3 p-1">
+                                                                            <p:inputText
+                                                                                id="txtPhone"
+                                                                                autocomplete="off"
+                                                                                placeholder="Phone Number"
+                                                                                value="#{pharmacySimpleRetailSaleController.patient.phoneNumberStringTransient}"
+                                                                                class="form-control" validatorMessage="Please enter valid Number">
+                                                                            </p:inputText>
+                                                                        </div>
+                                                                        <div class="col-md-3 p-1">
+                                                                            <p:inputText
+                                                                                autocomplete="off" id="txtEmail" placeholder="Enter Email here"
+                                                                                value="#{pharmacySimpleRetailSaleController.patient.person.email}"
+                                                                                class="form-control"
+                                                                                >
+                                                                            </p:inputText>
+                                                                        </div>
+                                                                        <div class="col-md-3 p-1">
+                                                                            <p:inputText
+                                                                                id="txtNic"
+                                                                                autocomplete="off"
+                                                                                placeholder="National ID Number"
+                                                                                value="#{pharmacySimpleRetailSaleController.patient.person.nic}"
+                                                                                class="form-control"/>
+                                                                        </div>
                                                                     </div>
-                                                                    <div class="col-md-3 p-1">
-                                                                        <p:inputText
-                                                                            id="txtPhone"
-                                                                            autocomplete="off"
-                                                                            placeholder="Phone Number"
-                                                                            value="#{pharmacySimpleRetailSaleController.patient.phoneNumberStringTransient}"
-                                                                            class="form-control" validatorMessage="Please enter valid Number">
-                                                                        </p:inputText>
-                                                                    </div>
-                                                                    <div class="col-md-3 p-1">
-                                                                        <p:inputText
-                                                                            autocomplete="off" id="txtEmail" placeholder="Enter Email here"
-                                                                            value="#{pharmacySimpleRetailSaleController.patient.person.email}"
-                                                                            class="form-control"
-                                                                            >
-                                                                        </p:inputText>
-                                                                    </div>
-                                                                    <div class="col-md-3 p-1">
-                                                                        <p:inputText
-                                                                            id="txtNic"
-                                                                            autocomplete="off"
-                                                                            placeholder="National ID Number"
-                                                                            value="#{pharmacySimpleRetailSaleController.patient.person.nic}"
-                                                                            class="form-control"/>
-                                                                    </div>
-                                                                </div>
 
-                                                                <div class="row">
-                                                                    <div class="col-md-8 p-1">
-                                                                        <p:inputText
-                                                                            id="txtAddress"
-                                                                            autocomplete="off"
-                                                                            placeholder="Address"
-                                                                            value="#{pharmacySimpleRetailSaleController.patient.person.address}"
-                                                                            class="form-control"/>
+                                                                    <div class="row">
+                                                                        <div class="col-md-8 p-1">
+                                                                            <p:inputText
+                                                                                id="txtAddress"
+                                                                                autocomplete="off"
+                                                                                placeholder="Address"
+                                                                                value="#{pharmacySimpleRetailSaleController.patient.person.address}"
+                                                                                class="form-control"/>
+                                                                        </div>
+                                                                        <div class="col-md-4 p-1">
+                                                                            <p:autoComplete
+                                                                                id="acNewPtArea"
+                                                                                placeholder="Search &amp; Select Area"
+                                                                                completeMethod="#{areaController.completeArea}"
+                                                                                var="pta" itemLabel="#{pta.name}"
+                                                                                itemValue="#{pta}" forceSelection="true"
+                                                                                value="#{pharmacySimpleRetailSaleController.patient.person.area}"
+                                                                                inputStyleClass="form-control"
+                                                                                class="w-100"/>
+                                                                        </div>
                                                                     </div>
-                                                                    <div class="col-md-4 p-1">
-                                                                        <p:autoComplete
-                                                                            id="acNewPtArea"
-                                                                            placeholder="Search &amp; Select Area"
-                                                                            completeMethod="#{areaController.completeArea}"
-                                                                            var="pta" itemLabel="#{pta.name}"
-                                                                            itemValue="#{pta}" forceSelection="true"
-                                                                            value="#{pharmacySimpleRetailSaleController.patient.person.area}"
-                                                                            inputStyleClass="form-control"
-                                                                            class="w-100"/>
-                                                                    </div>
-                                                                </div>
 
-                                                                <p:tooltip for="txtNewPtName" value="Patient Name"  showDelay="0" hideDelay="0"></p:tooltip>
-                                                                <p:tooltip for="txtNic" value="NIC / Passport No"  showDelay="0" hideDelay="0"></p:tooltip>
-                                                                <p:tooltip for="dpDob" value="Date Of Birth"  showDelay="0" hideDelay="0"></p:tooltip>
-                                                                <p:tooltip for="txtAddress" value="Address"  showDelay="0" hideDelay="0"></p:tooltip>
-                                                                <p:tooltip for="txtMobile" value="Mobile Number"  showDelay="0" hideDelay="0"></p:tooltip>
-                                                                <p:tooltip for="txtPhone" value="Home Phone Number"  showDelay="0" hideDelay="0"></p:tooltip>
-                                                                <p:tooltip for="cmbSex" value="Sex"  showDelay="0" hideDelay="0"></p:tooltip>
-                                                                <p:tooltip for="cmbTitle" value="Title"  showDelay="0" hideDelay="0"></p:tooltip>
-                                                                <p:tooltip for="acNewPtArea" value="Area"  showDelay="0" hideDelay="0"></p:tooltip>
-                                                                <p:tooltip for="txtEmail" value="Email"  showDelay="0" hideDelay="0"></p:tooltip>
+                                                                    <p:tooltip for="txtNewPtName" value="Patient Name"  showDelay="0" hideDelay="0"></p:tooltip>
+                                                                    <p:tooltip for="txtNic" value="NIC / Passport No"  showDelay="0" hideDelay="0"></p:tooltip>
+                                                                    <p:tooltip for="dpDob" value="Date Of Birth"  showDelay="0" hideDelay="0"></p:tooltip>
+                                                                    <p:tooltip for="txtAddress" value="Address"  showDelay="0" hideDelay="0"></p:tooltip>
+                                                                    <p:tooltip for="txtMobile" value="Mobile Number"  showDelay="0" hideDelay="0"></p:tooltip>
+                                                                    <p:tooltip for="txtPhone" value="Home Phone Number"  showDelay="0" hideDelay="0"></p:tooltip>
+                                                                    <p:tooltip for="cmbSex" value="Sex"  showDelay="0" hideDelay="0"></p:tooltip>
+                                                                    <p:tooltip for="cmbTitle" value="Title"  showDelay="0" hideDelay="0"></p:tooltip>
+                                                                    <p:tooltip for="acNewPtArea" value="Area"  showDelay="0" hideDelay="0"></p:tooltip>
+                                                                    <p:tooltip for="txtEmail" value="Email"  showDelay="0" hideDelay="0"></p:tooltip>
 
-                                                                <p:tooltip for="year" value="Age- Years Component"  showDelay="0" hideDelay="0"></p:tooltip>
-                                                                <p:tooltip for="month" value="Age- Month Component"  showDelay="0" hideDelay="0"></p:tooltip>
-                                                                <p:tooltip for="day" value="Age- Days Component"  showDelay="0" hideDelay="0"></p:tooltip>
+                                                                    <p:tooltip for="year" value="Age- Years Component"  showDelay="0" hideDelay="0"></p:tooltip>
+                                                                    <p:tooltip for="month" value="Age- Month Component"  showDelay="0" hideDelay="0"></p:tooltip>
+                                                                    <p:tooltip for="day" value="Age- Days Component"  showDelay="0" hideDelay="0"></p:tooltip>
 
 
+                                                                </h:panelGroup>
                                                             </h:panelGroup>
                                                         </h:panelGroup>
                                                     </h:panelGroup>
                                                 </h:panelGroup>
-                                            </h:panelGroup>
-                                            <h:panelGroup id="viewPatient" >
-                                                <h:panelGroup  rendered="#{not pharmacySimpleRetailSaleController.patientDetailsEditable}"  >
-                                                    <h:panelGroup  rendered="#{patientController.quickSearchPatientList eq null}" >
-                                                        <h:panelGrid columns="3" class="my-1" id="panelPatientDisplay" rendered="#{pharmacySimpleRetailSaleController.patient ne null}" >
-                                                            <h:outputLabel value="Name " class="mx-3"/>
-                                                            <h:outputLabel value=" : " class="mx-3"/>
-                                                            <h:outputText value="#{pharmacySimpleRetailSaleController.patient.person.nameWithTitle}" />
+                                                <h:panelGroup id="viewPatient" >
+                                                    <h:panelGroup  rendered="#{not pharmacySimpleRetailSaleController.patientDetailsEditable}"  >
+                                                        <h:panelGroup  rendered="#{patientController.quickSearchPatientList eq null}" >
+                                                            <h:panelGrid columns="3" class="my-1" id="panelPatientDisplay" rendered="#{pharmacySimpleRetailSaleController.patient ne null}" >
+                                                                <h:outputLabel value="Name " class="mx-3"/>
+                                                                <h:outputLabel value=" : " class="mx-3"/>
+                                                                <h:outputText value="#{pharmacySimpleRetailSaleController.patient.person.nameWithTitle}" />
 
-                                                            <h:outputLabel value="Gender " class="mx-3"/>
-                                                            <h:outputLabel value=" : " class="mx-3"/>
-                                                            <h:outputText value="#{pharmacySimpleRetailSaleController.patient.person.sex}" />
+                                                                <h:outputLabel value="Gender " class="mx-3"/>
+                                                                <h:outputLabel value=" : " class="mx-3"/>
+                                                                <h:outputText value="#{pharmacySimpleRetailSaleController.patient.person.sex}" />
 
-                                                            <h:outputLabel value="Date of Birth " class="mx-3"/>
-                                                            <h:outputLabel value=" : " class="mx-3"/>
-                                                            <h:outputText value="#{pharmacySimpleRetailSaleController.patient.person.dob}" >
-                                                                <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateFormat}" ></f:convertDateTime>
-                                                            </h:outputText>
+                                                                <h:outputLabel value="Date of Birth " class="mx-3"/>
+                                                                <h:outputLabel value=" : " class="mx-3"/>
+                                                                <h:outputText value="#{pharmacySimpleRetailSaleController.patient.person.dob}" >
+                                                                    <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateFormat}" ></f:convertDateTime>
+                                                                </h:outputText>
 
-                                                            <h:outputLabel value="Age  " class="mx-3"/>
-                                                            <h:outputLabel value=" : " class="mx-3"/>
-                                                            <h:outputText value="#{pharmacySimpleRetailSaleController.patient.person.ageAsString}" />
+                                                                <h:outputLabel value="Age  " class="mx-3"/>
+                                                                <h:outputLabel value=" : " class="mx-3"/>
+                                                                <h:outputText value="#{pharmacySimpleRetailSaleController.patient.person.ageAsString}" />
 
-                                                            <h:outputLabel value="Mobile No. " class="mx-3"/>
-                                                            <h:outputLabel value=" : " class="mx-3"/>
-                                                            <h:outputText value="#{pharmacySimpleRetailSaleController.patient.person.mobile}" />
+                                                                <h:outputLabel value="Mobile No. " class="mx-3"/>
+                                                                <h:outputLabel value=" : " class="mx-3"/>
+                                                                <h:outputText value="#{pharmacySimpleRetailSaleController.patient.person.mobile}" />
 
-                                                            <h:outputLabel value="Phone No. " class="mx-3"/>
-                                                            <h:outputLabel value=" : " class="mx-3"/>
-                                                            <h:outputText value="#{pharmacySimpleRetailSaleController.patient.person.phone}" />
+                                                                <h:outputLabel value="Phone No. " class="mx-3"/>
+                                                                <h:outputLabel value=" : " class="mx-3"/>
+                                                                <h:outputText value="#{pharmacySimpleRetailSaleController.patient.person.phone}" />
 
-                                                            <h:outputLabel value="Email " class="mx-3"/>
-                                                            <h:outputLabel value=" : " class="mx-3"/>
-                                                            <h:outputText value="#{pharmacySimpleRetailSaleController.patient.person.email}" />
+                                                                <h:outputLabel value="Email " class="mx-3"/>
+                                                                <h:outputLabel value=" : " class="mx-3"/>
+                                                                <h:outputText value="#{pharmacySimpleRetailSaleController.patient.person.email}" />
 
-                                                            <h:outputLabel value="National ID No. " class="mx-3"/>
-                                                            <h:outputLabel value=" : " class="mx-3"/>
-                                                            <h:outputText value="#{pharmacySimpleRetailSaleController.patient.person.nic}" />
+                                                                <h:outputLabel value="National ID No. " class="mx-3"/>
+                                                                <h:outputLabel value=" : " class="mx-3"/>
+                                                                <h:outputText value="#{pharmacySimpleRetailSaleController.patient.person.nic}" />
 
-                                                            <h:outputLabel value="Address " class="mx-3"/>
-                                                            <h:outputLabel value=" : " class="mx-3"/>
-                                                            <h:outputText value="#{pharmacySimpleRetailSaleController.patient.person.address}" />
+                                                                <h:outputLabel value="Address " class="mx-3"/>
+                                                                <h:outputLabel value=" : " class="mx-3"/>
+                                                                <h:outputText value="#{pharmacySimpleRetailSaleController.patient.person.address}" />
 
-                                                            <h:outputLabel value="Area " class="mx-3"/>
-                                                            <h:outputLabel value=" : " class="mx-3"/>
-                                                            <h:outputText value="#{pharmacySimpleRetailSaleController.patient.person.area.name}" />
+                                                                <h:outputLabel value="Area " class="mx-3"/>
+                                                                <h:outputLabel value=" : " class="mx-3"/>
+                                                                <h:outputText value="#{pharmacySimpleRetailSaleController.patient.person.area.name}" />
 
-                                                        </h:panelGrid>
+                                                            </h:panelGrid>
+                                                        </h:panelGroup>
                                                     </h:panelGroup>
                                                 </h:panelGroup>
-                                            </h:panelGroup>
-                                        </p:panel>
-                                        <div class="row">
-                                            <div class="col">
-                                                <p:panel id="panelPayment"  class="w-100">
-                                                    <f:facet name="header" >
-                                                        <h:outputText styleClass="fas fa-money-bill-wave" />
-                                                        <h:outputLabel value="Payment Details" class="mx-4"></h:outputLabel>
-                                                    </f:facet>
-                                                    <div class="row" >
-                                                        <div class="col-md-5" >
-                                                            <p:selectOneMenu   id="pay"
-                                                                               value="#{pharmacySimpleRetailSaleController.paymentMethod}">
-                                                                <f:selectItems value="#{enumController.paymentMethodsForPharmacyBilling}" var="p" itemLabel="#{p.label}"
-                                                                               itemValue="#{p}"/>
-                                                                <p:ajax process="@this cmbPs cmbPaymentScheme"
-                                                                        update="panelBillDetails panelPaymentDetails"
-                                                                        event="change"
-                                                                        listener="#{pharmacySimpleRetailSaleController.listnerForPaymentMethodChange()}"/>
-                                                            </p:selectOneMenu>
+                                            </p:panel>
+                                            <div class="row">
+                                                <div class="col">
+                                                    <p:panel id="panelPayment"  class="w-100">
+                                                        <f:facet name="header" >
+                                                            <h:outputText styleClass="fas fa-money-bill-wave" />
+                                                            <h:outputLabel value="Payment Details" class="mx-4"></h:outputLabel>
+                                                        </f:facet>
+                                                        <div class="row" >
+                                                            <div class="col-md-5" >
+                                                                <p:selectOneMenu   id="pay"
+                                                                                   value="#{pharmacySimpleRetailSaleController.paymentMethod}">
+                                                                    <f:selectItems value="#{enumController.paymentMethodsForPharmacyBilling}" var="p" itemLabel="#{p.label}"
+                                                                                   itemValue="#{p}"/>
+                                                                    <p:ajax process="@this cmbPs cmbPaymentScheme"
+                                                                            update="panelBillDetails panelPaymentDetails"
+                                                                            event="change"
+                                                                            listener="#{pharmacySimpleRetailSaleController.listnerForPaymentMethodChange()}"/>
+                                                                </p:selectOneMenu>
 
-                                                            <p:selectOneMenu   id="cmbPaymentScheme" value="#{pharmacySimpleRetailSaleController.paymentScheme}" rendered="#{sessionController.loggedPreference.checkPaymentSchemeValidation eq true}">
-                                                                <f:selectItems value="#{paymentSchemeController.items}" var="i" itemLabel="#{i.name}" itemValue="#{i}"/>
+                                                                <p:selectOneMenu   id="cmbPaymentScheme" value="#{pharmacySimpleRetailSaleController.paymentScheme}" rendered="#{sessionController.loggedPreference.checkPaymentSchemeValidation eq true}">
+                                                                    <f:selectItems value="#{paymentSchemeController.items}" var="i" itemLabel="#{i.name}" itemValue="#{i}"/>
+                                                                    <p:ajax process="@this pay "
+                                                                            update="panelBillDetails panelPaymentDetails"
+                                                                            event="change"
+                                                                            listener="#{pharmacySimpleRetailSaleController.listnerForPaymentMethodChange()}"/>
+                                                                </p:selectOneMenu>
+                                                            </div>
+                                                        </div>
+                                                        <div class="row" >
+                                                            <div class="my-1">
+                                                                <h:panelGroup id="panelPaymentDetails" class="row">
+                                                                    <div class="col" >
+                                                                        <h:panelGroup
+                                                                            class="row"
+                                                                            layout="block"
+                                                                            rendered="#{pharmacySimpleRetailSaleController.paymentMethod eq 'Credit'}" >
+                                                                            <div class="my-1" id="credit">
+                                                                                <div class="row">
+                                                                                    <div class="col-12 d-flex ">
+                                                                                        <p:autoComplete
+                                                                                            id="creditCompany"
+                                                                                            class="w-100 -mx-2"
+                                                                                            inputStyleClass="form-control"
+                                                                                            forceSelection="true"
+                                                                                            value="#{pharmacySimpleRetailSaleController.toInstitution}"
+                                                                                            completeMethod="#{institutionController.completeCreditCompany}"
+                                                                                            var="ix"
+                                                                                            minQueryLength="2"
+                                                                                            placeholder="Company (Type at least 4 letters to search)"
+                                                                                            itemLabel="#{ix.name}"
+                                                                                            itemValue="#{ix}"
+                                                                                            size="10"  >
+
+                                                                                            <f:ajax
+                                                                                                event="itemSelect"
+                                                                                                listener="#{pharmacySimpleRetailSaleController.calTotal()}"
+                                                                                                execute="@this"
+                                                                                                render=":#{p:resolveFirstComponentWithId('panelBillDetails',view).clientId}"/>
+                                                                                        </p:autoComplete>
+                                                                                        <p:commandLink
+                                                                                            id="btnAddNewCreditCom"
+                                                                                            value="(+)"
+                                                                                            class="mx-3 mt-1"
+                                                                                            title="Add New Credit Company"
+                                                                                            ajax="false"
+                                                                                            action="#{navigationController.navigateToCreditCompany()}"
+                                                                                            actionListener="#{creditCompanyController.prepareAdd()}" />
+                                                                                    </div>
+                                                                                </div>
+                                                                            </div>
+                                                                        </h:panelGroup>
+                                                                        <h:panelGroup
+                                                                            class="row"
+                                                                            layout="block"
+                                                                            rendered="#{pharmacySimpleRetailSaleController.paymentMethod eq 'Staff'}" >
+                                                                            <div class="my-1" id="staffCredit">
+                                                                                <div class="row mt-1">
+                                                                                    <div class="col-12">
+                                                                                        <p:autoComplete
+                                                                                            minQueryLength="2"
+                                                                                            forceSelection="true"
+                                                                                            value="#{pharmacySimpleRetailSaleController.toStaff}"
+                                                                                            id="creditStaff"
+                                                                                            completeMethod="#{staffController.completeStaff}"
+                                                                                            var="mys"
+                                                                                            class="w-100"
+                                                                                            placeholder="Staff (Type at least 4 letters to search)"
+                                                                                            inputStyleClass="form-control"
+                                                                                            itemLabel="#{mys.person.name}"
+                                                                                            itemValue="#{mys}"
+                                                                                            size="10">
+                                                                                            <p:column headerText="Name" style="padding: 2px;">
+                                                                                                <h:outputText value="#{mys.person.nameWithTitle}" ></h:outputText>
+                                                                                            </p:column>
+                                                                                            <p:column headerText="EPF" style="padding: 2px;">
+                                                                                                <h:outputText value="#{mys.epfNo}" ></h:outputText>
+                                                                                            </p:column>
+                                                                                            <p:column headerText="Credit Entitlement" style="padding: 2px;">
+                                                                                                <h:outputText value="#{mys.creditLimitQualified}" >
+                                                                                                    <f:convertNumber pattern="#,##0.00" ></f:convertNumber>
+                                                                                                </h:outputText>
+                                                                                            </p:column>
+                                                                                            <p:column  headerText="Credit Utilized" style="padding: 2px;">
+                                                                                                <h:outputText value="#{mys.currentCreditValue}" >
+                                                                                                    <f:convertNumber pattern="#,##0.00" ></f:convertNumber>
+                                                                                                </h:outputText>
+                                                                                            </p:column>
+                                                                                            <p:ajax process="@this"
+                                                                                                    update=":#{p:resolveFirstComponentWithId('panelBillDetails',view).clientId}"
+                                                                                                    event="itemSelect"
+                                                                                                    listener="#{pharmacySimpleRetailSaleController.calTotal()}" />
+                                                                                        </p:autoComplete>
+                                                                                    </div>
+                                                                                </div>
+                                                                            </div>
+                                                                        </h:panelGroup>
+                                                                        <h:panelGroup
+                                                                            class="row"
+                                                                            layout="block"
+                                                                            rendered="#{pharmacySimpleRetailSaleController.paymentMethod eq 'Staff_Welfare'}" >
+                                                                            <div class="my-1" id="credit">
+                                                                                <div class="row mt-1">
+                                                                                    <div class="col-12">
+                                                                                        <p:autoComplete
+                                                                                            minQueryLength="3"
+                                                                                            forceSelection="true"
+                                                                                            value="#{pharmacySimpleRetailSaleController.toStaff}"
+                                                                                            id="welfareStaff"
+                                                                                            completeMethod="#{staffController.completeStaff}"
+                                                                                            var="mys"
+                                                                                            class="w-100"
+                                                                                            placeholder="Staff (Type at least 4 letters to search)"
+                                                                                            inputStyleClass="form-control"
+                                                                                            itemLabel="#{mys.person.name}"
+                                                                                            itemValue="#{mys}"
+                                                                                            size="10">
+                                                                                            <p:column headerText="Name" style="padding: 2px;">
+                                                                                                <h:outputText value="#{mys.person.nameWithTitle}" ></h:outputText>
+                                                                                            </p:column>
+                                                                                            <p:column headerText="EPF" style="padding: 2px;">
+                                                                                                <h:outputText value="#{mys.epfNo}" ></h:outputText>
+                                                                                            </p:column>
+                                                                                            <p:column headerText="Welfare Entitlement" style="padding: 2px;">
+                                                                                                <h:outputText value="#{mys.annualWelfareQualified}" >
+                                                                                                    <f:convertNumber pattern="#,##0.00" ></f:convertNumber>
+                                                                                                </h:outputText>
+                                                                                            </p:column>
+                                                                                            <p:column  headerText="Welfare Utilized" style="padding: 2px;">
+                                                                                                <h:outputText value="#{mys.annualWelfareUtilized}" >
+                                                                                                    <f:convertNumber pattern="#,##0.00" ></f:convertNumber>
+                                                                                                </h:outputText>
+                                                                                            </p:column>
+                                                                                            <p:ajax process="@this"
+                                                                                                    update=":#{p:resolveFirstComponentWithId('panelBillDetails',view).clientId}"
+                                                                                                    event="itemSelect"
+                                                                                                    listener="#{pharmacySimpleRetailSaleController.calTotal()}" />
+                                                                                        </p:autoComplete>
+                                                                                    </div>
+                                                                                </div>
+                                                                            </div>
+                                                                        </h:panelGroup>
+                                                                        <h:panelGroup id="creditCard" rendered="#{pharmacySimpleRetailSaleController.paymentMethod eq 'Card'}">
+                                                                            <pa:creditCard paymentMethodData="#{pharmacySimpleRetailSaleController.paymentMethodData}"/>
+                                                                        </h:panelGroup>
+
+                                                                        <h:panelGroup id="ptdeposit" rendered="#{pharmacySimpleRetailSaleController.paymentMethod eq 'PatientDeposit'}">
+                                                                            <pa:patient_deposit paymentMethodData="#{pharmacySimpleRetailSaleController.paymentMethodData}"/>
+                                                                        </h:panelGroup>
+
+                                                                        <h:panelGroup id="ewallet" rendered="#{pharmacySimpleRetailSaleController.paymentMethod eq 'ewallet'}" >
+                                                                            <pa:ewallet paymentMethodData="#{pharmacySimpleRetailSaleController.paymentMethodData}"/>
+                                                                        </h:panelGroup>
+
+
+                                                                        <h:panelGroup id="cheque" rendered="#{pharmacySimpleRetailSaleController.paymentMethod eq 'Cheque'}" >
+                                                                            <pa:cheque paymentMethodData="#{pharmacySimpleRetailSaleController.paymentMethodData}"/>
+                                                                        </h:panelGroup>
+
+                                                                        <h:panelGroup id="slip" rendered="#{pharmacySimpleRetailSaleController.paymentMethod eq 'Slip'}">
+                                                                            <pa:slip paymentMethodData="#{pharmacySimpleRetailSaleController.paymentMethodData}"/>
+                                                                        </h:panelGroup>
+
+
+                                                                        <h:panelGroup
+                                                                            class="row my-1 w-100"
+                                                                            layout="block"
+                                                                            id="multiplePaymentMethods"  rendered="#{pharmacySimpleRetailSaleController.paymentMethod eq 'MultiplePaymentMethods'}"
+                                                                            >
+                                                                            <pa:multiple_payment_methods class="w-100" controller="#{pharmacySimpleRetailSaleController}" paymentMethods="#{enumController.paymentMethodsForMultiplePaymentMethod}"/>
+
+                                                                        </h:panelGroup>
+
+                                                                    </div>
+
+                                                                </h:panelGroup>
+                                                            </div>
+                                                        </div>
+
+                                                        <div class="col-5">
+                                                            <p:selectOneMenu   id="cmbPs" value="#{pharmacySimpleRetailSaleController.paymentScheme}" rendered="#{sessionController.loggedPreference.checkPaymentSchemeValidation eq false}" class="my-1">
+                                                                <f:selectItem itemLabel="Discount Scheme"/>
+                                                                <f:selectItems value="#{paymentSchemeController.paymentSchemesForPharmacy}" var="i" itemLabel="#{i.name}" itemValue="#{i}"/>
                                                                 <p:ajax process="@this pay "
                                                                         update="panelBillDetails panelPaymentDetails"
                                                                         event="change"
                                                                         listener="#{pharmacySimpleRetailSaleController.listnerForPaymentMethodChange()}"/>
                                                             </p:selectOneMenu>
                                                         </div>
-                                                    </div>
-                                                    <div class="row" >
-                                                        <div class="my-1">
-                                                            <h:panelGroup id="panelPaymentDetails" class="row">
-                                                                <div class="col" >
-                                                                    <h:panelGroup
-                                                                        class="row"
-                                                                        layout="block"
-                                                                        rendered="#{pharmacySimpleRetailSaleController.paymentMethod eq 'Credit'}" >
-                                                                        <div class="my-1" id="credit">
-                                                                            <div class="row">
-                                                                                <div class="col-12 d-flex ">
-                                                                                    <p:autoComplete
-                                                                                        id="creditCompany"
-                                                                                        class="w-100 -mx-2"
-                                                                                        inputStyleClass="form-control"
-                                                                                        forceSelection="true"
-                                                                                        value="#{pharmacySimpleRetailSaleController.toInstitution}"
-                                                                                        completeMethod="#{institutionController.completeCreditCompany}"
-                                                                                        var="ix"
-                                                                                        minQueryLength="2"
-                                                                                        placeholder="Company (Type at least 4 letters to search)"
-                                                                                        itemLabel="#{ix.name}"
-                                                                                        itemValue="#{ix}"
-                                                                                        size="10"  >
 
-                                                                                        <f:ajax
-                                                                                            event="itemSelect"
-                                                                                            listener="#{pharmacySimpleRetailSaleController.calTotal()}"
-                                                                                            execute="@this"
-                                                                                            render=":#{p:resolveFirstComponentWithId('panelBillDetails',view).clientId}"/>
-                                                                                    </p:autoComplete>
-                                                                                    <p:commandLink
-                                                                                        id="btnAddNewCreditCom"
-                                                                                        value="(+)"
-                                                                                        class="mx-3 mt-1"
-                                                                                        title="Add New Credit Company"
-                                                                                        ajax="false"
-                                                                                        action="#{navigationController.navigateToCreditCompany()}"
-                                                                                        actionListener="#{creditCompanyController.prepareAdd()}" />
-                                                                                </div>
-                                                                            </div>
-                                                                        </div>
-                                                                    </h:panelGroup>
-                                                                    <h:panelGroup
-                                                                        class="row"
-                                                                        layout="block"
-                                                                        rendered="#{pharmacySimpleRetailSaleController.paymentMethod eq 'Staff'}" >
-                                                                        <div class="my-1" id="staffCredit">
-                                                                            <div class="row mt-1">
-                                                                                <div class="col-12">
-                                                                                    <p:autoComplete
-                                                                                        minQueryLength="2"
-                                                                                        forceSelection="true"
-                                                                                        value="#{pharmacySimpleRetailSaleController.toStaff}"
-                                                                                        id="creditStaff"
-                                                                                        completeMethod="#{staffController.completeStaff}"
-                                                                                        var="mys"
-                                                                                        class="w-100"
-                                                                                        placeholder="Staff (Type at least 4 letters to search)"
-                                                                                        inputStyleClass="form-control"
-                                                                                        itemLabel="#{mys.person.name}"
-                                                                                        itemValue="#{mys}"
-                                                                                        size="10">
-                                                                                        <p:column headerText="Name" style="padding: 2px;">
-                                                                                            <h:outputText value="#{mys.person.nameWithTitle}" ></h:outputText>
-                                                                                        </p:column>
-                                                                                        <p:column headerText="EPF" style="padding: 2px;">
-                                                                                            <h:outputText value="#{mys.epfNo}" ></h:outputText>
-                                                                                        </p:column>
-                                                                                        <p:column headerText="Credit Entitlement" style="padding: 2px;">
-                                                                                            <h:outputText value="#{mys.creditLimitQualified}" >
-                                                                                                <f:convertNumber pattern="#,##0.00" ></f:convertNumber>
-                                                                                            </h:outputText>
-                                                                                        </p:column>
-                                                                                        <p:column  headerText="Credit Utilized" style="padding: 2px;">
-                                                                                            <h:outputText value="#{mys.currentCreditValue}" >
-                                                                                                <f:convertNumber pattern="#,##0.00" ></f:convertNumber>
-                                                                                            </h:outputText>
-                                                                                        </p:column>
-                                                                                        <p:ajax process="@this"
-                                                                                                update=":#{p:resolveFirstComponentWithId('panelBillDetails',view).clientId}"
-                                                                                                event="itemSelect"
-                                                                                                listener="#{pharmacySimpleRetailSaleController.calTotal()}" />
-                                                                                    </p:autoComplete>
-                                                                                </div>
-                                                                            </div>
-                                                                        </div>
-                                                                    </h:panelGroup>
-                                                                    <h:panelGroup
-                                                                        class="row"
-                                                                        layout="block"
-                                                                        rendered="#{pharmacySimpleRetailSaleController.paymentMethod eq 'Staff_Welfare'}" >
-                                                                        <div class="my-1" id="credit">
-                                                                            <div class="row mt-1">
-                                                                                <div class="col-12">
-                                                                                    <p:autoComplete
-                                                                                        minQueryLength="3"
-                                                                                        forceSelection="true"
-                                                                                        value="#{pharmacySimpleRetailSaleController.toStaff}"
-                                                                                        id="welfareStaff"
-                                                                                        completeMethod="#{staffController.completeStaff}"
-                                                                                        var="mys"
-                                                                                        class="w-100"
-                                                                                        placeholder="Staff (Type at least 4 letters to search)"
-                                                                                        inputStyleClass="form-control"
-                                                                                        itemLabel="#{mys.person.name}"
-                                                                                        itemValue="#{mys}"
-                                                                                        size="10">
-                                                                                        <p:column headerText="Name" style="padding: 2px;">
-                                                                                            <h:outputText value="#{mys.person.nameWithTitle}" ></h:outputText>
-                                                                                        </p:column>
-                                                                                        <p:column headerText="EPF" style="padding: 2px;">
-                                                                                            <h:outputText value="#{mys.epfNo}" ></h:outputText>
-                                                                                        </p:column>
-                                                                                        <p:column headerText="Welfare Entitlement" style="padding: 2px;">
-                                                                                            <h:outputText value="#{mys.annualWelfareQualified}" >
-                                                                                                <f:convertNumber pattern="#,##0.00" ></f:convertNumber>
-                                                                                            </h:outputText>
-                                                                                        </p:column>
-                                                                                        <p:column  headerText="Welfare Utilized" style="padding: 2px;">
-                                                                                            <h:outputText value="#{mys.annualWelfareUtilized}" >
-                                                                                                <f:convertNumber pattern="#,##0.00" ></f:convertNumber>
-                                                                                            </h:outputText>
-                                                                                        </p:column>
-                                                                                        <p:ajax process="@this"
-                                                                                                update=":#{p:resolveFirstComponentWithId('panelBillDetails',view).clientId}"
-                                                                                                event="itemSelect"
-                                                                                                listener="#{pharmacySimpleRetailSaleController.calTotal()}" />
-                                                                                    </p:autoComplete>
-                                                                                </div>
-                                                                            </div>
-                                                                        </div>
-                                                                    </h:panelGroup>
-                                                                    <h:panelGroup id="creditCard" rendered="#{pharmacySimpleRetailSaleController.paymentMethod eq 'Card'}">
-                                                                        <pa:creditCard paymentMethodData="#{pharmacySimpleRetailSaleController.paymentMethodData}"/>
-                                                                    </h:panelGroup>
-
-                                                                    <h:panelGroup id="ptdeposit" rendered="#{pharmacySimpleRetailSaleController.paymentMethod eq 'PatientDeposit'}">
-                                                                        <pa:patient_deposit paymentMethodData="#{pharmacySimpleRetailSaleController.paymentMethodData}"/>
-                                                                    </h:panelGroup>
-
-                                                                    <h:panelGroup id="ewallet" rendered="#{pharmacySimpleRetailSaleController.paymentMethod eq 'ewallet'}" >
-                                                                        <pa:ewallet paymentMethodData="#{pharmacySimpleRetailSaleController.paymentMethodData}"/>
-                                                                    </h:panelGroup>
+                                                        <h:panelGrid columns="2" class="my-2">
+                                                            <p:outputLabel value="Referring Doctor" ></p:outputLabel>
+                                                            <p:autoComplete forceSelection="true" id="cmbDoc" value="#{pharmacySimpleRetailSaleController.preBill.referredBy}"
+                                                                            completeMethod="#{doctorController.completeDoctor}"
+                                                                            var="ix" itemLabel="#{ix.person.name}"
+                                                                            itemValue="#{ix}" size="40"
+                                                                            class="mx-4 w-100 mt-1"
+                                                                            inputStyleClass="form-control">
+                                                            </p:autoComplete>
+                                                            <p:outputLabel value="Comments" ></p:outputLabel>
+                                                            <p:inputTextarea class="w-100 mx-4" value="#{pharmacySimpleRetailSaleController.comment}" id="comment"/>
 
 
-                                                                    <h:panelGroup id="cheque" rendered="#{pharmacySimpleRetailSaleController.paymentMethod eq 'Cheque'}" >
-                                                                        <pa:cheque paymentMethodData="#{pharmacySimpleRetailSaleController.paymentMethodData}"/>
-                                                                    </h:panelGroup>
 
-                                                                    <h:panelGroup id="slip" rendered="#{pharmacySimpleRetailSaleController.paymentMethod eq 'Slip'}">
-                                                                        <pa:slip paymentMethodData="#{pharmacySimpleRetailSaleController.paymentMethodData}"/>
-                                                                    </h:panelGroup>
+                                                        </h:panelGrid>
 
+                                                    </p:panel>
 
-                                                                    <h:panelGroup
-                                                                        class="row my-1 w-100"
-                                                                        layout="block"
-                                                                        id="multiplePaymentMethods"  rendered="#{pharmacySimpleRetailSaleController.paymentMethod eq 'MultiplePaymentMethods'}"
-                                                                        >
-                                                                        <pa:multiple_payment_methods class="w-100" controller="#{pharmacySimpleRetailSaleController}" paymentMethods="#{enumController.paymentMethodsForMultiplePaymentMethod}"/>
-
-                                                                    </h:panelGroup>
-
-                                                                </div>
-
+                                                    <p:panel  id="panelBillDetails" class="my-1">
+                                                        <f:facet name="header" >
+                                                            <h:outputText styleClass="fas fa-list" />
+                                                            <h:outputLabel value="Bill Details" class="mx-4"></h:outputLabel>
+                                                        </f:facet>
+                                                        <h:panelGrid columns="2" columnClasses="numberCol, textCol">
+                                                            <h:outputLabel value="Total" />
+                                                            <h:panelGroup layout="block" class="text-end mx-4 my-1">
+                                                                <h:outputLabel id="total" value="#{pharmacySimpleRetailSaleController.preBill.total}">
+                                                                    <f:convertNumber pattern="#,##0.00" />
+                                                                </h:outputLabel>
                                                             </h:panelGroup>
-                                                        </div>
-                                                    </div>
 
-                                                    <div class="col-5">
-                                                        <p:selectOneMenu   id="cmbPs" value="#{pharmacySimpleRetailSaleController.paymentScheme}" rendered="#{sessionController.loggedPreference.checkPaymentSchemeValidation eq false}" class="my-1">
-                                                            <f:selectItem itemLabel="Discount Scheme"/>
-                                                            <f:selectItems value="#{paymentSchemeController.paymentSchemesForPharmacy}" var="i" itemLabel="#{i.name}" itemValue="#{i}"/>
-                                                            <p:ajax process="@this pay "
-                                                                    update="panelBillDetails panelPaymentDetails"
-                                                                    event="change"
-                                                                    listener="#{pharmacySimpleRetailSaleController.listnerForPaymentMethodChange()}"/>
-                                                        </p:selectOneMenu>
-                                                    </div>
+                                                            <h:outputLabel value="Discount" />
+                                                            <h:panelGroup layout="block" class="text-end mx-4 my-1">
+                                                                <h:outputLabel id="dis" value="#{pharmacySimpleRetailSaleController.preBill.discount}">
+                                                                    <f:convertNumber pattern="#,##0.00" />
+                                                                </h:outputLabel>
+                                                            </h:panelGroup>
 
-                                                    <h:panelGrid columns="2" class="my-2">
-                                                        <p:outputLabel value="Referring Doctor" ></p:outputLabel>
-                                                        <p:autoComplete forceSelection="true" id="cmbDoc" value="#{pharmacySimpleRetailSaleController.preBill.referredBy}"
-                                                                        completeMethod="#{doctorController.completeDoctor}"
-                                                                        var="ix" itemLabel="#{ix.person.name}"
-                                                                        itemValue="#{ix}" size="40"
-                                                                        class="mx-4 w-100 mt-1"
-                                                                        inputStyleClass="form-control">
-                                                        </p:autoComplete>
-                                                        <p:outputLabel value="Comments" ></p:outputLabel>
-                                                        <p:inputTextarea class="w-100 mx-4" value="#{pharmacySimpleRetailSaleController.comment}" id="comment"/>
+                                                            <h:outputLabel value="Net Total" />
+                                                            <h:panelGroup layout="block" class="text-end mx-4 my-1">
+                                                                <h:outputLabel id="netTotal" value="#{pharmacySimpleRetailSaleController.preBill.netTotal}">
+                                                                    <f:convertNumber pattern="#,##0.00" />
+                                                                </h:outputLabel>
+                                                            </h:panelGroup>
 
+                                                            <h:outputLabel value="Tendered" />
+                                                            <h:panelGroup layout="block" class="text-end mx-4 my-1">
+                                                                <p:inputText
+                                                                    id="paid"
+                                                                    value="#{pharmacySimpleRetailSaleController.cashPaid}"
+                                                                    class="form-control text-end"
+                                                                    autocomplete="off"
+                                                                    accesskey="t"
+                                                                    onfocus="this.select()">
+                                                                    <p:ajax process="total dis netTotal paid" update="balance netTotal" event="keyup" />
+                                                                </p:inputText>
+                                                            </h:panelGroup>
 
-
-                                                    </h:panelGrid>
-
-                                                </p:panel>
-
-                                                <p:panel  id="panelBillDetails" class="my-1">
-                                                    <f:facet name="header" >
-                                                        <h:outputText styleClass="fas fa-list" />
-                                                        <h:outputLabel value="Bill Details" class="mx-4"></h:outputLabel>
-                                                    </f:facet>
-                                                    <h:panelGrid columns="2" columnClasses="numberCol, textCol">
-                                                        <h:outputLabel value="Total" />
-                                                        <h:panelGroup layout="block" class="text-end mx-4 my-1">
-                                                            <h:outputLabel id="total" value="#{pharmacySimpleRetailSaleController.preBill.total}">
-                                                                <f:convertNumber pattern="#,##0.00" />
-                                                            </h:outputLabel>
-                                                        </h:panelGroup>
-
-                                                        <h:outputLabel value="Discount" />
-                                                        <h:panelGroup layout="block" class="text-end mx-4 my-1">
-                                                            <h:outputLabel id="dis" value="#{pharmacySimpleRetailSaleController.preBill.discount}">
-                                                                <f:convertNumber pattern="#,##0.00" />
-                                                            </h:outputLabel>
-                                                        </h:panelGroup>
-
-                                                        <h:outputLabel value="Net Total" />
-                                                        <h:panelGroup layout="block" class="text-end mx-4 my-1">
-                                                            <h:outputLabel id="netTotal" value="#{pharmacySimpleRetailSaleController.preBill.netTotal}">
-                                                                <f:convertNumber pattern="#,##0.00" />
-                                                            </h:outputLabel>
-                                                        </h:panelGroup>
-
-                                                        <h:outputLabel value="Tendered" />
-                                                        <h:panelGroup layout="block" class="text-end mx-4 my-1">
-                                                            <p:inputText
-                                                                id="paid"
-                                                                value="#{pharmacySimpleRetailSaleController.cashPaid}"
-                                                                class="form-control text-end"
-                                                                autocomplete="off"
-                                                                accesskey="t"
-                                                                onfocus="this.select()">
-                                                                <p:ajax process="total dis netTotal paid" update="balance netTotal" event="keyup" />
-                                                            </p:inputText>
-                                                        </h:panelGroup>
-
-                                                        <h:outputLabel value="Balance" />
-                                                        <h:panelGroup layout="block" class="text-end mx-4 my-1">
-                                                            <h:outputLabel id="balance" value="#{pharmacySimpleRetailSaleController.balance}">
-                                                                <f:convertNumber pattern="#,##0.00" />
-                                                            </h:outputLabel>
-                                                        </h:panelGroup>
-                                                    </h:panelGrid>
+                                                            <h:outputLabel value="Balance" />
+                                                            <h:panelGroup layout="block" class="text-end mx-4 my-1">
+                                                                <h:outputLabel id="balance" value="#{pharmacySimpleRetailSaleController.balance}">
+                                                                    <f:convertNumber pattern="#,##0.00" />
+                                                                </h:outputLabel>
+                                                            </h:panelGroup>
+                                                        </h:panelGrid>
 
 
-                                                </p:panel>
+                                                    </p:panel>
 
+                                                </div>
                                             </div>
-                                        </div>
-                                    </h:panelGrid>
+                                        </h:panelGrid>
+                                    </div>
                                 </div>
-                            </div>
+                            </p:panel>
                         </p:panel>
-                    </p:panel>
-                </h:form>
-                <h:form>
+                    </h:form>
+                    <h:form>
 
-                    <p:panel  rendered="#{pharmacySimpleRetailSaleController.billPreview}" >
+                        <p:panel  rendered="#{pharmacySimpleRetailSaleController.billPreview}" >
 
-                        <p:commandButton id="nullButton3" value="No Action"
-                                         action="#" style="display: none;" ></p:commandButton>
-                        <!--<p:defaultCommand  target="btnPrint" />-->
+                            <p:commandButton id="nullButton3" value="No Action"
+                                             action="#" style="display: none;" ></p:commandButton>
+                            <!--<p:defaultCommand  target="btnPrint" />-->
 
-                        <div   >
-                            <div>
-                                <p:commandButton
-                                    accesskey="p"
-                                    id="btnPrint"
-                                    value="Print Bill"
-                                    style="width: 10em;"
-                                    class="ui-button-info"
-                                    rendered="#{!configOptionApplicationController.getBooleanValueByKey('Pharmacy Bill Support for Native Printers')}"
-                                    ajax="false"  >
-                                    <p:printer target="gpBillPreview" ></p:printer>
-                                </p:commandButton>
-                                <p:commandButton
+                            <div   >
+                                <div>
+                                    <p:commandButton
+                                        accesskey="p"
+                                        id="btnPrint"
+                                        value="Print Bill"
+                                        style="width: 10em;"
+                                        class="ui-button-info"
+                                        rendered="#{!configOptionApplicationController.getBooleanValueByKey('Pharmacy Bill Support for Native Printers')}"
+                                        ajax="false"  >
+                                        <p:printer target="gpBillPreview" ></p:printer>
+                                    </p:commandButton>
+                                    <p:commandButton
 
-                                    id="btnLabelPrint"
-                                    value="Print Labels"
-                                    style="width: 10em;"
-                                    oncomplete="PF('PrintLables').show()"
-                                    class="ui-button-info mx-3"
-                                    rendered="#{configOptionApplicationController.getBooleanValueByKey('Enable label printing for pharmacy medicines', false)}"
-                                    >
-
-                                </p:commandButton>
-
-                                <p:dialog
-                                    id="PrintLableSectionAfterSettleBill"
-                                    widgetVar="PrintLables"
-                                    resizable="false"
-                                    closable="true"
-                                    modal="true"
-                                    onShow="$('.ui-dialog').addClass('custom-dialog')"
-
-                                    >
-                                    <p:outputLabel for="@next" value="Select Bill Item : " class="m-2"/>
-                                    <p:selectOneMenu id="group" value="#{pharmacySimpleRetailSaleController.billItem}">
-                                        <f:selectItem itemLabel="Select One" itemValue=""/>
-                                        <f:selectItems value="#{pharmacySimpleRetailSaleController.printBill.billItems}" var="item" itemLabel="#{item.pharmaceuticalBillItem.itemBatch.item.name}" itemValue="#{item}"/>
-
-                                        <p:ajax event="change" process="group" update="printLabelSectionAfterSettle"></p:ajax>
-
-                                    </p:selectOneMenu>
-
-                                    <h:panelGroup id="printLabelSectionAfterSettle" class="my-3" rendered="#{pharmacySimpleRetailSaleController.billItem ne null}">
-                                        <phi:pharmacy_instruction_label billItem="#{pharmacySimpleRetailSaleController.billItem}" controller="#{pharmacySimpleRetailSaleController}"/>
-                                    </h:panelGroup>
-
-                                    <p:commandButton value="Print Label"
-                                                     class="ui-button-info w-100 my-4"
-                                                     action="#{pharmacySimpleRetailSaleController.enableLabelPrint(pharmacySimpleRetailSaleController.billItem.prescription)}"
-                                                     ajax="false"
-                                                     update="PrintLableSectionAfterSettleBill"
-                                                     oncomplete="PF('printLabelSectionView').show()"
-                                                     process="@this"
-                                                     >
-                                        <p:printer target="printLabelSectionAfterSettle"></p:printer>
+                                        id="btnLabelPrint"
+                                        value="Print Labels"
+                                        style="width: 10em;"
+                                        oncomplete="PF('PrintLables').show()"
+                                        class="ui-button-info mx-3"
+                                        rendered="#{configOptionApplicationController.getBooleanValueByKey('Enable label printing for pharmacy medicines', false)}"
+                                        >
 
                                     </p:commandButton>
-                                </p:dialog>
 
-                                <p:commandButton
-                                    accesskey="n"
-                                    value="New Bill"
-                                    icon="fa fa-plus"
-                                    ajax="false"
-                                    action="pharmacy_bill_retail_sale"
-                                    class="ui-button-warning mx-2"
-                                    actionListener="#{pharmacySimpleRetailSaleController.resetAll()}" ></p:commandButton>
-                                <p:outputLabel value="Paper Type" class="m-2"></p:outputLabel>
-                                <p:selectOneMenu value="#{sessionController.departmentPreference.pharmacyBillPaperType}" class="m-1" id='ph' style="width: 13em;">
-                                    <f:selectItem itemLabel="Please Select Paper Type" />
-                                    <f:selectItems value="#{enumController.paperTypes}" />
-                                </p:selectOneMenu>
-                                <p:commandButton ajax="false" icon="fa fa-sync-alt" class="ui-button" title="Redraw Bill"></p:commandButton>
-                                <p:spacer width="20em" ></p:spacer>
-                                <p:commandButton class="m-1" icon="fas fa-file-invoice" disabled="true" value="Sale 1"  action="pharmacy_bill_retail_sale?faces-redirect=true" rendered="#{webUserController.hasPrivilege('PharmacySale')}" actionListener="#{pharmacySimpleRetailSaleController.pharmacyRetailSale()}" />
-                                <p:commandButton class="m-1"  icon="fas fa-file-invoice" value="Sale 2" action="pharmacy_bill_retail_sale_1?faces-redirect=true" rendered="#{webUserController.hasPrivilege('PharmacySale')}" actionListener="#{pharmacySimpleRetailSaleController1.pharmacyRetailSale()}" />
-                                <p:commandButton class="m-1"  icon="fas fa-file-invoice" value="Sale 3" action="pharmacy_bill_retail_sale_2?faces-redirect=true" rendered="#{webUserController.hasPrivilege('PharmacySale')}" actionListener="#{pharmacySimpleRetailSaleController2.pharmacyRetailSale()}" />
-                                <p:commandButton class="m-1"  icon="fas fa-file-invoice" value="Sale 4" action="pharmacy_bill_retail_sale_3?faces-redirect=true" rendered="#{webUserController.hasPrivilege('PharmacySale')}" actionListener="#{pharmacySimpleRetailSaleController3.pharmacyRetailSale()}" />
+                                    <p:dialog
+                                        id="PrintLableSectionAfterSettleBill"
+                                        widgetVar="PrintLables"
+                                        resizable="false"
+                                        closable="true"
+                                        modal="true"
+                                        onShow="$('.ui-dialog').addClass('custom-dialog')"
 
+                                        >
+                                        <p:outputLabel for="@next" value="Select Bill Item : " class="m-2"/>
+                                        <p:selectOneMenu id="group" value="#{pharmacySimpleRetailSaleController.billItem}">
+                                            <f:selectItem itemLabel="Select One" itemValue=""/>
+                                            <f:selectItems value="#{pharmacySimpleRetailSaleController.printBill.billItems}" var="item" itemLabel="#{item.pharmaceuticalBillItem.itemBatch.item.name}" itemValue="#{item}"/>
+
+                                            <p:ajax event="change" process="group" update="printLabelSectionAfterSettle"></p:ajax>
+
+                                        </p:selectOneMenu>
+
+                                        <h:panelGroup id="printLabelSectionAfterSettle" class="my-3" rendered="#{pharmacySimpleRetailSaleController.billItem ne null}">
+                                            <phi:pharmacy_instruction_label billItem="#{pharmacySimpleRetailSaleController.billItem}" controller="#{pharmacySimpleRetailSaleController}"/>
+                                        </h:panelGroup>
+
+                                        <p:commandButton value="Print Label"
+                                                         class="ui-button-info w-100 my-4"
+                                                         action="#{pharmacySimpleRetailSaleController.enableLabelPrint(pharmacySimpleRetailSaleController.billItem.prescription)}"
+                                                         ajax="false"
+                                                         update="PrintLableSectionAfterSettleBill"
+                                                         oncomplete="PF('printLabelSectionView').show()"
+                                                         process="@this"
+                                                         >
+                                            <p:printer target="printLabelSectionAfterSettle"></p:printer>
+
+                                        </p:commandButton>
+                                    </p:dialog>
+
+                                    <p:commandButton
+                                        accesskey="n"
+                                        value="New Bill"
+                                        icon="fa fa-plus"
+                                        ajax="false"
+                                        action="pharmacy_bill_retail_sale"
+                                        class="ui-button-warning mx-2"
+                                        actionListener="#{pharmacySimpleRetailSaleController.resetAll()}" ></p:commandButton>
+                                    <p:outputLabel value="Paper Type" class="m-2"></p:outputLabel>
+                                    <p:selectOneMenu value="#{sessionController.departmentPreference.pharmacyBillPaperType}" class="m-1" id='ph' style="width: 13em;">
+                                        <f:selectItem itemLabel="Please Select Paper Type" />
+                                        <f:selectItems value="#{enumController.paperTypes}" />
+                                    </p:selectOneMenu>
+                                    <p:commandButton ajax="false" icon="fa fa-sync-alt" class="ui-button" title="Redraw Bill"></p:commandButton>
+                                    <p:spacer width="20em" ></p:spacer>
+                                    <p:commandButton class="m-1" icon="fas fa-file-invoice" disabled="true" value="Sale 1"  action="pharmacy_bill_retail_sale?faces-redirect=true" rendered="#{webUserController.hasPrivilege('PharmacySale')}" actionListener="#{pharmacySimpleRetailSaleController.pharmacyRetailSale()}" />
+                                    <p:commandButton class="m-1"  icon="fas fa-file-invoice" value="Sale 2" action="pharmacy_bill_retail_sale_1?faces-redirect=true" rendered="#{webUserController.hasPrivilege('PharmacySale')}" actionListener="#{pharmacySimpleRetailSaleController1.pharmacyRetailSale()}" />
+                                    <p:commandButton class="m-1"  icon="fas fa-file-invoice" value="Sale 3" action="pharmacy_bill_retail_sale_2?faces-redirect=true" rendered="#{webUserController.hasPrivilege('PharmacySale')}" actionListener="#{pharmacySimpleRetailSaleController2.pharmacyRetailSale()}" />
+                                    <p:commandButton class="m-1"  icon="fas fa-file-invoice" value="Sale 4" action="pharmacy_bill_retail_sale_3?faces-redirect=true" rendered="#{webUserController.hasPrivilege('PharmacySale')}" actionListener="#{pharmacySimpleRetailSaleController3.pharmacyRetailSale()}" />
+
+                                </div>
+
+                                <div>
+                                    <br/>
+                                    <br/>
+                                    <br/>
+                                </div>
                             </div>
 
-                            <div>
-                                <br/>
-                                <br/>
-                                <br/>
-                            </div>
-                        </div>
+                            <h:panelGroup id="gpBillPreview" >
+                                <h:panelGroup   id="gpBillWithOutItem" rendered="#{configOptionApplicationController.getBooleanValueByKey('Pharmacy Retail Sale Bill is PosPaper',true)}">
+                                    <div style="page-break-inside: avoid;">
+                                        <phi:saleBill_without_item bill="#{pharmacySimpleRetailSaleController.printBill}"></phi:saleBill_without_item>
+                                    </div>
+                                    <br/>
+                                    <div style="page-break-inside: avoid;">
+                                        <phi:saleBill bill="#{pharmacySimpleRetailSaleController.printBill}"></phi:saleBill>
+                                    </div>
+                                </h:panelGroup>
 
-                        <h:panelGroup id="gpBillPreview" >
-                            <h:panelGroup   id="gpBillWithOutItem" rendered="#{configOptionApplicationController.getBooleanValueByKey('Pharmacy Retail Sale Bill is PosPaper',true)}">
-                                <div style="page-break-inside: avoid;">
-                                    <phi:saleBill_without_item bill="#{pharmacySimpleRetailSaleController.printBill}"></phi:saleBill_without_item>
-                                </div>
-                                <br/>
-                                <div style="page-break-inside: avoid;">
-                                    <phi:saleBill bill="#{pharmacySimpleRetailSaleController.printBill}"></phi:saleBill>
-                                </div>
-                            </h:panelGroup>
+                                <h:panelGroup   id="gpBillWithItem" rendered="#{configOptionApplicationController.getBooleanValueByKey('Pharmacy Retail Sale Bill with Items is PosPaper',true)}">
+                                    <div style="page-break-inside: avoid;">
+                                        <phi:saleBill bill="#{pharmacySimpleRetailSaleController.printBill}"></phi:saleBill>
+                                    </div>
+                                </h:panelGroup>
 
-                            <h:panelGroup   id="gpBillWithItem" rendered="#{configOptionApplicationController.getBooleanValueByKey('Pharmacy Retail Sale Bill with Items is PosPaper',true)}">
-                                <div style="page-break-inside: avoid;">
-                                    <phi:saleBill bill="#{pharmacySimpleRetailSaleController.printBill}"></phi:saleBill>
-                                </div>
-                            </h:panelGroup>
+                                <h:panelGroup id="gpBillPreviewDouble" rendered="#{configOptionApplicationController.getBooleanValueByKey('Pharmacy Retail Sale Bill is PosPaper(prabodha)',true)}">
+                                    <phi:saleBill_prabodha bill="#{pharmacySimpleRetailSaleController.printBill}"></phi:saleBill_prabodha>
+                                </h:panelGroup>
 
-                            <h:panelGroup id="gpBillPreviewDouble" rendered="#{configOptionApplicationController.getBooleanValueByKey('Pharmacy Retail Sale Bill is PosPaper(prabodha)',true)}">
-                                <phi:saleBill_prabodha bill="#{pharmacySimpleRetailSaleController.printBill}"></phi:saleBill_prabodha>
-                            </h:panelGroup>
+                                <h:panelGroup id="gpBillPreviewFiveFive" rendered="#{configOptionApplicationController.getBooleanValueByKey('Pharmacy Retail Sale Bill is FiveFivePaper',true)}">
+                                    <phi:saleBill_five_five bill="#{pharmacySimpleRetailSaleController.printBill}"></phi:saleBill_five_five>
+                                </h:panelGroup>
 
-                            <h:panelGroup id="gpBillPreviewFiveFive" rendered="#{configOptionApplicationController.getBooleanValueByKey('Pharmacy Retail Sale Bill is FiveFivePaper',true)}">
-                                <phi:saleBill_five_five bill="#{pharmacySimpleRetailSaleController.printBill}"></phi:saleBill_five_five>
+                                <h:panelGroup id="gpBillPreviewPosHeader" rendered="#{configOptionApplicationController.getBooleanValueByKey('Pharmacy Retail Sale Bill is PosHeaderPaper',true)}">
+                                    <phi:saleBill_Header bill="#{pharmacySimpleRetailSaleController.printBill}"></phi:saleBill_Header>
+                                </h:panelGroup>
+                                <h:panelGroup id="gpBillPreviewFiveFiveCustom3" rendered="#{configOptionApplicationController.getBooleanValueByKey('Pharmacy Retail Sale Bill is FiveFiveCustom3',true)}">
+                                    <phi:sale_bill_five_five_custom_3 bill="#{pharmacySimpleRetailSaleController.printBill}"/>
+                                </h:panelGroup>
                             </h:panelGroup>
+                        </p:panel>
+                    </h:form>
+                </h:panelGroup>
 
-                            <h:panelGroup id="gpBillPreviewPosHeader" rendered="#{configOptionApplicationController.getBooleanValueByKey('Pharmacy Retail Sale Bill is PosHeaderPaper',true)}">
-                                <phi:saleBill_Header bill="#{pharmacySimpleRetailSaleController.printBill}"></phi:saleBill_Header>
-                            </h:panelGroup>
-                            <h:panelGroup id="gpBillPreviewFiveFiveCustom3" rendered="#{configOptionApplicationController.getBooleanValueByKey('Pharmacy Retail Sale Bill is FiveFiveCustom3',true)}">
-                                <phi:sale_bill_five_five_custom_3 bill="#{pharmacySimpleRetailSaleController.printBill}"/>
-                            </h:panelGroup>
-                        </h:panelGroup>
-                    </p:panel>
-                </h:form>
             </ui:define>
         </ui:composition>
 

--- a/src/main/webapp/resources/ezcomp/menu.xhtml
+++ b/src/main/webapp/resources/ezcomp/menu.xhtml
@@ -663,11 +663,6 @@
                             rendered="#{webUserController.hasPrivilege('PharmacySale')}" ></p:menuitem> 
                         <p:menuitem  
                             ajax="false" 
-                            action="#{pharmacySimpleRetailSaleController.navigateToPharmacySimpleRetailSale()}"  
-                            value="Simple Retail Sale" 
-                            rendered="#{webUserController.hasPrivilege('PharmacySale') and !configOptionApplicationController.getBooleanValueByKey('Pharmacy Simple Retail Sale is Available')}" ></p:menuitem> 
-                        <p:menuitem  
-                            ajax="false" 
                             action="#{pharmacySaleController.navigateToPharmacyBillForCashier()}"  
                             value="Sale for cashier" 
                             rendered="#{webUserController.hasPrivilege('PharmacySaleForCashier')}" ></p:menuitem>                                       


### PR DESCRIPTION
Now no more simplae sale as it is removed due to design concerns. Indexes removed from entity
if you go to Menu > Pharmacy > Simple Sale is no more there.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Marked certain fields and methods as deprecated in the pharmacy stock management.
  - Marked the simple retail sale controller as deprecated.
- **Style**
  - Removed the "Simple Retail Sale" menu item from the Pharmacy Retail Transactions submenu.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->