### PR TITLE
Fix duplicate user icons and refresh icons

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,3 +7,8 @@
 3. Update `src/main/webapp/home.xhtml` to reference the new `Icon` constant and image. This home page change should be tracked as a separate issue when creating pull requests.
 
 These guidelines apply to the entire repository.
+
+## Handling Privileges
+
+- Add all privilege constants to `src/main/java/com/divudi/core/data/Privileges.java`.
+- Use `WebUserController.hasPrivilege(String)` to verify a user's access for a department or feature.

--- a/src/main/java/com/divudi/bean/common/UserIconController.java
+++ b/src/main/java/com/divudi/bean/common/UserIconController.java
@@ -69,6 +69,19 @@ public class UserIconController implements Serializable {
             return;
         }
 
+        // Check for an existing icon for the same user and department
+        Map<String, Object> params = new HashMap<>();
+        params.put("u", user);
+        params.put("i", icon);
+        params.put("d", department);
+        params.put("ret", false);
+        String jpql = "select ui from UserIcon ui where ui.webUser=:u and ui.icon=:i and ui.department=:d and ui.retired=:ret";
+        UserIcon duplicate = getFacade().findFirstByJpql(jpql, params);
+        if (duplicate != null) {
+            JsfUtil.addErrorMessage("Icon already added for this department");
+            return;
+        }
+
         double newOrder = getUserIcons().size() + 1;
         UserIcon existingUI = findUserIconByOrder(newOrder);
 
@@ -273,7 +286,7 @@ public class UserIconController implements Serializable {
 
     public void setUser(WebUser user) {
         this.user = user;
-        userIcons = fillUserIcons(user, department);
+        fillDepartmentIcon();
     }
 
     public List<UserIcon> getUserIcons() {
@@ -301,6 +314,7 @@ public class UserIconController implements Serializable {
 
     public void setDepartment(Department department) {
         this.department = department;
+        fillDepartmentIcon();
     }
 
     public List<Department> getDepartments() {


### PR DESCRIPTION
## Summary
- prevent saving duplicates of UserIcon for the same user and department
- refresh the icon list whenever the user or department is changed
- document privilege handling guidelines in `AGENTS.md`

## Testing
- `mvn -q test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844826f7610832f8c0bbce03b5cf22d