### PR TITLE
Update direct purchase interactions

### DIFF
--- a/src/main/java/com/divudi/bean/pharmacy/PharmacyDirectPurchaseController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacyDirectPurchaseController.java
@@ -945,6 +945,8 @@ public class PharmacyDirectPurchaseController implements Serializable {
             it.setSearialNo(i++);
         }
 
+        pharmacyCostingService.distributeProportionalBillValuesToItems(billItems, bill);
+        calculateBillTotalsFromItems();
         calTotal();
         currentBillItem = null;
     }

--- a/src/main/webapp/pharmacy/direct_purchase.xhtml
+++ b/src/main/webapp/pharmacy/direct_purchase.xhtml
@@ -109,7 +109,8 @@
                                             listener="#{pharmacyDirectPurchaseController.onQuantityChange}"
                                             update="txtLineDiscountValue txtPurchaseValueMinusLineDiscountValue
                                             txtRetailValue txtCostValue
-                                            txtPurchaseValue txtUnitsPerPack txtPackOrUnit" />
+                                            txtPurchaseValue txtUnitsPerPack txtPackOrUnit
+                                            :#{p:resolveFirstComponentWithId('billFinanceDetails', view).clientId}" />
                                     </p:inputText>
                                 </div>
                                 <div class="col-1">
@@ -125,7 +126,8 @@
                                         <p:ajax 
                                             event="blur"
                                             process="@this"
-                                            update="txtLineDiscountValue txtPurchaseValueMinusLineDiscountValue txtRetailValue txtCostValue"
+                                            update="txtLineDiscountValue txtPurchaseValueMinusLineDiscountValue txtRetailValue txtCostValue
+                                            :#{p:resolveFirstComponentWithId('billFinanceDetails', view).clientId}"
                                             listener="#{pharmacyDirectPurchaseController.onFreeQuantityChange}" />
                                     </p:inputText>
                                 </div>
@@ -144,9 +146,10 @@
                                             event="blur"
                                             process="@this"
                                             listener="#{pharmacyDirectPurchaseController.onLineGrossRateChange}"
-                                            update="txtPurchaseValue txtLineDiscountValue txtPurchaseValueMinusLineDiscountValue 
+                                            update="txtPurchaseValue txtLineDiscountValue txtPurchaseValueMinusLineDiscountValue
                                             txtRetailValue txtCostValue
-                                            txtPackOrUnit txtUnitsPerPack" />
+                                            txtPackOrUnit txtUnitsPerPack
+                                            :#{p:resolveFirstComponentWithId('billFinanceDetails', view).clientId}" />
 
                                     </p:inputText>
 
@@ -166,9 +169,10 @@
                                             event="blur"
                                             process="@this"
                                             listener="#{pharmacyDirectPurchaseController.onLineDiscountRateChange}"
-                                            update="txtLineDiscountValue txtPurchaseValueMinusLineDiscountValue 
+                                            update="txtLineDiscountValue txtPurchaseValueMinusLineDiscountValue
                                             txtRetailValue txtCostValue
-                                            txtPurchaseValue txtUnitsPerPack txtPackOrUnit" />
+                                            txtPurchaseValue txtUnitsPerPack txtPackOrUnit
+                                            :#{p:resolveFirstComponentWithId('billFinanceDetails', view).clientId}" />
                                     </p:inputText>
                                 </div>
 
@@ -189,7 +193,8 @@
                                             event="blur"
                                             process="@this"
                                             listener="#{pharmacyDirectPurchaseController.onRetailSaleRateChange}"
-                                            update="txtRetailValue txtPackOrUnit txtUnitsPerPack" />
+                                            update="txtRetailValue txtPackOrUnit txtUnitsPerPack
+                                            :#{p:resolveFirstComponentWithId('billFinanceDetails', view).clientId}" />
                                     </p:inputText>
                                 </div>
 
@@ -231,7 +236,7 @@
                                         icon="fas fa-plus"
                                         action="#{pharmacyDirectPurchaseController.addItem}"
                                         process="@this" 
-                                        update="itemList itemselectgrid tot focusItem :#{p:resolveFirstComponentWithId('total',view).clientId} :#{p:resolveFirstComponentWithId('totalSaleValue',view).clientId} msg"/>
+                                        update="itemList itemselectgrid tot focusItem :#{p:resolveFirstComponentWithId('total',view).clientId} :#{p:resolveFirstComponentWithId('totalSaleValue',view).clientId} :#{p:resolveFirstComponentWithId('billFinanceDetails', view).clientId} msg"/>
 
                                 </div>
 


### PR DESCRIPTION
## Summary
- keep Bill Finance Details in sync when editing direct purchase items
- re-calc bill totals when removing an item

## Testing
- `mvn -q test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c85da11bc832f9fbc40e7f7a40259