### PR TITLE
Add defaults for direct issue return options

### DIFF
--- a/src/main/java/com/divudi/bean/common/ConfigOptionApplicationController.java
+++ b/src/main/java/com/divudi/bean/common/ConfigOptionApplicationController.java
@@ -89,6 +89,9 @@ public class ConfigOptionApplicationController implements Serializable {
         getBooleanValueByKey("Direct Issue Based On Retail Rate", true);
         getBooleanValueByKey("Direct Issue Based On Purchase Rate", false);
         getBooleanValueByKey("Direct Issue Based On Cost Rate", false);
+        getBooleanValueByKey("Direct Issue Return Based On Retail Rate", true);
+        getBooleanValueByKey("Direct Issue Return Based On Purchase Rate", false);
+        getBooleanValueByKey("Direct Issue Return Based On Cost Rate", false);
         getBooleanValueByKey("Show Profit Percentage in GRN", true);
     }
 


### PR DESCRIPTION
## Summary
- add boolean config defaults for directing issue returns

## Testing
- `mvn clean compile` *(fails: could not resolve maven plugins)*

------
https://chatgpt.com/codex/tasks/task_e_684be6d4e6e0832fbee792412b14c9c3