### PR TITLE
12690 sale rate incorrectly shows sale value when manage costing is enabled in direct purchase

### DIFF
--- a/src/main/java/com/divudi/bean/pharmacy/GrnController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/GrnController.java
@@ -226,6 +226,7 @@ public class GrnController implements Serializable {
         return "/pharmacy/pharmacy_grn_with_approval?faces-redirect=true";
     }
 
+    @Deprecated // Please use navigateToResive
     public String navigateToResiveAll() {
         grnBill = null;
         dealor = null;
@@ -991,9 +992,9 @@ public class GrnController implements Serializable {
     public void generateBillComponent() {
 
         for (PharmaceuticalBillItem i : getPharmaceuticalBillItemFacade().getPharmaceuticalBillItems(getApproveBill())) {
-            double calculatedReturns = getPharmacyCalculation().calQtyInTwoSql(i);
+            double calculatedReturns = getPharmacyCalculation().calculateRemainigQtyFromOrder(i);
             double remains = Math.abs(i.getQtyInUnit()) - Math.abs(calculatedReturns);
-            double remainFreeQty = i.getFreeQty() - getPharmacyCalculation().calFreeQtyInTwoSql(i);
+            double remainFreeQty = i.getFreeQty() - getPharmacyCalculation().calculateRemainingFreeQtyFromOrder(i);
 
             if (remains > 0 || remainFreeQty > 0) {
                 BillItem bi = new BillItem();
@@ -1041,8 +1042,8 @@ public class GrnController implements Serializable {
 
         for (BillItem importBi : importGrnBill.getBillItems()) {
             PharmaceuticalBillItem i = importBi.getPharmaceuticalBillItem();
-            double remains = i.getQty() - getPharmacyCalculation().calQtyInTwoSql(i);
-            double remainFreeQty = i.getFreeQty() - getPharmacyCalculation().calFreeQtyInTwoSql(i);
+            double remains = i.getQty() - getPharmacyCalculation().calculateRemainigQtyFromOrder(i);
+            double remainFreeQty = i.getFreeQty() - getPharmacyCalculation().calculateRemainingFreeQtyFromOrder(i);
 
             if (remains > 0 || remainFreeQty > 0) {
                 BillItem bi = new BillItem();
@@ -1092,7 +1093,7 @@ public class GrnController implements Serializable {
     public void generateBillComponentAll() {
 
         for (PharmaceuticalBillItem i : getPharmaceuticalBillItemFacade().getPharmaceuticalBillItems(getApproveBill())) {
-            double remains = i.getQtyInUnit() - getPharmacyCalculation().calQtyInTwoSql(i);
+            double remains = i.getQtyInUnit() - getPharmacyCalculation().calculateRemainigQtyFromOrder(i);
 
             BillItem bi = new BillItem();
             bi.setSearialNo(getBillItems().size());

--- a/src/main/java/com/divudi/ejb/PharmacyCalculation.java
+++ b/src/main/java/com/divudi/ejb/PharmacyCalculation.java
@@ -461,12 +461,14 @@ public class PharmacyCalculation implements Serializable {
         return (Math.abs(recieveNet));
     }
 
+    @Deprecated // Use calculateRemainigQtyFromOrder
     public double calQtyInTwoSql(PharmaceuticalBillItem po) {
         double grns = getTotalQty(po.getBillItem(), BillType.PharmacyGrnBill);
         double grnReturn = getReturnedTotalQty(po.getBillItem(), BillType.PharmacyGrnReturn);
         return Math.abs(grns) - Math.abs(grnReturn);
     }
 
+    @Deprecated // use calculateRemainingFreeQtyFromOrder
     public double calFreeQtyInTwoSql(PharmaceuticalBillItem po) {
 
         double grnsFree = getTotalFreeQty(po.getBillItem(), BillType.PharmacyGrnBill);

--- a/src/main/resources/META-INF/persistence.xml
+++ b/src/main/resources/META-INF/persistence.xml
@@ -2,19 +2,17 @@
 <persistence version="2.2" xmlns="http://java.sun.com/xml/ns/persistence" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/persistence http://xmlns.jcp.org/xml/ns/persistence/persistence_2_2.xsd">
     <persistence-unit name="hmisPU" transaction-type="JTA">
         <provider>org.eclipse.persistence.jpa.PersistenceProvider</provider>
-        <jta-data-source>jdbc/sl</jta-data-source>
+        <jta-data-source>${JDBC_DATASOURCE}</jta-data-source>
         <exclude-unlisted-classes>false</exclude-unlisted-classes>
         <properties>
             <property name="eclipselink.logging.level.sql" value="SEVERE"/>
-            <property name="eclipselink.logging.level" value="SEVERE"/>
         </properties>
     </persistence-unit>
     <persistence-unit name="hmisAuditPU" transaction-type="JTA">
-        <jta-data-source>jdbc/ruhunuAudit</jta-data-source>
+        <jta-data-source>${JDBC_AUDIT_DATASOURCE}</jta-data-source>
         <exclude-unlisted-classes>false</exclude-unlisted-classes>
         <properties>
             <property name="eclipselink.logging.level.sql" value="SEVERE"/>
-            <property name="eclipselink.logging.level" value="SEVERE"/>
         </properties>
     </persistence-unit>
 </persistence>

--- a/src/main/resources/META-INF/persistence.xml
+++ b/src/main/resources/META-INF/persistence.xml
@@ -2,7 +2,7 @@
 <persistence version="2.2" xmlns="http://java.sun.com/xml/ns/persistence" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/persistence http://xmlns.jcp.org/xml/ns/persistence/persistence_2_2.xsd">
     <persistence-unit name="hmisPU" transaction-type="JTA">
         <provider>org.eclipse.persistence.jpa.PersistenceProvider</provider>
-        <jta-data-source>${JDBC_DATASOURCE}</jta-data-source>
+        <jta-data-source>jdbc/sl</jta-data-source>
         <exclude-unlisted-classes>false</exclude-unlisted-classes>
         <properties>
             <property name="eclipselink.logging.level.sql" value="SEVERE"/>
@@ -10,7 +10,7 @@
         </properties>
     </persistence-unit>
     <persistence-unit name="hmisAuditPU" transaction-type="JTA">
-        <jta-data-source>${JDBC_AUDIT_DATASOURCE}</jta-data-source>
+        <jta-data-source>jdbc/ruhunuAudit</jta-data-source>
         <exclude-unlisted-classes>false</exclude-unlisted-classes>
         <properties>
             <property name="eclipselink.logging.level.sql" value="SEVERE"/>

--- a/src/main/webapp/pharmacy/direct_purchase.xhtml
+++ b/src/main/webapp/pharmacy/direct_purchase.xhtml
@@ -177,13 +177,13 @@
                                     <h:outputLabel 
                                         class="w-100 m-1"
                                         style="white-space: nowrap;"
-                                        value="Retail Rate - Unit" />
+                                        value="Retail Rate" />
                                     <p:inputText
                                         autocomplete="off"
                                         id="txtRetailRate"
                                         onfocus="this.select()"
                                         class="w-100 m-1 text-end"
-                                        value="#{pharmacyDirectPurchaseController.currentBillItem.billItemFinanceDetails.retailSaleRatePerUnit}">
+                                        value="#{pharmacyDirectPurchaseController.currentBillItem.billItemFinanceDetails.retailSaleRate}">
                                         <f:convertNumber pattern="#,##0.00" />
                                         <p:ajax 
                                             event="blur"
@@ -240,8 +240,7 @@
 
 
 
-                                <div class="col-4">
-                                </div>
+
 
                                 <div class="col-1 text-end">
                                     <h:outputLabel 
@@ -270,9 +269,18 @@
                                             class="w-100 m-1 text-end"
                                             value="#{pharmacyDirectPurchaseController.currentBillItem.item.dblValue}">
                                         </p:inputText>
+                                        <p:inputText
+                                            rendered="#{pharmacyDirectPurchaseController.currentBillItem.item.class.simpleName eq 'Amp'}"
+                                            disabled="true"
+                                            autocomplete="off"
+                                            class="w-100 m-1 text-end"
+                                            value="1">
+                                        </p:inputText>
                                     </h:panelGroup>
                                 </div>
 
+                                <div class="col-2">
+                                </div>
 
                                 <div class="col-1 text-end">
                                     <h:outputLabel 

--- a/src/main/webapp/pharmacy/pharmacy_purchase_order_list_for_recieve.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_purchase_order_list_for_recieve.xhtml
@@ -129,15 +129,6 @@
                                             disabled="#{p.cancelled or p.billClosed}">
                                             <f:setPropertyActionListener target="#{grnController.approveBill}" value="#{p}"/>
                                         </p:commandButton>
-                                        <p:commandButton 
-                                            ajax="false" 
-                                            value="Receive&nbsp;All" 
-                                            rendered="false"
-                                            class="w-50 ui-button-info"
-                                            action="#{grnController.navigateToResiveAll()}" 
-                                            disabled="#{p.cancelled or p.billClosed}">
-                                            <f:setPropertyActionListener target="#{grnController.approveBill}" value="#{p}"/>
-                                        </p:commandButton>
                                     </div>
                                     <div class="col-md-12">
                                         <p:commandButton 


### PR DESCRIPTION
Completed 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added a method to retrieve the last retail rate for an item and department in pharmacy management.
- **Bug Fixes**
	- Improved null-safety and reliability in direct purchase rate calculations and item selection.
- **Style**
	- Updated pharmacy direct purchase interface labels and layout for clarity.
- **Chores**
	- Removed unused logging configuration and obsolete UI buttons.
- **Refactor**
	- Deprecated certain quantity calculation methods and replaced their usage with updated logic for better accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->