### PR TITLE
Add GRN bill profit config

### DIFF
--- a/src/main/java/com/divudi/bean/common/ConfigOptionApplicationController.java
+++ b/src/main/java/com/divudi/bean/common/ConfigOptionApplicationController.java
@@ -8,6 +8,7 @@ import com.divudi.core.entity.Institution;
 import com.divudi.core.entity.ConfigOption;
 import com.divudi.core.entity.WebUser;
 import com.divudi.core.facade.ConfigOptionFacade;
+import com.divudi.bean.pharmacy.GrnCostingController;
 import javax.inject.Named;
 import java.io.Serializable;
 import java.util.Arrays;
@@ -89,6 +90,7 @@ public class ConfigOptionApplicationController implements Serializable {
         getBooleanValueByKey("Direct Issue Based On Retail Rate", true);
         getBooleanValueByKey("Direct Issue Based On Purchase Rate", false);
         getBooleanValueByKey("Direct Issue Based On Cost Rate", false);
+        getBooleanValueByKey(GrnCostingController.CFG_SHOW_PROFIT_IN_GRN_BILL, true);
     }
 
     private void loadPharmacyIssueReceiptConfigurationDefaults() {

--- a/src/main/java/com/divudi/bean/pharmacy/GrnCostingController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/GrnCostingController.java
@@ -97,6 +97,12 @@ public class GrnCostingController implements Serializable {
     private PharmacyCalculation pharmacyCalculation;
     @Inject
     ConfigOptionApplicationController configOptionApplicationController;
+
+    public static final String CFG_SHOW_PROFIT_IN_GRN_BILL = "Show Profit % in GRN Bill";
+
+    public boolean isShowProfitInGrnBill() {
+        return configOptionApplicationController.getBooleanValueByKey(CFG_SHOW_PROFIT_IN_GRN_BILL, true);
+    }
     /////////////////
     private Institution dealor;
     private Bill approveBill;

--- a/src/main/webapp/pharmacy/pharmacy_grn_costing.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_grn_costing.xhtml
@@ -233,8 +233,9 @@
                     </p:column>  
                     <p:column
                         width="4em"
-                        headerText="Profit %" 
-                        styleClass="text-end #{bi.item.category.profitMargin > ((bi.pharmaceuticalBillItem.retailRate - bi.pharmaceuticalBillItem.purchaseRate) / bi.pharmaceuticalBillItem.purchaseRate)*100 ? 'ui-messages-fatal' : ''}">                    
+                        headerText="Profit %"
+                        rendered="#{grnCostingController.showProfitInGrnBill}"
+                        styleClass="text-end #{bi.item.category.profitMargin > ((bi.pharmaceuticalBillItem.retailRate - bi.pharmaceuticalBillItem.purchaseRate) / bi.pharmaceuticalBillItem.purchaseRate)*100 ? 'ui-messages-fatal' : ''}">
                         <p:inputText
                             id="profMargin"
                             readonly="true"


### PR DESCRIPTION
## Summary
- add `CFG_SHOW_PROFIT_IN_GRN_BILL` constant and helper
- register GRN profit option during config boot
- render profit column conditionally in GRN costing UI

## Testing
- `mvn -q test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a001c38d4832f9b2eedf92a9f64c0