### PR TITLE
Fix performance tracking for movement out report

### DIFF
--- a/src/main/java/com/divudi/bean/pharmacy/PharmacySummaryReportController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacySummaryReportController.java
@@ -838,10 +838,12 @@ public class PharmacySummaryReportController implements Serializable {
     }
 
     public void processMovementOutWithStockReportByItem() {
-        List<BillTypeAtomic> billTypeAtomics = getPharmacyMovementOutBillTypes();
-        List<PharmaceuticalBillItem> pbis = billService.fetchPharmaceuticalBillItems(fromDate, toDate, institution, site, department, webUser, billTypeAtomics, admissionType, paymentScheme);
-        pharmacyBundle = new PharmacyBundle(pbis);
-        pharmacyBundle.groupSaleDetailsByItems();
+        reportTimerController.trackReportExecution(() -> {
+            List<BillTypeAtomic> billTypeAtomics = getPharmacyMovementOutBillTypes();
+            List<PharmaceuticalBillItem> pbis = billService.fetchPharmaceuticalBillItems(fromDate, toDate, institution, site, department, webUser, billTypeAtomics, admissionType, paymentScheme);
+            pharmacyBundle = new PharmacyBundle(pbis);
+            pharmacyBundle.groupSaleDetailsByItems();
+        }, SummaryReports.PHARMACY_MOVEMENT_OUT_REPORT, sessionController.getLoggedUser());
     }
 
     public void processPharmacyIncomeAndCostReportByBill() {

--- a/src/main/java/com/divudi/core/data/reports/SummaryReports.java
+++ b/src/main/java/com/divudi/core/data/reports/SummaryReports.java
@@ -6,6 +6,7 @@ public enum SummaryReports implements IReportType {
     PHARMACY_INCOME_REPORT("Pharmacy Income Report"),
     DAILY_STOCK_BALANCE_REPORT("Daily Stock Balance Report"),
     PHARMACY_INCOME_AND_COST_REPORT("Pharmacy Income and Cost Report"),
+    PHARMACY_MOVEMENT_OUT_REPORT("Pharmacy Movement Out Report"),
     BILL_TYPE_LIST_REPORT("Bill Type List Report"),;
 
 


### PR DESCRIPTION
## Summary
- add `PHARMACY_MOVEMENT_OUT_REPORT` enum
- wrap `processMovementOutWithStockReportByItem` in the report timer

## Testing
- `mvn -q -DskipTests clean compile` *(fails: Plugin org.apache.maven.plugins:maven-clean-plugin:2.5 or one of its dependencies could not be resolved)*

------
https://chatgpt.com/codex/tasks/task_e_6849b9052d38832f876893761a6d27f1