### PR TITLE
Add null safety checks for store items distributors

### DIFF
--- a/src/main/java/com/divudi/bean/store/StoreItemsDistributorsController.java
+++ b/src/main/java/com/divudi/bean/store/StoreItemsDistributorsController.java
@@ -83,6 +83,9 @@ public class StoreItemsDistributorsController implements Serializable {
     }
 
     private boolean checkItem() {
+        if (getCurrentInstitution() == null || getCurrentItem() == null) {
+            return false;
+        }
         String sql = "Select i from ItemsDistributors i where i.retired=false"
                 + " and i.institution.id= " + getCurrentInstitution().getId() + " and "
                 + " i.item.id=" + getCurrentItem().getId();
@@ -211,6 +214,11 @@ public class StoreItemsDistributorsController implements Serializable {
      * @return
      */
     public List<ItemsDistributors> getItems() {
+        if (getCurrentInstitution() == null) {
+            items = new ArrayList<>();
+            return items;
+        }
+
         String temSql;
         HashMap hm = new HashMap();
 


### PR DESCRIPTION
## Summary
- handle null `currentInstitution` and `currentItem` in `checkItem`
- return empty list if `currentInstitution` is not set in `getItems`

Closes #13091

------
https://chatgpt.com/codex/tasks/task_e_684edc61ae0c832f8b7d84d71769585c

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved stability by adding checks to prevent errors when required data is missing, reducing the risk of unexpected application crashes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->