### PR TITLE
12999-improve-pharmacy-bill-navigation

### DIFF
--- a/src/main/java/com/divudi/bean/pharmacy/PharmacyBillSearch.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacyBillSearch.java
@@ -134,6 +134,7 @@ public class PharmacyBillSearch implements Serializable {
     private String txtSearch;
     private String comment;
     private Bill bill;
+    private Long billId;
     private PaymentMethod paymentMethod;
     private PaymentScheme paymentScheme;
     private RefundBill billForRefund;
@@ -3150,6 +3151,15 @@ public class PharmacyBillSearch implements Serializable {
 //            paymentMethod = bb.getPaymentMethod();
 //        }
 
+    }
+
+    public Long getBillId() {
+        return billId;
+    }
+
+    public void setBillId(Long billId) {
+        this.billId = billId;
+        this.bill = billFacade.find(billId);
     }
 
     public List<BillEntry> getBillEntrys() {

--- a/src/main/webapp/pharmacy/pharmacy_search_adjustment_bill_item.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_search_adjustment_bill_item.xhtml
@@ -118,7 +118,8 @@
                                     
                                     <p:column>
                                         <p:commandButton ajax="false" action="pharmacy_reprint_adjustment" value="View BIll">
-                                            <f:setPropertyActionListener value="#{pi.bill}" target="#{pharmacyBillSearch.bill}"/>
+                                            <f:setPropertyActionListener value="#{pi.bill.id}" target="#{pharmacyBillSearch.billId}"/>
+                                            <f:setPropertyActionListener value="#{null}" target="#{searchController.bills}"/>
                                         </p:commandButton>
                                     </p:column>
 

--- a/src/main/webapp/pharmacy/pharmacy_search_issue_bill.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_search_issue_bill.xhtml
@@ -74,7 +74,8 @@
                                             value="#{bill.deptId}"
                                             ajax="false"
                                             action="/pharmacy/pharmacy_reprint_bill_unit_issue">
-                                            <f:setPropertyActionListener value="#{bill}" target="#{pharmacyBillSearch.bill}"/> 
+                                            <f:setPropertyActionListener value="#{bill.id}" target="#{pharmacyBillSearch.billId}"/>
+                                            <f:setPropertyActionListener value="#{null}" target="#{searchController.bills}"/>
                                         </p:commandLink>
                                     </p:column>
 

--- a/src/main/webapp/pharmacy/pharmacy_search_issue_bill_item.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_search_issue_bill_item.xhtml
@@ -75,11 +75,12 @@
                                         <h:outputLabel value="#{i+1}"/>
                                     </p:column>
                                     <p:column headerText="Bill No" styleClass="alignTop"  width="10em">
-                                        <p:commandLink 
-                                            ajax="false" 
+                                        <p:commandLink
+                                            ajax="false"
                                             value="#{pi.bill.deptId}"
                                             action="/pharmacy/pharmacy_reprint_bill_unit_issue">
-                                            <f:setPropertyActionListener value="#{pi.bill}" target="#{pharmacyBillSearch.bill}"/>
+                                            <f:setPropertyActionListener value="#{pi.bill.id}" target="#{pharmacyBillSearch.billId}"/>
+                                            <f:setPropertyActionListener value="#{null}" target="#{searchController.bills}"/>
                                         </p:commandLink>
                                     </p:column>
                                     <p:column headerText="Item Name"  styleClass="alignTop" width="20em">

--- a/src/main/webapp/pharmacy/pharmacy_search_pre_bill.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_search_pre_bill.xhtml
@@ -329,7 +329,8 @@
                                                     value="View Payment Bill"
                                                     action="pharmacy_reprint_bill_sale_cashier?faces-redirect=true"
                                                     disabled="#{bill.referenceBill eq null}">
-                                                    <f:setPropertyActionListener target="#{pharmacyBillSearch.bill}" value="#{rb}" />
+                                                    <f:setPropertyActionListener target="#{pharmacyBillSearch.billId}" value="#{rb.id}" />
+                                                    <f:setPropertyActionListener value="#{null}" target="#{searchController.bills}" />
                                                 </p:commandButton>
                                             </p:column>
                                         </p:dataTable>

--- a/src/main/webapp/pharmacy/pharmacy_search_pre_bill_for_return_item_and_cash.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_search_pre_bill_for_return_item_and_cash.xhtml
@@ -125,7 +125,8 @@
                                             value="View"
                                             class="mx-1 ui-button-success"
                                             action="pharmacy_reprint_bill_sale?faces-redirect=true">
-                                            <f:setPropertyActionListener value="#{bill.referenceBill}" target="#{pharmacyBillSearch.bill}"/>   
+                                            <f:setPropertyActionListener value="#{bill.referenceBill.id}" target="#{pharmacyBillSearch.billId}"/>
+                                            <f:setPropertyActionListener value="#{null}" target="#{searchController.bills}"/>
                                         </p:commandButton>
                                         <p:tooltip for="viewBill" value="View Bill"  showDelay="0" hideDelay="0"></p:tooltip>
                                         <p:commandButton 

--- a/src/main/webapp/pharmacy/pharmacy_search_pre_bill_for_return_item_only.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_search_pre_bill_for_return_item_only.xhtml
@@ -101,8 +101,9 @@
                                             id="viewBill" 
                                             icon="fas fa-file-invoice"
                                             action="pharmacy_reprint_bill_sale">
-                                            <f:setPropertyActionListener value="#{bill.referenceBill}" 
-                                                                         target="#{pharmacyBillSearch.bill}"/>   
+                                            <f:setPropertyActionListener value="#{bill.referenceBill.id}"
+                                                                         target="#{pharmacyBillSearch.billId}"/>
+                                            <f:setPropertyActionListener value="#{null}" target="#{searchController.bills}"/>
                                         </p:commandButton>
                                         <p:tooltip for="viewBill" value="View Bill"  showDelay="0" hideDelay="0"></p:tooltip>
                                         <p:commandButton 
@@ -156,7 +157,8 @@
                                                     icon="fas fa-file-invoice"
                                                     action="pharmacy_reprint_bill_return_pre" 
                                                     disabled="#{rb.creater eq null}">
-                                                    <f:setPropertyActionListener target="#{pharmacyBillSearch.bill}" value="#{rb}"/>
+                                                    <f:setPropertyActionListener target="#{pharmacyBillSearch.billId}" value="#{rb.id}"/>
+                                                    <f:setPropertyActionListener value="#{null}" target="#{searchController.bills}"/>
                                                 </p:commandButton>
                                                 <p:tooltip for="returnViewBill" value="View Return Bill"  showDelay="0" hideDelay="0"></p:tooltip>
                                             </p:column>

--- a/src/main/webapp/pharmacy/pharmacy_search_pre_bill_not_paid.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_search_pre_bill_not_paid.xhtml
@@ -118,7 +118,8 @@
 
                             <p:column >
                                 <p:commandButton ajax="false"  value="View Bill" action="pharmacy_reprint_bill_pre" icon="fas fa-file-invoice" class="ui-button-warning" disabled="#{bill.referenceBill ne null}">                                
-                                    <f:setPropertyActionListener  value="#{bill}" target="#{pharmacyBillSearch.bill}" />
+                                    <f:setPropertyActionListener  value="#{bill.id}" target="#{pharmacyBillSearch.billId}" />
+                                    <f:setPropertyActionListener value="#{null}" target="#{searchController.bills}" />
                                 </p:commandButton>
                             </p:column>
                         </p:dataTable>

--- a/src/main/webapp/pharmacy/pharmacy_search_pre_refund_bill_for_return_cash.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_search_pre_refund_bill_for_return_cash.xhtml
@@ -146,7 +146,8 @@
                                             <p:column>
                                                 <p:commandButton ajax="false" value="View Returned Bill"  rendered="#{rb.refundedBill eq null}"
                                                                  action="pharmacy_reprint_bill_return_cash"  >
-                                                    <f:setPropertyActionListener target="#{pharmacyBillSearch.bill}" value="#{rb}" />
+                                                    <f:setPropertyActionListener target="#{pharmacyBillSearch.billId}" value="#{rb.id}" />
+                                                    <f:setPropertyActionListener value="#{null}" target="#{searchController.bills}" />
                                                 </p:commandButton>
                                             </p:column>
                                         </p:dataTable>

--- a/src/main/webapp/pharmacy/pharmacy_search_purcharse_GRN_bill.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_search_purcharse_GRN_bill.xhtml
@@ -53,7 +53,8 @@
                                 
                                 <h:commandLink action="pharmacy_reprint_purchase" value="#{bill.deptId}">
                                     <h:outputLabel  ></h:outputLabel>
-                                    <f:setPropertyActionListener value="#{bill}" target="#{pharmacyBillSearch.bill}"/>
+                                    <f:setPropertyActionListener value="#{bill.id}" target="#{pharmacyBillSearch.billId}"/>
+                                <f:setPropertyActionListener value="#{null}" target="#{searchController.bills}"/>
                                 </h:commandLink>
                             </p:column> 
 
@@ -64,7 +65,8 @@
                                       filterMatchMode="contains">
                                 <h:commandLink action="pharmacy_reprint_purchase" value="#{bill.toInstitution.name}" rendered="#{bill.toInstitution.name eq null}">
                                     <h:outputLabel  ></h:outputLabel>
-                                    <f:setPropertyActionListener value="#{bill}" target="#{pharmacyBillSearch.bill}"/>
+                                    <f:setPropertyActionListener value="#{bill.id}" target="#{pharmacyBillSearch.billId}"/>
+                                <f:setPropertyActionListener value="#{null}" target="#{searchController.bills}"/>
                                 </h:commandLink>
                             </p:column> 
                             
@@ -76,7 +78,8 @@
                                       >
                                 <h:commandLink action="pharmacy_reprint_purchase" value="#{bill.billType}" >
                                     <h:outputLabel  ></h:outputLabel>
-                                    <f:setPropertyActionListener value="#{bill}" target="#{pharmacyBillSearch.bill}"/>
+                                    <f:setPropertyActionListener value="#{bill.id}" target="#{pharmacyBillSearch.billId}"/>
+                                <f:setPropertyActionListener value="#{null}" target="#{searchController.bills}"/>
                                 </h:commandLink>
                             </p:column> 
                             <p:column headerText="Billed at"  >
@@ -84,7 +87,8 @@
                                     <h:outputLabel value="#{bill.createdAt}" >
                                         <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateTimeFormat}"/>
                                     </h:outputLabel>
-                                    <f:setPropertyActionListener value="#{bill}" target="#{pharmacyBillSearch.bill}"/>
+                                    <f:setPropertyActionListener value="#{bill.id}" target="#{pharmacyBillSearch.billId}"/>
+                                <f:setPropertyActionListener value="#{null}" target="#{searchController.bills}"/>
                                 </h:commandLink>
                                 <br/>
                                 <h:panelGroup rendered="#{bill.cancelled}" >
@@ -104,7 +108,8 @@
                                 <h:commandLink action="pharmacy_reprint_purchase" >
                                     <h:outputLabel value="#{bill.creater.webUserPerson.name}" >                                      
                                     </h:outputLabel>
-                                    <f:setPropertyActionListener value="#{bill}" target="#{pharmacyBillSearch.bill}"/>
+                                    <f:setPropertyActionListener value="#{bill.id}" target="#{pharmacyBillSearch.billId}"/>
+                                <f:setPropertyActionListener value="#{null}" target="#{searchController.bills}"/>
                                 </h:commandLink>
                                 <br/>
                                 <h:panelGroup rendered="#{bill.cancelled}" >
@@ -127,7 +132,8 @@
                                       >
                                 <h:commandLink action="pharmacy_reprint_purchase" >
                                     <h:outputLabel value="#{bill.paymentMethod}" ></h:outputLabel>
-                                    <f:setPropertyActionListener value="#{bill}" target="#{pharmacyBillSearch.bill}"/>
+                                    <f:setPropertyActionListener value="#{bill.id}" target="#{pharmacyBillSearch.billId}"/>
+                                <f:setPropertyActionListener value="#{null}" target="#{searchController.bills}"/>
                                 </h:commandLink>
                             </p:column>                               
                             <p:column headerText="Net Value"  style="text-align: right;"  >
@@ -135,7 +141,8 @@
                                     <h:outputLabel value="#{bill.netTotal}" >
                                         <f:convertNumber pattern="#,##0.00"/>
                                     </h:outputLabel>
-                                    <f:setPropertyActionListener value="#{bill}" target="#{pharmacyBillSearch.bill}"/>
+                                    <f:setPropertyActionListener value="#{bill.id}" target="#{pharmacyBillSearch.billId}"/>
+                                <f:setPropertyActionListener value="#{null}" target="#{searchController.bills}"/>
                                 </h:commandLink>
                             </p:column>
 

--- a/src/main/webapp/pharmacy/pharmacy_search_purcharse_bill.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_search_purcharse_bill.xhtml
@@ -72,7 +72,8 @@
                                       >
                                 <h:commandLink action="pharmacy_reprint_purchase" value="#{bill.deptId}">
                                     <h:outputLabel  ></h:outputLabel>
-                                    <f:setPropertyActionListener value="#{bill}" target="#{pharmacyBillSearch.bill}"/>
+                                    <f:setPropertyActionListener value="#{bill.id}" target="#{pharmacyBillSearch.billId}"/>
+                                    <f:setPropertyActionListener value="#{null}" target="#{searchController.bills}"/>
                                 </h:commandLink>
                             </p:column> 
                             <p:column headerText="Bill Type" 

--- a/src/main/webapp/pharmacy/pharmacy_search_purcharse_bill_1.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_search_purcharse_bill_1.xhtml
@@ -51,7 +51,8 @@
                                       filterMatchMode="contains">
                                 <h:commandLink action="pharmacy_reprint_purchase" value="#{bill.deptId}">
                                     <h:outputLabel  ></h:outputLabel>
-                                    <f:setPropertyActionListener value="#{bill}" target="#{pharmacyBillSearch.bill}"/>
+                                    <f:setPropertyActionListener value="#{bill.id}" target="#{pharmacyBillSearch.billId}"/>
+                                    <f:setPropertyActionListener value="#{null}" target="#{searchController.bills}"/>
                                 </h:commandLink>
                             </p:column> 
 
@@ -65,7 +66,8 @@
                                       >
                                 <h:commandLink action="pharmacy_reprint_purchase" value="#{bill.toInstitution.name}"  rendered="#{bill.toInstitution.name eq null}">
                                     <h:outputLabel  ></h:outputLabel>
-                                    <f:setPropertyActionListener value="#{bill}" target="#{pharmacyBillSearch.bill}"/>
+                                    <f:setPropertyActionListener value="#{bill.id}" target="#{pharmacyBillSearch.billId}"/>
+                                    <f:setPropertyActionListener value="#{null}" target="#{searchController.bills}"/>
                                 </h:commandLink>
                             </p:column> 
                             <p:column headerText="Billed at"  >
@@ -73,7 +75,8 @@
                                     <h:outputLabel value="#{bill.createdAt}" >
                                         <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateTimeFormat}"/>
                                     </h:outputLabel>
