### PR TITLE
Fix null checks in pharmacy income query and report

### DIFF
--- a/src/main/java/com/divudi/core/data/IncomeBundle.java
+++ b/src/main/java/com/divudi/core/data/IncomeBundle.java
@@ -456,10 +456,18 @@ public class IncomeBundle implements Serializable {
         for (IncomeRow r : getRows()) {
             Bill b = r.getBill();
             if (b != null && b.getBillFinanceDetails() != null) {
-                saleValue += b.getBillFinanceDetails().getTotalRetailSaleValue().doubleValue();
-                purchaseValue += b.getBillFinanceDetails().getTotalPurchaseValue().doubleValue();
-                grossProfitValue += b.getBillFinanceDetails().getTotalRetailSaleValue().doubleValue()
-                        - b.getBillFinanceDetails().getTotalPurchaseValue().doubleValue();
+                BigDecimal retailBd = b.getBillFinanceDetails().getTotalRetailSaleValue();
+                BigDecimal purchaseBd = b.getBillFinanceDetails().getTotalPurchaseValue();
+
+                if (retailBd != null) {
+                    saleValue += retailBd.doubleValue();
+                }
+                if (purchaseBd != null) {
+                    purchaseValue += purchaseBd.doubleValue();
+                }
+                if (retailBd != null && purchaseBd != null) {
+                    grossProfitValue += retailBd.doubleValue() - purchaseBd.doubleValue();
+                }
             } else {
                 saleValue += r.getRetailValue();
                 purchaseValue += r.getPurchaseValue();

--- a/src/main/java/com/divudi/service/BillService.java
+++ b/src/main/java/com/divudi/service/BillService.java
@@ -1026,9 +1026,13 @@ public class BillService {
 
         String jpql = "select new com.divudi.core.data.dto.PharmacyIncomeCostBillDTO(" +
                 " b.id, b.deptId, b.billTypeAtomic, " +
-                " b.patient.person.name, b.patientEncounter.bhtNo, b.createdAt, " +
-                " bfd.totalRetailSaleValue, bfd.totalPurchaseValue) " +
-                " from Bill b join b.billFinanceDetails bfd " +
+                " coalesce(pers.name,'N/A'), coalesce(pe.bhtNo,''), b.createdAt, " +
+                " coalesce(bfd.totalRetailSaleValue,0), coalesce(bfd.totalPurchaseValue,0)) " +
+                " from Bill b " +
+                " left join b.billFinanceDetails bfd " +
+                " left join b.patient pat " +
+                " left join pat.person pers " +
+                " left join b.patientEncounter pe " +
                 " where b.retired=:ret " +
                 " and b.billTypeAtomic in :billTypesAtomics " +
                 " and b.createdAt between :fromDate and :toDate ";


### PR DESCRIPTION
## Summary
- make `fetchBillIncomeCostDtos` use left joins and COALESCE to avoid dropping records
- guard against null `BillFinanceDetails` fields when summing sale/purchase values

## Testing
- `apt-get update`
- `apt-get install -y maven`
- `mvn -q -DskipTests compile` *(fails: Could not transfer artifact maven-resources-plugin due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_6851c4962374832fa8cd221c10253a44