### PR TITLE
Add ScheduledProcess enum

### DIFF
--- a/src/main/java/com/divudi/bean/common/EnumController.java
+++ b/src/main/java/com/divudi/bean/common/EnumController.java
@@ -6,6 +6,7 @@
 package com.divudi.bean.common;
 
 import com.divudi.core.data.*;
+import com.divudi.core.data.ScheduledProcess;
 import com.divudi.core.data.analytics.ReportTemplateColumn;
 import com.divudi.core.data.analytics.ReportTemplateFilter;
 import com.divudi.core.data.hr.*;
@@ -277,6 +278,10 @@ public class EnumController implements Serializable {
 
     public List<HistoryType> getHistoryTypes() {
         return Arrays.asList(HistoryType.values());
+    }
+
+    public List<ScheduledProcess> getScheduledProcesses() {
+        return Arrays.asList(ScheduledProcess.values());
     }
 
     public Dashboard[] getDashboardTypes() {

--- a/src/main/java/com/divudi/core/data/ScheduledProcess.java
+++ b/src/main/java/com/divudi/core/data/ScheduledProcess.java
@@ -1,0 +1,22 @@
+package com.divudi.core.data;
+
+/**
+ * Enum representing scheduled processes for historical data recording.
+ * Additional values can be added as new requirements arise.
+ */
+public enum ScheduledProcess {
+    Record_Pharmacy_Stock_Values("Record Pharmacy Stock Values"),
+    All_Drawer_Balances("All Drawer Balances"),
+    All_Collection_Centre_Balances("All Collection Centre Balances"),
+    All_Credit_Company_Balances("All Credit Company Balances");
+
+    private final String label;
+
+    ScheduledProcess(String label) {
+        this.label = label;
+    }
+
+    public String getLabel() {
+        return label;
+    }
+}


### PR DESCRIPTION
## Summary
- add `ScheduledProcess` enum for scheduled historical record tasks
- expose `getScheduledProcesses` in `EnumController`

## Testing
- `mvn -q -DskipTests package` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684778afdb30832fb6292b3b97044b52