### PR TITLE
Add method to fetch config option audit events

### DIFF
--- a/src/main/java/com/divudi/bean/common/AuditEventController.java
+++ b/src/main/java/com/divudi/bean/common/AuditEventController.java
@@ -12,6 +12,7 @@ import com.divudi.core.data.AuditEventStatus;
 import com.divudi.core.entity.AuditEvent;
 import com.divudi.core.facade.AuditEventFacade;
 import com.divudi.core.util.CommonFunctions;
+import com.divudi.core.entity.ConfigOption;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Date;
@@ -226,6 +227,25 @@ public class AuditEventController implements Serializable {
                 + " order by a.eventDataTime desc";
         Map<String, Object> hm = new HashMap<>();
         hm.put("et", "ConfigOption");
+        hm.put("trigs", Arrays.asList("Update Config Option", "Delete Config Option"));
+        hm.put("fd", fromDate);
+        hm.put("td", toDate);
+        items = getFacade().findByJpql(jpql, hm, TemporalType.TIMESTAMP);
+        if (items != null) {
+            for (AuditEvent ae : items) {
+                ae.calculateDifference();
+            }
+        }
+    }
+
+    public void fillConfigOptionEvents() {
+        String jpql = "select a from AuditEvent a "
+                + " where a.entityType=:et"
+                + " and a.eventTrigger in :trigs"
+                + " and a.eventDataTime between :fd and :td"
+                + " order by a.eventDataTime desc";
+        Map<String, Object> hm = new HashMap<>();
+        hm.put("et", ConfigOption.class.getSimpleName());
         hm.put("trigs", Arrays.asList("Update Config Option", "Delete Config Option"));
         hm.put("fd", fromDate);
         hm.put("td", toDate);


### PR DESCRIPTION
## Summary
- fetch audit events for ConfigOption updates/deletes with new `fillConfigOptionEvents()`
- import `ConfigOption` entity

## Testing
- `mvn -q -DskipTests=false test` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684e7ce72970832f8c23ee405139355a