### PR TITLE
Implement shared return rate helper

### DIFF
--- a/src/main/java/com/divudi/bean/pharmacy/GoodsReturnController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/GoodsReturnController.java
@@ -187,6 +187,16 @@ public class GoodsReturnController implements Serializable {
 
     }
 
+    private double getReturnRate(BillItem item) {
+        double rate = item.getPharmaceuticalBillItem().getPurchaseRateInUnit();
+        if (configOptionApplicationController.getBooleanValueByKey("Direct Issue Return Based On Cost Rate", false)
+                && item.getBillItemFinanceDetails() != null
+                && item.getBillItemFinanceDetails().getLineCostRate() != null) {
+            rate = item.getBillItemFinanceDetails().getLineCostRate().doubleValue();
+        }
+        return rate;
+    }
+
     private void saveComponent() {
         for (BillItem i : getBillItems()) {
 
@@ -195,12 +205,7 @@ public class GoodsReturnController implements Serializable {
             }
 
             i.setBill(getReturnBill());
-            double rate = i.getPharmaceuticalBillItem().getPurchaseRateInUnit();
-            if (configOptionApplicationController.getBooleanValueByKey("Direct Issue Return Based On Cost Rate", false)
-                    && i.getBillItemFinanceDetails() != null
-                    && i.getBillItemFinanceDetails().getLineCostRate() != null) {
-                rate = i.getBillItemFinanceDetails().getLineCostRate().doubleValue();
-            }
+            double rate = getReturnRate(i);
             i.setNetValue(i.getPharmaceuticalBillItem().getQtyInUnit() * rate);
             i.setCreatedAt(Calendar.getInstance().getTime());
             i.setCreater(getSessionController().getLoggedUser());
@@ -242,12 +247,7 @@ public class GoodsReturnController implements Serializable {
             }
 
             i.setBill(getReturnBill());
-            double rate = i.getPharmaceuticalBillItem().getPurchaseRateInUnit();
-            if (configOptionApplicationController.getBooleanValueByKey("Direct Issue Return Based On Cost Rate", false)
-                    && i.getBillItemFinanceDetails() != null
-                    && i.getBillItemFinanceDetails().getLineCostRate() != null) {
-                rate = i.getBillItemFinanceDetails().getLineCostRate().doubleValue();
-            }
+            double rate = getReturnRate(i);
             i.setNetValue(i.getPharmaceuticalBillItem().getQtyInUnit() * rate);
             i.setCreatedAt(Calendar.getInstance().getTime());
             i.setCreater(getSessionController().getLoggedUser());
@@ -401,12 +401,7 @@ public class GoodsReturnController implements Serializable {
         double grossTotal = 0.0;
         int serialNo = 0;
         for (BillItem p : getBillItems()) {
-            double rate = p.getPharmaceuticalBillItem().getPurchaseRate();
-            if (configOptionApplicationController.getBooleanValueByKey("Direct Issue Return Based On Cost Rate", false)
-                    && p.getBillItemFinanceDetails() != null
-                    && p.getBillItemFinanceDetails().getLineCostRate() != null) {
-                rate = p.getBillItemFinanceDetails().getLineCostRate().doubleValue();
-            }
+            double rate = getReturnRate(p);
             grossTotal += rate * p.getTmpQty();
             p.setSearialNo(serialNo++);
         }

--- a/src/main/java/com/divudi/bean/pharmacy/PurchaseReturnController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PurchaseReturnController.java
@@ -184,6 +184,16 @@ public class PurchaseReturnController implements Serializable {
 
     }
 
+    private double getReturnRate(BillItem item) {
+        double rate = item.getPharmaceuticalBillItem().getPurchaseRateInUnit();
+        if (configOptionApplicationController.getBooleanValueByKey("Direct Issue Return Based On Cost Rate", false)
+                && item.getBillItemFinanceDetails() != null
+                && item.getBillItemFinanceDetails().getLineCostRate() != null) {
+            rate = item.getBillItemFinanceDetails().getLineCostRate().doubleValue();
+        }
+        return rate;
+    }
+
     private void saveComponent() {
         for (BillItem i : getBillItems()) {
             i.getPharmaceuticalBillItem().setQtyInUnit(0 - i.getQty());
@@ -192,12 +202,7 @@ public class PurchaseReturnController implements Serializable {
                 continue;
             }
 
-            double rate = i.getPharmaceuticalBillItem().getPurchaseRateInUnit();
-            if (configOptionApplicationController.getBooleanValueByKey("Direct Issue Return Based On Cost Rate", false)
-                    && i.getBillItemFinanceDetails() != null
-                    && i.getBillItemFinanceDetails().getLineCostRate() != null) {
-                rate = i.getBillItemFinanceDetails().getLineCostRate().doubleValue();
-            }
+            double rate = getReturnRate(i);
             i.setNetValue(i.getPharmaceuticalBillItem().getQtyInUnit() * rate);
             i.setCreatedAt(Calendar.getInstance().getTime());
             i.setCreater(getSessionController().getLoggedUser());
@@ -240,12 +245,7 @@ public class PurchaseReturnController implements Serializable {
                 continue;
             }
 
-            double rate = i.getPharmaceuticalBillItem().getPurchaseRateInUnit();
-            if (configOptionApplicationController.getBooleanValueByKey("Direct Issue Return Based On Cost Rate", false)
-                    && i.getBillItemFinanceDetails() != null
-                    && i.getBillItemFinanceDetails().getLineCostRate() != null) {
-                rate = i.getBillItemFinanceDetails().getLineCostRate().doubleValue();
-            }
+            double rate = getReturnRate(i);
             i.setNetValue(i.getPharmaceuticalBillItem().getQtyInUnit() * rate);
             i.setCreatedAt(Calendar.getInstance().getTime());
             i.setCreater(getSessionController().getLoggedUser());
@@ -326,12 +326,7 @@ public class PurchaseReturnController implements Serializable {
         double grossTotal = 0.0;
 
         for (BillItem p : getBillItems()) {
-            double rate = p.getPharmaceuticalBillItem().getPurchaseRate();
-            if (configOptionApplicationController.getBooleanValueByKey("Direct Issue Return Based On Cost Rate", false)
-                    && p.getBillItemFinanceDetails() != null
-                    && p.getBillItemFinanceDetails().getLineCostRate() != null) {
-                rate = p.getBillItemFinanceDetails().getLineCostRate().doubleValue();
-            }
+            double rate = getReturnRate(p);
             grossTotal += rate * p.getQty();
 
         }


### PR DESCRIPTION
## Summary
- add `getReturnRate()` helper to `GoodsReturnController`
- add `getReturnRate()` helper to `PurchaseReturnController`
- reuse new helper when updating bill items and totals

## Testing
- `mvn -q test` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684bea4e514c832fa3033610dc89ada1