### PR TITLE
Implement bulk SMS to patients

### DIFF
--- a/src/main/java/com/divudi/bean/common/SmsController.java
+++ b/src/main/java/com/divudi/bean/common/SmsController.java
@@ -6,15 +6,20 @@
 package com.divudi.bean.common;
 
 import com.divudi.core.data.MessageType;
+import com.divudi.core.data.Sex;
 import com.divudi.core.data.hr.ReportKeyWord;
 import com.divudi.ejb.SmsManagerEjb;
+import com.divudi.core.entity.Area;
+import com.divudi.core.entity.Patient;
 import com.divudi.core.entity.Sms;
+import com.divudi.core.facade.PatientFacade;
 import com.divudi.core.facade.SmsFacade;
 import com.divudi.core.util.JsfUtil;
 import com.divudi.core.util.CommonFunctions;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Calendar;
 
 import javax.inject.Named;
 import javax.enterprise.context.SessionScoped;
@@ -39,6 +44,8 @@ public class SmsController implements Serializable {
     @EJB
     SmsFacade smsFacade;
     @EJB
+    PatientFacade patientFacade;
+    @EJB
     private SmsManagerEjb smsManager;
     /*
     Controllers
@@ -57,6 +64,15 @@ public class SmsController implements Serializable {
     private String smsMessage;
     private String smsNumber;
     private String smsOutput;
+
+    // Bulk SMS related fields
+    private Integer ageFrom;
+    private Integer ageTo;
+    private Sex sex;
+    private Area area;
+    private String smsTemplate;
+    private List<Patient> patientsForSms;
+    private List<Patient> selectedPatients;
 
     // New variable to control SMS sending
     private static boolean doNotSendAnySms = false;
@@ -289,6 +305,101 @@ public class SmsController implements Serializable {
         }
     }
 
+    public void searchPatientsForBulkSms() {
+        String j = "select p from Patient p where p.retired=false";
+        Map<String, Object> m = new HashMap<>();
+        if (sex != null) {
+            j += " and p.person.sex=:sx";
+            m.put("sx", sex);
+        }
+        if (area != null) {
+            j += " and p.person.area=:ar";
+            m.put("ar", area);
+        }
+        Date dobFrom = null;
+        Date dobTo = null;
+        if (ageFrom != null) {
+            Calendar cal = Calendar.getInstance();
+            cal.add(Calendar.YEAR, -ageFrom);
+            dobTo = cal.getTime();
+        }
+        if (ageTo != null) {
+            Calendar cal = Calendar.getInstance();
+            cal.add(Calendar.YEAR, -ageTo);
+            dobFrom = cal.getTime();
+        }
+        if (dobFrom != null) {
+            j += " and p.person.dob >= :df";
+            m.put("df", dobFrom);
+        }
+        if (dobTo != null) {
+            j += " and p.person.dob <= :dt";
+            m.put("dt", dobTo);
+        }
+        j += " order by p.person.name";
+        patientsForSms = patientFacade.findByJpql(j, m, TemporalType.DATE);
+    }
+
+    private String applyPatientPlaceholders(Patient p, String template) {
+        if (p == null || p.getPerson() == null) {
+            return template;
+        }
+        String msg = template;
+        msg = msg.replace("{name}", nvl(p.getPerson().getName()));
+        msg = msg.replace("{phone1}", nvl(p.getPerson().getPhone()));
+        msg = msg.replace("{phone2}", nvl(p.getPerson().getMobile()));
+        msg = msg.replace("{address}", nvl(p.getPerson().getAddress()));
+        msg = msg.replace("{area}", p.getPerson().getArea()!=null ? p.getPerson().getArea().getName() : "");
+        if (p.getPerson().getSex() != null) {
+            msg = msg.replace("{he/she}", p.getPerson().getSex()==Sex.Male ? "he" : "she");
+            msg = msg.replace("{sir/madam}", p.getPerson().getSex()==Sex.Male ? "sir" : "madam");
+        }
+        msg = msg.replace("{title}", p.getPerson().getTitle()!=null ? p.getPerson().getTitle().getLabel() : "");
+        return msg;
+    }
+
+    private String nvl(String s) {
+        return s == null ? "" : s;
+    }
+
+    public void sendBulkSmsToPatients() {
+        if (selectedPatients == null || selectedPatients.isEmpty()) {
+            JsfUtil.addErrorMessage("No patients selected");
+            return;
+        }
+        if (smsTemplate == null || smsTemplate.trim().isEmpty()) {
+            JsfUtil.addErrorMessage("No SMS template");
+            return;
+        }
+        for (Patient p : selectedPatients) {
+            String msg = applyPatientPlaceholders(p, smsTemplate);
+            String number = nvl(p.getPerson().getMobile());
+            if (number.isEmpty()) {
+                number = nvl(p.getPerson().getPhone());
+            }
+            if (number.isEmpty()) {
+                continue;
+            }
+            Sms s = new Sms();
+            s.setReceipientNumber(number);
+            s.setSendingMessage(msg);
+            save(s);
+            smsManager.sendSms(s);
+        }
+        JsfUtil.addSuccessMessage("SMS sending initiated");
+    }
+
+    public String navigateToSendBulkSmsToPatients() {
+        selectedPatients = null;
+        patientsForSms = null;
+        smsTemplate = null;
+        ageFrom = null;
+        ageTo = null;
+        sex = null;
+        area = null;
+        return "/admin/users/send_bulk_sms_patients?faces-redirect=true";
+    }
+
     public class SmsSummeryRow {
 
         MessageType smsType;
@@ -345,6 +456,62 @@ public class SmsController implements Serializable {
 
     public void setSmses(List<Sms> smses) {
         this.smses = smses;
+    }
+
+    public Integer getAgeFrom() {
+        return ageFrom;
+    }
+
+    public void setAgeFrom(Integer ageFrom) {
+        this.ageFrom = ageFrom;
+    }
+
+    public Integer getAgeTo() {
+        return ageTo;
+    }
+
+    public void setAgeTo(Integer ageTo) {
+        this.ageTo = ageTo;
+    }
+
+    public Sex getSex() {
+        return sex;
+    }
+
+    public void setSex(Sex sex) {
+        this.sex = sex;
+    }
+
+    public Area getArea() {
+        return area;
+    }
+
+    public void setArea(Area area) {
+        this.area = area;
+    }
+
+    public String getSmsTemplate() {
+        return smsTemplate;
+    }
+
+    public void setSmsTemplate(String smsTemplate) {
+        this.smsTemplate = smsTemplate;
+    }
+
+    public List<Patient> getPatientsForSms() {
+        return patientsForSms;
+    }
+
+    public void setPatientsForSms(List<Patient> patientsForSms) {
+        this.patientsForSms = patientsForSms;
+    }
+
+    public List<Patient> getSelectedPatients() {
+        return selectedPatients;
+    }
+
+    public void setSelectedPatients(List<Patient> selectedPatients) {
+        this.selectedPatients = selectedPatients;
     }
 
 }

--- a/src/main/webapp/admin/users/index.xhtml
+++ b/src/main/webapp/admin/users/index.xhtml
@@ -61,11 +61,17 @@
                                             value="View Non Staff Users" 
                                             icon="fa fa-user-circle"
                                             action="#{webUserController.navigateToManageUsersWithoutStaff()}" />
-                                        <p:commandButton 
-                                            ajax="false" 
-                                            value="View Retired Users" 
+                                        <p:commandButton
+                                            ajax="false"
+                                            value="View Retired Users"
                                             icon="fa fa-user-slash"
                                             action="#{webUserController.navigateToListRetiredUsers()}" />
+
+                                        <p:commandButton
+                                            ajax="false"
+                                            value="Send Bulk SMS to Patients"
+                                            icon="fa fa-envelope"
+                                            action="#{smsController.navigateToSendBulkSmsToPatients()}" />
 
                                         <hr/>
                                     </div>

--- a/src/main/webapp/admin/users/send_bulk_sms_patients.xhtml
+++ b/src/main/webapp/admin/users/send_bulk_sms_patients.xhtml
@@ -1,0 +1,65 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
+      xmlns:h="http://xmlns.jcp.org/jsf/html"
+      xmlns:p="http://primefaces.org/ui"
+      xmlns:f="http://xmlns.jcp.org/jsf/core">
+    <h:body>
+        <ui:composition template="/admin/users/index.xhtml">
+            <ui:define name="subcontent">
+                <h:panelGroup rendered="#{!webUserController.hasPrivilege('AdminManagingUsers') and !sessionController.firstLogin }" >
+                    <h:outputText value="You are NOT authorized"/>
+                </h:panelGroup>
+
+                <h:panelGroup rendered="#{webUserController.hasPrivilege('AdminManagingUsers') or sessionController.firstLogin }" >
+                    <h:form id="form">
+                        <p:panel header="Send Bulk SMS to Patients">
+                            <h:panelGrid columns="4" class="w-100 p-2" >
+                                <h:outputLabel value="Age From"/>
+                                <p:inputText value="#{smsController.ageFrom}"/>
+                                <h:outputLabel value="Age To"/>
+                                <p:inputText value="#{smsController.ageTo}"/>
+
+                                <h:outputLabel value="Sex"/>
+                                <p:selectOneMenu value="#{smsController.sex}" >
+                                    <f:selectItem itemLabel="Select Sex" itemValue="" />
+                                    <f:selectItems value="#{sexController.items}" var="s" itemLabel="#{s}" itemValue="#{s}"/>
+                                </p:selectOneMenu>
+
+                                <h:outputLabel value="Area"/>
+                                <p:autoComplete value="#{smsController.area}" completeMethod="#{areaController.completeArea}" var="a" itemLabel="#{a.name}" itemValue="#{a}" forceSelection="true"/>
+
+                                <h:outputLabel value=""/>
+                                <p:commandButton value="Search" action="#{smsController.searchPatientsForBulkSms}" update="tbl" icon="fa fa-search" class="ui-button-warning"/>
+                            </h:panelGrid>
+
+                            <p:dataTable id="tbl" value="#{smsController.patientsForSms}" var="pt" rowKey="#{pt.id}" selection="#{smsController.selectedPatients}" selectionMode="multiple" paginator="true" rows="10" paginatorAlwaysVisible="false" class="w-100 mt-3" rowsPerPageTemplate="5,10,20">
+                                <p:column selectionMode="multiple" style="width:3%"/>
+                                <p:column headerText="Name">
+                                    <h:outputText value="#{pt.person.name}"/>
+                                </p:column>
+                                <p:column headerText="Phone">
+                                    <h:outputText value="#{pt.person.phone}"/>
+                                </p:column>
+                                <p:column headerText="Mobile">
+                                    <h:outputText value="#{pt.person.mobile}"/>
+                                </p:column>
+                                <p:column headerText="Area">
+                                    <h:outputText value="#{pt.person.area.name}"/>
+                                </p:column>
+                            </p:dataTable>
+
+                            <h:panelGrid columns="2" class="w-100 mt-3" >
+                                <h:outputLabel value="SMS Template"/>
+                                <p:inputTextarea value="#{smsController.smsTemplate}" class="w-100"/>
+                                <p:spacer/>
+                                <p:commandButton value="Send SMS" action="#{smsController.sendBulkSmsToPatients}" icon="fa fa-paper-plane" update="@form" class="ui-button-success"/>
+                            </h:panelGrid>
+                        </p:panel>
+                    </h:form>
+                </h:panelGroup>
+            </ui:define>
+        </ui:composition>
+    </h:body>
+</html>


### PR DESCRIPTION
## Summary
- add a bulk SMS page for patient selection
- navigate to new page from the user admin section
- support searching patients by age, sex and area
- send personalised SMS to selected patients

## Testing
- `mvn -q -DskipTests package` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684be6bc839c832fb0d93474083795b0