### PR TITLE
Add stock value calculation service

### DIFF
--- a/src/main/java/com/divudi/core/data/StockValueRow.java
+++ b/src/main/java/com/divudi/core/data/StockValueRow.java
@@ -1,0 +1,65 @@
+package com.divudi.core.data;
+
+import com.divudi.core.entity.Department;
+import com.divudi.core.entity.Institution;
+import java.io.Serializable;
+
+public class StockValueRow implements Serializable {
+    private static final long serialVersionUID = 1L;
+
+    private Institution institution;
+    private Institution site;
+    private Department department;
+
+    private double purchaseValue;
+    private double retailValue;
+    private double costValue;
+
+    public Institution getInstitution() {
+        return institution;
+    }
+
+    public void setInstitution(Institution institution) {
+        this.institution = institution;
+    }
+
+    public Institution getSite() {
+        return site;
+    }
+
+    public void setSite(Institution site) {
+        this.site = site;
+    }
+
+    public Department getDepartment() {
+        return department;
+    }
+
+    public void setDepartment(Department department) {
+        this.department = department;
+    }
+
+    public double getPurchaseValue() {
+        return purchaseValue;
+    }
+
+    public void setPurchaseValue(double purchaseValue) {
+        this.purchaseValue = purchaseValue;
+    }
+
+    public double getRetailValue() {
+        return retailValue;
+    }
+
+    public void setRetailValue(double retailValue) {
+        this.retailValue = retailValue;
+    }
+
+    public double getCostValue() {
+        return costValue;
+    }
+
+    public void setCostValue(double costValue) {
+        this.costValue = costValue;
+    }
+}

--- a/src/main/java/com/divudi/service/StockService.java
+++ b/src/main/java/com/divudi/service/StockService.java
@@ -1,9 +1,15 @@
 package com.divudi.service;
 
 import com.divudi.core.entity.pharmacy.Stock;
+import com.divudi.core.entity.Department;
+import com.divudi.core.entity.Institution;
 import com.divudi.core.facade.StockFacade;
 import com.divudi.core.util.CommonFunctions;
+import com.divudi.core.data.StockValueRow;
 import java.util.List;
+import java.util.HashMap;
+import java.util.Map;
+import javax.persistence.TemporalType;
 import javax.ejb.Asynchronous;
 import javax.ejb.EJB;
 import javax.ejb.Stateless;
@@ -68,6 +74,46 @@ public class StockService {
             System.out.println("Updated stock id=" + s.getId() + " (" + count + "/" + allStocks.size() + ")");
         }
         System.out.println("addItemNamesToAllStocksSimple finished. Total updated: " + count);
+    }
+
+    // ChatGPT contributed - 2025-06
+    public StockValueRow calculateStockValues(Institution institution, Institution site, Department department) {
+        Map<String, Object> params = new HashMap<>();
+        StringBuilder jpql = new StringBuilder();
+        jpql.append("select sum(s.stock * s.itemBatch.purcahseRate), "
+                + "sum(s.stock * s.itemBatch.retailsaleRate), "
+                + "sum(s.stock * coalesce(s.itemBatch.costRate,0)) "
+                + "from Stock s where s.stock>0");
+
+        if (department != null) {
+            jpql.append(" and s.department=:dep");
+            params.put("dep", department);
+        } else if (site != null) {
+            jpql.append(" and s.department.site=:site");
+            params.put("site", site);
+        } else if (institution != null) {
+            jpql.append(" and s.department.institution=:ins");
+            params.put("ins", institution);
+        }
+
+        Object[] obj = stockFacade.findAggregateModified(jpql.toString(), params, TemporalType.TIMESTAMP);
+
+        StockValueRow row = new StockValueRow();
+        row.setInstitution(institution);
+        row.setSite(site);
+        row.setDepartment(department);
+        if (obj != null) {
+            if (obj[0] != null) {
+                row.setPurchaseValue((Double) obj[0]);
+            }
+            if (obj[1] != null) {
+                row.setRetailValue((Double) obj[1]);
+            }
+            if (obj[2] != null) {
+                row.setCostValue((Double) obj[2]);
+            }
+        }
+        return row;
     }
 
 }


### PR DESCRIPTION
## Summary
- add `StockValueRow` DTO to hold aggregated stock values
- extend `StockService` with `calculateStockValues()` to compute purchase, retail and cost totals filtered by institution, site or department

## Testing
- `mvn -q test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_68481906f988832fb4333d7f5546cec4