### PR TITLE
Replace debug prints in AuditEvent

### DIFF
--- a/src/main/java/com/divudi/core/entity/AuditEvent.java
+++ b/src/main/java/com/divudi/core/entity/AuditEvent.java
@@ -17,6 +17,8 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 import javax.persistence.Temporal;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 /**
  *
@@ -24,6 +26,8 @@ import javax.persistence.Temporal;
  */
 @Entity
 public class AuditEvent implements Serializable {
+
+    private static final Logger logger = LogManager.getLogger(AuditEvent.class);
 
     private static final long serialVersionUID = 1L;
     @Id
@@ -96,9 +100,9 @@ public class AuditEvent implements Serializable {
     
     
     public void calculateDifference() {
-        System.out.println("calculateDifference");
-        System.out.println("Before JSON: " + beforeJson);
-        System.out.println("After JSON: " + afterJson);
+        logger.debug("calculateDifference");
+        logger.debug("Before JSON: {}", beforeJson);
+        logger.debug("After JSON: {}", afterJson);
         if (beforeJson == null || afterJson == null) {
             this.difference = "One or both JSON values are null.";
             return;
@@ -114,19 +118,19 @@ public class AuditEvent implements Serializable {
             // Ensure JSON was parsed successfully
             if (beforeMap == null || afterMap == null) {
                 this.difference = "Failed to parse JSON.";
-                System.out.println("Failed to parse JSON.");
+                logger.warn("Failed to parse JSON.");
                 return;
             }
 
             this.difference = formatDifference(getDifference(beforeMap, afterMap));
         } catch (Exception e) {
-            e.printStackTrace();
+            logger.error("Error calculating difference", e);
             this.difference = "Error calculating difference: " + e.getMessage();
         }
     }
 
     private Map<String, String> getDifference(Map<String, Object> before, Map<String, Object> after) {
-        System.out.println("getDifference");
+        logger.debug("getDifference");
         Map<String, String> diff = new HashMap<>();
 
         // Create a new HashSet with the keys from 'before' to ensure it's modifiable
@@ -134,28 +138,28 @@ public class AuditEvent implements Serializable {
         allKeys.addAll(after.keySet()); // Now this operation is safe
 
         for (String key : allKeys) {
-            System.out.println("key = " + key);
+            logger.debug("key = {}", key);
             Object beforeValue = before.get(key);
             Object afterValue = after.get(key);
             if ((beforeValue == null && afterValue != null)
                     || (beforeValue != null && !beforeValue.equals(afterValue))) {
                 diff.put(key, "Before: " + beforeValue + ", After: " + afterValue);
-                System.out.println("diff = " + diff);
+                logger.debug("diff = {}", diff);
             }
         }
         return diff;
     }
 
     private String formatDifference(Map<String, String> diff) {
-        System.out.println("formatDifference");
-        System.out.println("diff = " + diff);
+        logger.debug("formatDifference");
+        logger.debug("diff = {}", diff);
 
         if (diff.isEmpty()) {
             return "No differences found.";
         }
         StringBuilder sb = new StringBuilder();
         diff.forEach((key, value) -> sb.append(key).append(": ").append(value).append("\n"));
-        System.out.println("sb = " + sb);
+        logger.debug("sb = {}", sb);
         return sb.toString();
     }
 


### PR DESCRIPTION
## Summary
- use Log4j logger in `AuditEvent`
- replace `System.out.println` calls with logger usage

## Testing
- `mvn -q test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_684e4ddd4348832f98e2e109c46b7703