### PR TITLE
12957 add costing toggle for GRN receive

### DIFF
--- a/src/main/java/com/divudi/bean/pharmacy/GrnCostingController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/GrnCostingController.java
@@ -170,6 +170,14 @@ public class GrnCostingController implements Serializable {
         return "/pharmacy/pharmacy_grn?faces-redirect=true";
     }
 
+    public String navigateToResiveCosting() {
+        clear();
+        createGrn();
+        getGrnBill().setPaymentMethod(getApproveBill().getPaymentMethod());
+        getGrnBill().setCreditDuration(getApproveBill().getCreditDuration());
+        return "/pharmacy/pharmacy_grn_costing?faces-redirect=true";
+    }
+
     public String navigateToResiveFromImportGrn(Bill importGrn) {
         clear();
         saveImportBill(importGrn);

--- a/src/main/webapp/pharmacy/pharmacy_purchase_order_list_for_recieve.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_purchase_order_list_for_recieve.xhtml
@@ -121,13 +121,23 @@
                                 width="6em">
                                 <div class="row">
                                     <div class="d-flex gap-2 mb-1">
-                                        <p:commandButton 
+                                        <p:commandButton
                                             ajax="false"
                                             value="Receive"
                                             class="w-100 ui-button-warning"
-                                            action="#{grnController.navigateToResive()}" 
+                                            rendered="#{!configOptionApplicationController.getBooleanValueByKey('Manage Costing', true)}"
+                                            action="#{grnController.navigateToResive()}"
                                             disabled="#{p.cancelled or p.billClosed}">
                                             <f:setPropertyActionListener target="#{grnController.approveBill}" value="#{p}"/>
+                                        </p:commandButton>
+                                        <p:commandButton
+                                            ajax="false"
+                                            value="Receive"
+                                            class="w-100 ui-button-warning"
+                                            rendered="#{configOptionApplicationController.getBooleanValueByKey('Manage Costing', true)}"
+                                            action="#{grnCostingController.navigateToResiveCosting()}"
+                                            disabled="#{p.cancelled or p.billClosed}">
+                                            <f:setPropertyActionListener target="#{grnCostingController.approveBill}" value="#{p}"/>
                                         </p:commandButton>
                                     </div>
                                     <div class="col-md-12">


### PR DESCRIPTION
## Summary
- add navigateToResiveCosting in `GrnCostingController`
- show Receive buttons conditionally in Purchase Order list

## Testing
- `mvn -q test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849f75b8cdc832f8518c216e3a7cf21