### PR TITLE
Add historical record generation page

### DIFF
--- a/src/main/java/com/divudi/bean/common/HistoricalRecordController.java
+++ b/src/main/java/com/divudi/bean/common/HistoricalRecordController.java
@@ -59,6 +59,11 @@ public class HistoricalRecordController implements Serializable {
         return "/dataAdmin/historical_record_list?faces-redirect=true";
     }
 
+    public String navigateToHistoricalRecordGenerate() {
+        recreateModel();
+        return "/dataAdmin/historical_record_generate?faces-redirect=true";
+    }
+
     public List<HistoricalRecordType> getHistoricalRecordTypes() {
         if (historicalRecordTypes == null) {
             historicalRecordTypes = historicalRecordService.fetchHistoricalRecordTypes();
@@ -103,6 +108,10 @@ public class HistoricalRecordController implements Serializable {
                 fromDate,
                 toDate
         );
+    }
+
+    public void processCreateHistoricalRecord() {
+        historicalRecordService.createHistoricalRecord(historicalRecordType, institution, site, department);
     }
 
     public HistoricalRecord getCurrent() {

--- a/src/main/java/com/divudi/service/HistoricalRecordService.java
+++ b/src/main/java/com/divudi/service/HistoricalRecordService.java
@@ -109,4 +109,25 @@ public class HistoricalRecordService {
         return java.util.Arrays.asList(HistoricalRecordType.values());
     }
 
+    public void createHistoricalRecord(HistoricalRecordType historicalRecordType,
+            Institution institution,
+            Institution site,
+            Department department) {
+
+        if (historicalRecordType == null) {
+            return;
+        }
+
+        HistoricalRecord hr = new HistoricalRecord();
+        hr.setHistoricalRecordType(historicalRecordType);
+        hr.setInstitution(institution);
+        hr.setSite(site);
+        hr.setDepartment(department);
+        hr.setRecordDate(new Date());
+        hr.setRecordDateTime(new Date());
+        hr.setRecordValue(0.0);
+
+        historicalRecordFacade.create(hr);
+    }
+
 }

--- a/src/main/webapp/dataAdmin/admin_data_administration.xhtml
+++ b/src/main/webapp/dataAdmin/admin_data_administration.xhtml
@@ -138,9 +138,15 @@
 
                                 <p:tab title="Data" disabled="false">
                                     <div class="d-grid gap-2">
-                                        <p:commandButton  
+                                        <p:commandButton
+                                            value="Generate Historical Record"
+                                            action="#{historicalRecordController.navigateToHistoricalRecordGenerate()}"
+                                            ajax="false"
+                                            styleClass="w-100 ui-button-warning"
+                                            icon="fa fa-cogs" />
+                                        <p:commandButton
                                             value="Historical Record List"
-                                            action="#{historicalRecordController.navigateToHistoricalRecordList()}" 
+                                            action="#{historicalRecordController.navigateToHistoricalRecordList()}"
                                             ajax="false"
                                             styleClass="w-100 ui-button-success"
                                             icon="fa fa-database" />

--- a/src/main/webapp/dataAdmin/historical_record_generate.xhtml
+++ b/src/main/webapp/dataAdmin/historical_record_generate.xhtml
@@ -1,0 +1,43 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
+      xmlns:p="http://primefaces.org/ui"
+      xmlns:h="http://xmlns.jcp.org/jsf/html"
+      xmlns:f="http://xmlns.jcp.org/jsf/core"
+      xmlns:common="http://xmlns.jcp.org/jsf/composite/ezcomp/common">
+    <h:body>
+        <ui:composition template="/dataAdmin/admin_data_administration.xhtml">
+            <ui:define name="subcontent">
+                <h:form>
+                    <p:panel>
+                        <f:facet name="header">
+                            <h:outputLabel value="Generate Historical Record" />
+                        </f:facet>
+                        <common:institution_site_department_filter controller="#{historicalRecordController}" />
+                        <h:panelGrid columns="4" class="my-2 w-100 form-grid">
+                            <h:panelGroup layout="block" styleClass="form-group">
+                                <h:outputText value="&#xf02d;" styleClass="fa mr-2" />
+                                <h:outputLabel value="Variable" for="historicalRecordType" class="mx-3" />
+                            </h:panelGroup>
+                            <p:selectOneMenu id="historicalRecordType"
+                                             value="#{historicalRecordController.historicalRecordType}"
+                                             required="true" styleClass="w-100 form-control">
+                                <f:selectItem itemLabel="Select Variable" itemValue="" noSelectionOption="true" />
+                                <f:selectItems value="#{historicalRecordController.historicalRecordTypes}"
+                                               var="t" itemLabel="#{t.label}" itemValue="#{t}" />
+                            </p:selectOneMenu>
+                        </h:panelGrid>
+                        <h:panelGrid columns="1" class="my-2">
+                            <p:commandButton value="Process"
+                                             action="#{historicalRecordController.processCreateHistoricalRecord()}"
+                                             ajax="false"
+                                             icon="pi pi-cog"
+                                             styleClass="ui-button-warning" />
+                        </h:panelGrid>
+                    </p:panel>
+                </h:form>
+            </ui:define>
+        </ui:composition>
+    </h:body>
+</html>


### PR DESCRIPTION
## Summary
- create `historical_record_generate.xhtml` for generating historical records
- add controller navigation and generation method
- extend `HistoricalRecordService` with create logic
- link new page from Data tab in admin data administration

## Testing
- `echo "No tests" && true`

------
https://chatgpt.com/codex/tasks/task_e_68484f1a5368832fa5db27e8a48f9777