### PR TITLE
Implement stock value retail and cost calculators

### DIFF
--- a/src/main/java/com/divudi/bean/common/HistoricalRecordController.java
+++ b/src/main/java/com/divudi/bean/common/HistoricalRecordController.java
@@ -173,14 +173,20 @@ public class HistoricalRecordController implements Serializable {
 
     private HistoricalRecord generatePharmacyStockValueRetailRate() {
         HistoricalRecord rec = buildRecord(HistoricalRecordType.PHARMACY_STOCK_VALUE_RETAIL_RATE);
-        // TODO: implement generation logic
+        StockValueRow result = stockService.calculateStockValues(institution, site, department);
+        if (result != null) {
+            rec.setRecordValue(result.getRetailValue());
+        }
         historicalRecordService.createHistoricalRecord(rec);
         return rec;
     }
 
     private HistoricalRecord generatePharmacyStockValueCostRate() {
         HistoricalRecord rec = buildRecord(HistoricalRecordType.PHARMACY_STOCK_VALUE_COST_RATE);
-        // TODO: implement generation logic
+        StockValueRow result = stockService.calculateStockValues(institution, site, department);
+        if (result != null) {
+            rec.setRecordValue(result.getCostValue());
+        }
         historicalRecordService.createHistoricalRecord(rec);
         return rec;
     }


### PR DESCRIPTION
## Summary
- implement `generatePharmacyStockValueRetailRate` and `generatePharmacyStockValueCostRate`
- call `stockService.calculateStockValues` and store retail and cost values in historical records

## Testing
- `mvn test` *(fails: Could not transfer artifact due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68486ccfa320832f8316c56c356fa4a2