### PR TITLE
Add purchase return quantity config defaults

### DIFF
--- a/src/main/java/com/divudi/bean/common/ConfigOptionApplicationController.java
+++ b/src/main/java/com/divudi/bean/common/ConfigOptionApplicationController.java
@@ -92,6 +92,8 @@ public class ConfigOptionApplicationController implements Serializable {
         getBooleanValueByKey("Direct Purchase Return Based On Purchase Rate", true);
         getBooleanValueByKey("Direct Purchase Return Based On Line Cost Rate", false);
         getBooleanValueByKey("Direct Purchase Return Based On Total Cost Rate", false);
+        getBooleanValueByKey("Direct Purchase Return by Quantity and Free Quantity", true);
+        getBooleanValueByKey("Direct Purchase Return by Total Quantity", false);
         getBooleanValueByKey("Show Profit Percentage in GRN", true);
     }
 


### PR DESCRIPTION
## Summary
- update pharmacy config defaults with purchase return quantity options

## Testing
- `mvn -q test` *(fails: Network is unreachable for repo.maven.apache.org)*

------
https://chatgpt.com/codex/tasks/task_e_684c293491f0832f90fe4efa24baebca