### PR TITLE
Fix finance details refresh

### DIFF
--- a/src/main/webapp/pharmacy/direct_purchase.xhtml
+++ b/src/main/webapp/pharmacy/direct_purchase.xhtml
@@ -110,7 +110,7 @@
                                             update="txtLineDiscountValue txtPurchaseValueMinusLineDiscountValue
                                             txtRetailValue txtCostValue
                                             txtPurchaseValue txtUnitsPerPack txtPackOrUnit
-                                            :#{p:resolveFirstComponentWithId('billFinanceDetails', view).clientId}" />
+                                            :#{p:resolveFirstComponentWithId('billFinanceDetailsPanel', view).clientId}" />
                                     </p:inputText>
                                 </div>
                                 <div class="col-1">
@@ -127,7 +127,7 @@
                                             event="blur"
                                             process="@this"
                                             update="txtLineDiscountValue txtPurchaseValueMinusLineDiscountValue txtRetailValue txtCostValue
-                                            :#{p:resolveFirstComponentWithId('billFinanceDetails', view).clientId}"
+                                            :#{p:resolveFirstComponentWithId('billFinanceDetailsPanel', view).clientId}"
                                             listener="#{pharmacyDirectPurchaseController.onFreeQuantityChange}" />
                                     </p:inputText>
                                 </div>
@@ -149,7 +149,7 @@
                                             update="txtPurchaseValue txtLineDiscountValue txtPurchaseValueMinusLineDiscountValue
                                             txtRetailValue txtCostValue
                                             txtPackOrUnit txtUnitsPerPack
-                                            :#{p:resolveFirstComponentWithId('billFinanceDetails', view).clientId}" />
+                                            :#{p:resolveFirstComponentWithId('billFinanceDetailsPanel', view).clientId}" />
 
                                     </p:inputText>
 
@@ -172,7 +172,7 @@
                                             update="txtLineDiscountValue txtPurchaseValueMinusLineDiscountValue
                                             txtRetailValue txtCostValue
                                             txtPurchaseValue txtUnitsPerPack txtPackOrUnit
-                                            :#{p:resolveFirstComponentWithId('billFinanceDetails', view).clientId}" />
+                                            :#{p:resolveFirstComponentWithId('billFinanceDetailsPanel', view).clientId}" />
                                     </p:inputText>
                                 </div>
 
@@ -194,7 +194,7 @@
                                             process="@this"
                                             listener="#{pharmacyDirectPurchaseController.onRetailSaleRateChange}"
                                             update="txtRetailValue txtPackOrUnit txtUnitsPerPack
-                                            :#{p:resolveFirstComponentWithId('billFinanceDetails', view).clientId}" />
+                                            :#{p:resolveFirstComponentWithId('billFinanceDetailsPanel', view).clientId}" />
                                     </p:inputText>
                                 </div>
 
@@ -236,7 +236,7 @@
                                         icon="fas fa-plus"
                                         action="#{pharmacyDirectPurchaseController.addItem}"
                                         process="@this" 
-                                        update="itemList itemselectgrid tot focusItem :#{p:resolveFirstComponentWithId('total',view).clientId} :#{p:resolveFirstComponentWithId('totalSaleValue',view).clientId} :#{p:resolveFirstComponentWithId('billFinanceDetails', view).clientId} msg"/>
+                                        update="itemList itemselectgrid tot focusItem :#{p:resolveFirstComponentWithId('total',view).clientId} :#{p:resolveFirstComponentWithId('totalSaleValue',view).clientId} :#{p:resolveFirstComponentWithId('billFinanceDetailsPanel', view).clientId} msg"/>
 
                                 </div>
 
@@ -538,7 +538,7 @@
                                             value="#{pharmacyDirectPurchaseController.bill.tax}">
                                             <p:ajax 
                                                 process="tx" 
-                                                update=":#{p:resolveFirstComponentWithId('net', view).clientId} :#{p:resolveFirstComponentWithId('billFinanceDetails', view).clientId}" 
+                                                update=":#{p:resolveFirstComponentWithId('net', view).clientId} :#{p:resolveFirstComponentWithId('billFinanceDetailsPanel', view).clientId}" 
                                                 event="blur"
                                                 listener="#{pharmacyDirectPurchaseController.billDiscountChangedByUser()}" />
                                         </p:inputText>
@@ -551,7 +551,7 @@
                                             value="#{pharmacyDirectPurchaseController.bill.discount}">
                                             <p:ajax 
                                                 process="@this" 
-                                                update=":#{p:resolveFirstComponentWithId('net', view).clientId} :#{p:resolveFirstComponentWithId('billFinanceDetails', view).clientId}" 
+                                                update=":#{p:resolveFirstComponentWithId('net', view).clientId} :#{p:resolveFirstComponentWithId('billFinanceDetailsPanel', view).clientId}" 
                                                 event="blur"
                                                 listener="#{pharmacyDirectPurchaseController.billDiscountChangedByUser()}" />
                                         </p:inputText>
@@ -576,7 +576,9 @@
 
                                 <!-- Detailed Finance Tab -->
                                 <p:tab title="Financial Summary">
-                                    <ph:bill_finance_details id="billFinanceDetails" bill="#{pharmacyDirectPurchaseController.bill}" ></ph:bill_finance_details>
+                                    <p:panel id="billFinanceDetailsPanel">
+                                        <ph:bill_finance_details bill="#{pharmacyDirectPurchaseController.bill}" />
+                                    </p:panel>
                                 </p:tab>
 
                             </p:tabView>


### PR DESCRIPTION
## Summary
- refresh finance tab correctly after changing bill discount by wrapping component in a `p:panel`
- update all AJAX and command button references to use `billFinanceDetailsPanel`

## Testing
- `mvn -q -DskipTests package` *(fails: Could not transfer artifact org.apache.maven.plugins:maven-resources-plugin)*

------
https://chatgpt.com/codex/tasks/task_e_684dba9583f4832f9a1bc030265c9497