### PR TITLE
Add bulk SMS to numbers feature

### DIFF
--- a/src/main/java/com/divudi/bean/common/SmsController.java
+++ b/src/main/java/com/divudi/bean/common/SmsController.java
@@ -418,6 +418,10 @@ public class SmsController implements Serializable {
     }
 
     public void sendBulkSmsToNumbers() {
++        if (doNotSendAnySms) {
++            JsfUtil.addErrorMessage("SMS sending is disabled");
++            return;
++        }
         if (smsNumbersInput == null || smsNumbersInput.trim().isEmpty()) {
             JsfUtil.addErrorMessage("No numbers specified");
             return;
@@ -426,12 +430,17 @@ public class SmsController implements Serializable {
             JsfUtil.addErrorMessage("No SMS message specified");
             return;
         }
-        String[] arr = smsNumbersInput.split("[\n,]+");
-        for (String n : arr) {
+-       String[] arr = smsNumbersInput.split("[\n,]+");
+-       for (String n : arr) {
++       Set<String> uniqueNumbers = new HashSet<>();
++       for (String n : smsNumbersInput.split("[\\s,\\n]+")) {
             String number = n.trim();
             if (number.isEmpty()) {
                 continue;
             }
++           if (!uniqueNumbers.add(number)) {
++               continue; // skip duplicates
++           }
             Sms s = new Sms();
             s.setReceipientNumber(number);
             s.setSendingMessage(smsMessage.trim());

--- a/src/main/java/com/divudi/bean/common/SmsController.java
+++ b/src/main/java/com/divudi/bean/common/SmsController.java
@@ -126,8 +126,6 @@ public class SmsController implements Serializable {
     }
 
     public void sendSmsFromWeb() {
-        System.out.println("sendSmsFromWeb");
-        System.out.println("doNotSendAnySms = " + doNotSendAnySms);
         if (doNotSendAnySms) {
             return;
         }
@@ -310,7 +308,11 @@ public class SmsController implements Serializable {
     }
 
     public void searchPatientsForBulkSms() {
-        System.out.println("searchPatientsForBulkSms");
+        if (doNotSendAnySms) {
+            JsfUtil.addErrorMessage("SMS sending is disabled");
+            return;
+        }
+
         String j = "select p from Patient p where p.retired=false";
         Map<String, Object> m = new HashMap<>();
         if (sex != null) {
@@ -342,10 +344,7 @@ public class SmsController implements Serializable {
             m.put("dt", dobTo);
         }
         j += " order by p.person.name";
-        System.out.println("j = " + j);
-        System.out.println("m = " + m);
         patientsForSms = patientFacade.findByJpql(j, m, TemporalType.DATE, maxNumberToList.intValue());
-        System.out.println("patientsForSms = " + patientsForSms);
     }
 
     private String applyPatientPlaceholders(Patient p, String template) {
@@ -371,7 +370,6 @@ public class SmsController implements Serializable {
     }
 
     public void sendBulkSmsToPatients() {
-        System.out.println("sendBulkSmsToPatients");
         if (selectedPatients == null || selectedPatients.isEmpty()) {
             JsfUtil.addErrorMessage("No patients selected");
             return;
@@ -381,9 +379,7 @@ public class SmsController implements Serializable {
             return;
         }
         for (Patient p : selectedPatients) {
-            System.out.println("selectedPatients = " + selectedPatients);
             String msg = applyPatientPlaceholders(p, smsTemplate);
-            System.out.println("msg = " + msg);
             String number = nvl(p.getPerson().getMobile());
             if (number.isEmpty()) {
                 number = nvl(p.getPerson().getPhone());
@@ -418,10 +414,10 @@ public class SmsController implements Serializable {
     }
 
     public void sendBulkSmsToNumbers() {
-+        if (doNotSendAnySms) {
-+            JsfUtil.addErrorMessage("SMS sending is disabled");
-+            return;
-+        }
+        if (doNotSendAnySms) {
+            JsfUtil.addErrorMessage("SMS sending is disabled");
+            return;
+        }
         if (smsNumbersInput == null || smsNumbersInput.trim().isEmpty()) {
             JsfUtil.addErrorMessage("No numbers specified");
             return;
@@ -430,17 +426,12 @@ public class SmsController implements Serializable {
             JsfUtil.addErrorMessage("No SMS message specified");
             return;
         }
--       String[] arr = smsNumbersInput.split("[\n,]+");
--       for (String n : arr) {
-+       Set<String> uniqueNumbers = new HashSet<>();
-+       for (String n : smsNumbersInput.split("[\\s,\\n]+")) {
+        String[] arr = smsNumbersInput.split("[\n,]+");
+        for (String n : arr) {
             String number = n.trim();
             if (number.isEmpty()) {
                 continue;
             }
-+           if (!uniqueNumbers.add(number)) {
-+               continue; // skip duplicates
-+           }
             Sms s = new Sms();
             s.setReceipientNumber(number);
             s.setSendingMessage(smsMessage.trim());

--- a/src/main/java/com/divudi/bean/common/SmsController.java
+++ b/src/main/java/com/divudi/bean/common/SmsController.java
@@ -65,6 +65,7 @@ public class SmsController implements Serializable {
 
     private String smsMessage;
     private String smsNumber;
+    private String smsNumbersInput;
     private String smsOutput;
 
     // Bulk SMS related fields
@@ -410,6 +411,37 @@ public class SmsController implements Serializable {
         return "/admin/users/send_bulk_sms_patients?faces-redirect=true";
     }
 
+    public String navigateToSendBulkSmsToNumbers() {
+        smsNumbersInput = null;
+        smsMessage = null;
+        return "/admin/users/send_bulk_sms_numbers?faces-redirect=true";
+    }
+
+    public void sendBulkSmsToNumbers() {
+        if (smsNumbersInput == null || smsNumbersInput.trim().isEmpty()) {
+            JsfUtil.addErrorMessage("No numbers specified");
+            return;
+        }
+        if (smsMessage == null || smsMessage.trim().isEmpty()) {
+            JsfUtil.addErrorMessage("No SMS message specified");
+            return;
+        }
+        String[] arr = smsNumbersInput.split("[\n,]+");
+        for (String n : arr) {
+            String number = n.trim();
+            if (number.isEmpty()) {
+                continue;
+            }
+            Sms s = new Sms();
+            s.setReceipientNumber(number);
+            s.setSendingMessage(smsMessage.trim());
+            s.setSmsType(MessageType.BulkNumberSms);
+            save(s);
+            smsManager.sendSms(s);
+        }
+        JsfUtil.addSuccessMessage("SMS sending initiated");
+    }
+
     public Long getMaxNumberToList() {
         if (maxNumberToList == null) {
             maxNumberToList = configOptionApplicationController.getLongValueByKey("Maximum Number of Patients to List to Send Bulkl SMS", 100l);
@@ -533,6 +565,14 @@ public class SmsController implements Serializable {
 
     public void setSelectedPatients(List<Patient> selectedPatients) {
         this.selectedPatients = selectedPatients;
+    }
+
+    public String getSmsNumbersInput() {
+        return smsNumbersInput;
+    }
+
+    public void setSmsNumbersInput(String smsNumbersInput) {
+        this.smsNumbersInput = smsNumbersInput;
     }
 
 }

--- a/src/main/java/com/divudi/core/data/MessageType.java
+++ b/src/main/java/com/divudi/core/data/MessageType.java
@@ -29,5 +29,7 @@ public enum MessageType {
     ChannelTimeDateChange,
     ChannelDoctorReminder,
     ChannelStatusUpdate,
-    DoctorPayment
+    DoctorPayment,
+    BulkPatientSms,
+    BulkNumberSms
 }

--- a/src/main/webapp/admin/users/index.xhtml
+++ b/src/main/webapp/admin/users/index.xhtml
@@ -76,6 +76,13 @@
                                             class="ui-button-warning"
                                             action="#{smsController.navigateToSendBulkSmsToPatients()}" />
 
+                                        <p:commandButton
+                                            ajax="false"
+                                            value="Send SMS for Phone Numbers"
+                                            icon="fa fa-envelope"
+                                            class="ui-button-warning"
+                                            action="#{smsController.navigateToSendBulkSmsToNumbers()}" />
+
                                         <hr/>
                                     </div>
 

--- a/src/main/webapp/admin/users/send_bulk_sms_numbers.xhtml
+++ b/src/main/webapp/admin/users/send_bulk_sms_numbers.xhtml
@@ -1,0 +1,37 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
+      xmlns:h="http://xmlns.jcp.org/jsf/html"
+      xmlns:p="http://primefaces.org/ui"
+      xmlns:f="http://xmlns.jcp.org/jsf/core">
+    <h:body>
+        <ui:composition template="/admin/users/index.xhtml">
+            <ui:define name="subcontent">
+                <h:panelGroup rendered="#{!webUserController.hasPrivilege('AdminManagingUsers') and !sessionController.firstLogin }" >
+                    <h:outputText value="You are NOT authorized"/>
+                </h:panelGroup>
+
+                <h:panelGroup rendered="#{webUserController.hasPrivilege('AdminManagingUsers') or sessionController.firstLogin }" >
+                    <h:form id="form">
+                        <p:panel header="Send SMS to Phone Numbers" class="m-1 w-100">
+                            <h:panelGrid columns="2" class="w-100 p-2" >
+                                <h:outputText value="Enter numbers separated by newline or comma"/>
+                                <p:inputTextarea value="#{smsController.smsNumbersInput}" rows="10" class="w-100"/>
+                                <h:outputLabel value="Message"/>
+                                <p:inputTextarea value="#{smsController.smsMessage}" class="w-100"/>
+                                <p:spacer/>
+                                <p:commandButton
+                                    value="Send SMS"
+                                    action="#{smsController.sendBulkSmsToNumbers()}"
+                                    icon="fa fa-paper-plane"
+                                    ajax="false"
+                                    class="ui-button-success"/>
+                            </h:panelGrid>
+                        </p:panel>
+                    </h:form>
+                </h:panelGroup>
+            </ui:define>
+        </ui:composition>
+    </h:body>
+</html>


### PR DESCRIPTION
## Summary
- introduce `BulkPatientSms` and `BulkNumberSms` message types
- add bulk number sending workflow to `SmsController`
- create new `send_bulk_sms_numbers.xhtml` page
- expose navigation from admin users index

## Testing
- `mvn -q -DskipTests package` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c37f2e36c832f8119d4a4abbbc4ac

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added the ability for administrators to send bulk SMS messages to any list of phone numbers entered manually.
  - Introduced a new page in the admin interface for composing and sending SMS messages to arbitrary numbers.
  - Added a button in the user management section to access the new bulk SMS feature.

- **User Interface**
  - Enhanced the admin user interface with a new form for entering phone numbers and SMS content for bulk sending.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->