### PR TITLE
12688 print preview not displayed by default in disposal issue

### DIFF
--- a/src/main/java/com/divudi/bean/common/ConfigOptionApplicationController.java
+++ b/src/main/java/com/divudi/bean/common/ConfigOptionApplicationController.java
@@ -49,27 +49,15 @@ public class ConfigOptionApplicationController implements Serializable {
 
     }
 
-//    private void initializeDenominations() {
-//        String denominationsStr = getLongTextValueByKey("Currency Denominations");
-//        if (denominationsStr == null || !denominationsStr.trim().isEmpty()) {
-//            denominationsStr = "1,2,5,10,20,50,100,500,1000,5000";
-//        }
-//        denominations = Arrays.stream(denominationsStr.split(","))
-//                .map(String::trim) // Trim any extra spaces
-//                .filter(s -> !s.isEmpty()) // Filter out empty strings
-//                .map(Integer::parseInt)
-//                .map(value -> new Denomination(value, 0))
-//                .collect(Collectors.toList());
-//    }
     public void loadApplicationOptions() {
         applicationOptions = new HashMap<>();
         List<ConfigOption> options = getApplicationOptions();
         for (ConfigOption option : options) {
             applicationOptions.put(option.getOptionKey(), option);
         }
-//        initializeDenominations();
         loadEmailGatewayConfigurationDefaults();
         loadPharmacyConfigurationDefaults();
+        loadPharmacyIssueReceiptConfigurationDefaults();
     }
 
     private void loadEmailGatewayConfigurationDefaults() {
@@ -98,6 +86,65 @@ public class ConfigOptionApplicationController implements Serializable {
         getDoubleValueByKey("Wholesale Rate Factor", 1.08);
         getDoubleValueByKey("Retail to Purchase Factor", 1.15);
         getDoubleValueByKey("Maximum Retail Price Change Percentage", 15.0);
+    }
+
+    private void loadPharmacyIssueReceiptConfigurationDefaults() {
+        getLongTextValueByKey("Pharmacy Issue Receipt CSS",
+                ".receipt-container {\n"
+                + "    font-family: Verdana, sans-serif;\n"
+                + "    font-size: 12px;\n"
+                + "    color: #000;\n"
+                + "}\n"
+                + ".receipt-header, .receipt-title, .receipt-separator, .receipt-summary {\n"
+                + "    margin-bottom: 10px;\n"
+                + "}\n"
+                + ".receipt-institution-name {\n"
+                + "    font-weight: bold;\n"
+                + "    font-size: 16px;\n"
+                + "    text-align: center;\n"
+                + "}\n"
+                + ".receipt-institution-contact {\n"
+                + "    text-align: center;\n"
+                + "    font-size: 11px;\n"
+                + "}\n"
+                + ".receipt-title {\n"
+                + "    text-align: center;\n"
+                + "    font-size: 14px;\n"
+                + "    font-weight: bold;\n"
+                + "    text-decoration: underline;\n"
+                + "}\n"
+                + ".receipt-details-table, .receipt-items-table, .receipt-summary-table {\n"
+                + "    width: 100%;\n"
+                + "    border-collapse: collapse;\n"
+                + "}\n"
+                + ".receipt-items-header {\n"
+                + "    font-weight: bold;\n"
+                + "    border-bottom: 1px solid #ccc;\n"
+                + "}\n"
+                + ".item-name, .item-qty, .item-rate, .item-value {\n"
+                + "    padding: 4px;\n"
+                + "    text-align: left;\n"
+                + "}\n"
+                + ".item-qty, .item-rate, .item-value {\n"
+                + "    text-align: right;\n"
+                + "}\n"
+                + ".summary-label {\n"
+                + "    font-weight: bold;\n"
+                + "}\n"
+                + ".summary-value {\n"
+                + "    text-align: right;\n"
+                + "    font-weight: bold;\n"
+                + "}\n"
+                + ".total-amount {\n"
+                + "    font-size: 14px;\n"
+                + "    font-weight: bold;\n"
+                + "}\n"
+                + ".receipt-cashier {\n"
+                + "    margin-top: 20px;\n"
+                + "    text-align: right;\n"
+                + "    text-decoration: overline;\n"
+                + "}"
+        );
     }
 
     public ConfigOption getApplicationOption(String key) {

--- a/src/main/resources/META-INF/persistence.xml
+++ b/src/main/resources/META-INF/persistence.xml
@@ -2,17 +2,19 @@
 <persistence version="2.2" xmlns="http://java.sun.com/xml/ns/persistence" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/persistence http://xmlns.jcp.org/xml/ns/persistence/persistence_2_2.xsd">
     <persistence-unit name="hmisPU" transaction-type="JTA">
         <provider>org.eclipse.persistence.jpa.PersistenceProvider</provider>
-        <jta-data-source>${JDBC_DATASOURCE}</jta-data-source>
+        <jta-data-source>jdbc/coop</jta-data-source>
         <exclude-unlisted-classes>false</exclude-unlisted-classes>
         <properties>
             <property name="eclipselink.logging.level.sql" value="SEVERE"/>
+            <property name="eclipselink.logging.level" value="SEVERE"/>
         </properties>
     </persistence-unit>
     <persistence-unit name="hmisAuditPU" transaction-type="JTA">
-        <jta-data-source>${JDBC_AUDIT_DATASOURCE}</jta-data-source>
+        <jta-data-source>jdbc/ruhunuAudit</jta-data-source>
         <exclude-unlisted-classes>false</exclude-unlisted-classes>
         <properties>
             <property name="eclipselink.logging.level.sql" value="SEVERE"/>
+            <property name="eclipselink.logging.level" value="SEVERE"/>
         </properties>
     </persistence-unit>
 </persistence>

--- a/src/main/resources/META-INF/persistence.xml
+++ b/src/main/resources/META-INF/persistence.xml
@@ -2,19 +2,17 @@
 <persistence version="2.2" xmlns="http://java.sun.com/xml/ns/persistence" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/persistence http://xmlns.jcp.org/xml/ns/persistence/persistence_2_2.xsd">
     <persistence-unit name="hmisPU" transaction-type="JTA">
         <provider>org.eclipse.persistence.jpa.PersistenceProvider</provider>
-        <jta-data-source>jdbc/coop</jta-data-source>
+        <jta-data-source>${JDBC_DATASOURCE}</jta-data-source>
         <exclude-unlisted-classes>false</exclude-unlisted-classes>
         <properties>
             <property name="eclipselink.logging.level.sql" value="SEVERE"/>
-            <property name="eclipselink.logging.level" value="SEVERE"/>
         </properties>
     </persistence-unit>
     <persistence-unit name="hmisAuditPU" transaction-type="JTA">
-        <jta-data-source>jdbc/ruhunuAudit</jta-data-source>
+        <jta-data-source>${JDBC_AUDIT_DATASOURCE}</jta-data-source>
         <exclude-unlisted-classes>false</exclude-unlisted-classes>
         <properties>
             <property name="eclipselink.logging.level.sql" value="SEVERE"/>
-            <property name="eclipselink.logging.level" value="SEVERE"/>
         </properties>
     </persistence-unit>
 </persistence>

--- a/src/main/webapp/pharmacy/pharmacy_issue.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_issue.xhtml
@@ -267,12 +267,12 @@
 
 
                                     <p:commandButton
-                                            accesskey="s"
-                                            value="Issue"
-                                            ajax="false"
-                                            icon="fas fa-check"
-                                            action="#{pharmacyIssueController.checkTheDepartment()}"
-                                            class="w-25 ui-button-warning">
+                                        accesskey="s"
+                                        value="Issue"
+                                        ajax="false"
+                                        icon="fas fa-check"
+                                        action="#{pharmacyIssueController.checkTheDepartment()}"
+                                        class="w-25 ui-button-warning">
                                     </p:commandButton>
 
                                 </p:panel>
@@ -338,15 +338,7 @@
                         </div>
 
                         <h:panelGroup   id="gpBillPreview" >
-
-                            <h:panelGroup rendered="#{sessionController.loggedPreference.pharmacyBillPaperType eq 'FiveFivePaper'}" >
-                                <phi:pharmacy_disposal_bill_five_five bill="#{pharmacyIssueController.printBill}"/>
-                            </h:panelGroup>
-
-                            <h:panelGroup rendered="#{sessionController.loggedPreference.pharmacyBillPaperType eq 'PosPaper'}" >
-                                <phi:pharmacy_disposal_bill_pos bill="#{pharmacyIssueController.printBill}"/>
-                            </h:panelGroup>
-
+                            <phi:pharmacy_issue_receipt bill="#{pharmacyIssueController.printBill}"/>
                         </h:panelGroup>
                     </p:panel>
                 </h:form>

--- a/src/main/webapp/resources/pharmacy/pharmacy_issue_receipt.xhtml
+++ b/src/main/webapp/resources/pharmacy/pharmacy_issue_receipt.xhtml
@@ -15,8 +15,6 @@
     <!-- IMPLEMENTATION -->
     <cc:implementation>
 
-        <cc:implementation>
-
             <style>
                 <h:outputText escape="false"
                 value="#{configOptionApplicationController.getLongTextValueByKey('Pharmacy Issue Receipt CSS')}"/>

--- a/src/main/webapp/resources/pharmacy/pharmacy_issue_receipt.xhtml
+++ b/src/main/webapp/resources/pharmacy/pharmacy_issue_receipt.xhtml
@@ -1,0 +1,223 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:cc="http://xmlns.jcp.org/jsf/composite"
+      xmlns:f="http://xmlns.jcp.org/jsf/core"
+      xmlns:h="http://xmlns.jcp.org/jsf/html"
+      xmlns:ui="http://xmlns.jcp.org/jsf/facelets">
+
+
+    <!-- INTERFACE -->
+    <cc:interface>
+        <cc:attribute name="bill" type="com.divudi.core.entity.Bill"/>
+    </cc:interface>
+
+    <!-- IMPLEMENTATION -->
+    <cc:implementation>
+
+        <cc:implementation>
+
+            <style>
+                <h:outputText escape="false"
+                value="#{configOptionApplicationController.getLongTextValueByKey('Pharmacy Issue Receipt CSS')}"/>
+            </style>
+
+
+            <h:outputText escape="false"
+                          value="#{configOptionApplicationController.getLongTextValueByKey('Pharmacy Issue Receipt Header')}"/>
+
+            <div class="receipt-container">
+                <div class="receipt-header">
+                    <div class="receipt-institution-name">
+                        <h:outputLabel value="#{cc.attrs.bill.department.printingName}" />
+                    </div>
+                    <div class="receipt-institution-contact">
+                        <h:outputLabel value="#{cc.attrs.bill.department.address}" /><br />
+                        <h:outputLabel value="#{cc.attrs.bill.department.telephone1}" />
+                        <h:outputLabel value=" #{cc.attrs.bill.department.telephone2}" /><br />
+                        <h:outputLabel value="#{cc.attrs.bill.department.fax}" />
+                    </div>
+                </div>
+
+                <div class="receipt-title">
+                    <h:outputLabel value="Pharmacy Issue Receipt" />
+                </div>
+
+                <div class="receipt-separator"><hr /></div>
+
+                <div class="receipt-bill-details">
+                    <table class="receipt-details-table">
+                        <!-- Table rows for bill metadata -->
+                        <tr>
+                            <td><h:outputLabel value="Date" styleClass="label" /></td>
+                            <td><h:outputLabel value=":" /></td>
+                            <td>
+                                <h:outputLabel value="#{cc.attrs.bill.createdAt}">
+                                    <f:convertDateTime pattern="dd/MM/yy" />
+                                </h:outputLabel>
+                                <h:outputLabel value="#{cc.attrs.bill.createdAt}">
+                                    <f:convertDateTime timeZone="Asia/Colombo" pattern="#{sessionController.applicationPreference.shortTimeFormat}" />
+                                </h:outputLabel>
+                            </td>
+                            <td><h:outputLabel value="BHT No" rendered="#{cc.attrs.bill.patientEncounter.bhtNo ne null}" /></td>
+                            <td><h:outputLabel value=":" rendered="#{cc.attrs.bill.patientEncounter.bhtNo ne null}" /></td>
+                            <td><h:outputLabel value="#{cc.attrs.bill.patientEncounter.bhtNo}" rendered="#{cc.attrs.bill.patientEncounter.bhtNo ne null}" /></td>
+                        </tr>
+                        <tr>
+                            <td><h:outputLabel value="Invoice No" styleClass="label" /></td>
+                            <td><h:outputLabel value=":" /></td>
+                            <td colspan="4"><h:outputLabel value="#{cc.attrs.bill.deptId}" /></td>
+                        </tr>
+
+                        <h:panelGroup rendered="#{cc.attrs.bill.invoiceNumber ne null}">
+                            <tr>
+                                <td><h:outputLabel value="Request No" styleClass="label" /></td>
+                                <td><h:outputLabel value=":" /></td>
+                                <td colspan="4"><h:outputLabel value="#{cc.attrs.bill.invoiceNumber}" /></td>
+                            </tr>
+                        </h:panelGroup>
+
+                        <tr>
+                            <td><h:outputLabel value="Payment Method" styleClass="label" rendered="#{cc.attrs.bill.paymentMethod ne null}" /></td>
+                            <td><h:outputLabel value=":" rendered="#{cc.attrs.bill.paymentMethod ne null}" /></td>
+                            <td><h:outputLabel value="#{cc.attrs.bill.paymentMethod}" rendered="#{cc.attrs.bill.paymentMethod ne null}" /></td>
+                        </tr>
+
+                        <tr>
+                            <td><h:outputLabel value="Payment Scheme" styleClass="label" rendered="#{cc.attrs.bill.paymentScheme.printingName ne null}" /></td>
+                            <td><h:outputLabel value=":" rendered="#{cc.attrs.bill.paymentScheme.printingName ne null}" /></td>
+                            <td><h:outputLabel value="#{cc.attrs.bill.paymentScheme.printingName}" rendered="#{cc.attrs.bill.paymentScheme.printingName ne null}" /></td>
+                        </tr>
+
+                        <tr>
+                            <td><h:outputLabel value="Patient Name" styleClass="label" rendered="#{cc.attrs.bill.patient.person.nameWithTitle ne null}" /></td>
+                            <td><h:outputLabel value=":" rendered="#{cc.attrs.bill.patient.person.nameWithTitle ne null}" /></td>
+                            <td colspan="4"><h:outputLabel value="#{cc.attrs.bill.patient.person.nameWithTitle}" rendered="#{cc.attrs.bill.patient.person.nameWithTitle ne null}" /></td>
+                        </tr>
+
+                        <tr>
+                            <td><h:outputLabel value="Staff Name" styleClass="label" rendered="#{cc.attrs.bill.toStaff.person.nameWithTitle ne null}" /></td>
+                            <td><h:outputLabel value=":" rendered="#{cc.attrs.bill.toStaff.person.nameWithTitle ne null}" /></td>
+                            <td colspan="4"><h:outputLabel value="#{cc.attrs.bill.toStaff.person.nameWithTitle}" rendered="#{cc.attrs.bill.toStaff.person.nameWithTitle ne null}" /></td>
+                        </tr>
+
+                        <h:panelGroup rendered="#{cc.attrs.bill.toDepartment ne null}">
+                            <tr>
+                                <td><h:outputLabel value="To Unit" styleClass="label" /></td>
+                                <td><h:outputLabel value=":" /></td>
+                                <td colspan="4"><h:outputLabel value="#{cc.attrs.bill.toDepartment.name}" /></td>
+                            </tr>
+                        </h:panelGroup>
+
+                        <h:panelGroup rendered="#{cc.attrs.bill.toInstitution ne null}">
+                            <tr>
+                                <td><h:outputLabel value="Company" styleClass="label" /></td>
+                                <td><h:outputLabel value=":" /></td>
+                                <td colspan="4"><h:outputLabel value="#{cc.attrs.bill.toInstitution.name}" /></td>
+                            </tr>
+                        </h:panelGroup>
+
+                        <h:panelGroup rendered="#{cc.attrs.bill.comments ne null}">
+                            <tr>
+                                <td><h:outputLabel value="Comment" styleClass="label" /></td>
+                                <td><h:outputLabel value=":" /></td>
+                                <td colspan="4"><h:outputLabel value="#{cc.attrs.bill.comments}" /></td>
+                            </tr>
+                        </h:panelGroup>
+
+                    </table>
+                </div>
+
+                <div class="receipt-separator"><hr /></div>
+
+                <div class="receipt-items-section">
+                    <table class="receipt-items-table">
+                        <thead>
+                            <tr>
+                                <th class="item-name">Item</th>
+                                <th class="item-qty">Qty</th>
+                                <th class="item-rate">Rate</th>
+                                <th class="item-value">Value</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            <ui:repeat value="#{cc.attrs.bill.billItems}" var="bip">
+                                <tr>
+                                    <td class="item-name">
+                                        <h:outputLabel value="#{bip.searialNo+1} - #{bip.item.name}" />
+                                    </td>
+                                    <td class="item-qty">
+                                        <h:outputLabel value="#{bip.qty}">
+                                            <f:convertNumber pattern="#,##0.00" />
+                                        </h:outputLabel>
+                                    </td>
+                                    <td class="item-rate">
+                                        <h:outputLabel value="#{bip.pharmaceuticalBillItem.retailRate}">
+                                            <f:convertNumber pattern="#,##0.00" />
+                                        </h:outputLabel>
+                                    </td>
+                                    <td class="item-value">
+                                        <h:outputLabel value="#{bip.pharmaceuticalBillItem.retailRate * bip.qty}">
+                                            <f:convertNumber pattern="#,##0.00" />
+                                        </h:outputLabel>
+                                    </td>
+                                </tr>
+                            </ui:repeat>
+                        </tbody>
+                    </table>
+                </div>
+
+                <div class="receipt-separator"><hr /></div>
+
+                <div class="receipt-summary">
+                    <table class="receipt-summary-table">
+                        <tr>
+                            <td class="summary-label">Total</td>
+                            <td class="summary-value">
+                                <h:outputLabel value="0.00" styleClass="total-amount">
+                                    <f:convertNumber pattern="#,##0.00" />
+                                </h:outputLabel>
+                            </td>
+                        </tr>
+                        <h:panelGroup rendered="#{cc.attrs.bill.discount ne 0.0}">
+                            <tr>
+                                <td class="summary-label">Discount</td>
+                                <td class="summary-value">
+                                    <h:outputLabel value="#{-cc.attrs.bill.discount}">
+                                        <f:convertNumber pattern="#,##0.00" />
+                                    </h:outputLabel>
+                                </td>
+                            </tr>
+                            <tr>
+                                <td class="summary-label">Net Total</td>
+                                <td class="summary-value">
+                                    <h:outputLabel value="#{cc.attrs.bill.netTotal}">
+                                        <f:convertNumber pattern="#,##0.00" />
+                                    </h:outputLabel>
+                                </td>
+                            </tr>
+                        </h:panelGroup>
+                        <tr>
+                            <td class="summary-label">Number of Items</td>
+                            <td class="summary-value">
+                                <h:outputLabel value="#{cc.attrs.bill.billItems.size()}">
+                                    <f:convertNumber pattern="#,##0.00" />
+                                </h:outputLabel>
+                            </td>
+                        </tr>
+                    </table>
+                </div>
+
+                <div class="receipt-cashier">
+                    <h:outputLabel value="Cashier : #{cc.attrs.bill.creater.name}" />
+                </div>
+            </div>
+
+            <h:outputText escape="false"
+                          value="#{configOptionApplicationController.getLongTextValueByKey('Pharmacy Issue Receipt Footer')}"/>
+
+        </cc:implementation>
+
+
+    </cc:implementation>
+</html>

--- a/src/main/webapp/resources/pharmacy/pharmacy_issue_receipt.xhtml
+++ b/src/main/webapp/resources/pharmacy/pharmacy_issue_receipt.xhtml
@@ -15,206 +15,206 @@
     <!-- IMPLEMENTATION -->
     <cc:implementation>
 
-            <style>
-                <h:outputText escape="false"
-                value="#{configOptionApplicationController.getLongTextValueByKey('Pharmacy Issue Receipt CSS')}"/>
-            </style>
-
-
+        <style>
             <h:outputText escape="false"
-                          value="#{configOptionApplicationController.getLongTextValueByKey('Pharmacy Issue Receipt Header')}"/>
+            value="#{configOptionApplicationController.getLongTextValueByKey('Pharmacy Issue Receipt CSS')}"/>
+        </style>
 
-            <div class="receipt-container">
-                <div class="receipt-header">
-                    <div class="receipt-institution-name">
-                        <h:outputLabel value="#{cc.attrs.bill.department.printingName}" />
-                    </div>
-                    <div class="receipt-institution-contact">
-                        <h:outputLabel value="#{cc.attrs.bill.department.address}" /><br />
-                        <h:outputLabel value="#{cc.attrs.bill.department.telephone1}" />
-                        <h:outputLabel value=" #{cc.attrs.bill.department.telephone2}" /><br />
-                        <h:outputLabel value="#{cc.attrs.bill.department.fax}" />
-                    </div>
+
+        <h:outputText escape="false"
+                      value="#{configOptionApplicationController.getLongTextValueByKey('Pharmacy Issue Receipt Header')}"/>
+
+        <div class="receipt-container">
+            <div class="receipt-header">
+                <div class="receipt-institution-name">
+                    <h:outputLabel value="#{cc.attrs.bill.department.printingName}" />
                 </div>
-
-                <div class="receipt-title">
-                    <h:outputLabel value="Pharmacy Issue Receipt" />
-                </div>
-
-                <div class="receipt-separator"><hr /></div>
-
-                <div class="receipt-bill-details">
-                    <table class="receipt-details-table">
-                        <!-- Table rows for bill metadata -->
-                        <tr>
-                            <td><h:outputLabel value="Date" styleClass="label" /></td>
-                            <td><h:outputLabel value=":" /></td>
-                            <td>
-                                <h:outputLabel value="#{cc.attrs.bill.createdAt}">
-                                    <f:convertDateTime pattern="dd/MM/yy" />
-                                </h:outputLabel>
-                                <h:outputLabel value="#{cc.attrs.bill.createdAt}">
-                                    <f:convertDateTime timeZone="Asia/Colombo" pattern="#{sessionController.applicationPreference.shortTimeFormat}" />
-                                </h:outputLabel>
-                            </td>
-                            <td><h:outputLabel value="BHT No" rendered="#{cc.attrs.bill.patientEncounter.bhtNo ne null}" /></td>
-                            <td><h:outputLabel value=":" rendered="#{cc.attrs.bill.patientEncounter.bhtNo ne null}" /></td>
-                            <td><h:outputLabel value="#{cc.attrs.bill.patientEncounter.bhtNo}" rendered="#{cc.attrs.bill.patientEncounter.bhtNo ne null}" /></td>
-                        </tr>
-                        <tr>
-                            <td><h:outputLabel value="Invoice No" styleClass="label" /></td>
-                            <td><h:outputLabel value=":" /></td>
-                            <td colspan="4"><h:outputLabel value="#{cc.attrs.bill.deptId}" /></td>
-                        </tr>
-
-                        <h:panelGroup rendered="#{cc.attrs.bill.invoiceNumber ne null}">
-                            <tr>
-                                <td><h:outputLabel value="Request No" styleClass="label" /></td>
-                                <td><h:outputLabel value=":" /></td>
-                                <td colspan="4"><h:outputLabel value="#{cc.attrs.bill.invoiceNumber}" /></td>
-                            </tr>
-                        </h:panelGroup>
-
-                        <tr>
-                            <td><h:outputLabel value="Payment Method" styleClass="label" rendered="#{cc.attrs.bill.paymentMethod ne null}" /></td>
-                            <td><h:outputLabel value=":" rendered="#{cc.attrs.bill.paymentMethod ne null}" /></td>
-                            <td><h:outputLabel value="#{cc.attrs.bill.paymentMethod}" rendered="#{cc.attrs.bill.paymentMethod ne null}" /></td>
-                        </tr>
-
-                        <tr>
-                            <td><h:outputLabel value="Payment Scheme" styleClass="label" rendered="#{cc.attrs.bill.paymentScheme.printingName ne null}" /></td>
-                            <td><h:outputLabel value=":" rendered="#{cc.attrs.bill.paymentScheme.printingName ne null}" /></td>
-                            <td><h:outputLabel value="#{cc.attrs.bill.paymentScheme.printingName}" rendered="#{cc.attrs.bill.paymentScheme.printingName ne null}" /></td>
-                        </tr>
-
-                        <tr>
-                            <td><h:outputLabel value="Patient Name" styleClass="label" rendered="#{cc.attrs.bill.patient.person.nameWithTitle ne null}" /></td>
-                            <td><h:outputLabel value=":" rendered="#{cc.attrs.bill.patient.person.nameWithTitle ne null}" /></td>
-                            <td colspan="4"><h:outputLabel value="#{cc.attrs.bill.patient.person.nameWithTitle}" rendered="#{cc.attrs.bill.patient.person.nameWithTitle ne null}" /></td>
-                        </tr>
-
-                        <tr>
-                            <td><h:outputLabel value="Staff Name" styleClass="label" rendered="#{cc.attrs.bill.toStaff.person.nameWithTitle ne null}" /></td>
-                            <td><h:outputLabel value=":" rendered="#{cc.attrs.bill.toStaff.person.nameWithTitle ne null}" /></td>
-                            <td colspan="4"><h:outputLabel value="#{cc.attrs.bill.toStaff.person.nameWithTitle}" rendered="#{cc.attrs.bill.toStaff.person.nameWithTitle ne null}" /></td>
-                        </tr>
-
-                        <h:panelGroup rendered="#{cc.attrs.bill.toDepartment ne null}">
-                            <tr>
-                                <td><h:outputLabel value="To Unit" styleClass="label" /></td>
-                                <td><h:outputLabel value=":" /></td>
-                                <td colspan="4"><h:outputLabel value="#{cc.attrs.bill.toDepartment.name}" /></td>
-                            </tr>
-                        </h:panelGroup>
-
-                        <h:panelGroup rendered="#{cc.attrs.bill.toInstitution ne null}">
-                            <tr>
-                                <td><h:outputLabel value="Company" styleClass="label" /></td>
-                                <td><h:outputLabel value=":" /></td>
-                                <td colspan="4"><h:outputLabel value="#{cc.attrs.bill.toInstitution.name}" /></td>
-                            </tr>
-                        </h:panelGroup>
-
-                        <h:panelGroup rendered="#{cc.attrs.bill.comments ne null}">
-                            <tr>
-                                <td><h:outputLabel value="Comment" styleClass="label" /></td>
-                                <td><h:outputLabel value=":" /></td>
-                                <td colspan="4"><h:outputLabel value="#{cc.attrs.bill.comments}" /></td>
-                            </tr>
-                        </h:panelGroup>
-
-                    </table>
-                </div>
-
-                <div class="receipt-separator"><hr /></div>
-
-                <div class="receipt-items-section">
-                    <table class="receipt-items-table">
-                        <thead>
-                            <tr>
-                                <th class="item-name">Item</th>
-                                <th class="item-qty">Qty</th>
-                                <th class="item-rate">Rate</th>
-                                <th class="item-value">Value</th>
-                            </tr>
-                        </thead>
-                        <tbody>
-                            <ui:repeat value="#{cc.attrs.bill.billItems}" var="bip">
-                                <tr>
-                                    <td class="item-name">
-                                        <h:outputLabel value="#{bip.searialNo+1} - #{bip.item.name}" />
-                                    </td>
-                                    <td class="item-qty">
-                                        <h:outputLabel value="#{bip.qty}">
-                                            <f:convertNumber pattern="#,##0.00" />
-                                        </h:outputLabel>
-                                    </td>
-                                    <td class="item-rate">
-                                        <h:outputLabel value="#{bip.pharmaceuticalBillItem.retailRate}">
-                                            <f:convertNumber pattern="#,##0.00" />
-                                        </h:outputLabel>
-                                    </td>
-                                    <td class="item-value">
-                                        <h:outputLabel value="#{bip.pharmaceuticalBillItem.retailRate * bip.qty}">
-                                            <f:convertNumber pattern="#,##0.00" />
-                                        </h:outputLabel>
-                                    </td>
-                                </tr>
-                            </ui:repeat>
-                        </tbody>
-                    </table>
-                </div>
-
-                <div class="receipt-separator"><hr /></div>
-
-                <div class="receipt-summary">
-                    <table class="receipt-summary-table">
-                        <tr>
-                            <td class="summary-label">Total</td>
-                            <td class="summary-value">
-                                <h:outputLabel value="#{cc.attrs.bill.total}" styleClass="total-amount">
-                                    <f:convertNumber pattern="#,##0.00" />
-                                </h:outputLabel>
-                            </td>
-                        </tr>
-                        <h:panelGroup rendered="#{cc.attrs.bill.discount ne 0.0}">
-                            <tr>
-                                <td class="summary-label">Discount</td>
-                                <td class="summary-value">
-                                    <h:outputLabel value="#{-cc.attrs.bill.discount}">
-                                        <f:convertNumber pattern="#,##0.00" />
-                                    </h:outputLabel>
-                                </td>
-                            </tr>
-                            <tr>
-                                <td class="summary-label">Net Total</td>
-                                <td class="summary-value">
-                                    <h:outputLabel value="#{cc.attrs.bill.netTotal}">
-                                        <f:convertNumber pattern="#,##0.00" />
-                                    </h:outputLabel>
-                                </td>
-                            </tr>
-                        </h:panelGroup>
-                        <tr>
-                            <td class="summary-label">Number of Items</td>
-                            <td class="summary-value">
-                                <h:outputLabel value="#{cc.attrs.bill.billItems.size()}">
-                                    <f:convertNumber pattern="#,##0.00" />
-                                </h:outputLabel>
-                            </td>
-                        </tr>
-                    </table>
-                </div>
-
-                <div class="receipt-cashier">
-                    <h:outputLabel value="Cashier : #{cc.attrs.bill.creater.name}" />
+                <div class="receipt-institution-contact">
+                    <h:outputLabel value="#{cc.attrs.bill.department.address}" /><br />
+                    <h:outputLabel value="#{cc.attrs.bill.department.telephone1}" />
+                    <h:outputLabel value=" #{cc.attrs.bill.department.telephone2}" /><br />
+                    <h:outputLabel value="#{cc.attrs.bill.department.fax}" />
                 </div>
             </div>
 
-            <h:outputText escape="false"
-                          value="#{configOptionApplicationController.getLongTextValueByKey('Pharmacy Issue Receipt Footer')}"/>
+            <div class="receipt-title">
+                <h:outputLabel value="Pharmacy Issue Receipt" />
+            </div>
 
-        </cc:implementation>
+            <div class="receipt-separator"><hr /></div>
+
+            <div class="receipt-bill-details">
+                <table class="receipt-details-table">
+                    <!-- Table rows for bill metadata -->
+                    <tr>
+                        <td><h:outputLabel value="Date" styleClass="label" /></td>
+                        <td><h:outputLabel value=":" /></td>
+                        <td>
+                            <h:outputLabel value="#{cc.attrs.bill.createdAt}">
+                                <f:convertDateTime pattern="dd/MM/yy" />
+                            </h:outputLabel>
+                            <h:outputLabel value="#{cc.attrs.bill.createdAt}">
+                                <f:convertDateTime timeZone="Asia/Colombo" pattern="#{sessionController.applicationPreference.shortTimeFormat}" />
+                            </h:outputLabel>
+                        </td>
+                        <td><h:outputLabel value="BHT No" rendered="#{cc.attrs.bill.patientEncounter.bhtNo ne null}" /></td>
+                        <td><h:outputLabel value=":" rendered="#{cc.attrs.bill.patientEncounter.bhtNo ne null}" /></td>
+                        <td><h:outputLabel value="#{cc.attrs.bill.patientEncounter.bhtNo}" rendered="#{cc.attrs.bill.patientEncounter.bhtNo ne null}" /></td>
+                    </tr>
+                    <tr>
+                        <td><h:outputLabel value="Invoice No" styleClass="label" /></td>
+                        <td><h:outputLabel value=":" /></td>
+                        <td colspan="4"><h:outputLabel value="#{cc.attrs.bill.deptId}" /></td>
+                    </tr>
+
+                    <h:panelGroup rendered="#{cc.attrs.bill.invoiceNumber ne null}">
+                        <tr>
+                            <td><h:outputLabel value="Request No" styleClass="label" /></td>
+                            <td><h:outputLabel value=":" /></td>
+                            <td colspan="4"><h:outputLabel value="#{cc.attrs.bill.invoiceNumber}" /></td>
+                        </tr>
+                    </h:panelGroup>
+
+                    <tr>
+                        <td><h:outputLabel value="Payment Method" styleClass="label" rendered="#{cc.attrs.bill.paymentMethod ne null}" /></td>
+                        <td><h:outputLabel value=":" rendered="#{cc.attrs.bill.paymentMethod ne null}" /></td>
+                        <td><h:outputLabel value="#{cc.attrs.bill.paymentMethod}" rendered="#{cc.attrs.bill.paymentMethod ne null}" /></td>
+                    </tr>
+
+                    <tr>
+                        <td><h:outputLabel value="Payment Scheme" styleClass="label" rendered="#{cc.attrs.bill.paymentScheme.printingName ne null}" /></td>
+                        <td><h:outputLabel value=":" rendered="#{cc.attrs.bill.paymentScheme.printingName ne null}" /></td>
+                        <td><h:outputLabel value="#{cc.attrs.bill.paymentScheme.printingName}" rendered="#{cc.attrs.bill.paymentScheme.printingName ne null}" /></td>
+                    </tr>
+
+                    <tr>
+                        <td><h:outputLabel value="Patient Name" styleClass="label" rendered="#{cc.attrs.bill.patient.person.nameWithTitle ne null}" /></td>
+                        <td><h:outputLabel value=":" rendered="#{cc.attrs.bill.patient.person.nameWithTitle ne null}" /></td>
+                        <td colspan="4"><h:outputLabel value="#{cc.attrs.bill.patient.person.nameWithTitle}" rendered="#{cc.attrs.bill.patient.person.nameWithTitle ne null}" /></td>
+                    </tr>
+
+                    <tr>
+                        <td><h:outputLabel value="Staff Name" styleClass="label" rendered="#{cc.attrs.bill.toStaff.person.nameWithTitle ne null}" /></td>
+                        <td><h:outputLabel value=":" rendered="#{cc.attrs.bill.toStaff.person.nameWithTitle ne null}" /></td>
+                        <td colspan="4"><h:outputLabel value="#{cc.attrs.bill.toStaff.person.nameWithTitle}" rendered="#{cc.attrs.bill.toStaff.person.nameWithTitle ne null}" /></td>
+                    </tr>
+
+                    <h:panelGroup rendered="#{cc.attrs.bill.toDepartment ne null}">
+                        <tr>
+                            <td><h:outputLabel value="To Unit" styleClass="label" /></td>
+                            <td><h:outputLabel value=":" /></td>
+                            <td colspan="4"><h:outputLabel value="#{cc.attrs.bill.toDepartment.name}" /></td>
+                        </tr>
+                    </h:panelGroup>
+
+                    <h:panelGroup rendered="#{cc.attrs.bill.toInstitution ne null}">
+                        <tr>
+                            <td><h:outputLabel value="Company" styleClass="label" /></td>
+                            <td><h:outputLabel value=":" /></td>
+                            <td colspan="4"><h:outputLabel value="#{cc.attrs.bill.toInstitution.name}" /></td>
+                        </tr>
+                    </h:panelGroup>
+
+                    <h:panelGroup rendered="#{cc.attrs.bill.comments ne null}">
+                        <tr>
+                            <td><h:outputLabel value="Comment" styleClass="label" /></td>
+                            <td><h:outputLabel value=":" /></td>
+                            <td colspan="4"><h:outputLabel value="#{cc.attrs.bill.comments}" /></td>
+                        </tr>
+                    </h:panelGroup>
+
+                </table>
+            </div>
+
+            <div class="receipt-separator"><hr /></div>
+
+            <div class="receipt-items-section">
+                <table class="receipt-items-table">
+                    <thead>
+                        <tr>
+                            <th class="item-name">Item</th>
+                            <th class="item-qty">Qty</th>
+                            <th class="item-rate">Rate</th>
+                            <th class="item-value">Value</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <ui:repeat value="#{cc.attrs.bill.billItems}" var="bip">
+                            <tr>
+                                <td class="item-name">
+                                    <h:outputLabel value="#{bip.searialNo+1} - #{bip.item.name}" />
+                                </td>
+                                <td class="item-qty">
+                                    <h:outputLabel value="#{bip.qty}">
+                                        <f:convertNumber pattern="#,##0.00" />
+                                    </h:outputLabel>
+                                </td>
+                                <td class="item-rate">
+                                    <h:outputLabel value="#{bip.pharmaceuticalBillItem.retailRate}">
+                                        <f:convertNumber pattern="#,##0.00" />
+                                    </h:outputLabel>
+                                </td>
+                                <td class="item-value">
+                                    <h:outputLabel value="#{bip.pharmaceuticalBillItem.retailRate * bip.qty}">
+                                        <f:convertNumber pattern="#,##0.00" />
+                                    </h:outputLabel>
+                                </td>
+                            </tr>
+                        </ui:repeat>
+                    </tbody>
+                </table>
+            </div>
+
+            <div class="receipt-separator"><hr /></div>
+
+            <div class="receipt-summary">
+                <table class="receipt-summary-table">
+                    <tr>
+                        <td class="summary-label">Total</td>
+                        <td class="summary-value">
+                            <h:outputLabel value="#{cc.attrs.bill.total}" styleClass="total-amount">
+                                <f:convertNumber pattern="#,##0.00" />
+                            </h:outputLabel>
+                        </td>
+                    </tr>
+                    <h:panelGroup rendered="#{cc.attrs.bill.discount ne 0.0}">
+                        <tr>
+                            <td class="summary-label">Discount</td>
+                            <td class="summary-value">
+                                <h:outputLabel value="#{-cc.attrs.bill.discount}">
+                                    <f:convertNumber pattern="#,##0.00" />
+                                </h:outputLabel>
+                            </td>
+                        </tr>
+                        <tr>
+                            <td class="summary-label">Net Total</td>
+                            <td class="summary-value">
+                                <h:outputLabel value="#{cc.attrs.bill.netTotal}">
+                                    <f:convertNumber pattern="#,##0.00" />
+                                </h:outputLabel>
+                            </td>
+                        </tr>
+                    </h:panelGroup>
+                    <tr>
+                        <td class="summary-label">Number of Items</td>
+                        <td class="summary-value">
+                            <h:outputLabel value="#{cc.attrs.bill.billItems.size()}">
+                                <f:convertNumber pattern="#,##0.00" />
+                            </h:outputLabel>
+                        </td>
+                    </tr>
+                </table>
+            </div>
+
+            <div class="receipt-cashier">
+                <h:outputLabel value="Cashier : #{cc.attrs.bill.creater.name}" />
+            </div>
+        </div>
+
+        <h:outputText escape="false"
+                      value="#{configOptionApplicationController.getLongTextValueByKey('Pharmacy Issue Receipt Footer')}"/>
+
+
 
 
     </cc:implementation>

--- a/src/main/webapp/resources/pharmacy/pharmacy_issue_receipt.xhtml
+++ b/src/main/webapp/resources/pharmacy/pharmacy_issue_receipt.xhtml
@@ -174,7 +174,7 @@
                         <tr>
                             <td class="summary-label">Total</td>
                             <td class="summary-value">
-                                <h:outputLabel value="0.00" styleClass="total-amount">
+                                <h:outputLabel value="#{cc.attrs.bill.total}" styleClass="total-amount">
                                     <f:convertNumber pattern="#,##0.00" />
                                 </h:outputLabel>
                             </td>


### PR DESCRIPTION
The Pharmacy Issue Receipt is now printing correctly.

The receipt uses a default CSS layout that is automatically loaded if not already configured. You can customise the appearance of the bill by updating the config option with the key **`Pharmacy Issue Receipt CSS`**.

To adjust the layout, go to **Config Options**, search for the key, and edit the CSS as required. You can change font sizes, alignments, borders, spacing, etc., to suit your preferences.

Header and footer content can also be set using the keys **`Pharmacy Issue Receipt Header`** and **`Pharmacy Issue Receipt Footer`**.

Refer to the default print view here for visual reference:
![Image](https://github.com/user-attachments/assets/7e738377-4e0a-4a1c-b5df-427c792217bb)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a new pharmacy issue receipt component with enhanced layout, dynamic content, and embedded CSS styling for improved receipt formatting.
- **Improvements**
  - Standardized the bill preview to always use the new pharmacy issue receipt, simplifying the user experience.
- **Bug Fixes**
  - Removed redundant or unused bill components from the bill preview section.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->