### PR TITLE
Update Goods Receipt navigation

### DIFF
--- a/src/main/webapp/home.xhtml
+++ b/src/main/webapp/home.xhtml
@@ -1024,11 +1024,21 @@
                 <h:panelGroup layout="block" class="col-1 p-1"  rendered="#{ui.icon eq 'Goods_Receipt'}">
                     <h:form>
                         <p:tooltip for="Goods_Receipt" value="Goods Receipt"  showDelay="0" hideDelay="0"></p:tooltip>
-                        <p:commandLink 
+                        <p:commandLink
                             id="Goods_Receipt"
-                            ajax="false" 
+                            ajax="false"
                             action="/pharmacy/pharmacy_purchase_order_list_for_recieve?faces-redirect=true"
-                            styleClass="svg-link" >
+                            styleClass="svg-link"
+                            rendered="#{!configOptionApplicationController.getBooleanValueByKey('Manage Costing', true)}" >
+                            <p:graphicImage class="img-thumbnail"  cache="true" library="images" name="home/grn.svg" style="cursor: pointer;" width="80" height="80" />
+                            <h:outputText style="display: none;" value="Goods Receipt" />
+                        </p:commandLink>
+                        <p:commandLink
+                            id="Goods_Receipt_Costing"
+                            ajax="false"
+                            action="/pharmacy/pharmacy_grn_costing?faces-redirect=true"
+                            styleClass="svg-link"
+                            rendered="#{configOptionApplicationController.getBooleanValueByKey('Manage Costing', true)}" >
                             <p:graphicImage class="img-thumbnail"  cache="true" library="images" name="home/grn.svg" style="cursor: pointer;" width="80" height="80" />
                             <h:outputText style="display: none;" value="Goods Receipt" />
                         </p:commandLink>

--- a/src/main/webapp/resources/ezcomp/menu.xhtml
+++ b/src/main/webapp/resources/ezcomp/menu.xhtml
@@ -918,13 +918,24 @@
                             icon="fas fa-clipboard-check"
                             actionListener="#{searchController.makeListNull()}" 
                             rendered="#{webUserController.hasPrivilege('PurchaseOrdersApprovel') or webUserController.hasPrivilege('CreatePurchaseOrder')}" ></p:menuitem>
-                        <p:menuitem  
-                            ajax="false" 
-                            action="/pharmacy/pharmacy_purchase_order_list_for_recieve?faces-redirect=true"  
-                            value="Goods Receipt"  
+                        <p:menuitem
+                            ajax="false"
+                            action="/pharmacy/pharmacy_purchase_order_list_for_recieve?faces-redirect=true"
+                            value="Goods Receipt"
                             icon="fas fa-dolly-flatbed"
-                            actionListener="#{searchController.makeListNull()}" 
-                            rendered="#{webUserController.hasPrivilege('GoodsRecipt') and !configOptionApplicationController.getBooleanValueByKey('Pharmacy Good Recipt With Approval')}"  ></p:menuitem> 
+                            actionListener="#{searchController.makeListNull()}"
+                            rendered="#{webUserController.hasPrivilege('GoodsRecipt') 
+                                        and !configOptionApplicationController.getBooleanValueByKey('Pharmacy Good Recipt With Approval') 
+                                        and !configOptionApplicationController.getBooleanValueByKey('Manage Costing', true)}"  ></p:menuitem>
+                        <p:menuitem
+                            ajax="false"
+                            action="/pharmacy/pharmacy_grn_costing?faces-redirect=true"
+                            value="Goods Receipt"
+                            icon="fas fa-dolly-flatbed"
+                            actionListener="#{searchController.makeListNull()}"
+                            rendered="#{webUserController.hasPrivilege('GoodsRecipt') 
+                                        and !configOptionApplicationController.getBooleanValueByKey('Pharmacy Good Recipt With Approval') 
+                                        and configOptionApplicationController.getBooleanValueByKey('Manage Costing', true)}"  ></p:menuitem>
                         <p:menuitem  
                             ajax="false" 
                             action="/pharmacy/pharmacy_purchase_order_list_for_recieve_with_approval?faces-redirect=true"  


### PR DESCRIPTION
## Summary
- change Goods Receipt menu action based on Manage Costing option
- update homepage Goods Receipt icon link accordingly

## Testing
- `mvn -q test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a035d2184832faee67435855d4856