### PR TITLE
Add configurable rendering for pharmacy history tabs

### DIFF
--- a/src/main/webapp/resources/pharmacy/history.xhtml
+++ b/src/main/webapp/resources/pharmacy/history.xhtml
@@ -556,7 +556,7 @@
 
                 </p:tab>
 
-                <p:tab   title="Sale"    >
+                <p:tab title="Sale" rendered="#{configOptionApplicationController.getBooleanValueByKey('Pharmacy Item Details Section - Display Sale Tab', true)}">
                     <p:dataTable styleClass="noBorder" value="#{pharmacyController.institutionSales}" var="ins">
                         <p:columnGroup type="header">
                             <p:row>
@@ -641,7 +641,7 @@
                     </p:dataTable>                
                 </p:tab>
 
-                <p:tab   title="Sale Bill Item"  class="w-100"  >
+                <p:tab title="Sale Bill Item" class="w-100" rendered="#{configOptionApplicationController.getBooleanValueByKey('Pharmacy Item Details Section - Display Sale Bill Item Tab', true)}">
 
                     <p:commandButton ajax="false" icon="fas fa-file-excel"
                                      class="ui-button-success" value="Excel" action="#{pharmacyController.createTable()}" >
@@ -683,7 +683,7 @@
                     </p:dataTable>
                 </p:tab>
 
-                <p:tab   title="Whole Sale"    >
+                <p:tab title="Whole Sale" rendered="#{configOptionApplicationController.getBooleanValueByKey('Pharmacy Item Details Section - Display Whole Sale Tab', true)}">
                     <p:dataTable styleClass="noBorder" value="#{pharmacyController.institutionWholeSales}" var="ins">
                         <p:columnGroup type="header">
                             <p:row>
@@ -768,7 +768,7 @@
                     </p:dataTable>                
                 </p:tab>
 
-                <p:tab   title="BHT Issue"    >
+                <p:tab title="BHT Issue" rendered="#{configOptionApplicationController.getBooleanValueByKey('Pharmacy Item Details Section - Display BHT Issue Tab', true)}">
                     <p:dataTable styleClass="noBorder" value="#{pharmacyController.institutionBhtIssue}" var="ins">
                         <p:columnGroup type="header">
                             <p:row>
@@ -854,7 +854,7 @@
                 </p:tab>
 
 
-                <p:tab   title="Transfer Issue"    >
+                <p:tab title="Transfer Issue" rendered="#{configOptionApplicationController.getBooleanValueByKey('Pharmacy Item Details Section - Display Transfer Issue Tab', true)}">
                     <p:dataTable styleClass="noBorder" id="trIssue" value="#{pharmacyController.institutionTransferIssue}" var="ins">
                         <p:columnGroup type="header">
                             <p:row>
@@ -939,7 +939,7 @@
                     </p:dataTable>                
                 </p:tab>
 
-                <p:tab   title="Transfer Receive "    >
+                <p:tab title="Transfer Receive" rendered="#{configOptionApplicationController.getBooleanValueByKey('Pharmacy Item Details Section - Display Transfer Receive Tab', true)}">
                     <p:dataTable styleClass="noBorder" id="trRceive" 
                                  value="#{pharmacyController.institutionTransferReceive}" var="ins">
                         <p:columnGroup type="header">
@@ -1025,7 +1025,7 @@
                     </p:dataTable>                
                 </p:tab>
 
-                <p:tab   title="Department Issue"    >
+                <p:tab title="Department Issue" rendered="#{configOptionApplicationController.getBooleanValueByKey('Pharmacy Item Details Section - Display Department Issue Tab', true)}">
                     <p:dataTable styleClass="noBorder" id="depIssue"
                                  value="#{pharmacyController.institutionIssue}" var="ins">
                         <p:columnGroup type="header">
@@ -1111,7 +1111,7 @@
                     </p:dataTable>                
                 </p:tab>
 
-                <p:tab  title="GRN"  >
+                <p:tab title="GRN" rendered="#{configOptionApplicationController.getBooleanValueByKey('Pharmacy Item Details Section - Display GRN Tab', true)}">
 
                     <p:dataTable styleClass="noBorder" id="grn" value="#{pharmacyController.grns}" 
                                  var="dd2" scrollable="true"  paginator="true" 
@@ -1154,7 +1154,7 @@
                     </p:dataTable>
                 </p:tab>
 
-                <p:tab  title="Pending GRN"  >
+                <p:tab title="Pending GRN" rendered="#{configOptionApplicationController.getBooleanValueByKey('Pharmacy Item Details Section - Display Pending GRN Tab', true)}">
 
                     <p:dataTable styleClass="noBorder" id="pendinggrn" value="#{pharmacyController.grns}"
                                  var="dd2" scrollable="true"  paginator="true"
@@ -1200,7 +1200,7 @@
                     </p:dataTable>
                 </p:tab>
 
-                <p:tab  title="GRN Return"  >
+                <p:tab title="GRN Return" rendered="#{configOptionApplicationController.getBooleanValueByKey('Pharmacy Item Details Section - Display GRN Return Tab', true)}">
 
                     <p:dataTable styleClass="noBorder" id="grnr" value="#{pharmacyController.grns}"
                                  var="dd2" scrollable="true"  paginator="true"
@@ -1231,7 +1231,7 @@
                     </p:dataTable>
                 </p:tab>
 
-                <p:tab  title="Purchase Orders"  >
+                <p:tab title="Purchase Orders" rendered="#{configOptionApplicationController.getBooleanValueByKey('Pharmacy Item Details Section - Display Purchase Orders Tab', true)}">
 
                     <p:dataTable styleClass="noBorder" id="po" value="#{pharmacyController.pos}" var="dd3" 
                                  rows="10" 
@@ -1259,7 +1259,7 @@
                     </p:dataTable>
                 </p:tab>
 
-                <p:tab  title="Pending PO"  >
+                <p:tab title="Pending PO" rendered="#{configOptionApplicationController.getBooleanValueByKey('Pharmacy Item Details Section - Display Pending PO Tab', true)}">
 
                     <p:dataTable styleClass="noBorder" id="ppo" value="#{pharmacyController.pos}" var="dd3"
                                  rows="10"
@@ -1290,7 +1290,7 @@
                     </p:dataTable>
                 </p:tab>
 
-                <p:tab  title="Direct Purchase"  >
+                <p:tab title="Direct Purchase" rendered="#{configOptionApplicationController.getBooleanValueByKey('Pharmacy Item Details Section - Display Direct Purchase Tab', true)}">
 
                     <p:dataTable styleClass="noBorder" id="dp" value="#{pharmacyController.directPurchase}" var="dd3"
                                  rows="10" 
@@ -1329,7 +1329,7 @@
                         </p:column> 
                     </p:dataTable>
                 </p:tab>
-                <p:tab title="Pack Sizes" >
+                <p:tab title="Pack Sizes" rendered="#{configOptionApplicationController.getBooleanValueByKey('Pharmacy Item Details Section - Display Pack Sizes Tab', true)}">
                     <p:dataTable value="#{pharmacyController.ampps}" var="p" >
                         <p:column>
                             <h:outputLabel value="#{p.name}" ></h:outputLabel>


### PR DESCRIPTION
## Summary
- show pharmacy item history tabs only when config option enabled

## Testing
- `mvn -q test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f3f99d464832f89de4cac47947dc4