### PR TITLE
Add institution/site filters to zero stock report

### DIFF
--- a/src/main/java/com/divudi/bean/pharmacy/ReportsStock.java
+++ b/src/main/java/com/divudi/bean/pharmacy/ReportsStock.java
@@ -602,24 +602,30 @@ public class ReportsStock implements Serializable, ControllerWithReportFilters {
 
     public void fillDepartmentZeroItemStocks() {
         reportTimerController.trackReportExecution(() -> {
-            if (department == null) {
-                JsfUtil.addErrorMessage("Please select a department");
+            if (department == null && site == null && institution == null) {
+                JsfUtil.addErrorMessage("Please select a department, site, or institution");
                 return;
             }
             Map m = new HashMap();
-            String sql;
-            sql = "select new com.divudi.core.data.dataStructure.PharmacyStockRow(" +
-                  "s.itemBatch.item.code, " +
-                  "s.itemBatch.item.name, " +
-                  "sum(s.stock), " +
-                  "sum(s.itemBatch.purcahseRate * s.stock), " +
-                  "sum(s.itemBatch.retailsaleRate * s.stock)) " +
-                  "from Stock s where s.department=:d " +
-                  "group by s.itemBatch.item.code, s.itemBatch.item.name " +
-                  "having sum(s.stock) = 0 " +
-                  "order by s.itemBatch.item.name";
-            m.put("d", department);
-            List<PharmacyStockRow> lsts = (List) getStockFacade().findObjects(sql, m);
+            StringBuilder sql = new StringBuilder("select new com.divudi.core.data.dataStructure.PharmacyStockRow(" +
+                    "s.itemBatch.item.code, " +
+                    "s.itemBatch.item.name, " +
+                    "sum(s.stock), " +
+                    "sum(s.itemBatch.purcahseRate * s.stock), " +
+                    "sum(s.itemBatch.retailsaleRate * s.stock)) " +
+                    "from Stock s where 1=1 ");
+            if (department != null) {
+                sql.append(" and s.department=:d");
+                m.put("d", department);
+            } else if (site != null) {
+                sql.append(" and s.department.site=:site");
+                m.put("site", site);
+            } else if (institution != null) {
+                sql.append(" and s.department.institution=:ins");
+                m.put("ins", institution);
+            }
+            sql.append(" group by s.itemBatch.item.code, s.itemBatch.item.name having sum(s.stock) = 0 order by s.itemBatch.item.name");
+            List<PharmacyStockRow> lsts = (List) getStockFacade().findObjects(sql.toString(), m);
             stockPurchaseValue = 0.0;
             stockSaleValue = 0.0;
             for (PharmacyStockRow r : lsts) {

--- a/src/main/webapp/pharmacy/pharmacy_analytics.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_analytics.xhtml
@@ -112,7 +112,7 @@
                                             <p:commandButton
                                                 class="w-100"
                                                 icon="fa fa-cubes"
-                                                value="Stock Report by Zero Item"
+                                                value="Zero Stock Item Report"
                                                 action="#{reportsStock.navigateToPharmacyReportDepartmentStockByZeroItem()}"
                                                 ajax="false" />
                                             <p:commandButton class="w-100 ui-button-warning" value="Suppliers Expiring Stocks" action="pharmacy_report_supplier_expiary_stock_by_batch?faces-redirect=true" ajax="false" />

--- a/src/main/webapp/pharmacy/pharmacy_report_department_stock_by_zero_item.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_report_department_stock_by_zero_item.xhtml
@@ -5,6 +5,7 @@
       xmlns:p="http://primefaces.org/ui"
       xmlns:h="http://xmlns.jcp.org/jsf/html"
       xmlns:f="http://xmlns.jcp.org/jsf/core"
+      xmlns:common="http://xmlns.jcp.org/jsf/composite/ezcomp/common"
       >
 
     <h:body>
@@ -13,25 +14,22 @@
 
             <ui:define name="subcontent">
                 <h:form id="frm">
-                    <p:panel header="Stock Report by Zero Item" >
+                    <p:panel header="Zero Stock Item Report" >
 
-                        <h:panelGrid columns="6" >
-                            <h:outputLabel value="Department" ></h:outputLabel>
-                            <p:autoComplete class=" mx-2"  completeMethod="#{departmentController.completeDept}"
-                                            var="dept" itemLabel="#{dept.name}" 
-                                            itemValue="#{dept}" forceSelection="true" 
-                                            value="#{reportsStock.department}"  >
-                            </p:autoComplete>
-                            <p:commandButton class="ui-button-warning" icon="fas fa-cogs" ajax="false" value="Process"
-                                             actionListener="#{reportsStock.fillDepartmentZeroItemStocks()}" ></p:commandButton>
-                            <p:commandButton class="ui-button-success mx-2" icon="fas fa-file-excel" value="Excel" ajax="false">
-                                <p:dataExporter type="xlsx" target="tbl" fileName="Total_Stock"
-
-                                                />
+                        <common:institution_site_department_filter controller="#{reportsStock}"/>
+                        <p:fieldset styleClass="my-2" legend="About this report">
+                            <p>
+                                This report lists all pharmacy items that currently have zero stock. Items appear here only if they previously had stock within the selected institution, site, or department.
+                            </p>
+                        </p:fieldset>
+                        <h:panelGrid columns="6" styleClass="my-2">
+                            <p:commandButton class="ui-button-warning" icon="fas fa-cogs" ajax="false" value="Generate Report"
+                                             actionListener="#{reportsStock.fillDepartmentZeroItemStocks()}" />
+                            <p:commandButton class="ui-button-success mx-2" icon="fas fa-file-excel" value="Download Excel" ajax="false">
+                                <p:dataExporter type="xlsx" target="tbl" fileName="zero_stock_items" />
                             </p:commandButton>
-                            <p:commandButton class="ui-button-info" icon="fas fa-print" value="Print" actionListener="#{reportsStock.prepareForPrint()}" 
-                                             oncomplete="$('#frm\\:print').click()"
-                                             update=":frm:tbl"/>
+                            <p:commandButton class="ui-button-info" icon="fas fa-print" value="Print" actionListener="#{reportsStock.prepareForPrint()}"
+                                             oncomplete="$('#frm\\:print').click()" update=":frm:tbl"/>
                             <p:commandButton id="print" value="Actual print" style="display: none">
                                 <p:ajax event="click" listener="#{reportsStock.prepareForView()}" update=":frm:tbl"/>
                                 <p:printer target=":frm:tbl" />
@@ -50,7 +48,7 @@
                                 paginatorTemplate="{CurrentPageReport}  {FirstPageLink} {PreviousPageLink} {PageLinks} {NextPageLink} {LastPageLink} {RowsPerPageDropdown}"
                                 rowsPerPageTemplate="20, 50, 100">
                                 <f:facet name="header">
-                                    <h:outputLabel value="Stock Report by Zero Item - #{reportsStock.department.name}"/>
+                                <h:outputLabel value="Zero Stock Item Report - #{reportsStock.department.name}"/>
                                 </f:facet>
 
                                 <p:column width="20px;" headerText="No" sortBy="#{ii}"
@@ -77,64 +75,6 @@
                                     <h:outputLabel value="#{i.name}" ></h:outputLabel>
                                 </p:column>
 
-                                <p:column headerText="Quantity" 
-                                          styleClass="averageNumericColumn"
-                                          style="text-align: right;" sortBy="#{i.qty}">
-                                    <f:facet name="header">
-                                        <h:outputLabel value="Quantity"/>                                     
-                                    </f:facet>
-                                    <h:outputLabel value="#{i.qty}"  >
-                                        <f:convertNumber pattern="#,###" ></f:convertNumber>
-                                    </h:outputLabel>                                 
-                                </p:column>
-
-
-                                <p:column headerText="Purchase Value" 
-                                          styleClass="averageNumericColumn"
-                                          style="text-align: right;" sortBy="#{i.purchaseValue}">
-                                    <f:facet name="header">
-                                        <h:outputLabel value="Purchase Value"/>                                     
-                                    </f:facet>
-                                    <h:outputLabel value="#{i.purchaseValue}"  >
-                                        <f:convertNumber pattern="#,##0.00" ></f:convertNumber>
-                                    </h:outputLabel>
-                                </p:column>
-
-
-                                <p:column headerText="Retail Sale Value" 
-                                          styleClass="averageNumericColumn"
-                                          style="text-align: right;" sortBy="#{i.saleValue}">
-                                    <f:facet name="header">
-                                        <h:outputLabel value="Sale Value"/>                                     
-                                    </f:facet>
-                                    <h:outputLabel value="#{i.saleValue}"  >
-                                        <f:convertNumber pattern="#,##0.00" ></f:convertNumber>
-                                    </h:outputLabel>
-                                </p:column>
-                                <p:columnGroup type="footer">
-                                    <p:row>
-                                        <p:column colspan="4" footerText="Total">
-                                            <f:facet name="footer">
-                                                <h:outputLabel value="Total" />
-                                            </f:facet>
-                                        </p:column>
-                                        <p:column style="text-align: right;" footerText="#{reportsStock.stockPurchaseValue}">
-                                            <f:facet name="footer" >
-                                                <h:outputLabel value="#{reportsStock.stockPurchaseValue}" >
-                                                    <f:convertNumber parent="#,##0.00" />
-                                                </h:outputLabel>
-                                            </f:facet>
-                                        </p:column>
-
-                                        <p:column style="text-align: right;" footerText="#{reportsStock.stockSaleValue}">
-                                            <f:facet name="footer" >
-                                                <h:outputLabel value="#{reportsStock.stockSaleValue}" >
-                                                    <f:convertNumber parent="#,##0.00" />
-                                                </h:outputLabel>
-                                            </f:facet>
-                                        </p:column>
-                                    </p:row>
-                                </p:columnGroup>
                             </p:dataTable>
                         </h:panelGroup>
                     </p:panel>


### PR DESCRIPTION
## Summary
- add institution-site-department filter to zero stock report page
- rename navigation labels to "Zero Stock Item Report"
- document report purpose on the page
- drop columns showing zero values
- allow filtering by institution or site in `ReportsStock.fillDepartmentZeroItemStocks`

## Testing
- `mvn -version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684e399238d0832fabcb8af4772cc55a