### PR TITLE
Fix cost rate calculations using units

### DIFF
--- a/src/main/java/com/divudi/service/pharmacy/PharmacyCostingService.java
+++ b/src/main/java/com/divudi/service/pharmacy/PharmacyCostingService.java
@@ -184,14 +184,17 @@ public class PharmacyCostingService {
             BigDecimal billCost = netTotal.subtract(lineNetTotal);
             f.setBillCost(billCost);
 
-            BigDecimal lineCostRate = totalQty.compareTo(BigDecimal.ZERO) > 0
-                    ? lineNetTotal.divide(totalQty, 6, RoundingMode.HALF_UP)
+            BigDecimal qtyUnits = Optional.ofNullable(f.getTotalQuantityByUnits())
+                    .orElse(totalQty);
+
+            BigDecimal lineCostRate = qtyUnits.compareTo(BigDecimal.ZERO) > 0
+                    ? lineNetTotal.divide(qtyUnits, 6, RoundingMode.HALF_UP)
                     : BigDecimal.ZERO;
-            BigDecimal billCostRate = totalQty.compareTo(BigDecimal.ZERO) > 0
-                    ? billCost.divide(totalQty, 6, RoundingMode.HALF_UP)
+            BigDecimal billCostRate = qtyUnits.compareTo(BigDecimal.ZERO) > 0
+                    ? billCost.divide(qtyUnits, 6, RoundingMode.HALF_UP)
                     : BigDecimal.ZERO;
-            BigDecimal totalCostRate = totalQty.compareTo(BigDecimal.ZERO) > 0
-                    ? netTotal.divide(totalQty, 6, RoundingMode.HALF_UP)
+            BigDecimal totalCostRate = qtyUnits.compareTo(BigDecimal.ZERO) > 0
+                    ? netTotal.divide(qtyUnits, 6, RoundingMode.HALF_UP)
                     : BigDecimal.ZERO;
 
             f.setLineCostRate(lineCostRate.setScale(4, RoundingMode.HALF_UP));


### PR DESCRIPTION
## Summary
- compute cost rate values in `PharmacyCostingService` using quantity in units

## Testing
- `mvn -q test` *(fails: PluginResolutionException due to network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_684cd2025840832f81822f796cb8c252