### PR TITLE
Add BillItemLight and integrate DTO for summary reports

### DIFF
--- a/src/main/java/com/divudi/bean/pharmacy/PharmacySummaryReportController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacySummaryReportController.java
@@ -647,35 +647,10 @@ public class PharmacySummaryReportController implements Serializable {
         // Instead we will use a DTO
         List<BillTypeAtomic> billTypeAtomics = BillTypeAtomic.findByServiceType(ServiceType.PHARMACY);
         
-        // this is where all bills are loaded
-        List<Bill> incomeBills = billService.fetchBills(fromDate, toDate, institution, site, department, webUser, billTypeAtomics, admissionType, paymentScheme);
-        // instead of above line, we have to do this
-        // Create new BillItemLight like BillLight
-        // Create suitable constructor
-        //
-        // create new attribute for BillItemLight in IncomeBundle
-        // 
-        // Load bill Lights with follwing details without iteraging each bill item        
-        
-        bundle = new IncomeBundle(incomeBills);
-        
-        for (IncomeRow r : bundle.getRows()) {
-            if (r.getBillItem()== null) {
-                continue;
-            }
-            BillItem bi = r.getBillItem();
-            Bill b = bi.getBill();
-            PharmaceuticalBillItem pbi = bi.getPharmaceuticalBillItem();
-            
-            r.setInstitution(b.getInstitution());
-            r.setDepartment(b.getDepartment());
-            r.setItem(b.getItem());
-            r.setBillTypeAtomic(b.getBillTypeAtomic());
-            r.setQty(b.getQty());
-            r.setFreeQty(pbi.getFreeQty());
-            r.setNetTotal(bi.getNetValue());
-            
-        }
+        List<com.divudi.core.light.common.BillItemLight> lights = billService.fetchBillItemLights(
+                fromDate, toDate, institution, site, department, webUser, billTypeAtomics, admissionType, paymentScheme);
+
+        bundle = new IncomeBundle(lights);
        
     }
 

--- a/src/main/java/com/divudi/core/data/IncomeBundle.java
+++ b/src/main/java/com/divudi/core/data/IncomeBundle.java
@@ -314,6 +314,15 @@ public class IncomeBundle implements Serializable {
         }
     }
 
+    public IncomeBundle(List<com.divudi.core.light.common.BillItemLight> lights) {
+        this();
+        if (lights != null) {
+            for (com.divudi.core.light.common.BillItemLight l : lights) {
+                rows.add(new IncomeRow(l));
+            }
+        }
+    }
+
     public void generateRetailAndCostDetailsForPharmaceuticalBillItems() {
         saleValue = 0;
         purchaseValue = 0;

--- a/src/main/java/com/divudi/core/data/IncomeRow.java
+++ b/src/main/java/com/divudi/core/data/IncomeRow.java
@@ -34,6 +34,7 @@ public class IncomeRow implements Serializable {
     private Bill referanceBill;
     private BillItem billItem;
     private PharmaceuticalBillItem pharmaceuticalBillItem;
+    private com.divudi.core.light.common.BillItemLight billItemLight;
     private BillFee billFee;
     private Payment payment;
 
@@ -205,6 +206,27 @@ public class IncomeRow implements Serializable {
             this.bill = billItem.getBill();
         } else {
             rowType = "BillItem";
+        }
+    }
+
+    public IncomeRow(com.divudi.core.light.common.BillItemLight billItemLight) {
+        this();
+        this.billItemLight = billItemLight;
+        rowType = "BillItemLight";
+        if (billItemLight != null) {
+            this.institution = billItemLight.getInstitution();
+            this.department = billItemLight.getDepartment();
+            this.item = billItemLight.getItem();
+            this.billTypeAtomic = billItemLight.getBillTypeAtomic();
+            if (billItemLight.getQty() != null) {
+                this.qty = billItemLight.getQty();
+            }
+            if (billItemLight.getFreeQty() != null) {
+                this.freeQty = billItemLight.getFreeQty();
+            }
+            if (billItemLight.getNetTotal() != null) {
+                this.netTotal = billItemLight.getNetTotal();
+            }
         }
     }
 
@@ -1057,6 +1079,14 @@ public class IncomeRow implements Serializable {
 
     public void setBillItem(BillItem billItem) {
         this.billItem = billItem;
+    }
+
+    public com.divudi.core.light.common.BillItemLight getBillItemLight() {
+        return billItemLight;
+    }
+
+    public void setBillItemLight(com.divudi.core.light.common.BillItemLight billItemLight) {
+        this.billItemLight = billItemLight;
     }
 
     public Institution getSite() {

--- a/src/main/java/com/divudi/core/light/common/BillItemLight.java
+++ b/src/main/java/com/divudi/core/light/common/BillItemLight.java
@@ -1,0 +1,87 @@
+package com.divudi.core.light.common;
+
+import com.divudi.core.data.BillTypeAtomic;
+import com.divudi.core.entity.Department;
+import com.divudi.core.entity.Institution;
+import com.divudi.core.entity.Item;
+
+public class BillItemLight {
+
+    private Institution institution;
+    private Department department;
+    private Item item;
+    private BillTypeAtomic billTypeAtomic;
+    private Double qty;
+    private Double freeQty;
+    private Double netTotal;
+
+    public BillItemLight() {
+    }
+
+    public BillItemLight(Institution institution, Department department, Item item,
+            BillTypeAtomic billTypeAtomic, Double qty, Double freeQty, Double netTotal) {
+        this.institution = institution;
+        this.department = department;
+        this.item = item;
+        this.billTypeAtomic = billTypeAtomic;
+        this.qty = qty;
+        this.freeQty = freeQty;
+        this.netTotal = netTotal;
+    }
+
+    public Institution getInstitution() {
+        return institution;
+    }
+
+    public void setInstitution(Institution institution) {
+        this.institution = institution;
+    }
+
+    public Department getDepartment() {
+        return department;
+    }
+
+    public void setDepartment(Department department) {
+        this.department = department;
+    }
+
+    public Item getItem() {
+        return item;
+    }
+
+    public void setItem(Item item) {
+        this.item = item;
+    }
+
+    public BillTypeAtomic getBillTypeAtomic() {
+        return billTypeAtomic;
+    }
+
+    public void setBillTypeAtomic(BillTypeAtomic billTypeAtomic) {
+        this.billTypeAtomic = billTypeAtomic;
+    }
+
+    public Double getQty() {
+        return qty;
+    }
+
+    public void setQty(Double qty) {
+        this.qty = qty;
+    }
+
+    public Double getFreeQty() {
+        return freeQty;
+    }
+
+    public void setFreeQty(Double freeQty) {
+        this.freeQty = freeQty;
+    }
+
+    public Double getNetTotal() {
+        return netTotal;
+    }
+
+    public void setNetTotal(Double netTotal) {
+        this.netTotal = netTotal;
+    }
+}


### PR DESCRIPTION
## Summary
- introduce `BillItemLight` for lightweight bill item data transfer
- extend `IncomeRow` and `IncomeBundle` to work with `BillItemLight`
- fetch bill item information as DTOs in `BillService`
- update pharmacy summary report to use new DTOs

## Testing
- `mvn -version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68575024c208832f8e892f8a0b80e463