### PR TITLE
Add icons for settings menu items

### DIFF
--- a/src/main/webapp/resources/ezcomp/menu.xhtml
+++ b/src/main/webapp/resources/ezcomp/menu.xhtml
@@ -1675,26 +1675,26 @@
                         ajax="false"  
                         rendered="#{webUserController.hasPrivilege('MyFinanacialTransactionManager')}" 
                         action="#{sessionController.navigateToChangePasswordByUser}" 
-                        value="Change My Password"></p:menuitem>
+                        value="Change My Password" icon="pi pi-lock"></p:menuitem>
                     <p:menuitem 
                         ajax="false"  
                         rendered="#{webUserController.hasPrivilege('ChangeMyTheme')}" 
                         action="#{themeController.navigateToChangeOwnTheme()}"
-                        value="Change My Theme"  ></p:menuitem>
+                        value="Change My Theme" icon="pi pi-palette" ></p:menuitem>
                     <p:menuitem 
                         ajax="false" 
                         rendered="#{webUserController.hasPrivilege('ChangePreferece')}" 
                         action="#{sessionController.navigateToManageOwnWebUserPreferences()}"
-                        value="Change My Preferences"  ></p:menuitem>
+                        value="Change My Preferences" icon="pi pi-sliders-h"  ></p:menuitem>
                     <p:menuitem  
                         ajax="false"  
                         rendered="#{webUserController.hasPrivilege('ChangeMyApiKeys')}" 
                         action="#{apiKeyController.toManageMyApiKeys()}" 
-                        value="Manage My API Keys"  ></p:menuitem>
+                        value="Manage My API Keys" icon="pi pi-key"  ></p:menuitem>
                     <p:menuitem
                         ajax="false"
                         action="#{versionController.navigateToAboutSoftware()}"
-                        value="About Software"  ></p:menuitem>
+                        value="About Software" icon="pi pi-info-circle"  ></p:menuitem>
 
                 </p:submenu>
 


### PR DESCRIPTION
## Summary
- add PrimeFaces icons for user settings submenu items

## Testing
- `mvn test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845b885ea58832f8f7cca01fe4e331f