### PR TITLE
Add config option audit history page

### DIFF
--- a/src/main/webapp/audit/config_option_changes.xhtml
+++ b/src/main/webapp/audit/config_option_changes.xhtml
@@ -1,0 +1,84 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
+      xmlns:p="http://primefaces.org/ui"
+      xmlns:h="http://xmlns.jcp.org/jsf/html"
+      xmlns:f="http://xmlns.jcp.org/jsf/core">
+
+    <h:body>
+        <ui:composition template="/admin/institutions/admin_institutions_index.xhtml">
+            <ui:define name="admin">
+                <h:form>
+                    <p:panel>
+                        <f:facet name="header">
+                            <h:outputText value="Config Option Change History" />
+                        </f:facet>
+
+                        <h:panelGrid columns="2" class="my-2">
+                            <h:outputLabel value="From Date"/>
+                            <p:datePicker class="w-100 mx-4" inputStyleClass="w-100"
+                                          id="fromDate"
+                                          value="#{auditEventController.fromDate}"
+                                          showTime="true"
+                                          pattern="#{sessionController.applicationPreference.longDateTimeFormat}" />
+                            <h:outputLabel value="To Date"/>
+                            <p:datePicker class="w-100 mx-4" inputStyleClass="w-100"
+                                          id="toDate"
+                                          value="#{auditEventController.toDate}"
+                                          showTime="true"
+                                          pattern="#{sessionController.applicationPreference.longDateTimeFormat}" />
+                        </h:panelGrid>
+
+                        <h:panelGrid columns="3" class="my-2">
+                            <p:commandButton id="btnSearch"
+                                             class="ui-button-warning"
+                                             icon="pi pi-search"
+                                             ajax="false"
+                                             value="Search"
+                                             action="#{auditEventController.fillConfigOptionChanges}" />
+                        </h:panelGrid>
+
+                        <p:dataTable rowIndexVar="i" id="tblChanges"
+                                     value="#{auditEventController.items}"
+                                     var="ae"
+                                     style="min-width:100%;"
+                                     paginator="true"
+                                     paginatorPosition="bottom"
+                                     rows="10"
+                                     paginatorTemplate="{CurrentPageReport} {FirstPageLink} {PreviousPageLink} {PageLinks} {NextPageLink} {LastPageLink} {RowsPerPageDropdown}"
+                                     rowsPerPageTemplate="5,10,15">
+
+                            <p:column headerText="User">
+                                <h:outputText value="#{webUserController.findWebUserNameWithTitleById(ae.webUserId)}" />
+                            </p:column>
+
+                            <p:column headerText="Time">
+                                <h:outputText value="#{ae.eventDataTime}">
+                                    <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateTimeFormat}" />
+                                </h:outputText>
+                            </p:column>
+
+                            <p:column headerText="Option Key">
+                                <h:outputText value="#{auditEventController.getOptionKey(ae)}" />
+                            </p:column>
+
+                            <p:column headerText="Before Value">
+                                <h:outputText value="#{auditEventController.getBeforeValue(ae)}" />
+                            </p:column>
+
+                            <p:column headerText="After Value">
+                                <h:outputText value="#{auditEventController.getAfterValue(ae)}" />
+                            </p:column>
+
+                            <p:column headerText="Differences">
+                                <h:outputText value="#{ae.difference}" style="white-space: pre-line;" />
+                            </p:column>
+
+                        </p:dataTable>
+                    </p:panel>
+                </h:form>
+            </ui:define>
+        </ui:composition>
+    </h:body>
+</html>


### PR DESCRIPTION
## Summary
- track config option changes in `AuditEventController`
- parse option key and values from audit JSON
- add `config_option_changes.xhtml` page to list audit entries

## Testing
- `mvn -q -DskipTests package` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_684e4ebceb0c832f884a9a3908d10f46