### PR TITLE
Add cost rate and value to batch stock report

### DIFF
--- a/src/main/java/com/divudi/bean/pharmacy/ReportsStock.java
+++ b/src/main/java/com/divudi/bean/pharmacy/ReportsStock.java
@@ -85,6 +85,7 @@ public class ReportsStock implements Serializable, ControllerWithReportFilters {
     List<Stock> stocks;
     double stockSaleValue;
     double stockPurchaseValue;
+    double stockCostValue;
     List<PharmacyStockRow> pharmacyStockRows;
     List<StockReportRecord> records;
     Date fromDate;
@@ -218,6 +219,13 @@ public class ReportsStock implements Serializable, ControllerWithReportFilters {
             stockSaleValue = stocks.stream()
                     .mapToDouble(s -> s.getItemBatch().getRetailsaleRate() * s.getStock())
                     .sum();
+
+            stockCostValue = stocks.stream()
+                    .mapToDouble(s -> {
+                        Double cr = s.getItemBatch().getCostRate();
+                        return (cr == null ? 0.0 : cr) * s.getStock();
+                    })
+                    .sum();
             Date afterCal = new Date();
             System.out.println("afterCal = " + afterCal);
         }, PharmacyReports.STOCK_REPORT_BY_BATCH, sessionController.getLoggedUser());
@@ -268,9 +276,11 @@ public class ReportsStock implements Serializable, ControllerWithReportFilters {
         stocks = getStockFacade().findByJpql(sql, m);
         stockPurchaseValue = 0.0;
         stockSaleValue = 0.0;
+        stockCostValue = 0.0;
         for (Stock ts : stocks) {
             stockPurchaseValue = stockPurchaseValue + (ts.getItemBatch().getPurcahseRate() * ts.getStock());
             stockSaleValue = stockSaleValue + (ts.getItemBatch().getRetailsaleRate() * ts.getStock());
+            stockCostValue = stockCostValue + ((ts.getItemBatch().getCostRate()==null?0:ts.getItemBatch().getCostRate()) * ts.getStock());
         }
 
     }
@@ -295,9 +305,11 @@ public class ReportsStock implements Serializable, ControllerWithReportFilters {
         stocks = getStockFacade().findByJpql(sql, m);
         stockPurchaseValue = 0.0;
         stockSaleValue = 0.0;
+        stockCostValue = 0.0;
         for (Stock ts : stocks) {
             stockPurchaseValue = stockPurchaseValue + (ts.getItemBatch().getPurcahseRate() * ts.getStock());
             stockSaleValue = stockSaleValue + (ts.getItemBatch().getRetailsaleRate() * ts.getStock());
+            stockCostValue = stockCostValue + ((ts.getItemBatch().getCostRate()==null?0:ts.getItemBatch().getCostRate()) * ts.getStock());
         }
 
         return "pharmacy_report_department_stock_by_single_product";
@@ -649,9 +661,11 @@ public class ReportsStock implements Serializable, ControllerWithReportFilters {
         stocks = getStockFacade().findByJpql(sql, m);
         stockPurchaseValue = 0.0;
         stockSaleValue = 0.0;
+        stockCostValue = 0.0;
         for (Stock ts : stocks) {
             stockPurchaseValue = stockPurchaseValue + (ts.getItemBatch().getPurcahseRate() * ts.getStock());
             stockSaleValue = stockSaleValue + (ts.getItemBatch().getRetailsaleRate() * ts.getStock());
+            stockCostValue = stockCostValue + ((ts.getItemBatch().getCostRate()==null?0:ts.getItemBatch().getCostRate()) * ts.getStock());
         }
 
     }
@@ -849,9 +863,11 @@ public class ReportsStock implements Serializable, ControllerWithReportFilters {
             stocks = getStockFacade().findByJpql(sql, m);
             stockPurchaseValue = 0.0;
             stockSaleValue = 0.0;
+            stockCostValue = 0.0;
             for (Stock ts : stocks) {
                 stockPurchaseValue = stockPurchaseValue + (ts.getItemBatch().getPurcahseRate() * ts.getStock());
                 stockSaleValue = stockSaleValue + (ts.getItemBatch().getRetailsaleRate() * ts.getStock());
+                stockCostValue = stockCostValue + ((ts.getItemBatch().getCostRate()==null?0:ts.getItemBatch().getCostRate()) * ts.getStock());
             }
         }, PharmacyReports.STOCK_REPORT_BY_EXPIRY, sessionController.getLoggedUser());
     }
