### PR TITLE
Add ManageCreditCompany privilege

### DIFF
--- a/src/main/java/com/divudi/bean/common/UserPrivilageController.java
+++ b/src/main/java/com/divudi/bean/common/UserPrivilageController.java
@@ -424,6 +424,7 @@ public class UserPrivilageController implements Serializable {
         new DefaultTreeNode(new PrivilegeHolder(Privileges.AdminStaff, "Manage Staff"), adminNode);
         new DefaultTreeNode(new PrivilegeHolder(Privileges.AdminItems, "Manage Items/Services"), adminNode);
         new DefaultTreeNode(new PrivilegeHolder(Privileges.AdminPrices, "Manage Fees/Prices/Packages"), adminNode);
+        new DefaultTreeNode(new PrivilegeHolder(Privileges.ManageCreditCompany, "Manage Credit Companies"), adminNode);
         new DefaultTreeNode(new PrivilegeHolder(Privileges.AdminFilterWithoutDepartment, "Filter Without Department"), adminNode);
         new DefaultTreeNode(new PrivilegeHolder(Privileges.SearchAll, "Search All"), adminNode);
         new DefaultTreeNode(new PrivilegeHolder(Privileges.ChangeProfessionalFee, "Change Professional Fee"), adminNode);

--- a/src/main/java/com/divudi/core/data/Privileges.java
+++ b/src/main/java/com/divudi/core/data/Privileges.java
@@ -615,6 +615,7 @@ public enum Privileges {
     AdminStaff("Admin Staff"),
     AdminItems("Admin Items"),
     AdminPrices("Admin Prices"),
+    ManageCreditCompany("Manage Credit Company"),
     AdminFilterWithoutDepartment("Admin Filter Without Department"),
     //</editor-fold>
 

--- a/src/main/webapp/admin/institutions/admin_institutions_index.xhtml
+++ b/src/main/webapp/admin/institutions/admin_institutions_index.xhtml
@@ -111,11 +111,12 @@
                                             action="#{navigationController.navigateToCollectingCenter()}" >
                                         </p:commandButton>
                                         
-                                        <p:commandButton  
-                                            styleClass="linkButton" 
-                                            ajax="false" 
-                                            value="Credit Companies" 
-                                            icon="fas fa-credit-card" action="#{navigationController.navigateToCreditCompany()}" >
+                                        <p:commandButton
+                                            styleClass="linkButton"
+                                            ajax="false"
+                                            value="Credit Companies"
+                                            icon="fas fa-credit-card" action="#{navigationController.navigateToCreditCompany()}"
+                                            rendered="#{webUserController.hasPrivilege('ManageCreditCompany')}" >
                                         </p:commandButton>
 
                                         <p:commandButton  

--- a/src/main/webapp/admin/institutions/credit_company.xhtml
+++ b/src/main/webapp/admin/institutions/credit_company.xhtml
@@ -10,7 +10,11 @@
 
     <ui:define name="admin">
 
-        <h:panelGroup >
+        <h:panelGroup rendered="#{!webUserController.hasPrivilege('ManageCreditCompany')}">
+            <p:outputLabel value="YOU ARE NOT AUTHORIZED." />
+        </h:panelGroup>
+
+        <h:panelGroup rendered="#{webUserController.hasPrivilege('ManageCreditCompany')}">
             <h:form  >
 
                 <p:focus id="selectFocus" for="lstSelect" />


### PR DESCRIPTION
## Summary
- add ManageCreditCompany to Privileges enum
- allow assigning ManageCreditCompany in UserPrivilageController
- hide Manage Credit Company navigation if user lacks privilege
- restrict credit company page by privilege

## Testing
- `mvn -q -DskipTests package` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844fb36c240832fbe7aa5f79c7ed6c6