### PR TITLE
Implement bill item DTO for pharmacy income report

### DIFF
--- a/src/main/java/com/divudi/bean/common/BillSearch.java
+++ b/src/main/java/com/divudi/bean/common/BillSearch.java
@@ -3232,6 +3232,10 @@ public class BillSearch implements Serializable {
 //        bill.setTransError(flag);
     }
 
+    public Bill findBill(Long id) {
+        return getBillFacade().find(id);
+    }
+
     public String navigateToCancelOpdBill() {
         if (bill == null) {
             JsfUtil.addErrorMessage("Nothing to cancel");

--- a/src/main/java/com/divudi/bean/pharmacy/PharmacySummaryReportController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacySummaryReportController.java
@@ -50,6 +50,7 @@ import static com.divudi.core.data.ReportViewType.BY_BILL_TYPE;
 import static com.divudi.core.data.ReportViewType.BY_BILL_TYPE_AND_DISCOUNT_TYPE_AND_ADMISSION_TYPE;
 import static com.divudi.core.data.ReportViewType.BY_DISCOUNT_TYPE_AND_ADMISSION_TYPE;
 import com.divudi.core.data.dto.PharmacyIncomeCostBillDTO;
+import com.divudi.core.data.dto.PharmacyIncomeCostBillItemDTO;
 import com.divudi.core.data.pharmacy.DailyStockBalanceReport;
 import com.divudi.core.entity.Bill;
 import com.divudi.core.entity.BillFinanceDetails;
@@ -826,6 +827,7 @@ public class PharmacySummaryReportController implements Serializable {
             switch (reportViewType) {
                 case BY_BILL_ITEM:
                     processPharmacyIncomeAndCostReportByBillItem();
+                    processPharmacyIncomeAndCostReportByBillItemDto();
                     break;
                 case BY_BILL_TYPE:
                     processPharmacyIncomeAndCostReportByBillType();
@@ -847,6 +849,14 @@ public class PharmacySummaryReportController implements Serializable {
             List<PharmaceuticalBillItem> pbis = billService.fetchPharmaceuticalBillItems(fromDate, toDate, institution, site, department, webUser, billTypeAtomics, admissionType, paymentScheme);
             bundle = new IncomeBundle(pbis);
             bundle.generateRetailAndCostDetailsForPharmaceuticalBillItems();
+        }, SummaryReports.PHARMACY_INCOME_REPORT, sessionController.getLoggedUser());
+    }
+
+    public void processPharmacyIncomeAndCostReportByBillItemDto() {
+        reportTimerController.trackReportExecution(() -> {
+            List<PharmacyIncomeCostBillItemDTO> dtos = billService.fetchBillItemIncomeCostDtos(fromDate, toDate, institution, site, department, webUser, getPharmacyIncomeBillTypes(), admissionType, paymentScheme);
+            bundle = new IncomeBundle(dtos);
+            bundle.generateRetailAndCostDetailsForBillItemDtos();
         }, SummaryReports.PHARMACY_INCOME_REPORT, sessionController.getLoggedUser());
     }
 

--- a/src/main/java/com/divudi/core/data/IncomeBundle.java
+++ b/src/main/java/com/divudi/core/data/IncomeBundle.java
@@ -27,6 +27,7 @@ import com.divudi.core.entity.*;
 import com.divudi.core.entity.channel.SessionInstance;
 import com.divudi.core.entity.pharmacy.PharmaceuticalBillItem;
 import com.divudi.core.data.dto.PharmacyIncomeCostBillDTO;
+import com.divudi.core.data.dto.PharmacyIncomeCostBillItemDTO;
 
 import java.io.Serializable;
 import java.math.BigDecimal;
@@ -314,6 +315,15 @@ public class IncomeBundle implements Serializable {
         }
     }
 
+    public IncomeBundle(List<PharmacyIncomeCostBillItemDTO> dtos) {
+        this();
+        if (dtos != null) {
+            for (PharmacyIncomeCostBillItemDTO dto : dtos) {
+                rows.add(new IncomeRow(dto));
+            }
+        }
+    }
+
     public void generateRetailAndCostDetailsForPharmaceuticalBillItems() {
         saleValue = 0;
         purchaseValue = 0;
@@ -378,6 +388,57 @@ public class IncomeBundle implements Serializable {
             saleValue += retailTotal;
             purchaseValue += purchaseTotal;
             grossProfitValue += grossProfit;
+        }
+    }
+
+    public void generateRetailAndCostDetailsForBillItemDtos() {
+        saleValue = 0;
+        purchaseValue = 0;
+        grossProfitValue = 0;
+        quantity = 0.0;
+
+        for (IncomeRow r : getRows()) {
+            BillTypeAtomic bta = r.getBillTypeAtomic();
+            if (bta == null || bta.getBillCategory() == null) {
+                continue;
+            }
+            BillCategory bc = bta.getBillCategory();
+
+            double qty = Math.abs(r.getQty());
+            double retail = Math.abs(r.getRetailRate());
+            double purchase = Math.abs(r.getPurchaseRate());
+
+            double retailTotal = 0;
+            double purchaseTotal = 0;
+            double grossProfit = 0;
+
+            switch (bc) {
+                case BILL:
+                case PAYMENTS:
+                case PREBILL:
+                    retailTotal = retail * qty;
+                    purchaseTotal = purchase * qty;
+                    grossProfit = (retail - purchase) * qty;
+                    break;
+                case CANCELLATION:
+                case REFUND:
+                    retailTotal = -retail * qty;
+                    purchaseTotal = -purchase * qty;
+                    grossProfit = -(retail - purchase) * qty;
+                    qty = -qty;
+                    break;
+                default:
+                    break;
+            }
+
+            r.setRetailValue(retailTotal);
+            r.setPurchaseValue(purchaseTotal);
+            r.setGrossProfit(grossProfit);
+
+            saleValue += retailTotal;
+            purchaseValue += purchaseTotal;
+            grossProfitValue += grossProfit;
+            quantity += qty;
         }
     }
 

--- a/src/main/java/com/divudi/core/data/IncomeRow.java
+++ b/src/main/java/com/divudi/core/data/IncomeRow.java
@@ -1,6 +1,7 @@
 package com.divudi.core.data;
 
 import com.divudi.core.data.dto.PharmacyIncomeCostBillDTO;
+import com.divudi.core.data.dto.PharmacyIncomeCostBillItemDTO;
 import com.divudi.core.entity.*;
 import com.divudi.core.entity.channel.SessionInstance;
 import com.divudi.core.entity.inward.AdmissionType;
@@ -164,6 +165,10 @@ public class IncomeRow implements Serializable {
 
     private double qty;
 
+    private double retailRate;
+
+    private double purchaseRate;
+
     private long duration;
 
     private UUID id;
@@ -232,6 +237,31 @@ public class IncomeRow implements Serializable {
             if (dto.getPurchaseValue() != null) {
                 this.purchaseValue = dto.getPurchaseValue().doubleValue();
             }
+            this.grossProfit = this.retailValue - this.purchaseValue;
+        }
+    }
+
+    public IncomeRow(PharmacyIncomeCostBillItemDTO dto) {
+        this();
+        if (dto != null) {
+            this.billId = dto.getBillId();
+            this.billNo = dto.getBillNo();
+            this.billTypeAtomic = dto.getBillTypeAtomic();
+            this.patientName = dto.getPatientName();
+            this.bhtNo = dto.getBhtNo();
+            this.createdAt = dto.getCreatedAt();
+            this.itemName = dto.getItemName();
+            if (dto.getQty() != null) {
+                this.qty = dto.getQty();
+            }
+            if (dto.getRetailRate() != null) {
+                this.retailRate = dto.getRetailRate().doubleValue();
+            }
+            if (dto.getPurchaseRate() != null) {
+                this.purchaseRate = dto.getPurchaseRate().doubleValue();
+            }
+            this.retailValue = this.retailRate * this.qty;
+            this.purchaseValue = this.purchaseRate * this.qty;
             this.grossProfit = this.retailValue - this.purchaseValue;
         }
     }
@@ -1052,6 +1082,22 @@ public class IncomeRow implements Serializable {
 
     public void setQty(double qty) {
         this.qty = qty;
+    }
+
+    public double getRetailRate() {
+        return retailRate;
+    }
+
+    public void setRetailRate(double retailRate) {
+        this.retailRate = retailRate;
+    }
+
+    public double getPurchaseRate() {
+        return purchaseRate;
+    }
+
+    public void setPurchaseRate(double purchaseRate) {
+        this.purchaseRate = purchaseRate;
     }
 
     public void setBillItem(BillItem billItem) {

--- a/src/main/java/com/divudi/core/data/dto/PharmacyIncomeCostBillItemDTO.java
+++ b/src/main/java/com/divudi/core/data/dto/PharmacyIncomeCostBillItemDTO.java
@@ -1,0 +1,119 @@
+package com.divudi.core.data.dto;
+
+import com.divudi.core.data.BillTypeAtomic;
+import java.io.Serializable;
+import java.math.BigDecimal;
+import java.util.Date;
+
+public class PharmacyIncomeCostBillItemDTO implements Serializable {
+
+    private Long billId;
+    private String billNo;
+    private BillTypeAtomic billTypeAtomic;
+    private String patientName;
+    private String bhtNo;
+    private Date createdAt;
+    private String itemName;
+    private Double qty;
+    private BigDecimal retailRate;
+    private BigDecimal purchaseRate;
+
+    public PharmacyIncomeCostBillItemDTO() {
+    }
+
+    public PharmacyIncomeCostBillItemDTO(Long billId, String billNo, BillTypeAtomic billTypeAtomic,
+                                         String patientName, String bhtNo, Date createdAt,
+                                         String itemName, Double qty,
+                                         BigDecimal retailRate, BigDecimal purchaseRate) {
+        this.billId = billId;
+        this.billNo = billNo;
+        this.billTypeAtomic = billTypeAtomic;
+        this.patientName = patientName;
+        this.bhtNo = bhtNo;
+        this.createdAt = createdAt;
+        this.itemName = itemName;
+        this.qty = qty;
+        this.retailRate = retailRate;
+        this.purchaseRate = purchaseRate;
+    }
+
+    public Long getBillId() {
+        return billId;
+    }
+
+    public void setBillId(Long billId) {
+        this.billId = billId;
+    }
+
+    public String getBillNo() {
+        return billNo;
+    }
+
+    public void setBillNo(String billNo) {
+        this.billNo = billNo;
+    }
+
+    public BillTypeAtomic getBillTypeAtomic() {
+        return billTypeAtomic;
+    }
+
+    public void setBillTypeAtomic(BillTypeAtomic billTypeAtomic) {
+        this.billTypeAtomic = billTypeAtomic;
+    }
+
+    public String getPatientName() {
+        return patientName;
+    }
+
+    public void setPatientName(String patientName) {
+        this.patientName = patientName;
+    }
+
+    public String getBhtNo() {
+        return bhtNo;
+    }
+
+    public void setBhtNo(String bhtNo) {
+        this.bhtNo = bhtNo;
+    }
+
+    public Date getCreatedAt() {
+        return createdAt;
+    }
+
+    public void setCreatedAt(Date createdAt) {
+        this.createdAt = createdAt;
+    }
+
+    public String getItemName() {
+        return itemName;
+    }
+
+    public void setItemName(String itemName) {
+        this.itemName = itemName;
+    }
+
+    public Double getQty() {
+        return qty;
+    }
+
+    public void setQty(Double qty) {
+        this.qty = qty;
+    }
+
+    public BigDecimal getRetailRate() {
+        return retailRate;
+    }
+
+    public void setRetailRate(BigDecimal retailRate) {
+        this.retailRate = retailRate;
+    }
+
+    public BigDecimal getPurchaseRate() {
+        return purchaseRate;
+    }
+
+    public void setPurchaseRate(BigDecimal purchaseRate) {
+        this.purchaseRate = purchaseRate;
+    }
+}

--- a/src/main/java/com/divudi/service/BillService.java
+++ b/src/main/java/com/divudi/service/BillService.java
@@ -1197,6 +1197,72 @@ public class BillService {
         return fetchedPharmaceuticalBillItems;
     }
 
+    public List<PharmacyIncomeCostBillItemDTO> fetchBillItemIncomeCostDtos(Date fromDate,
+            Date toDate,
+            Institution institution,
+            Institution site,
+            Department department,
+            WebUser webUser,
+            List<BillTypeAtomic> billTypeAtomics,
+            AdmissionType admissionType,
+            PaymentScheme paymentScheme) {
+
+        String jpql = "select new com.divudi.core.data.dto.PharmacyIncomeCostBillItemDTO(" +
+                " b.id, b.deptId, b.billTypeAtomic, " +
+                " coalesce(pers.name,'N/A'), coalesce(pe.bhtNo,''), b.createdAt, " +
+                " ib.item.name, pbi.qty, pbi.retailRate, pbi.purchaseRate) " +
+                " from PharmaceuticalBillItem pbi " +
+                " join pbi.billItem bi " +
+                " join bi.bill b " +
+                " left join b.patient pat " +
+                " left join pat.person pers " +
+                " left join b.patientEncounter pe " +
+                " left join pbi.itemBatch ib " +
+                " where (b.retired=false or b.retired is null) " +
+                " and (bi.retired=false or bi.retired is null) " +
+                " and b.billTypeAtomic in :billTypesAtomics " +
+                " and b.createdAt between :fromDate and :toDate ";
+
+        Map params = new HashMap();
+        params.put("billTypesAtomics", billTypeAtomics);
+        params.put("fromDate", fromDate);
+        params.put("toDate", toDate);
+
+        if (institution != null) {
+            jpql += " and b.institution=:ins ";
+            params.put("ins", institution);
+        }
+
+        if (webUser != null) {
+            jpql += " and b.creater=:user ";
+            params.put("user", webUser);
+        }
+
+        if (department != null) {
+            jpql += " and b.department=:dep ";
+            params.put("dep", department);
+        }
+
+        if (site != null) {
+            jpql += " and b.department.site=:site ";
+            params.put("site", site);
+        }
+
+        if (admissionType != null) {
+            jpql += " and b.patientEncounter.admissionType=:admissionType ";
+            params.put("admissionType", admissionType);
+        }
+
+        if (paymentScheme != null) {
+            jpql += " and b.paymentScheme=:paymentScheme ";
+            params.put("paymentScheme", paymentScheme);
+        }
+
+        jpql += " order by b.createdAt desc";
+
+        return (List<PharmacyIncomeCostBillItemDTO>) pharmaceuticalBillItemFacade.findLightsByJpql(jpql, params, TemporalType.TIMESTAMP);
+    }
+
     public List<Bill> fetchBillsWithToInstitution(Date fromDate,
             Date toDate,
             Institution institution,

--- a/src/main/webapp/pharmacy/reports/summary_reports/pharmacy_income_and_cost_report.xhtml
+++ b/src/main/webapp/pharmacy/reports/summary_reports/pharmacy_income_and_cost_report.xhtml
@@ -325,33 +325,33 @@
                                 rowsPerPageTemplate="#{pharmacySummaryReportController.rowsPerPageForScreen}, 5,10,15,50,100,500,1000,2000,5000,10000"
                                 paginatorPosition="bottom">
                                 <p:column headerText="Bill No" width="16em" style="padding: 0px!important; margin: 0px!important;" >
-                                    <h:outputText value="#{row.pharmaceuticalBillItem.billItem.bill.deptId}"  style="padding: 0px!important; margin: 0px!important;" />
+                                    <h:outputText value="#{row.billNo}"  style="padding: 0px!important; margin: 0px!important;" />
                                     <f:facet name="footer" >
                                         <h:outputText value="Total Amounts" style="padding: 0px!important; margin: 0px!important; font-weight: bold" >
                                         </h:outputText>
                                     </f:facet>
                                 </p:column>
-                                <p:column 
+                                <p:column
                                     headerText="Bill Type"  style="padding: 0px!important; margin: 0px!important;" >
-                                    <h:outputText value="#{row.pharmaceuticalBillItem.billItem.bill.billTypeAtomic}"  style="padding: 0px!important; margin: 0px!important;" />
+                                    <h:outputText value="#{row.billTypeAtomic}"  style="padding: 0px!important; margin: 0px!important;" />
                                 </p:column>
                                 <p:column headerText="Patient"  style="padding: 0px!important; margin: 0px!important;" >
-                                    <h:outputText value="#{row.pharmaceuticalBillItem.billItem.bill.patient.person.nameWithTitle}"  style="padding: 0px!important; margin: 0px!important;" />
+                                    <h:outputText value="#{row.patientName}"  style="padding: 0px!important; margin: 0px!important;" />
                                 </p:column>
                                 <p:column headerText="BHT No"  style="padding: 0px!important; margin: 0px!important;" >
-                                    <h:outputText value="#{row.pharmaceuticalBillItem.billItem.bill.patientEncounter.bhtNo}"  style="padding: 0px!important; margin: 0px!important;" />
+                                    <h:outputText value="#{row.bhtNo}"  style="padding: 0px!important; margin: 0px!important;" />
                                 </p:column>
                                 <p:column headerText="Date"   width="10em" >
-                                    <h:outputText value="#{row.pharmaceuticalBillItem.billItem.bill.createdAt}"  style="padding: 0px!important; margin: 0px!important;" >
+                                    <h:outputText value="#{row.createdAt}"  style="padding: 0px!important; margin: 0px!important;" >
                                         <f:convertDateTime pattern="#{sessionController.applicationPreference.shortDateTimeFormat}" />
                                     </h:outputText>
                                 </p:column>
                                 <p:column headerText="Item"   width="10em" >
-                                    <h:outputText value="#{row.pharmaceuticalBillItem.itemBatch.item.name}"  style="padding: 0px!important; margin: 0px!important;" >
+                                    <h:outputText value="#{row.itemName}"  style="padding: 0px!important; margin: 0px!important;" >
                                     </h:outputText>
                                 </p:column>
                                 <p:column headerText="Qty" width="10em" class="text-end" style="padding: 0px!important; margin: 0px!important;">
-                                    <h:outputText value="#{row.pharmaceuticalBillItem.qty}">
+                                    <h:outputText value="#{row.qty}">
                                         <f:convertNumber pattern="#,##0.00" />
                                     </h:outputText>
                                     <f:facet name="footer">
@@ -361,12 +361,12 @@
                                     </f:facet>
                                 </p:column>
                                 <p:column headerText="Retail Rate" width="10em" class="text-end" style="padding: 0px!important; margin: 0px!important;">
-                                    <h:outputText value="#{row.pharmaceuticalBillItem.retailRate}">
+                                    <h:outputText value="#{row.retailRate}">
                                         <f:convertNumber pattern="#,##0.00" />
                                     </h:outputText>
                                 </p:column>
                                 <p:column headerText="Retail Value" width="10em" class="text-end" style="padding: 0px!important; margin: 0px!important;">
-                                    <h:outputText value="#{commonFunctionsProxy.abs(row.pharmaceuticalBillItem.retailRate * row.pharmaceuticalBillItem.qty)}">
+                                    <h:outputText value="#{commonFunctionsProxy.abs(row.retailValue)}">
                                         <f:convertNumber pattern="#,##0.00" />
                                     </h:outputText>
                                     <f:facet name="footer">
@@ -377,7 +377,7 @@
                                 </p:column>
 
                                 <p:column headerText="Cost Value" width="10em" class="text-end" style="padding: 0px!important; margin: 0px!important;">
-                                    <h:outputText value="#{commonFunctionsProxy.abs(row.pharmaceuticalBillItem.purchaseRate * row.pharmaceuticalBillItem.qty)}">
+                                    <h:outputText value="#{commonFunctionsProxy.abs(row.purchaseValue)}">
                                         <f:convertNumber pattern="#,##0.00" />
                                     </h:outputText>
                                     <f:facet name="footer">
@@ -388,7 +388,7 @@
                                 </p:column>
 
                                 <p:column headerText="Gross Profit" width="10em" class="text-end" style="padding: 0px!important; margin: 0px!important;">
-                                    <h:outputText value="#{commonFunctionsProxy.abs((row.pharmaceuticalBillItem.retailRate - row.pharmaceuticalBillItem.purchaseRate) * row.pharmaceuticalBillItem.qty)}">
+                                    <h:outputText value="#{commonFunctionsProxy.abs(row.grossProfit)}">
                                         <f:convertNumber pattern="#,##0.00" />
                                     </h:outputText>
                                     <f:facet name="footer">
@@ -406,7 +406,7 @@
                                         class="mx-1"
                                         action="#{billSearch.navigateToViewBillByAtomicBillType()}" 
                                         ajax="false">
-                                        <f:setPropertyActionListener value="#{row.pharmaceuticalBillItem.billItem.bill}" target="#{billSearch.bill}" />
+                                        <f:setPropertyActionListener value="#{billSearch.findBill(row.billId)}" target="#{billSearch.bill}" />
                                     </p:commandLink>
                                 </p:column>
 


### PR DESCRIPTION
## Summary
- optimize pharmacy income & cost report by bill item
- add `PharmacyIncomeCostBillItemDTO`
- fetch bill item DTOs in `BillService`
- support DTO rows in `IncomeBundle` and `IncomeRow`
- adjust report controller and JSF view
- allow loading bill by id in bill search

## Testing
- `mvn test` *(fails: mvn not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68521947c2f8832fb41575f65e61c6d2