### PR TITLE
13480 focus on discount rate get the calculations wrong in grn

### DIFF
--- a/src/main/java/com/divudi/bean/pharmacy/GrnCostingController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/GrnCostingController.java
@@ -613,7 +613,7 @@ public class GrnCostingController implements Serializable {
         getGrnBill().setCreatedAt(Calendar.getInstance().getTime());
         getGrnBill().setBillExpenses(billExpenses);
         getGrnBill().setExpenseTotal(calExpenses());
-        calGrossTotal();
+//        calGrossTotal();
         getGrnBill().setNetTotal(getGrnBill().getNetTotal() - calExpenses());
         pharmacyCalculation.calculateRetailSaleValueAndFreeValueAtPurchaseRate(getGrnBill());
         updateBalanceForGrn(getGrnBill());

--- a/src/main/java/com/divudi/bean/pharmacy/GrnCostingController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/GrnCostingController.java
@@ -553,10 +553,6 @@ public class GrnCostingController implements Serializable {
 
     private void processBillItems() {
         for (BillItem i : getBillItems()) {
-            if ((i.getTmpQty() == 0.0 && i.getTmpFreeQty() == 0.0)
-                    || (i.getTmpQty() < 0.0 && i.getTmpFreeQty() < 0.0)) {
-                continue;
-            }
             applyFinanceDetailsToPharmaceutical(i);
             PharmaceuticalBillItem ph = i.getPharmaceuticalBillItem();
             i.setPharmaceuticalBillItem(null);

--- a/src/main/java/com/divudi/service/pharmacy/PharmacyCostingService.java
+++ b/src/main/java/com/divudi/service/pharmacy/PharmacyCostingService.java
@@ -107,9 +107,6 @@ public class PharmacyCostingService {
      * @param bill
      */
     public void distributeProportionalBillValuesToItems(List<BillItem> billItems, Bill bill) {
-        System.out.println("distributeProportionalBillValuesToItems");
-        System.out.println("bill = " + bill);
-        System.out.println("billItems = " + billItems);
         if (bill == null) {
             return;
         }
@@ -118,7 +115,6 @@ public class PharmacyCostingService {
             bill.setBillFinanceDetails(new BillFinanceDetails(bill));
         }
 
-        System.out.println("bill.getDiscount() = " + bill.getDiscount());
 
         bill.getBillFinanceDetails().setBillDiscount(BigDecimal.valueOf(bill.getDiscount()));
         bill.getBillFinanceDetails().setBillTaxValue(BigDecimal.valueOf(bill.getTax()));
@@ -148,7 +144,6 @@ public class PharmacyCostingService {
         }
 
         BigDecimal billDiscountTotal = Optional.ofNullable(bill.getBillFinanceDetails().getBillDiscount()).orElse(BigDecimal.ZERO);
-        System.out.println("billDiscountTotal = " + billDiscountTotal);
         BigDecimal billExpenseTotal = Optional.ofNullable(bill.getBillFinanceDetails().getBillExpense()).orElse(BigDecimal.ZERO);
         BigDecimal billTaxTotal = Optional.ofNullable(bill.getBillFinanceDetails().getBillTaxValue()).orElse(BigDecimal.ZERO);
 
@@ -287,12 +282,10 @@ public class PharmacyCostingService {
     }
 
     public void calculateBillTotalsFromItemsForPurchases(Bill bill, List<BillItem> billItems) {
-        System.out.println("calculateBillTotalsFromItemsForPurchases");
         int serialNo = 0;
 
         // Only bill-level values provided by user
         BigDecimal billDiscount = BigDecimal.valueOf(bill.getDiscount());
-        System.out.println("billDiscount = " + billDiscount);
         BigDecimal billExpense = BigDecimal.valueOf(bill.getExpenseTotal());
         BigDecimal billTax = BigDecimal.valueOf(bill.getTax());
         BigDecimal billCost = billDiscount.subtract(billExpense.add(billTax));
@@ -382,7 +375,6 @@ public class PharmacyCostingService {
         // Set legacy totals on Bill
         bill.setTotal(grossTotal.doubleValue());
         bill.setNetTotal(netTotal.doubleValue());
-        System.out.println("bill.getNetTotal() = " + bill.getNetTotal());
         bill.setSaleValue(totalRetail.doubleValue());
 
         // Ensure BillFinanceDetails is present
@@ -394,7 +386,6 @@ public class PharmacyCostingService {
 
         // Set calculated values
         bfd.setBillDiscount(billDiscount);
-        System.out.println("bfd.getBillDiscount() = " + bfd.getBillDiscount());
         bfd.setBillExpense(billExpense);
         bfd.setBillTaxValue(billTax);
         bfd.setBillCostValue(billCost);
@@ -519,7 +510,6 @@ public class PharmacyCostingService {
         // Set legacy totals on Bill
         bill.setTotal(grossTotal.doubleValue());
         bill.setNetTotal(netTotal.doubleValue());
-        System.out.println("bill.getNetTotal() = " + bill.getNetTotal());
         bill.setSaleValue(totalRetail.doubleValue());
 
         // Ensure BillFinanceDetails is present
@@ -531,7 +521,6 @@ public class PharmacyCostingService {
 
         // Set calculated values
         bfd.setBillDiscount(billDiscount);
-        System.out.println("bfd.getBillDiscount() = " + bfd.getBillDiscount());
         bfd.setBillExpense(billExpense);
         bfd.setBillTaxValue(billTax);
         bfd.setBillCostValue(billCost);

--- a/src/main/resources/META-INF/persistence.xml
+++ b/src/main/resources/META-INF/persistence.xml
@@ -2,7 +2,7 @@
 <persistence version="2.2" xmlns="http://java.sun.com/xml/ns/persistence" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/persistence http://xmlns.jcp.org/xml/ns/persistence/persistence_2_2.xsd">
     <persistence-unit name="hmisPU" transaction-type="JTA">
         <provider>org.eclipse.persistence.jpa.PersistenceProvider</provider>
-        <jta-data-source>${JDBC_DATASOURCE}</jta-data-source>
+        <jta-data-source>jdbc/coop</jta-data-source>
         <exclude-unlisted-classes>false</exclude-unlisted-classes>
         <properties>
             <property name="eclipselink.logging.level.sql" value="SEVERE"/>
@@ -10,7 +10,7 @@
         </properties>
     </persistence-unit>
     <persistence-unit name="hmisAuditPU" transaction-type="JTA">
-        <jta-data-source>${JDBC_AUDIT_DATASOURCE}</jta-data-source>
+        <jta-data-source>jdbc/ruhunuAudit</jta-data-source>
         <exclude-unlisted-classes>false</exclude-unlisted-classes>
         <properties>
             <property name="eclipselink.logging.level.sql" value="SEVERE"/>

--- a/src/main/resources/META-INF/persistence.xml
+++ b/src/main/resources/META-INF/persistence.xml
@@ -2,7 +2,7 @@
 <persistence version="2.2" xmlns="http://java.sun.com/xml/ns/persistence" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/persistence http://xmlns.jcp.org/xml/ns/persistence/persistence_2_2.xsd">
     <persistence-unit name="hmisPU" transaction-type="JTA">
         <provider>org.eclipse.persistence.jpa.PersistenceProvider</provider>
-        <jta-data-source>jdbc/coop</jta-data-source>
+        <jta-data-source>${JDBC_DATASOURCE}</jta-data-source>
         <exclude-unlisted-classes>false</exclude-unlisted-classes>
         <properties>
             <property name="eclipselink.logging.level.sql" value="SEVERE"/>
@@ -10,7 +10,7 @@
         </properties>
     </persistence-unit>
     <persistence-unit name="hmisAuditPU" transaction-type="JTA">
-        <jta-data-source>jdbc/ruhunuAudit</jta-data-source>
+        <jta-data-source>${JDBC_AUDIT_DATASOURCE}</jta-data-source>
         <exclude-unlisted-classes>false</exclude-unlisted-classes>
         <properties>
             <property name="eclipselink.logging.level.sql" value="SEVERE"/>

--- a/src/main/webapp/pharmacy/direct_purchase.xhtml
+++ b/src/main/webapp/pharmacy/direct_purchase.xhtml
@@ -500,9 +500,17 @@
                                     itemValue="#{vt}" />
 
                                 <p:outputLabel value="Invoice No  "/>
-                                <p:inputText class="w-100" autocomplete="off" value="#{pharmacyDirectPurchaseController.bill.invoiceNumber}" />
+                                <p:inputText class="w-100" autocomplete="off" value="#{pharmacyDirectPurchaseController.bill.invoiceNumber}" >
+                                    <p:ajax process="@this" event="keyup"></p:ajax>
+                                </p:inputText>
                                 <p:outputLabel value="Invoice Date"/>
-                                <p:calendar class="w-100" inputStyleClass="w-100" value="#{pharmacyDirectPurchaseController.bill.invoiceDate}"   navigator="true" pattern="#{sessionController.applicationPreference.shortDateFormat}" />
+                                <p:calendar class="w-100" 
+                                            inputStyleClass="w-100" 
+                                            value="#{pharmacyDirectPurchaseController.bill.invoiceDate}"  
+                                            navigator="true"
+                                            pattern="#{sessionController.applicationPreference.shortDateFormat}" >
+                                    <p:ajax process="@this" ></p:ajax>
+                                </p:calendar>
 
                                 <h:outputLabel value="Payment Method" class="mb-2"/>
                                 <p:selectOneMenu style="width: 300px;" id="cmbPs" value="#{pharmacyDirectPurchaseController.bill.paymentMethod}">
@@ -580,7 +588,7 @@
                                     <h:panelGroup id="billFinanceDetails" >
                                         <ph:bill_finance_details bill="#{pharmacyDirectPurchaseController.bill}" ></ph:bill_finance_details>
                                     </h:panelGroup>
-                                    
+
                                 </p:tab>
 
                             </p:tabView>


### PR DESCRIPTION
The error of lossing invoice number etc was not sending data by ajes for those and refreshing the controls, It was corrected
THe bill items were lost not because of discount, but because errornously checikng a retired attribute, but it arise only when free items added. Both corrected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced the direct purchase form with dynamic, real-time updates for invoice number and date fields using AJAX, improving user interaction and responsiveness.

* **Refactor**
  * Removed debug print statements from the pharmacy costing service for cleaner application logs.

* **Bug Fixes**
  * Adjusted bill item processing so all items are handled regardless of temporary quantity values.
  * Disabled recalculation of gross total during final settlement in bill processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->