### PR TITLE
Prevent duplicate CC bill settling

### DIFF
--- a/src/main/webapp/collecting_centre/bill.xhtml
+++ b/src/main/webapp/collecting_centre/bill.xhtml
@@ -356,14 +356,15 @@
                                     </p:commandButton>
                                     <p:focus id="focusIx" for=":#{p:resolveFirstComponentWithId('acIx',view).clientId}" />
 
-                                    <p:commandButton  
+                                    <p:commandButton
                                         style="float: right;"
-                                        value="Settle" 
+                                        value="Settle"
                                         icon="fa fa-check"
-                                        action="#{collectingCentreBillController.settleCcBill()}" 
-                                        ajax="false" 
+                                        action="#{collectingCentreBillController.settleCcBill()}"
+                                        ajax="false"
+                                        disabled="#{collectingCentreBillController.ccBillSettlingStarted}"
                                         onclick="if (!confirm('Are you sure you want to Settle This Bill ?'))
-                                                    return false;"
+                                                    return false; this.disabled=true;"
 
                                         class="ui-button-success ">
                                     </p:commandButton>


### PR DESCRIPTION
## Summary
- guard CollectingCentreBillController with AtomicBoolean to avoid double-settle
- reset the flag on navigation and exit paths
- disable Settle button once clicked

## Testing
- `mvn -q test` *(fails: PluginResolutionException)*

------
https://chatgpt.com/codex/tasks/task_e_68454aa29c50832fb1ef7fb464507ec7