### PR TITLE
Add scheduled process config management

### DIFF
--- a/src/main/java/com/divudi/bean/process/ScheduledProcessConfigurationController.java
+++ b/src/main/java/com/divudi/bean/process/ScheduledProcessConfigurationController.java
@@ -1,0 +1,151 @@
+package com.divudi.bean.process;
+
+import com.divudi.core.entity.ScheduledProcessConfiguration;
+import com.divudi.core.facade.ScheduledProcessConfigurationFacade;
+import com.divudi.core.util.JsfUtil;
+import com.divudi.bean.common.SessionController;
+import java.io.Serializable;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import javax.ejb.EJB;
+import javax.enterprise.context.SessionScoped;
+import javax.faces.application.FacesMessage;
+import javax.faces.component.UIComponent;
+import javax.faces.context.FacesContext;
+import javax.faces.convert.Converter;
+import javax.faces.convert.FacesConverter;
+import javax.inject.Inject;
+import javax.inject.Named;
+import javax.persistence.TemporalType;
+
+@Named
+@SessionScoped
+public class ScheduledProcessConfigurationController implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    @EJB
+    private ScheduledProcessConfigurationFacade scheduledProcessConfigurationFacade;
+
+    @Inject
+    private SessionController sessionController;
+
+    private List<ScheduledProcessConfiguration> items;
+    private ScheduledProcessConfiguration current;
+    private boolean editable;
+
+    public String navigateToManageScheduledProcessConfigurations() {
+        fillItems();
+        return "/process/admin/scheduled_process_configurations?faces-redirect=true";
+    }
+
+    public void fillItems() {
+        String jpql = "select c from ScheduledProcessConfiguration c where c.retired=false order by c.scheduledProcess";
+        items = scheduledProcessConfigurationFacade.findByJpql(jpql, new HashMap<>(), TemporalType.TIMESTAMP);
+    }
+
+    public void prepareAdd() {
+        current = new ScheduledProcessConfiguration();
+        editable = true;
+    }
+
+    public void edit() {
+        if (current == null) {
+            JsfUtil.addErrorMessage("Select one to edit");
+            return;
+        }
+        editable = true;
+    }
+
+    public void cancel() {
+        current = null;
+        editable = false;
+    }
+
+    public void save() {
+        if (current == null) {
+            JsfUtil.addErrorMessage("Nothing to save");
+            return;
+        }
+        if (current.getId() == null) {
+            current.setCreatedAt(new Date());
+            current.setCreatedBy(sessionController.getLoggedUser());
+            scheduledProcessConfigurationFacade.create(current);
+            JsfUtil.addSuccessMessage("Saved");
+        } else {
+            scheduledProcessConfigurationFacade.edit(current);
+            JsfUtil.addSuccessMessage("Updated");
+        }
+        fillItems();
+        editable = false;
+    }
+
+    public void delete() {
+        if (current == null) {
+            JsfUtil.addErrorMessage("Nothing to delete");
+            return;
+        }
+        current.setRetired(true);
+        current.setRetiredAt(new Date());
+        current.setRetiredBy(sessionController.getLoggedUser());
+        scheduledProcessConfigurationFacade.edit(current);
+        JsfUtil.addSuccessMessage("Deleted");
+        fillItems();
+        current = null;
+        editable = false;
+    }
+
+    public List<ScheduledProcessConfiguration> getItems() {
+        if (items == null) {
+            fillItems();
+        }
+        return items;
+    }
+
+    public ScheduledProcessConfiguration getCurrent() {
+        return current;
+    }
+
+    public void setCurrent(ScheduledProcessConfiguration current) {
+        this.current = current;
+    }
+
+    public boolean isEditable() {
+        return editable;
+    }
+
+    public void setEditable(boolean editable) {
+        this.editable = editable;
+    }
+
+    public ScheduledProcessConfigurationFacade getScheduledProcessConfigurationFacade() {
+        return scheduledProcessConfigurationFacade;
+    }
+
+    @FacesConverter(forClass = ScheduledProcessConfiguration.class)
+    public static class ScheduledProcessConfigurationConverter implements Converter {
+
+        @Override
+        public Object getAsObject(FacesContext facesContext, UIComponent component, String value) {
+            if (value == null || value.isEmpty()) {
+                return null;
+            }
+            ScheduledProcessConfigurationController controller = (ScheduledProcessConfigurationController) facesContext.getApplication().getELResolver()
+                    .getValue(facesContext.getELContext(), null, "scheduledProcessConfigurationController");
+            return controller.getScheduledProcessConfigurationFacade().find(Long.valueOf(value));
+        }
+
+        @Override
+        public String getAsString(FacesContext facesContext, UIComponent component, Object object) {
+            if (object == null) {
+                return "";
+            }
+            if (object instanceof ScheduledProcessConfiguration) {
+                return String.valueOf(((ScheduledProcessConfiguration) object).getId());
+            } else {
+                throw new IllegalArgumentException("object " + object + " is of type " + object.getClass().getName() + "; expected type: " + ScheduledProcessConfiguration.class.getName());
+            }
+        }
+    }
+}

