### PR TITLE
12957 add costing toggle for GRN receive

### DIFF
--- a/src/main/java/com/divudi/bean/pharmacy/GrnCostingController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/GrnCostingController.java
@@ -103,6 +103,13 @@ public class GrnCostingController implements Serializable {
     public boolean isShowProfitInGrnBill() {
         return configOptionApplicationController.getBooleanValueByKey(CFG_SHOW_PROFIT_IN_GRN_BILL, true);
     }
+
+    /**
+     * Wrapper for PharmacyCostingService.calcProfitMargin to be used in JSF.
+     */
+    public double calcProfitMargin(BillItem bi) {
+        return pharmacyCostingService.calcProfitMargin(bi);
+    }
     /////////////////
     private Institution dealor;
     private Bill approveBill;
@@ -168,6 +175,14 @@ public class GrnCostingController implements Serializable {
         getGrnBill().setPaymentMethod(getApproveBill().getPaymentMethod());
         getGrnBill().setCreditDuration(getApproveBill().getCreditDuration());
         return "/pharmacy/pharmacy_grn?faces-redirect=true";
+    }
+
+    public String navigateToResiveCosting() {
+        clear();
+        createGrn();
+        getGrnBill().setPaymentMethod(getApproveBill().getPaymentMethod());
+        getGrnBill().setCreditDuration(getApproveBill().getCreditDuration());
+        return "/pharmacy/pharmacy_grn_costing?faces-redirect=true";
     }
 
     public String navigateToResiveFromImportGrn(Bill importGrn) {

--- a/src/main/webapp/pharmacy/pharmacy_purchase_order_list_for_recieve.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_purchase_order_list_for_recieve.xhtml
@@ -121,13 +121,23 @@
                                 width="6em">
                                 <div class="row">
                                     <div class="d-flex gap-2 mb-1">
-                                        <p:commandButton 
+                                        <p:commandButton
                                             ajax="false"
                                             value="Receive"
                                             class="w-100 ui-button-warning"
-                                            action="#{grnController.navigateToResive()}" 
+                                            rendered="#{!configOptionApplicationController.getBooleanValueByKey('Manage Costing', true)}"
+                                            action="#{grnController.navigateToResive()}"
                                             disabled="#{p.cancelled or p.billClosed}">
                                             <f:setPropertyActionListener target="#{grnController.approveBill}" value="#{p}"/>
+                                        </p:commandButton>
+                                        <p:commandButton
+                                            ajax="false"
+                                            value="Receive"
+                                            class="w-100 ui-button-warning"
+                                            rendered="#{configOptionApplicationController.getBooleanValueByKey('Manage Costing', true)}"
+                                            action="#{grnCostingController.navigateToResiveCosting()}"
+                                            disabled="#{p.cancelled or p.billClosed}">
+                                            <f:setPropertyActionListener target="#{grnCostingController.approveBill}" value="#{p}"/>
                                         </p:commandButton>
                                     </div>
                                     <div class="col-md-12">


### PR DESCRIPTION
## Summary
- add navigateToResiveCosting in `GrnCostingController`
- show Receive buttons conditionally in Purchase Order list
- calculate profit margin for GRN items via `PharmacyCostingService`

## Testing
- `mvn -q test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849f75b8cdc832f8518c216e3a7cf21