### PR TITLE
13435: GRN costing rounding fix

### DIFF
--- a/src/main/java/com/divudi/ejb/PharmacyCalculation.java
+++ b/src/main/java/com/divudi/ejb/PharmacyCalculation.java
@@ -35,6 +35,7 @@ import com.divudi.core.facade.ItemsDistributorsFacade;
 import com.divudi.core.facade.PharmaceuticalBillItemFacade;
 import java.io.Serializable;
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Calendar;
@@ -79,6 +80,8 @@ public class PharmacyCalculation implements Serializable {
 
     @Inject
     ConfigOptionApplicationController configOptionApplicationController;
+
+    private static final int PRICE_SCALE = 6;
 
 //    public void editBill(Bill bill, Bill ref, SessionController sc) {
 //
@@ -783,7 +786,11 @@ public class PharmacyCalculation implements Serializable {
             }
 
             BigDecimal prGiven = inputBillItem.getBillItemFinanceDetails().getRetailSaleRatePerUnit();
-            BigDecimal prPerUnit = prGiven.divide(inputBillItem.getBillItemFinanceDetails().getUnitsPerPack());
+            BigDecimal prPerUnit = prGiven.divide(
+                    inputBillItem.getBillItemFinanceDetails().getUnitsPerPack(),
+                    PRICE_SCALE,
+                    RoundingMode.HALF_EVEN
+            );
             
             purchaseRatePerUnit = prPerUnit.doubleValue();
             retailRatePerUnit = inputBillItem.getBillItemFinanceDetails().getRetailSaleRatePerUnit().doubleValue();


### PR DESCRIPTION
## Summary
- fix rounding when computing price per unit
- use constant scale for price calculations

## Testing
- `mvn -q test` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:2.6 or one of its dependencies could not be resolved)*

------
https://chatgpt.com/codex/tasks/task_e_685ea85db160832fb75887657b27ffe3