-                                    <f:setPropertyActionListener value="#{bill}" target="#{pharmacyBillSearch.bill}"/>
+                                    <f:setPropertyActionListener value="#{bill.id}" target="#{pharmacyBillSearch.billId}"/>
+                                    <f:setPropertyActionListener value="#{null}" target="#{searchController.bills}"/>
                                 </h:commandLink>
                                 <br/>
                                 <h:panelGroup rendered="#{bill.cancelled}" >
@@ -93,7 +96,8 @@
                                 <h:commandLink action="pharmacy_reprint_purchase" >
                                     <h:outputLabel value="#{bill.creater.webUserPerson.name}" >                                      
                                     </h:outputLabel>
-                                    <f:setPropertyActionListener value="#{bill}" target="#{pharmacyBillSearch.bill}"/>
+                                    <f:setPropertyActionListener value="#{bill.id}" target="#{pharmacyBillSearch.billId}"/>
+                                    <f:setPropertyActionListener value="#{null}" target="#{searchController.bills}"/>
                                 </h:commandLink>
                                 <br/>
                                 <h:panelGroup rendered="#{bill.cancelled}" >
@@ -116,7 +120,8 @@
                                       >
                                 <h:commandLink action="pharmacy_reprint_purchase" >
                                     <h:outputLabel value="#{bill.paymentMethod}" ></h:outputLabel>
