### PR TITLE
Add PharmacyCostingService and integrate costing logic

### DIFF
--- a/src/main/java/com/divudi/bean/pharmacy/GrnController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/GrnController.java
@@ -36,6 +36,7 @@ import com.divudi.core.facade.ItemBatchFacade;
 import com.divudi.core.facade.ItemFacade;
 import com.divudi.core.facade.PaymentFacade;
 import com.divudi.core.facade.PharmaceuticalBillItemFacade;
+import com.divudi.service.pharmacy.PharmacyCostingService;
 import com.divudi.core.util.CommonFunctions;
 import java.io.Serializable;
 import java.text.DateFormat;
@@ -88,6 +89,8 @@ public class GrnController implements Serializable {
     BillFeeFacade billFeeFacade;
     @EJB
     PaymentFacade paymentFacade;
+    @EJB
+    PharmacyCostingService pharmacyCostingService;
     @Inject
     private PharmacyCalculation pharmacyCalculation;
     @Inject
@@ -668,6 +671,7 @@ public class GrnController implements Serializable {
         getGrnBill().setBillExpenses(billExpenses);
         getGrnBill().setExpenseTotal(calExpenses());
         calGrossTotal();
+        pharmacyCostingService.distributeProportionalBillValuesToItems(getBillItems(), getGrnBill());
         getGrnBill().setNetTotal(getGrnBill().getNetTotal() - calExpenses());
 
         pharmacyCalculation.calculateRetailSaleValueAndFreeValueAtPurchaseRate(getGrnBill());

--- a/src/main/java/com/divudi/bean/pharmacy/PharmacyDirectPurchaseController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacyDirectPurchaseController.java
@@ -47,6 +47,7 @@ import com.divudi.core.facade.PaymentFacade;
 import com.divudi.core.facade.PharmaceuticalBillItemFacade;
 import com.divudi.core.util.CommonFunctions;
 import com.divudi.service.PaymentService;
+import com.divudi.service.pharmacy.PharmacyCostingService;
 import java.io.Serializable;
 import java.math.BigDecimal;
 import java.math.MathContext;
@@ -149,7 +150,7 @@ public class PharmacyDirectPurchaseController implements Serializable {
             getBillFacade().create(getBill());
         }
 
-        recalculateFinancialsBeforeAddingBillItem(f);
+        pharmacyCostingService.recalculateFinancialsBeforeAddingBillItem(f);
 
         BigDecimal qty = f.getQuantity() != null ? f.getQuantity() : BigDecimal.ZERO;
         BigDecimal freeQty = f.getFreeQuantity() != null ? f.getFreeQuantity() : BigDecimal.ZERO;
@@ -192,225 +193,12 @@ public class PharmacyDirectPurchaseController implements Serializable {
         getBillItems().add(currentBillItem);
 
         currentBillItem = null;
-        distributeProportionalBillValuesToItems(getBillItems(), getBill());
+        pharmacyCostingService.distributeProportionalBillValuesToItems(getBillItems(), getBill());
         calculateBillTotalsFromItems();
 //        calulateTotalsWhenAddingItemsOldMethod();
     }
 
 // ChatGPT contributed - Recalculates line-level financial values before adding BillItem to bill
-    private void recalculateFinancialsBeforeAddingBillItem(BillItemFinanceDetails f) {
-        // 1. Retrieve user-entered input values, ensuring non-null defaults
-        BigDecimal qty = f.getQuantity() != null ? f.getQuantity() : BigDecimal.ZERO;                   // actual quantity
-        BigDecimal freeQty = f.getFreeQuantity() != null ? f.getFreeQuantity() : BigDecimal.ZERO;       // free quantity
-        BigDecimal lineGrossRate = f.getLineGrossRate() != null ? f.getLineGrossRate() : BigDecimal.ZERO; // rate per item
-        BigDecimal lineDiscountRate = f.getLineDiscountRate() != null ? f.getLineDiscountRate() : BigDecimal.ZERO; // discount per unit
-        BigDecimal retailRate = f.getRetailSaleRatePerUnit() != null ? f.getRetailSaleRatePerUnit() : BigDecimal.ZERO; // retail sale rate
-
-        Item item = f.getBillItem().getItem();
-
-        // 2. Calculate total quantity
-        BigDecimal totalQty = qty.add(freeQty); // total quantity in packs
-
-        // 3. Declare variables for unit-based calculations
-        BigDecimal unitsPerPack = null;         // units per pack
-        BigDecimal totalQtyInUnits = null;      // total quantity in units
-        BigDecimal qtyInUnits = null;           // quantity in units
-        BigDecimal freeQtyInUnits = null;       // free quantity in units
-
-        // 4. Handle conversion to units if item is Ampp (e.g., 1 pack = 10 tablets)
-        if (item instanceof Ampp) {
-            double dblVal = item.getDblValue(); // e.g., 10 units per pack
-            if (dblVal > 0.0) {
-                unitsPerPack = BigDecimal.valueOf(dblVal);
-            } else {
-                unitsPerPack = BigDecimal.ONE; // fallback if unitsPerPack not defined
-            }
-            qtyInUnits = qty.multiply(unitsPerPack);
-            freeQtyInUnits = freeQty.multiply(unitsPerPack);
-            totalQtyInUnits = totalQty.multiply(unitsPerPack);
-        } else {
-            // If not Ampp, assume quantity is already in units
-            unitsPerPack = BigDecimal.ONE;
-            qtyInUnits = qty;
-            freeQtyInUnits = freeQty;
-            totalQtyInUnits = totalQty;
-        }
-
-        f.setUnitsPerPack(unitsPerPack);
-
-        // 5. Record unit-based quantities in finance details
-        f.setQuantityByUnits(qtyInUnits);
-        f.setFreeQuantityByUnits(freeQtyInUnits);
-        f.setTotalQuantityByUnits(totalQtyInUnits);
-
-        // 6. Financial Calculations (all line-level)
-        BigDecimal lineGrossTotal = lineGrossRate.multiply(qty);               // gross = rate × quantity (only actual qty)
-        BigDecimal lineDiscountValue = lineDiscountRate.multiply(qty);         // discount = rate × quantity (only actual qty)
-        BigDecimal lineNetTotal = lineGrossTotal.subtract(lineDiscountValue);  // net = gross - discount
-
-        // 7. Cost rate based on quantity in units
-        BigDecimal lineCostRate = totalQtyInUnits.compareTo(BigDecimal.ZERO) > 0
-                ? lineNetTotal.divide(totalQtyInUnits, 4, RoundingMode.HALF_UP)
-                : BigDecimal.ZERO;
-
-        // 8. Retail value = retail rate × total quantity in units
-        BigDecimal retailValue = retailRate.multiply(totalQtyInUnits);
-
-        // 9. Assign computed values to line-level fields only (no bill-level values touched)
-        f.setLineGrossRate(lineGrossRate);  // retained
-        f.setLineNetRate(
-                totalQty.compareTo(BigDecimal.ZERO) > 0
-                ? lineNetTotal.divide(totalQty, 4, RoundingMode.HALF_UP)
-                : BigDecimal.ZERO
-        ); // average net rate per pack
-
-        f.setRetailSaleRate(retailRate.multiply(unitsPerPack));
-        f.setLineDiscount(lineDiscountValue);     // calculated
-        f.setLineGrossTotal(lineGrossTotal);      // calculated
-        f.setLineNetTotal(lineNetTotal);          // calculated
-        f.setLineCost(lineNetTotal);              // cost = net total
-        f.setLineCostRate(lineCostRate);          // cost per unit
-        f.setTotalQuantity(totalQty);             // pack-based total (with free)
-        // 10. Comments:
-        // - No bill-level values (billDiscount, billCost, etc.) are changed here
-        // - Only line-specific fields are calculated based on user inputs
-        // - Units-per-pack logic is safely handled with fallback
-    }
-
-// ChatGPT contributed - Distributes user-entered bill-level values proportionally to items and calculates derived totals and rates
-    public void distributeProportionalBillValuesToItems(List<BillItem> billItems, Bill bill) {
-        if (bill == null || bill.getBillFinanceDetails() == null || billItems == null || billItems.isEmpty()) {
-            return;
-        }
-
-        // Step 1: Calculate proportional basis per item (based on quantity + freeQuantity)
-        BigDecimal totalBasis = BigDecimal.ZERO;
-        Map<BillItem, BigDecimal> itemBases = new HashMap<>();
-
-        for (BillItem bi : billItems) {
-            BillItemFinanceDetails f = bi.getBillItemFinanceDetails();
-            if (f == null) {
-                continue;
-            }
-
-            BigDecimal qty = Optional.ofNullable(f.getQuantity()).orElse(BigDecimal.ZERO);             // user-entered
-            BigDecimal freeQty = Optional.ofNullable(f.getFreeQuantity()).orElse(BigDecimal.ZERO);     // user-entered
-            BigDecimal lineGrossRate = Optional.ofNullable(f.getLineGrossRate()).orElse(BigDecimal.ZERO); // user-entered
-
-            BigDecimal basis = lineGrossRate.multiply(qty.add(freeQty)); // calculated
-            itemBases.put(bi, basis);
-            totalBasis = totalBasis.add(basis);
-        }
-
-        if (totalBasis.compareTo(BigDecimal.ZERO) == 0) {
-            return;
-        }
-
-        // Step 2: Convert and assign user-entered bill-level values to finance details
-        bill.getBillFinanceDetails().setBillDiscount(BigDecimal.valueOf(bill.getDiscount()));
-        bill.getBillFinanceDetails().setBillTaxValue(BigDecimal.valueOf(bill.getTax()));
-        bill.getBillFinanceDetails().setBillExpense(BigDecimal.valueOf(bill.getExpenseTotal()));
-
-        BigDecimal billDiscountTotal = Optional.ofNullable(bill.getBillFinanceDetails().getBillDiscount()).orElse(BigDecimal.ZERO);
-        BigDecimal billExpenseTotal = Optional.ofNullable(bill.getBillFinanceDetails().getBillExpense()).orElse(BigDecimal.ZERO);
-        BigDecimal billTaxTotal = Optional.ofNullable(bill.getBillFinanceDetails().getBillTaxValue()).orElse(BigDecimal.ZERO);
-
-        // Step 3: Distribute and calculate item-level derived values
-        for (BillItem bi : billItems) {
-            BillItemFinanceDetails f = bi.getBillItemFinanceDetails();
-            if (f == null) {
-                continue;
-            }
-
-            BigDecimal basis = itemBases.get(bi);
-            BigDecimal ratio = basis.divide(totalBasis, 12, RoundingMode.HALF_UP); // calculated
-
-            // User-entered line values
-            BigDecimal lineDiscount = Optional.ofNullable(f.getLineDiscount()).orElse(BigDecimal.ZERO);
-            BigDecimal lineExpense = Optional.ofNullable(f.getLineExpense()).orElse(BigDecimal.ZERO);
-            BigDecimal lineTax = Optional.ofNullable(f.getLineTax()).orElse(BigDecimal.ZERO);
-            BigDecimal lineNetTotal = Optional.ofNullable(f.getLineNetTotal()).orElse(BigDecimal.ZERO);
-            BigDecimal lineGrossTotal = Optional.ofNullable(f.getLineGrossTotal()).orElse(BigDecimal.ZERO);
-            BigDecimal lineGrossRate = Optional.ofNullable(f.getLineGrossRate()).orElse(BigDecimal.ZERO);
-
-            // Distributed bill-level values
-            BigDecimal billDiscount = billDiscountTotal.multiply(ratio).setScale(2, RoundingMode.HALF_UP);
-            BigDecimal billExpense = billExpenseTotal.multiply(ratio).setScale(2, RoundingMode.HALF_UP);
-            BigDecimal billTax = billTaxTotal.multiply(ratio).setScale(2, RoundingMode.HALF_UP);
-
-            f.setBillDiscount(billDiscount);
-            f.setBillExpense(billExpense);
-            f.setBillTax(billTax);
-
-            // Totals = line + bill
-            BigDecimal totalDiscount = lineDiscount.add(billDiscount);
-            BigDecimal totalExpense = lineExpense.add(billExpense);
-            BigDecimal totalTax = lineTax.add(billTax);
-
-            f.setTotalDiscount(totalDiscount);
-            f.setTotalExpense(totalExpense);
-            f.setTotalTax(totalTax);
-
-            // Quantities
-            BigDecimal quantity = Optional.ofNullable(f.getQuantity()).orElse(BigDecimal.ZERO);         // used for rates
-            BigDecimal freeQty = Optional.ofNullable(f.getFreeQuantity()).orElse(BigDecimal.ZERO);      // used for cost
-            BigDecimal totalQty = quantity.add(freeQty);                                                 // full total
-            f.setTotalQuantity(totalQty); // recorded
-
-            // Rates using only quantity (excluding free)
-            BigDecimal billDiscountRate = quantity.compareTo(BigDecimal.ZERO) > 0
-                    ? billDiscount.divide(quantity, 4, RoundingMode.HALF_UP)
-                    : BigDecimal.ZERO;
-            f.setBillDiscountRate(billDiscountRate);
-
-            BigDecimal totalDiscountRate = quantity.compareTo(BigDecimal.ZERO) > 0
-                    ? totalDiscount.divide(quantity, 4, RoundingMode.HALF_UP)
-                    : BigDecimal.ZERO;
-            f.setTotalDiscountRate(totalDiscountRate);
-
-            // Net and cost values
-            BigDecimal netTotal = lineGrossTotal.subtract(totalDiscount).add(totalTax).add(totalExpense);
-            f.setNetTotal(netTotal);
-            f.setTotalCost(netTotal);
-
-            BigDecimal billCost = netTotal.subtract(lineNetTotal);
-            f.setBillCost(billCost);
-
-            // Cost-related rates use totalQty
-            BigDecimal lineCostRate = totalQty.compareTo(BigDecimal.ZERO) > 0
-                    ? lineNetTotal.divide(totalQty, 6, RoundingMode.HALF_UP)
-                    : BigDecimal.ZERO;
-            BigDecimal billCostRate = billCost.compareTo(BigDecimal.ZERO) > 0 && totalQty.compareTo(BigDecimal.ZERO) > 0
-                    ? billCost.divide(totalQty, 6, RoundingMode.HALF_UP)
-                    : BigDecimal.ZERO;
-            BigDecimal totalCostRate = totalQty.compareTo(BigDecimal.ZERO) > 0
-                    ? netTotal.divide(totalQty, 6, RoundingMode.HALF_UP)
-                    : BigDecimal.ZERO;
-
-            f.setLineCostRate(lineCostRate.setScale(4, RoundingMode.HALF_UP));
-            f.setBillCostRate(billCostRate.setScale(4, RoundingMode.HALF_UP));
-            f.setTotalCostRate(totalCostRate.setScale(4, RoundingMode.HALF_UP));
-
-            // Reapply or reset gross and net rates
-            f.setLineGrossRate(lineGrossRate);       // retained
-            f.setBillGrossRate(BigDecimal.ZERO);     // reset
-            f.setGrossRate(lineGrossRate);           // derived
-
-            f.setLineGrossTotal(lineGrossTotal);     // retained
-            f.setBillGrossTotal(BigDecimal.ZERO);    // reset
-            f.setGrossTotal(lineGrossTotal);         // sum of line + bill
-
-            if (f.getLineNetRate() == null || f.getLineNetRate().compareTo(BigDecimal.ZERO) == 0) {
-                BigDecimal lineNetRate = totalQty.compareTo(BigDecimal.ZERO) > 0
-                        ? lineNetTotal.divide(totalQty, 4, RoundingMode.HALF_UP)
-                        : BigDecimal.ZERO;
-                f.setLineNetRate(lineNetRate);
-            }
-
-            f.setBillNetRate(BigDecimal.ZERO);       // reset
-            f.setNetRate(f.getLineNetRate());        // final assigned
-        }
-    }
 
     public void onQuantityChange() {
         BillItem bi = currentBillItem;
@@ -418,7 +206,7 @@ public class PharmacyDirectPurchaseController implements Serializable {
             return;
         }
         BillItemFinanceDetails f = bi.getBillItemFinanceDetails();
-        recalculateFinancialsBeforeAddingBillItem(f);
+        pharmacyCostingService.recalculateFinancialsBeforeAddingBillItem(f);
     }
 
     public void onFreeQuantityChange() {
@@ -429,7 +217,7 @@ public class PharmacyDirectPurchaseController implements Serializable {
 
         BillItemFinanceDetails f = bi.getBillItemFinanceDetails();
 
-        recalculateFinancialsBeforeAddingBillItem(f);
+        pharmacyCostingService.recalculateFinancialsBeforeAddingBillItem(f);
     }
 
     public void onLineGrossRateChange() {
@@ -439,7 +227,7 @@ public class PharmacyDirectPurchaseController implements Serializable {
         }
 
         BillItemFinanceDetails f = bi.getBillItemFinanceDetails();
-        recalculateFinancialsBeforeAddingBillItem(f); // Rate drives discount value
+        pharmacyCostingService.recalculateFinancialsBeforeAddingBillItem(f); // Rate drives discount value
 
     }
 
@@ -450,7 +238,7 @@ public class PharmacyDirectPurchaseController implements Serializable {
         }
 
         BillItemFinanceDetails f = bi.getBillItemFinanceDetails();
-        recalculateFinancialsBeforeAddingBillItem(f);
+        pharmacyCostingService.recalculateFinancialsBeforeAddingBillItem(f);
     }
 
     // ChatGPT contributed: Optimized for null-safety and readability
@@ -473,7 +261,7 @@ public class PharmacyDirectPurchaseController implements Serializable {
             f.setRetailSaleRatePerUnit(f.getRetailSaleRate());
         }
 
-        recalculateFinancialsBeforeAddingBillItem(f);
+        pharmacyCostingService.recalculateFinancialsBeforeAddingBillItem(f);
     }
 
     // </editor-fold>  
@@ -508,6 +296,8 @@ public class PharmacyDirectPurchaseController implements Serializable {
     BillEjb billEjb;
     @EJB
     PaymentService paymentService;
+    @EJB
+    PharmacyCostingService pharmacyCostingService;
 
     /**
      * Controllers
@@ -634,7 +424,7 @@ public class PharmacyDirectPurchaseController implements Serializable {
             System.out.println("DEBUG: Non-Ampp Item - PackRate: " + packRate);
         }
 
-        recalculateFinancialsBeforeAddingBillItem(f);
+        pharmacyCostingService.recalculateFinancialsBeforeAddingBillItem(f);
     }
 
     public void createGrnAndPurchaseBillsWithCancellsAndReturnsOfSingleDepartment() {
@@ -992,16 +782,16 @@ public class PharmacyDirectPurchaseController implements Serializable {
             getBill().setNetTotal(grossTotal);
             ////// // System.out.println("net2" + getBill().getNetTotal());
         }
-        distributeProportionalBillValuesToItems(billItems, bill);
+        pharmacyCostingService.distributeProportionalBillValuesToItems(billItems, bill);
     }
 
     public void billDiscountChangedByUser() {
-        distributeProportionalBillValuesToItems(getBillItems(), getBill());
+        pharmacyCostingService.distributeProportionalBillValuesToItems(getBillItems(), getBill());
         calculateBillTotalsFromItems();
     }
 
     public void billTaxChangedByUser() {
-        distributeProportionalBillValuesToItems(getBillItems(), getBill());
+        pharmacyCostingService.distributeProportionalBillValuesToItems(getBillItems(), getBill());
         calculateBillTotalsFromItems();
     }
 

--- a/src/main/java/com/divudi/service/pharmacy/PharmacyCostingService.java
+++ b/src/main/java/com/divudi/service/pharmacy/PharmacyCostingService.java
@@ -1,0 +1,202 @@
+package com.divudi.service.pharmacy;
+
+import com.divudi.core.entity.Bill;
+import com.divudi.core.entity.BillItem;
+import com.divudi.core.entity.BillItemFinanceDetails;
+import com.divudi.core.entity.pharmacy.Ampp;
+import com.divudi.core.entity.Item;
+import java.math.BigDecimal;
+import java.math.MathContext;
+import java.math.RoundingMode;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.List;
+import java.util.Optional;
+import javax.ejb.Stateless;
+
+@Stateless
+public class PharmacyCostingService {
+
+    /**
+     * Recalculate line-level financial values before adding a BillItem to a bill.
+     */
+    public void recalculateFinancialsBeforeAddingBillItem(BillItemFinanceDetails f) {
+        if (f == null || f.getBillItem() == null) {
+            return;
+        }
+
+        BigDecimal qty = Optional.ofNullable(f.getQuantity()).orElse(BigDecimal.ZERO);
+        BigDecimal freeQty = Optional.ofNullable(f.getFreeQuantity()).orElse(BigDecimal.ZERO);
+        BigDecimal lineGrossRate = Optional.ofNullable(f.getLineGrossRate()).orElse(BigDecimal.ZERO);
+        BigDecimal lineDiscountRate = Optional.ofNullable(f.getLineDiscountRate()).orElse(BigDecimal.ZERO);
+        BigDecimal retailRate = Optional.ofNullable(f.getRetailSaleRatePerUnit()).orElse(BigDecimal.ZERO);
+
+        Item item = f.getBillItem().getItem();
+        BigDecimal totalQty = qty.add(freeQty);
+
+        BigDecimal unitsPerPack;
+        BigDecimal qtyInUnits;
+        BigDecimal freeQtyInUnits;
+        BigDecimal totalQtyInUnits;
+        if (item instanceof Ampp) {
+            double dblVal = item.getDblValue();
+            unitsPerPack = dblVal > 0.0 ? BigDecimal.valueOf(dblVal) : BigDecimal.ONE;
+            qtyInUnits = qty.multiply(unitsPerPack);
+            freeQtyInUnits = freeQty.multiply(unitsPerPack);
+            totalQtyInUnits = totalQty.multiply(unitsPerPack);
+        } else {
+            unitsPerPack = BigDecimal.ONE;
+            qtyInUnits = qty;
+            freeQtyInUnits = freeQty;
+            totalQtyInUnits = totalQty;
+        }
+
+        f.setUnitsPerPack(unitsPerPack);
+        f.setQuantityByUnits(qtyInUnits);
+        f.setFreeQuantityByUnits(freeQtyInUnits);
+        f.setTotalQuantityByUnits(totalQtyInUnits);
+
+        BigDecimal lineGrossTotal = lineGrossRate.multiply(qty);
+        BigDecimal lineDiscountValue = lineDiscountRate.multiply(qty);
+        BigDecimal lineNetTotal = lineGrossTotal.subtract(lineDiscountValue);
+        BigDecimal lineCostRate = totalQtyInUnits.compareTo(BigDecimal.ZERO) > 0
+                ? lineNetTotal.divide(totalQtyInUnits, 4, RoundingMode.HALF_UP)
+                : BigDecimal.ZERO;
+        BigDecimal retailValue = retailRate.multiply(totalQtyInUnits);
+
+        f.setLineGrossRate(lineGrossRate);
+        f.setLineNetRate(totalQty.compareTo(BigDecimal.ZERO) > 0
+                ? lineNetTotal.divide(totalQty, 4, RoundingMode.HALF_UP)
+                : BigDecimal.ZERO);
+
+        f.setRetailSaleRate(retailRate.multiply(unitsPerPack));
+        f.setLineDiscount(lineDiscountValue);
+        f.setLineGrossTotal(lineGrossTotal);
+        f.setLineNetTotal(lineNetTotal);
+        f.setLineCost(lineNetTotal);
+        f.setLineCostRate(lineCostRate);
+        f.setTotalQuantity(totalQty);
+    }
+
+    /**
+     * Distribute bill-level values (discounts, expenses, taxes) proportionally to items.
+     */
+    public void distributeProportionalBillValuesToItems(List<BillItem> billItems, Bill bill) {
+        if (bill == null || bill.getBillFinanceDetails() == null || billItems == null || billItems.isEmpty()) {
+            return;
+        }
+
+        BigDecimal totalBasis = BigDecimal.ZERO;
+        Map<BillItem, BigDecimal> itemBases = new HashMap<>();
+        for (BillItem bi : billItems) {
+            BillItemFinanceDetails f = bi.getBillItemFinanceDetails();
+            if (f == null) {
+                continue;
+            }
+            BigDecimal qty = Optional.ofNullable(f.getQuantity()).orElse(BigDecimal.ZERO);
+            BigDecimal freeQty = Optional.ofNullable(f.getFreeQuantity()).orElse(BigDecimal.ZERO);
+            BigDecimal lineGrossRate = Optional.ofNullable(f.getLineGrossRate()).orElse(BigDecimal.ZERO);
+            BigDecimal basis = lineGrossRate.multiply(qty.add(freeQty));
+            itemBases.put(bi, basis);
+            totalBasis = totalBasis.add(basis);
+        }
+
+        if (totalBasis.compareTo(BigDecimal.ZERO) == 0) {
+            return;
+        }
+
+        bill.getBillFinanceDetails().setBillDiscount(BigDecimal.valueOf(bill.getDiscount()));
+        bill.getBillFinanceDetails().setBillTaxValue(BigDecimal.valueOf(bill.getTax()));
+        bill.getBillFinanceDetails().setBillExpense(BigDecimal.valueOf(bill.getExpenseTotal()));
+
+        BigDecimal billDiscountTotal = Optional.ofNullable(bill.getBillFinanceDetails().getBillDiscount()).orElse(BigDecimal.ZERO);
+        BigDecimal billExpenseTotal = Optional.ofNullable(bill.getBillFinanceDetails().getBillExpense()).orElse(BigDecimal.ZERO);
+        BigDecimal billTaxTotal = Optional.ofNullable(bill.getBillFinanceDetails().getBillTaxValue()).orElse(BigDecimal.ZERO);
+
+        for (BillItem bi : billItems) {
+            BillItemFinanceDetails f = bi.getBillItemFinanceDetails();
+            if (f == null) {
+                continue;
+            }
+            BigDecimal basis = itemBases.get(bi);
+            BigDecimal ratio = basis.divide(totalBasis, 12, RoundingMode.HALF_UP);
+
+            BigDecimal lineDiscount = Optional.ofNullable(f.getLineDiscount()).orElse(BigDecimal.ZERO);
+            BigDecimal lineExpense = Optional.ofNullable(f.getLineExpense()).orElse(BigDecimal.ZERO);
+            BigDecimal lineTax = Optional.ofNullable(f.getLineTax()).orElse(BigDecimal.ZERO);
+            BigDecimal lineNetTotal = Optional.ofNullable(f.getLineNetTotal()).orElse(BigDecimal.ZERO);
+            BigDecimal lineGrossTotal = Optional.ofNullable(f.getLineGrossTotal()).orElse(BigDecimal.ZERO);
+            BigDecimal lineGrossRate = Optional.ofNullable(f.getLineGrossRate()).orElse(BigDecimal.ZERO);
+
+            BigDecimal billDiscount = billDiscountTotal.multiply(ratio).setScale(2, RoundingMode.HALF_UP);
+            BigDecimal billExpense = billExpenseTotal.multiply(ratio).setScale(2, RoundingMode.HALF_UP);
+            BigDecimal billTax = billTaxTotal.multiply(ratio).setScale(2, RoundingMode.HALF_UP);
+
+            f.setBillDiscount(billDiscount);
+            f.setBillExpense(billExpense);
+            f.setBillTax(billTax);
+
+            BigDecimal totalDiscount = lineDiscount.add(billDiscount);
+            BigDecimal totalExpense = lineExpense.add(billExpense);
+            BigDecimal totalTax = lineTax.add(billTax);
+
+            f.setTotalDiscount(totalDiscount);
+            f.setTotalExpense(totalExpense);
+            f.setTotalTax(totalTax);
+
+            BigDecimal quantity = Optional.ofNullable(f.getQuantity()).orElse(BigDecimal.ZERO);
+            BigDecimal freeQty = Optional.ofNullable(f.getFreeQuantity()).orElse(BigDecimal.ZERO);
+            BigDecimal totalQty = quantity.add(freeQty);
+            f.setTotalQuantity(totalQty);
+
+            BigDecimal billDiscountRate = quantity.compareTo(BigDecimal.ZERO) > 0
+                    ? billDiscount.divide(quantity, 4, RoundingMode.HALF_UP)
+                    : BigDecimal.ZERO;
+            f.setBillDiscountRate(billDiscountRate);
+
+            BigDecimal totalDiscountRate = quantity.compareTo(BigDecimal.ZERO) > 0
+                    ? totalDiscount.divide(quantity, 4, RoundingMode.HALF_UP)
+                    : BigDecimal.ZERO;
+            f.setTotalDiscountRate(totalDiscountRate);
+
+            BigDecimal netTotal = lineGrossTotal.subtract(totalDiscount).add(totalTax).add(totalExpense);
+            f.setNetTotal(netTotal);
+            f.setTotalCost(netTotal);
+
+            BigDecimal billCost = netTotal.subtract(lineNetTotal);
+            f.setBillCost(billCost);
+
+            BigDecimal lineCostRate = totalQty.compareTo(BigDecimal.ZERO) > 0
+                    ? lineNetTotal.divide(totalQty, 6, RoundingMode.HALF_UP)
+                    : BigDecimal.ZERO;
+            BigDecimal billCostRate = billCost.compareTo(BigDecimal.ZERO) > 0 && totalQty.compareTo(BigDecimal.ZERO) > 0
+                    ? billCost.divide(totalQty, 6, RoundingMode.HALF_UP)
+                    : BigDecimal.ZERO;
+            BigDecimal totalCostRate = totalQty.compareTo(BigDecimal.ZERO) > 0
+                    ? netTotal.divide(totalQty, 6, RoundingMode.HALF_UP)
+                    : BigDecimal.ZERO;
+
+            f.setLineCostRate(lineCostRate.setScale(4, RoundingMode.HALF_UP));
+            f.setBillCostRate(billCostRate.setScale(4, RoundingMode.HALF_UP));
+            f.setTotalCostRate(totalCostRate.setScale(4, RoundingMode.HALF_UP));
+
+            f.setLineGrossRate(lineGrossRate);
+            f.setBillGrossRate(BigDecimal.ZERO);
+            f.setGrossRate(lineGrossRate);
+
+            f.setLineGrossTotal(lineGrossTotal);
+            f.setBillGrossTotal(BigDecimal.ZERO);
+            f.setGrossTotal(lineGrossTotal);
+
+            if (f.getLineNetRate() == null || f.getLineNetRate().compareTo(BigDecimal.ZERO) == 0) {
+                BigDecimal lineNetRate = totalQty.compareTo(BigDecimal.ZERO) > 0
+                        ? lineNetTotal.divide(totalQty, 4, RoundingMode.HALF_UP)
+                        : BigDecimal.ZERO;
+                f.setLineNetRate(lineNetRate);
+            }
+
+            f.setBillNetRate(BigDecimal.ZERO);
+            f.setNetRate(f.getLineNetRate());
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- introduce `PharmacyCostingService` EJB with costing helpers
- remove helper methods from `PharmacyDirectPurchaseController`
- inject `PharmacyCostingService` into `PharmacyDirectPurchaseController` and `GrnController`
- delegate costing operations in controllers to the new service

## Testing
- `mvn -q test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849fa1b4f20832fab6db4196060593b