@@ -1427,6 +1443,14 @@ public class ReportsStock implements Serializable, ControllerWithReportFilters {
 
     public void setStockPurchaseValue(double stockPurchaseValue) {
         this.stockPurchaseValue = stockPurchaseValue;
+    }
+
+    public double getStockCostValue() {
+        return stockCostValue;
+    }
+
+    public void setStockCostValue(double stockCostValue) {
+        this.stockCostValue = stockCostValue;
     }
 
     public Staff getStaff() {

--- a/src/main/webapp/pharmacy/pharmacy_report_department_stock_by_batch.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_report_department_stock_by_batch.xhtml
@@ -158,14 +158,38 @@
                                     </h:outputLabel>
                                 </p:column>
 
-                                <p:column headerText="Purchase Value" 
+                                <p:column headerText="Purchase Value"
                                           style="text-align: right;"
                                           sortBy="#{i.itemBatch.purcahseRate * i.stock}"
                                           styleClass="averageNumericColumn">
                                     <f:facet name="header">
-                                        <h:outputLabel value="Purchase Value"/>                                     
+                                        <h:outputLabel value="Purchase Value"/>
                                     </f:facet>
                                     <h:outputLabel value="#{i.itemBatch.purcahseRate * i.stock}"  >
+                                        <f:convertNumber pattern="#,##0.00" ></f:convertNumber>
+                                    </h:outputLabel>
+                                </p:column>
+
+                                <p:column headerText="Cost Rate"
+                                          style="text-align: right;"
+                                          sortBy="#{i.itemBatch.costRate}"
+                                          styleClass="averageNumericColumn">
+                                    <f:facet name="header">
+                                        <h:outputLabel value="Cost Rate"/>
+                                    </f:facet>
+                                    <h:outputLabel value="#{i.itemBatch.costRate}"  >
+                                        <f:convertNumber pattern="#,##0.00" ></f:convertNumber>
+                                    </h:outputLabel>
+                                </p:column>
+
+                                <p:column headerText="Cost Value"
+                                          style="text-align: right;"
+                                          sortBy="#{i.itemBatch.costRate * i.stock}"
+                                          styleClass="averageNumericColumn">
+                                    <f:facet name="header">
+                                        <h:outputLabel value="Cost Value"/>
+                                    </f:facet>
+                                    <h:outputLabel value="#{i.itemBatch.costRate * i.stock}"  >
                                         <f:convertNumber pattern="#,##0.00" ></f:convertNumber>
                                     </h:outputLabel>
                                 </p:column>
@@ -182,12 +206,12 @@
                                     </h:outputLabel>
                                 </p:column>
 
-                                <p:column headerText="Sale Value" 
+                                <p:column headerText="Retail Value"
                                           style="text-align: right;"
                                           sortBy="#{i.itemBatch.retailsaleRate * i.stock}"
                                           styleClass="averageNumericColumn">
                                     <f:facet name="header">
-                                        <h:outputLabel value="Sale Value"/>                                     
+                                        <h:outputLabel value="Retail Value"/>
                                     </f:facet>
                                     <h:outputLabel value="#{i.itemBatch.retailsaleRate * i.stock}"  >
                                         <f:convertNumber pattern="#,##0.00" ></f:convertNumber>
@@ -196,34 +220,42 @@
 
                                 <p:columnGroup type="footer">
                                     <p:row>
-                                        <p:column colspan="6" footerText="Total">
-                                            <f:facet name="footer">
-                                                <h:outputLabel value="Total" />
-                                            </f:facet>
-                                        </p:column>
-                                        <p:column style="text-align: right;" footerText="#{reportsStock.stockPurchaseValue}">
-                                            <f:facet name="footer" >
-                                                <h:outputLabel value="#{reportsStock.stockPurchaseValue}" >
-                                                    <f:convertNumber pattern="#,##0.00" />
-                                                </h:outputLabel>
-                                            </f:facet>
-                                        </p:column>
-                                        <p:column></p:column>
-                                        <p:column style="text-align: right;" footerText="#{reportsStock.stockSaleValue}">
-                                            <f:facet name="footer" >
-                                                <h:outputLabel value="#{reportsStock.stockSaleValue}" >
-                                                    <f:convertNumber pattern="#,##0.00" />
-                                                </h:outputLabel>
-                                            </f:facet>
-                                        </p:column>
+                                    <p:column colspan="6" footerText="Total">
+                                        <f:facet name="footer">
+                                            <h:outputLabel value="Total" />
+                                        </f:facet>
+                                    </p:column>
+                                    <p:column style="text-align: right;" footerText="#{reportsStock.stockPurchaseValue}">
+                                        <f:facet name="footer" >
+                                            <h:outputLabel value="#{reportsStock.stockPurchaseValue}" >
+                                                <f:convertNumber pattern="#,##0.00" />
+                                            </h:outputLabel>
+                                        </f:facet>
+                                    </p:column>
+                                    <p:column></p:column>
+                                    <p:column style="text-align: right;" footerText="#{reportsStock.stockCostValue}">
+                                        <f:facet name="footer" >
+                                            <h:outputLabel value="#{reportsStock.stockCostValue}" >
+                                                <f:convertNumber pattern="#,##0.00" />
+                                            </h:outputLabel>
+                                        </f:facet>
+                                    </p:column>
+                                    <p:column></p:column>
+                                    <p:column style="text-align: right;" footerText="#{reportsStock.stockSaleValue}">
+                                        <f:facet name="footer" >
+                                            <h:outputLabel value="#{reportsStock.stockSaleValue}" >
+                                                <f:convertNumber pattern="#,##0.00" />
+                                            </h:outputLabel>
+                                        </f:facet>
+                                    </p:column>
                                     </p:row>
                                     <p:row>
-                                        <p:column colspan="9" >
-                                            <f:facet name="footer" >
-                                                <h:outputLabel value="Printed At " ></h:outputLabel>
-                                                <h:outputLabel value="#{sessionController.currentDate}" >
-                                                    <f:convertDateTime pattern="dd MMMM yyyy - hh:mm a" ></f:convertDateTime>
-                                                </h:outputLabel>
+                                    <p:column colspan="11" >
+                                        <f:facet name="footer" >
+                                            <h:outputLabel value="Printed At " ></h:outputLabel>
+                                            <h:outputLabel value="#{sessionController.currentDate}" >
+                                                <f:convertDateTime pattern="dd MMMM yyyy - hh:mm a" ></f:convertDateTime>
+                                            </h:outputLabel>
                                             </f:facet>
                                         </p:column>
                                     </p:row>


### PR DESCRIPTION
## Summary
- show cost rate and cost value in `Stock by Batch` report
- compute total cost value in `ReportsStock` bean
- rename sale value column to retail value
- fix duplicate cost value calculation

## Testing
- `mvn -q test` *(fails: mvn not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68480ba6b6d8832f94826cd63db6e582