### PR TITLE
Added a common header to debtor balance report

### DIFF
--- a/src/main/webapp/reports/financialReports/debtor_balance_report.xhtml
+++ b/src/main/webapp/reports/financialReports/debtor_balance_report.xhtml
@@ -177,25 +177,26 @@
                             value="PDF">
                     </p:commandButton>
                     <h:panelGroup id="printPanel">
+                        <ui:fragment id="commonHeader">
+                            <br/>
+                            <h:outputLabel style="font-weight: bold" value="Debtor Balance Report"/><br/><br/>
+                            <h:panelGrid columns="2" class="mb-2">
+                                <h:outputLabel value="From Date :"/>
+                                <h:outputLabel value="#{reportsController.fromDate}">
+                                    <f:convertDateTime
+                                            pattern="#{sessionController.applicationPreference.longDateTimeFormat}"/>
+                                </h:outputLabel>
+                                <h:outputLabel value="To Date :"/>
+                                <h:outputLabel value="#{reportsController.toDate}">
+                                    <f:convertDateTime
+                                            pattern="#{sessionController.applicationPreference.longDateTimeFormat}"/>
+                                </h:outputLabel>
+                            </h:panelGrid>
+                        </ui:fragment>
+
                         <p:dataTable id="tbl" styleClass="noBorder normalFont"
                                      value="#{reportsController.bundle.reportTemplateRows}" var="i" rowIndexVar="in"
                                      rendered="#{reportsController.visitType eq 'OP'}">
-                            <f:facet name="header">
-                                <h:outputLabel value="Debtor Balance Report"
-                                               style="font-weight: bold; margin-bottom: 10px;"/>
-                                <h:panelGrid columns="4">
-                                    <h:outputLabel value="From  "/>
-                                    <h:outputLabel value="#{reportsController.fromDate}">
-                                        <f:convertDateTime
-                                                pattern="#{sessionController.applicationPreference.longDateTimeFormat}"/>
-                                    </h:outputLabel>
-                                    <h:outputLabel value="To  "/>
-                                    <h:outputLabel value="#{reportsController.toDate}">
-                                        <f:convertDateTime
-                                                pattern="#{sessionController.applicationPreference.longDateTimeFormat}"/>
-                                    </h:outputLabel>
-                                </h:panelGrid>
-                            </f:facet>
                             <p:column headerText="No">
                                 <f:facet name="header">
                                     <h:outputLabel value="No"/>
@@ -388,30 +389,6 @@
                                       rendered="#{reportsController.visitType eq 'IP'}">
                             <table id="tblExport1" style="width: 100%; border-collapse: collapse;">
                                 <thead>
-                                <tr>
-                                    <th colspan="14"
-                                        style="font-size: 18px; font-weight: bold; text-align: center; background-color: lightgrey;">
-                                        Debtor Balance Report
-                                    </th>
-                                </tr>
-                                <tr>
-                                    <th colspan="7" style="text-align: right; padding-right: 5px;">From:</th>
-                                    <th colspan="7" style="text-align: left; padding-left: 5px;">
-                                        <h:outputText value="#{reportsController.fromDate}">
-                                            <f:convertDateTime
-                                                    pattern="#{sessionController.applicationPreference.longDateTimeFormat}"/>
-                                        </h:outputText>
-                                    </th>
-                                </tr>
-                                <tr>
-                                    <th colspan="7" style="text-align: right; padding-right: 5px;">To:</th>
-                                    <th colspan="7" style="text-align: left; padding-left: 5px;">
-                                        <h:outputText value="#{reportsController.toDate}">
-                                            <f:convertDateTime
-                                                    pattern="#{sessionController.applicationPreference.longDateTimeFormat}"/>
-                                        </h:outputText>
-                                    </th>
-                                </tr>
                                 <tr>
                                     <th style="width: 6rem; background-color: #f2f2f2; border-bottom: 1px solid #d9d9d9;"></th>
                                     <th style="width: 6rem; background-color: #f2f2f2; border-bottom: 1px solid #d9d9d9;">BHT</th>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Unified the report title and date range display into a reusable header section for the Debtor Balance Report.
  - Improved consistency in how report headers are presented across different sections of the report.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->