### PR TITLE
Fix GRN costing quantity bindings

### DIFF
--- a/src/main/webapp/pharmacy/pharmacy_grn_costing.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_grn_costing.xhtml
@@ -156,7 +156,7 @@
                             onfocus="this.select();"
                             autocomplete="off" 
                             class="text-end text-primary w-100"
-                            value="#{bi.tmpQty}" >
+                            value="#{bi.billItemFinanceDetails.quantity}" >
                             <f:ajax event="blur" execute="@this pRate rRate doeDateOnlyShort batch ordQty" render="@this :#{p:resolveFirstComponentWithId('tot',view).clientId} total ordQty doeDateOnlyShort profMargin batch pRate rRate" listener="#{grnCostingController.checkQty(bi)}"></f:ajax>
                         </p:inputText>
                     </p:column>  
@@ -171,7 +171,7 @@
                             autocomplete="off" 
                             class="text-end text-primary w-100"
                             onfocus="this.select();"
-                            value="#{bi.tmpFreeQty}" 
+                            value="#{bi.billItemFinanceDetails.freeQuantity}"
                             id="freeQty" >
                             <f:ajax event="blur" execute="@this pRate freeQty rRate ordQty doeDateOnlyShort batch" render="@this :#{p:resolveFirstComponentWithId('tot',view).clientId} total freeQty doeDateOnlyShort profMargin batch pRate rRate" listener="#{grnCostingController.checkQty(bi)}"></f:ajax>
                         </p:inputText>


### PR DESCRIPTION
## Summary
- use bill item finance details quantity fields in `pharmacy_grn_costing.xhtml`

## Testing
- `mvn -q test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b059bd300832fa375988daa971f8c