### PR TITLE
Add detailed pharmacy stock value enum rates

### DIFF
--- a/src/main/java/com/divudi/bean/common/HistoricalRecordController.java
+++ b/src/main/java/com/divudi/bean/common/HistoricalRecordController.java
@@ -128,8 +128,12 @@ public class HistoricalRecordController implements Serializable {
             return null;
         }
         switch (type) {
-            case PHARMACY_STOCK_VALUE:
-                return generatePharmacyStockValue();
+            case PHARMACY_STOCK_VALUE_PURCHASE_RATE:
+                return generatePharmacyStockValuePurchaseRate();
+            case PHARMACY_STOCK_VALUE_RETAIL_RATE:
+                return generatePharmacyStockValueRetailRate();
+            case PHARMACY_STOCK_VALUE_COST_RATE:
+                return generatePharmacyStockValueCostRate();
             case COLLECTION_CENTRE_BALANCE:
                 return generateCollectionCentreBalance();
             case CREDIT_COMPANY_BALANCE:
@@ -153,8 +157,22 @@ public class HistoricalRecordController implements Serializable {
     }
 
 
-    private HistoricalRecord generatePharmacyStockValue() {
-        HistoricalRecord rec = buildRecord(HistoricalRecordType.PHARMACY_STOCK_VALUE);
+    private HistoricalRecord generatePharmacyStockValuePurchaseRate() {
+        HistoricalRecord rec = buildRecord(HistoricalRecordType.PHARMACY_STOCK_VALUE_PURCHASE_RATE);
+        // TODO: implement generation logic
+        historicalRecordService.createHistoricalRecord(rec);
+        return rec;
+    }
+
+    private HistoricalRecord generatePharmacyStockValueRetailRate() {
+        HistoricalRecord rec = buildRecord(HistoricalRecordType.PHARMACY_STOCK_VALUE_RETAIL_RATE);
+        // TODO: implement generation logic
+        historicalRecordService.createHistoricalRecord(rec);
+        return rec;
+    }
+
+    private HistoricalRecord generatePharmacyStockValueCostRate() {
+        HistoricalRecord rec = buildRecord(HistoricalRecordType.PHARMACY_STOCK_VALUE_COST_RATE);
         // TODO: implement generation logic
         historicalRecordService.createHistoricalRecord(rec);
         return rec;

--- a/src/main/java/com/divudi/bean/pharmacy/PharmacySummaryReportController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacySummaryReportController.java
@@ -307,7 +307,7 @@ public class PharmacySummaryReportController implements Serializable {
         dailyStockBalanceReport.setDate(fromDate);
         dailyStockBalanceReport.setDepartment(department);
 
-        HistoricalRecord openingBalance = historicalRecordService.findRecord(HistoricalRecordType.PHARMACY_STOCK_VALUE, null, null, department, fromDate);
+        HistoricalRecord openingBalance = historicalRecordService.findRecord(HistoricalRecordType.PHARMACY_STOCK_VALUE_PURCHASE_RATE, null, null, department, fromDate);
         if (openingBalance != null) {
             dailyStockBalanceReport.setOpeningStockValue(openingBalance.getRecordValue());
         }
@@ -333,7 +333,7 @@ public class PharmacySummaryReportController implements Serializable {
         PharmacyBundle adjustmentBundle = pharmacyService.fetchPharmacyAdjustmentValueByBillType(startOfTheDay, endOfTheDay, null, null, department, null, null, null);
         dailyStockBalanceReport.setPharmacyAdjustmentsByBillTypeBundle(adjustmentBundle);
 
-        HistoricalRecord closingBalance = historicalRecordService.findRecord(HistoricalRecordType.PHARMACY_STOCK_VALUE, null, null, department, toDate);
+        HistoricalRecord closingBalance = historicalRecordService.findRecord(HistoricalRecordType.PHARMACY_STOCK_VALUE_PURCHASE_RATE, null, null, department, toDate);
         if (closingBalance != null) {
             dailyStockBalanceReport.setClosingStockValue(closingBalance.getRecordValue());
         }

--- a/src/main/java/com/divudi/core/data/HistoricalRecordType.java
+++ b/src/main/java/com/divudi/core/data/HistoricalRecordType.java
@@ -4,7 +4,9 @@ package com.divudi.core.data;
  * Enum representing predefined categories of historical records.
  */
 public enum HistoricalRecordType {
-    PHARMACY_STOCK_VALUE("Pharmacy Stock Value"),
+    PHARMACY_STOCK_VALUE_PURCHASE_RATE("Pharmacy Stock Value Purchase Rate"),
+    PHARMACY_STOCK_VALUE_RETAIL_RATE("Pharmacy Stock Value Retail Rate"),
+    PHARMACY_STOCK_VALUE_COST_RATE("Pharmacy Stock Value Cost Rate"),
     COLLECTION_CENTRE_BALANCE("Collection Centre Balance"),
     CREDIT_COMPANY_BALANCE("Credit Company Balance"),
     DRAWER_BALANCE("Drawer Balance");

--- a/src/main/java/com/divudi/service/StockHistoryService.java
+++ b/src/main/java/com/divudi/service/StockHistoryService.java
@@ -70,7 +70,7 @@ public class StockHistoryService {
     }
 
     public double fetchOpeningStockQuantity(Department department, Date date) {
-        HistoricalRecord openingBalance = historicalRecordService.findRecord(HistoricalRecordType.PHARMACY_STOCK_VALUE, null, null, department, date);
+        HistoricalRecord openingBalance = historicalRecordService.findRecord(HistoricalRecordType.PHARMACY_STOCK_VALUE_PURCHASE_RATE, null, null, department, date);
         if (openingBalance != null) {
             return openingBalance.getRecordValue();
         } else {


### PR DESCRIPTION
## Summary
- expand `HistoricalRecordType` with new pharmacy stock value rate entries
- use new purchase rate enum where old constant was referenced
- update `HistoricalRecordController` generation methods for the new enums

## Testing
- `apt-get update`
- `apt-get install -y maven`
- `mvn -q -DskipTests package` *(fails: Plugin resolution exception due to network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68484aadd654832f8099912336ab6c2b