### PR TITLE
13117 if change retail rate more than one time it wasnt updated in rates and vales

### DIFF
--- a/src/main/java/com/divudi/bean/pharmacy/PurchaseOrderController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PurchaseOrderController.java
@@ -127,6 +127,13 @@ public class PurchaseOrderController implements Serializable {
     }
 
     public String navigateToPurchaseOrderApproval() {
+        Bill temRequestedBill = requestedBill;
+        clearList();
+        requestedBill = temRequestedBill;
+        getAprovedBill().setPaymentMethod(getRequestedBill().getPaymentMethod());
+        getAprovedBill().setToInstitution(getRequestedBill().getToInstitution());
+        getAprovedBill().setCreditDuration(getRequestedBill().getCreditDuration());
+        generateBillComponent();
         printPreview = false;
         return "/pharmacy/pharmacy_purhcase_order_approving?faces-redirect=true";
     }
@@ -144,7 +151,7 @@ public class PurchaseOrderController implements Serializable {
         saveBill();
         totalBillItemsCount = 0;
         saveBillComponent();
-        if (totalBillItemsCount == 0){
+        if (totalBillItemsCount == 0) {
             JsfUtil.addErrorMessage("Please add item quantities for the bill");
             return "";
         }
@@ -173,7 +180,10 @@ public class PurchaseOrderController implements Serializable {
     private PharmacyController pharmacyController;
 
     public void onEdit(BillItem tmp) {
+        System.out.println("onEdit");
         tmp.setNetValue(tmp.getPharmaceuticalBillItem().getQty() * tmp.getPharmaceuticalBillItem().getPurchaseRate());
+        System.out.println("tmp.getPharmaceuticalBillItem().getQty() = " + tmp.getPharmaceuticalBillItem().getQty());
+        System.out.println("tmp.getPharmaceuticalBillItem().getPurchaseRate() = " + tmp.getPharmaceuticalBillItem().getPurchaseRate());
         calTotal();
     }
 
@@ -212,8 +222,6 @@ public class PurchaseOrderController implements Serializable {
         getAprovedBill().setCreatedAt(Calendar.getInstance().getTime());
 
         getAprovedBill().setBillTypeAtomic(BillTypeAtomic.PHARMACY_ORDER_APPROVAL);
-
-
 
         try {
             if (getAprovedBill().getId() == null) {
@@ -285,15 +293,21 @@ public class PurchaseOrderController implements Serializable {
 
             PharmaceuticalBillItem ph = new PharmaceuticalBillItem();
             ph.setBillItem(bi);
-            ////// // System.out.println("i.getFreeQty() = " + i.getFreeQty());
+            System.out.println("bi.getItem().getName() = " + bi.getItem().getName());
+            
             ph.setFreeQty(i.getFreeQty());
-            ph.setQtyInUnit(i.getQtyInUnit());
-            ph.setPurchaseRateInUnit(i.getPurchaseRateInUnit());
-            ph.setRetailRateInUnit(i.getRetailRateInUnit());
+            System.out.println("i.getQty() = " + i.getQty());
+            ph.setQty(i.getQty());
+            System.out.println("ph = " + ph.getQty());
+            ph.setPurchaseRate(i.getPurchaseRate());
+            ph.setRetailRate(i.getRetailRate());
             bi.setPharmaceuticalBillItem(ph);
 
-            bi.setTmpQty(ph.getQtyInUnit());
+            bi.setTmpQty(ph.getQty());
+            System.out.println("bi.getTmpQty() = " + bi.getTmpQty());
 
+            System.out.println("ph.getQty() = " + ph.getQty());
+            
             getBillItems().add(bi);
         }
 
@@ -302,18 +316,20 @@ public class PurchaseOrderController implements Serializable {
     }
 
     public void setRequestedBill(Bill requestedBill) {
-        clearList();
+        // The logic inside getter was taken to the navigator method
+//        clearList();
         this.requestedBill = requestedBill;
-        getAprovedBill().setPaymentMethod(getRequestedBill().getPaymentMethod());
-        getAprovedBill().setToInstitution(getRequestedBill().getToInstitution());
-        getAprovedBill().setCreditDuration(getRequestedBill().getCreditDuration());
-        generateBillComponent();
+//        getAprovedBill().setPaymentMethod(getRequestedBill().getPaymentMethod());
+//        getAprovedBill().setToInstitution(getRequestedBill().getToInstitution());
+//        getAprovedBill().setCreditDuration(getRequestedBill().getCreditDuration());
+//        generateBillComponent();
     }
 
     public Bill getAprovedBill() {
         if (aprovedBill == null) {
             aprovedBill = new BilledBill();
             aprovedBill.setBillType(BillType.PharmacyOrderApprove);
+            aprovedBill.setBillTypeAtomic(BillTypeAtomic.PHARMACY_ORDER_APPROVAL);
         }
         return aprovedBill;
     }
@@ -367,6 +383,7 @@ public class PurchaseOrderController implements Serializable {
         int serialNo = 0;
         for (BillItem bi : getBillItems()) {
             tmp += bi.getPharmaceuticalBillItem().getQty() * bi.getPharmaceuticalBillItem().getPurchaseRate();
+            System.out.println(" bi.getPharmaceuticalBillItem().getQty() = " +  bi.getPharmaceuticalBillItem().getQty());
             bi.setSearialNo(serialNo++);
         }
         getAprovedBill().setTotal(tmp);

--- a/src/main/java/com/divudi/bean/pharmacy/PurchaseOrderController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PurchaseOrderController.java
@@ -242,7 +242,7 @@ public class PurchaseOrderController implements Serializable {
             i.setNetValue(i.getPharmaceuticalBillItem().getQty() * i.getPharmaceuticalBillItem().getPurchaseRate());
 
             double qty;
-            qty = i.getTmpQty() + i.getPharmaceuticalBillItem().getFreeQty();
+            qty = i.getQty() + i.getPharmaceuticalBillItem().getFreeQty();
             if (qty <= 0.0) {
                 i.setRetired(true);
                 i.setRetirer(sessionController.getLoggedUser());
@@ -303,8 +303,7 @@ public class PurchaseOrderController implements Serializable {
             ph.setRetailRate(i.getRetailRate());
             bi.setPharmaceuticalBillItem(ph);
 
-            bi.setTmpQty(ph.getQty());
-            System.out.println("bi.getTmpQty() = " + bi.getTmpQty());
+//            bi.setTmpQty(ph.getQty());
 
             System.out.println("ph.getQty() = " + ph.getQty());
             

--- a/src/main/java/com/divudi/bean/pharmacy/PurchaseOrderController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PurchaseOrderController.java
@@ -180,10 +180,7 @@ public class PurchaseOrderController implements Serializable {
     private PharmacyController pharmacyController;
 
     public void onEdit(BillItem tmp) {
-        System.out.println("onEdit");
         tmp.setNetValue(tmp.getPharmaceuticalBillItem().getQty() * tmp.getPharmaceuticalBillItem().getPurchaseRate());
-        System.out.println("tmp.getPharmaceuticalBillItem().getQty() = " + tmp.getPharmaceuticalBillItem().getQty());
-        System.out.println("tmp.getPharmaceuticalBillItem().getPurchaseRate() = " + tmp.getPharmaceuticalBillItem().getPurchaseRate());
         calTotal();
     }
 
@@ -293,19 +290,14 @@ public class PurchaseOrderController implements Serializable {
 
             PharmaceuticalBillItem ph = new PharmaceuticalBillItem();
             ph.setBillItem(bi);
-            System.out.println("bi.getItem().getName() = " + bi.getItem().getName());
             
             ph.setFreeQty(i.getFreeQty());
-            System.out.println("i.getQty() = " + i.getQty());
             ph.setQty(i.getQty());
-            System.out.println("ph = " + ph.getQty());
             ph.setPurchaseRate(i.getPurchaseRate());
             ph.setRetailRate(i.getRetailRate());
             bi.setPharmaceuticalBillItem(ph);
-
 //            bi.setTmpQty(ph.getQty());
 
-            System.out.println("ph.getQty() = " + ph.getQty());
             
             getBillItems().add(bi);
         }
@@ -382,7 +374,6 @@ public class PurchaseOrderController implements Serializable {
         int serialNo = 0;
         for (BillItem bi : getBillItems()) {
             tmp += bi.getPharmaceuticalBillItem().getQty() * bi.getPharmaceuticalBillItem().getPurchaseRate();
-            System.out.println(" bi.getPharmaceuticalBillItem().getQty() = " +  bi.getPharmaceuticalBillItem().getQty());
             bi.setSearialNo(serialNo++);
         }
         getAprovedBill().setTotal(tmp);

--- a/src/main/java/com/divudi/bean/pharmacy/PurchaseOrderRequestController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PurchaseOrderRequestController.java
@@ -324,8 +324,8 @@ public class PurchaseOrderRequestController implements Serializable {
     public void finalizeBillComponent() {
         getBillItems().removeIf(BillItem::isRetired);
         for (BillItem b : getBillItems()) {
-            b.setRate(b.getPharmaceuticalBillItem().getPurchaseRateInUnit());
-            b.setNetValue(b.getPharmaceuticalBillItem().getQtyInUnit() * b.getPharmaceuticalBillItem().getPurchaseRateInUnit());
+            b.setRate(b.getPharmaceuticalBillItem().getPurchaseRate());
+            b.setNetValue(b.getPharmaceuticalBillItem().getQty() * b.getPharmaceuticalBillItem().getPurchaseRate());
             b.setBill(getCurrentBill());
             b.setCreatedAt(new Date());
             b.setCreater(getSessionController().getLoggedUser());
@@ -435,10 +435,6 @@ public class PurchaseOrderRequestController implements Serializable {
     }
 
     public void requestFinalize() {
-        Date startTime = new Date();
-        Date fromDate = null;
-        Date toDate = null;
-
         if (getCurrentBill().getPaymentMethod() == null) {
             JsfUtil.addErrorMessage("Please Select Paymntmethod");
             return;

--- a/src/main/java/com/divudi/bean/pharmacy/StockController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/StockController.java
@@ -119,7 +119,7 @@ public class StockController implements Serializable {
         if (item instanceof Ampp) {
             Ampp ampp = (Ampp) item;
             amp = ampp.getAmp();
-            if (item == null) {
+            if (amp == null) {
                 return;
             }
         } else if (item instanceof Amp) {

--- a/src/main/java/com/divudi/bean/pharmacy/StockController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/StockController.java
@@ -19,6 +19,7 @@ import com.divudi.core.entity.Department;
 import com.divudi.core.entity.Institution;
 import com.divudi.core.entity.Item;
 import com.divudi.core.entity.pharmacy.Amp;
+import com.divudi.core.entity.pharmacy.Ampp;
 import com.divudi.core.entity.pharmacy.Stock;
 import com.divudi.core.entity.pharmacy.Vmp;
 import com.divudi.core.facade.BillItemFacade;
@@ -114,17 +115,29 @@ public class StockController implements Serializable {
         if (item == null) {
             return;
         }
-        String sql;
-        Map m = new HashMap();
+        Amp amp;
+        if (item instanceof Ampp) {
+            Ampp ampp = (Ampp) item;
+            amp = ampp.getAmp();
+            if (item == null) {
+                return;
+            }
+        } else if (item instanceof Amp) {
+            amp = (Amp) item;
+        } else {
+            return;
+        }
+        String jpql;
+        Map params = new HashMap();
         double d = 0.0;
-        m.put("s", d);
-        m.put("item", item);
-        sql = "select s "
+        params.put("s", d);
+        params.put("item", amp);
+        jpql = "select s "
                 + "from Stock s "
                 + "where s.stock > :s "
                 + "and s.itemBatch.item = :item "
                 + "order by s.itemBatch.dateOfExpire desc";
-        selectedItemStocks = ejbFacade.findByJpql(sql, m, 20);
+        selectedItemStocks = ejbFacade.findByJpql(jpql, params, 20);
         totalStockQty = calculateStockQty(selectedItemStocks);
     }
 
@@ -353,6 +366,10 @@ public class StockController implements Serializable {
     public double findStock(Institution institution, Item item) {
         if (item instanceof Amp) {
             Amp amp = (Amp) item;
+            return findStock(institution, amp);
+        } else if (item instanceof Ampp) {
+            Ampp ampp = (Ampp) item;
+            Amp amp = ampp.getAmp();
             return findStock(institution, amp);
         } else if (item instanceof Vmp) {
             List<Amp> amps = vmpController.ampsOfVmp(item);

--- a/src/main/java/com/divudi/core/entity/BillItem.java
+++ b/src/main/java/com/divudi/core/entity/BillItem.java
@@ -762,6 +762,7 @@ public class BillItem implements Serializable, RetirableEntity {
         }
     }
 
+    @Deprecated // Will be remnoved soon. Use other variables like qty, free qty
     public void setTmpQty(double tmpQty) {
         qty = tmpQty;
         if (getItem() instanceof Ampp || getItem() instanceof Vmpp) {

--- a/src/main/java/com/divudi/ejb/PharmacyBean.java
+++ b/src/main/java/com/divudi/ejb/PharmacyBean.java
@@ -966,7 +966,7 @@ public class PharmacyBean {
         if (item == null) {
             return;
         }
-        
+
         Item amp = item instanceof Ampp ? ((Ampp) item).getAmp() : item;
 
         StockHistory sh = new StockHistory();
@@ -1649,6 +1649,15 @@ public class PharmacyBean {
     }
 
     public double getLastPurchaseRate(Item item, Department dept) {
+        boolean manageCosting = configOptionApplicationController.getBooleanValueByKey("Manage Costing", true);
+        if (manageCosting) {
+            return getLastRetailRateByBillItemFinanceDetails(item, dept);
+        } else {
+            return getLastPurchaseRateByPharmaceuticalBillItem(item, dept);
+        }
+    }
+
+    public double getLastPurchaseRateByPharmaceuticalBillItem(Item item, Department dept) {
         if (item instanceof Ampp) {
             item = ((Ampp) item).getAmp();
         }

--- a/src/main/resources/META-INF/persistence.xml
+++ b/src/main/resources/META-INF/persistence.xml
@@ -2,17 +2,19 @@
 <persistence version="2.2" xmlns="http://java.sun.com/xml/ns/persistence" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/persistence http://xmlns.jcp.org/xml/ns/persistence/persistence_2_2.xsd">
     <persistence-unit name="hmisPU" transaction-type="JTA">
         <provider>org.eclipse.persistence.jpa.PersistenceProvider</provider>
-        <jta-data-source>${JDBC_DATASOURCE}</jta-data-source>
+        <jta-data-source>jdbc/coop</jta-data-source>
         <exclude-unlisted-classes>false</exclude-unlisted-classes>
         <properties>
             <property name="eclipselink.logging.level.sql" value="SEVERE"/>
+            <property name="eclipselink.logging.level" value="SEVERE"/>
         </properties>
     </persistence-unit>
     <persistence-unit name="hmisAuditPU" transaction-type="JTA">
-        <jta-data-source>${JDBC_AUDIT_DATASOURCE}</jta-data-source>
+        <jta-data-source>jdbc/ruhunuAudit</jta-data-source>
         <exclude-unlisted-classes>false</exclude-unlisted-classes>
         <properties>
             <property name="eclipselink.logging.level.sql" value="SEVERE"/>
+            <property name="eclipselink.logging.level" value="SEVERE"/>
         </properties>
     </persistence-unit>
 </persistence>

--- a/src/main/resources/META-INF/persistence.xml
+++ b/src/main/resources/META-INF/persistence.xml
@@ -2,19 +2,17 @@
 <persistence version="2.2" xmlns="http://java.sun.com/xml/ns/persistence" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/persistence http://xmlns.jcp.org/xml/ns/persistence/persistence_2_2.xsd">
     <persistence-unit name="hmisPU" transaction-type="JTA">
         <provider>org.eclipse.persistence.jpa.PersistenceProvider</provider>
-        <jta-data-source>jdbc/coop</jta-data-source>
+        <jta-data-source>${JDBC_DATASOURCE}</jta-data-source>
         <exclude-unlisted-classes>false</exclude-unlisted-classes>
         <properties>
             <property name="eclipselink.logging.level.sql" value="SEVERE"/>
-            <property name="eclipselink.logging.level" value="SEVERE"/>
         </properties>
     </persistence-unit>
     <persistence-unit name="hmisAuditPU" transaction-type="JTA">
-        <jta-data-source>jdbc/ruhunuAudit</jta-data-source>
+        <jta-data-source>${JDBC_AUDIT_DATASOURCE}</jta-data-source>
         <exclude-unlisted-classes>false</exclude-unlisted-classes>
         <properties>
             <property name="eclipselink.logging.level.sql" value="SEVERE"/>
-            <property name="eclipselink.logging.level" value="SEVERE"/>
         </properties>
     </persistence-unit>
 </persistence>

--- a/src/main/webapp/pharmacy/pharmacy_purhcase_order_approving.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_purhcase_order_approving.xhtml
@@ -110,7 +110,7 @@
                             </p:column>  
 
                             <p:column headerText="Qty" styleClass="averageNumericColumn" width="6em">                         
-                                <p:inputText autocomplete="off" id="qty" value="#{bi.tmpQty}" style="width:100%" label="Qty" onfocus="this.select()">
+                                <p:inputText autocomplete="off" id="qty" value="#{bi.pharmaceuticalBillItem.qty}" style="width:100%" label="Qty" onfocus="this.select()">
                                     <f:convertNumber pattern="#,#00"/>
                                     <f:ajax event="blur" render="total :#{p:resolveFirstComponentWithId('tot',view).clientId}"  execute="@this price" listener="#{purchaseOrderController.onEdit(bi)}" ></f:ajax>
                                     <f:ajax event="focus" render=":#{p:resolveFirstComponentWithId('tab',view).clientId}" listener="#{purchaseOrderController.onFocus(bi)}" />
@@ -143,6 +143,8 @@
                             </p:column>  
 
                             <p:column headerText="Total" style="text-align: right;" styleClass="averageNumericColumn" >  
+                                #{bi.pharmaceuticalBillItem.purchaseRate} X
+                                #{bi.pharmaceuticalBillItem.qty} =
                                 <h:panelGroup id="total">
                                     <h:outputText value="#{bi.pharmaceuticalBillItem.purchaseRate*bi.pharmaceuticalBillItem.qty}" >
                                         <f:convertNumber pattern="#,##0.00"/>

--- a/src/main/webapp/pharmacy/pharmacy_purhcase_order_approving.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_purhcase_order_approving.xhtml
@@ -109,50 +109,58 @@
                                 <h:outputText value="#{bi.item.code}" ></h:outputText>
                             </p:column>  
 
-                            <p:column headerText="Qty" styleClass="averageNumericColumn" width="6em">                         
-                                <p:inputText autocomplete="off" id="qty" value="#{bi.pharmaceuticalBillItem.qty}" style="width:100%" label="Qty" onfocus="this.select()">
+                            <p:column 
+                                headerText="Qty"  
+                                class="text-end px-1" 
+                                width="6em">                         
+                                <p:inputText
+                                    autocomplete="off"
+                                    id="qty"
+                                    value="#{bi.pharmaceuticalBillItem.qty}" 
+                                    class="w-100 text-end"
+                                    label="Qty" onfocus="this.select()">
                                     <f:convertNumber pattern="#,#00"/>
                                     <f:ajax event="blur" render="total :#{p:resolveFirstComponentWithId('tot',view).clientId}"  execute="@this price" listener="#{purchaseOrderController.onEdit(bi)}" ></f:ajax>
                                     <f:ajax event="focus" render=":#{p:resolveFirstComponentWithId('tab',view).clientId}" listener="#{purchaseOrderController.onFocus(bi)}" />
                                 </p:inputText>
                             </p:column>  
-                            <p:column headerText="Free Qty" styleClass="averageNumericColumn" >                         
-                                <p:inputText autocomplete="off" id="freeQty" value="#{bi.pharmaceuticalBillItem.freeQty}" style="width:100%" onfocus="this.select()">
+                            <p:column 
+                                width="6em"
+                                headerText="Free Qty"
+                                class="text-end px-1"  >                         
+                                <p:inputText 
+                                    autocomplete="off"
+                                    id="freeQty" 
+                                    value="#{bi.pharmaceuticalBillItem.freeQty}" 
+                                    class="w-100 text-end"
+                                    onfocus="this.select()">
                                     <f:convertNumber pattern="#,#00"/>
                                     <f:ajax event="blur" render="total :#{p:resolveFirstComponentWithId('tot',view).clientId}"  execute="@this price" listener="#{purchaseOrderController.onEdit(bi)}" ></f:ajax>
                                     <f:ajax event="focus" render=":#{p:resolveFirstComponentWithId('tab',view).clientId}" listener="#{purchaseOrderController.onFocus(bi)}" />
                                 </p:inputText>
                             </p:column> 
-                            <p:column headerText="Purchse Price"  styleClass="averageNumericColumn" >  
-                                <h:panelGroup id="price">
-                                    <p:inputText autocomplete="off" value="#{bi.pharmaceuticalBillItem.purchaseRate}" onfocus="this.select()">   
-                                        <f:convertNumber pattern="#00.00"/>
-                                        <f:ajax event="blur" render="total :#{p:resolveFirstComponentWithId('tot',view).clientId}"  execute="@this" listener="#{purchaseOrderController.onEdit(bi)}" ></f:ajax>
-                                        <f:ajax event="focus" render=":#{p:resolveFirstComponentWithId('tab',view).clientId}" listener="#{purchaseOrderController.onFocus(bi)}" />
-                                    </p:inputText>
-                                </h:panelGroup>
+                            <p:column 
+                                width="6em"
+                                headerText="Purchase Price"   
+                                class="text-end px-1"  >  
+                                <p:inputText
+                                    id="price"
+                                    class="w-100 text-end"
+                                    style="margin: 0px;"
+                                    autocomplete="off"
+                                    value="#{bi.pharmaceuticalBillItem.purchaseRate}" onfocus="this.select()">   
+                                    <f:convertNumber pattern="#00.00"/>
+                                    <f:ajax event="blur" render="total :#{p:resolveFirstComponentWithId('tot',view).clientId}"  execute="@this" listener="#{purchaseOrderController.onEdit(bi)}" ></f:ajax>
+                                    <f:ajax event="focus" render=":#{p:resolveFirstComponentWithId('tab',view).clientId}" listener="#{purchaseOrderController.onFocus(bi)}" />
+                                </p:inputText>
                             </p:column>  
 
-
-                            <p:column headerText="Last Sale Price" style="text-align: right;" styleClass="averageNumericColumn" >  
-                                <h:panelGroup >
-                                    <h:outputText value="#{bi.pharmaceuticalBillItem.retailRate}">
-                                        <f:convertNumber pattern="#00.00"/>
-                                    </h:outputText>
-                                </h:panelGroup>
+                            <p:column headerText="Total" width="6em"  class="text-end px-1"  >  
+                                <h:outputText id="total" value="#{bi.pharmaceuticalBillItem.purchaseRate*bi.pharmaceuticalBillItem.qty}" >
+                                    <f:convertNumber pattern="#,##0.00"/>
+                                </h:outputText>
                             </p:column>  
-
-                            <p:column headerText="Total" style="text-align: right;" styleClass="averageNumericColumn" >  
-                                #{bi.pharmaceuticalBillItem.purchaseRate} X
-                                #{bi.pharmaceuticalBillItem.qty} =
-                                <h:panelGroup id="total">
-                                    <h:outputText value="#{bi.pharmaceuticalBillItem.purchaseRate*bi.pharmaceuticalBillItem.qty}" >
-                                        <f:convertNumber pattern="#,##0.00"/>
-                                    </h:outputText>
-                                </h:panelGroup>
-                            </p:column>  
-
-                            <p:column styleClass="averageNumericColumn" width="3em" >
+                            <p:column  class="text-end px-1"  width="4em" >
                                 <p:commandButton  process="itemList" update="itemList :#{p:resolveFirstComponentWithId('po',view).clientId}" icon="fas fa-trash"  class="ui-button-Danger" action="#{purchaseOrderController.removeItem(bi)}"/>
                             </p:column>
                         </p:dataTable> 

--- a/src/main/webapp/pharmacy/pharmacy_purhcase_order_request.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_purhcase_order_request.xhtml
@@ -39,26 +39,30 @@
                                     </div>
                                 </f:facet>  
 
-                                <p:column style="width: 20px; padding: 0;"/>
+                                <p:column selectionBox="true" width="2em"  style="padding: 0;" />
 
-                                <p:column headerText="No" style="width: 40px; padding: 0;" >
+                                <p:column headerText="No" width="2em" style="padding: 0;" >
                                     <h:outputLabel value="#{bi.searialNo+1}" >
                                         <f:convertNumber pattern="00" ></f:convertNumber>
                                     </h:outputLabel>
-
                                 </p:column>
 
                                 <p:column headerText="Item"  style=" padding: 0;">  
-                                    #{bi.item.name}  - #{bi.item.code} 
+                                    <h:outputLabel value="#{bi.item.name}  - #{bi.item.code}" ></h:outputLabel>
                                 </p:column>
 
-                                <p:column headerText="Qty" styleClass="averageNumericColumn" style="width:5em; padding: 0px;"> 
+                                <p:column 
+                                    headerText="Qty" 
+                                    width="6em"
+                                    class="text-end px-1"
+                                    style="padding: 0px;"> 
                                     <p:inputText 
                                         autocomplete="off"  
                                         id="qty" 
                                         value="#{bi.qty}" 
-                                        style="width:4em; text-align: right; padding: 0;" 
+                                        style="padding: 0;" 
                                         label="Qty"
+                                        class="text-end w-100"
                                         onfocus="this.select()">  
                                         <f:convertNumber pattern="0.#" ></f:convertNumber>
                                         <f:ajax event="blur" render="total :#{p:resolveFirstComponentWithId('tot',view).clientId} "  execute="@this price" listener="#{purchaseOrderRequestController.onEdit(bi)}" ></f:ajax>
@@ -66,47 +70,68 @@
                                     </p:inputText>
                                 </p:column> 
 
-                                <p:column headerText="Free Qty" styleClass="averageNumericColumn" style="width:4em; padding: 0px;"> 
+                                <p:column 
+                                    width="5em"
+                                    headerText="Free Qty"
+                                    class="text-end px-1"
+                                    style="padding: 0px;"> 
                                     <p:inputText 
                                         autocomplete="off" 
                                         id="freeQty" 
                                         onfocus="this.select()"
+                                        class="text-end w-100"
                                         value="#{bi.pharmaceuticalBillItem.freeQty}" 
-                                        style="width:4rem; text-align: right; padding: 0;" label="Qty">  
+                                        style="padding: 0;" 
+                                        label="Qty">  
                                         <f:convertNumber pattern="0.#" ></f:convertNumber>
                                         <f:ajax event="blur" render="total :#{p:resolveFirstComponentWithId('tot',view).clientId} "  execute="@this price" listener="#{purchaseOrderRequestController.onEdit(bi)}" ></f:ajax>
                                         <f:ajax event="focus" render=":#{p:resolveFirstComponentWithId('tab',view).clientId}" listener="#{purchaseOrderRequestController.onFocus(bi)}" />
                                     </p:inputText>
                                 </p:column>
 
-                                <p:column headerText="P Price" styleClass="averageNumericColumn" style="width:6em; text-align: right; padding: 0;">  
+                                <p:column 
+                                    headerText="P Price"
+                                    class="text-end px-1"
+                                    style="padding: 0px;"
+                                    width="6em">  
                                     <h:panelGroup id="price">
                                         <p:inputText
                                             onfocus="this.select()"
                                             autocomplete="off" 
-                                            value="#{bi.pharmaceuticalBillItem.purchaseRate}" style="width:4em; text-align: right; padding: 0;">
-                                            <f:convertNumber pattern="#00.00"/>
+                                            style="padding: 0;" 
+                                            value="#{bi.pharmaceuticalBillItem.purchaseRate}" 
+                                            class="w-100 text-end">
+                                            <f:convertNumber pattern="#,##0.00"/>
                                             <f:ajax event="blur" render="total :#{p:resolveFirstComponentWithId('tot',view).clientId}"  execute="@this qty" listener="#{purchaseOrderRequestController.onEdit(bi)}" ></f:ajax>
                                             <f:ajax event="focus" render=":#{p:resolveFirstComponentWithId('tab',view).clientId}" listener="#{purchaseOrderRequestController.onFocus(bi)}" />
                                         </p:inputText>
                                     </h:panelGroup>
                                 </p:column>  
 
-                                <p:column headerText="Total" styleClass="averageNumericColumn" style="width:4em; text-align: right; padding: 0;">  
+                                <p:column 
+                                    headerText="Total" 
+                                    class="text-end px-1"
+                                    style="padding: 0;" 
+                                    width="6em">  
                                     <h:panelGroup id="total">
                                         <h:outputText 
-                                            value="#{bi.pharmaceuticalBillItem.purchaseRate*bi.pharmaceuticalBillItem.qty}" style="width:4rem; text-align: right;">
+                                            value="#{bi.pharmaceuticalBillItem.purchaseRate*bi.pharmaceuticalBillItem.qty}" >
                                             <f:convertNumber pattern="#,##0.00"/>
                                         </h:outputText>
                                     </h:panelGroup>
                                 </p:column>  
 
-                                <p:column headerText="Stock" style="width:4em; text-align: right; padding: 0;">
-                                    <p:commandLink value="#{stockController.findStock(bi.item)}"
-                                                   oncomplete="PF('stockDetailsDialog').show();"
-                                                   process="itemList"
-                                                   update="stockDetailsForm"
-                                                   actionListener="#{stockController.listStocksOfSelectedItem(bi.item)}">
+                                <p:column 
+                                    headerText="Stock" 
+                                    width="5em" 
+                                    style="padding: 0;" 
+                                    class="text-end">
+                                    <p:commandLink 
+                                        value="#{stockController.findStock(bi.item)}"
+                                        oncomplete="PF('stockDetailsDialog').show();"
+                                        process="itemList"
+                                        update="stockDetailsForm"
+                                        actionListener="#{stockController.listStocksOfSelectedItem(bi.item)}">
                                     </p:commandLink>
                                 </p:column>
 
@@ -127,7 +152,7 @@
                                     <p:outputLabel value="#{pharmacyController.findAllOutTransactions(bi.item)}" style="width:4em; text-align: right;"/>                            
                                 </p:column>
 
-                                <p:column styleClass="averageNumericColumn" style="width:5em; text-align: right; padding: 0;">
+                                <p:column  style="width:5em; text-align: right; padding: 0;">
                                     <p:commandButton 
                                         class="ui-button-danger" 
                                         icon="fas fa-trash"
@@ -184,6 +209,7 @@
                                     <div class="d-flex" >
                                         <div class="ui-inputgroup mx-1 my-1">
                                             <p:inputText  
+                                                onfocus="this.select();"  
                                                 value="#{purchaseOrderRequestController.currentBill.creditDuration}"
                                                 style="width: 10em;">
                                             </p:inputText>

--- a/src/main/webapp/pharmacy/pharmacy_search_by_bill_type_atomic.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_search_by_bill_type_atomic.xhtml
@@ -60,7 +60,6 @@
                                 </h:panelGrid>                              
                             </div>
                             <div class="col-10" style="overflow: scroll;">
-                                #{searchController.billTypeAtomic.billType}
                                 <h:panelGroup id="detail" rendered="#{searchController.billTypeAtomic ne null}">
                                     <h:panelGroup rendered="#{searchController.billTypeAtomic.billType eq 'PharmacyGrnBill'}" >
                                         <se:grn/>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added support for handling additional item types in pharmacy stock management.
	- Introduced a configuration option to control how the last purchase rate is determined.

- **Bug Fixes**
	- Corrected quantity calculations and value bindings in pharmacy purchase order approval and request workflows.

- **Refactor**
	- Improved and unified the layout and styling of pharmacy purchase order tables for better usability and consistency.

- **Documentation**
	- Marked a quantity-related method as deprecated with guidance for alternative usage.

- **Style**
	- Enhanced UI components with consistent alignment, padding, and formatting in pharmacy order screens.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->