### PR TITLE
12944 incorrect month end calcl

### DIFF
--- a/src/main/java/com/divudi/service/ScheduledProcessService.java
+++ b/src/main/java/com/divudi/service/ScheduledProcessService.java
@@ -163,12 +163,15 @@ public class ScheduledProcessService {
                 cal.set(Calendar.MILLISECOND, 0);
                 break;
             case MonthEnd:
-                cal.set(Calendar.DAY_OF_MONTH, cal.getActualMaximum(Calendar.DAY_OF_MONTH));
+                // Move to the last day of the next month from the provided date
+                cal.add(Calendar.MONTH, 1); // jump to same day next month (handles month length overflow)
+                cal.set(Calendar.DAY_OF_MONTH, 1); // first day of that month
+                cal.add(Calendar.MONTH, 1); // move to first day of the following month
+                cal.add(Calendar.DAY_OF_MONTH, -1); // step back one day -> last day of next month
                 cal.set(Calendar.HOUR_OF_DAY, 0);
                 cal.set(Calendar.MINUTE, 0);
                 cal.set(Calendar.SECOND, 0);
                 cal.set(Calendar.MILLISECOND, 0);
-                cal.add(Calendar.MONTH, 1);
                 break;
             case YearEnd:
                 cal.add(Calendar.YEAR, 1);

--- a/src/test/java/com/divudi/service/ScheduledProcessServiceTest.java
+++ b/src/test/java/com/divudi/service/ScheduledProcessServiceTest.java
@@ -41,7 +41,21 @@ public class ScheduledProcessServiceTest {
     @Test
     public void monthEndMovesToEndOfNextMonth() {
         Date from = new GregorianCalendar(2024, Calendar.JUNE, 15, 12, 0, 0).getTime();
-        Date expected = new GregorianCalendar(2024, Calendar.JULY, 30, 0, 0, 0).getTime();
+        Date expected = new GregorianCalendar(2024, Calendar.JULY, 31, 0, 0, 0).getTime();
+        assertEquals(expected, service.calculateNextSupposedAt(ScheduledFrequency.MonthEnd, from));
+    }
+
+    @Test
+    public void monthEndHandlesJanuaryEdge() {
+        Date from = new GregorianCalendar(2023, Calendar.JANUARY, 31, 8, 0, 0).getTime();
+        Date expected = new GregorianCalendar(2023, Calendar.FEBRUARY, 28, 0, 0, 0).getTime();
+        assertEquals(expected, service.calculateNextSupposedAt(ScheduledFrequency.MonthEnd, from));
+    }
+
+    @Test
+    public void monthEndHandlesLeapYear() {
+        Date from = new GregorianCalendar(2024, Calendar.JANUARY, 31, 8, 0, 0).getTime();
+        Date expected = new GregorianCalendar(2024, Calendar.FEBRUARY, 29, 0, 0, 0).getTime();
         assertEquals(expected, service.calculateNextSupposedAt(ScheduledFrequency.MonthEnd, from));
     }
 


### PR DESCRIPTION
## Summary
- fix month end schedule calculation
- update ScheduledProcessService tests for month-end edge cases

## Testing
- `mvn -q test` *(fails: PluginResolutionException)*

------
https://chatgpt.com/codex/tasks/task_e_6849bbc22acc832f83cf8edc795bed4a