### PR TITLE
Fix slip memo binding

### DIFF
--- a/src/main/java/com/divudi/bean/pharmacy/GoodsReturnController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/GoodsReturnController.java
@@ -454,6 +454,7 @@ public class GoodsReturnController implements Serializable {
     public Payment createPayment(Bill bill, PaymentMethod pm) {
         Payment p = new Payment();
         p.setBill(bill);
+        p.setComments(bill.getPaymentMemo());
         setPaymentMethodData(p, pm);
         return p;
     }

--- a/src/main/java/com/divudi/core/entity/Bill.java
+++ b/src/main/java/com/divudi/core/entity/Bill.java
@@ -112,6 +112,8 @@ public class Bill implements Serializable, RetirableEntity {
     @Lob
     private String comments;
     @Lob
+    private String paymentMemo;
+    @Lob
     private String indication;
     // Bank Detail
     private String creditCardRefNo;
@@ -943,6 +945,7 @@ public class Bill implements Serializable, RetirableEntity {
         referringDepartment = bill.getReferringDepartment();
         surgeryBillType = bill.getSurgeryBillType();
         comments = bill.getComments();
+        paymentMemo = bill.getPaymentMemo();
         indication = bill.getIndication();
         paymentMethod = bill.getPaymentMethod();
         paymentScheme = bill.getPaymentScheme();
@@ -1018,6 +1021,7 @@ public class Bill implements Serializable, RetirableEntity {
         referringDepartment = bill.getReferringDepartment();
         surgeryBillType = bill.getSurgeryBillType();
         comments = bill.getComments();
+        paymentMemo = bill.getPaymentMemo();
         indication = bill.getIndication();
         paymentMethod = bill.getPaymentMethod();
         paymentScheme = bill.getPaymentScheme();
@@ -1759,6 +1763,14 @@ public class Bill implements Serializable, RetirableEntity {
 
     public void setComments(String comments) {
         this.comments = comments;
+    }
+
+    public String getPaymentMemo() {
+        return paymentMemo;
+    }
+
+    public void setPaymentMemo(String paymentMemo) {
+        this.paymentMemo = paymentMemo;
     }
 
     public Bill getReferenceBill() {

--- a/src/main/webapp/pharmacy/pharmacy_return_good.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_return_good.xhtml
@@ -171,7 +171,7 @@
                                 <h:outputLabel id="lblSlipRef" value="Slip Memo"
                                                rendered="#{goodsReturnController.returnBill.paymentMethod eq 'Slip'}" />
                                 <p:inputText autocomplete="off" id="txtSlipRef"
-                                             value="#{goodsReturnController.returnBill.comments}"
+                                             value="#{goodsReturnController.returnBill.paymentMemo}"
                                              rendered="#{goodsReturnController.returnBill.paymentMethod eq 'Slip'}" />
 
                                 <h:outputLabel value="Bank"


### PR DESCRIPTION
## Summary
- add paymentMemo field to Bill
- copy paymentMemo when cloning bills
- include payment memo in GoodsReturnController payment
- bind Slip Memo field to paymentMemo

Closes #12728

------
https://chatgpt.com/codex/tasks/task_e_6860276df6a8832f90d7701709465c91