### PR TITLE
Add description field to Manage VMPP

### DIFF
--- a/src/main/webapp/pharmacy/admin/vmpp.xhtml
+++ b/src/main/webapp/pharmacy/admin/vmpp.xhtml
@@ -97,6 +97,13 @@
                                     <f:selectItems value="#{measurementUnitController.items}" var="m" itemValue="#{m}" itemLabel="#{m.name}"/>
                                 </p:selectOneMenu>
 
+                                <p:outputLabel for="txtComments" value="Description" class="form-label"></p:outputLabel>
+                                <h:inputTextarea
+                                    id="txtComments"
+                                    value="#{vmppController.current.comments}"
+                                    required="false"
+                                    class="w-100" ></h:inputTextarea>
+
 
 
                             </h:panelGrid>


### PR DESCRIPTION
## Summary
- add a Description textarea for VMPP entries

## Testing
- `mvn -q -DskipTests package` *(fails: `mvn` not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684c3b246e8c832fa67ca9367abb9e7f