### PR TITLE
Implement DTO-based pharmacy income reporting

### DIFF
--- a/src/main/java/com/divudi/bean/pharmacy/PharmacySummaryReportController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacySummaryReportController.java
@@ -50,6 +50,7 @@ import static com.divudi.core.data.ReportViewType.BY_BILL_TYPE;
 import static com.divudi.core.data.ReportViewType.BY_BILL_TYPE_AND_DISCOUNT_TYPE_AND_ADMISSION_TYPE;
 import static com.divudi.core.data.ReportViewType.BY_DISCOUNT_TYPE_AND_ADMISSION_TYPE;
 import com.divudi.core.data.dto.PharmacyIncomeCostBillDTO;
+import com.divudi.core.data.dto.PharmacyIncomeCostBillItemDTO;
 import com.divudi.core.data.pharmacy.DailyStockBalanceReport;
 import com.divudi.core.entity.Bill;
 import com.divudi.core.entity.BillFinanceDetails;
@@ -845,6 +846,17 @@ public class PharmacySummaryReportController implements Serializable {
             List<BillTypeAtomic> billTypeAtomics = getPharmacyIncomeBillTypes();
             List<PharmaceuticalBillItem> pbis = billService.fetchPharmaceuticalBillItems(fromDate, toDate, institution, site, department, webUser, billTypeAtomics, admissionType, paymentScheme);
             bundle = new IncomeBundle(pbis);
+            bundle.generateRetailAndCostDetailsForPharmaceuticalBillItems();
+        }, SummaryReports.PHARMACY_INCOME_REPORT, sessionController.getLoggedUser());
+    }
+
+    public void processPharmacyIncomeAndCostReportByBillItemDto() {
+        reportTimerController.trackReportExecution(() -> {
+            List<BillTypeAtomic> billTypeAtomics = getPharmacyIncomeBillTypes();
+            List<PharmacyIncomeCostBillItemDTO> dtos =
+                    billService.fetchBillItemIncomeCostDtos(fromDate, toDate, institution, site,
+                            department, webUser, billTypeAtomics, admissionType, paymentScheme);
+            bundle = new IncomeBundle(dtos);
             bundle.generateRetailAndCostDetailsForPharmaceuticalBillItems();
         }, SummaryReports.PHARMACY_INCOME_REPORT, sessionController.getLoggedUser());
     }

--- a/src/main/java/com/divudi/core/data/IncomeRow.java
+++ b/src/main/java/com/divudi/core/data/IncomeRow.java
@@ -1,6 +1,7 @@
 package com.divudi.core.data;
 
 import com.divudi.core.data.dto.PharmacyIncomeCostBillDTO;
+import com.divudi.core.data.dto.PharmacyIncomeCostBillItemDTO;
 import com.divudi.core.entity.*;
 import com.divudi.core.entity.channel.SessionInstance;
 import com.divudi.core.entity.inward.AdmissionType;
@@ -164,6 +165,9 @@ public class IncomeRow implements Serializable {
 
     private double qty;
 
+    private double retailRate;
+    private double purchaseRate;
+
     private long duration;
 
     private UUID id;
@@ -232,6 +236,30 @@ public class IncomeRow implements Serializable {
             if (dto.getPurchaseValue() != null) {
                 this.purchaseValue = dto.getPurchaseValue().doubleValue();
             }
+            this.grossProfit = this.retailValue - this.purchaseValue;
+        }
+    }
+
+    public IncomeRow(PharmacyIncomeCostBillItemDTO dto) {
+        this();
+        if (dto != null) {
+            this.billNo = dto.getBillNo();
+            this.billTypeAtomic = dto.getBillTypeAtomic();
+            this.patientName = dto.getPatientName();
+            this.bhtNo = dto.getBhtNo();
+            this.createdAt = dto.getCreatedAt();
+            this.itemName = dto.getItemName();
+            if (dto.getQty() != null) {
+                this.qty = dto.getQty();
+            }
+            if (dto.getRetailRate() != null) {
+                this.retailRate = dto.getRetailRate();
+            }
+            if (dto.getPurchaseRate() != null) {
+                this.purchaseRate = dto.getPurchaseRate();
+            }
+            this.retailValue = this.retailRate * this.qty;
+            this.purchaseValue = this.purchaseRate * this.qty;
             this.grossProfit = this.retailValue - this.purchaseValue;
         }
     }
