### PR TITLE
Add null safety to checkOnlyNumeric

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -370,7 +370,13 @@
             <version>2.8.9</version>
             <type>jar</type>
         </dependency>
-        
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.13.2</version>
+            <scope>test</scope>
+        </dependency>
+
     </dependencies>
 
     

--- a/src/main/java/com/divudi/core/util/CommonFunctions.java
+++ b/src/main/java/com/divudi/core/util/CommonFunctions.java
@@ -121,6 +121,9 @@ public class CommonFunctions {
     }
 
     public static boolean checkOnlyNumeric(String text) {
+        if (text == null) {
+            return false;
+        }
         String cleandtext = text.replaceAll("[\\s+\\-()]", "");
         String regex = "^[0-9]+$";
         // Check if the text matches the pattern

--- a/src/test/java/com/divudi/core/util/CommonFunctionsTest.java
+++ b/src/test/java/com/divudi/core/util/CommonFunctionsTest.java
@@ -1,0 +1,12 @@
+package com.divudi.core.util;
+
+import org.junit.Test;
+import static org.junit.Assert.*;
+
+public class CommonFunctionsTest {
+
+    @Test
+    public void checkOnlyNumericHandlesNull() {
+        assertFalse(CommonFunctions.checkOnlyNumeric(null));
+    }
+}


### PR DESCRIPTION
## Summary
- guard against null input in `checkOnlyNumeric`
- add JUnit test covering null handling
- include JUnit dependency for tests

## Testing
- `mvn -q test` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:2.6 could not be resolved)*

------
https://chatgpt.com/codex/tasks/task_e_684255ec5a1c832fb2859215eb75c7dd