-                                    <f:setPropertyActionListener value="#{bill}" target="#{pharmacyBillSearch.bill}"/>
+                                    <f:setPropertyActionListener value="#{bill.id}" target="#{pharmacyBillSearch.billId}"/>
+                                    <f:setPropertyActionListener value="#{null}" target="#{searchController.bills}"/>
                                 </h:commandLink>
                             </p:column>                               
                             <p:column headerText="Net Value"  style="text-align: right;"  >
@@ -124,7 +129,8 @@
                                     <h:outputLabel value="#{bill.netTotal}" >
                                         <f:convertNumber pattern="#,##0.00"/>
                                     </h:outputLabel>
-                                    <f:setPropertyActionListener value="#{bill}" target="#{pharmacyBillSearch.bill}"/>
+                                    <f:setPropertyActionListener value="#{bill.id}" target="#{pharmacyBillSearch.billId}"/>
+                                    <f:setPropertyActionListener value="#{null}" target="#{searchController.bills}"/>
                                 </h:commandLink>
                             </p:column>
 

--- a/src/main/webapp/pharmacy/pharmacy_search_return_bill_pre.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_search_return_bill_pre.xhtml
@@ -108,7 +108,8 @@
                                             disabled="#{bill.checkActiveReturnCashBill() or bill.cancelled}" 
                                             value="Cancel Return Item Bill" 
                                             action="pharmacy_reprint_bill_return_pre">
