### PR TITLE
Wrap history detail blocks with option-based panels

### DIFF
--- a/src/main/webapp/resources/pharmacy/history.xhtml
+++ b/src/main/webapp/resources/pharmacy/history.xhtml
@@ -22,7 +22,7 @@
                     </div>
                     <div>
                         <h:outputLabel value="From Date"/>
-                        <p:calendar class="mx-2" id="frmDate" value="#{pharmacyController.fromDate}" 
+                        <p:calendar class="mx-2" id="frmDate" value="#{pharmacyController.fromDate}"
                                     navigator="true"  pattern="#{sessionController.applicationPreference.longDateTimeFormat}"  >
 
                         </p:calendar>
@@ -31,19 +31,20 @@
                         <p:calendar class="mx-2" id="toDate" value="#{pharmacyController.toDate}" navigator="true" pattern="#{sessionController.applicationPreference.longDateTimeFormat}"  >
 
                         </p:calendar>
-                        <p:commandButton 
+                        <p:commandButton
                             update=":#{p:resolveFirstComponentWithId('grn',view).clientId} :#{p:resolveFirstComponentWithId('po',view).clientId} :#{p:resolveFirstComponentWithId('dp',view).clientId}
                             :#{p:resolveFirstComponentWithId('depIssue',view).clientId} :#{p:resolveFirstComponentWithId('phSale',view).clientId}
                             :#{p:resolveFirstComponentWithId('stock',view).clientId} :#{p:resolveFirstComponentWithId('bht',view).clientId}
-                            :#{p:resolveFirstComponentWithId('phWhSale',view).clientId}" 
-                            process="@this frmDate toDate" 
+                            :#{p:resolveFirstComponentWithId('phWhSale',view).clientId}"
+                            process="@this frmDate toDate"
                             action="#{pharmacyController.createTable()}"
                             class="ui-button-info" icon="far fa-eye" value="View Detail"/>
                     </div>
+                    </h:panelGroup>
                 </div>
             </f:facet>
 
-            <h:panelGroup 
+            <h:panelGroup
                 rendered="#{configOptionApplicationController.getBooleanValueByKey('Pharmacy Item Details Section - Display Blocks', true)}">
                 <div class="row">
 
@@ -79,9 +80,9 @@
                                             #{dep.department.name}
                                         </p:column>
                                         <p:column style="text-align: right;">
-                                            <h:outputLabel value="#{dep.stock}">       
+                                            <h:outputLabel value="#{dep.stock}">
                                                 <f:convertNumber integerOnly="true" />
-                                            </h:outputLabel> 
+                                            </h:outputLabel>
                                         </p:column>
                                         <p:columnGroup type="footer">
                                             <p:row>
@@ -95,7 +96,7 @@
                                                 </p:column>
                                             </p:row>
                                         </p:columnGroup>
-                                    </p:subTable>  
+                                    </p:subTable>
                                     <p:columnGroup type="footer">
                                         <p:row>
                                             <p:column>
@@ -113,14 +114,15 @@
                                         </p:row>
                                     </p:columnGroup>
 
-                                </p:dataTable> 
+                                </p:dataTable>
                             </p:panel>
                         </div>
 
                     </h:panelGroup>
 
 
-                    <div class="col-3">
+                    <h:panelGroup rendered="#{configOptionApplicationController.getBooleanValueByKey('Pharmacy Item Details Section - Display Pharmacy Sale Block', true)}">
+                        <div class="col-3">
                         <p:panel>
                             <div style="background-color: #337357; padding: 10px; font-weight: bold; color: white; text-align: center;">
                                 Pharmacy Sale
@@ -153,14 +155,14 @@
                                         #{dep.department.name}
                                     </p:column>
                                     <p:column style="text-align: right;">
-                                        <h:outputLabel value="#{dep.saleQty}">   
+                                        <h:outputLabel value="#{dep.saleQty}">
                                             <f:convertNumber integerOnly="true" />
