### PR TITLE
Fix return bill concurrency

### DIFF
--- a/src/main/webapp/collecting_centre/bill_return.xhtml
+++ b/src/main/webapp/collecting_centre/bill_return.xhtml
@@ -135,13 +135,13 @@
                                         <p:inputTextarea value="#{billReturnController.refundComment}"  class="w-100"></p:inputTextarea>
 
                                         <p:spacer ></p:spacer>
-                                        <p:commandButton 
-                                            id="btnSave" 
-                                            value="Return Selected Items" 
+                                        <p:commandButton
+                                            id="btnSave"
+                                            value="Return Selected Items"
                                             ajax="false"
                                             class="ui-button-warning"
-                                            onclick="if (!confirm('Are You Sure You Want to Refund this Items?'))
-                                                        return false;"
+                                            disabled="#{billReturnController.returningStarted}"
+                                            onclick="if (!confirm('Are You Sure You Want to Refund this Items?')) return false; this.disabled=true;"
                                             action="#{billReturnController.settleCCReturnBill()}"
                                             oncomplete="PF('dlg').hide();" >
                                         </p:commandButton>

--- a/src/main/webapp/opd/bill_return.xhtml
+++ b/src/main/webapp/opd/bill_return.xhtml
@@ -73,15 +73,15 @@
                                 <p:panel >
                                     <f:facet name="header" >
                                         <h:outputText value="Return Details" class="mt-2" ></h:outputText>
-                                        <p:commandButton 
-                                            id="btnSave" 
-                                            value="Refund" 
+                                        <p:commandButton
+                                            id="btnSave"
+                                            value="Refund"
                                             ajax="false"
                                             icon="fa fa-money-bill-wave"
                                             style="float:right; width: 8em;"
                                             class="ui-button-warning"
-                                            onclick="if (!confirm('Are You Sure You Want to Refund this Items?'))
-                                                        return false;"
+                                            disabled="#{billReturnController.returningStarted}"
+                                            onclick="if (!confirm('Are You Sure You Want to Refund this Items?')) return false; this.disabled=true;"
                                             action="#{billReturnController.settleOpdReturnBill()}">
                                         </p:commandButton>
                                     </f:facet>


### PR DESCRIPTION
## Summary
- prevent multiple return bill actions by using AtomicBoolean
- disable refund buttons in CC and OPD when process running

## Testing
- `mvn test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845555c191c832f86fb6540e25882d4