### PR TITLE
Use enum for HistoricalRecord type

### DIFF
--- a/src/main/java/com/divudi/bean/common/HistoricalRecordController.java
+++ b/src/main/java/com/divudi/bean/common/HistoricalRecordController.java
@@ -6,6 +6,7 @@ package com.divudi.bean.common;
 
 import com.divudi.core.entity.HistoricalRecord;
 import com.divudi.core.facade.HistoricalRecordFacade;
+import com.divudi.core.data.HistoricalRecordType;
 import com.divudi.core.entity.Department;
 import com.divudi.core.entity.Institution;
 import com.divudi.service.HistoricalRecordService;
@@ -44,53 +45,53 @@ public class HistoricalRecordController implements Serializable {
 
     private HistoricalRecord current;
     private List<HistoricalRecord> items = null;
-    private List<String> variableNames;
+    private List<HistoricalRecordType> historicalRecordTypes;
 
     private Date fromDate;
     private Date toDate;
     private Institution institution;
     private Institution site;
     private Department department;
-    private String variableName;
+    private HistoricalRecordType historicalRecordType;
 
     public String navigateToHistoricalRecordList() {
         recreateModel();
         return "/dataAdmin/historical_record_list?faces-redirect=true";
     }
 
-    public List<String> getVariableNames() {
-        if (variableNames == null) {
-            variableNames = historicalRecordService.fetchVariableNames();
+    public List<HistoricalRecordType> getHistoricalRecordTypes() {
+        if (historicalRecordTypes == null) {
+            historicalRecordTypes = historicalRecordService.fetchHistoricalRecordTypes();
         }
-        return variableNames;
+        return historicalRecordTypes;
     }
 
     public HistoricalRecordController() {
     }
 
-    public HistoricalRecord findRecord(String variableName, Date recordDate) {
-        if (variableName == null || recordDate == null) {
+    public HistoricalRecord findRecord(HistoricalRecordType historicalRecordType, Date recordDate) {
+        if (historicalRecordType == null || recordDate == null) {
             return null;
         }
-        return findRecord(variableName, null, null, null, recordDate);
+        return findRecord(historicalRecordType, null, null, null, recordDate);
     }
 
-    public HistoricalRecord findRecord(String variableName, Institution institution, Date recordDate) {
-        if (variableName == null || recordDate == null) {
+    public HistoricalRecord findRecord(HistoricalRecordType historicalRecordType, Institution institution, Date recordDate) {
+        if (historicalRecordType == null || recordDate == null) {
             return null;
         }
-        return findRecord(variableName, institution, null, null, recordDate);
+        return findRecord(historicalRecordType, institution, null, null, recordDate);
     }
 
-    public HistoricalRecord findRecord(String variableName, Institution institution, Department department, Date recordDate) {
-        if (variableName == null || recordDate == null) {
+    public HistoricalRecord findRecord(HistoricalRecordType historicalRecordType, Institution institution, Department department, Date recordDate) {
+        if (historicalRecordType == null || recordDate == null) {
             return null;
         }
-        return findRecord(variableName, institution, null, department, recordDate);
+        return findRecord(historicalRecordType, institution, null, department, recordDate);
     }
 
-    public HistoricalRecord findRecord(String variableName, Institution institution, Institution site, Department department, Date recordDate) {
-        return historicalRecordService.findRecord(variableName, institution, site, department, recordDate);
+    public HistoricalRecord findRecord(HistoricalRecordType historicalRecordType, Institution institution, Institution site, Department department, Date recordDate) {
+        return historicalRecordService.findRecord(historicalRecordType, institution, site, department, recordDate);
     }
 
     public HistoricalRecord getCurrent() {
@@ -172,12 +173,12 @@ public class HistoricalRecordController implements Serializable {
         this.department = department;
     }
 
-    public String getVariableName() {
-        return variableName;
+    public HistoricalRecordType getHistoricalRecordType() {
+        return historicalRecordType;
     }
 
-    public void setVariableName(String variableName) {
-        this.variableName = variableName;
+    public void setHistoricalRecordType(HistoricalRecordType historicalRecordType) {
+        this.historicalRecordType = historicalRecordType;
     }
 
     @FacesConverter(forClass = HistoricalRecord.class)

--- a/src/main/java/com/divudi/bean/pharmacy/PharmacySummaryReportController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacySummaryReportController.java
@@ -55,6 +55,7 @@ import com.divudi.core.entity.BillFinanceDetails;
 import com.divudi.core.entity.BillItem;
 import com.divudi.core.entity.Category;
 import com.divudi.core.entity.HistoricalRecord;
+import com.divudi.core.data.HistoricalRecordType;
 import com.divudi.core.entity.PaymentScheme;
 import com.divudi.core.entity.WebUser;
 import com.divudi.core.entity.inward.AdmissionType;
@@ -306,7 +307,7 @@ public class PharmacySummaryReportController implements Serializable {
         dailyStockBalanceReport.setDate(fromDate);
         dailyStockBalanceReport.setDepartment(department);
 
-        HistoricalRecord openingBalance = historicalRecordService.findRecord("Pharmacy Stock Value at Retail Sale Rate", null, null, department, fromDate);
+        HistoricalRecord openingBalance = historicalRecordService.findRecord(HistoricalRecordType.Pharmacy_Stock_Value, null, null, department, fromDate);
         if (openingBalance != null) {
             dailyStockBalanceReport.setOpeningStockValue(openingBalance.getRecordValue());
         }
@@ -332,7 +333,7 @@ public class PharmacySummaryReportController implements Serializable {
         PharmacyBundle adjustmentBundle = pharmacyService.fetchPharmacyAdjustmentValueByBillType(startOfTheDay, endOfTheDay, null, null, department, null, null, null);
         dailyStockBalanceReport.setPharmacyAdjustmentsByBillTypeBundle(adjustmentBundle);
 
-        HistoricalRecord closingBalance = historicalRecordService.findRecord("Pharmacy Stock Value at Retail Sale Rate", null, null, department, toDate);
+        HistoricalRecord closingBalance = historicalRecordService.findRecord(HistoricalRecordType.Pharmacy_Stock_Value, null, null, department, toDate);
         if (closingBalance != null) {
             dailyStockBalanceReport.setClosingStockValue(closingBalance.getRecordValue());
         }

--- a/src/main/java/com/divudi/core/data/HistoricalRecordType.java
+++ b/src/main/java/com/divudi/core/data/HistoricalRecordType.java
@@ -1,0 +1,21 @@
+package com.divudi.core.data;
+
+/**
+ * Enum representing predefined categories of historical records.
+ */
+public enum HistoricalRecordType {
+    Pharmacy_Stock_Value("Pharmacy Stock Value"),
+    Collection_Centre_Balance("Collection Centre Balance"),
+    Credit_Company_Balance("Credit Company Balance"),
+    Drawer_Balance("Drawer Balance");
+
+    private final String label;
+
+    HistoricalRecordType(String label) {
+        this.label = label;
+    }
+
+    public String getLabel() {
+        return label;
+    }
+}

--- a/src/main/java/com/divudi/core/entity/HistoricalRecord.java
+++ b/src/main/java/com/divudi/core/entity/HistoricalRecord.java
@@ -3,14 +3,17 @@ package com.divudi.core.entity;
 import java.io.Serializable;
 import java.util.Date;
 import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
+import com.divudi.core.data.HistoricalRecordType;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.ManyToOne;
 import javax.persistence.Temporal;
 import javax.persistence.TemporalType;
-import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Size;
+import javax.validation.constraints.NotNull;
 
 /**
  *
@@ -24,9 +27,15 @@ public class HistoricalRecord implements Serializable {
     @GeneratedValue(strategy = GenerationType.AUTO)
     private Long id;
 
-    @NotNull
-    @Size(min = 1, max = 255)
+    /**
+     * @deprecated use {@link #historicalRecordType} instead.
+     */
+    @Deprecated
+    @Size(max = 255)
     private String variableName;
+
+    @Enumerated(EnumType.STRING)
+    private HistoricalRecordType historicalRecordType;
 
     @NotNull
     private Double recordValue;
@@ -39,6 +48,12 @@ public class HistoricalRecord implements Serializable {
 
     @ManyToOne
     private Department department;
+
+    @ManyToOne
+    private WebUser webUser;
+
+    @ManyToOne
+    private Institution collectionCentre;
 
     @Temporal(TemporalType.DATE)
     private Date recordDate;
@@ -90,12 +105,28 @@ public class HistoricalRecord implements Serializable {
         return "com.divudi.core.entity.HistoricalRecord[ id=" + id + " ]";
     }
 
+    /**
+     * @deprecated use {@link #historicalRecordType}
+     */
+    @Deprecated
     public String getVariableName() {
         return variableName;
     }
 
+    /**
+     * @deprecated use {@link #historicalRecordType}
+     */
+    @Deprecated
     public void setVariableName(String variableName) {
         this.variableName = variableName;
+    }
+
+    public HistoricalRecordType getHistoricalRecordType() {
+        return historicalRecordType;
+    }
+
+    public void setHistoricalRecordType(HistoricalRecordType historicalRecordType) {
+        this.historicalRecordType = historicalRecordType;
     }
 
     public Double getRecordValue() {
@@ -128,6 +159,22 @@ public class HistoricalRecord implements Serializable {
 
     public void setDepartment(Department department) {
         this.department = department;
+    }
+
+    public WebUser getWebUser() {
+        return webUser;
+    }
+
+    public void setWebUser(WebUser webUser) {
+        this.webUser = webUser;
+    }
+
+    public Institution getCollectionCentre() {
+        return collectionCentre;
+    }
+
+    public void setCollectionCentre(Institution collectionCentre) {
+        this.collectionCentre = collectionCentre;
     }
 
     public Date getRecordDate() {

--- a/src/main/java/com/divudi/service/HistoricalRecordService.java
+++ b/src/main/java/com/divudi/service/HistoricalRecordService.java
@@ -3,6 +3,7 @@
  */
 package com.divudi.service;
 
+import com.divudi.core.data.HistoricalRecordType;
 import com.divudi.core.entity.Department;
 import com.divudi.core.entity.HistoricalRecord;
 import com.divudi.core.entity.Institution;
@@ -25,15 +26,15 @@ public class HistoricalRecordService {
     @EJB
     private HistoricalRecordFacade historicalRecordFacade;
 
-    public HistoricalRecord findRecord(String variableName, Institution institution, Institution site, Department department, Date recordDate) {
+    public HistoricalRecord findRecord(HistoricalRecordType historicalRecordType, Institution institution, Institution site, Department department, Date recordDate) {
         String jpql = "select hr "
                 + " from HistoricalRecord hr "
                 + " where hr.retired=false "
-                + " and hr.variableName=:vn "
+                + " and hr.historicalRecordType=:vn "
                 + " and hr.recordDate=:rd ";
 
         Map<String, Object> parameters = new HashMap<>();
-        parameters.put("vn", variableName);
+        parameters.put("vn", historicalRecordType);
         parameters.put("rd", recordDate);
 
         if (institution != null) {
@@ -59,14 +60,14 @@ public class HistoricalRecordService {
         return r;
     }
 
-    public List<HistoricalRecord> findRecords(String variableName, Institution institution, Institution site, Department department, Date fromDate, Date toDate) {
+    public List<HistoricalRecord> findRecords(HistoricalRecordType historicalRecordType, Institution institution, Institution site, Department department, Date fromDate, Date toDate) {
         String jpql = "select hr "
                 + " from HistoricalRecord hr "
                 + " where hr.retired=false "
-                + " and hr.variableName=:vn ";
+                + " and hr.historicalRecordType=:vn ";
 
         Map<String, Object> parameters = new HashMap<>();
-        parameters.put("vn", variableName);
+        parameters.put("vn", historicalRecordType);
 
         if (institution != null) {
             jpql += " and hr.institution=:ins ";
@@ -104,12 +105,8 @@ public class HistoricalRecordService {
         return historicalRecordFacade.findByJpql(jpql, parameters, TemporalType.DATE);
     }
 
-    public List<String> fetchVariableNames() {
-        String jpql = "select distinct(hr.variableName) "
-                + " from HistoricalRecord hr "
-                + " where hr.retired=false "
-                + " order by hr.variableName";
-        return historicalRecordFacade.findStringListByJpql(jpql);
+    public List<HistoricalRecordType> fetchHistoricalRecordTypes() {
+        return java.util.Arrays.asList(HistoricalRecordType.values());
     }
 
 }

--- a/src/main/java/com/divudi/service/StockHistoryService.java
+++ b/src/main/java/com/divudi/service/StockHistoryService.java
@@ -2,6 +2,7 @@ package com.divudi.service;
 
 import com.divudi.core.entity.Department;
 import com.divudi.core.entity.HistoricalRecord;
+import com.divudi.core.data.HistoricalRecordType;
 import com.divudi.core.entity.Item;
 import com.divudi.core.entity.pharmacy.StockHistory;
 import com.divudi.core.facade.StockHistoryFacade;
@@ -69,7 +70,7 @@ public class StockHistoryService {
     }
 
     public double fetchOpeningStockQuantity(Department department, Date date) {
-        HistoricalRecord openingBalance = historicalRecordService.findRecord("Pharmacy Stock Value at Retail Sale Rate", null, null, department, date);
+        HistoricalRecord openingBalance = historicalRecordService.findRecord(HistoricalRecordType.Pharmacy_Stock_Value, null, null, department, date);
         if (openingBalance != null) {
             return openingBalance.getRecordValue();
         } else {

--- a/src/main/webapp/dataAdmin/historical_record_list.xhtml
+++ b/src/main/webapp/dataAdmin/historical_record_list.xhtml
@@ -65,11 +65,11 @@
 
                             <h:panelGroup layout="block" styleClass="form-group">
                                 <h:outputText value="&#xf02d;" styleClass="fa mr-2" />
-                                <h:outputLabel value="Variable" for="variableName" class="mx-3"/>
+                                <h:outputLabel value="Variable" for="historicalRecordType" class="mx-3"/>
                             </h:panelGroup>
-                            <p:selectOneMenu id="variableName" value="#{historicalRecordController.variableName}" styleClass="w-100 form-control" filter="true">
+                            <p:selectOneMenu id="historicalRecordType" value="#{historicalRecordController.historicalRecordType}" styleClass="w-100 form-control" filter="true">
                                 <f:selectItem itemLabel="All Variables" itemValue="#{null}"/>
-                                <f:selectItems value="#{historicalRecordController.variableNames}" var="v" itemLabel="#{v}" itemValue="#{v}" />
+                                <f:selectItems value="#{historicalRecordController.historicalRecordTypes}" var="v" itemLabel="#{v.label}" itemValue="#{v}" />
                             </p:selectOneMenu>
                         </h:panelGrid>
                         <h:panelGrid columns="6" class="my-2">
@@ -109,7 +109,7 @@
                             </p:column>
 
                             <p:column headerText="Variable">
-                                <h:outputText value="#{rec.variableName}" />
+                                <h:outputText value="#{rec.historicalRecordType != null ? rec.historicalRecordType.label : rec.variableName}" />
                             </p:column>
 
                             <p:column headerText="Value">


### PR DESCRIPTION
## Summary
- add `HistoricalRecordType` enum
- update `HistoricalRecord` entity to use the enum and new fields
- modify services and controllers to work with `HistoricalRecordType`
- update JSF page for enum values
- keep old `variableName` field as deprecated

## Testing
- `mvn -q test` *(fails: PluginResolutionException - network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6848256af39c832fbaaf2007a90f1307