-                                        </h:outputLabel> 
+                                        </h:outputLabel>
                                     </p:column>
                                     <p:column style="text-align: right;">
-                                        <h:outputLabel value="#{dep.saleValue}">  
+                                        <h:outputLabel value="#{dep.saleValue}">
                                             <f:convertNumber pattern="#,##0.00" />
-                                        </h:outputLabel> 
+                                        </h:outputLabel>
                                     </p:column>
                                     <p:columnGroup type="footer">
                                         <p:row>
@@ -181,7 +183,7 @@
                                             </p:column>
                                         </p:row>
                                     </p:columnGroup>
-                                </p:subTable>  
+                                </p:subTable>
                                 <p:columnGroup type="footer">
                                     <p:row>
                                         <p:column>
@@ -191,7 +193,7 @@
                                         </p:column>
                                         <p:column style="text-align: right;">
                                             <f:facet name="footer">
-                                                <h:outputLabel  value="#{pharmacyController.grantSaleQty}">   
+                                                <h:outputLabel  value="#{pharmacyController.grantSaleQty}">
                                                     <f:convertNumber integerOnly="true" />
                                                 </h:outputLabel>
                                             </f:facet>
@@ -206,10 +208,12 @@
                                     </p:row>
                                 </p:columnGroup>
 
-                            </p:dataTable> 
+                            </p:dataTable>
                         </p:panel>
                     </div>
-                    <div class="col-3">
+                    </h:panelGroup>
+                    <h:panelGroup rendered="#{configOptionApplicationController.getBooleanValueByKey('Pharmacy Item Details Section - Display BHT Issue Block', true)}">
+                        <div class="col-3">
                         <p:panel>
                             <div style="background-color: #337357; padding: 10px; font-weight: bold; color: white; text-align: center;">
                                 BHT Issue
@@ -242,14 +246,14 @@
                                         #{dep.department.name}
                                     </p:column>
                                     <p:column style="text-align: right;">
-                                        <h:outputLabel value="#{dep.saleQty}">   
+                                        <h:outputLabel value="#{dep.saleQty}">
                                             <f:convertNumber integerOnly="true" />
-                                        </h:outputLabel> 
+                                        </h:outputLabel>
                                     </p:column>
                                     <p:column style="text-align: right;">
-                                        <h:outputLabel value="#{dep.saleValue}">  
+                                        <h:outputLabel value="#{dep.saleValue}">
                                             <f:convertNumber pattern="#,##0.00" />
-                                        </h:outputLabel> 
+                                        </h:outputLabel>
                                     </p:column>
                                     <p:columnGroup type="footer">
                                         <p:row>
@@ -270,7 +274,7 @@
                                             </p:column>
                                         </p:row>
                                     </p:columnGroup>
-                                </p:subTable>  
+                                </p:subTable>
                                 <p:columnGroup type="footer">
                                     <p:row>
                                         <p:column>
@@ -280,7 +284,7 @@
                                         </p:column>
                                         <p:column style="text-align: right;">
                                             <f:facet name="footer">
-                                                <h:outputLabel  value="#{pharmacyController.grantBhtIssueQty}">   
+                                                <h:outputLabel  value="#{pharmacyController.grantBhtIssueQty}">
                                                     <f:convertNumber integerOnly="true" />
                                                 </h:outputLabel>
                                             </f:facet>
@@ -295,11 +299,13 @@
                                     </p:row>
                                 </p:columnGroup>
 
-                            </p:dataTable>   
+                            </p:dataTable>
 
                         </p:panel>
                     </div>
-                    <div class="col-3" >
+                    </h:panelGroup>
+                    <h:panelGroup rendered="#{configOptionApplicationController.getBooleanValueByKey('Pharmacy Item Details Section - Display Whole Sale Block', true)}">
+                        <div class="col-3" >
                         <p:panel>
                             <div style="background-color: #337357; padding: 10px; font-weight: bold; color: white; text-align: center;">
                                 Pharmacy Whole Sale
