### PR TITLE
Add JSoup sanitization for admin HTML

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -164,6 +164,8 @@ In XHTML pages, configuration values can be checked or used directly for renderi
 - Use `.getBooleanValueByKey()` for true/false logic.
 - Use `.getShortTextValueByKey(key, true)` for text values.
 - Missing keys will be auto-created with default values if provided.
+- `setLongTextValueByKey` sanitises HTML input using JSoup's basic Safelist
+  before storing long text configuration options.
 
 
 ## Adding and Managing Privileges

--- a/README.md
+++ b/README.md
@@ -63,6 +63,12 @@ The installation is very easy for testing. In a development setting, simply clon
 
 The features available to different roles of the users are stated in detail in the User Manual.
 
+### Sanitizing Admin-Defined HTML
+
+Text values saved via `setLongTextValueByKey` are cleaned with JSoup's basic
+safelist before being stored. This prevents administrators from accidentally
+introducing unsafe markup.
+
 ## Request Originators 
 * Dr M H B Ariyaratne
 * Dr Jagath Samarasekara

--- a/pom.xml
+++ b/pom.xml
@@ -371,6 +371,11 @@
             <type>jar</type>
         </dependency>
         <dependency>
+            <groupId>org.jsoup</groupId>
+            <artifactId>jsoup</artifactId>
+            <version>1.20.1</version>
+        </dependency>
+        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <version>4.13.2</version>

--- a/src/main/java/com/divudi/bean/common/ConfigOptionApplicationController.java
+++ b/src/main/java/com/divudi/bean/common/ConfigOptionApplicationController.java
@@ -20,6 +20,8 @@ import java.util.stream.Collectors;
 import javax.annotation.PostConstruct;
 import javax.ejb.EJB;
 import javax.enterprise.context.ApplicationScoped;
+import org.jsoup.Jsoup;
+import org.jsoup.safety.Safelist;
 
 /**
  *
@@ -382,7 +384,8 @@ public class ConfigOptionApplicationController implements Serializable {
             option.setValueType(OptionValueType.LONG_TEXT);
             optionFacade.create(option);
         }
-        option.setOptionValue(value);
+        String sanitized = Jsoup.clean(value, Safelist.basic());
+        option.setOptionValue(sanitized);
         optionFacade.edit(option);
         loadApplicationOptions();
     }


### PR DESCRIPTION
## Summary
- add jsoup dependency
- sanitize ConfigOptionApplicationController.setLongTextValueByKey
- document sanitization behaviour in docs

Closes #11890

------
https://chatgpt.com/codex/tasks/task_e_684edb93eb98832fa681cd38f2f0a64d

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Long text configuration values are now automatically sanitized to allow only safe HTML before being saved, enhancing security for admin-defined content.
- **Documentation**
	- Updated documentation to explain the new HTML sanitization process for admin-defined text values.
- **Chores**
	- Added the JSoup library as a new project dependency to support HTML sanitization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->