### PR TITLE
13399 need to hide edit request button when requesting drugs for bht patients

### DIFF
--- a/src/main/webapp/ward/ward_pharmacy_bht_issue_request_bill_search.xhtml
+++ b/src/main/webapp/ward/ward_pharmacy_bht_issue_request_bill_search.xhtml
@@ -92,7 +92,7 @@
                                     </h:panelGroup>
                                 </p:column>  
                                 <p:column>
-                                    <p:commandButton ajax="false" value="View Request" action="/ward/ward_pharmacy_reprint_bht_issue_request" class="ui-button-success">
+                                    <p:commandButton ajax="false" value="View Request" action="/ward/ward_pharmacy_reprint_bht_issue_request?faces-redirect=true" class="ui-button-success">
                                         <f:setPropertyActionListener value="#{p}" target="#{pharmacyBillSearch.bill}"/>
                                     </p:commandButton>
                                 </p:column>
@@ -132,7 +132,7 @@
                                             </h:outputLabel>                                  
                                         </p:column>
                                         <p:column>
-                                            <p:commandButton ajax="false" value="View Bill" action="/ward/ward_pharmacy_reprint_bht_issue_bill_reprint" >
+                                            <p:commandButton ajax="false" value="View Bill" action="/ward/ward_pharmacy_reprint_bht_issue_bill_reprint?faces-redirect=true" >
                                                 <f:setPropertyActionListener target="#{pharmacyBillSearch.bill}" value="#{b}"/>
                                             </p:commandButton>
                                         </p:column>

--- a/src/main/webapp/ward/ward_pharmacy_reprint_bht_issue_request.xhtml
+++ b/src/main/webapp/ward/ward_pharmacy_reprint_bht_issue_request.xhtml
@@ -24,7 +24,7 @@
                         style="float: right;"
                         icon="fas fa-pen"
                         value="Edit Request"
-                        disabled="#{not empty pharmacyBillSearch.bill.listOfBill or pharmacyBillSearch.bill.cancelled or pharmacyBillSearch.bill.refunded}"
+                        disabled="#{configOptionApplicationController.getBooleanValueByKey('Disable Edit Button on Pharmacy Request Reprint',false) or (not empty pharmacyBillSearch.bill.listOfBill or pharmacyBillSearch.bill.cancelled or pharmacyBillSearch.bill.refunded)}"
                         action="#{pharmacyBillSearch.editInwardPharmacyRequestBill()}"
                         ajax="false">
                     </p:commandButton>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a configurable option to control whether the "Edit Request" button is enabled or disabled on the pharmacy request reprint page.

* **Improvements**
  * Updated navigation for "View Request" and "View Bill" buttons to ensure proper page redirection after actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->