### PR TITLE
Add pharmacy token number search option

### DIFF
--- a/src/main/java/com/divudi/bean/common/SearchController.java
+++ b/src/main/java/com/divudi/bean/common/SearchController.java
@@ -7850,6 +7850,11 @@ public class SearchController implements Serializable {
             temMap.put("total", "%" + getSearchKeyword().getTotal().trim().toUpperCase() + "%");
         }
 
+        if (getSearchKeyword().getTokenNumber() != null && !getSearchKeyword().getTokenNumber().trim().equals("")) {
+            sql += " and exists (select t from Token t where t.bill=b and upper(t.tokenNumber) like :token)";
+            temMap.put("token", "%" + getSearchKeyword().getTokenNumber().trim().toUpperCase() + "%");
+        }
+
         if (getReportKeyWord().getDepartment() != null) {
             sql += " and b.department=:dep ";
             temMap.put("dep", getReportKeyWord().getDepartment());
@@ -8183,6 +8188,11 @@ public class SearchController implements Serializable {
             parameters.put("total", "%" + getSearchKeyword().getTotal().trim().toUpperCase() + "%");
         }
 
+        if (getSearchKeyword().getTokenNumber() != null && !getSearchKeyword().getTokenNumber().trim().equals("")) {
+            sql += " and  (upper(token.tokenNumber) like :token)";
+            parameters.put("token", "%" + getSearchKeyword().getTokenNumber().trim().toUpperCase() + "%");
+        }
+
         sql += " order by token.tokenAt desc";
 
         List<Token> tokenList = tokenFacade.findByJpqlWithoutCache(sql, parameters, TemporalType.TIMESTAMP, 25);
@@ -8230,6 +8240,11 @@ public class SearchController implements Serializable {
         if (getSearchKeyword().getTotal() != null && !getSearchKeyword().getTotal().trim().equals("")) {
             sql += " and  ((token.bill.total) like :total )";
             parameters.put("total", "%" + getSearchKeyword().getTotal().trim().toUpperCase() + "%");
+        }
+
+        if (getSearchKeyword().getTokenNumber() != null && !getSearchKeyword().getTokenNumber().trim().equals("")) {
+            sql += " and  (upper(token.tokenNumber) like :token)";
+            parameters.put("token", "%" + getSearchKeyword().getTokenNumber().trim().toUpperCase() + "%");
         }
 
         sql += " order by token.tokenAt desc";

--- a/src/main/java/com/divudi/core/data/dataStructure/SearchKeyword.java
+++ b/src/main/java/com/divudi/core/data/dataStructure/SearchKeyword.java
@@ -49,6 +49,7 @@ public class SearchKeyword {
     private String insId;
     private String deptId;
     private String serialNumber;
+    private String tokenNumber;
     private String serviceName;
     private PatientEncounter patientEncounter;
     private PaymentMethod paymentMethod;
@@ -422,6 +423,14 @@ public class SearchKeyword {
 
     public void setSerialNumber(String serialNumber) {
         this.serialNumber = serialNumber;
+    }
+
+    public String getTokenNumber() {
+        return tokenNumber;
+    }
+
+    public void setTokenNumber(String tokenNumber) {
+        this.tokenNumber = tokenNumber;
     }
 
     public Department getItemDepartment() {

--- a/src/main/webapp/pharmacy/pharmacy_search_pre_bill.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_search_pre_bill.xhtml
@@ -43,6 +43,8 @@
 
                                 <h:outputLabel value="Bill No"/>
                                 <p:inputText autocomplete="off" class="w-100" value="#{searchController.searchKeyword.billNo}" />
+                                <h:outputLabel rendered="#{configOptionApplicationController.getBooleanValueByKey('Enable token system in sale for cashier', false)}" value="Token Number"/>
+                                <p:inputText autocomplete="off" class="w-100" rendered="#{configOptionApplicationController.getBooleanValueByKey('Enable token system in sale for cashier', false)}" value="#{searchController.searchKeyword.tokenNumber}" />
                                 <h:outputLabel value="Patient Name"/>
                                 <p:inputText autocomplete="off" class="w-100" value="#{searchController.searchKeyword.patientName}" />
                                 <h:outputLabel value="Total"/>


### PR DESCRIPTION
## Summary
- store token number in `SearchKeyword`
- filter pharmacy bill queries by token number
- allow searching by token number in the cashier bill search page

## Testing
- `mvn -q test` *(fails: Could not download maven-resources-plugin)*

------
https://chatgpt.com/codex/tasks/task_e_686027e87454832f884ae1dfada99676