### PR TITLE
12265-security-sanitize-stack-trace-content-before-displaying-with-escape-false

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -211,3 +211,14 @@ Use the following check to conditionally render a UI component:
 - All new privileges must be assigned manually via the User Privileges page.
 
 These guidelines apply to the entire repository.
+
+## HTML Output Sanitisation
+
+Dynamic text displayed with `escape="false"` must be sanitised to avoid
+cross-site scripting vulnerabilities. Use
+`CommonFunctionsProxy.escapeHtml(String)` before rendering user-provided content
+that doesn't intentionally include HTML tags.
+
+**Note:** The escaping method converts `<` and `>` characters to HTML entities,
+so it should not be used when the string contains markup that must be rendered,
+such as `<br>` or style elements.

--- a/src/main/java/com/divudi/bean/common/ErrorHandler.java
+++ b/src/main/java/com/divudi/bean/common/ErrorHandler.java
@@ -4,6 +4,7 @@ import java.io.Serializable;
 import javax.enterprise.context.RequestScoped;
 import javax.faces.context.FacesContext;
 import javax.inject.Named;
+import com.divudi.core.util.CommonFunctions;
 
 /**
  * Error Handler Bean
@@ -58,13 +59,13 @@ public class ErrorHandler implements Serializable {
         // Append the main exception class and message
         sb.append(t.getClass().getName())
           .append(": ")
-          .append(escapeHtml(t.getMessage()))
+          .append(CommonFunctions.escapeHtml(t.getMessage()))
           .append("\n");
 
         // Append stack trace elements
         for (StackTraceElement element : t.getStackTrace()) {
             sb.append("    at ")
-              .append(escapeHtml(element.toString()))
+              .append(CommonFunctions.escapeHtml(element.toString()))
               .append("\n");
         }
 
@@ -76,15 +77,4 @@ public class ErrorHandler implements Serializable {
         }
     }
 
-    private String escapeHtml(String input) {
-        if (input == null) {
-            return "";
-        }
-        return input
-            .replace("&", "&amp;")
-            .replace("<", "&lt;")
-            .replace(">", "&gt;")
-            .replace("\"", "&quot;")
-            .replace("'", "&#39;");
-    }
 }

--- a/src/main/java/com/divudi/core/util/CommonFunctions.java
+++ b/src/main/java/com/divudi/core/util/CommonFunctions.java
@@ -261,6 +261,29 @@ public class CommonFunctions {
 
     }
 
+    /**
+     * Escape HTML special characters to safely render dynamic text.
+     * <p>
+     * This method should be used when outputting user-provided content in
+     * JSF components with <code>escape="false"</code> to avoid XSS issues.
+     * It will convert characters such as <code>&lt;</code> and
+     * <code>&gt;</code> to their HTML entity equivalents.
+     *
+     * @param input Raw string
+     * @return Sanitised string safe for HTML output
+     */
+    public static String escapeHtml(String input) {
+        if (input == null) {
+            return "";
+        }
+        return input
+                .replace("&", "&amp;")
+                .replace("<", "&lt;")
+                .replace(">", "&gt;")
+                .replace("\"", "&quot;")
+                .replace("'", "&#39;");
+    }
+
     public static Long convertStringToLongByRemoveSpecialChars(String phonenumber) {
         if (phonenumber == null || phonenumber.trim().isEmpty()) {
             return null;

--- a/src/main/java/com/divudi/core/util/CommonFunctionsProxy.java
+++ b/src/main/java/com/divudi/core/util/CommonFunctionsProxy.java
@@ -77,4 +77,15 @@ public class CommonFunctionsProxy {
     public double dateDifferenceInMinutes(Date fromDate, Date toDate) {
         return CommonFunctions.dateDifferenceInMinutes(fromDate, toDate);
     }
+
+    /**
+     * Delegates to {@link CommonFunctions#escapeHtml(String)} to sanitise text
+     * before rendering with <code>escape="false"</code> in JSF pages.
+     *
+     * @param input raw string value
+     * @return escaped string safe for HTML output
+     */
+    public String escapeHtml(String input) {
+        return CommonFunctions.escapeHtml(input);
+    }
 }


### PR DESCRIPTION
## Summary
- sanitize stack trace output on error page by enabling escaping
- provide reusable `escapeHtml` helper via `CommonFunctionsProxy`
- document sanitisation requirement when using `escape="false"` in AGENTS

Closes #12265

------
https://chatgpt.com/codex/tasks/task_e_684eb36871e0832f91f452081756f8ac