### PR TITLE
Update return controllers to use configurable cost rate

### DIFF
--- a/src/main/java/com/divudi/bean/pharmacy/GoodsReturnController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/GoodsReturnController.java
@@ -6,6 +6,7 @@ package com.divudi.bean.pharmacy;
 
 import com.divudi.bean.common.SessionController;
 import com.divudi.core.util.JsfUtil;
+import com.divudi.bean.common.ConfigOptionApplicationController;
 import com.divudi.core.data.BillClassType;
 import com.divudi.core.data.BillNumberSuffix;
 import com.divudi.core.data.BillType;
@@ -78,6 +79,8 @@ public class GoodsReturnController implements Serializable {
     private PharmacyController pharmacyController;
     @Inject
     private SessionController sessionController;
+    @Inject
+    private ConfigOptionApplicationController configOptionApplicationController;
     /**
      * Properties
      */
@@ -192,7 +195,13 @@ public class GoodsReturnController implements Serializable {
             }
 
             i.setBill(getReturnBill());
-            i.setNetValue(i.getPharmaceuticalBillItem().getQtyInUnit() * i.getPharmaceuticalBillItem().getPurchaseRateInUnit());
+            double rate = i.getPharmaceuticalBillItem().getPurchaseRateInUnit();
+            if (configOptionApplicationController.getBooleanValueByKey("Direct Issue Return Based On Cost Rate", false)
+                    && i.getBillItemFinanceDetails() != null
+                    && i.getBillItemFinanceDetails().getLineCostRate() != null) {
+                rate = i.getBillItemFinanceDetails().getLineCostRate().doubleValue();
+            }
+            i.setNetValue(i.getPharmaceuticalBillItem().getQtyInUnit() * rate);
             i.setCreatedAt(Calendar.getInstance().getTime());
             i.setCreater(getSessionController().getLoggedUser());
 
@@ -233,7 +242,13 @@ public class GoodsReturnController implements Serializable {
             }
 
             i.setBill(getReturnBill());
-            i.setNetValue(i.getPharmaceuticalBillItem().getQtyInUnit() * i.getPharmaceuticalBillItem().getPurchaseRateInUnit());
+            double rate = i.getPharmaceuticalBillItem().getPurchaseRateInUnit();
+            if (configOptionApplicationController.getBooleanValueByKey("Direct Issue Return Based On Cost Rate", false)
+                    && i.getBillItemFinanceDetails() != null
+                    && i.getBillItemFinanceDetails().getLineCostRate() != null) {
+                rate = i.getBillItemFinanceDetails().getLineCostRate().doubleValue();
+            }
+            i.setNetValue(i.getPharmaceuticalBillItem().getQtyInUnit() * rate);
             i.setCreatedAt(Calendar.getInstance().getTime());
             i.setCreater(getSessionController().getLoggedUser());
 
@@ -386,7 +401,13 @@ public class GoodsReturnController implements Serializable {
         double grossTotal = 0.0;
         int serialNo = 0;
         for (BillItem p : getBillItems()) {
-            grossTotal += p.getPharmaceuticalBillItem().getPurchaseRate() * p.getTmpQty();
+            double rate = p.getPharmaceuticalBillItem().getPurchaseRate();
+            if (configOptionApplicationController.getBooleanValueByKey("Direct Issue Return Based On Cost Rate", false)
+                    && p.getBillItemFinanceDetails() != null
+                    && p.getBillItemFinanceDetails().getLineCostRate() != null) {
+                rate = p.getBillItemFinanceDetails().getLineCostRate().doubleValue();
+            }
+            grossTotal += rate * p.getTmpQty();
             p.setSearialNo(serialNo++);
         }
 
@@ -556,6 +577,14 @@ public class GoodsReturnController implements Serializable {
 
     public void setSessionController(SessionController sessionController) {
         this.sessionController = sessionController;
+    }
+
+    public ConfigOptionApplicationController getConfigOptionApplicationController() {
+        return configOptionApplicationController;
+    }
+
+    public void setConfigOptionApplicationController(ConfigOptionApplicationController configOptionApplicationController) {
+        this.configOptionApplicationController = configOptionApplicationController;
     }
 
     public BillNumberGenerator getBillNumberBean() {

--- a/src/main/java/com/divudi/bean/pharmacy/PurchaseReturnController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PurchaseReturnController.java
@@ -6,6 +6,7 @@ package com.divudi.bean.pharmacy;
 
 import com.divudi.bean.common.SessionController;
 import com.divudi.core.util.JsfUtil;
+import com.divudi.bean.common.ConfigOptionApplicationController;
 import com.divudi.core.data.BillClassType;
 import com.divudi.core.data.BillNumberSuffix;
 import com.divudi.core.data.BillType;
@@ -81,6 +82,8 @@ public class PurchaseReturnController implements Serializable {
     private PharmacyController pharmacyController;
     @Inject
     private SessionController sessionController;
+    @Inject
+    private ConfigOptionApplicationController configOptionApplicationController;
     /**
      * Properties
      *
@@ -189,7 +192,13 @@ public class PurchaseReturnController implements Serializable {
                 continue;
             }
 
-            i.setNetValue(i.getPharmaceuticalBillItem().getQtyInUnit() * i.getPharmaceuticalBillItem().getPurchaseRateInUnit());
+            double rate = i.getPharmaceuticalBillItem().getPurchaseRateInUnit();
+            if (configOptionApplicationController.getBooleanValueByKey("Direct Issue Return Based On Cost Rate", false)
+                    && i.getBillItemFinanceDetails() != null
+                    && i.getBillItemFinanceDetails().getLineCostRate() != null) {
+                rate = i.getBillItemFinanceDetails().getLineCostRate().doubleValue();
+            }
+            i.setNetValue(i.getPharmaceuticalBillItem().getQtyInUnit() * rate);
             i.setCreatedAt(Calendar.getInstance().getTime());
             i.setCreater(getSessionController().getLoggedUser());
 
@@ -231,7 +240,13 @@ public class PurchaseReturnController implements Serializable {
                 continue;
             }
 
-            i.setNetValue(i.getPharmaceuticalBillItem().getQtyInUnit() * i.getPharmaceuticalBillItem().getPurchaseRateInUnit());
+            double rate = i.getPharmaceuticalBillItem().getPurchaseRateInUnit();
+            if (configOptionApplicationController.getBooleanValueByKey("Direct Issue Return Based On Cost Rate", false)
+                    && i.getBillItemFinanceDetails() != null
+                    && i.getBillItemFinanceDetails().getLineCostRate() != null) {
+                rate = i.getBillItemFinanceDetails().getLineCostRate().doubleValue();
+            }
+            i.setNetValue(i.getPharmaceuticalBillItem().getQtyInUnit() * rate);
             i.setCreatedAt(Calendar.getInstance().getTime());
             i.setCreater(getSessionController().getLoggedUser());
 
@@ -311,7 +326,13 @@ public class PurchaseReturnController implements Serializable {
         double grossTotal = 0.0;
 
         for (BillItem p : getBillItems()) {
-            grossTotal += p.getPharmaceuticalBillItem().getPurchaseRate() * p.getQty();
+            double rate = p.getPharmaceuticalBillItem().getPurchaseRate();
+            if (configOptionApplicationController.getBooleanValueByKey("Direct Issue Return Based On Cost Rate", false)
+                    && p.getBillItemFinanceDetails() != null
+                    && p.getBillItemFinanceDetails().getLineCostRate() != null) {
+                rate = p.getBillItemFinanceDetails().getLineCostRate().doubleValue();
+            }
+            grossTotal += rate * p.getQty();
 
         }
 
@@ -458,6 +479,14 @@ public class PurchaseReturnController implements Serializable {
 
     public void setSessionController(SessionController sessionController) {
         this.sessionController = sessionController;
+    }
+
+    public ConfigOptionApplicationController getConfigOptionApplicationController() {
+        return configOptionApplicationController;
+    }
+
+    public void setConfigOptionApplicationController(ConfigOptionApplicationController configOptionApplicationController) {
+        this.configOptionApplicationController = configOptionApplicationController;
     }
 
     public BillNumberGenerator getBillNumberBean() {


### PR DESCRIPTION
## Summary
- inject `ConfigOptionApplicationController` into `GoodsReturnController` and `PurchaseReturnController`
- calculate return item values based on cost rate when `Direct Issue Return Based On Cost Rate` is enabled
- update totals using the selected rate

## Testing
- `mvn` command was unavailable, so compilation/tests were not run

------
https://chatgpt.com/codex/tasks/task_e_684be78a76e0832fbc6d0f5b337df585