### PR TITLE
Implement duplicate institution detection

### DIFF
--- a/src/main/java/com/divudi/bean/common/InstitutionController.java
+++ b/src/main/java/com/divudi/bean/common/InstitutionController.java
@@ -16,6 +16,7 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 import javax.ejb.EJB;
 import javax.enterprise.context.SessionScoped;
 import javax.faces.component.UIComponent;
@@ -70,6 +71,7 @@ public class InstitutionController implements Serializable {
     private Boolean codeDisabled = false;
     private int managaeInstitutionIndex = -1;
     private List<Institution> sites;
+    private List<InstitutionDuplicateGroup> duplicateGroups;
 
     public void fillAllSites() {
         sites = new ArrayList<>();
@@ -165,6 +167,10 @@ public class InstitutionController implements Serializable {
     public String saveSelectedInstitution() {
         if (current == null) {
             JsfUtil.addErrorMessage("Nothing selected");
+            return "";
+        }
+        if (isDuplicateName(current)) {
+            JsfUtil.addErrorMessage("Another institution with same name exists");
             return "";
         }
         if (current.getId() == null) {
@@ -553,6 +559,10 @@ public class InstitutionController implements Serializable {
     }
 
     public void save(Institution ins) {
+        if (!ins.isRetired() && isDuplicateName(ins)) {
+            JsfUtil.addErrorMessage("Another institution with same name exists");
+            return;
+        }
         if (ins.getId() == null) {
             getFacade().create(ins);
         } else {
@@ -563,6 +573,11 @@ public class InstitutionController implements Serializable {
     public void saveSelectedSite() {
         if (getCurrent().getInstitutionType() != InstitutionType.Site) {
             JsfUtil.addErrorMessage("Invalid Institution Type");
+            return;
+        }
+
+        if (isDuplicateName(getCurrent())) {
+            JsfUtil.addErrorMessage("Another institution with same name exists");
             return;
         }
 
@@ -596,6 +611,11 @@ public class InstitutionController implements Serializable {
             return;
         }
 
+        if (isDuplicateName(getCurrent())) {
+            JsfUtil.addErrorMessage("Another institution with same name exists");
+            return;
+        }
+
         if (getCurrent().getId() != null && getCurrent().getId() > 0) {
 //
 //            if (getCurrent().getCode() != null) {
@@ -623,6 +643,11 @@ public class InstitutionController implements Serializable {
     public void saveSelectedAgency() {
         if (getAgency().getInstitutionType() == null) {
             JsfUtil.addErrorMessage("Select Institution Type");
+            return;
+        }
+
+        if (isDuplicateName(getAgency())) {
+            JsfUtil.addErrorMessage("Another institution with same name exists");
             return;
         }
 
@@ -843,6 +868,21 @@ public class InstitutionController implements Serializable {
         return ejbFacade;
     }
 
+    private boolean isDuplicateName(Institution ins) {
+        if (ins == null || ins.getName() == null) {
+            return false;
+        }
+        String name = ins.getName().trim();
+        if (name.isEmpty()) {
+            return false;
+        }
+        String jpql = "select i from Institution i where i.retired=false and upper(trim(i.name))=:n";
+        Map<String, Object> m = new HashMap<>();
+        m.put("n", name.toUpperCase());
+        Institution other = getFacade().findFirstByJpql(jpql, m);
+        return other != null && (ins.getId() == null || !other.getId().equals(ins.getId()));
+    }
+
     public List<Institution> getItems() {
         if (items == null) {
             fillItems();
@@ -985,6 +1025,59 @@ public class InstitutionController implements Serializable {
 
     public void setInstitutions(List<Institution> institutions) {
         this.institutions = institutions;
+    }
+
+    public String navigateToDuplicateInstitutions() {
+        detectDuplicateInstitutions();
+        return "/admin/institutions/institution_duplicates?faces-redirect=true";
+    }
+
+    public List<InstitutionDuplicateGroup> getDuplicateGroups() {
+        return duplicateGroups;
+    }
+
+    public void detectDuplicateInstitutions() {
+        String jpql = "SELECT i FROM Institution i WHERE i.retired=false ORDER BY upper(trim(i.name)), i.id";
+        List<Institution> all = getFacade().findByJpql(jpql);
+        Map<String, List<Institution>> grouped = all.stream()
+                .filter(ins -> ins.getName() != null)
+                .collect(Collectors.groupingBy(ins -> ins.getName().trim().toUpperCase()));
+        duplicateGroups = grouped.values().stream()
+                .filter(l -> l.size() > 1)
+                .map(l -> new InstitutionDuplicateGroup(l))
+                .collect(Collectors.toList());
+    }
+
+    public void retireDuplicateGroup(InstitutionDuplicateGroup g) {
+        if (g == null || g.getInstitutions() == null || g.getInstitutions().size() < 2) {
+            return;
+        }
+        g.getInstitutions().sort((a, b) -> a.getId().compareTo(b.getId()));
+        for (int i = 1; i < g.getInstitutions().size(); i++) {
+            Institution ins = g.getInstitutions().get(i);
+            ins.setRetired(true);
+            ins.setRetiredAt(new Date());
+            ins.setRetirer(sessionController.getLoggedUser());
+            save(ins);
+        }
+        detectDuplicateInstitutions();
+        JsfUtil.addSuccessMessage("Duplicates retired for " + g.getName());
+    }
+
+    public static class InstitutionDuplicateGroup {
+        private List<Institution> institutions;
+
+        public InstitutionDuplicateGroup(List<Institution> institutions) {
+            this.institutions = institutions;
+        }
+
+        public List<Institution> getInstitutions() {
+            return institutions;
+        }
+
+        public String getName() {
+            return institutions.get(0).getName();
+        }
     }
 
     /**

--- a/src/main/webapp/admin/institutions/admin_institutions_index.xhtml
+++ b/src/main/webapp/admin/institutions/admin_institutions_index.xhtml
@@ -186,6 +186,7 @@
                                         <p:commandButton  styleClass="linkButton" ajax="false" value="Bulk Delete Institutions" action="#{navigationController.navigateToInstitutionBulkDelete()}" icon="fa-solid fa-trash"/>
                                         <p:commandButton  styleClass="linkButton" ajax="false" value="Bulk Delete Departments" action="#{navigationController.navigateToDepartmentBulkDelete()}"  icon="fa-solid fa-trash-can"/>
                                         <p:commandButton  styleClass="linkButton" ajax="false" value="Duplicate Config Options" icon="pi pi-database" action="#{configOptionController.navigateToDuplicateOptions()}"/>
+                                        <p:commandButton  styleClass="linkButton" ajax="false" value="Duplicate Institutions" icon="pi pi-database" action="#{institutionController.navigateToDuplicateInstitutions()}"/>
 
 
                                     </div>

--- a/src/main/webapp/admin/institutions/institution_duplicates.xhtml
+++ b/src/main/webapp/admin/institutions/institution_duplicates.xhtml
@@ -1,0 +1,30 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
+      xmlns:p="http://primefaces.org/ui"
+      xmlns:h="http://xmlns.jcp.org/jsf/html"
+      xmlns:f="http://xmlns.jcp.org/jsf/core">
+    <h:body>
+        <ui:composition template="/admin/institutions/admin_institutions_index.xhtml">
+            <ui:define name="admin">
+                <h:form id="dupForm">
+                    <p:panel header="Duplicate Institutions">
+                        <p:commandButton value="Refresh" icon="pi pi-refresh"
+                                         action="#{institutionController.detectDuplicateInstitutions()}"
+                                         update="dupTable"/>
+                        <p:dataTable id="dupTable" var="grp" value="#{institutionController.duplicateGroups}" paginator="true" rows="10">
+                            <p:column headerText="Name">#{grp.name}</p:column>
+                            <p:column headerText="Count">#{grp.institutions.size()}</p:column>
+                            <p:column headerText="Action">
+                                <p:commandButton value="Retire Extras" icon="pi pi-trash"
+                                                 action="#{institutionController.retireDuplicateGroup(grp)}"
+                                                 update="dupTable"/>
+                            </p:column>
+                        </p:dataTable>
+                    </p:panel>
+                </h:form>
+            </ui:define>
+        </ui:composition>
+    </h:body>
+</html>


### PR DESCRIPTION
## Summary
- detect duplicate institutions by name and allow retiring them
- prevent saving institutions with duplicate names
- add page for listing duplicate institutions
- link duplicate institutions page from Developer tools

## Testing
- `mvn -q test` *(fails: Plugin resolution error)*

------
https://chatgpt.com/codex/tasks/task_e_685f62434300832f9cb7c54ce588b701