### PR TITLE
12728 fix field binding conflict between slip memo and general comments in pharmacy return goods

### DIFF
--- a/src/main/java/com/divudi/bean/pharmacy/GoodsReturnController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/GoodsReturnController.java
@@ -454,6 +454,7 @@ public class GoodsReturnController implements Serializable {
     public Payment createPayment(Bill bill, PaymentMethod pm) {
         Payment p = new Payment();
         p.setBill(bill);
+        p.setComments(bill.getPaymentMemo());
         setPaymentMethodData(p, pm);
         return p;
     }

--- a/src/main/java/com/divudi/core/entity/Bill.java
+++ b/src/main/java/com/divudi/core/entity/Bill.java
@@ -112,6 +112,8 @@ public class Bill implements Serializable, RetirableEntity {
     @Lob
     private String comments;
     @Lob
+    private String paymentMemo;
+    @Lob
     private String indication;
     // Bank Detail
     private String creditCardRefNo;
@@ -943,6 +945,7 @@ public class Bill implements Serializable, RetirableEntity {
         referringDepartment = bill.getReferringDepartment();
         surgeryBillType = bill.getSurgeryBillType();
         comments = bill.getComments();
+        paymentMemo = bill.getPaymentMemo();
         indication = bill.getIndication();
         paymentMethod = bill.getPaymentMethod();
         paymentScheme = bill.getPaymentScheme();
@@ -1018,6 +1021,7 @@ public class Bill implements Serializable, RetirableEntity {
         referringDepartment = bill.getReferringDepartment();
         surgeryBillType = bill.getSurgeryBillType();
         comments = bill.getComments();
+        paymentMemo = bill.getPaymentMemo();
         indication = bill.getIndication();
         paymentMethod = bill.getPaymentMethod();
         paymentScheme = bill.getPaymentScheme();
@@ -1759,6 +1763,14 @@ public class Bill implements Serializable, RetirableEntity {
 
     public void setComments(String comments) {
         this.comments = comments;
+    }
+
+    public String getPaymentMemo() {
+        return paymentMemo;
+    }
+
+    public void setPaymentMemo(String paymentMemo) {
+        this.paymentMemo = paymentMemo;
     }
 
     public Bill getReferenceBill() {

--- a/src/main/webapp/pharmacy/pharmacy_return_good.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_return_good.xhtml
@@ -171,7 +171,7 @@
                                 <h:outputLabel id="lblSlipRef" value="Slip Memo"
                                                rendered="#{goodsReturnController.returnBill.paymentMethod eq 'Slip'}" />
                                 <p:inputText autocomplete="off" id="txtSlipRef"
-                                             value="#{goodsReturnController.returnBill.comments}"
+                                             value="#{goodsReturnController.returnBill.paymentMemo}"
                                              rendered="#{goodsReturnController.returnBill.paymentMethod eq 'Slip'}" />
 
                                 <h:outputLabel value="Bank"


### PR DESCRIPTION
add paymentMemo field to Bill
copy paymentMemo when cloning bills
include payment memo in GoodsReturnController payment
bind Slip Memo field to paymentMemo

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new "Slip Memo" field for payment details during goods return, allowing users to enter and save additional payment-related notes.

* **Improvements**
  * The memo entered in the "Slip Memo" field is now properly saved and associated with the payment record for better tracking and reference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->