### PR TITLE
Add support for PharmacyIncomeCostBillDTO in IncomeBundle

### DIFF
--- a/src/main/java/com/divudi/core/data/IncomeBundle.java
+++ b/src/main/java/com/divudi/core/data/IncomeBundle.java
@@ -26,6 +26,7 @@ import static com.divudi.core.data.PaymentMethod.ewallet;
 import com.divudi.core.entity.*;
 import com.divudi.core.entity.channel.SessionInstance;
 import com.divudi.core.entity.pharmacy.PharmaceuticalBillItem;
+import com.divudi.core.data.dto.PharmacyIncomeCostBillDTO;
 
 import java.io.Serializable;
 import java.math.BigDecimal;
@@ -260,10 +261,10 @@ public class IncomeBundle implements Serializable {
         }
     }
 
-    public IncomeBundle(List<?> entries) {
+    public IncomeBundle(Collection<?> entries) {
         this(); // Initialize id and rows list
         if (entries != null && !entries.isEmpty()) {
-            Object firstElement = entries.get(0);
+            Object firstElement = entries.iterator().next();
             if (firstElement instanceof Bill) {
                 // Process list as Bills
                 for (Object obj : entries) {
@@ -300,6 +301,15 @@ public class IncomeBundle implements Serializable {
                         rows.add(incomeRow);
                     }
                 }
+            }
+        }
+    }
+
+    public IncomeBundle(List<PharmacyIncomeCostBillDTO> dtos) {
+        this();
+        if (dtos != null) {
+            for (PharmacyIncomeCostBillDTO dto : dtos) {
+                rows.add(new IncomeRow(dto));
             }
         }
     }
@@ -445,17 +455,16 @@ public class IncomeBundle implements Serializable {
 
         for (IncomeRow r : getRows()) {
             Bill b = r.getBill();
-            if (b == null) {
-                continue;
+            if (b != null && b.getBillFinanceDetails() != null) {
+                saleValue += b.getBillFinanceDetails().getTotalRetailSaleValue().doubleValue();
+                purchaseValue += b.getBillFinanceDetails().getTotalPurchaseValue().doubleValue();
+                grossProfitValue += b.getBillFinanceDetails().getTotalRetailSaleValue().doubleValue()
+                        - b.getBillFinanceDetails().getTotalPurchaseValue().doubleValue();
+            } else {
+                saleValue += r.getRetailValue();
+                purchaseValue += r.getPurchaseValue();
+                grossProfitValue += r.getRetailValue() - r.getPurchaseValue();
             }
-
-            if (b.getBillFinanceDetails() == null) {
-                continue;
-            }
-
-            saleValue += b.getBillFinanceDetails().getTotalRetailSaleValue().doubleValue();
-            purchaseValue += b.getBillFinanceDetails().getTotalPurchaseValue().doubleValue();
-            grossProfitValue += (b.getBillFinanceDetails().getTotalRetailSaleValue().doubleValue() - b.getBillFinanceDetails().getTotalPurchaseValue().doubleValue());
         }
     }
 

--- a/src/main/java/com/divudi/core/data/IncomeRow.java
+++ b/src/main/java/com/divudi/core/data/IncomeRow.java
@@ -40,6 +40,13 @@ public class IncomeRow implements Serializable {
     private BillClassType billClassType;
     BillTypeAtomic billTypeAtomic;
 
+    // Fields populated from PharmacyIncomeCostBillDTO
+    private Long billId;
+    private String billNo;
+    private String patientName;
+    private String bhtNo;
+    private Date createdAt;
+
     private boolean selected;
 
     private Item item;
@@ -207,6 +214,25 @@ public class IncomeRow implements Serializable {
     public IncomeRow(BillFee billFee) {
         this();
         this.billFee = billFee;
+    }
+
+    public IncomeRow(PharmacyIncomeCostBillDTO dto) {
+        this();
+        if (dto != null) {
+            this.billId = dto.getId();
+            this.billNo = dto.getBillNo();
+            this.billTypeAtomic = dto.getBillTypeAtomic();
+            this.patientName = dto.getPatientName();
+            this.bhtNo = dto.getBhtNo();
+            this.createdAt = dto.getCreatedAt();
+            if (dto.getRetailValue() != null) {
+                this.retailValue = dto.getRetailValue().doubleValue();
+            }
+            if (dto.getPurchaseValue() != null) {
+                this.purchaseValue = dto.getPurchaseValue().doubleValue();
+            }
+            this.grossProfit = this.retailValue - this.purchaseValue;
+        }
     }
 
     // Getter for UUID (optional, depending on use case)
@@ -1284,6 +1310,46 @@ public class IncomeRow implements Serializable {
 
     public void setAdmissionType(AdmissionType admissionType) {
         this.admissionType = admissionType;
+    }
+
+    public Long getBillId() {
+        return billId;
+    }
+
+    public void setBillId(Long billId) {
+        this.billId = billId;
+    }
+
+    public String getBillNo() {
+        return billNo;
+    }
+
+    public void setBillNo(String billNo) {
+        this.billNo = billNo;
+    }
+
+    public String getPatientName() {
+        return patientName;
+    }
+
+    public void setPatientName(String patientName) {
+        this.patientName = patientName;
+    }
+
+    public String getBhtNo() {
+        return bhtNo;
+    }
+
+    public void setBhtNo(String bhtNo) {
+        this.bhtNo = bhtNo;
+    }
+
+    public Date getCreatedAt() {
+        return createdAt;
+    }
+
+    public void setCreatedAt(Date createdAt) {
+        this.createdAt = createdAt;
     }
     
     


### PR DESCRIPTION
## Summary
- extend `IncomeRow` with fields for pharmacy DTO data
- add constructor to build `IncomeRow` from `PharmacyIncomeCostBillDTO`
- support constructing `IncomeBundle` with DTO lists
- compute retail/cost totals from DTO values when bills are absent

## Testing
- `mvn -q -DskipTests package` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6851b036f558832f94c931f53946edff