### PR TITLE
Add confirmations for Collecting Centre bill actions

### DIFF
--- a/src/main/webapp/collecting_centre/bill.xhtml
+++ b/src/main/webapp/collecting_centre/bill.xhtml
@@ -362,7 +362,9 @@
                                         icon="fa fa-check"
                                         action="#{collectingCentreBillController.settleCcBill()}"
                                         ajax="false"
-                                        class="ui-button-success ">
+                                        class="ui-button-success "
+                                        onclick="if (!confirm('Are you sure you want to Settle This Bill ?'))
+                                                    return false;">
                                     </p:commandButton>
 
                                 </f:facet>

--- a/src/main/webapp/collecting_centre/bill_cancel.xhtml
+++ b/src/main/webapp/collecting_centre/bill_cancel.xhtml
@@ -49,7 +49,9 @@
                                         icon="fa fa-cancel"
                                         style="float: right"
                                         class="ui-button-danger"
-                                        action="#{billSearch.cancelCollectingCentreBill()}">
+                                        action="#{billSearch.cancelCollectingCentreBill()}"
+                                        onclick="if (!confirm('Are you sure you want to Cancel This Bill ?'))
+                                                    return false;">
                                     </p:commandButton>
                                     <p:commandButton  
                                         class="ui-button-secondary d-flex justify-content-end mx-2"

--- a/src/main/webapp/collecting_centre/bill_return.xhtml
+++ b/src/main/webapp/collecting_centre/bill_return.xhtml
@@ -141,6 +141,8 @@
                                             ajax="false"
                                             class="ui-button-warning"
                                             action="#{billReturnController.settleCCReturnBill()}"
+                                            onclick="if (!confirm('Are you sure you want to Return Selected Items ?'))
+                                                        return false;"
                                             oncomplete="PF('dlg').hide();" >
                                         </p:commandButton>
                                     </p:panelGrid>

--- a/src/main/webapp/collecting_centre/collecting_centre_deposit_bill.xhtml
+++ b/src/main/webapp/collecting_centre/collecting_centre_deposit_bill.xhtml
@@ -24,15 +24,17 @@
                                 <div class="d-flex justify-content-between">
                                     <h:outputLabel value="Collecting Centre Payment" class="mt-2"/>
                                     <div class="d-flex gap-2">
-                                        <p:commandButton 
-                                            id="btnSettle" 
-                                            value="Settle" 
+                                        <p:commandButton
+                                            id="btnSettle"
+                                            value="Settle"
                                             class="ui-button-success"
                                             icon="fa fa-check"
-                                            action="#{agentAndCcPaymentController.collectingCentrePaymentRecieveSettleBill}" 
-                                            ajax="false"  
+                                            action="#{agentAndCcPaymentController.collectingCentrePaymentRecieveSettleBill}"
+                                            ajax="false"
+                                            onclick="if (!confirm('Are you sure you want to Settle This Bill ?'))
+                                                        return false;"
                                             style="width: 150px; padding: 1px;border: 1px solid ; margin: auto;" >
-                                        </p:commandButton> 
+                                        </p:commandButton>
                                         <p:defaultCommand target="btnSettle"/>
                                         <p:commandButton 
                                             value="New Bill" 


### PR DESCRIPTION
## Summary
- add confirmation prompt to `Settle` button on collecting centre bill view
- add confirmation prompt when returning items
- add confirmation prompt for cancelling bills
- add confirmation prompt to deposit bill settlement

## Testing
- `mvn -q test` *(fails: mvn not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68474f9aeb68832faee87cac4ecb6708