### PR TITLE
Add Appointments icon

### DIFF
--- a/src/main/java/com/divudi/core/data/Icon.java
+++ b/src/main/java/com/divudi/core/data/Icon.java
@@ -114,6 +114,7 @@ public enum Icon {
     Optician_Product_Catalog("Optician - Product Catalog"),
     Optician_Repair_Management("Optician - Repair Management"),
     Optician_Retail_Sale("Optician - Retail Sale"),
+    Appointments("Appointments"),
     Channel_Booking("Channel Booking"),
     Cashier_Summaries("Cashier Summaries"),
     Shift_End_Summary("Shift End Summary"),

--- a/src/main/webapp/home.xhtml
+++ b/src/main/webapp/home.xhtml
@@ -1509,14 +1509,28 @@
                 <h:panelGroup layout="block" class="col-1 p-1"  rendered="#{ui.icon eq 'pharmacy_generate_report'}">
                     <h:form>
                         <p:tooltip for="pharmacy_generate_report" value="Generate Reports"  showDelay="0" hideDelay="0"></p:tooltip>
-                        <p:commandLink 
+                        <p:commandLink
                             id="pharmacy_generate_report"
-                            ajax="false" 
-                            action="/pharmacy/pharmacy_reports_index?faces-redirect=true" 
+                            ajax="false"
+                            action="/pharmacy/pharmacy_reports_index?faces-redirect=true"
                             rendered="#{webUserController.hasPrivilege('PharmacyReports')}"
                             styleClass="svg-link" >
                             <p:graphicImage class="img-thumbnail" cache="true" library="image" name="home/reports.svg" style="cursor: pointer;" width="80" height="80"/>
                             <h:outputText style="display: none;" value="Generate Reports" />
+                        </p:commandLink>
+                    </h:form>
+                </h:panelGroup>
+
+                <h:panelGroup rendered="#{ui.icon eq 'Appointments' and webUserController.hasPrivilege('ChannellingChannelBooking')}" layout="block" class="col-1 p-1">
+                    <h:form>
+                        <p:tooltip for="Appointments" value="Appointments" showDelay="0" hideDelay="0"/>
+                        <p:commandLink id="Appointments" ajax="false"
+                                       action="#{bookingController.navigateToChannelBookingFromMenu()}"
+                                       styleClass="svg-link">
+                            <p:graphicImage class="img-thumbnail" library="image"
+                                            name="home/appointments.svg"
+                                            style="cursor:pointer;" width="80" height="80"/>
+                            <h:outputText style="display:none;" value="Appointments"/>
                         </p:commandLink>
                     </h:form>
                 </h:panelGroup>

--- a/src/main/webapp/resources/image/home/appointments.svg
+++ b/src/main/webapp/resources/image/home/appointments.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <rect x="8" y="14" width="48" height="42" rx="4" ry="4" fill="#ffffff" stroke="#000" stroke-width="2"/>
+  <line x1="8" y1="22" x2="56" y2="22" stroke="#000" stroke-width="2"/>
+  <line x1="20" y1="8" x2="20" y2="14" stroke="#000" stroke-width="2"/>
+  <line x1="44" y1="8" x2="44" y2="14" stroke="#000" stroke-width="2"/>
+</svg>


### PR DESCRIPTION
## Summary
- add `Appointments` enum value
- add Appointments home menu entry
- include appointments icon asset

## Testing
- `mvn -q test` *(fails: PluginResolutionException due to network)*

------
https://chatgpt.com/codex/tasks/task_e_684445dc7844832f81a612c78c723cec

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an "Appointments" icon to the home page, visible to users with the appropriate privilege.
  - Users can now access appointment booking directly from the home page via the new icon.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->