-                                            <f:setPropertyActionListener value="#{bill}" target="#{pharmacyBillSearch.bill}"/>
+                                            <f:setPropertyActionListener value="#{bill.id}" target="#{pharmacyBillSearch.billId}"/>
+                                            <f:setPropertyActionListener value="#{null}" target="#{searchController.bills}"/>
                                         </p:commandButton>                                
                                     </p:column>
 
@@ -154,7 +155,8 @@
                                                     class="ui-button-primary"
                                                     action="pharmacy_reprint_bill_return_cash" 
                                                     disabled="#{rb.cancelled}">
-                                                    <f:setPropertyActionListener value="#{rb}" target="#{pharmacyBillSearch.bill}"/>
+                                                    <f:setPropertyActionListener value="#{rb.id}" target="#{pharmacyBillSearch.billId}"/>
+                                                    <f:setPropertyActionListener value="#{null}" target="#{searchController.bills}"/>
                                                 </p:commandButton> 
                                                 <p:tooltip for="cancelRefundCashBill" value="View Bill"   showDelay="0" hideDelay="0"></p:tooltip>
                                             </p:column>

--- a/src/main/webapp/pharmacy/pharmacy_search_sale_bill.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_search_sale_bill.xhtml
@@ -81,7 +81,8 @@
                                             value="#{bill.deptId}" 
                                             disabled="#{bill.referenceBill eq null}"
                                             action="#{pharmacyBillSearch.navigatePharmacyReprintRetailBill()}">
