### PR TITLE
Fix error messaging when cancelling package bills

### DIFF
--- a/src/main/java/com/divudi/bean/common/BillPackageController.java
+++ b/src/main/java/com/divudi/bean/common/BillPackageController.java
@@ -692,10 +692,8 @@ public class BillPackageController implements Serializable, ControllerWithPatien
         boolean labStatusOk = checkCancelBill(billToCancel);
 
         if (!labStatusOk) {
-            JsfUtil.addErrorMessage("This bill is processed in the Laboratory.");
-            if (getWebUserController().hasPrivilege("OpdPackageBillCancel")) {
-                JsfUtil.addSuccessMessage("Special privilege granted to cancel processed bill");
-            } else {
+            if (!getWebUserController().hasPrivilege("OpdPackageBillCancel")) {
+                JsfUtil.addErrorMessage("This bill is processed in the Laboratory.");
                 JsfUtil.addErrorMessage(
                         "You have no Privilege to Cancel Package Bills. Please Contact System Administrator.");
                 return false;


### PR DESCRIPTION
## Summary
- tweak privilege check logic in `BillPackageController`

## Testing
- `mvn -q test` *(fails: Plugin resolution failed - network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_684e41a1852c832f8afb9e2bb56ac389