### PR TITLE
Add bulk convert investigations to services

### DIFF
--- a/src/main/java/com/divudi/bean/lab/InvestigationController.java
+++ b/src/main/java/com/divudi/bean/lab/InvestigationController.java
@@ -1236,6 +1236,24 @@ public class InvestigationController implements Serializable {
 
     }
 
+    public void convertSelectedInvestigationsToServices() {
+        if (selectedInvestigations == null || selectedInvestigations.isEmpty()) {
+            JsfUtil.addErrorMessage("Nothing to Convert");
+            return;
+        }
+        for (Investigation ix : selectedInvestigations) {
+            try {
+                String sql = "UPDATE Item SET DTYPE = 'Service' WHERE id = " + ix.getId();
+                itemFacade.executeNativeSql(sql);
+            } catch (Exception e) {
+                Logger.getLogger(InvestigationController.class.getName()).log(Level.SEVERE, null, e);
+            }
+        }
+        itemFacade.flush();
+        selectedInvestigations = null;
+        JsfUtil.addSuccessMessage("Successfully Converted");
+    }
+
     public Institution getInstitution() {
         return institution;
     }

--- a/src/main/webapp/dataAdmin/lab_investigation_list.xhtml
+++ b/src/main/webapp/dataAdmin/lab_investigation_list.xhtml
@@ -43,6 +43,7 @@
                     
                     <p:commandButton value="Active Selected" action="#{investigationController.markSelectedActive}" ajax="false" ></p:commandButton>
                     <p:commandButton value="Inactive Selected" action="#{investigationController.markSelectedInactive}" ajax="false" ></p:commandButton>
+                    <p:commandButton icon="pi pi-sync" value="Convert Selected to Services" action="#{investigationController.convertSelectedInvestigationsToServices()}" ajax="false" ></p:commandButton>
 
 
                     <p:dataTable id="tbl" rowIndexVar="rowIndex" value="#{investigationController.items}" var="ix"  


### PR DESCRIPTION
## Summary
- add `convertSelectedInvestigationsToServices` method for Investigation controller
- provide command button to trigger conversion from investigation list

## Testing
- `mvn -q test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ea6fd1944832fa13544b2da393f9c