@@ -332,14 +338,14 @@
                                         #{dep.department.name}
                                     </p:column>
                                     <p:column style="text-align: right;">
-                                        <h:outputLabel value="#{dep.saleQty}">   
+                                        <h:outputLabel value="#{dep.saleQty}">
                                             <f:convertNumber integerOnly="true" />
-                                        </h:outputLabel> 
+                                        </h:outputLabel>
                                     </p:column>
                                     <p:column style="text-align: right;">
-                                        <h:outputLabel value="#{dep.saleValue}">  
+                                        <h:outputLabel value="#{dep.saleValue}">
                                             <f:convertNumber pattern="#,##0.00" />
-                                        </h:outputLabel> 
+                                        </h:outputLabel>
                                     </p:column>
                                     <p:columnGroup type="footer">
                                         <p:row>
@@ -360,7 +366,7 @@
                                             </p:column>
                                         </p:row>
                                     </p:columnGroup>
-                                </p:subTable>  
+                                </p:subTable>
                                 <p:columnGroup type="footer">
                                     <p:row>
                                         <p:column>
@@ -370,7 +376,7 @@
                                         </p:column>
                                         <p:column style="text-align: right;">
                                             <f:facet name="footer">
-                                                <h:outputLabel  value="#{pharmacyController.grantWholeSaleQty}">   
+                                                <h:outputLabel  value="#{pharmacyController.grantWholeSaleQty}">
                                                     <f:convertNumber integerOnly="true" />
                                                 </h:outputLabel>
                                             </f:facet>
@@ -385,13 +391,14 @@
                                     </p:row>
                                 </p:columnGroup>
 
-                            </p:dataTable>                
+                            </p:dataTable>
 
                         </p:panel>
                     </div>
+                    </h:panelGroup>
 
-
-                    <div class="col-3">
+                    <h:panelGroup rendered="#{configOptionApplicationController.getBooleanValueByKey('Pharmacy Item Details Section - Display Transfer Issue Block', true)}">
+                        <div class="col-3">
                         <p:panel >
                             <div style="background-color: #337357; padding: 10px; font-weight: bold; color: white; text-align: center;">
                                 Transfer Issue
@@ -424,14 +431,14 @@
                                         #{dep.department.name}
                                     </p:column>
                                     <p:column style="text-align: right;">
-                                        <h:outputLabel value="#{dep.saleQtyAbs}">    
+                                        <h:outputLabel value="#{dep.saleQtyAbs}">
                                             <f:convertNumber integerOnly="true" />
-                                        </h:outputLabel> 
+                                        </h:outputLabel>
                                     </p:column>
                                     <p:column style="text-align: right;">
-                                        <h:outputLabel value="#{dep.saleValueAbs}">    
+                                        <h:outputLabel value="#{dep.saleValueAbs}">
                                             <f:convertNumber  pattern="#,##0.00" />
-                                        </h:outputLabel> 
+                                        </h:outputLabel>
                                     </p:column>
                                     <p:columnGroup type="footer">
                                         <p:row>
@@ -452,7 +459,7 @@
                                             </p:column>
                                         </p:row>
                                     </p:columnGroup>
-                                </p:subTable>  
+                                </p:subTable>
                                 <p:columnGroup type="footer">
                                     <p:row>
                                         <p:column>
@@ -477,21 +484,22 @@
                                     </p:row>
                                 </p:columnGroup>
 
-                            </p:dataTable> 
+                            </p:dataTable>
                         </p:panel>
                     </div>
+                    </h:panelGroup>
                 </div>
             </h:panelGroup>
 
 
 
-            <p:tabView  
+            <p:tabView
                 rendered="#{configOptionApplicationController.getBooleanValueByKey('Pharmacy Item Details Section - Display Tabview', true)}"
