### PR TITLE
Fix finance summary update on GRN costing page

### DIFF
--- a/src/main/webapp/pharmacy/pharmacy_grn_costing.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_grn_costing.xhtml
@@ -158,7 +158,7 @@
                             autocomplete="off" 
                             class="text-end text-primary w-100"
                             value="#{bi.billItemFinanceDetails.quantity}" >
-                            <f:ajax event="blur" execute="txtQty" render=":#{p:resolveFirstComponentWithId('tot',view).clientId} total ordQty doeDateOnlyShort profMargin batch pRate rRate" listener="#{grnCostingController.checkQty(bi)}"></f:ajax>
+                            <f:ajax event="blur" execute="txtQty" render=":#{p:resolveFirstComponentWithId('tot',view).clientId} total ordQty doeDateOnlyShort profMargin batch pRate rRate :#{p:resolveFirstComponentWithId('billFinanceDetails', view).clientId}" listener="#{grnCostingController.checkQty(bi)}"></f:ajax>
                         </p:inputText>
                     </p:column>  
 
@@ -174,7 +174,7 @@
                             onfocus="this.select();"
                             value="#{bi.billItemFinanceDetails.freeQuantity}"
                             id="freeQty" >
-                            <f:ajax event="blur" execute="freeQty" render=":#{p:resolveFirstComponentWithId('tot',view).clientId} total freeQty doeDateOnlyShort profMargin batch pRate rRate" listener="#{grnCostingController.checkQty(bi)}"></f:ajax>
+                            <f:ajax event="blur" execute="freeQty" render=":#{p:resolveFirstComponentWithId('tot',view).clientId} total freeQty doeDateOnlyShort profMargin batch pRate rRate :#{p:resolveFirstComponentWithId('billFinanceDetails', view).clientId}" listener="#{grnCostingController.checkQty(bi)}"></f:ajax>
                         </p:inputText>
                     </p:column> 
 
@@ -188,7 +188,7 @@
                             value="#{bi.billItemFinanceDetails.lineGrossRate}"
                             id="pRate"
                             onfocus="this.select()">
-                            <f:ajax event="blur" execute="pRate" render=":#{p:resolveFirstComponentWithId('tot',view).clientId} total doeDateOnlyShort profMargin batch pRate rRate" listener="#{grnCostingController.onEdit(bi)}"></f:ajax>
+                            <f:ajax event="blur" execute="pRate" render=":#{p:resolveFirstComponentWithId('tot',view).clientId} total doeDateOnlyShort profMargin batch pRate rRate :#{p:resolveFirstComponentWithId('billFinanceDetails', view).clientId}" listener="#{grnCostingController.onEdit(bi)}"></f:ajax>
                         </p:inputText>
                     </p:column>
                     <p:column
@@ -214,7 +214,7 @@
                             class="text-end text-primary w-100"
                             value="#{bi.billItemFinanceDetails.retailSaleRate}"  
                             onfocus="this.select()">
-                            <f:ajax event="blur" execute="rRate" render=":#{p:resolveFirstComponentWithId('tot',view).clientId} total doeDateOnlyShort profMargin batch pRate rRate" listener="#{grnCostingController.onEdit(bi)}"></f:ajax>
+                            <f:ajax event="blur" execute="rRate" render=":#{p:resolveFirstComponentWithId('tot',view).clientId} total doeDateOnlyShort profMargin batch pRate rRate :#{p:resolveFirstComponentWithId('billFinanceDetails', view).clientId}" listener="#{grnCostingController.onEdit(bi)}"></f:ajax>
                             <f:convertNumber pattern="#,##0.00" />
                         </p:inputText>
                     </p:column>


### PR DESCRIPTION
## Summary
- update ajax renders on GRN costing fields so finance tab updates

## Testing
- `mvn -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_684b6b163e70832f867da0ef24f4780a