### PR TITLE
Implement DTO-based pharmacy income cost calculation

### DIFF
--- a/src/main/java/com/divudi/bean/pharmacy/PharmacySummaryReportController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacySummaryReportController.java
@@ -49,6 +49,7 @@ import static com.divudi.core.data.ReportViewType.BY_BILL;
 import static com.divudi.core.data.ReportViewType.BY_BILL_TYPE;
 import static com.divudi.core.data.ReportViewType.BY_BILL_TYPE_AND_DISCOUNT_TYPE_AND_ADMISSION_TYPE;
 import static com.divudi.core.data.ReportViewType.BY_DISCOUNT_TYPE_AND_ADMISSION_TYPE;
+import com.divudi.core.data.dto.PharmacyIncomeCostBillDTO;
 import com.divudi.core.data.pharmacy.DailyStockBalanceReport;
 import com.divudi.core.entity.Bill;
 import com.divudi.core.entity.BillFinanceDetails;
@@ -866,6 +867,17 @@ public class PharmacySummaryReportController implements Serializable {
             List<PharmaceuticalBillItem> pbis = billService.fetchPharmaceuticalBillItems(fromDate, toDate, institution, site, department, webUser, billTypeAtomics, admissionType, paymentScheme);
             bundle = new IncomeBundle(pbis);
             bundle.generateRetailAndCostDetailsForPharmaceuticalBillType();
+        }, SummaryReports.PHARMACY_INCOME_REPORT, sessionController.getLoggedUser());
+    }
+
+    public void processPharmacyIncomeAndCostReportByBillDto() {
+        reportTimerController.trackReportExecution(() -> {
+            List<PharmacyIncomeCostBillDTO> dtos =
+                    billService.fetchBillIncomeCostDtos(fromDate, toDate, institution, site,
+                            department, webUser, getPharmacyIncomeBillTypes(),
+                            admissionType, paymentScheme);
+            bundle = new IncomeBundle(dtos);
+            bundle.generateRetailAndCostDetailsForPharmaceuticalBill();
         }, SummaryReports.PHARMACY_INCOME_REPORT, sessionController.getLoggedUser());
     }
 


### PR DESCRIPTION
## Summary
- add PharmacyIncomeCostBillDTO import
- implement `processPharmacyIncomeAndCostReportByBillDto` to compute totals

## Testing
- `mvn -q -DskipTests package` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6851b88066e0832fbf58a4244499660f