### PR TITLE
Add finalize and approval purchase order menu

### DIFF
--- a/src/main/java/com/divudi/bean/common/SearchController.java
+++ b/src/main/java/com/divudi/bean/common/SearchController.java
@@ -14364,6 +14364,16 @@ public class SearchController implements Serializable {
         return "/pharmacy/pharmacy_purhcase_order_list_to_cancel?faces-redirect=true";
     }
 
+    public String navigateToPurchaseOrderFinalize() {
+        makeNull();
+        return "/pharmacy/pharmacy_purhcase_order_list?faces-redirect=true";
+    }
+
+    public String navigateToPurchaseOrderApprove() {
+        makeNull();
+        return "/pharmacy/pharmacy_purhcase_order_list_to_approve?faces-redirect=true";
+    }
+
     public void createDocPaymentDue() {
         if (getReportKeyWord().getString().equals("0")) {
             fetchDueFeeTable(new BillType[]{BillType.OpdBill, BillType.CollectingCentreBill}, false);

--- a/src/main/webapp/resources/ezcomp/menu.xhtml
+++ b/src/main/webapp/resources/ezcomp/menu.xhtml
@@ -912,12 +912,17 @@
                             rendered="#{webUserController.hasPrivilege('DirectPurchase') and configOptionApplicationController.getBooleanValueByKey('Manage Costing', true)}" >
                         </p:menuitem>
 
-                        <p:menuitem  
-                            ajax="false" 
-                            action="/pharmacy/pharmacy_purhcase_order_list_to_approve?faces-redirect=true"  
+                        <p:menuitem
+                            ajax="false"
+                            action="#{searchController.navigateToPurchaseOrderFinalize}"
+                            value="Finalize Purchase Orders"
+                            icon="fas fa-tasks"
+                            rendered="#{webUserController.hasPrivilege('PurchaseOrdersApprovel') or webUserController.hasPrivilege('CreatePurchaseOrder')}" ></p:menuitem>
+                        <p:menuitem
+                            ajax="false"
+                            action="#{searchController.navigateToPurchaseOrderApprove}"
                             value="Purchase Orders Approval"
                             icon="fas fa-clipboard-check"
-                            actionListener="#{searchController.makeListNull()}" 
                             rendered="#{webUserController.hasPrivilege('PurchaseOrdersApprovel') or webUserController.hasPrivilege('CreatePurchaseOrder')}" ></p:menuitem>
                         <p:menuitem
                             ajax="false"


### PR DESCRIPTION
## Summary
- split Purchase Orders Approval menu into Finalize Purchase Orders and Purchase Orders Approval
- add new search controller navigation methods for finalization and approval lists

## Testing
- `mvn -q -DskipTests install` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6860caa9a3e0832fb28b2ab4891bfb04