-                class="w-100"  
-                activeIndex="0" 
+                class="w-100"
+                activeIndex="0"
                 style="border: 1px solid lightgray; padding: 10px;">
-                <p:tab 
-                    title="Stock" 
+                <p:tab
+                    title="Stock"
                     rendered="#{configOptionApplicationController.getBooleanValueByKey('Pharmacy Item Details Section - Display Stocks Tab', true)}">
                     <p:panel header="Stock">
                         <p:dataTable styleClass="noBorder" value="#{pharmacyController.institutionStocks}" var="ins" class="w-100">
@@ -517,9 +525,9 @@
                                     #{dep.department.name}
                                 </p:column>
                                 <p:column style="text-align: right;">
-                                    <h:outputLabel value="#{dep.stock}">       
+                                    <h:outputLabel value="#{dep.stock}">
                                         <f:convertNumber integerOnly="true" />
-                                    </h:outputLabel> 
+                                    </h:outputLabel>
                                 </p:column>
                                 <p:columnGroup type="footer">
                                     <p:row>
@@ -533,7 +541,7 @@
                                         </p:column>
                                     </p:row>
                                 </p:columnGroup>
-                            </p:subTable>  
+                            </p:subTable>
                             <p:columnGroup type="footer">
                                 <p:row>
                                     <p:column>
@@ -551,7 +559,7 @@
                                 </p:row>
                             </p:columnGroup>
 
-                        </p:dataTable> 
+                        </p:dataTable>
                     </p:panel>
 
                 </p:tab>
@@ -585,14 +593,14 @@
                                 #{dep.department.name}
                             </p:column>
                             <p:column style="text-align: right;">
-                                <h:outputLabel value="#{dep.saleQty}">   
+                                <h:outputLabel value="#{dep.saleQty}">
                                     <f:convertNumber integerOnly="true" />
-                                </h:outputLabel> 
+                                </h:outputLabel>
                             </p:column>
                             <p:column style="text-align: right;">
-                                <h:outputLabel value="#{dep.saleValue}">  
+                                <h:outputLabel value="#{dep.saleValue}">
                                     <f:convertNumber pattern="#,##0.00" />
-                                </h:outputLabel> 
+                                </h:outputLabel>
                             </p:column>
                             <p:columnGroup type="footer">
                                 <p:row>
@@ -613,7 +621,7 @@
                                     </p:column>
                                 </p:row>
                             </p:columnGroup>
-                        </p:subTable>  
+                        </p:subTable>
                         <p:columnGroup type="footer">
                             <p:row>
                                 <p:column>
@@ -623,7 +631,7 @@
                                 </p:column>
                                 <p:column style="text-align: right;">
                                     <f:facet name="footer">
-                                        <h:outputLabel  value="#{pharmacyController.grantSaleQty}">   
+                                        <h:outputLabel  value="#{pharmacyController.grantSaleQty}">
                                             <f:convertNumber integerOnly="true" />
                                         </h:outputLabel>
                                     </f:facet>
@@ -638,7 +646,7 @@
                             </p:row>
                         </p:columnGroup>
 
-                    </p:dataTable>                
+                    </p:dataTable>
                 </p:tab>
 
                 <p:tab   title="Sale Bill Item"  class="w-100"  >
@@ -650,8 +658,8 @@
                     </p:commandButton>
                     <br/>
                     <p:dataTable id="tbl" styleClass="noBorder" value="#{pharmacyController.grns}" var="bi"
-                                 paginator="true" 
-                                 rows="10" 
+                                 paginator="true"
+                                 rows="10"
                                  paginatorPosition="bottom"
                                  paginatorTemplate="{CurrentPageReport}  {FirstPageLink} {PreviousPageLink} {PageLinks} {NextPageLink} {LastPageLink} {RowsPerPageDropdown}"
                                  rowsPerPageTemplate="5,10,15">
