### PR TITLE
Add zero-stock item report

### DIFF
--- a/src/main/java/com/divudi/core/data/reports/PharmacyReports.java
+++ b/src/main/java/com/divudi/core/data/reports/PharmacyReports.java
@@ -20,7 +20,8 @@ public enum PharmacyReports implements IReportType {
     SALE_SUMMARY_BY_PAYMENT_METHOD("Sale summary by payment method"),
     SALE_SUMMARY_BY_PAYMENT_METHOD_BY_BILL("Sale summary by payment method by Bill"),
     STOCK_REPORT_BY_EXPIRY("Stock report by Expiry"),
-    STOCK_REPORT_BY_ITEM("Stock report by Item"),;
+    STOCK_REPORT_BY_ITEM("Stock report by Item"),
+    STOCK_REPORT_BY_ZERO_ITEM("Stock report by Zero Item");
 
 
     private final String displayName;

--- a/src/main/webapp/pharmacy/pharmacy_analytics.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_analytics.xhtml
@@ -109,6 +109,12 @@
                                             <p:commandButton class="w-100" value="Stock Report by Batch" action="pharmacy_report_department_stock_by_batch?faces-redirect=true" ajax="false" />
                                             <p:commandButton class="w-100" value="Expiring Stock Report by Batch" action="pharmacy_report_department?faces-redirect=true" ajax="false" />
                                             <p:commandButton class="w-100" value="Stock Report by Expiry" action="pharmacy_report_department_stock_by_batch_expiary?faces-redirect=true" ajax="false" />
+                                            <p:commandButton
+                                                class="w-100"
+                                                icon="fa fa-cubes"
+                                                value="Stock Report by Zero Item"
+                                                action="#{reportsStock.navigateToPharmacyReportDepartmentStockByZeroItem()}"
+                                                ajax="false" />
                                             <p:commandButton class="w-100 ui-button-warning" value="Suppliers Expiring Stocks" action="pharmacy_report_supplier_expiary_stock_by_batch?faces-redirect=true" ajax="false" />
                                             <p:commandButton 
                                                 class="w-100"

--- a/src/main/webapp/pharmacy/pharmacy_report_department_stock_by_zero_item.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_report_department_stock_by_zero_item.xhtml
@@ -1,0 +1,150 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
+      xmlns:p="http://primefaces.org/ui"
+      xmlns:h="http://xmlns.jcp.org/jsf/html"
+      xmlns:f="http://xmlns.jcp.org/jsf/core"
+      >
+
+    <h:body>
+
+        <ui:composition template="/pharmacy/pharmacy_analytics.xhtml">
+
+            <ui:define name="subcontent">
+                <h:form id="frm">
+                    <p:panel header="Stock Report by Zero Item" >
+
+                        <h:panelGrid columns="6" >
+                            <h:outputLabel value="Department" ></h:outputLabel>
+                            <p:autoComplete class=" mx-2"  completeMethod="#{departmentController.completeDept}"
+                                            var="dept" itemLabel="#{dept.name}" 
+                                            itemValue="#{dept}" forceSelection="true" 
+                                            value="#{reportsStock.department}"  >
+                            </p:autoComplete>
+                            <p:commandButton class="ui-button-warning" icon="fas fa-cogs" ajax="false" value="Process"
+                                             actionListener="#{reportsStock.fillDepartmentZeroItemStocks()}" ></p:commandButton>
+                            <p:commandButton class="ui-button-success mx-2" icon="fas fa-file-excel" value="Excel" ajax="false">
+                                <p:dataExporter type="xlsx" target="tbl" fileName="Total_Stock"
+
+                                                />
+                            </p:commandButton>
+                            <p:commandButton class="ui-button-info" icon="fas fa-print" value="Print" actionListener="#{reportsStock.prepareForPrint()}" 
+                                             oncomplete="$('#frm\\:print').click()"
+                                             update=":frm:tbl"/>
+                            <p:commandButton id="print" value="Actual print" style="display: none">
+                                <p:ajax event="click" listener="#{reportsStock.prepareForView()}" update=":frm:tbl"/>
+                                <p:printer target=":frm:tbl" />
+                            </p:commandButton>
+                        </h:panelGrid>
+
+                        <h:panelGroup id="gpBillPreview"  styleClass="noBorder summeryBorder" class="w-100">
+
+                            <p:dataTable 
+                                id="tbl" 
+                                rowIndexVar="ii" 
+                                value="#{reportsStock.pharmacyStockRows}" var="i"  
+                                rendered="#{reportsStock.pharmacyStockRows.size() ne 0 }"
+                                rows="#{reportsStock.paginator?'20':reportsStock.pharmacyStockRows.size()}"
+                                paginator="#{reportsStock.paginator}"
+                                paginatorTemplate="{CurrentPageReport}  {FirstPageLink} {PreviousPageLink} {PageLinks} {NextPageLink} {LastPageLink} {RowsPerPageDropdown}"
+                                rowsPerPageTemplate="20, 50, 100">
+                                <f:facet name="header">
+                                    <h:outputLabel value="Stock Report by Zero Item - #{reportsStock.department.name}"/>
+                                </f:facet>
+
+                                <p:column width="20px;" headerText="No" sortBy="#{ii}"
+                                          style="width: 20px;">
+                                    <h:outputLabel value="#{ii+1}" />
+                                </p:column>
+
+                                <p:column headerText="Code" 
+                                          sortBy="#{i.code}" filterBy="#{i.code}"
+                                          styleClass="averageNumericColumn"
+                                          filterMatchMode="startsWith">
+                                    <f:facet name="header">
+                                        <h:outputLabel value="Code"/>
+                                    </f:facet>
+                                    <h:outputLabel value="#{i.code}" ></h:outputLabel>
+                                </p:column>
+
+                                <p:column headerText="Item" 
+                                          sortBy="#{i.name}" filterBy="#{i.name}"
+                                          filterMatchMode="contains">
+                                    <f:facet name="header">
+                                        <h:outputLabel value="Item"/>
+                                    </f:facet>
+                                    <h:outputLabel value="#{i.name}" ></h:outputLabel>
+                                </p:column>
+
+                                <p:column headerText="Quantity" 
+                                          styleClass="averageNumericColumn"
+                                          style="text-align: right;" sortBy="#{i.qty}">
+                                    <f:facet name="header">
+                                        <h:outputLabel value="Quantity"/>                                     
+                                    </f:facet>
+                                    <h:outputLabel value="#{i.qty}"  >
+                                        <f:convertNumber pattern="#,###" ></f:convertNumber>
+                                    </h:outputLabel>                                 
+                                </p:column>
+
+
+                                <p:column headerText="Purchase Value" 
+                                          styleClass="averageNumericColumn"
+                                          style="text-align: right;" sortBy="#{i.purchaseValue}">
+                                    <f:facet name="header">
+                                        <h:outputLabel value="Purchase Value"/>                                     
+                                    </f:facet>
+                                    <h:outputLabel value="#{i.purchaseValue}"  >
+                                        <f:convertNumber pattern="#,##0.00" ></f:convertNumber>
+                                    </h:outputLabel>
+                                </p:column>
+
+
+                                <p:column headerText="Retail Sale Value" 
+                                          styleClass="averageNumericColumn"
+                                          style="text-align: right;" sortBy="#{i.saleValue}">
+                                    <f:facet name="header">
+                                        <h:outputLabel value="Sale Value"/>                                     
+                                    </f:facet>
+                                    <h:outputLabel value="#{i.saleValue}"  >
+                                        <f:convertNumber pattern="#,##0.00" ></f:convertNumber>
+                                    </h:outputLabel>
+                                </p:column>
+                                <p:columnGroup type="footer">
+                                    <p:row>
+                                        <p:column colspan="4" footerText="Total">
+                                            <f:facet name="footer">
+                                                <h:outputLabel value="Total" />
+                                            </f:facet>
+                                        </p:column>
+                                        <p:column style="text-align: right;" footerText="#{reportsStock.stockPurchaseValue}">
+                                            <f:facet name="footer" >
+                                                <h:outputLabel value="#{reportsStock.stockPurchaseValue}" >
+                                                    <f:convertNumber parent="#,##0.00" />
+                                                </h:outputLabel>
+                                            </f:facet>
+                                        </p:column>
+
+                                        <p:column style="text-align: right;" footerText="#{reportsStock.stockSaleValue}">
+                                            <f:facet name="footer" >
+                                                <h:outputLabel value="#{reportsStock.stockSaleValue}" >
+                                                    <f:convertNumber parent="#,##0.00" />
+                                                </h:outputLabel>
+                                            </f:facet>
+                                        </p:column>
+                                    </p:row>
+                                </p:columnGroup>
+                            </p:dataTable>
+                        </h:panelGroup>
+                    </p:panel>
+                </h:form>
+
+
+            </ui:define>
+
+
+        </ui:composition>
+
+    </h:body>
+</html>


### PR DESCRIPTION
## Summary
- implement navigation to zero item report
- support STOCK_REPORT_BY_ZERO_ITEM report enum
- add new zero item stock report page
- link new report from analytics view

## Testing
- `mvn -q -DskipTests install` *(fails: mvn not found)*
- `mvn -q test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c7fffc8dc832f834817bedf7a2954