### PR TITLE
Add description field for VMP admin

### DIFF
--- a/src/main/webapp/pharmacy/admin/vmp.xhtml
+++ b/src/main/webapp/pharmacy/admin/vmp.xhtml
@@ -158,11 +158,17 @@
                                     <f:selectItems value="#{measurementUnitController.issueUnits}" var="m" itemValue="#{m}" itemLabel="#{m.name}"/>
                                 </p:selectOneMenu>  
 
+                                <p:outputLabel for="txtComments" value="Description" class="form-label"></p:outputLabel>
+                                <h:inputTextarea id="txtComments"
+                                                 value="#{vmpController.current.comments}"
+                                                 required="false"
+                                                 class="w-100" />
+
                                 <p:outputLabel for="txtIns" value="Instructions" class="form-label"></p:outputLabel>
-                                <h:inputTextarea 
-                                    id="txtIns" 
-                                    value="#{vmpController.current.instructions}" 
-                                    required="false" 
+                                <h:inputTextarea
+                                    id="txtIns"
+                                    value="#{vmpController.current.instructions}"
+                                    required="false"
                                     class="form-control" ></h:inputTextarea>
 
                             </h:panelGrid>


### PR DESCRIPTION
## Summary
- add new `Description` textarea to the VMP admin page

## Testing
- `mvn -q -DskipTests package` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c3ddd2530832f8d30dfa2d22cc500