@@ -712,14 +720,14 @@
                                 #{dep.department.name}
                             </p:column>
                             <p:column style="text-align: right;">
-                                <h:outputLabel value="#{dep.saleQty}">   
+                                <h:outputLabel value="#{dep.saleQty}">
                                     <f:convertNumber integerOnly="true" />
-                                </h:outputLabel> 
+                                </h:outputLabel>
                             </p:column>
                             <p:column style="text-align: right;">
-                                <h:outputLabel value="#{dep.saleValue}">  
+                                <h:outputLabel value="#{dep.saleValue}">
                                     <f:convertNumber pattern="#,##0.00" />
-                                </h:outputLabel> 
+                                </h:outputLabel>
                             </p:column>
                             <p:columnGroup type="footer">
                                 <p:row>
@@ -740,7 +748,7 @@
                                     </p:column>
                                 </p:row>
                             </p:columnGroup>
-                        </p:subTable>  
+                        </p:subTable>
                         <p:columnGroup type="footer">
                             <p:row>
                                 <p:column>
@@ -750,7 +758,7 @@
                                 </p:column>
                                 <p:column style="text-align: right;">
                                     <f:facet name="footer">
-                                        <h:outputLabel  value="#{pharmacyController.grantWholeSaleQty}">   
+                                        <h:outputLabel  value="#{pharmacyController.grantWholeSaleQty}">
                                             <f:convertNumber integerOnly="true" />
                                         </h:outputLabel>
                                     </f:facet>
@@ -765,7 +773,7 @@
                             </p:row>
                         </p:columnGroup>
 
-                    </p:dataTable>                
+                    </p:dataTable>
                 </p:tab>
 
                 <p:tab   title="BHT Issue"    >
@@ -797,14 +805,14 @@
                                 #{dep.department.name}
                             </p:column>
                             <p:column style="text-align: right;">
-                                <h:outputLabel value="#{dep.saleQty}">   
+                                <h:outputLabel value="#{dep.saleQty}">
                                     <f:convertNumber integerOnly="true" />
-                                </h:outputLabel> 
+                                </h:outputLabel>
                             </p:column>
                             <p:column style="text-align: right;">
-                                <h:outputLabel value="#{dep.saleValue}">  
+                                <h:outputLabel value="#{dep.saleValue}">
                                     <f:convertNumber pattern="#,##0.00" />
-                                </h:outputLabel> 
+                                </h:outputLabel>
                             </p:column>
                             <p:columnGroup type="footer">
                                 <p:row>
@@ -825,7 +833,7 @@
                                     </p:column>
                                 </p:row>
                             </p:columnGroup>
-                        </p:subTable>  
+                        </p:subTable>
                         <p:columnGroup type="footer">
                             <p:row>
                                 <p:column>
@@ -835,7 +843,7 @@
                                 </p:column>
                                 <p:column style="text-align: right;">
                                     <f:facet name="footer">
-                                        <h:outputLabel  value="#{pharmacyController.grantBhtIssueQty}">   
+                                        <h:outputLabel  value="#{pharmacyController.grantBhtIssueQty}">
                                             <f:convertNumber integerOnly="true" />
                                         </h:outputLabel>
                                     </f:facet>
@@ -850,7 +858,7 @@
                             </p:row>
                         </p:columnGroup>
 
-                    </p:dataTable>                
+                    </p:dataTable>
                 </p:tab>
 
 
@@ -883,14 +891,14 @@
                                 #{dep.department.name}
                             </p:column>
                             <p:column style="text-align: right;">
-                                <h:outputLabel value="#{dep.saleQtyAbs}">    
+                                <h:outputLabel value="#{dep.saleQtyAbs}">
                                     <f:convertNumber integerOnly="true" />
-                                </h:outputLabel> 
+                                </h:outputLabel>
                             </p:column>
                             <p:column style="text-align: right;">
