### PR TITLE
13357-should-not-allow-to-add-expired-items-in-direct-purchase

### DIFF
--- a/src/main/java/com/divudi/bean/pharmacy/PharmacyDirectPurchaseController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacyDirectPurchaseController.java
@@ -146,6 +146,13 @@ public class PharmacyDirectPurchaseController implements Serializable {
             return;
         }
 
+        if (pbi.getDoe() != null) {
+            if (pbi.getDoe().getTime() < Calendar.getInstance().getTimeInMillis()) {
+                JsfUtil.addErrorMessage("Check Date of Expiry");
+                return;
+            }
+        }
+
         if (getBill().getId() == null) {
             getBillFacade().create(getBill());
         }


### PR DESCRIPTION
## Summary
- validate direct purchase items to disallow past expiry dates

## Testing
- `mvn -q test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_685eb7be8bd8832f9430a6aba8109ec1