### PR TITLE
Add supplier GRN return list

### DIFF
--- a/src/main/java/com/divudi/bean/pharmacy/SupplierPaymentController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/SupplierPaymentController.java
@@ -175,6 +175,12 @@ public class SupplierPaymentController implements Serializable {
         return "/dealerPayment/list_bills_to_generate_supplier_payments?faces-redirect=true";
     }
 
+    public String navigateToGenerateSupplierReturnPayments() {
+        bills = new ArrayList<>();
+        netTotal = 0.0;
+        return "/dealerPayment/list_grn_returns_to_generate_supplier_payments?faces-redirect=true";
+    }
+
     public String navigateToApproveSupplierPayments() {
         bills = new ArrayList<>();
         netTotal = 0.0;
@@ -1042,9 +1048,32 @@ public class SupplierPaymentController implements Serializable {
             BillTypeAtomic.PHARMACY_WHOLESALE_GRN_BILL,
             BillTypeAtomic.PHARMACY_DIRECT_PURCHASE,
             BillTypeAtomic.PHARMACY_WHOLESALE_DIRECT_PURCHASE_BILL,
-            BillTypeAtomic.PHARMACY_WHOLESALE_GRN_BILL,
+            BillTypeAtomic.PHARMACY_WHOLESALE_GRN_BILL};
+        List<BillTypeAtomic> billTypesListBilled = Arrays.asList(billTypesArrayBilled);
+
+        boolean needPaymentApproval = configOptionApplicationController.getBooleanValueByKey("Approval is necessary for Procument Payments", false);
+        if (needPaymentApproval) {
+            bills = billController.findUnpaidBills(fromDate, toDate, billTypesListBilled, PaymentMethod.Credit, 0.01, true);
+        } else {
+            bills = billController.findUnpaidBills(fromDate, toDate, billTypesListBilled, PaymentMethod.Credit, 0.01);
+        }
+
+        netTotal = 0.0;
+        paidAmount = 0.0;
+        refundAmount = 0.0;
+        balance = 0.0;
+        for (Bill b : bills) {
+            netTotal += b.getNetTotal();
+            paidAmount += b.getPaidAmount();
+            balance += b.getBalance();
+            refundAmount += b.getRefundAmount();
+        }
+    }
+
+    public void fillUnsettledCreditPharmacyReturnBills() {
+        BillTypeAtomic[] billTypesArrayBilled = {
             BillTypeAtomic.PHARMACY_GRN_RETURN,
-            BillTypeAtomic.PHARMACY_GRN_REFUND,};
+            BillTypeAtomic.PHARMACY_GRN_REFUND};
         List<BillTypeAtomic> billTypesListBilled = Arrays.asList(billTypesArrayBilled);
 
         boolean needPaymentApproval = configOptionApplicationController.getBooleanValueByKey("Approval is necessary for Procument Payments", false);

--- a/src/main/webapp/dealerPayment/index.xhtml
+++ b/src/main/webapp/dealerPayment/index.xhtml
@@ -57,13 +57,22 @@
                                 </h:panelGroup>
 
                                 <h:panelGroup rendered="#{configOptionApplicationController.getBooleanValueByKey('Approval is necessary for Procument Payments', false)}">
-                                    <p:commandButton 
+                                    <p:commandButton
                                         class="w-100"
                                         ajax="false"
                                         value="Generate Payments"
-                                        icon="fas fa-file-invoice"  
+                                        icon="fas fa-file-invoice"
                                         styleClass="ui-button-danger"
                                         action="#{supplierPaymentController.navigateToGenerateSupplierPayments()}"
+                                        rendered="#{webUserController.hasPrivilege('PharmacyDealerDueSearch')}" />
+
+                                    <p:commandButton
+                                        class="w-100"
+                                        ajax="false"
+                                        value="Generate Return Payments"
+                                        icon="fas fa-undo"
+                                        styleClass="ui-button-danger"
+                                        action="#{supplierPaymentController.navigateToGenerateSupplierReturnPayments()}"
                                         rendered="#{webUserController.hasPrivilege('PharmacyDealerDueSearch')}" />
 
                                     <p:commandButton 

--- a/src/main/webapp/dealerPayment/list_grn_returns_to_generate_supplier_payments.xhtml
+++ b/src/main/webapp/dealerPayment/list_grn_returns_to_generate_supplier_payments.xhtml
@@ -14,7 +14,7 @@
                     <p:panel>
                         <f:facet name="header" > 
                             <h:outputText styleClass="fas fa-file-invoice"/>
-                            <h:outputLabel class="mx-4" value="Generate Supplier Payments"/>  
+                            <h:outputLabel class="mx-4" value="Generate Supplier Return Payments"/>
                         </f:facet>
                         <div class="row">
                             <div class="col-2">
@@ -34,25 +34,11 @@
                                 <p:separator></p:separator>
 
                                 <p:commandButton
-                                    value="Pharmacy GRNs to Generate Payments"
-                                    action="#{supplierPaymentController.fillUnsettledCreditPharmacyBills}"
+                                    value="Pharmacy GRN Returns to Generate Payments"
+                                    action="#{supplierPaymentController.fillUnsettledCreditPharmacyReturnBills}"
                                     ajax="false"
-                                    icon="fas fa-prescription-bottle-alt"
+                                    icon="fas fa-undo"
                                     class="my-1 w-100 ui-button-warning" />
-
-                                <p:commandButton 
-                                    value="Store Credit Bills to Generate Payments" 
-                                    action="#{supplierPaymentController.fillUnsettledCreditStoreBills()}" 
-                                    ajax="false"  
-                                    icon="fas fa-store-alt" 
-                                    class="my-1 w-100  ui-button-warning" />
-
-                                <p:commandButton 
-                                    value="All Credit Bills to Generate Payments"
-                                    action="#{supplierPaymentController.fillUnsettledCreditBills()}"
-                                    ajax="false"
-                                    icon="fas fa-file-invoice-dollar"
-                                    class="my-1 w-100  ui-button-warning" />
 
 
                                 <p:separator></p:separator>


### PR DESCRIPTION
## Summary
- show only GRNs when listing bills to generate payments
- allow navigating to a new list that shows GRN returns
- add new controller methods for navigation and data loading

## Testing
- `mvn -q test` *(fails: Plugin could not be resolved)*

------
https://chatgpt.com/codex/tasks/task_e_68445d3e45a8832fabcdbcecce5773b0