### PR TITLE
Add Maven install instructions

### DIFF
--- a/INSTALL_GUIDE.md
+++ b/INSTALL_GUIDE.md
@@ -2,10 +2,11 @@
 
 ## Table of Contents
 1. [Obtaining the source code](#obtaining-the-source-code)
-2. [Building project](#building-project)
-3. [Installing Glassfish](#installing-glassfish)
-4. [Preparing the database](#preparing-the-database)
-5. [Deploying the project](#deploying-the-project)
+2. [Installing Maven](#installing-maven)
+3. [Building project](#building-project)
+4. [Installing Glassfish](#installing-glassfish)
+5. [Preparing the database](#preparing-the-database)
+6. [Deploying the project](#deploying-the-project)
 
 ## Obtaining the source code
 
@@ -14,6 +15,16 @@
 ```
 git clone https://github.com/hmislk/hmis.git
 ```
+
+## Installing Maven
+
+On Debian-based systems, install Maven via:
+
+```
+sudo apt-get install maven
+```
+
+For other operating systems, download Maven from the [official website](https://maven.apache.org/download.cgi) and follow the provided installation instructions.
 
 ## Building project
 


### PR DESCRIPTION
## Summary
- describe how to install Maven on common platforms in INSTALL_GUIDE.md

## Testing
- `mvn -q test` *(fails: PluginResolutionException)*

------
https://chatgpt.com/codex/tasks/task_e_6842461457c0832fb1f22a731412199e

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the installation guide to include a new section on installing Maven, with instructions for Debian-based systems and a link for other operating systems.
  - Adjusted the table of contents to reflect the new installation step.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->