### PR TITLE
Add scheduled process configuration entity

### DIFF
--- a/src/main/java/com/divudi/bean/common/EnumController.java
+++ b/src/main/java/com/divudi/bean/common/EnumController.java
@@ -7,6 +7,7 @@ package com.divudi.bean.common;
 
 import com.divudi.core.data.*;
 import com.divudi.core.data.ScheduledProcess;
+import com.divudi.core.data.ScheduledFrequency;
 import com.divudi.core.data.analytics.ReportTemplateColumn;
 import com.divudi.core.data.analytics.ReportTemplateFilter;
 import com.divudi.core.data.hr.*;
@@ -282,6 +283,10 @@ public class EnumController implements Serializable {
 
     public List<ScheduledProcess> getScheduledProcesses() {
         return Arrays.asList(ScheduledProcess.values());
+    }
+
+    public List<ScheduledFrequency> getScheduledFrequencies() {
+        return Arrays.asList(ScheduledFrequency.values());
     }
 
     public Dashboard[] getDashboardTypes() {

--- a/src/main/java/com/divudi/core/data/ScheduledFrequency.java
+++ b/src/main/java/com/divudi/core/data/ScheduledFrequency.java
@@ -1,0 +1,22 @@
+package com.divudi.core.data;
+
+/**
+ * Enum representing the frequency at which a scheduled process should run.
+ */
+public enum ScheduledFrequency {
+    Midnight("Midnight"),
+    Hourly("Hourly"),
+    WeekEnd("Week End"),
+    MonthEnd("Month End"),
+    YearEnd("Year End");
+
+    private final String label;
+
+    ScheduledFrequency(String label) {
+        this.label = label;
+    }
+
+    public String getLabel() {
+        return label;
+    }
+}

--- a/src/main/java/com/divudi/core/entity/ScheduledProcessConfiguration.java
+++ b/src/main/java/com/divudi/core/entity/ScheduledProcessConfiguration.java
@@ -1,0 +1,170 @@
+package com.divudi.core.entity;
+
+import com.divudi.core.data.ScheduledFrequency;
+import com.divudi.core.data.ScheduledProcess;
+import java.io.Serializable;
+import java.util.Date;
+import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.ManyToOne;
+import javax.persistence.Temporal;
+import javax.persistence.TemporalType;
+import com.divudi.core.entity.Institution;
+import com.divudi.core.entity.Department;
+import com.divudi.core.entity.WebUser;
+
+/**
+ * Entity representing a configuration for a scheduled process.
+ */
+@Entity
+public class ScheduledProcessConfiguration implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO)
+    private Long id;
+
+    @Enumerated(EnumType.STRING)
+    private ScheduledProcess scheduledProcess;
+
+    @Enumerated(EnumType.STRING)
+    private ScheduledFrequency scheduledFrequency;
+
+    @ManyToOne
+    private Institution institution;
+
+    @ManyToOne
+    private Department department;
+
+    @Temporal(TemporalType.TIMESTAMP)
+    private Date createdAt;
+
+    @ManyToOne
+    private WebUser createdBy;
+
+    private boolean retired;
+
+    @ManyToOne
+    private WebUser retiredBy;
+
+    @Temporal(TemporalType.TIMESTAMP)
+    private Date retiredAt;
+
+    private String retireComments;
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public ScheduledProcess getScheduledProcess() {
+        return scheduledProcess;
+    }
+
+    public void setScheduledProcess(ScheduledProcess scheduledProcess) {
+        this.scheduledProcess = scheduledProcess;
+    }
+
+    public ScheduledFrequency getScheduledFrequency() {
+        return scheduledFrequency;
+    }
+
+    public void setScheduledFrequency(ScheduledFrequency scheduledFrequency) {
+        this.scheduledFrequency = scheduledFrequency;
+    }
+
+    public Institution getInstitution() {
+        return institution;
+    }
+
+    public void setInstitution(Institution institution) {
+        this.institution = institution;
+    }
+
+    public Department getDepartment() {
+        return department;
+    }
+
+    public void setDepartment(Department department) {
+        this.department = department;
+    }
+
+    public Date getCreatedAt() {
+        return createdAt;
+    }
+
+    public void setCreatedAt(Date createdAt) {
+        this.createdAt = createdAt;
+    }
+
+    public WebUser getCreatedBy() {
+        return createdBy;
+    }
+
+    public void setCreatedBy(WebUser createdBy) {
+        this.createdBy = createdBy;
+    }
+
+    public boolean isRetired() {
+        return retired;
+    }
+
+    public void setRetired(boolean retired) {
+        this.retired = retired;
+    }
+
+    public WebUser getRetiredBy() {
+        return retiredBy;
+    }
+
+    public void setRetiredBy(WebUser retiredBy) {
+        this.retiredBy = retiredBy;
+    }
+
+    public Date getRetiredAt() {
+        return retiredAt;
+    }
+
+    public void setRetiredAt(Date retiredAt) {
+        this.retiredAt = retiredAt;
+    }
+
+    public String getRetireComments() {
+        return retireComments;
+    }
+
+    public void setRetireComments(String retireComments) {
+        this.retireComments = retireComments;
+    }
+
+    @Override
+    public int hashCode() {
+        int hash = 0;
+        hash += (id != null ? id.hashCode() : 0);
+        return hash;
+    }
+
+    @Override
+    public boolean equals(Object object) {
+        if (!(object instanceof ScheduledProcessConfiguration)) {
+            return false;
+        }
+        ScheduledProcessConfiguration other = (ScheduledProcessConfiguration) object;
+        if ((this.id == null && other.id != null) || (this.id != null && !this.id.equals(other.id))) {
+            return false;
+        }
+        return true;
+    }
+
+    @Override
+    public String toString() {
+        return "com.divudi.core.entity.ScheduledProcessConfiguration[ id=" + id + " ]";
+    }
+}


### PR DESCRIPTION
## Summary
- define `ScheduledFrequency` enum for scheduling intervals
- expose new `getScheduledFrequencies()` in `EnumController`
- introduce `ScheduledProcessConfiguration` entity with standard audit fields

## Testing
- `mvn -q -DskipTests package` *(fails: PluginResolutionException - network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68477fd9a824832f83876ad7dddce623