### PR TITLE
Detect and handle duplicate departments

### DIFF
--- a/src/main/java/com/divudi/bean/common/DepartmentController.java
+++ b/src/main/java/com/divudi/bean/common/DepartmentController.java
@@ -21,6 +21,7 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 import javax.ejb.EJB;
 import javax.enterprise.context.SessionScoped;
 import javax.faces.component.UIComponent;
@@ -56,6 +57,8 @@ public class DepartmentController implements Serializable {
     private Department superDepartment;
 
     List<Department> itemsToRemove;
+
+    private List<DepartmentDuplicateGroup> duplicateGroups;
 
     public Department findAndSaveDepartmentByName(String name) {
         if (name == null) {
@@ -371,6 +374,17 @@ public class DepartmentController implements Serializable {
     public String saveSelectedDepartment() {
         if (current == null) {
             JsfUtil.addErrorMessage("Nothing selected");
+            return "";
+        }
+        if (current.getName() != null) {
+            current.setName(current.getName().trim());
+        }
+        String sql = "select d from Department d where upper(d.name)=:nm and d.retired=false";
+        Map<String, Object> m = new HashMap<>();
+        m.put("nm", current.getName() == null ? "" : current.getName().toUpperCase());
+        Department existing = getFacade().findFirstByJpql(sql, m);
+        if (existing != null && (current.getId() == null || !existing.getId().equals(current.getId()))) {
+            JsfUtil.addErrorMessage("Department with same name already exists");
             return "";
         }
         if (current.getId() == null) {
@@ -863,6 +877,58 @@ public class DepartmentController implements Serializable {
 
     public void setSuperDepartment(Department superDepartment) {
         this.superDepartment = superDepartment;
+    }
+
+    public List<DepartmentDuplicateGroup> getDuplicateGroups() {
+        return duplicateGroups;
+    }
+
+    public String navigateToDuplicateDepartments() {
+        detectDuplicateDepartments();
+        return "/admin/institutions/department_duplicates?faces-redirect=true";
+    }
+
+    public void detectDuplicateDepartments() {
+        String jpql = "SELECT d FROM Department d WHERE d.retired=false ORDER BY UPPER(TRIM(d.name)), d.id";
+        List<Department> all = getFacade().findByJpql(jpql);
+        Map<String, List<Department>> grouped = all.stream()
+                .collect(Collectors.groupingBy(d -> d.getName() == null ? "" : d.getName().trim().toUpperCase()));
+        duplicateGroups = grouped.values().stream()
+                .filter(l -> l.size() > 1)
+                .map(l -> new DepartmentDuplicateGroup(l))
+                .collect(Collectors.toList());
+    }
+
+    public void retireDuplicateGroup(DepartmentDuplicateGroup g) {
+        if (g == null || g.getDepartments() == null || g.getDepartments().size() < 2) {
+            return;
+        }
+        g.getDepartments().sort((a, b) -> a.getId().compareTo(b.getId()));
+        for (int i = 1; i < g.getDepartments().size(); i++) {
+            Department d = g.getDepartments().get(i);
+            d.setRetired(true);
+            d.setRetiredAt(new Date());
+            d.setRetirer(sessionController.getLoggedUser());
+            getFacade().edit(d);
+        }
+        detectDuplicateDepartments();
+        JsfUtil.addSuccessMessage("Duplicates retired for " + g.getName());
+    }
+
+    public static class DepartmentDuplicateGroup {
+        private List<Department> departments;
+
+        public DepartmentDuplicateGroup(List<Department> departments) {
+            this.departments = departments;
+        }
+
+        public List<Department> getDepartments() {
+            return departments;
+        }
+
+        public String getName() {
+            return departments.get(0).getName();
+        }
     }
 
     /**

--- a/src/main/webapp/admin/institutions/admin_institutions_index.xhtml
+++ b/src/main/webapp/admin/institutions/admin_institutions_index.xhtml
@@ -186,6 +186,7 @@
                                         <p:commandButton  styleClass="linkButton" ajax="false" value="Bulk Delete Institutions" action="#{navigationController.navigateToInstitutionBulkDelete()}" icon="fa-solid fa-trash"/>
                                         <p:commandButton  styleClass="linkButton" ajax="false" value="Bulk Delete Departments" action="#{navigationController.navigateToDepartmentBulkDelete()}"  icon="fa-solid fa-trash-can"/>
                                         <p:commandButton  styleClass="linkButton" ajax="false" value="Duplicate Config Options" icon="pi pi-database" action="#{configOptionController.navigateToDuplicateOptions()}"/>
+                                        <p:commandButton  styleClass="linkButton" ajax="false" value="Duplicate Departments" icon="pi pi-database" action="#{departmentController.navigateToDuplicateDepartments()}"/>
 
 
                                     </div>

--- a/src/main/webapp/admin/institutions/department_duplicates.xhtml
+++ b/src/main/webapp/admin/institutions/department_duplicates.xhtml
@@ -1,0 +1,30 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
+      xmlns:p="http://primefaces.org/ui"
+      xmlns:h="http://xmlns.jcp.org/jsf/html"
+      xmlns:f="http://xmlns.jcp.org/jsf/core">
+    <h:body>
+        <ui:composition template="/admin/institutions/admin_institutions_index.xhtml">
+            <ui:define name="admin">
+                <h:form id="dupForm">
+                    <p:panel header="Duplicate Departments">
+                        <p:commandButton value="Refresh" icon="pi pi-refresh"
+                                         action="#{departmentController.detectDuplicateDepartments()}"
+                                         update="dupTable"/>
+                        <p:dataTable id="dupTable" var="grp" value="#{departmentController.duplicateGroups}" paginator="true" rows="10">
+                            <p:column headerText="Name">#{grp.name}</p:column>
+                            <p:column headerText="Count">#{grp.departments.size()}</p:column>
+                            <p:column headerText="Action">
+                                <p:commandButton value="Retire Extras" icon="pi pi-trash"
+                                                 action="#{departmentController.retireDuplicateGroup(grp)}"
+                                                 update="dupTable"/>
+                            </p:column>
+                        </p:dataTable>
+                    </p:panel>
+                </h:form>
+            </ui:define>
+        </ui:composition>
+    </h:body>
+</html>


### PR DESCRIPTION
## Summary
- prevent saving duplicate departments based on case-insensitive name matching
- provide methods to find and retire duplicate departments
- add duplicate-department management page and link from admin index

## Testing
- `mvn -q -DskipTests package` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f621b0e24832f8cac4880054b0341