### PR TITLE
Fix cost rate calculations using units

### DIFF
--- a/src/main/java/com/divudi/bean/pharmacy/GrnCostingController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/GrnCostingController.java
@@ -1263,13 +1263,22 @@ public class GrnCostingController implements Serializable {
         pharmacyCostingService.recalculateFinancialsBeforeAddingBillItem(f);
 
         if (bi.getItem() instanceof com.divudi.core.entity.pharmacy.Ampp) {
-            pbi.setQty(java.util.Optional.ofNullable(f.getQuantity()).orElse(java.math.BigDecimal.ZERO).doubleValue());
-            pbi.setQtyInUnit(pbi.getQty());
-            pbi.setQtyPacks(pbi.getQty());
+            BigDecimal unitsPerPack = Optional.ofNullable(f.getUnitsPerPack())
+                    .orElse(BigDecimal.ONE);
+            BigDecimal qtyUnits = Optional.ofNullable(f.getQuantity())
+                    .orElse(BigDecimal.ZERO)
+                    .multiply(unitsPerPack);
+            BigDecimal freeQtyUnits = Optional.ofNullable(f.getFreeQuantity())
+                    .orElse(BigDecimal.ZERO)
+                    .multiply(unitsPerPack);
 
-            pbi.setFreeQty(java.util.Optional.ofNullable(f.getFreeQuantity()).orElse(java.math.BigDecimal.ZERO).doubleValue());
+            pbi.setQty(qtyUnits.doubleValue());
+            pbi.setQtyInUnit(pbi.getQty());
+            pbi.setQtyPacks(Optional.ofNullable(f.getQuantity()).orElse(BigDecimal.ZERO).doubleValue());
+
+            pbi.setFreeQty(freeQtyUnits.doubleValue());
             pbi.setFreeQtyInUnit(pbi.getFreeQty());
-            pbi.setFreeQtyPacks(pbi.getFreeQty());
+            pbi.setFreeQtyPacks(Optional.ofNullable(f.getFreeQuantity()).orElse(BigDecimal.ZERO).doubleValue());
 
             pbi.setPurchaseRate(java.util.Optional.ofNullable(f.getNetRate()).orElse(java.math.BigDecimal.ZERO).doubleValue());
             pbi.setPurchaseRatePack(pbi.getPurchaseRate());

--- a/src/main/java/com/divudi/bean/pharmacy/PharmacyDirectPurchaseController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacyDirectPurchaseController.java
@@ -156,10 +156,15 @@ public class PharmacyDirectPurchaseController implements Serializable {
         BigDecimal freeQty = f.getFreeQuantity() != null ? f.getFreeQuantity() : BigDecimal.ZERO;
 
         if (item instanceof Ampp) {
-            pbi.setQty(f.getQuantity().doubleValue());
+            BigDecimal unitsPerPack = Optional.ofNullable(f.getUnitsPerPack())
+                    .orElse(BigDecimal.ONE);
+            BigDecimal qtyUnits = f.getQuantity().multiply(unitsPerPack);
+            BigDecimal freeQtyUnits = f.getFreeQuantity().multiply(unitsPerPack);
+
+            pbi.setQty(qtyUnits.doubleValue());
             pbi.setQtyPacks(f.getQuantity().doubleValue());
 
-            pbi.setFreeQty(f.getFreeQuantity().doubleValue());
+            pbi.setFreeQty(freeQtyUnits.doubleValue());
             pbi.setFreeQtyPacks(f.getFreeQuantity().doubleValue());
 
             pbi.setPurchaseRate(f.getNetRate().doubleValue());

--- a/src/main/java/com/divudi/service/pharmacy/PharmacyCostingService.java
+++ b/src/main/java/com/divudi/service/pharmacy/PharmacyCostingService.java
@@ -184,14 +184,17 @@ public class PharmacyCostingService {
             BigDecimal billCost = netTotal.subtract(lineNetTotal);
             f.setBillCost(billCost);
 
-            BigDecimal lineCostRate = totalQty.compareTo(BigDecimal.ZERO) > 0
-                    ? lineNetTotal.divide(totalQty, 6, RoundingMode.HALF_UP)
+            BigDecimal qtyUnits = Optional.ofNullable(f.getTotalQuantityByUnits())
+                    .orElse(totalQty);
+
+            BigDecimal lineCostRate = qtyUnits.compareTo(BigDecimal.ZERO) > 0
+                    ? lineNetTotal.divide(qtyUnits, 6, RoundingMode.HALF_UP)
                     : BigDecimal.ZERO;
-            BigDecimal billCostRate = totalQty.compareTo(BigDecimal.ZERO) > 0
-                    ? billCost.divide(totalQty, 6, RoundingMode.HALF_UP)
+            BigDecimal billCostRate = qtyUnits.compareTo(BigDecimal.ZERO) > 0
+                    ? billCost.divide(qtyUnits, 6, RoundingMode.HALF_UP)
                     : BigDecimal.ZERO;
-            BigDecimal totalCostRate = totalQty.compareTo(BigDecimal.ZERO) > 0
-                    ? netTotal.divide(totalQty, 6, RoundingMode.HALF_UP)
+            BigDecimal totalCostRate = qtyUnits.compareTo(BigDecimal.ZERO) > 0
+                    ? netTotal.divide(qtyUnits, 6, RoundingMode.HALF_UP)
                     : BigDecimal.ZERO;
 
             f.setLineCostRate(lineCostRate.setScale(4, RoundingMode.HALF_UP));


### PR DESCRIPTION
## Summary
- compute cost rate values in `PharmacyCostingService` using quantity in units
- update `PharmacyDirectPurchaseController` and `GrnCostingController` to convert AMPP pack quantities into unit quantities before updating stock

## Testing
- `mvn -q test` *(fails: PluginResolutionException due to network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_684cd2025840832f81822f796cb8c252