--- a/src/main/java/com/divudi/core/facade/ScheduledProcessConfigurationFacade.java
+++ b/src/main/java/com/divudi/core/facade/ScheduledProcessConfigurationFacade.java
@@ -1,0 +1,22 @@
+package com.divudi.core.facade;
+
+import com.divudi.core.entity.ScheduledProcessConfiguration;
+import javax.ejb.Stateless;
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+
+@Stateless
+public class ScheduledProcessConfigurationFacade extends AbstractFacade<ScheduledProcessConfiguration> {
+    @PersistenceContext(unitName = "hmisPU")
+    private EntityManager em;
+
+    @Override
+    protected EntityManager getEntityManager() {
+        if(em == null){}
+        return em;
+    }
+
+    public ScheduledProcessConfigurationFacade() {
+        super(ScheduledProcessConfiguration.class);
+    }
+}

--- a/src/main/webapp/dataAdmin/admin_data_administration.xhtml
+++ b/src/main/webapp/dataAdmin/admin_data_administration.xhtml
@@ -22,23 +22,33 @@
 
                                 <p:tab title="Manage Processes" disabled="false" >
                                     <div class="d-grid gap-2">
-                                        <p:commandButton  
+                                        <p:commandButton
                                             class="w-100"
-                                            ajax="false" 
+                                            ajax="false"
                                             value="Process Definition"
-                                            action="#{processDefinitionController.navigateToManageProcessDefinitions()}" 
+                                            action="#{processDefinitionController.navigateToManageProcessDefinitions()}"
                                             icon="fa fa-money-bill-wave" />
-                                        <p:commandButton  
+                                        <p:commandButton
                                             class="w-100"
-                                            ajax="false" 
+                                            ajax="false"
                                             value="Process Definition Step"
-                                            action="#{processStepDefinitionController.navigateToManageProcessStepDefinitions()}" 
+                                            action="#{processStepDefinitionController.navigateToManageProcessStepDefinitions()}"
                                             icon="fa fa-money-bill-wave" />
-                                        <p:commandButton  
+                                        <p:commandButton
                                             class="w-100"
-                                            ajax="false" 
+                                            ajax="false"
                                             value="Process Definition Step Action"
-                                            action="#{processStepActionDefinitionController.navigateToManageProcessStepActionDefinitions()}" 
+                                            action="#{processStepActionDefinitionController.navigateToManageProcessStepActionDefinitions()}"
+                                            icon="fa fa-money-bill-wave" />
+                                    </div>
+                                </p:tab>
+                                <p:tab title="Schedules" disabled="false" >
+                                    <div class="d-grid gap-2">
+                                        <p:commandButton
+                                            class="w-100"
+                                            ajax="false"
+                                            value="Scheduled Process Configuration"
+                                            action="#{scheduledProcessConfigurationController.navigateToManageScheduledProcessConfigurations()}"
                                             icon="fa fa-money-bill-wave" />
                                     </div>
                                 </p:tab>

