### PR TITLE
Add purchase bill view button on return page

### DIFF
--- a/src/main/webapp/pharmacy/pharmacy_return_purchase.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_return_purchase.xhtml
@@ -42,6 +42,10 @@
 
                             <p:commandButton  value="Return" action="#{purchaseReturnController.settle}" ajax="false"  style="width: 150px; padding: 1px;border: 1px solid ; margin: auto;">
                             </p:commandButton>
+                            <p:commandButton value="View Bill" ajax="false" class="ui-button-info" icon="fa fa-eye"
+                                             action="pharmacy_reprint_purchase?faces-redirect=true">
+                                <f:setPropertyActionListener target="#{pharmacyBillSearch.bill}" value="#{purchaseReturnController.bill}"/>
+                            </p:commandButton>
                             <p:outputLabel  value="Recievable Amount" />
                             <p:outputLabel id="total"  value="#{purchaseReturnController.returnBill.total}" style="float: right;">
                                 <f:convertNumber pattern="#,##0.00" />


### PR DESCRIPTION
## Summary
- allow navigation to purchase bill view from purchase return page

## Testing
- `mvn -q test` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c3dba2bb8832fb46223ff133f94d4