@@ -1052,6 +1080,22 @@ public class IncomeRow implements Serializable {
 
     public void setQty(double qty) {
         this.qty = qty;
+    }
+
+    public double getRetailRate() {
+        return retailRate;
+    }
+
+    public void setRetailRate(double retailRate) {
+        this.retailRate = retailRate;
+    }
+
+    public double getPurchaseRate() {
+        return purchaseRate;
+    }
+
+    public void setPurchaseRate(double purchaseRate) {
+        this.purchaseRate = purchaseRate;
     }
 
     public void setBillItem(BillItem billItem) {

--- a/src/main/java/com/divudi/core/data/dto/PharmacyIncomeCostBillItemDTO.java
+++ b/src/main/java/com/divudi/core/data/dto/PharmacyIncomeCostBillItemDTO.java
@@ -1,0 +1,107 @@
+package com.divudi.core.data.dto;
+
+import com.divudi.core.data.BillTypeAtomic;
+import java.io.Serializable;
+import java.util.Date;
+
+public class PharmacyIncomeCostBillItemDTO implements Serializable {
+
+    private String billNo;
+    private BillTypeAtomic billTypeAtomic;
+    private String patientName;
+    private String bhtNo;
+    private Date createdAt;
+    private String itemName;
+    private Double qty;
+    private Double retailRate;
+    private Double purchaseRate;
+
+    public PharmacyIncomeCostBillItemDTO() {
+    }
+
+    public PharmacyIncomeCostBillItemDTO(String billNo, BillTypeAtomic billTypeAtomic,
+            String patientName, String bhtNo, Date createdAt,
+            String itemName, Double qty, Double retailRate, Double purchaseRate) {
+        this.billNo = billNo;
+        this.billTypeAtomic = billTypeAtomic;
+        this.patientName = patientName;
+        this.bhtNo = bhtNo;
+        this.createdAt = createdAt;
+        this.itemName = itemName;
+        this.qty = qty;
+        this.retailRate = retailRate;
+        this.purchaseRate = purchaseRate;
+    }
+
+    public String getBillNo() {
+        return billNo;
+    }
+
+    public void setBillNo(String billNo) {
+        this.billNo = billNo;
+    }
+
+    public BillTypeAtomic getBillTypeAtomic() {
+        return billTypeAtomic;
+    }
+
+    public void setBillTypeAtomic(BillTypeAtomic billTypeAtomic) {
+        this.billTypeAtomic = billTypeAtomic;
+    }
+
+    public String getPatientName() {
+        return patientName;
+    }
+
+    public void setPatientName(String patientName) {
+        this.patientName = patientName;
+    }
+
+    public String getBhtNo() {
+        return bhtNo;
+    }
+
+    public void setBhtNo(String bhtNo) {
+        this.bhtNo = bhtNo;
+    }
+
+    public Date getCreatedAt() {
+        return createdAt;
+    }
+
+    public void setCreatedAt(Date createdAt) {
+        this.createdAt = createdAt;
+    }
+
+    public String getItemName() {
+        return itemName;
+    }
+
+    public void setItemName(String itemName) {
+        this.itemName = itemName;
+    }
+
+    public Double getQty() {
+        return qty;
+    }
+
+    public void setQty(Double qty) {
+        this.qty = qty;
+    }
+
+    public Double getRetailRate() {
+        return retailRate;
+    }
+
+    public void setRetailRate(Double retailRate) {
+        this.retailRate = retailRate;
+    }
+
+    public Double getPurchaseRate() {
+        return purchaseRate;
+    }
+
+    public void setPurchaseRate(Double purchaseRate) {
+        this.purchaseRate = purchaseRate;
+    }
+}

--- a/src/main/webapp/pharmacy/reports/summary_reports/pharmacy_income_and_cost_report.xhtml
+++ b/src/main/webapp/pharmacy/reports/summary_reports/pharmacy_income_and_cost_report.xhtml
@@ -341,7 +341,7 @@
                                 rowsPerPageTemplate="#{pharmacySummaryReportController.rowsPerPageForScreen}, 5,10,15,50,100,500,1000,2000,5000,10000"
                                 paginatorPosition="bottom">
                                 <p:column headerText="Bill No" width="16em" style="padding: 0px!important; margin: 0px!important;" >
-                                    <h:outputText value="#{row.pharmaceuticalBillItem.billItem.bill.deptId}"  style="padding: 0px!important; margin: 0px!important;" />
+                                    <h:outputText value="#{row.billNo}"  style="padding: 0px!important; margin: 0px!important;" />
                                     <f:facet name="footer" >
                                         <h:outputText value="Total Amounts" style="padding: 0px!important; margin: 0px!important; font-weight: bold" >
                                         </h:outputText>
@@ -349,25 +349,25 @@
                                 </p:column>
                                 <p:column 
                                     headerText="Bill Type"  style="padding: 0px!important; margin: 0px!important;" >
-                                    <h:outputText value="#{row.pharmaceuticalBillItem.billItem.bill.billTypeAtomic}"  style="padding: 0px!important; margin: 0px!important;" />
+                                    <h:outputText value="#{row.billTypeAtomic}"  style="padding: 0px!important; margin: 0px!important;" />
                                 </p:column>
                                 <p:column headerText="Patient"  style="padding: 0px!important; margin: 0px!important;" >
-                                    <h:outputText value="#{row.pharmaceuticalBillItem.billItem.bill.patient.person.nameWithTitle}"  style="padding: 0px!important; margin: 0px!important;" />
+                                    <h:outputText value="#{row.patientName}"  style="padding: 0px!important; margin: 0px!important;" />
                                 </p:column>
                                 <p:column headerText="BHT No"  style="padding: 0px!important; margin: 0px!important;" >
-                                    <h:outputText value="#{row.pharmaceuticalBillItem.billItem.bill.patientEncounter.bhtNo}"  style="padding: 0px!important; margin: 0px!important;" />
+                                    <h:outputText value="#{row.bhtNo}"  style="padding: 0px!important; margin: 0px!important;" />
                                 </p:column>
                                 <p:column headerText="Date"   width="10em" >
-                                    <h:outputText value="#{row.pharmaceuticalBillItem.billItem.bill.createdAt}"  style="padding: 0px!important; margin: 0px!important;" >
+                                    <h:outputText value="#{row.createdAt}"  style="padding: 0px!important; margin: 0px!important;" >
                                         <f:convertDateTime pattern="#{sessionController.applicationPreference.shortDateTimeFormat}" />
                                     </h:outputText>
                                 </p:column>
                                 <p:column headerText="Item"   width="10em" >
-                                    <h:outputText value="#{row.pharmaceuticalBillItem.itemBatch.item.name}"  style="padding: 0px!important; margin: 0px!important;" >
+                                    <h:outputText value="#{row.itemName}"  style="padding: 0px!important; margin: 0px!important;" >
                                     </h:outputText>
                                 </p:column>
                                 <p:column headerText="Qty" width="10em" class="text-end" style="padding: 0px!important; margin: 0px!important;">
-                                    <h:outputText value="#{row.pharmaceuticalBillItem.qty}">
+                                    <h:outputText value="#{row.qty}">
                                         <f:convertNumber pattern="#,##0.00" />
                                     </h:outputText>
                                     <f:facet name="footer">
@@ -377,12 +377,12 @@
                                     </f:facet>
                                 </p:column>
                                 <p:column headerText="Retail Rate" width="10em" class="text-end" style="padding: 0px!important; margin: 0px!important;">
-                                    <h:outputText value="#{row.pharmaceuticalBillItem.retailRate}">
+                                    <h:outputText value="#{row.retailRate}">
                                         <f:convertNumber pattern="#,##0.00" />
                                     </h:outputText>
                                 </p:column>
                                 <p:column headerText="Retail Value" width="10em" class="text-end" style="padding: 0px!important; margin: 0px!important;">
-                                    <h:outputText value="#{commonFunctionsProxy.abs(row.pharmaceuticalBillItem.retailRate * row.pharmaceuticalBillItem.qty)}">
+                                    <h:outputText value="#{commonFunctionsProxy.abs(row.retailRate * row.qty)}">
                                         <f:convertNumber pattern="#,##0.00" />
                                     </h:outputText>
                                     <f:facet name="footer">
@@ -393,7 +393,7 @@
                                 </p:column>
 
                                 <p:column headerText="Cost Value" width="10em" class="text-end" style="padding: 0px!important; margin: 0px!important;">
-                                    <h:outputText value="#{commonFunctionsProxy.abs(row.pharmaceuticalBillItem.purchaseRate * row.pharmaceuticalBillItem.qty)}">
+                                    <h:outputText value="#{commonFunctionsProxy.abs(row.purchaseRate * row.qty)}">
                                         <f:convertNumber pattern="#,##0.00" />
                                     </h:outputText>
                                     <f:facet name="footer">
@@ -404,7 +404,7 @@
                                 </p:column>
 
                                 <p:column headerText="Gross Profit" width="10em" class="text-end" style="padding: 0px!important; margin: 0px!important;">
-                                    <h:outputText value="#{commonFunctionsProxy.abs((row.pharmaceuticalBillItem.retailRate - row.pharmaceuticalBillItem.purchaseRate) * row.pharmaceuticalBillItem.qty)}">
+                                    <h:outputText value="#{commonFunctionsProxy.abs((row.retailRate - row.purchaseRate) * row.qty)}">
                                         <f:convertNumber pattern="#,##0.00" />
                                     </h:outputText>
                                     <f:facet name="footer">


### PR DESCRIPTION
## Summary
- add `PharmacyIncomeCostBillItemDTO`
- expose `fetchBillItemIncomeCostDtos` in `BillService`
- support DTO creation in `IncomeRow` and `IncomeBundle`
- compute retail and cost values when DTOs are used
- handle DTO reporting in `PharmacySummaryReportController`
- update report view to reference fields on `IncomeRow`

## Testing
- `mvn -q -DskipTests package` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852045aef0c832f85ed1a52d233dad8