### PR TITLE
Add icons for Admissions search and Investigations trace

### DIFF
--- a/src/main/java/com/divudi/core/data/Icon.java
+++ b/src/main/java/com/divudi/core/data/Icon.java
@@ -125,6 +125,8 @@ public enum Icon {
     Day_End_Summary("Day End Summary"),
     Admit("Admit Patient"),
     Inpatient_Appointments("Inpatient Appointments"),
+    Search_Admissions("Search Admissions"),
+    Investigation_Trace("Trace Investigations"),
     Manage_Shift_Fund_Bills("Manage Shift Fund Bills"),
     // icons for cashier
     Cashier_Drawer("Logged User Drawer"),;

--- a/src/main/webapp/home.xhtml
+++ b/src/main/webapp/home.xhtml
@@ -1544,6 +1544,28 @@
                     </h:form>
                 </h:panelGroup>
 
+                <!-- Search Admissions -->
+                <h:panelGroup layout="block" class="col-1 p-1"  rendered="#{ui.icon eq 'Search_Admissions'}">
+                    <h:form>
+                        <p:tooltip for="search_admissions" value="Search Admissions" showDelay="0" hideDelay="0"></p:tooltip>
+                        <p:commandLink id="search_admissions" ajax="false" action="#{admissionController.navigateToListAdmissions}" styleClass="svg-link">
+                            <p:graphicImage class="img-thumbnail"  library="image" name="home/search.svg" style="cursor: pointer;" width="80" height="80"/>
+                            <h:outputText style="display: none;" value="Search Admissions" />
+                        </p:commandLink>
+                    </h:form>
+                </h:panelGroup>
+
+                <!-- Trace Investigations -->
+                <h:panelGroup layout="block" class="col-1 p-1"  rendered="#{ui.icon eq 'Investigation_Trace'}">
+                    <h:form>
+                        <p:tooltip for="investigation_trace" value="Trace Investigations" showDelay="0" hideDelay="0"></p:tooltip>
+                        <p:commandLink id="investigation_trace" ajax="false" action="/inward/investigation_search_for_reporting_bht?faces-redirect=true" styleClass="svg-link">
+                            <p:graphicImage class="img-thumbnail"  library="image" name="home/search.svg" style="cursor: pointer;" width="80" height="80"/>
+                            <h:outputText style="display: none;" value="Trace Investigations" />
+                        </p:commandLink>
+                    </h:form>
+                </h:panelGroup>
+
                 <!-- Summary Views -->
                 <h:panelGroup layout="block" class="col-1 p-1"  rendered="#{ui.icon eq 'pharmacy_summary_views'}">
                     <h:form>

--- a/src/main/webapp/resources/ezcomp/menu.xhtml
+++ b/src/main/webapp/resources/ezcomp/menu.xhtml
@@ -391,10 +391,11 @@
                         <p:menuitem  ajax="false"  action="/inward/inward_search_intrim" value="Interim Bill Search" actionListener="#{searchController.makeNull()}" rendered="#{webUserController.hasPrivilege('InwardBillingInterimBillSearch')}" ></p:menuitem>        
                     </p:submenu>
                     <p:submenu label="Search " rendered="#{webUserController.hasPrivilege('InwardSearch')}">
-                        <p:menuitem  ajax="false"  
+                        <p:menuitem  ajax="false"
                                      action="#{admissionController.navigateToListAdmissions}"
                                      value="Admissions"
-                                     rendered="#{webUserController.hasPrivilege('InwardSearchServiceBill')}" ></p:menuitem>  
+                                     icon="fa fa-search"
+                                     rendered="#{webUserController.hasPrivilege('InwardSearchServiceBill')}" ></p:menuitem>
                         <p:menuitem  ajax="false"  action="/inward/inward_search_service?faces-redirect=true" value="Service Bill" actionListener="#{searchController.makeListNull}"  rendered="#{webUserController.hasPrivilege('InwardSearchServiceBill')}" ></p:menuitem>  
                         <p:menuitem  ajax="false"  action="/inward/inward_search_professional?faces-redirect=true" value="Professional Bill" actionListener="#{searchController.makeListNull}"  rendered="#{webUserController.hasPrivilege('InwardSearchProfessionalBill')}" ></p:menuitem>  
                         <p:menuitem  ajax="false"  action="/inward/inward_search_professional_estimate?faces-redirect=true" value="Estimated Professional Bill" actionListener="#{searchController.makeListNull}"  rendered="#{webUserController.hasPrivilege('InwardSearchProfessionalBill')}" ></p:menuitem>
@@ -444,7 +445,7 @@
 
                     </p:submenu>
 
-                    <p:menuitem  ajax="false"  action="/inward/investigation_search_for_reporting_bht?faces-redirect=true" value="Investigation Trace"></p:menuitem>
+                    <p:menuitem  ajax="false"  action="/inward/investigation_search_for_reporting_bht?faces-redirect=true" value="Investigation Trace" icon="fa fa-search"></p:menuitem>
                     <p:menuitem  
                         ajax="false"  
                         action="/inward/inward_reports?faces-redirect=true" 


### PR DESCRIPTION
## Summary
- add `Search_Admissions` and `Investigation_Trace` icons
- show icons on home page for admissions search and investigation trace
- add search icons to Inpatient menu

## Testing
- `mvn -q test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_684479ca4e70832fb39095a4a9ea3744