-                                            <f:setPropertyActionListener value="#{bill.referenceBill}" target="#{pharmacyBillSearch.bill}"/>  
+                                            <f:setPropertyActionListener value="#{bill.referenceBill.id}" target="#{pharmacyBillSearch.billId}"/>
+                                            <f:setPropertyActionListener value="#{null}" target="#{searchController.bills}"/>
                                         </p:commandLink>
                                     </p:column>
 

--- a/src/main/webapp/pharmacy/pharmacy_search_sale_bill_item.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_search_sale_bill_item.xhtml
@@ -135,7 +135,8 @@
                                             ajax="false" 
                                             icon="fas fa-file-invoice"
                                             action="pharmacy_reprint_bill_sale">
-                                            <f:setPropertyActionListener value="#{pi.bill.referenceBill}" target="#{pharmacyBillSearch.bill}"/>                                     
+                                            <f:setPropertyActionListener value="#{pi.bill.referenceBill.id}" target="#{pharmacyBillSearch.billId}"/>
+                                            <f:setPropertyActionListener value="#{null}" target="#{searchController.bills}"/>
                                         </p:commandButton>
                                         
                                         <p:tooltip for="btnViewBill" value="View Bill"  showDelay="0" hideDelay="0"></p:tooltip>

--- a/src/main/webapp/pharmacy/pharmacy_search_sale_pre_bill.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_search_sale_pre_bill.xhtml
@@ -73,8 +73,9 @@
                                             value="#{bill.deptId}" 
                                             disabled="#{bill.referenceBill eq null}"                                            
                                             >
-                                            <f:setPropertyActionListener value="#{bill.referenceBill}" target="#{pharmacyBillSearch.bill}"/> 
-                                            <f:setPropertyActionListener value="#{bill.referenceBill.paymentMethod}" target="#{pharmacyBillSearch.paymentMethod}"/> 
+                                            <f:setPropertyActionListener value="#{bill.referenceBill.id}" target="#{pharmacyBillSearch.billId}"/>
+                                            <f:setPropertyActionListener value="#{bill.referenceBill.paymentMethod}" target="#{pharmacyBillSearch.paymentMethod}"/>
+                                            <f:setPropertyActionListener value="#{null}" target="#{searchController.bills}"/>
                                         </p:commandLink>
                                     </p:column>
                                     


### PR DESCRIPTION
## Summary
- add billId property to `PharmacyBillSearch`
- fetch selected Bill using billId
- use billId in pharmacy search navigation links
- clear search results after navigation

## Testing
- `mvn -version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6855ecc77678832f9a0ad1684c8f1a5b