### PR TITLE
12958-add-privilege-checks-for-home-icons

### DIFF
--- a/src/main/webapp/home.xhtml
+++ b/src/main/webapp/home.xhtml
@@ -1591,7 +1591,7 @@
                 </h:panelGroup>
 
                 <!-- Financial Transaction Manager -->
-                <h:panelGroup rendered="#{ui.icon eq 'Financial_Transaction_Manager'}" layout="block" class="col-1 p-1" >
+                <h:panelGroup rendered="#{ui.icon eq 'Financial_Transaction_Manager' and webUserController.hasPrivilege('PaymentBilling')}" layout="block" class="col-1 p-1" >
                     <h:form>
                         <p:tooltip for="Financial_Transaction_Manager" value="Financial Transaction Manager" showDelay="0" hideDelay="0"></p:tooltip>
                         <p:commandLink
@@ -1606,7 +1606,7 @@
                 </h:panelGroup>
 
                 <!-- Channel Booking by Dates -->
-                <h:panelGroup rendered="#{ui.icon eq 'Channel_Booking_by_Dates'}" layout="block" class="col-1 p-1" >
+                <h:panelGroup rendered="#{ui.icon eq 'Channel_Booking_by_Dates' and webUserController.hasPrivilege('ChannellingChannelBooking')}" layout="block" class="col-1 p-1" >
                     <h:form>
                         <p:tooltip for="channel_booking_by_dates" value="Channel Booking by Dates" showDelay="0" hideDelay="0"></p:tooltip>
                         <p:commandLink


### PR DESCRIPTION
## Summary
- add privilege check to Financial Transaction Manager home icon
- add privilege check to Channel Booking by Dates home icon

## Testing
- `mvn -q test` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849fb6e2578832fa0be0c2b75ba0187

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Icons for "Financial Transaction Manager" and "Channel Booking by Dates" are now only visible to users with the appropriate privileges, enhancing access control on the home page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->