### PR TITLE
Fix history tabs by loading purchase details

### DIFF
--- a/src/main/java/com/divudi/bean/pharmacy/PharmacyController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacyController.java
@@ -3885,6 +3885,10 @@ public class PharmacyController implements Serializable {
         createInstitutionTransferIssue();
         createInstitutionIssue();
         createInstitutionTransferReceive();
+        // Ensure related purchase details are also loaded
+        createGrnTable();
+        createPoTable();
+        createDirectPurchaseTable();
     }
 
     public void createGrnTable() {


### PR DESCRIPTION
## Summary
- ensure purchase order and direct purchase history data loads when viewing item history

## Testing
- `mvn -q -DskipTests package` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f4979e144832f90ac9ff3a576972a