### PR TITLE
12957 add costing toggle for GRN receive

### DIFF
--- a/src/main/java/com/divudi/bean/pharmacy/GrnCostingController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/GrnCostingController.java
@@ -103,6 +103,13 @@ public class GrnCostingController implements Serializable {
     public boolean isShowProfitInGrnBill() {
         return configOptionApplicationController.getBooleanValueByKey(CFG_SHOW_PROFIT_IN_GRN_BILL, true);
     }
+
+    /**
+     * Wrapper for PharmacyCostingService.calcProfitMargin to be used in JSF.
+     */
+    public double calcProfitMargin(BillItem bi) {
+        return pharmacyCostingService.calcProfitMargin(bi);
+    }
     /////////////////
     private Institution dealor;
     private Bill approveBill;
@@ -168,6 +175,14 @@ public class GrnCostingController implements Serializable {
         getGrnBill().setPaymentMethod(getApproveBill().getPaymentMethod());
         getGrnBill().setCreditDuration(getApproveBill().getCreditDuration());
         return "/pharmacy/pharmacy_grn?faces-redirect=true";
+    }
+
+    public String navigateToResiveCosting() {
+        clear();
+        createGrn();
+        getGrnBill().setPaymentMethod(getApproveBill().getPaymentMethod());
+        getGrnBill().setCreditDuration(getApproveBill().getCreditDuration());
+        return "/pharmacy/pharmacy_grn_costing?faces-redirect=true";
     }
 
     public String navigateToResiveFromImportGrn(Bill importGrn) {

--- a/src/main/webapp/pharmacy/pharmacy_grn_costing.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_grn_costing.xhtml
@@ -70,9 +70,9 @@
                                  value="#{grnCostingController.grnBill.comments}" style="width:75%" />  
 
                 </h:panelGrid>
-                <p:dataTable 
-                    var="bi" 
-                    styleClass="noBorder" 
+                <p:dataTable
+                    var="bi" rowIndexVar="i"
+                    styleClass="noBorder"
                     rowKey="#{bi.searialNo}"
                     selection="#{grnCostingController.selectedBillItems}"
                     value="#{grnCostingController.billItems}" 
@@ -97,12 +97,30 @@
                         width="2em"
                         selectionBox="true"
                         styleClass="#{bi.item.category.profitMargin > ((bi.pharmaceuticalBillItem.retailRate - bi.pharmaceuticalBillItem.purchaseRate) / bi.pharmaceuticalBillItem.purchaseRate)*100 ? 'ui-messages-fatal' : ''}"/>
-                    <p:column 
-                        headerText="Item Name" 
+                    <p:column
+                        headerText="Item Name"
                         width="20em"
-                        styleClass="#{bi.item.category.profitMargin > ((bi.pharmaceuticalBillItem.retailRate - bi.pharmaceuticalBillItem.purchaseRate) / bi.pharmaceuticalBillItem.purchaseRate)*100 ? 'ui-messages-fatal' : ''}" > 
-                        <h:outputText id="item" value="#{bi.item.name}" ></h:outputText>
-                    </p:column>  
+                        styleClass="#{bi.item.category.profitMargin > ((bi.pharmaceuticalBillItem.retailRate - bi.pharmaceuticalBillItem.purchaseRate) / bi.pharmaceuticalBillItem.purchaseRate)*100 ? 'ui-messages-fatal' : ''}" >
+                        <h:outputText id="item" value="#{bi.item.name}" />
+                        <p:commandLink
+                            styleClass="ms-1"
+                            title="View Finance Details"
+                            oncomplete="PF('dialog#{i}').show()"
+                            process="@this"
+                            update="@none">
+                            <i class="fas fa-info-circle" />
+                        </p:commandLink>
+                        <p:dialog id="dialog"
+                                  widgetVar="dialog#{i}"
+                                  header="Details"
+                                  modal="true"
+                                  closable="true"
+                                  resizable="false"
+                                  class="w-75"
+                                  dynamic="true">
+                            <ph:bill_item_finance_details pbi="#{bi}"/>
+                        </p:dialog>
+                    </p:column>
                     <p:column 
                         headerText="Code" 
                         width="4em"
@@ -264,8 +282,10 @@
                     </p:column>
 
                 </p:dataTable>  
-                <p:panel>
-                    <p:panelGrid columns="3" style="min-width: 100%" id="tot">
+                <p:panel id="panelBillDetails" header="Bill Details" class="m-1">
+                    <p:tabView id="billTabs">
+                        <p:tab title="Bill Summary">
+                            <p:panelGrid columns="3" style="min-width: 100%" id="tot">
 
                         <p:panelGrid columns="2">
                             <p:outputLabel value="Invoice No "/>
@@ -317,7 +337,12 @@
 
                         </p:panelGrid>
 
-                    </p:panelGrid>
+                            </p:panelGrid>
+                        </p:tab>
+                        <p:tab title="Financial Summary">
+                            <ph:bill_finance_details id="billFinanceDetails" bill="#{grnCostingController.grnBill}" ></ph:bill_finance_details>
+                        </p:tab>
+                    </p:tabView>
                 </p:panel>
 
                 <p:panel header="Bill Expenses" >

--- a/src/main/webapp/pharmacy/pharmacy_purchase_order_list_for_recieve.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_purchase_order_list_for_recieve.xhtml
@@ -121,13 +121,23 @@
                                 width="6em">
                                 <div class="row">
                                     <div class="d-flex gap-2 mb-1">
-                                        <p:commandButton 
+                                        <p:commandButton
                                             ajax="false"
                                             value="Receive"
                                             class="w-100 ui-button-warning"
-                                            action="#{grnController.navigateToResive()}" 
+                                            rendered="#{!configOptionApplicationController.getBooleanValueByKey('Manage Costing', true)}"
+                                            action="#{grnController.navigateToResive()}"
                                             disabled="#{p.cancelled or p.billClosed}">
                                             <f:setPropertyActionListener target="#{grnController.approveBill}" value="#{p}"/>
+                                        </p:commandButton>
+                                        <p:commandButton
+                                            ajax="false"
+                                            value="Receive"
+                                            class="w-100 ui-button-warning"
+                                            rendered="#{configOptionApplicationController.getBooleanValueByKey('Manage Costing', true)}"
+                                            action="#{grnCostingController.navigateToResiveCosting()}"
+                                            disabled="#{p.cancelled or p.billClosed}">
+                                            <f:setPropertyActionListener target="#{grnCostingController.approveBill}" value="#{p}"/>
                                         </p:commandButton>
                                     </div>
                                     <div class="col-md-12">


### PR DESCRIPTION
## Summary
- add navigateToResiveCosting in `GrnCostingController`
- show Receive buttons conditionally in Purchase Order list
- calculate profit margin for GRN items via `PharmacyCostingService`
- show item and bill finance details in costing GRN screen

## Testing
- `mvn -q test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849f75b8cdc832f8518c216e3a7cf21