### PR TITLE
Update Maven compiler plugin for offline build

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -386,7 +386,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.8.1</version>
+                <version>3.10.1</version>
                 <configuration>
                     <release>8</release> <!-- Compile with Java 8 compatibility -->
                     <debug>false</debug>


### PR DESCRIPTION
## Summary
- update Maven compiler plugin version to 3.10.1 to match available local packages

Compilation still fails offline due to missing `ca.uhn.hapi.fhir:hapi-fhir-base` dependency.

## Testing
- `mvn -q -DskipTests -o compile` *(fails: Could not resolve ca.uhn.hapi.fhir:hapi-fhir-base)*

------
https://chatgpt.com/codex/tasks/task_e_68439c330430832fb6301d51a277c1ae

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the Maven Compiler Plugin to a newer version for improved build tooling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->