### PR TITLE
12840 cc billing prevent double clicking

### DIFF
--- a/src/main/java/com/divudi/bean/common/AgentAndCcApplicationController.java
+++ b/src/main/java/com/divudi/bean/common/AgentAndCcApplicationController.java
@@ -257,8 +257,6 @@ public class AgentAndCcApplicationController {
             double balanceBeforeTx = collectingCentre.getBallance();
             double balanceAfterTx = balanceBeforeTx + Math.abs(hospitalFee);
 
-            System.out.println("Before Balance = " + collectingCentre.getBallance());
-            System.out.println("Refund Value = " + hospitalFee);
 
             agentHistory.setBalanceBeforeTransaction(
                     CommonFunctions.roundToTwoDecimalsBigDecimal(balanceBeforeTx)
@@ -272,7 +270,6 @@ public class AgentAndCcApplicationController {
             collectingCentre.setBallance(balanceAfterTx);
             institutionFacade.editAndCommit(collectingCentre);
 
-            System.out.println("After Balance = " + collectingCentre.getBallance());
 
         } finally {
             lock.unlock();

--- a/src/main/java/com/divudi/bean/common/AgentAndCcApplicationController.java
+++ b/src/main/java/com/divudi/bean/common/AgentAndCcApplicationController.java
@@ -183,8 +183,8 @@ public class AgentAndCcApplicationController {
 
             agentHistoryFacade.create(agentHistory);
 
-//            collectingCentre.setBallance(balanceAfterTx);
-//            institutionFacade.edit(collectingCentre);
+            collectingCentre.setBallance(balanceAfterTx);
+            institutionFacade.editAndCommit(collectingCentre);
         } finally {
             lock.unlock();
         }

--- a/src/main/java/com/divudi/bean/common/AgentAndCcPaymentController.java
+++ b/src/main/java/com/divudi/bean/common/AgentAndCcPaymentController.java
@@ -285,7 +285,7 @@ public class AgentAndCcPaymentController implements Serializable {
         
         if ((getCurrent().getNetTotal() > (ccToResetAllowedCredit.getMaxCreditLimit() - ccToResetAllowedCredit.getStandardCreditLimit())) && (ccToResetAllowedCredit.getMaxCreditLimit() != ccToResetAllowedCredit.getStandardCreditLimit())) {
             ccToResetAllowedCredit.setAllowedCredit(getCurrent().getFromInstitution().getStandardCreditLimit());
-            getInstitutionFacade().edit(ccToResetAllowedCredit);
+            getInstitutionFacade().editAndCommit(ccToResetAllowedCredit);
         }
         JsfUtil.addSuccessMessage("Bill Saved");
         ccDepositSettlingStarted = false;

--- a/src/main/java/com/divudi/bean/common/AgentAndCcPaymentController.java
+++ b/src/main/java/com/divudi/bean/common/AgentAndCcPaymentController.java
@@ -357,7 +357,6 @@ public class AgentAndCcPaymentController implements Serializable {
         }
 
         updateBallance(current.getFromInstitution(), current.getNetTotal(), HistoryType.AgentBalanceUpdateBill, current);
-        System.out.println(current.getFromInstitution().getBallance());
         saveBillItem();
 
         List<Payment> p = billService.createPayment(current, getCurrent().getPaymentMethod(), paymentMethodData);

--- a/src/main/java/com/divudi/bean/pharmacy/SupplierPaymentController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/SupplierPaymentController.java
@@ -1053,7 +1053,6 @@ public class SupplierPaymentController implements Serializable {
         BillTypeAtomic[] billTypesArrayBilled = {
             BillTypeAtomic.PHARMACY_GRN,
             BillTypeAtomic.PHARMACY_GRN_CANCELLED,
-            BillTypeAtomic.PHARMACY_WHOLESALE_GRN_BILL,
             BillTypeAtomic.PHARMACY_DIRECT_PURCHASE,
             BillTypeAtomic.PHARMACY_WHOLESALE_DIRECT_PURCHASE_BILL,
             BillTypeAtomic.PHARMACY_WHOLESALE_GRN_BILL};
@@ -1220,8 +1219,6 @@ public class SupplierPaymentController implements Serializable {
             BillTypeAtomic.PHARMACY_GRN,
             BillTypeAtomic.PHARMACY_GRN_CANCELLED,
             BillTypeAtomic.PHARMACY_GRN_RETURN,
-            BillTypeAtomic.PHARMACY_GRN_RETURN,
-            BillTypeAtomic.PHARMACY_WHOLESALE_GRN_BILL,
             BillTypeAtomic.PHARMACY_WHOLESALE_GRN_BILL_CANCELLED,
             BillTypeAtomic.PHARMACY_DIRECT_PURCHASE,
             BillTypeAtomic.PHARMACY_WHOLESALE_DIRECT_PURCHASE_BILL,
@@ -1287,7 +1284,6 @@ public class SupplierPaymentController implements Serializable {
             BillTypeAtomic.PHARMACY_WHOLESALE_GRN_BILL,
             BillTypeAtomic.PHARMACY_DIRECT_PURCHASE,
             BillTypeAtomic.PHARMACY_WHOLESALE_DIRECT_PURCHASE_BILL,
-            BillTypeAtomic.PHARMACY_WHOLESALE_GRN_BILL,
             BillTypeAtomic.PHARMACY_GRN_RETURN,
             BillTypeAtomic.PHARMACY_GRN_REFUND,
             BillTypeAtomic.STORE_GRN,
@@ -1315,7 +1311,13 @@ public class SupplierPaymentController implements Serializable {
     }
 
     public void fillSettledCreditBills() {
-        BillTypeAtomic[] billTypesArrayBilled = {BillTypeAtomic.PHARMACY_GRN, BillTypeAtomic.PHARMACY_WHOLESALE_GRN_BILL, BillTypeAtomic.PHARMACY_DIRECT_PURCHASE, BillTypeAtomic.PHARMACY_WHOLESALE_DIRECT_PURCHASE_BILL, BillTypeAtomic.PHARMACY_WHOLESALE_GRN_BILL, BillTypeAtomic.STORE_GRN, BillTypeAtomic.STORE_DIRECT_PURCHASE};
+        BillTypeAtomic[] billTypesArrayBilled = {
+            BillTypeAtomic.PHARMACY_GRN,
+            BillTypeAtomic.PHARMACY_WHOLESALE_GRN_BILL,
+            BillTypeAtomic.PHARMACY_DIRECT_PURCHASE, 
+            BillTypeAtomic.PHARMACY_WHOLESALE_DIRECT_PURCHASE_BILL, 
+            BillTypeAtomic.STORE_GRN, 
+            BillTypeAtomic.STORE_DIRECT_PURCHASE};
         List<BillTypeAtomic> billTypesListBilled = Arrays.asList(billTypesArrayBilled);
         bills = billController.findPaidBills(fromDate, toDate, billTypesListBilled, PaymentMethod.Credit, 0.01);
         netTotal = 0.0;

--- a/src/main/java/com/divudi/bean/pharmacy/SupplierPaymentController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/SupplierPaymentController.java
@@ -768,9 +768,11 @@ public class SupplierPaymentController implements Serializable {
     }
 
     public void removeselected(BillItem billItem) {
-        getSelectedBillItems().remove(billItem); // removes by object, not by index
-        calTotalWithResetingIndexSelected();
-        calculateTotalBySelectedBillItems();
+        if (selectedBillItems != null) {
+            selectedBillItems.remove(billItem); // removes by object, not by index
+            calTotalWithResetingIndexSelected();
+            calculateTotalBySelectedBillItems();
+        }
     }
 
     public void removeFromCurrent(BillItem billItem) {
@@ -1215,14 +1217,14 @@ public class SupplierPaymentController implements Serializable {
 
     public void fillSettledCreditPharmacyBills() {
         BillTypeAtomic[] billTypesArrayBilled = {
-            BillTypeAtomic.PHARMACY_GRN, 
-            BillTypeAtomic.PHARMACY_GRN_CANCELLED, 
+            BillTypeAtomic.PHARMACY_GRN,
+            BillTypeAtomic.PHARMACY_GRN_CANCELLED,
             BillTypeAtomic.PHARMACY_GRN_RETURN,
             BillTypeAtomic.PHARMACY_GRN_RETURN,
-            BillTypeAtomic.PHARMACY_WHOLESALE_GRN_BILL, 
+            BillTypeAtomic.PHARMACY_WHOLESALE_GRN_BILL,
             BillTypeAtomic.PHARMACY_WHOLESALE_GRN_BILL_CANCELLED,
-            BillTypeAtomic.PHARMACY_DIRECT_PURCHASE, 
-            BillTypeAtomic.PHARMACY_WHOLESALE_DIRECT_PURCHASE_BILL, 
+            BillTypeAtomic.PHARMACY_DIRECT_PURCHASE,
+            BillTypeAtomic.PHARMACY_WHOLESALE_DIRECT_PURCHASE_BILL,
             BillTypeAtomic.PHARMACY_WHOLESALE_GRN_BILL};
         List<BillTypeAtomic> billTypesListBilled = Arrays.asList(billTypesArrayBilled);
         bills = billController.findPaidBills(fromDate, toDate, billTypesListBilled, PaymentMethod.Credit, 0.01);

--- a/src/main/java/com/divudi/core/facade/AbstractFacade.java
+++ b/src/main/java/com/divudi/core/facade/AbstractFacade.java
@@ -271,7 +271,9 @@ public abstract class AbstractFacade<T> {
         getEntityManager().merge(entity);
         getEntityManager().flush(); // Immediately write to the database
         getEntityManager().clear(); // Clear first-level (persistence context) cache
-        getEntityManager().getEntityManagerFactory().getCache().evict(entityClass, id); // Evict from second-level cache
+        if (id != null) {
+            getEntityManager().getEntityManagerFactory().getCache().evict(entityClass, id); // Evict from second-level cache
+        }
     }
 
     public void refresh(T entity) {
@@ -325,7 +327,9 @@ public abstract class AbstractFacade<T> {
         getEntityManager().merge(entity);
         getEntityManager().flush(); // Write to DB immediately
         getEntityManager().clear(); // Clear first-level (persistence context) cache
-        getEntityManager().getEntityManagerFactory().getCache().evict(entityClass, id); // Evict from second-level cache
+        if (id != null) {
+            getEntityManager().getEntityManagerFactory().getCache().evict(entityClass, id); // Evict from second-level cache
+        }
     }
 
     public void remove(T entity) {

--- a/src/main/resources/META-INF/persistence.xml
+++ b/src/main/resources/META-INF/persistence.xml
@@ -2,14 +2,14 @@
 <persistence version="2.2" xmlns="http://java.sun.com/xml/ns/persistence" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/persistence http://xmlns.jcp.org/xml/ns/persistence/persistence_2_2.xsd">
     <persistence-unit name="hmisPU" transaction-type="JTA">
         <provider>org.eclipse.persistence.jpa.PersistenceProvider</provider>
-        <jta-data-source>${JDBC_DATASOURCE}</jta-data-source>
+        <jta-data-source>jdbc/ruhunuProduction</jta-data-source>
         <exclude-unlisted-classes>false</exclude-unlisted-classes>
         <properties>
             <property name="eclipselink.logging.level.sql" value="SEVERE"/>
         </properties>
     </persistence-unit>
     <persistence-unit name="hmisAuditPU" transaction-type="JTA">
-        <jta-data-source>${JDBC_AUDIT_DATASOURCE}</jta-data-source>
+        <jta-data-source>jdbc/ruhunuAudit</jta-data-source>
         <exclude-unlisted-classes>false</exclude-unlisted-classes>
         <properties>
             <property name="eclipselink.logging.level.sql" value="SEVERE"/>

--- a/src/main/resources/META-INF/persistence.xml
+++ b/src/main/resources/META-INF/persistence.xml
@@ -2,14 +2,14 @@
 <persistence version="2.2" xmlns="http://java.sun.com/xml/ns/persistence" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/persistence http://xmlns.jcp.org/xml/ns/persistence/persistence_2_2.xsd">
     <persistence-unit name="hmisPU" transaction-type="JTA">
         <provider>org.eclipse.persistence.jpa.PersistenceProvider</provider>
-        <jta-data-source>jdbc/ruhunuProduction</jta-data-source>
+        <jta-data-source>${JDBC_DATASOURCE}</jta-data-source>
         <exclude-unlisted-classes>false</exclude-unlisted-classes>
         <properties>
             <property name="eclipselink.logging.level.sql" value="SEVERE"/>
         </properties>
     </persistence-unit>
     <persistence-unit name="hmisAuditPU" transaction-type="JTA">
-        <jta-data-source>jdbc/ruhunuAudit</jta-data-source>
+        <jta-data-source>${JDBC_AUDIT_DATASOURCE}</jta-data-source>
         <exclude-unlisted-classes>false</exclude-unlisted-classes>
         <properties>
             <property name="eclipselink.logging.level.sql" value="SEVERE"/>

--- a/src/main/webapp/collecting_centre/bill.xhtml
+++ b/src/main/webapp/collecting_centre/bill.xhtml
@@ -362,7 +362,9 @@
                                         icon="fa fa-check"
                                         action="#{collectingCentreBillController.settleCcBill()}"
                                         ajax="false"
-                                        class="ui-button-success ">
+                                        class="ui-button-success "
+                                        onclick="if (!confirm('Are you sure you want to Settle This Bill ?'))
+                                                    return false;">
                                     </p:commandButton>
 
                                 </f:facet>

--- a/src/main/webapp/collecting_centre/bill_cancel.xhtml
+++ b/src/main/webapp/collecting_centre/bill_cancel.xhtml
@@ -49,7 +49,9 @@
                                         icon="fa fa-cancel"
                                         style="float: right"
                                         class="ui-button-danger"
-                                        action="#{billSearch.cancelCollectingCentreBill()}">
+                                        action="#{billSearch.cancelCollectingCentreBill()}"
+                                        onclick="if (!confirm('Are you sure you want to Cancel This Bill ?'))
+                                                    return false;">
                                     </p:commandButton>
                                     <p:commandButton  
                                         class="ui-button-secondary d-flex justify-content-end mx-2"

--- a/src/main/webapp/collecting_centre/bill_return.xhtml
+++ b/src/main/webapp/collecting_centre/bill_return.xhtml
@@ -141,6 +141,8 @@
                                             ajax="false"
                                             class="ui-button-warning"
                                             action="#{billReturnController.settleCCReturnBill()}"
+                                            onclick="if (!confirm('Are you sure you want to Return Selected Items ?'))
+                                                        return false;"
                                             oncomplete="PF('dlg').hide();" >
                                         </p:commandButton>
                                     </p:panelGrid>

--- a/src/main/webapp/collecting_centre/collecting_centre_deposit_bill.xhtml
+++ b/src/main/webapp/collecting_centre/collecting_centre_deposit_bill.xhtml
@@ -24,15 +24,17 @@
                                 <div class="d-flex justify-content-between">
                                     <h:outputLabel value="Collecting Centre Payment" class="mt-2"/>
                                     <div class="d-flex gap-2">
-                                        <p:commandButton 
-                                            id="btnSettle" 
-                                            value="Settle" 
+                                        <p:commandButton
+                                            id="btnSettle"
+                                            value="Settle"
                                             class="ui-button-success"
                                             icon="fa fa-check"
-                                            action="#{agentAndCcPaymentController.collectingCentrePaymentRecieveSettleBill}" 
-                                            ajax="false"  
+                                            action="#{agentAndCcPaymentController.collectingCentrePaymentRecieveSettleBill}"
+                                            ajax="false"
+                                            onclick="if (!confirm('Are you sure you want to Settle This Bill ?'))
+                                                        return false;"
                                             style="width: 150px; padding: 1px;border: 1px solid ; margin: auto;" >
-                                        </p:commandButton> 
+                                        </p:commandButton>
                                         <p:defaultCommand target="btnSettle"/>
                                         <p:commandButton 
                                             value="New Bill" 

--- a/src/main/webapp/opd/view/bill_admin.xhtml
+++ b/src/main/webapp/opd/view/bill_admin.xhtml
@@ -32,7 +32,11 @@
                                 <p:tabView orientation="left">
                                     <p:tab title="Summary" >
                                         <p:panel header="Bill Summary">
-                                            <p:panelGrid columns="2" styleClass="w-100" columnClasses="w-25,w-75">
+                                            <h:panelGrid columns="2" styleClass="w-100" columnClasses="w-25,w-75">
+
+                                                <h:outputLabel value="Bill Number:" />
+                                                <h:outputText value="#{billSearch.viewingBill.deptId}" />
+
 
                                                 <h:outputLabel value="Bill Type Atomic:" />
                                                 <h:outputText value="#{billSearch.viewingBill.billTypeAtomic}" />
@@ -78,7 +82,7 @@
                                                 <h:outputLabel value="Refunded?" />
                                                 <h:outputText value="#{billSearch.viewingBill.refunded ? 'Yes' : 'No'}" />
 
-                                            </p:panelGrid>
+                                            </h:panelGrid>
                                         </p:panel>
 
                                     </p:tab>

--- a/src/main/webapp/resources/ezcomp/view/out.xhtml
+++ b/src/main/webapp/resources/ezcomp/view/out.xhtml
@@ -318,7 +318,7 @@
                             itemLabel="#{pta.name}"
                             itemValue="#{pta}"
                             forceSelection="true"
-                            value="#{cc.attrs.bill.institution}" >
+                            value="#{cc.attrs.bill.collectingCentre}" >
                             <p:ajax process="acIns" update="cmbDept"/>
                         </p:autoComplete>
                     </h:panelGroup>


### PR DESCRIPTION
Done

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added confirmation dialogs to key actions (settle, cancel, return items) in collecting centre billing pages, prompting users before proceeding.

- **Bug Fixes**
  - Improved safety in supplier payment item removal to prevent errors when no items are selected.
  - Corrected the binding for the "Collecting Centre" autocomplete input to ensure accurate data entry.

- **Improvements**
  - Enhanced bill summary in OPD view by displaying the bill number and switching to a standard panel layout.
  - Improved data consistency by ensuring immediate cache updates after certain billing and payment actions.
  - Updated persistence behavior to commit changes immediately for collecting centre payments and balances.

- **Style**
  - Minor formatting adjustments for improved code readability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->