### PR TITLE
Add total quantity mode for purchase returns

### DIFF
--- a/src/main/java/com/divudi/bean/pharmacy/PurchaseReturnController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PurchaseReturnController.java
@@ -130,16 +130,42 @@ public class PurchaseReturnController implements Serializable {
     private PharmacyCalculation pharmacyRecieveBean;
 
     private double getRemainingQty(BillItem bilItem) {
-        String sql = "Select sum(p.pharmaceuticalBillItem.qty) from BillItem p where"
+        if (configOptionApplicationController.getBooleanValueByKey("Direct Purchase Return by Total Quantity", false)) {
+            double originalQty = bilItem.getQty();
+            double originalFreeQty = 0.0;
+            if (bilItem.getPharmaceuticalBillItem() != null) {
+                originalFreeQty = bilItem.getPharmaceuticalBillItem().getFreeQty();
+            }
+            double returnedTotal = getPharmacyRecieveBean().getTotalQtyWithFreeQty(bilItem, BillType.PurchaseReturn, new BilledBill());
+            return originalQty + originalFreeQty - Math.abs(returnedTotal);
+        } else {
+            String sql = "Select sum(p.pharmaceuticalBillItem.qty) from BillItem p where"
+                    + "   p.creater is not null and"
+                    + " p.referanceBillItem=:bt and p.bill.billType=:btp";
+
+            HashMap hm = new HashMap();
+            hm.put("bt", bilItem);
+            hm.put("btp", BillType.PurchaseReturn);
+
+            return bilItem.getQty() + getPharmaceuticalBillItemFacade().findDoubleByJpql(sql, hm);
+        }
+    }
+
+    private double getRemainingFreeQty(BillItem bilItem) {
+        String sql = "Select sum(p.pharmaceuticalBillItem.freeQty) from BillItem p where"
                 + "   p.creater is not null and"
                 + " p.referanceBillItem=:bt and p.bill.billType=:btp";
 
         HashMap hm = new HashMap();
         hm.put("bt", bilItem);
         hm.put("btp", BillType.PurchaseReturn);
-        ///    hm.put("class", bill.getClass());
 
-        return bilItem.getQty() + getPharmaceuticalBillItemFacade().findDoubleByJpql(sql, hm);
+        double originalFreeQty = 0.0;
+        if (bilItem.getPharmaceuticalBillItem() != null) {
+            originalFreeQty = bilItem.getPharmaceuticalBillItem().getFreeQty();
+        }
+
+        return originalFreeQty + getPharmaceuticalBillItemFacade().findDoubleByJpql(sql, hm);
     }
 
     public void onEdit(BillItem tmp) {
@@ -149,6 +175,14 @@ public class PurchaseReturnController implements Serializable {
         if (tmp.getQty() > remain) {
             tmp.setQty(remain);
             JsfUtil.addErrorMessage("You cant return over than ballanced Qty ");
+        }
+
+        if (!configOptionApplicationController.getBooleanValueByKey("Direct Purchase Return by Total Quantity", false)) {
+            double remainFree = getRemainingFreeQty(tmp.getReferanceBillItem());
+            if (tmp.getPharmaceuticalBillItem().getFreeQty() > remainFree) {
+                tmp.getPharmaceuticalBillItem().setFreeQty(remainFree);
+                JsfUtil.addErrorMessage("You cant return over than ballanced Free Qty ");
+            }
         }
 
         calTotal();
@@ -367,11 +401,19 @@ public class PurchaseReturnController implements Serializable {
             tmp.copy(i);
             tmp.setBillItem(bi);
 
-            double rBilled = getPharmacyRecieveBean().getTotalQty(i.getBillItem(), BillType.PurchaseReturn, new BilledBill());
+            double originalQty = i.getQty();
+            double originalFreeQty = i.getFreeQty();
 
-            //System.err.println("Billed Qty " + i.getQty());
-            //System.err.println("Return Qty " + rBilled);
-            tmp.setQty(i.getQty() - Math.abs(rBilled));
+            if (configOptionApplicationController.getBooleanValueByKey("Direct Purchase Return by Total Quantity", false)) {
+                double returnedTotal = getPharmacyRecieveBean().getTotalQtyWithFreeQty(i.getBillItem(), BillType.PurchaseReturn, new BilledBill());
+                tmp.setQty(originalQty + originalFreeQty - Math.abs(returnedTotal));
+                tmp.setFreeQty(0.0);
+            } else {
+                double returnedQty = getPharmacyRecieveBean().getTotalQty(i.getBillItem(), BillType.PurchaseReturn, new BilledBill());
+                double returnedFreeQty = getPharmacyRecieveBean().getTotalFreeQty(i.getBillItem(), BillType.PurchaseReturn, new BilledBill());
+                tmp.setQty(originalQty - Math.abs(returnedQty));
+                tmp.setFreeQty(originalFreeQty - Math.abs(returnedFreeQty));
+            }
 
             bi.setPharmaceuticalBillItem(tmp);
 


### PR DESCRIPTION
## Summary
- support configuration for calculating purchase return remaining qty by total qty
- compute free qty remainder when returning separately
- validate free qty and qty depending on config

## Testing
- `mvn -q -DskipTests package` *(fails: Could not transfer artifact)*

------
https://chatgpt.com/codex/tasks/task_e_684c2c9aabd4832f9b106095ac66792e