### PR TITLE
Resolve issue 12709

### DIFF
--- a/src/main/java/com/divudi/bean/common/ConfigOptionApplicationController.java
+++ b/src/main/java/com/divudi/bean/common/ConfigOptionApplicationController.java
@@ -86,6 +86,9 @@ public class ConfigOptionApplicationController implements Serializable {
         getDoubleValueByKey("Wholesale Rate Factor", 1.08);
         getDoubleValueByKey("Retail to Purchase Factor", 1.15);
         getDoubleValueByKey("Maximum Retail Price Change Percentage", 15.0);
+        getBooleanValueByKey("Direct Issue Based On Retail Rate", true);
+        getBooleanValueByKey("Direct Issue Based On Purchase Rate", false);
+        getBooleanValueByKey("Direct Issue Based On Cost Rate", false);
     }
 
     private void loadPharmacyIssueReceiptConfigurationDefaults() {


### PR DESCRIPTION
## Summary
- allow configuring rate used for pharmacy direct issue totals
- compute totals using configured rate
- record minimal BillItemFinanceDetails
- generate BillFinanceDetails for direct issue bills
- add default config keys for rate basis

## Testing
- `mvn -q -DskipTests install` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849ca01d3bc832f9f37a813dbdf6b18

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added new configuration options allowing pharmacy direct issue rates to be based on retail, purchase, or cost rates.
- **Improvements**
  - Bill item rate calculations in pharmacy transfers now use the selected preferred rate, providing more flexibility and accuracy.
  - Enhanced financial details are now generated and updated for pharmacy bills during settlement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->