### PR TITLE
Implement dynamic quantity headers in purchase return page

### DIFF
--- a/src/main/webapp/pharmacy/pharmacy_return_purchase.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_return_purchase.xhtml
@@ -62,7 +62,10 @@
                         <h:outputLabel value="#{ph.item.name}"/>
                     </p:column>
 
-                    <p:column  headerText="Balance Qty in Unit" style="width:25px!important;">
+                    <p:column  style="width:25px!important;">
+                        <f:facet name="header">
+                            <h:outputText value="#{configOptionApplicationController.getBooleanValueByKey('Direct Purchase Return by Total Quantity', false) ? 'Balance Total Qty in Unit' : 'Balance Qty in Unit'}" />
+                        </f:facet>
                         <h:outputText id="qty" value="#{ph.pharmaceuticalBillItem.qty}" />
                     </p:column>
 
@@ -85,17 +88,20 @@
                     </p:column>
 
 
-                    <p:column headerText="Returning Qty in Unit" style="width:25px!important;">
-                        <p:inputText autocomplete="off" value="#{ph.qty}" >
-                            <f:ajax event="blur" render="@this :#{p:resolveFirstComponentWithId('total',view).clientId} "  listener="#{purchaseReturnController.onEdit(ph)}" ></f:ajax>
-                        </p:inputText>
+                    <p:column style="width:25px!important;">
+                        <p:panel header="#{configOptionApplicationController.getBooleanValueByKey('Direct Purchase Return by Total Quantity', false) ? 'Returning Total Qty in Unit' : 'Returning Qty in Unit'}" style="margin:0;padding:0;border:0;">
+                            <p:inputText autocomplete="off" value="#{ph.qty}">
+                                <f:ajax event="blur" render="@this :#{p:resolveFirstComponentWithId('total',view).clientId}" listener="#{purchaseReturnController.onEdit(ph)}" />
+                            </p:inputText>
+                        </p:panel>
                     </p:column>
 
                      <p:column
                          headerText="Returning Free Qty in Unit"
-                         style="width:25px!important;">
-                         <p:inputText autocomplete="off" value="#{ph.pharmaceuticalBillItem.freeQty}" >
-                            <f:ajax event="blur" render="@this :#{p:resolveFirstComponentWithId('total',view).clientId} "  listener="#{purchaseReturnController.onEdit(ph)}" ></f:ajax>
+                         style="width:25px!important;"
+                         rendered="#{configOptionApplicationController.getBooleanValueByKey('Direct Purchase Return by Quantity and Free Quantity', false)}">
+                         <p:inputText autocomplete="off" value="#{ph.pharmaceuticalBillItem.freeQty}">
+                            <f:ajax event="blur" render="@this :#{p:resolveFirstComponentWithId('total',view).clientId}"  listener="#{purchaseReturnController.onEdit(ph)}" />
                         </p:inputText>
                     </p:column>
 


### PR DESCRIPTION
## Summary
- switch balance column header to show total quantity label when needed
- wrap returning quantity field in panel with dynamic header
- show free quantity column only when configured

## Testing
- `mvn -q -DskipTests package` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c30ce5ad8832f869b861250b94c83