### PR TITLE
Replace nested bill fields with IncomeRow data

### DIFF
--- a/src/main/webapp/pharmacy/reports/summary_reports/pharmacy_income_and_cost_report.xhtml
+++ b/src/main/webapp/pharmacy/reports/summary_reports/pharmacy_income_and_cost_report.xhtml
@@ -422,7 +422,7 @@
                                         class="mx-1"
                                         action="#{billSearch.navigateToViewBillByAtomicBillType()}" 
                                         ajax="false">
-                                        <f:setPropertyActionListener value="#{row.pharmaceuticalBillItem.billItem.bill}" target="#{billSearch.bill}" />
+                                        <f:setPropertyActionListener value="#{row.bill}" target="#{billSearch.bill}" />
                                     </p:commandLink>
                                 </p:column>
 

--- a/src/main/webapp/pharmacy/reports/summary_reports/pharmacy_income_report.xhtml
+++ b/src/main/webapp/pharmacy/reports/summary_reports/pharmacy_income_report.xhtml
@@ -248,7 +248,7 @@
                                 rowsPerPageTemplate="#{pharmacySummaryReportController.rowsPerPageForScreen}, 5,10,15,50,100,500,1000,2000,5000,10000"
                                 paginatorPosition="bottom">
                                 <p:column headerText="Bill No" width="16em" style="padding: 0px!important; margin: 0px!important;" >
-                                    <h:outputText value="#{row.bill.deptId}"  style="padding: 0px!important; margin: 0px!important;" />
+                                    <h:outputText value="#{row.billNo}"  style="padding: 0px!important; margin: 0px!important;" />
                                     <f:facet name="footer" >
                                         <h:outputText value="Total Amounts" style="padding: 0px!important; margin: 0px!important; font-weight: bold" >
 
@@ -256,20 +256,20 @@
                                     </f:facet>
                                 </p:column>
                                 <p:column headerText="Patient"  style="padding: 0px!important; margin: 0px!important;" >
-                                    <h:outputText value="#{row.bill.patient.person.nameWithTitle}"  style="padding: 0px!important; margin: 0px!important;" />
+                                    <h:outputText value="#{row.patientName}"  style="padding: 0px!important; margin: 0px!important;" />
                                 </p:column>
-                                <p:column 
+                                <p:column
                                     rendered="#{webUserController.hasPrivilege('Developers')}"
                                     headerText="Bill Type"  style="padding: 0px!important; margin: 0px!important;" >
-                                    <h:outputText value="#{row.bill.billTypeAtomic}"  style="padding: 0px!important; margin: 0px!important;" />
+                                    <h:outputText value="#{row.billTypeAtomic}"  style="padding: 0px!important; margin: 0px!important;" />
                                 </p:column>
                                 <p:column headerText="Date"   width="10em" >
-                                    <h:outputText value="#{row.bill.createdAt}"  style="padding: 0px!important; margin: 0px!important;" >
+                                    <h:outputText value="#{row.createdAt}"  style="padding: 0px!important; margin: 0px!important;" >
                                         <f:convertDateTime pattern="#{sessionController.applicationPreference.shortDateTimeFormat}" />
                                     </h:outputText>
                                 </p:column>
                                 <p:column headerText="Net Total"  width="10em" class="text-end" style="padding: 0px!important; margin: 0px!important;" >
-                                    <h:outputText value="#{row.bill.netTotal}">
+                                    <h:outputText value="#{row.netTotal}">
                                         <f:convertNumber pattern="#,##0.00" />
                                     </h:outputText>
                                     <f:facet name="footer" >

--- a/src/main/webapp/pharmacy/reports/summary_reports/pharmacy_income_report_print.xhtml
+++ b/src/main/webapp/pharmacy/reports/summary_reports/pharmacy_income_report_print.xhtml
@@ -60,15 +60,15 @@
                         <tbody>
                             <ui:repeat value="#{pharmacySummaryReportController.bundle.rows}" var="row" varStatus="status">
                                 <tr>
-                                    <td><h:outputText value="#{row.bill.deptId}" /></td>
-                                    <td style="text-align: left;"><h:outputText value="#{row.bill.patient.person.nameWithTitle}" /></td>
+                                    <td><h:outputText value="#{row.billNo}" /></td>
+                                    <td style="text-align: left;"><h:outputText value="#{row.patientName}" /></td>
                                     <td>
-                                        <h:outputText value="#{row.bill.createdAt}">
+                                        <h:outputText value="#{row.createdAt}">
                                             <f:convertDateTime pattern="#{sessionController.applicationPreference.shortDateFormat}" />
                                         </h:outputText>
                                     </td>
                                     <td class="text-end">
-                                        <h:outputText value="#{row.bill.netTotal}">
+                                        <h:outputText value="#{row.netTotal}">
                                             <f:convertNumber pattern="#,##0.00" />
                                         </h:outputText>
                                     </td>

--- a/src/main/webapp/pharmacy/reports/summary_reports/pharmacy_income_report_print_view.xhtml
+++ b/src/main/webapp/pharmacy/reports/summary_reports/pharmacy_income_report_print_view.xhtml
@@ -208,15 +208,15 @@
                                                         <h:outputText value="#{i.index +1}" style="margin-left: 1mm;"/>
                                                     </td>
                                                     <td style="width: 25mm; text-align: left;">
-                                                        <h:outputText value="#{row.bill.deptId}" style="margin-left: 1mm;"/>
+                                                        <h:outputText value="#{row.billNo}" style="margin-left: 1mm;"/>
                                                     </td>
                                                     <td style="width: 17mm; text-align: left;">
-                                                        <h:outputText value="#{row.bill.createdAt}" style="margin-left: 1mm;">
+                                                        <h:outputText value="#{row.createdAt}" style="margin-left: 1mm;">
                                                             <f:convertDateTime pattern="dd/MM/YY" />
                                                         </h:outputText>
                                                     </td>
                                                     <td style="width: 17mm; text-align: right;">
-                                                        <h:outputText value="#{row.bill.netTotal}" style="margin-right: 1mm;">
+                                                        <h:outputText value="#{row.netTotal}" style="margin-right: 1mm;">
                                                             <f:convertNumber pattern="#,##0.00" />
                                                         </h:outputText>
                                                     </td>


### PR DESCRIPTION
## Summary
- simplify pharmacy income report pages
- use IncomeRow fields instead of nested bill references
- update gross profit calculation inputs

## Testing
- `mvn -q test` *(fails: mvn not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68520fd33ea0832f8dcbc73a7bd2b6fc