### PR TITLE
Add item detail button to transfer request

### DIFF
--- a/src/main/java/com/divudi/bean/pharmacy/TransferRequestController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/TransferRequestController.java
@@ -203,6 +203,10 @@ public class TransferRequestController implements Serializable {
         getPharmacyController().setPharmacyItem(getCurrentBillItem().getItem());
     }
 
+    public void displayItemDetails(BillItem bi) {
+        getPharmacyController().fillItemDetails(bi.getItem());
+    }
+
     public void saveBill() {
         if (getBill().getId() == null) {
 

--- a/src/main/webapp/pharmacy/pharmacy_transfer_request.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_transfer_request.xhtml
@@ -145,14 +145,23 @@
                                       scrollHeight="250"  value="#{transferRequestController.billItems}"
                                       id="itemList" editable="true" >
 
-                            <p:column headerText="Item Name" >
-                                #{bi.item.name}
+                            <p:column headerText="Item Name">
+                                <h:outputText
+                                    id="item"
+                                    value="#{bi.item.name}" />
+                                <p:commandButton
+                                    icon="pi pi-search"
+                                    id="btnViewSelectedItemDetails"
+                                    title="View Item Details"
+                                    action="#{transferRequestController.displayItemDetails(bi)}"
+                                    update=":#{p:resolveFirstComponentWithId('tab',view).clientId}"
+                                    process="@this"
+                                    class="ui-button-icon-only mx-3"/>
                             </p:column>
 
                             <p:column headerText="Qty" >
                                 <p:inputText autocomplete="off"  id="qty" value="#{bi.tmpQty}" label="Qty">
                                     <f:ajax event="blur" render=":#{p:resolveFirstComponentWithId('tab',view).clientId} "  execute="@this" listener="#{transferRequestController.onEdit(bi)}" ></f:ajax>
-                                    <f:ajax event="focus" render=":#{p:resolveFirstComponentWithId('tab',view).clientId} "  execute="@this" listener="#{transferRequestController.onEdit(bi)}" ></f:ajax>
                                 </p:inputText>
                             </p:column>
 


### PR DESCRIPTION
## Summary
- add item history button to view selected item details in `pharmacy_transfer_request.xhtml`
- remove focus listener that previously loaded item details on focus
- support new button by implementing `displayItemDetails` in `TransferRequestController`

## Testing
- `mvn -q test` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6860cb93dc54832fb30c6504411e7dae