### PR TITLE
Fix collecting-centre bill validation

### DIFF
--- a/src/main/java/com/divudi/service/BillService.java
+++ b/src/main/java/com/divudi/service/BillService.java
@@ -1729,8 +1729,10 @@ public class BillService {
             case CC_PAYMENT_RECEIVED_BILL:
             case CC_PAYMENT_MADE_BILL:
             case CC_PAYMENT_MADE_CANCELLATION_BILL:
-                boolean billHasNoBillItems = billHasNoBillItems(bill);
-                if (billHasNoBillItems) {
+                boolean noItemsError = billHasNoBillItems(bill);
+                boolean netTotalError = billNetTotalIsNotEqualToBillItemNetTotal(bill);
+
+                if (noItemsError || netTotalError) {
                     hasAtLeatOneError = true;
                 }
                 break;


### PR DESCRIPTION
## Summary
- check collecting centre bills for net total mismatches

## Testing
- `mvn -q -DskipTests package` *(fails: Plugin maven-resources-plugin could not be resolved)*

------
https://chatgpt.com/codex/tasks/task_e_68453e32cdd0832fa4cd6c087480493b

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved error detection for certain bill types to ensure discrepancies in bill totals are properly flagged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->