### PR TITLE
Fix TransferIssue empty bill save check

### DIFF
--- a/src/main/java/com/divudi/bean/pharmacy/TransferIssueController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/TransferIssueController.java
@@ -582,6 +582,11 @@ public class TransferIssueController implements Serializable {
         //Replase the billItem with out Zero Qty Item
         setBillItems(billItemList);
 
+        if (getBillItems() == null || getBillItems().isEmpty()) {
+            JsfUtil.addErrorMessage("No Bill Items are added to Transfer");
+            return;
+        }
+
         saveBill();
         for (BillItem i : getBillItems()) {
 


### PR DESCRIPTION
## Summary
- validate bill items again after filtering out zero quantity items in `TransferIssueController.settle`
- prevent empty transfer from being saved

## Testing
- `mvn -q test` *(fails: could not resolve Maven dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_685e0ff09dd0832fb6c960b626e860ee