-                                <h:outputLabel value="#{dep.saleValueAbs}">    
+                                <h:outputLabel value="#{dep.saleValueAbs}">
                                     <f:convertNumber  pattern="#,##0.00" />
-                                </h:outputLabel> 
+                                </h:outputLabel>
                             </p:column>
                             <p:columnGroup type="footer">
                                 <p:row>
@@ -911,7 +919,7 @@
                                     </p:column>
                                 </p:row>
                             </p:columnGroup>
-                        </p:subTable>  
+                        </p:subTable>
                         <p:columnGroup type="footer">
                             <p:row>
                                 <p:column>
@@ -936,11 +944,11 @@
                             </p:row>
                         </p:columnGroup>
 
-                    </p:dataTable>                
+                    </p:dataTable>
                 </p:tab>
 
                 <p:tab   title="Transfer Receive "    >
-                    <p:dataTable styleClass="noBorder" id="trRceive" 
+                    <p:dataTable styleClass="noBorder" id="trRceive"
                                  value="#{pharmacyController.institutionTransferReceive}" var="ins">
                         <p:columnGroup type="header">
                             <p:row>
@@ -969,14 +977,14 @@
                                 #{dep.department.name}
                             </p:column>
                             <p:column style="text-align: right;">
-                                <h:outputLabel value="#{dep.saleQtyAbs}"> 
+                                <h:outputLabel value="#{dep.saleQtyAbs}">
                                     <f:convertNumber integerOnly="true" />
-                                </h:outputLabel> 
+                                </h:outputLabel>
                             </p:column>
                             <p:column style="text-align: right;">
-                                <h:outputLabel value="#{dep.saleValueAbs}"> 
+                                <h:outputLabel value="#{dep.saleValueAbs}">
                                     <f:convertNumber  pattern="#,##0.00" />
-                                </h:outputLabel> 
+                                </h:outputLabel>
                             </p:column>
                             <p:columnGroup type="footer">
                                 <p:row>
@@ -997,7 +1005,7 @@
                                     </p:column>
                                 </p:row>
                             </p:columnGroup>
-                        </p:subTable>  
+                        </p:subTable>
                         <p:columnGroup type="footer">
                             <p:row>
                                 <p:column>
@@ -1022,7 +1030,7 @@
                             </p:row>
                         </p:columnGroup>
 
-                    </p:dataTable>                
+                    </p:dataTable>
                 </p:tab>
 
                 <p:tab   title="Department Issue"    >
@@ -1055,14 +1063,14 @@
                                 #{dep.department.name}
                             </p:column>
                             <p:column style="text-align: right;">
-                                <h:outputLabel value="#{dep.saleQtyAbs}">    
+                                <h:outputLabel value="#{dep.saleQtyAbs}">
                                     <f:convertNumber integerOnly="true" />
-                                </h:outputLabel> 
+                                </h:outputLabel>
                             </p:column>
                             <p:column style="text-align: right;">
-                                <h:outputLabel value="#{dep.saleValueAbs}">    
+                                <h:outputLabel value="#{dep.saleValueAbs}">
                                     <f:convertNumber  pattern="#,##0.00" />
-                                </h:outputLabel> 
+                                </h:outputLabel>
                             </p:column>
                             <p:columnGroup type="footer">
                                 <p:row>
@@ -1083,7 +1091,7 @@
                                     </p:column>
                                 </p:row>
                             </p:columnGroup>
-                        </p:subTable>  
+                        </p:subTable>
                         <p:columnGroup type="footer">
                             <p:row>
                                 <p:column>
@@ -1108,14 +1116,14 @@
                             </p:row>
                         </p:columnGroup>
 
-                    </p:dataTable>                
+                    </p:dataTable>
                 </p:tab>
 
                 <p:tab  title="GRN"  >
 
