### PR TITLE
Enhance BillExpense UX and validation

### DIFF
--- a/src/main/java/com/divudi/bean/common/BillExpenseController.java
+++ b/src/main/java/com/divudi/bean/common/BillExpenseController.java
@@ -11,6 +11,8 @@ import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
+import java.util.Map;
+import java.util.HashMap;
 import javax.ejb.EJB;
 import javax.enterprise.context.SessionScoped;
 import javax.faces.component.UIComponent;
@@ -56,6 +58,39 @@ public class BillExpenseController implements Serializable {
     }
 
     public void saveSelected() {
+        if (current == null) {
+            JsfUtil.addErrorMessage("Nothing to save");
+            return;
+        }
+        if (current.getName() == null || current.getName().trim().isEmpty()) {
+            JsfUtil.addErrorMessage("Enter Name");
+            return;
+        }
+
+        if (current.getPrintName() == null || current.getPrintName().trim().isEmpty()) {
+            current.setPrintName(current.getName());
+        }
+
+        if (current.getFullName() == null || current.getFullName().trim().isEmpty()) {
+            current.setFullName(current.getName());
+        }
+
+        if (current.getCode() == null || current.getCode().trim().isEmpty()) {
+            String n = current.getName().replaceAll("\\s+", "").toUpperCase();
+            n = n + "0000";
+            current.setCode(n.substring(0, 4));
+        }
+
+        Map<String, Object> params = new HashMap<>();
+        params.put("ret", false);
+        params.put("cd", current.getCode().toUpperCase());
+        String jpql = "select b from BillExpense b where b.retired=:ret and upper(b.code)=:cd";
+        BillExpense dup = getFacade().findFirstByJpql(jpql, params);
+        if (dup != null && (current.getId() == null || !dup.getId().equals(current.getId()))) {
+            JsfUtil.addErrorMessage("Duplicate code");
+            return;
+        }
+
         if (getCurrent().getId() != null) {
             getFacade().edit(getCurrent());
             JsfUtil.addSuccessMessage("Updated Successfully.");

--- a/src/main/webapp/admin/items/bill_expenses.xhtml
+++ b/src/main/webapp/admin/items/bill_expenses.xhtml
@@ -18,24 +18,26 @@
                     <div class="row">
                         <div class="col-md-5">
                             <div class="d-flex align-items-center">
-                                <p:commandButton 
-                                    id="btnAdd" 
-                                    value="Add"  
-                                    action="#{billExpenseController.prepareAdd()}" 
+                                <p:commandButton
+                                    id="btnAdd"
+                                    value="Add"
+                                    action="#{billExpenseController.prepareAdd()}"
                                     class="m-1 ui-button-success w-25 "
                                     process="btnAdd"
-                                    update="gpDetail">
+                                    update="gpDetail"
+                                    oncomplete="PrimeFaces.focus('form:txtName')">
 
                                 </p:commandButton>
                                 <p:commandButton
                                     id="btnDelete" 
                                     onclick="if (!confirm('Are you sure you want to delete this record?'))
                                                 return false;" 
-                                    action="#{billExpenseController.delete()}" 
+                                    action="#{billExpenseController.delete()}"
                                     class="m-1 ui-button-danger w-25"
                                     value="Delete"
                                     process="btnDelete"
-                                    update="lstSelect gpDetail">
+                                    update="lstSelect gpDetail"
+                                    oncomplete="PrimeFaces.focus('form:lstSelect')">
                                 </p:commandButton> 
                             </div>
                             <p:selectOneListbox 
@@ -73,10 +75,11 @@
                                     <p:commandButton
                                         id="btnSave" 
                                         value="Save"  
-                                        action="#{billExpenseController.saveSelected()}" 
+                                        action="#{billExpenseController.saveSelected()}"
                                         class="ui-button-warning w-25"
                                         process="btnSave gpDetail"
-                                        update="lstSelect gpDetail">
+                                        update="lstSelect gpDetail"
+                                        oncomplete="PrimeFaces.focus('form:lstSelect')">
                                     </p:commandButton>
                                     <p:defaultCommand target="btnSave"/>
                                 </f:facet>


### PR DESCRIPTION
## Summary
- improve focus handling for Bill Expenses page
- validate and auto-fill fields when saving a Bill Expense

## Testing
- `mvn -q -DskipTests compile` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_684b6577e740832fb0d2f82a8c41b8ad