### PR TITLE
12947 year-end schedule fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,12 @@ Commercial support was introduced to enhance the system's reach and reliability,
 * Inventory Management System
 * Assets and Consumable Management System
 
+### Scheduled Processes
+Scheduled tasks such as stock value recordings run automatically based on
+configured frequencies. The date calculations for these schedules are handled
+by `ScheduledProcessService`. The `Year End` calculation now correctly sets the
+next run to December 31st of the following year.
+
 
 ## Installation
 

--- a/src/main/java/com/divudi/service/ScheduledProcessService.java
+++ b/src/main/java/com/divudi/service/ScheduledProcessService.java
@@ -171,12 +171,13 @@ public class ScheduledProcessService {
                 cal.add(Calendar.MONTH, 1);
                 break;
             case YearEnd:
-                cal.set(Calendar.DAY_OF_YEAR, cal.getActualMaximum(Calendar.DAY_OF_YEAR));
+                cal.add(Calendar.YEAR, 1);
+                cal.set(Calendar.MONTH, Calendar.DECEMBER);
+                cal.set(Calendar.DAY_OF_MONTH, 31);
                 cal.set(Calendar.HOUR_OF_DAY, 0);
                 cal.set(Calendar.MINUTE, 0);
                 cal.set(Calendar.SECOND, 0);
                 cal.set(Calendar.MILLISECOND, 0);
-                cal.add(Calendar.YEAR, 1);
                 break;
             default:
                 cal.add(Calendar.HOUR_OF_DAY, 1);

--- a/src/test/java/com/divudi/service/ScheduledProcessServiceTest.java
+++ b/src/test/java/com/divudi/service/ScheduledProcessServiceTest.java
@@ -1,0 +1,56 @@
+package com.divudi.service;
+
+import com.divudi.core.data.ScheduledFrequency;
+import org.junit.Test;
+
+import java.util.Calendar;
+import java.util.Date;
+import java.util.GregorianCalendar;
+import java.util.TimeZone;
+
+import static org.junit.Assert.assertEquals;
+
+public class ScheduledProcessServiceTest {
+
+    private final ScheduledProcessService service = new ScheduledProcessService();
+
+    static {
+        // Ensure consistent timezone
+        TimeZone.setDefault(TimeZone.getTimeZone("UTC"));
+    }
+
+    @Test
+    public void hourlyAddsOneHour() {
+        Date from = new GregorianCalendar(2024, Calendar.JUNE, 1, 10, 0, 0).getTime();
+        Date expected = new GregorianCalendar(2024, Calendar.JUNE, 1, 11, 0, 0).getTime();
+        assertEquals(expected, service.calculateNextSupposedAt(ScheduledFrequency.Hourly, from));
+    }
+
+    @Test
+    public void midnightMovesToNextMidnight() {
+        Date from = new GregorianCalendar(2024, Calendar.JUNE, 1, 15, 0, 0).getTime();
+        Date expected = new GregorianCalendar(2024, Calendar.JUNE, 2, 0, 0, 0).getTime();
+        assertEquals(expected, service.calculateNextSupposedAt(ScheduledFrequency.Midnight, from));
+    }
+
+    @Test
+    public void weekEndMovesToNextSaturday() {
+        Date from = new GregorianCalendar(2024, Calendar.SEPTEMBER, 30, 13, 0, 0).getTime(); // Monday
+        Date expected = new GregorianCalendar(2024, Calendar.OCTOBER, 5, 0, 0, 0).getTime(); // Saturday
+        assertEquals(expected, service.calculateNextSupposedAt(ScheduledFrequency.WeekEnd, from));
+    }
+
+    @Test
+    public void monthEndMovesToEndOfNextMonth() {
+        Date from = new GregorianCalendar(2024, Calendar.JUNE, 15, 12, 0, 0).getTime();
+        Date expected = new GregorianCalendar(2024, Calendar.JULY, 30, 0, 0, 0).getTime();
+        assertEquals(expected, service.calculateNextSupposedAt(ScheduledFrequency.MonthEnd, from));
+    }
+
+    @Test
+    public void yearEndMovesToEndOfNextYear() {
+        Date from = new GregorianCalendar(2024, Calendar.DECEMBER, 31, 0, 0, 0).getTime();
+        Date expected = new GregorianCalendar(2025, Calendar.DECEMBER, 31, 0, 0, 0).getTime();
+        assertEquals(expected, service.calculateNextSupposedAt(ScheduledFrequency.YearEnd, from));
+    }
+}

--- a/src/test/java/com/divudi/service/ScheduledProcessServiceTest.java
+++ b/src/test/java/com/divudi/service/ScheduledProcessServiceTest.java
@@ -14,10 +14,8 @@ public class ScheduledProcessServiceTest {
 
     private final ScheduledProcessService service = new ScheduledProcessService();
 
-    static {
-        // Ensure consistent timezone
-        TimeZone.setDefault(TimeZone.getTimeZone("UTC"));
-    }
+    // per-test timezone constant instead of mutating JVM-wide default
+    private static final TimeZone UTC = TimeZone.getTimeZone("UTC");
 
     @Test
     public void hourlyAddsOneHour() {


### PR DESCRIPTION
## Summary
- ensure YearEnd calculation resets to Dec 31 of next year
- document scheduled process handling
- add unit tests for ScheduledProcessService

## Testing
- `mvn -q test` *(fails: Could not transfer artifact org.apache.maven.plugins:maven-resources-plugin)*

------
https://chatgpt.com/codex/tasks/task_e_6849b6e6f200832f99f8e95122d59619

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added a new "Scheduled Processes" subsection to the Functionality section, clarifying how scheduled tasks operate and how the "Year End" process schedules its next run date.

- **Bug Fixes**
  - Improved the calculation for the "Year End" scheduled process to ensure the next run date is correctly set to December 31st of the following year.

- **Tests**
  - Introduced comprehensive unit tests for scheduled date calculations across multiple scheduling frequencies to ensure accuracy and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->