### PR TITLE
Fix duplicate bill settlement

### DIFF
--- a/src/main/java/com/divudi/bean/common/OpdPreSettleController.java
+++ b/src/main/java/com/divudi/bean/common/OpdPreSettleController.java
@@ -848,6 +848,15 @@ public class OpdPreSettleController implements Serializable, ControllerWithMulti
             return;
         }
 
+        Bill latestPreBill = getBillFacade().findWithoutCache(getPreBill().getId());
+        Map<String, Object> params = new HashMap<>();
+        params.put("pre", latestPreBill);
+        Bill existing = getBillFacade().findFirstByJpql("select b from BilledBill b where b.referenceBill=:pre", params);
+        if (existing != null) {
+            JsfUtil.addErrorMessage("Already Paid");
+            return;
+        }
+
         if (getCashPaid() < getPreBill().getNetTotal()) {
             JsfUtil.addErrorMessage("Tendered Amount is lower than Total");
             return;

--- a/src/main/java/com/divudi/bean/pharmacy/PharmacyPreSettleController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacyPreSettleController.java
@@ -67,6 +67,7 @@ import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.HashMap;
+import java.util.Map;
 import java.util.List;
 import javax.ejb.EJB;
 import javax.enterprise.context.SessionScoped;
@@ -1062,7 +1063,16 @@ public class PharmacyPreSettleController implements Serializable, ControllerWith
             JsfUtil.addErrorMessage(discountSchemeValidation.getMessage());
             return;
         }
-        
+
+        Bill latestPreBill = getBillFacade().findWithoutCache(getPreBill().getId());
+        Map<String, Object> params = new HashMap<>();
+        params.put("pre", latestPreBill);
+        Bill existing = getBillFacade().findFirstByJpql("select b from BilledBill b where b.referenceBill=:pre", params);
+        if (existing != null) {
+            JsfUtil.addErrorMessage("Already Paid");
+            return;
+        }
+
         saveSaleBill();
 //        saveSaleBillItems();
 


### PR DESCRIPTION
## Summary
- prevent settling a bill more than once in `settleBillWithPay2`
- load the bill separately to avoid overriding its status

## Testing
- `mvn -q -DskipTests package` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68503e83958c832fb465c93f48da571d