### PR TITLE
Add PharmacyIncomeRow DTO and use it for cost report

### DIFF
--- a/src/main/java/com/divudi/bean/common/BillSearch.java
+++ b/src/main/java/com/divudi/bean/common/BillSearch.java
@@ -3232,6 +3232,13 @@ public class BillSearch implements Serializable {
 //        bill.setTransError(flag);
     }
 
+    public Bill fetchBillById(Long id) {
+        if (id == null) {
+            return null;
+        }
+        return billService.fetchBillById(id);
+    }
+
     public String navigateToCancelOpdBill() {
         if (bill == null) {
             JsfUtil.addErrorMessage("Nothing to cancel");

--- a/src/main/java/com/divudi/bean/pharmacy/PharmacySummaryReportController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacySummaryReportController.java
@@ -60,6 +60,7 @@ import com.divudi.core.entity.PaymentScheme;
 import com.divudi.core.entity.WebUser;
 import com.divudi.core.entity.inward.AdmissionType;
 import com.divudi.core.entity.pharmacy.PharmaceuticalBillItem;
+import com.divudi.core.light.pharmacy.PharmacyIncomeRow;
 import com.divudi.core.facade.DrawerFacade;
 import com.divudi.core.facade.PaymentFacade;
 import com.divudi.core.util.CommonFunctions;
@@ -835,9 +836,9 @@ public class PharmacySummaryReportController implements Serializable {
     public void processPharmacyIncomeAndCostReportByBillItem() {
         reportTimerController.trackReportExecution(() -> {
             List<BillTypeAtomic> billTypeAtomics = getPharmacyIncomeBillTypes();
-            List<PharmaceuticalBillItem> pbis = billService.fetchPharmaceuticalBillItems(fromDate, toDate, institution, site, department, webUser, billTypeAtomics, admissionType, paymentScheme);
-            bundle = new IncomeBundle(pbis);
-            bundle.generateRetailAndCostDetailsForPharmaceuticalBillItems();
+            List<PharmacyIncomeRow> rows = billService.fetchPharmacyIncomeRows(fromDate, toDate, institution, site, department, webUser, billTypeAtomics, admissionType, paymentScheme);
+            bundle = new IncomeBundle(rows);
+            bundle.generateRetailAndCostDetailsForPharmacyIncomeRows();
         }, SummaryReports.PHARMACY_INCOME_REPORT, sessionController.getLoggedUser());
     }
 

--- a/src/main/java/com/divudi/core/data/IncomeBundle.java
+++ b/src/main/java/com/divudi/core/data/IncomeBundle.java
@@ -292,6 +292,15 @@ public class IncomeBundle implements Serializable {
                         rows.add(ir);
                     }
                 }
+            } else if (firstElement instanceof com.divudi.core.light.pharmacy.PharmacyIncomeRow) {
+                for (Object obj : entries) {
+                    if (obj instanceof com.divudi.core.light.pharmacy.PharmacyIncomeRow) {
+                        com.divudi.core.light.pharmacy.PharmacyIncomeRow pir =
+                                (com.divudi.core.light.pharmacy.PharmacyIncomeRow) obj;
+                        IncomeRow ir = new IncomeRow(pir);
+                        rows.add(ir);
+                    }
+                }
             } else if (firstElement instanceof IncomeRow) {
                 // Process list as IncomeRows
                 for (Object obj : entries) {
@@ -338,6 +347,63 @@ public class IncomeBundle implements Serializable {
             }
 
             double qty = Math.abs(q);
+            double retail = Math.abs(rRate);
+            double purchase = Math.abs(pRate);
+
+            double retailTotal = 0;
+            double purchaseTotal = 0;
+            double grossProfit = 0;
+
+            switch (bc) {
+                case BILL:
+                case PAYMENTS:
+                case PREBILL:
+                    retailTotal = retail * qty;
+                    purchaseTotal = purchase * qty;
+                    grossProfit = (retail - purchase) * qty;
+                    break;
+
+                case CANCELLATION:
+                case REFUND:
+                    retailTotal = -retail * qty;
+                    purchaseTotal = -purchase * qty;
+                    grossProfit = -(retail - purchase) * qty;
+                    break;
+
+                default:
+                    break;
+            }
+
+            saleValue += retailTotal;
+            purchaseValue += purchaseTotal;
+            grossProfitValue += grossProfit;
+        }
+    }
+
+    public void generateRetailAndCostDetailsForPharmacyIncomeRows() {
+        saleValue = 0;
+        purchaseValue = 0;
+        grossProfitValue = 0;
+        quantity = 0.0;
+
+        for (IncomeRow r : getRows()) {
+            com.divudi.core.light.pharmacy.PharmacyIncomeRow pir = r.getPharmacyIncomeRow();
+            if (pir == null || pir.getBillTypeAtomic() == null || pir.getBillTypeAtomic().getBillCategory() == null) {
+                continue;
+            }
+
+            com.divudi.core.data.BillCategory bc = pir.getBillTypeAtomic().getBillCategory();
+
+            Double q = pir.getQty();
+            Double rRate = pir.getRetailRate();
+            Double pRate = pir.getPurchaseRate();
+
+            if (q == null || rRate == null || pRate == null) {
+                continue;
+            }
+
+            double qty = Math.abs(q);
+            quantity += qty;
             double retail = Math.abs(rRate);
             double purchase = Math.abs(pRate);
 

--- a/src/main/java/com/divudi/core/data/IncomeRow.java
+++ b/src/main/java/com/divudi/core/data/IncomeRow.java
@@ -33,6 +33,7 @@ public class IncomeRow implements Serializable {
     private Bill referanceBill;
     private BillItem billItem;
     private PharmaceuticalBillItem pharmaceuticalBillItem;
+    private com.divudi.core.light.pharmacy.PharmacyIncomeRow pharmacyIncomeRow;
     private BillFee billFee;
     private Payment payment;
 
@@ -181,6 +182,13 @@ public class IncomeRow implements Serializable {
         this();
         this.pharmaceuticalBillItem = pbi;
         rowType = "PharmaceuticalBillItem";
+    }
+
+    public IncomeRow(com.divudi.core.light.pharmacy.PharmacyIncomeRow pir) {
+        this();
+        this.pharmacyIncomeRow = pir;
+        rowType = "PharmacyIncomeRow";
+        this.qty = pir.getQty() == null ? 0 : pir.getQty();
     }
 
     public IncomeRow(SessionInstance sessionInstance) {
@@ -1284,6 +1292,14 @@ public class IncomeRow implements Serializable {
 
     public void setAdmissionType(AdmissionType admissionType) {
         this.admissionType = admissionType;
+    }
+
+    public com.divudi.core.light.pharmacy.PharmacyIncomeRow getPharmacyIncomeRow() {
+        return pharmacyIncomeRow;
+    }
+
+    public void setPharmacyIncomeRow(com.divudi.core.light.pharmacy.PharmacyIncomeRow pharmacyIncomeRow) {
+        this.pharmacyIncomeRow = pharmacyIncomeRow;
     }
     
     

--- a/src/main/java/com/divudi/core/light/pharmacy/PharmacyIncomeRow.java
+++ b/src/main/java/com/divudi/core/light/pharmacy/PharmacyIncomeRow.java
@@ -1,0 +1,125 @@
+package com.divudi.core.light.pharmacy;
+
+import com.divudi.core.data.BillTypeAtomic;
+import java.util.Date;
+
+/**
+ * Lightweight DTO for pharmacy income queries.
+ */
+public class PharmacyIncomeRow {
+    private Long billId;
+    private String billNo;
+    private BillTypeAtomic billTypeAtomic;
+    private String patientName;
+    private String bhtNo;
+    private Date billDate;
+    private String itemName;
+    private Double qty;
+    private Double retailRate;
+    private Double purchaseRate;
+
+    public PharmacyIncomeRow() {
+    }
+
+    public PharmacyIncomeRow(Long billId,
+                             String billNo,
+                             BillTypeAtomic billTypeAtomic,
+                             String patientName,
+                             String bhtNo,
+                             Date billDate,
+                             String itemName,
+                             Double qty,
+                             Double retailRate,
+                             Double purchaseRate) {
+        this.billId = billId;
+        this.billNo = billNo;
+        this.billTypeAtomic = billTypeAtomic;
+        this.patientName = patientName;
+        this.bhtNo = bhtNo;
+        this.billDate = billDate;
+        this.itemName = itemName;
+        this.qty = qty;
+        this.retailRate = retailRate;
+        this.purchaseRate = purchaseRate;
+    }
+
+    public Long getBillId() {
+        return billId;
+    }
+
+    public void setBillId(Long billId) {
+        this.billId = billId;
+    }
+
+    public String getBillNo() {
+        return billNo;
+    }
+
+    public void setBillNo(String billNo) {
+        this.billNo = billNo;
+    }
+
+    public BillTypeAtomic getBillTypeAtomic() {
+        return billTypeAtomic;
+    }
+
+    public void setBillTypeAtomic(BillTypeAtomic billTypeAtomic) {
+        this.billTypeAtomic = billTypeAtomic;
+    }
+
+    public String getPatientName() {
+        return patientName;
+    }
+
+    public void setPatientName(String patientName) {
+        this.patientName = patientName;
+    }
+
+    public String getBhtNo() {
+        return bhtNo;
+    }
+
+    public void setBhtNo(String bhtNo) {
+        this.bhtNo = bhtNo;
+    }
+
+    public Date getBillDate() {
+        return billDate;
+    }
+
+    public void setBillDate(Date billDate) {
+        this.billDate = billDate;
+    }
+
+    public String getItemName() {
+        return itemName;
+    }
+
+    public void setItemName(String itemName) {
+        this.itemName = itemName;
+    }
+
+    public Double getQty() {
+        return qty;
+    }
+
+    public void setQty(Double qty) {
+        this.qty = qty;
+    }
+
+    public Double getRetailRate() {
+        return retailRate;
+    }
+
+    public void setRetailRate(Double retailRate) {
+        this.retailRate = retailRate;
+    }
+
+    public Double getPurchaseRate() {
+        return purchaseRate;
+    }
+
+    public void setPurchaseRate(Double purchaseRate) {
+        this.purchaseRate = purchaseRate;
+    }
+}

--- a/src/main/webapp/pharmacy/reports/summary_reports/pharmacy_income_and_cost_report.xhtml
+++ b/src/main/webapp/pharmacy/reports/summary_reports/pharmacy_income_and_cost_report.xhtml
@@ -345,7 +345,7 @@
                                 rowsPerPageTemplate="#{pharmacySummaryReportController.rowsPerPageForScreen}, 5,10,15,50,100,500,1000,2000,5000,10000"
                                 paginatorPosition="bottom">
                                 <p:column headerText="Bill No" width="16em" style="padding: 0px!important; margin: 0px!important;" >
-                                    <h:outputText value="#{row.pharmaceuticalBillItem.billItem.bill.deptId}"  style="padding: 0px!important; margin: 0px!important;" />
+                                    <h:outputText value="#{row.pharmacyIncomeRow.billNo}"  style="padding: 0px!important; margin: 0px!important;" />
                                     <f:facet name="footer" >
                                         <h:outputText value="Total Amounts" style="padding: 0px!important; margin: 0px!important; font-weight: bold" >
                                         </h:outputText>
@@ -353,25 +353,25 @@
                                 </p:column>
                                 <p:column 
                                     headerText="Bill Type"  style="padding: 0px!important; margin: 0px!important;" >
-                                    <h:outputText value="#{row.pharmaceuticalBillItem.billItem.bill.billTypeAtomic}"  style="padding: 0px!important; margin: 0px!important;" />
+                                    <h:outputText value="#{row.pharmacyIncomeRow.billTypeAtomic}"  style="padding: 0px!important; margin: 0px!important;" />
                                 </p:column>
                                 <p:column headerText="Patient"  style="padding: 0px!important; margin: 0px!important;" >
-                                    <h:outputText value="#{row.pharmaceuticalBillItem.billItem.bill.patient.person.nameWithTitle}"  style="padding: 0px!important; margin: 0px!important;" />
+                                    <h:outputText value="#{row.pharmacyIncomeRow.patientName}"  style="padding: 0px!important; margin: 0px!important;" />
                                 </p:column>
                                 <p:column headerText="BHT No"  style="padding: 0px!important; margin: 0px!important;" >
-                                    <h:outputText value="#{row.pharmaceuticalBillItem.billItem.bill.patientEncounter.bhtNo}"  style="padding: 0px!important; margin: 0px!important;" />
+                                    <h:outputText value="#{row.pharmacyIncomeRow.bhtNo}"  style="padding: 0px!important; margin: 0px!important;" />
                                 </p:column>
                                 <p:column headerText="Date"   width="10em" >
-                                    <h:outputText value="#{row.pharmaceuticalBillItem.billItem.bill.createdAt}"  style="padding: 0px!important; margin: 0px!important;" >
+                                    <h:outputText value="#{row.pharmacyIncomeRow.billDate}"  style="padding: 0px!important; margin: 0px!important;" >
                                         <f:convertDateTime pattern="#{sessionController.applicationPreference.shortDateTimeFormat}" />
                                     </h:outputText>
                                 </p:column>
                                 <p:column headerText="Item"   width="10em" >
-                                    <h:outputText value="#{row.pharmaceuticalBillItem.itemBatch.item.name}"  style="padding: 0px!important; margin: 0px!important;" >
+                                    <h:outputText value="#{row.pharmacyIncomeRow.itemName}"  style="padding: 0px!important; margin: 0px!important;" >
                                     </h:outputText>
                                 </p:column>
                                 <p:column headerText="Qty" width="10em" class="text-end" style="padding: 0px!important; margin: 0px!important;">
-                                    <h:outputText value="#{row.pharmaceuticalBillItem.qty}">
+                                    <h:outputText value="#{row.pharmacyIncomeRow.qty}">
                                         <f:convertNumber pattern="#,##0.00" />
                                     </h:outputText>
                                     <f:facet name="footer">
@@ -381,12 +381,12 @@
                                     </f:facet>
                                 </p:column>
                                 <p:column headerText="Retail Rate" width="10em" class="text-end" style="padding: 0px!important; margin: 0px!important;">
-                                    <h:outputText value="#{row.pharmaceuticalBillItem.retailRate}">
+                                    <h:outputText value="#{row.pharmacyIncomeRow.retailRate}">
                                         <f:convertNumber pattern="#,##0.00" />
                                     </h:outputText>
                                 </p:column>
                                 <p:column headerText="Retail Value" width="10em" class="text-end" style="padding: 0px!important; margin: 0px!important;">
-                                    <h:outputText value="#{commonFunctionsProxy.abs(row.pharmaceuticalBillItem.retailRate * row.pharmaceuticalBillItem.qty)}">
+                                    <h:outputText value="#{commonFunctionsProxy.abs(row.pharmacyIncomeRow.retailRate * row.pharmacyIncomeRow.qty)}">
                                         <f:convertNumber pattern="#,##0.00" />
                                     </h:outputText>
                                     <f:facet name="footer">
@@ -397,7 +397,7 @@
                                 </p:column>
 
                                 <p:column headerText="Cost Value" width="10em" class="text-end" style="padding: 0px!important; margin: 0px!important;">
-                                    <h:outputText value="#{commonFunctionsProxy.abs(row.pharmaceuticalBillItem.purchaseRate * row.pharmaceuticalBillItem.qty)}">
+                                    <h:outputText value="#{commonFunctionsProxy.abs(row.pharmacyIncomeRow.purchaseRate * row.pharmacyIncomeRow.qty)}">
                                         <f:convertNumber pattern="#,##0.00" />
                                     </h:outputText>
                                     <f:facet name="footer">
@@ -408,7 +408,7 @@
                                 </p:column>
 
                                 <p:column headerText="Gross Profit" width="10em" class="text-end" style="padding: 0px!important; margin: 0px!important;">
-                                    <h:outputText value="#{commonFunctionsProxy.abs((row.pharmaceuticalBillItem.retailRate - row.pharmaceuticalBillItem.purchaseRate) * row.pharmaceuticalBillItem.qty)}">
+                                    <h:outputText value="#{commonFunctionsProxy.abs((row.pharmacyIncomeRow.retailRate - row.pharmacyIncomeRow.purchaseRate) * row.pharmacyIncomeRow.qty)}">
                                         <f:convertNumber pattern="#,##0.00" />
                                     </h:outputText>
                                     <f:facet name="footer">
@@ -426,7 +426,7 @@
                                         class="mx-1"
                                         action="#{billSearch.navigateToViewBillByAtomicBillType()}" 
                                         ajax="false">
-                                        <f:setPropertyActionListener value="#{row.pharmaceuticalBillItem.billItem.bill}" target="#{billSearch.bill}" />
+                                        <f:setPropertyActionListener value="#{billSearch.fetchBillById(row.pharmacyIncomeRow.billId)}" target="#{billSearch.bill}" />
                                     </p:commandLink>
                                 </p:column>
 


### PR DESCRIPTION
## Summary
- introduce `PharmacyIncomeRow` lightweight DTO
- fetch only selected fields in `BillService.fetchPharmacyIncomeRows`
- update `IncomeBundle` and `IncomeRow` to support the DTO
- use the lightweight DTO in pharmacy income & cost report
- adjust report page to reference new DTO fields
- expose helper to fetch bills by id for view actions

## Testing
- `mvn -version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68518673d000832f8c0b0b987ac16be5