### PR TITLE
Fix spelling and generics in revenue count

### DIFF
--- a/src/main/java/com/divudi/bean/report/PharmacySaleReportController.java
+++ b/src/main/java/com/divudi/bean/report/PharmacySaleReportController.java
@@ -4870,7 +4870,7 @@ public class PharmacySaleReportController implements Serializable {
             proTot = calBillFee(nowDate, FeeType.Staff, btps);
             regentFee = calBillFee(nowDate, FeeType.Chemical, btps);
 
-            count = billReportBean.calulateRevenueBillItemCount(CommonFunctions.getStartOfDay(nowDate),
+            count = billReportBean.calculateRevenueBillItemCount(CommonFunctions.getStartOfDay(nowDate),
                     CommonFunctions.getEndOfDay(nowDate), null, institution, department, btps);
             countTotal += count;
 

--- a/src/main/java/com/divudi/ejb/BillReportBean.java
+++ b/src/main/java/com/divudi/ejb/BillReportBean.java
@@ -34,9 +34,9 @@ public class BillReportBean {
 
 
 
-    public Long calulateRevenueBillItemCount(Date fd, Date td, PaymentMethod pm, Institution institution, Department department, BillType[] billTypes, Class bc) {
+    public Long calculateRevenueBillItemCount(Date fd, Date td, PaymentMethod pm, Institution institution, Department department, BillType[] billTypes, Class bc) {
         String sql;
-        Map m = new HashMap();
+        Map<String, Object> m = new HashMap<>();
         sql = "select count(bi) "
                 + " from BillItem bi "
                 + " where bi.bill.retired=false "
@@ -68,10 +68,10 @@ public class BillReportBean {
         return billFacade.findLongByJpql(sql, m, TemporalType.TIMESTAMP);
     }
 
-    public Long calulateRevenueBillItemCount(Date fd, Date td, PaymentMethod pm, Institution institution, Department department, BillType[] billTypes) {
-        return calulateRevenueBillItemCount(fd, td, pm, institution, department, billTypes, BilledBill.class)
-                - calulateRevenueBillItemCount(fd, td, pm, institution, department, billTypes, CancelledBill.class)
-                - calulateRevenueBillItemCount(fd, td, pm, institution, department, billTypes, RefundBill.class);
+    public Long calculateRevenueBillItemCount(Date fd, Date td, PaymentMethod pm, Institution institution, Department department, BillType[] billTypes) {
+        return calculateRevenueBillItemCount(fd, td, pm, institution, department, billTypes, BilledBill.class)
+                - calculateRevenueBillItemCount(fd, td, pm, institution, department, billTypes, CancelledBill.class)
+                - calculateRevenueBillItemCount(fd, td, pm, institution, department, billTypes, RefundBill.class);
     }
 
 }


### PR DESCRIPTION
## Summary
- fix misspelled `calculateRevenueBillItemCount` in `BillReportBean`
- use typed `Map<String, Object>` when building JPQL params
- update call site in `PharmacySaleReportController`

## Testing
- `mvn -q test` *(fails: Could not transfer artifact)*

------
https://chatgpt.com/codex/tasks/task_e_68424631b66c832f9a8f461dac1aa702