-                    <p:dataTable styleClass="noBorder" id="grn" value="#{pharmacyController.grns}" 
-                                 var="dd2" scrollable="true"  paginator="true" 
-                                 rows="10" 
+                    <p:dataTable styleClass="noBorder" id="grn" value="#{pharmacyController.grns}"
+                                 var="dd2" scrollable="true"  paginator="true"
+                                 rows="10"
                                  paginatorPosition="bottom"
                                  paginatorTemplate="{CurrentPageReport}  {FirstPageLink} {PreviousPageLink} {PageLinks} {NextPageLink} {LastPageLink} {RowsPerPageDropdown}"
                                  rowsPerPageTemplate="5,10,15" >
@@ -1233,8 +1241,8 @@
 
                 <p:tab  title="Purchase Orders"  >
 
-                    <p:dataTable styleClass="noBorder" id="po" value="#{pharmacyController.pos}" var="dd3" 
-                                 rows="10" 
+                    <p:dataTable styleClass="noBorder" id="po" value="#{pharmacyController.pos}" var="dd3"
+                                 rows="10"
                                  paginator="true"
                                  paginatorPosition="bottom"
                                  paginatorTemplate="{CurrentPageReport}  {FirstPageLink} {PreviousPageLink} {PageLinks} {NextPageLink} {LastPageLink} {RowsPerPageDropdown}"
@@ -1252,10 +1260,10 @@
                         </p:column>
                         <p:column headerText="PO Qty">
                             #{dd3.pharmaceuticalBillItem.qty}
-                        </p:column>                           
+                        </p:column>
                         <p:column headerText="Grn Qty">
                             #{dd3.totalGrnQty}
-                        </p:column>                            
+                        </p:column>
                     </p:dataTable>
                 </p:tab>
 
@@ -1293,7 +1301,7 @@
                 <p:tab  title="Direct Purchase"  >
 
                     <p:dataTable styleClass="noBorder" id="dp" value="#{pharmacyController.directPurchase}" var="dd3"
-                                 rows="10" 
+                                 rows="10"
                                  paginator="true"
                                  paginatorPosition="bottom"
                                  paginatorTemplate="{CurrentPageReport}  {FirstPageLink} {PreviousPageLink} {PageLinks} {NextPageLink} {LastPageLink} {RowsPerPageDropdown}"
@@ -1306,27 +1314,27 @@
                         </p:column>
                         <p:column headerText="Billed By">
                             #{dd3.bill.creater.webUserPerson.name}
-                        </p:column>    
+                        </p:column>
                         <p:column headerText="Billed At">
                             <p:outputLabel value="#{dd3.bill.createdAt}" >
                                 <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateFormat}"></f:convertDateTime>
                             </p:outputLabel>
-                        </p:column> 
+                        </p:column>
                         <p:column headerText="Purchase Rate">
                             #{dd3.pharmaceuticalBillItem.purchaseRate}
-                        </p:column>    
+                        </p:column>
                         <p:column headerText="Sale Rate">
                             #{dd3.pharmaceuticalBillItem.retailRate}
-                        </p:column>    
+                        </p:column>
                         <p:column headerText="Purchase Qty">
                             #{dd3.pharmaceuticalBillItem.qty}
-                        </p:column>    
+                        </p:column>
                         <p:column headerText="Free Qty">
                             #{dd3.pharmaceuticalBillItem.freeQty}
-                        </p:column>    
+                        </p:column>
                         <p:column headerText="Purchase Value">
                             #{-dd3.netValue}
-                        </p:column> 
+                        </p:column>
                     </p:dataTable>
                 </p:tab>
                 <p:tab title="Pack Sizes" >


### PR DESCRIPTION
## Summary
- conditionally wrap Pharmacy Sale, BHT Issue, Whole Sale and Transfer Issue blocks in pharmacy history page

## Testing
- `mvn test` *(fails: mvn not installed)*

------
https://chatgpt.com/codex/tasks/task_e_685f3f971c5c832fa3b1df4807fb6f30