### PR TITLE
Ensure bills commit immediately on settle

### DIFF
--- a/src/main/java/com/divudi/bean/common/OpdPreSettleController.java
+++ b/src/main/java/com/divudi/bean/common/OpdPreSettleController.java
@@ -553,7 +553,7 @@ public class OpdPreSettleController implements Serializable, ControllerWithMulti
         if (getSaleBill().getId() == null) {
             getBillFacade().create(getSaleBill());
         } else {
-            getBillFacade().edit(getSaleBill());
+            getBillFacade().editAndCommit(getSaleBill());
         }
 
         updateSettledBatchBill();
@@ -592,10 +592,10 @@ public class OpdPreSettleController implements Serializable, ControllerWithMulti
         if (outputBilledBill.getId() == null) {
             getBillFacade().create(outputBilledBill);
         } else {
-            getBillFacade().edit(outputBilledBill);
+            getBillFacade().editAndCommit(outputBilledBill);
         }
         inputPreBill.setReferenceBill(outputBilledBill);
-        getBillFacade().edit(inputPreBill);
+        getBillFacade().editAndCommit(inputPreBill);
         return outputBilledBill;
     }
 
@@ -736,18 +736,18 @@ public class OpdPreSettleController implements Serializable, ControllerWithMulti
         if (savingSettlingIndividualBill.getId() == null) {
             getBillFacade().create(savingSettlingIndividualBill);
         } else {
-            getBillFacade().edit(savingSettlingIndividualBill);
+            getBillFacade().editAndCommit(savingSettlingIndividualBill);
         }
 
         individualBill.setReferenceBill(savingSettlingIndividualBill);
-        getBillFacade().edit(individualBill);
+        getBillFacade().editAndCommit(individualBill);
 
         return savingSettlingIndividualBill;
     }
 
     private void updateSettledBatchBill() {
         getPreBill().setReferenceBill(getSaleBill());
-        getBillFacade().edit(getPreBill());
+        getBillFacade().editAndCommit(getPreBill());
 
     }
 
@@ -781,8 +781,8 @@ public class OpdPreSettleController implements Serializable, ControllerWithMulti
 
             getBillBean().setPaymentMethodData(newlyCreatedIndividualBilledBillOfBilledBatchBill, getPreBill().getPaymentMethod(), paymentMethodData);
 
-            getBillFacade().edit(newlyCreatedIndividualBilledBillOfBilledBatchBill);
-            getBillFacade().edit(preBill);
+            getBillFacade().editAndCommit(newlyCreatedIndividualBilledBillOfBilledBatchBill);
+            getBillFacade().editAndCommit(preBill);
             billsOfBatchBilledBill.add(newlyCreatedIndividualBilledBillOfBilledBatchBill);
         }
     }
@@ -804,7 +804,7 @@ public class OpdPreSettleController implements Serializable, ControllerWithMulti
             saveBillFee(originalBillFees, newSettlingBillItem);
             newlyCreatedSettlingIndividualBill.getBillItems().add(newSettlingBillItem);
         }
-        getBillFacade().edit(individualPreBill);
+        getBillFacade().editAndCommit(individualPreBill);
 
     }
 
@@ -865,7 +865,7 @@ public class OpdPreSettleController implements Serializable, ControllerWithMulti
         saveIndividualBilledBillsOfPreBatchBill();
 
 //        getPreBill().getCashBillsPre().add(getSaleBill());
-        getBillFacade().edit(getPreBill());
+        getBillFacade().editAndCommit(getPreBill());
 
         WebUser wb = getCashTransactionBean().saveBillCashInTransaction(getSaleBill(), getSessionController().getLoggedUser());
         getSessionController().setLoggedUser(wb);
@@ -1064,7 +1064,7 @@ public class OpdPreSettleController implements Serializable, ControllerWithMulti
         saveSettlingBatchBill();
         saveIndividualBilledBillsOfPreBatchBill();
 
-        getBillFacade().edit(getPreBill());
+        getBillFacade().editAndCommit(getPreBill());
         setBill(getBillFacade().find(getSaleBill().getId()));
 
         billPreview = true;

--- a/src/main/java/com/divudi/bean/pharmacy/PharmacyPreSettleController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacyPreSettleController.java
@@ -641,12 +641,12 @@ public class PharmacyPreSettleController implements Serializable, ControllerWith
 
     private void updateSaleReturnPreBill() {
         getPreBill().setReferenceBill(getSaleReturnBill());
-        getBillFacade().edit(getPreBill());
+        getBillFacade().editAndCommit(getPreBill());
     }
 
     private void updatePreBill() {
         getPreBill().setReferenceBill(getSaleBill());
-        getBillFacade().edit(getPreBill());
+        getBillFacade().editAndCommit(getPreBill());
     }
 
     private void saveSaleBillItems() {
@@ -677,7 +677,7 @@ public class PharmacyPreSettleController implements Serializable, ControllerWith
             //   getPharmacyBean().deductFromStock(tbi.getItem(), tbi.getQty(), tbi.getBill().getDepartment());
             getSaleBill().getBillItems().add(newBil);
         }
-        getBillFacade().edit(getSaleBill());
+        getBillFacade().editAndCommit(getSaleBill());
 
     }
 
@@ -712,7 +712,7 @@ public class PharmacyPreSettleController implements Serializable, ControllerWith
 
             getSaleBill().getBillItems().add(newBil);
         }
-        getBillFacade().edit(getSaleBill());
+        getBillFacade().editAndCommit(getSaleBill());
 
     }
 
@@ -1082,7 +1082,7 @@ public class PharmacyPreSettleController implements Serializable, ControllerWith
         saveSaleBillItems();
 
 //        getPreBill().getCashBillsPre().add(getSaleBill());
-        getBillFacade().edit(getPreBill());
+        getBillFacade().editAndCommit(getPreBill());
 
         WebUser wb = getCashTransactionBean().saveBillCashInTransaction(getSaleBill(), getSessionController().getLoggedUser());
         getSessionController().setLoggedUser(wb);


### PR DESCRIPTION
## Summary
- commit Pharmacy sale bills directly with `editAndCommit`
- flush prebill and salebill edits in OPD cashier settlement

## Testing
- `mvn -q test` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6850425dcb00832faed3009208d99d5e