### PR TITLE
Fix NPE risk in removeselected

### DIFF
--- a/src/main/java/com/divudi/bean/pharmacy/SupplierPaymentController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/SupplierPaymentController.java
@@ -768,7 +768,9 @@ public class SupplierPaymentController implements Serializable {
     }
 
     public void removeselected(BillItem billItem) {
-        getSelectedBillItems().remove(billItem); // removes by object, not by index
+        if (selectedBillItems != null) {
+            selectedBillItems.remove(billItem); // removes by object, not by index
+        }
         calTotalWithResetingIndexSelected();
         calculateTotalBySelectedBillItems();
     }


### PR DESCRIPTION
## Summary
- avoid NullPointerException in `SupplierPaymentController.removeselected` by checking `selectedBillItems`

## Testing
- `mvn -q test` *(fails: PluginResolutionException, network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68469dd68c7c832f92cebb0f26f0db51