### PR TITLE
Adjust purchase return config options

### DIFF
--- a/src/main/java/com/divudi/bean/common/ConfigOptionApplicationController.java
+++ b/src/main/java/com/divudi/bean/common/ConfigOptionApplicationController.java
@@ -89,9 +89,9 @@ public class ConfigOptionApplicationController implements Serializable {
         getBooleanValueByKey("Direct Issue Based On Retail Rate", true);
         getBooleanValueByKey("Direct Issue Based On Purchase Rate", false);
         getBooleanValueByKey("Direct Issue Based On Cost Rate", false);
-        getBooleanValueByKey("Direct Purchase Return Based On Retail Rate", true);
-        getBooleanValueByKey("Direct Purchase Return Based On Purchase Rate", false);
-        getBooleanValueByKey("Direct Purchase Return Based On Cost Rate", false);
+        getBooleanValueByKey("Direct Purchase Return Based On Purchase Rate", true);
+        getBooleanValueByKey("Direct Purchase Return Based On Line Cost Rate", false);
+        getBooleanValueByKey("Direct Purchase Return Based On Total Cost Rate", false);
         getBooleanValueByKey("Show Profit Percentage in GRN", true);
     }
 

--- a/src/main/java/com/divudi/bean/pharmacy/GoodsReturnController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/GoodsReturnController.java
@@ -187,14 +187,28 @@ public class GoodsReturnController implements Serializable {
 
     }
 
-    private double getReturnRate(BillItem item) {
+    public double getReturnRate(BillItem item) {
         double rate = item.getPharmaceuticalBillItem().getPurchaseRateInUnit();
-        if (configOptionApplicationController.getBooleanValueByKey("Direct Purchase Return Based On Cost Rate", false)
+        if (configOptionApplicationController.getBooleanValueByKey("Direct Purchase Return Based On Line Cost Rate", false)
                 && item.getBillItemFinanceDetails() != null
                 && item.getBillItemFinanceDetails().getLineCostRate() != null) {
             rate = item.getBillItemFinanceDetails().getLineCostRate().doubleValue();
+        } else if (configOptionApplicationController.getBooleanValueByKey("Direct Purchase Return Based On Total Cost Rate", false)
+                && item.getBillItemFinanceDetails() != null
+                && item.getBillItemFinanceDetails().getTotalCostRate() != null) {
+            rate = item.getBillItemFinanceDetails().getTotalCostRate().doubleValue();
         }
         return rate;
+    }
+
+    public String getReturnRateLabel() {
+        if (configOptionApplicationController.getBooleanValueByKey("Direct Purchase Return Based On Line Cost Rate", false)) {
+            return "Line Cost Rate";
+        }
+        if (configOptionApplicationController.getBooleanValueByKey("Direct Purchase Return Based On Total Cost Rate", false)) {
+            return "Total Cost Rate";
+        }
+        return "Purchase Rate";
     }
 
     private void saveComponent() {

--- a/src/main/java/com/divudi/bean/pharmacy/PurchaseReturnController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PurchaseReturnController.java
@@ -184,14 +184,28 @@ public class PurchaseReturnController implements Serializable {
 
     }
 
-    private double getReturnRate(BillItem item) {
+    public double getReturnRate(BillItem item) {
         double rate = item.getPharmaceuticalBillItem().getPurchaseRateInUnit();
-        if (configOptionApplicationController.getBooleanValueByKey("Direct Purchase Return Based On Cost Rate", false)
+        if (configOptionApplicationController.getBooleanValueByKey("Direct Purchase Return Based On Line Cost Rate", false)
                 && item.getBillItemFinanceDetails() != null
                 && item.getBillItemFinanceDetails().getLineCostRate() != null) {
             rate = item.getBillItemFinanceDetails().getLineCostRate().doubleValue();
+        } else if (configOptionApplicationController.getBooleanValueByKey("Direct Purchase Return Based On Total Cost Rate", false)
+                && item.getBillItemFinanceDetails() != null
+                && item.getBillItemFinanceDetails().getTotalCostRate() != null) {
+            rate = item.getBillItemFinanceDetails().getTotalCostRate().doubleValue();
         }
         return rate;
+    }
+
+    public String getReturnRateLabel() {
+        if (configOptionApplicationController.getBooleanValueByKey("Direct Purchase Return Based On Line Cost Rate", false)) {
+            return "Line Cost Rate";
+        }
+        if (configOptionApplicationController.getBooleanValueByKey("Direct Purchase Return Based On Total Cost Rate", false)) {
+            return "Total Cost Rate";
+        }
+        return "Purchase Rate";
     }
 
     private void saveComponent() {

--- a/src/main/webapp/pharmacy/pharmacy_return_good.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_return_good.xhtml
@@ -46,14 +46,14 @@
                                     <h:outputText id="freeQty" value="#{ph.referanceBillItem.pharmaceuticalBillItem.freeQty}" />
                                 </p:column>
 
-                                <p:column headerText="Purchase Rate" style="width:25px!important;">
-                                    <h:panelGroup id="purchase" >
-                                        <h:outputText  value="#{ph.pharmaceuticalBillItem.purchaseRate}"  >
-                                            <f:convertNumber pattern="#,##0.00" />
-                                        </h:outputText>
-                                        <h:outputText value="perPack" rendered="#{ph.item.class eq 'class com.divudi.core.entity.pharmacy.Ampp'}" />
-                                    </h:panelGroup>
-                                </p:column>
+                                  <p:column headerText="#{goodsReturnController.returnRateLabel}" style="width:25px!important;">
+                                      <h:panelGroup id="purchase" >
+                                          <h:outputText  value="#{goodsReturnController.getReturnRate(ph)}"  >
+                                              <f:convertNumber pattern="#,##0.00" />
+                                          </h:outputText>
+                                          <h:outputText value="perPack" rendered="#{ph.item.class eq 'class com.divudi.core.entity.pharmacy.Ampp'}" />
+                                      </h:panelGroup>
+                                  </p:column>
 
 
                                 <p:column headerText="Batch No" style="width:25px!important;">

--- a/src/main/webapp/pharmacy/pharmacy_return_purchase.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_return_purchase.xhtml
@@ -66,9 +66,9 @@
                         <h:outputText id="qty" value="#{ph.pharmaceuticalBillItem.qty}" />
                     </p:column>
 
-                    <p:column headerText="Purchase Rate" style="width:25px!important;">
+                    <p:column headerText="#{purchaseReturnController.returnRateLabel}" style="width:25px!important;">
                         <h:panelGroup id="purchase" >
-                            <h:outputText  value="#{ph.pharmaceuticalBillItem.purchaseRate}"  >
+                            <h:outputText  value="#{purchaseReturnController.getReturnRate(ph)}"  >
                                   <f:convertNumber pattern="#,##0.00" />
                             </h:outputText>
                             <h:outputText value="perPack" rendered="#{ph.item.class eq 'class com.divudi.core.entity.pharmacy.Ampp'}" />


### PR DESCRIPTION
## Summary
- add new configuration options for purchase return cost rates
- update return rate calculation for purchase and goods returns
- show selected rate in purchase/goods return UIs

## Testing
- `mvn -q -DskipTests install` *(fails: `mvn: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_684bfaa0038c832f9d6bee5b0d2670a1