### PR TITLE
Add scheduled process support

### DIFF
--- a/src/main/java/com/divudi/core/entity/ScheduledProcessConfiguration.java
+++ b/src/main/java/com/divudi/core/entity/ScheduledProcessConfiguration.java
@@ -56,6 +56,20 @@ public class ScheduledProcessConfiguration implements Serializable {
 
     private String retireComments;
 
+    @Temporal(TemporalType.TIMESTAMP)
+    private Date nextSupposedAt;
+
+    @Temporal(TemporalType.TIMESTAMP)
+    private Date lastSupposedAt;
+
+    private Boolean lastProcessCompleted;
+
+    @Temporal(TemporalType.TIMESTAMP)
+    private Date lastRunStarted;
+
+    @Temporal(TemporalType.TIMESTAMP)
+    private Date lastRunEnded;
+
     public Long getId() {
         return id;
     }
@@ -142,6 +156,46 @@ public class ScheduledProcessConfiguration implements Serializable {
 
     public void setRetireComments(String retireComments) {
         this.retireComments = retireComments;
+    }
+
+    public Date getNextSupposedAt() {
+        return nextSupposedAt;
+    }
+
+    public void setNextSupposedAt(Date nextSupposedAt) {
+        this.nextSupposedAt = nextSupposedAt;
+    }
+
+    public Date getLastSupposedAt() {
+        return lastSupposedAt;
+    }
+
+    public void setLastSupposedAt(Date lastSupposedAt) {
+        this.lastSupposedAt = lastSupposedAt;
+    }
+
+    public Boolean getLastProcessCompleted() {
+        return lastProcessCompleted;
+    }
+
+    public void setLastProcessCompleted(Boolean lastProcessCompleted) {
+        this.lastProcessCompleted = lastProcessCompleted;
+    }
+
+    public Date getLastRunStarted() {
+        return lastRunStarted;
+    }
+
+    public void setLastRunStarted(Date lastRunStarted) {
+        this.lastRunStarted = lastRunStarted;
+    }
+
+    public Date getLastRunEnded() {
+        return lastRunEnded;
+    }
+
+    public void setLastRunEnded(Date lastRunEnded) {
+        this.lastRunEnded = lastRunEnded;
     }
 
     @Override

--- a/src/main/java/com/divudi/service/ScheduledProcessService.java
+++ b/src/main/java/com/divudi/service/ScheduledProcessService.java
@@ -1,0 +1,100 @@
+package com.divudi.service;
+
+import com.divudi.core.entity.ScheduledProcessConfiguration;
+import com.divudi.core.facade.ScheduledProcessConfigurationFacade;
+import com.divudi.core.data.ScheduledFrequency;
+import java.util.Calendar;
+import java.util.Date;
+import javax.ejb.Asynchronous;
+import javax.ejb.EJB;
+import javax.ejb.Stateless;
+
+@Stateless
+public class ScheduledProcessService {
+
+    @EJB
+    private ScheduledProcessConfigurationFacade configFacade;
+
+    @Asynchronous
+    public void executeScheduledProcess(ScheduledProcessConfiguration config) {
+        if (config == null) {
+            return;
+        }
+        // Mark start
+        config.setLastProcessCompleted(false);
+        config.setLastRunStarted(new Date());
+        config.setLastSupposedAt(config.getNextSupposedAt());
+        config.setNextSupposedAt(calculateNextSupposedAt(config.getScheduledFrequency(), config.getNextSupposedAt()));
+        configFacade.edit(config);
+
+        // Placeholder switch for future implementations
+        switch (config.getScheduledProcess()) {
+            case Record_Pharmacy_Stock_Values:
+                // TODO: implement process
+                break;
+            case All_Drawer_Balances:
+                // TODO: implement process
+                break;
+            case All_Collection_Centre_Balances:
+                // TODO: implement process
+                break;
+            case All_Credit_Company_Balances:
+                // TODO: implement process
+                break;
+            default:
+                break;
+        }
+
+        // Mark end
+        config.setLastRunEnded(new Date());
+        config.setLastProcessCompleted(true);
+        configFacade.edit(config);
+    }
+
+    public Date calculateNextSupposedAt(ScheduledFrequency frequency, Date from) {
+        Calendar cal = Calendar.getInstance();
+        if (from != null) {
+            cal.setTime(from);
+        }
+        switch (frequency) {
+            case Hourly:
+                cal.add(Calendar.HOUR_OF_DAY, 1);
+                break;
+            case Midnight:
+                cal.add(Calendar.DATE, 1);
+                cal.set(Calendar.HOUR_OF_DAY, 0);
+                cal.set(Calendar.MINUTE, 0);
+                cal.set(Calendar.SECOND, 0);
+                cal.set(Calendar.MILLISECOND, 0);
+                break;
+            case WeekEnd:
+                while (cal.get(Calendar.DAY_OF_WEEK) != Calendar.SATURDAY) {
+                    cal.add(Calendar.DATE, 1);
+                }
+                cal.set(Calendar.HOUR_OF_DAY, 0);
+                cal.set(Calendar.MINUTE, 0);
+                cal.set(Calendar.SECOND, 0);
+                cal.set(Calendar.MILLISECOND, 0);
+                break;
+            case MonthEnd:
+                cal.set(Calendar.DAY_OF_MONTH, cal.getActualMaximum(Calendar.DAY_OF_MONTH));
+                cal.set(Calendar.HOUR_OF_DAY, 0);
+                cal.set(Calendar.MINUTE, 0);
+                cal.set(Calendar.SECOND, 0);
+                cal.set(Calendar.MILLISECOND, 0);
+                cal.add(Calendar.MONTH, 1);
+                break;
+            case YearEnd:
+                cal.set(Calendar.DAY_OF_YEAR, cal.getActualMaximum(Calendar.DAY_OF_YEAR));
+                cal.set(Calendar.HOUR_OF_DAY, 0);
+                cal.set(Calendar.MINUTE, 0);
+                cal.set(Calendar.SECOND, 0);
+                cal.set(Calendar.MILLISECOND, 0);
+                cal.add(Calendar.YEAR, 1);
+                break;
+            default:
+                cal.add(Calendar.HOUR_OF_DAY, 1);
+        }
+        return cal.getTime();
+    }
+}

--- a/src/main/java/com/divudi/service/ScheduledTaskManager.java
+++ b/src/main/java/com/divudi/service/ScheduledTaskManager.java
@@ -4,6 +4,13 @@ import javax.ejb.EJB;
 import javax.ejb.Schedule;
 import javax.ejb.Singleton;
 import javax.ejb.Startup;
+import javax.persistence.TemporalType;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import com.divudi.core.entity.ScheduledProcessConfiguration;
+import com.divudi.core.facade.ScheduledProcessConfigurationFacade;
+import com.divudi.service.ScheduledProcessService;
 
 /**
  *
@@ -18,6 +25,12 @@ public class ScheduledTaskManager {
     @EJB
     private ChannelService channelService;
 
+    @EJB
+    private ScheduledProcessConfigurationFacade configFacade;
+
+    @EJB
+    private ScheduledProcessService scheduledProcessService;
+
         /**
      * Scheduled method to retire non-settled online bills every 5 minutes.
      */
@@ -28,6 +41,28 @@ public class ScheduledTaskManager {
             // Optionally, add logging here
         } catch (Exception e) {
             // Handle exceptions appropriately
+            e.printStackTrace();
+        }
+    }
+
+    /**
+     * Check and execute scheduled processes every hour end.
+     */
+    @Schedule(minute = "59", hour = "*", persistent = false)
+    public void executeScheduledProcesses() {
+        try {
+            List<ScheduledProcessConfiguration> configs = configFacade.findByJpql(
+                    "select c from ScheduledProcessConfiguration c where c.retired=false",
+                    new HashMap<>(), TemporalType.TIMESTAMP);
+            Date now = new Date();
+            for (ScheduledProcessConfiguration c : configs) {
+                if (c.getNextSupposedAt() != null
+                        && !c.getNextSupposedAt().after(now)
+                        && (c.getLastProcessCompleted() == null || c.getLastProcessCompleted())) {
+                    scheduledProcessService.executeScheduledProcess(c);
+                }
+            }
+        } catch (Exception e) {
             e.printStackTrace();
         }
     }


### PR DESCRIPTION
## Summary
- extend `ScheduledProcessConfiguration` entity with runtime tracking fields
- add `ScheduledProcessService` to execute processes asynchronously
- update `ScheduledTaskManager` to run scheduled processes hourly

## Testing
- `mvn -q -DskipTests package` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848eb007974832fb029484821b0424e