### PR TITLE
Fix return bill calculations

### DIFF
--- a/src/main/java/com/divudi/bean/pharmacy/DirectPurchaseReturnController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/DirectPurchaseReturnController.java
@@ -30,6 +30,7 @@ import com.divudi.core.facade.BillItemFacade;
 import com.divudi.core.facade.PaymentFacade;
 import com.divudi.core.facade.PharmaceuticalBillItemFacade;
 import com.divudi.core.entity.BillItemFinanceDetails;
+import com.divudi.core.entity.BillFinanceDetails;
 import com.divudi.service.pharmacy.PharmacyCostingService;
 import java.math.BigDecimal;
 import java.io.Serializable;
@@ -39,6 +40,8 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
+import java.math.RoundingMode;
 import javax.ejb.EJB;
 import javax.enterprise.context.SessionScoped;
 import javax.inject.Inject;
@@ -296,16 +299,27 @@ public class DirectPurchaseReturnController implements Serializable {
     }
 
     public BigDecimal getReturnRate(BillItem originalBillItem) {
-        BigDecimal rate = originalBillItem.getBillItemFinanceDetails().getGrossRate();
-        if (configOptionApplicationController.getBooleanValueByKey("Direct Purchase Return Based On Line Cost Rate", false)
-                && originalBillItem.getBillItemFinanceDetails() != null
-                && originalBillItem.getBillItemFinanceDetails().getLineCostRate() != null) {
-            rate = originalBillItem.getBillItemFinanceDetails().getLineCostRate();
-        } else if (configOptionApplicationController.getBooleanValueByKey("Direct Purchase Return Based On Total Cost Rate", false)
-                && originalBillItem.getBillItemFinanceDetails() != null
-                && originalBillItem.getBillItemFinanceDetails().getTotalCostRate() != null) {
-            rate = originalBillItem.getBillItemFinanceDetails().getTotalCostRate();
+        BillItemFinanceDetails fd = originalBillItem.getBillItemFinanceDetails();
+        if (fd == null) {
+            return BigDecimal.ZERO;
         }
+
+        BigDecimal rate = fd.getGrossRate();
+        if (configOptionApplicationController.getBooleanValueByKey("Direct Purchase Return Based On Line Cost Rate", false)
+                && fd.getLineCostRate() != null) {
+            rate = fd.getLineCostRate();
+        } else if (configOptionApplicationController.getBooleanValueByKey("Direct Purchase Return Based On Total Cost Rate", false)
+                && fd.getTotalCostRate() != null) {
+            rate = fd.getTotalCostRate();
+        }
+
+        if (originalBillItem.getItem() instanceof Ampp) {
+            BigDecimal upp = Optional.ofNullable(fd.getUnitsPerPack()).orElse(BigDecimal.ONE);
+            if (upp.compareTo(BigDecimal.ZERO) > 0) {
+                rate = rate.divide(upp, 4, RoundingMode.HALF_UP);
+            }
+        }
+
         return rate;
     }
 
@@ -478,6 +492,27 @@ public class DirectPurchaseReturnController implements Serializable {
         }
         getReturnBill();
         getReturnBill().setBilledBill(bill);
+        // Reset inherited financial values
+        getReturnBill().setDiscount(0.0);
+        getReturnBill().setExpenseTotal(0.0);
+        getReturnBill().setTax(0.0);
+        if (getReturnBill().getBillFinanceDetails() == null) {
+            getReturnBill().setBillFinanceDetails(new BillFinanceDetails(getReturnBill()));
+        } else {
+            BillFinanceDetails bfd = getReturnBill().getBillFinanceDetails();
+            bfd.setBillDiscount(BigDecimal.ZERO);
+            bfd.setBillExpense(BigDecimal.ZERO);
+            bfd.setBillTaxValue(BigDecimal.ZERO);
+            bfd.setTotalDiscount(BigDecimal.ZERO);
+            bfd.setTotalExpense(BigDecimal.ZERO);
+            bfd.setTotalTaxValue(BigDecimal.ZERO);
+            bfd.setLineDiscount(BigDecimal.ZERO);
+            bfd.setLineExpense(BigDecimal.ZERO);
+            bfd.setItemTaxValue(BigDecimal.ZERO);
+            bfd.setBillCostValue(BigDecimal.ZERO);
+            bfd.setLineCostValue(BigDecimal.ZERO);
+            bfd.setTotalCostValue(BigDecimal.ZERO);
+        }
         prepareBillItems(bill);
     }
 
