### PR TITLE
Add config option events audit view

### DIFF
--- a/src/main/java/com/divudi/bean/common/AuditEventController.java
+++ b/src/main/java/com/divudi/bean/common/AuditEventController.java
@@ -219,10 +219,6 @@ public class AuditEventController implements Serializable {
         return auditEvents;
     }
 
-    public void fillConfigOptionChanges() {
-        fillConfigOption(Arrays.asList("Update Config Option", "Delete Config Option"));
-    }
-
     public void fillConfigOptionEvents() {
         fillConfigOption(Arrays.asList("Update Config Option", "Delete Config Option"));
     }

--- a/src/main/webapp/audit/config_option_events.xhtml
+++ b/src/main/webapp/audit/config_option_events.xhtml
@@ -12,7 +12,7 @@
                 <h:form>
                     <p:panel>
                         <f:facet name="header">
-                            <h:outputText value="Config Option Change History" />
+                            <h:outputText value="Config Option Events" />
                         </f:facet>
 
                         <h:panelGrid columns="2" class="my-2">
@@ -31,7 +31,7 @@
                         </h:panelGrid>
 
                         <h:panelGrid columns="3" class="my-2">
-                                            <p:commandButton id="btnSearch"
+                            <p:commandButton id="btnSearch"
                                              class="ui-button-warning"
                                              icon="pi pi-search"
                                              ajax="false"
@@ -39,7 +39,7 @@
                                              action="#{auditEventController.fillConfigOptionEvents}" />
                         </h:panelGrid>
 
-                        <p:dataTable rowIndexVar="i" id="tblChanges"
+                        <p:dataTable rowIndexVar="i" id="tblEvents"
                                      value="#{auditEventController.items}"
                                      var="ae"
                                      style="min-width:100%;"

--- a/src/main/webapp/dataAdmin/admin_data_administration.xhtml
+++ b/src/main/webapp/dataAdmin/admin_data_administration.xhtml
@@ -221,14 +221,20 @@
                                         <div class="d-grid gap-2">
                                             <p:commandButton
                                                 ajax="false"
-                                                action="/audit/items_and_fees?faces-redirect=true;"
-                                                value="Items &amp; Fees"
-                                                icon="fa fa-comments" >
+                                            action="/audit/items_and_fees?faces-redirect=true;"
+                                            value="Items &amp; Fees"
+                                            icon="fa fa-comments" >
                                             </p:commandButton>
                                             <p:commandButton
                                                 ajax="false"
                                                 action="/audit/config_option_changes?faces-redirect=true;"
                                                 value="Config Option Changes"
+                                                icon="pi pi-history" >
+                                            </p:commandButton>
+                                            <p:commandButton
+                                                ajax="false"
+                                                action="/audit/config_option_events?faces-redirect=true;"
+                                                value="Config Option Events"
                                                 icon="pi pi-history" >
                                             </p:commandButton>
                                         </div>


### PR DESCRIPTION
## Summary
- show config option events in a new audit page
- link the new page from the Audit tab
- use `fillConfigOptionEvents` for both events and changes pages
- drop unused `fillConfigOptionChanges` method

## Testing
- `mvn -q test` *(fails: PluginResolutionException)*

------
https://chatgpt.com/codex/tasks/task_e_684eca2448a0832f920a7f953713fd81