### PR TITLE
Fix package bill cancellation privileges

### DIFF
--- a/src/main/java/com/divudi/bean/common/BillPackageController.java
+++ b/src/main/java/com/divudi/bean/common/BillPackageController.java
@@ -693,18 +693,24 @@ public class BillPackageController implements Serializable, ControllerWithPatien
 
         if (!labStatusOk) {
             JsfUtil.addErrorMessage("This bill is processed in the Laboratory.");
-            if (!configOptionApplicationController.getBooleanValueByKey("Enable the Special Privilege of Canceling Package Bills", false)) {
+            if (configOptionApplicationController.getBooleanValueByKey(
+                    "Enable the Special Privilege of Canceling Package Bills", false)) {
                 if (getWebUserController().hasPrivilege("BillCancel")) {
-                    JsfUtil.addErrorMessage("You have Special privilege to cancel This Bill");
+                    JsfUtil.addSuccessMessage("Special privilege granted to cancel processed bill");
                 } else {
-                    JsfUtil.addErrorMessage("You have no Privilege to Cancel Package Bills. Please Contact System Administrator.");
+                    JsfUtil.addErrorMessage(
+                            "You have no Privilege to Cancel Package Bills. Please Contact System Administrator.");
                     return false;
                 }
+            } else {
+                JsfUtil.addErrorMessage("Cancellation of processed bills is not allowed.");
+                return false;
             }
         }
 
         if (!getWebUserController().hasPrivilege("OpdCancel")) {
-            JsfUtil.addErrorMessage("You have no Privilege to Cancel Package Bills. Please Contact System Administrator.");
+            JsfUtil.addErrorMessage(
+                    "You have no Privilege to Cancel Package Bills. Please Contact System Administrator.");
             return false;
         }
 


### PR DESCRIPTION
## Summary
- centralize privilege checking for package bill cancellations
- reference the new helper in single and batch cancellation flows
- revert README note on configuration

## Testing
- `mvn -q -DskipTests package` *(fails: PluginResolutionException)*

------
https://chatgpt.com/codex/tasks/task_e_68477ecde2e4832f8b1978b45e700acc

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Improved reliability and consistency of privilege checks when canceling package bills and batch package bills. Error messages are now more accurate and cancellation permissions are enforced more uniformly. No changes to the overall cancellation process or user interface.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->