### PR TITLE
13311 updated purchase rate isnt updated in net totaldifference and financial summary

### DIFF
--- a/src/main/webapp/pharmacy/pharmacy_grn_costing.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_grn_costing.xhtml
@@ -177,7 +177,6 @@
                             <f:ajax event="blur" execute="freeQty" render=":#{p:resolveFirstComponentWithId('panelBillDetails',view).clientId} total freeQty doeDateOnlyShort profMargin batch pRate rRate diff :#{p:resolveFirstComponentWithId('txtBillNetTotal', view).clientId} :#{p:resolveFirstComponentWithId('billFinanceDetails', view).clientId}" listener="#{grnCostingController.checkQty(bi)}"></f:ajax>
                         </p:inputText>
                     </p:column> 
-
                     <p:column
                         width="8em"
                         headerText="Purchase Rate"

--- a/src/main/webapp/pharmacy/pharmacy_grn_costing.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_grn_costing.xhtml
@@ -187,7 +187,11 @@
                             class="text-end text-primary w-100"
                             value="#{bi.billItemFinanceDetails.lineGrossRate}"
                             id="pRate" >
-                            <f:ajax event="blur" execute="pRate" render=":#{p:resolveFirstComponentWithId('panelBillDetails',view).clientId} total doeDateOnlyShort profMargin batch pRate rRate :#{p:resolveFirstComponentWithId('billFinanceDetails', view).clientId}" listener="#{grnCostingController.onEdit(bi)}"></f:ajax>
+                            <f:ajax 
+                                event="blur" 
+                                execute="pRate" 
+                                render=":#{p:resolveFirstComponentWithId('panelBillDetails',view).clientId} total doeDateOnlyShort profMargin batch pRate rRate :#{p:resolveFirstComponentWithId('billFinanceDetails', view).clientId}" 
+                                listener="#{grnCostingController.onEdit(bi)}"></f:ajax>
                         </p:inputText>
                     </p:column>
                     <p:column


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Ensured that proportional bill values are redistributed to all bill items immediately after editing an item in the GRN bill.

- **Enhancements**
  - Updated the interface so that changes to bill item details now automatically refresh the difference display and bill net total, providing more accurate and immediate feedback to users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->