### PR TITLE
13337 before quantity in duplicate adjustment bill is wrong

### DIFF
--- a/src/main/java/com/divudi/bean/pharmacy/PharmacyAdjustmentController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacyAdjustmentController.java
@@ -553,7 +553,10 @@ public class PharmacyAdjustmentController implements Serializable {
 
         changingQty = qty - stockQty;
 
+        //set before, after values
+        getBillItem().getPharmaceuticalBillItem().setBeforeAdjustmentValue(stockQty);
         getBillItem().getPharmaceuticalBillItem().setQty(changingQty);
+        getBillItem().getPharmaceuticalBillItem().setAfterAdjustmentValue(stockQty + changingQty);
 
         //Rates
         //Values

--- a/src/main/webapp/pharmacy/pharmacy_search_adjustment_bill_item.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_search_adjustment_bill_item.xhtml
@@ -117,7 +117,7 @@
                                     </p:column>
                                     
                                     <p:column>
-                                        <p:commandButton ajax="false" action="pharmacy_reprint_adjustment" value="View BIll">
+                                        <p:commandButton ajax="false" action="pharmacy_reprint_adjustment?faces-redirect=true" value="View Bill">
                                             <f:setPropertyActionListener value="#{pi.bill}" target="#{pharmacyBillSearch.bill}"/>
                                         </p:commandButton>
                                     </p:column>

--- a/src/main/webapp/resources/pharmacy/adjustmentBill.xhtml
+++ b/src/main/webapp/resources/pharmacy/adjustmentBill.xhtml
@@ -93,7 +93,7 @@
             <div >
                 <p:spacer height="15px"/>
                 <p:dataTable rowIndexVar="rowIndex" styleClass="noBorder normalFont" 
-                             value="#{cc.attrs.bill.billItems}" var="bip" style=" text-align: center;">                                     
+                             value="#{billBeanController.fetchBillItems(cc.attrs.bill)}" var="bip" style=" text-align: center;">                                     
                     <p:column style="text-align: left!important;"  >
                         <f:facet name="header">
                             <h:outputLabel value="Item" style="font-weight: bold!important; " />
@@ -113,8 +113,8 @@
                         <f:facet name="header">                           
                             <h:outputLabel value="Before Qty" style="font-weight: bold!important;" />
                         </f:facet>
-                        <h:outputLabel value="#{bip.pharmaceuticalBillItem.stock.stock}">
-                            <f:convertNumber pattern="#,##" ></f:convertNumber>
+                        <h:outputLabel value="#{bip.pharmaceuticalBillItem.beforeAdjustmentValue}">
+                            <f:convertNumber pattern="#,###" ></f:convertNumber>
                         </h:outputLabel>
                     </p:column>                  
 
@@ -132,7 +132,7 @@
                         <f:facet name="header">                           
                             <h:outputLabel value="After QTY" style="font-weight: bold!important;" />
                         </f:facet>
-                        <h:outputLabel value="#{bip.pharmaceuticalBillItem.qty + bip.pharmaceuticalBillItem.stock.stock}">
+                        <h:outputLabel value="#{bip.pharmaceuticalBillItem.afterAdjustmentValue}">
                             <f:convertNumber pattern="#,###.##"/>
                         </h:outputLabel>
                     </p:column>                  


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Corrected the label on the adjustment bill item view button from "View BIll" to "View Bill".
- **New Features**
	- The adjustment bill item view now displays stock quantities before and after adjustments for greater clarity.
- **Improvements**
	- Enhanced navigation when viewing adjustment bills to ensure smoother page redirects.
	- Updated the data table to dynamically fetch and display bill items and improved number formatting for quantities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->