--- a/src/main/webapp/process/admin/scheduled_process_configurations.xhtml
+++ b/src/main/webapp/process/admin/scheduled_process_configurations.xhtml
@@ -1,0 +1,98 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
+      xmlns:h="http://xmlns.jcp.org/jsf/html"
+      xmlns:p="http://primefaces.org/ui"
+      xmlns:f="http://xmlns.jcp.org/jsf/core">
+    <h:head>
+        <title>Scheduled Process Configuration</title>
+    </h:head>
+    <h:body>
+
+        <ui:composition template="/dataAdmin/admin_data_administration.xhtml">
+
+            <ui:define name="subcontent">
+                <h:form id="scheduleConfigForm">
+                    <p:panel>
+                        <f:facet name="header">
+                            <h:outputLabel value="Manage Scheduled Process Configurations" />
+                        </f:facet>
+
+                        <div class="row">
+                            <div class="col-md-4">
+                                <p:panel>
+                                    <f:facet name="header">
+                                        <div class="mt-3">
+                                            <p:commandButton id="addBtn" value="Add New" icon="fa fa-plus" class="ui-button-success m-1"
+                                                             action="#{scheduledProcessConfigurationController.prepareAdd}" process="addBtn" update="@form"
+                                                             disabled="#{scheduledProcessConfigurationController.editable}" />
+                                            <p:commandButton id="editBtn" value="Edit" icon="fa fa-edit" class="ui-button-warning m-1"
+                                                             action="#{scheduledProcessConfigurationController.edit}" process="editBtn" update="@form"
+                                                             disabled="#{scheduledProcessConfigurationController.editable or scheduledProcessConfigurationController.current == null}" />
+                                            <p:commandButton id="deleteBtn" value="Delete" icon="fa fa-trash" class="ui-button-danger m-1"
+                                                             action="#{scheduledProcessConfigurationController.delete}" process="deleteBtn" update="@form"
+                                                             onclick="return confirm('Are you sure?');"
+                                                             disabled="#{scheduledProcessConfigurationController.editable or scheduledProcessConfigurationController.current == null}" />
+                                        </div>
+                                    </f:facet>
+
+                                    <p:selectOneListbox id="configSelect" filter="true" filterMatchMode="contains"
+                                                       value="#{scheduledProcessConfigurationController.current}" class="w-100">
+                                        <f:selectItems value="#{scheduledProcessConfigurationController.items}" var="cfg"
+                                                       itemValue="#{cfg}" itemLabel="#{cfg.scheduledProcess.label} - #{cfg.scheduledFrequency.label}" />
+                                        <p:ajax update="detailPanel" />
+                                    </p:selectOneListbox>
+                                </p:panel>
+                            </div>
+
+                            <div class="col-md-8">
+                                <p:panel id="detailPanel">
+                                    <f:facet name="header">
+                                        <h:outputLabel value="Configuration Details" />
+                                    </f:facet>
+
+                                    <p:panelGrid columns="2" class="mt-3" rendered="#{scheduledProcessConfigurationController.current ne null}">
+                                        <h:outputLabel value="Process" />
+                                        <p:selectOneMenu value="#{scheduledProcessConfigurationController.current.scheduledProcess}" class="w-100">
+                                            <f:selectItem itemLabel="Select" />
+                                            <f:selectItems value="#{enumController.scheduledProcesses}" var="sp" itemValue="#{sp}" itemLabel="#{sp.label}" />
+                                        </p:selectOneMenu>
+
+                                        <h:outputLabel value="Frequency" />
+                                        <p:selectOneMenu value="#{scheduledProcessConfigurationController.current.scheduledFrequency}" class="w-100">
+                                            <f:selectItem itemLabel="Select" />
+                                            <f:selectItems value="#{enumController.scheduledFrequencies}" var="sf" itemValue="#{sf}" itemLabel="#{sf.label}" />
+                                        </p:selectOneMenu>
+
+                                        <h:outputLabel value="Institution" />
+                                        <p:autoComplete value="#{scheduledProcessConfigurationController.current.institution}"
+                                                        completeMethod="#{institutionController.completeCompany}"
+                                                        var="ins" itemValue="#{ins}" itemLabel="#{ins.name}"
+                                                        forceSelection="true" class="w-100" inputStyleClass="w-100" />
+
+                                        <h:outputLabel value="Department" />
+                                        <p:autoComplete value="#{scheduledProcessConfigurationController.current.department}"
+                                                        completeMethod="#{departmentController.completeDept}"
+                                                        var="dep" itemValue="#{dep}" itemLabel="#{dep.name}"
+                                                        forceSelection="true" class="w-100" inputStyleClass="w-100" />
+                                    </p:panelGrid>
+
+                                    <f:facet name="footer">
+                                        <p:commandButton id="saveBtn" value="Save" icon="fa fa-save" class="ui-button-success m-1"
+                                                         action="#{scheduledProcessConfigurationController.save}" process="saveBtn detailPanel"
+                                                         update="@form" rendered="#{scheduledProcessConfigurationController.editable}" />
+                                        <p:commandButton id="cancelBtn" value="Cancel" icon="fa fa-times" class="ui-button-warning m-1"
+                                                         action="#{scheduledProcessConfigurationController.cancel}" process="cancelBtn detailPanel"
+                                                         update="@form" rendered="#{scheduledProcessConfigurationController.editable}" />
+                                    </f:facet>
+                                </p:panel>
+                            </div>
+                        </div>
+                    </p:panel>
+                </h:form>
+                <p:messages id="messages" showDetail="true" />
+            </ui:define>
+        </ui:composition>
+    </h:body>
+</html>


### PR DESCRIPTION
## Summary
- add facade and controller for `ScheduledProcessConfiguration`
- create JSF page to manage scheduled process configs
- integrate new navigation tab and button in admin UI

## Testing
- `mvn -q test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68478327c5a4832fb79f140df4fbe07b