### PR TITLE
Fix disbursement receive cancel payment method

### DIFF
--- a/src/main/java/com/divudi/bean/pharmacy/PharmacyBillSearch.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacyBillSearch.java
@@ -2735,6 +2735,7 @@ public class PharmacyBillSearch implements Serializable {
             cb.setInsId(getBillNumberBean().institutionBillNumberGenerator(getSessionController().getInstitution(), cb.getBillType(), BillClassType.CancelledBill, BillNumberSuffix.PHTRCAN));
             cb.setBackwardReferenceBill(getBill().getBackwardReferenceBill());
             cb.setBillTypeAtomic(BillTypeAtomic.PHARMACY_RECEIVE_CANCELLED);
+            cb.setPaymentMethod(PaymentMethod.None);
             cb.setReferenceBill(getBill());
             if (cb.getId() == null) {
                 getBillFacade().create(cb);

--- a/src/main/webapp/pharmacy/pharmacy_cancel_transfer_receive.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_cancel_transfer_receive.xhtml
@@ -29,9 +29,7 @@
 
                             </f:facet>
 
-                            <p:selectOneMenu   id="cmbPs" value="#{pharmacyBillSearch.bill.paymentMethod}" required="true"  >
-                                <f:selectItems value="#{enumController.paymentMethods}"/>
-                            </p:selectOneMenu>
+
 
                         </p:panel>
 


### PR DESCRIPTION
## Summary
- remove payment method selector from Disbursement Receive Cancel page
- set payment method to `PaymentMethod.None` when cancelling a transfer receive

## Testing
- `mvn test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849ad1df938832f99dbc2dc51e50e88

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Removed the payment method dropdown from the transfer receive cancellation form to prevent unnecessary selection and validation.
  - Ensured cancelled transfer receive bills are always set with no payment method.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->