### PR TITLE
Implement BillLight search for pharmacy

### DIFF
--- a/src/main/java/com/divudi/bean/common/SearchController.java
+++ b/src/main/java/com/divudi/bean/common/SearchController.java
@@ -4008,6 +4008,90 @@ public class SearchController implements Serializable {
 
     }
 
+    public void processPharmacyBillSearchLights() {
+        if (billTypeAtomic == null) {
+            JsfUtil.addErrorMessage("Please Select Bill Type");
+            return;
+        }
+        String jpql;
+        Map params = new HashMap();
+        jpql = "select new com.divudi.core.light.common.BillLight(b.id, b.deptId, b.createdAt, b.institution.name, b.toDepartment.name, b.creater.name, b.patient.person.name, b.patient.person.phone, b.total, b.discount, b.netTotal, b.patient.id, b.referenceBill.deptId, b.invoiceNumber, b.invoiceDate, b.paymentMethod, b.saleValue) "
+                + " from Bill b "
+                + " where b.retired=false "
+                + " and b.billTypeAtomic = :billTypeAtomic  "
+                + " and b.department=:dep "
+                + " and b.createdAt between :fromDate and :toDate ";
+
+        if (getSearchKeyword().getBillNo() != null && !getSearchKeyword().getBillNo().trim().equals("")) {
+            jpql += " and  ((b.deptId) like :billNo )";
+            params.put("billNo", "%" + getSearchKeyword().getBillNo().trim().toUpperCase() + "%");
+        }
+
+        if (getSearchKeyword().getRequestNo() != null && !getSearchKeyword().getRequestNo().trim().equals("")) {
+            jpql += " and  ((b.insId) like :requestNo )";
+            params.put("requestNo", "%" + getSearchKeyword().getRequestNo().trim().toUpperCase() + "%");
+        }
+
+        if (getSearchKeyword().getNetTotal() != null && !getSearchKeyword().getNetTotal().trim().equals("")) {
+            jpql += " and  ((b.netTotal) = :netTotal )";
+            params.put("netTotal", "%" + getSearchKeyword().getNetTotal().trim().toUpperCase() + "%");
+        }
+
+        if (getSearchKeyword().getFromInstitution() != null && !getSearchKeyword().getFromInstitution().trim().equals("")) {
+            jpql += " and  ((b.fromInstitution.name) like :frmIns )";
+            params.put("frmIns", "%" + getSearchKeyword().getFromInstitution().trim().toUpperCase() + "%");
+        }
+
+        if (getSearchKeyword().getFromDepartment() != null && !getSearchKeyword().getFromDepartment().trim().equals("")) {
+            jpql += " and  ((b.fromDepartment.name) like :frmDept )";
+            params.put("frmDept", "%" + getSearchKeyword().getFromDepartment().trim().toUpperCase() + "%");
+        }
+
+        if (getSearchKeyword().getToInstitution() != null && !getSearchKeyword().getToInstitution().trim().equals("")) {
+            jpql += " and  ((b.toInstitution.name) like :toIns )";
+            params.put("toIns", "%" + getSearchKeyword().getToInstitution().trim().toUpperCase() + "%");
+        }
+
+        if (getSearchKeyword().getToDepartment() != null && !getSearchKeyword().getToDepartment().trim().equals("")) {
+            jpql += " and  ((b.toDepartment.name) like :toDept )";
+            params.put("toDept", "%" + getSearchKeyword().getToDepartment().trim().toUpperCase() + "%");
+        }
+
+        if (getSearchKeyword().getRefBillNo() != null && !getSearchKeyword().getRefBillNo().trim().equals("")) {
+            jpql += " and  ((b.referenceBill.deptId) like :refId )";
+            params.put("refId", "%" + getSearchKeyword().getRefBillNo().trim().toUpperCase() + "%");
+        }
+
+        if (getSearchKeyword().getNumber() != null && !getSearchKeyword().getNumber().trim().equals("")) {
+            jpql += " and  ((b.invoiceNumber) like :inv )";
+            params.put("inv", "%" + getSearchKeyword().getNumber().trim().toUpperCase() + "%");
+        }
+
+        if (getSearchKeyword().getItemName() != null && !getSearchKeyword().getItemName().trim().equals("")) {
+            jpql += " and b.id in (select bItem.bill.id  "
+                    + " from BillItem bItem where bItem.retired=false and  "
+                    + " ((bItem.item.name) like :itm ))";
+            params.put("itm", "%" + getSearchKeyword().getItemName().trim().toUpperCase() + "%");
+        }
+
+        if (getSearchKeyword().getCode() != null && !getSearchKeyword().getCode().trim().equals("")) {
+            jpql += " and b.id in (select bItem.bill.id  "
+                    + " from BillItem bItem where bItem.retired=false and  "
+                    + " ((bItem.item.code) like :cde ))";
+            params.put("cde", "%" + getSearchKeyword().getCode().trim().toUpperCase() + "%");
+        }
+
+        jpql += " order by b.createdAt desc  ";
+
+        params.put("billTypeAtomic", billTypeAtomic);
+        params.put("dep", getSessionController().getDepartment());
+        params.put("toDate", getToDate());
+        params.put("fromDate", getFromDate());
+
+        billLights = getBillFacade().findLightsByJpql(jpql, params, TemporalType.TIMESTAMP, maxResult);
+
+    }
+
     public void createTableByBillType() {
         if (billType == null) {
             JsfUtil.addErrorMessage("Please Select Bill Type");

--- a/src/main/java/com/divudi/core/light/common/BillLight.java
+++ b/src/main/java/com/divudi/core/light/common/BillLight.java
@@ -2,6 +2,7 @@ package com.divudi.core.light.common;
 
 import com.divudi.core.data.BillTypeAtomic;
 import com.divudi.core.entity.Department;
+import com.divudi.core.data.PaymentMethod;
 import java.util.Date;
 import java.util.Objects;
 
@@ -24,6 +25,11 @@ public class BillLight {
     private Double discount;
     private Double netValue;
     private Long patientId;
+    private String referenceBillNo;
+    private String invoiceNo;
+    private Date invoiceDate;
+    private PaymentMethod paymentMethod;
+    private Double saleValue;
     private String canterName;
     private String referringDoctorName;
     private BillTypeAtomic billTypeAtomic;
@@ -101,6 +107,31 @@ public class BillLight {
         this.discount = discount;
         this.netValue = netValue;
         this.patientId = patientId;
+    }
+
+    public BillLight(Long id, String billNo, Date billDate,
+            String institutionName, String departmentName, String userName,
+            String patientName, String patientPhone, Double grossValue,
+            Double discount, Double netValue, Long patientId,
+            String referenceBillNo, String invoiceNo, Date invoiceDate,
+            PaymentMethod paymentMethod, Double saleValue) {
+        this.id = id;
+        this.billNo = billNo;
+        this.billDate = billDate;
+        this.institutionName = institutionName;
+        this.departmentName = departmentName;
+        this.userName = userName;
+        this.patientName = patientName;
+        this.patientPhone = patientPhone;
+        this.grossValue = grossValue;
+        this.discount = discount;
+        this.netValue = netValue;
+        this.patientId = patientId;
+        this.referenceBillNo = referenceBillNo;
+        this.invoiceNo = invoiceNo;
+        this.invoiceDate = invoiceDate;
+        this.paymentMethod = paymentMethod;
+        this.saleValue = saleValue;
     }
 
     public Long getId() {
@@ -197,6 +228,46 @@ public class BillLight {
 
     public void setPatientId(Long patientId) {
         this.patientId = patientId;
+    }
+
+    public String getReferenceBillNo() {
+        return referenceBillNo;
+    }
+
+    public void setReferenceBillNo(String referenceBillNo) {
+        this.referenceBillNo = referenceBillNo;
+    }
+
+    public String getInvoiceNo() {
+        return invoiceNo;
+    }
+
+    public void setInvoiceNo(String invoiceNo) {
+        this.invoiceNo = invoiceNo;
+    }
+
+    public Date getInvoiceDate() {
+        return invoiceDate;
+    }
+
+    public void setInvoiceDate(Date invoiceDate) {
+        this.invoiceDate = invoiceDate;
+    }
+
+    public PaymentMethod getPaymentMethod() {
+        return paymentMethod;
+    }
+
+    public void setPaymentMethod(PaymentMethod paymentMethod) {
+        this.paymentMethod = paymentMethod;
+    }
+
+    public Double getSaleValue() {
+        return saleValue;
+    }
+
+    public void setSaleValue(Double saleValue) {
+        this.saleValue = saleValue;
     }
 
     public String getReferringDoctorName() {

--- a/src/main/webapp/pharmacy/pharmacy_search.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_search.xhtml
@@ -49,7 +49,7 @@
                                     icon="fas fa-search"
                                     class="ui-button-warning w-100 mt-2"
                                     value="Search" 
-                                    action="#{searchController.createTableByBillType}">
+                                    action="#{searchController.processPharmacyBillSearchLights}">
                                 </p:commandButton>
 
                                 <p:commandButton 

--- a/src/main/webapp/pharmacy/pharmacy_search_by_bill_type_atomic.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_search_by_bill_type_atomic.xhtml
@@ -54,7 +54,7 @@
                                         icon="fas fa-search"
                                         class="ui-button-warning w-100 mt-2"
                                         value="Search" 
-                                        action="#{searchController.processPharmacyBillSearch}">
+                                        action="#{searchController.processPharmacyBillSearchLights}">
                                     </p:commandButton>
 
                                 </h:panelGrid>                              


### PR DESCRIPTION
## Summary
- extend `BillLight` with invoice and reference details
- add new constructor for additional bill info
- implement `processPharmacyBillSearchLights` in `SearchController`
- use new search method in pharmacy search pages

## Testing
- `mvn -q test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6855ecc31c64832f8b11bc75099633a7