### PR TITLE
Add bill item count check before settling pharmacy pre bills

### DIFF
--- a/src/main/java/com/divudi/bean/pharmacy/PharmacyPreSettleController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacyPreSettleController.java
@@ -1070,6 +1070,11 @@ public class PharmacyPreSettleController implements Serializable, ControllerWith
         }
 
         Bill latestPreBill = getBillFacade().findWithoutCache(getPreBill().getId());
+        if (latestPreBill.getBillItems().size() != getPreBill().getBillItems().size()) {
+            JsfUtil.addErrorMessage("Bill was opened in multiple windows. Please close all windows and start again.");
+            billSettlingStarted = false;
+            return;
+        }
         Map<String, Object> params = new HashMap<>();
         params.put("pre", latestPreBill);
         Bill existing = getBillFacade().findFirstByJpql("select b from BilledBill b where b.referenceBill=:pre", params);


### PR DESCRIPTION
## Summary
- reload the latest PreBill in `PharmacyPreSettleController` and compare bill item counts
- abort settlement with an error message when counts mismatch to avoid duplicate items

## Testing
- `mvn -q test` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:2.6 or one of its dependencies could not be resolved)*

------
https://chatgpt.com/codex/tasks/task_e_68503c428818832f9be486baa5cac2ba