@@ -498,7 +533,8 @@ public class DirectPurchaseReturnController implements Serializable {
         for (PharmaceuticalBillItem pbiOfBilledBill : pbisOfBilledBill) {
             System.out.println("i = " + pbiOfBilledBill);
             BillItem newBillItemInReturnBill = new BillItem();
-            newBillItemInReturnBill.copy(pbiOfBilledBill.getBillItem());
+            // Copy basic item data but ignore any financial values
+            newBillItemInReturnBill.copyWithoutFinancialData(pbiOfBilledBill.getBillItem());
             newBillItemInReturnBill.setQty(0.0);
             newBillItemInReturnBill.setBill(getReturnBill());
             newBillItemInReturnBill.setItem(pbiOfBilledBill.getBillItem().getItem());
@@ -544,6 +580,34 @@ public class DirectPurchaseReturnController implements Serializable {
             if (originalFd != null) {
                 fd = originalFd.clone();
                 fd.setBillItem(newBillItemInReturnBill);
+                // Remove any previously calculated discounts, taxes or expenses
+                fd.setLineDiscountRate(BigDecimal.ZERO);
+                fd.setBillDiscountRate(BigDecimal.ZERO);
+                fd.setTotalDiscountRate(BigDecimal.ZERO);
+                fd.setLineDiscount(BigDecimal.ZERO);
+                fd.setBillDiscount(BigDecimal.ZERO);
+                fd.setTotalDiscount(BigDecimal.ZERO);
+
+                fd.setLineExpenseRate(BigDecimal.ZERO);
+                fd.setBillExpenseRate(BigDecimal.ZERO);
+                fd.setTotalExpenseRate(BigDecimal.ZERO);
+                fd.setLineExpense(BigDecimal.ZERO);
+                fd.setBillExpense(BigDecimal.ZERO);
+                fd.setTotalExpense(BigDecimal.ZERO);
+
+                fd.setBillTaxRate(BigDecimal.ZERO);
+                fd.setLineTaxRate(BigDecimal.ZERO);
+                fd.setTotalTaxRate(BigDecimal.ZERO);
+                fd.setBillTax(BigDecimal.ZERO);
+                fd.setLineTax(BigDecimal.ZERO);
+                fd.setTotalTax(BigDecimal.ZERO);
+
+                fd.setBillCostRate(BigDecimal.ZERO);
+                fd.setLineCostRate(BigDecimal.ZERO);
+                fd.setTotalCostRate(BigDecimal.ZERO);
+                fd.setBillCost(BigDecimal.ZERO);
+                fd.setLineCost(BigDecimal.ZERO);
+                fd.setTotalCost(BigDecimal.ZERO);
             } else {
                 fd = new BillItemFinanceDetails(newBillItemInReturnBill);
             }

--- a/src/main/webapp/pharmacy/direct_purchase_return.xhtml
+++ b/src/main/webapp/pharmacy/direct_purchase_return.xhtml
@@ -147,7 +147,7 @@
                                     <h:outputLabel value="Supplier : " />
                                     <h:outputLabel value="#{directPurchaseReturnController.returnBill.toInstitution.name}" />
                                     <p:outputLabel  value="Recievable Amount" />
-                                    <p:outputLabel id="total"  value="#{directPurchaseReturnController.returnBill.netTotal}" >
+                                    <p:outputLabel id="total"  value="#{0-directPurchaseReturnController.returnBill.netTotal}" >
                                         <f:convertNumber pattern="#,##0.00" />
                                     </p:outputLabel>
 


### PR DESCRIPTION
## Summary
- compute return rate per unit for Ampp packs
- ensure return bills start with zeroed discounts, taxes, and expenses
- ignore financial fields when copying original bill items
- clear copied financial details on returned items
- display positive return total in UI

## Testing
- `mvn -q test` *(fails: Could not resolve Maven dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6850b9e735c8832fae3d4eed21d24f0b