### PR TITLE
Add Admission icon and menu entry (#12791)

### DIFF
--- a/src/main/java/com/divudi/core/data/Icon.java
+++ b/src/main/java/com/divudi/core/data/Icon.java
@@ -118,6 +118,7 @@ public enum Icon {
     Cashier_Summaries("Cashier Summaries"),
     Shift_End_Summary("Shift End Summary"),
     Day_End_Summary("Day End Summary"),
+    Admission("Admission"),
     Admit("Admit Patient"),
     Manage_Shift_Fund_Bills("Manage Shift Fund Bills"),
     // icons for cashier

--- a/src/main/webapp/home.xhtml
+++ b/src/main/webapp/home.xhtml
@@ -25,6 +25,21 @@
                     </h:form>
                 </h:panelGroup>
 
+                <!-- Admission -->
+                <h:panelGroup rendered="#{ui.icon eq 'Admission'}" layout="block" class="col-1 p-1" >
+                    <h:form>
+                        <p:tooltip for="Admission" value="Admission" showDelay="0" hideDelay="0"></p:tooltip>
+                        <p:commandLink
+                            id="Admission"
+                            ajax="false"
+                            action="#{admissionController.navigateToAdmitFromMenu()}"
+                            styleClass="svg-link" >
+                            <p:graphicImage class="img-thumbnail" cache="true" library="image" name="home/admission.svg" style="cursor: pointer;" width="80" height="80"/>
+                            <h:outputText style="display: none;" value="Admission"/>
+                        </p:commandLink>
+                    </h:form>
+                </h:panelGroup>
+
                 <!-- Patient Lookup -->
                 <h:panelGroup rendered="#{ui.icon eq 'Patient_Lookup' and webUserController.hasPrivilege('OpdPreBilling')}" layout="block" class="col-1 p-1" >
                     <h:form>

--- a/src/main/webapp/home.xhtml
+++ b/src/main/webapp/home.xhtml
@@ -26,7 +26,7 @@
                 </h:panelGroup>
 
                 <!-- Admission -->
-                <h:panelGroup rendered="#{ui.icon eq 'Admission'}" layout="block" class="col-1 p-1" >
+                <h:panelGroup rendered="#{ui.icon eq 'Admission' and webUserController.hasPrivilege('InwardAdmissionsAdmission')}" layout="block" class="col-1 p-1" >
                     <h:form>
                         <p:tooltip for="Admission" value="Admission" showDelay="0" hideDelay="0"></p:tooltip>
                         <p:commandLink

--- a/src/main/webapp/resources/image/home/admission.svg
+++ b/src/main/webapp/resources/image/home/admission.svg
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg">
+  <rect width="60" height="20" x="20" y="40" fill="#000000"/>
+  <rect width="20" height="60" x="40" y="20" fill="#000000"/>
+</svg>


### PR DESCRIPTION
## Summary
- add new `Admission` enum constant
- add new icon file `admission.svg`
- render the Admission icon and menu link in `home.xhtml`

## Testing
- `mvn -q test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844117fc70c832fbcc74c4c326fc8c4

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a new "Admission" icon to the home page menu, enabling users with the appropriate privilege to navigate directly to the admission section via a clickable icon.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->