### PR TITLE
13457 - fix GRN history display

### DIFF
--- a/src/main/java/com/divudi/core/data/dto/PharmacyGrnItemDTO.java
+++ b/src/main/java/com/divudi/core/data/dto/PharmacyGrnItemDTO.java
@@ -1,0 +1,138 @@
+package com.divudi.core.data.dto;
+
+import java.io.Serializable;
+import java.math.BigDecimal;
+import java.util.Date;
+
+public class PharmacyGrnItemDTO implements Serializable {
+    private String grnNo;
+    private String departmentName;
+    private Date createdAt;
+    private String poNo;
+    private String supplierName;
+    private String itemName;
+    private BigDecimal quantity;
+    private BigDecimal freeQuantity;
+    private BigDecimal purchaseRate;
+    private BigDecimal totalCostRate;
+    private BigDecimal retailSaleRate;
+    private BigDecimal netTotal;
+
+    public PharmacyGrnItemDTO() {
+    }
+
+    public PharmacyGrnItemDTO(String grnNo, String departmentName, Date createdAt,
+                              String poNo, String supplierName, String itemName,
+                              BigDecimal quantity, BigDecimal freeQuantity,
+                              BigDecimal purchaseRate, BigDecimal totalCostRate,
+                              BigDecimal retailSaleRate, BigDecimal netTotal) {
+        this.grnNo = grnNo;
+        this.departmentName = departmentName;
+        this.createdAt = createdAt;
+        this.poNo = poNo;
+        this.supplierName = supplierName;
+        this.itemName = itemName;
+        this.quantity = quantity;
+        this.freeQuantity = freeQuantity;
+        this.purchaseRate = purchaseRate;
+        this.totalCostRate = totalCostRate;
+        this.retailSaleRate = retailSaleRate;
+        this.netTotal = netTotal;
+    }
+
+    public String getGrnNo() {
+        return grnNo;
+    }
+
+    public void setGrnNo(String grnNo) {
+        this.grnNo = grnNo;
+    }
+
+    public String getDepartmentName() {
+        return departmentName;
+    }
+
+    public void setDepartmentName(String departmentName) {
+        this.departmentName = departmentName;
+    }
+
+    public Date getCreatedAt() {
+        return createdAt;
+    }
+
+    public void setCreatedAt(Date createdAt) {
+        this.createdAt = createdAt;
+    }
+
+    public String getPoNo() {
+        return poNo;
+    }
+
+    public void setPoNo(String poNo) {
+        this.poNo = poNo;
+    }
+
+    public String getSupplierName() {
+        return supplierName;
+    }
+
+    public void setSupplierName(String supplierName) {
+        this.supplierName = supplierName;
+    }
+
+    public String getItemName() {
+        return itemName;
+    }
+
+    public void setItemName(String itemName) {
+        this.itemName = itemName;
+    }
+
+    public BigDecimal getQuantity() {
+        return quantity;
+    }
+
+    public void setQuantity(BigDecimal quantity) {
+        this.quantity = quantity;
+    }
+
+    public BigDecimal getFreeQuantity() {
+        return freeQuantity;
+    }
+
+    public void setFreeQuantity(BigDecimal freeQuantity) {
+        this.freeQuantity = freeQuantity;
+    }
+
+    public BigDecimal getPurchaseRate() {
+        return purchaseRate;
+    }
+
+    public void setPurchaseRate(BigDecimal purchaseRate) {
+        this.purchaseRate = purchaseRate;
+    }
+
+    public BigDecimal getTotalCostRate() {
+        return totalCostRate;
+    }
+
+    public void setTotalCostRate(BigDecimal totalCostRate) {
+        this.totalCostRate = totalCostRate;
+    }
+
+    public BigDecimal getRetailSaleRate() {
+        return retailSaleRate;
+    }
+
+    public void setRetailSaleRate(BigDecimal retailSaleRate) {
+        this.retailSaleRate = retailSaleRate;
+    }
+
+    public BigDecimal getNetTotal() {
+        return netTotal;
+    }
+
+    public void setNetTotal(BigDecimal netTotal) {
+        this.netTotal = netTotal;
+    }
+}

--- a/src/main/webapp/resources/pharmacy/history.xhtml
+++ b/src/main/webapp/resources/pharmacy/history.xhtml
@@ -486,7 +486,33 @@
                                     </p:row>
                                 </p:columnGroup>
 
-                            </p:dataTable> 
+                            </p:dataTable>
+                        </p:panel>
+                    </h:panelGroup>
+                    <h:panelGroup
+                        layout="block"
+                        class="col-3"
+                        id="itemDetailsBlockGrn"
+                        rendered="#{configOptionApplicationController.getBooleanValueByKey('Pharmacy Item Details Section - Display GRN Block', true)}" >
+                        <p:panel>
+                            <div style="background-color: #337357; padding: 10px; font-weight: bold; color: white; text-align: center;">
+                                GRN Details
+                            </div>
+                            <p:dataTable styleClass="noBorder" value="#{pharmacyController.grnDtos}" var="g">
+                                <p:column headerText="GRN No">#{g.grnNo}</p:column>
+                                <p:column headerText="Dept">#{g.departmentName}</p:column>
+                                <p:column headerText="Date">
+                                    <h:outputLabel value="#{g.createdAt}">
+                                        <f:convertDateTime timeZone="Asia/Colombo" pattern="#{sessionController.applicationPreference.longDateFormat}" />
+                                    </h:outputLabel>
+                                </p:column>
+                                <p:column headerText="Qty">#{g.quantity}</p:column>
+                                <p:column headerText="Value">
+                                    <h:outputText value="#{g.netTotal}">
+                                        <f:convertNumber pattern="#,##0.00" />
+                                    </h:outputText>
+                                </p:column>
+                            </p:dataTable>
                         </p:panel>
                     </h:panelGroup>
                 </div>
@@ -1135,55 +1161,55 @@
                     title="GRN" 
                     rendered="#{configOptionApplicationController.getBooleanValueByKey('Pharmacy Item Details Section - Display GRN Tab', true)}">
 
-                    <p:dataTable styleClass="noBorder" id="grn" value="#{pharmacyController.grns}" 
-                                 var="dd2" scrollable="true"  paginator="true" 
-                                 rows="10" 
+                    <p:dataTable styleClass="noBorder" id="grn" value="#{pharmacyController.grnDtos}"
+                                 var="dd2" scrollable="true"  paginator="true"
+                                 rows="10"
                                  paginatorPosition="bottom"
                                  paginatorTemplate="{CurrentPageReport}  {FirstPageLink} {PreviousPageLink} {PageLinks} {NextPageLink} {LastPageLink} {RowsPerPageDropdown}"
                                  rowsPerPageTemplate="5,10,15" >
                         <p:column headerText="GRN No">
-                            #{dd2.bill.deptId}
+                            #{dd2.grnNo}
                         </p:column>
                         <p:column headerText="Department">
-                            #{dd2.bill.department.name}
+                            #{dd2.departmentName}
                         </p:column>
                         <p:column headerText="Date">
-                            <h:outputLabel value="#{dd2.bill.createdAt}" >
+                            <h:outputLabel value="#{dd2.createdAt}" >
                                 <f:convertDateTime  timeZone="Asia/Colombo" pattern="#{sessionController.applicationPreference.longDateFormat}" ></f:convertDateTime>
                             </h:outputLabel>
                         </p:column>
                         <p:column headerText="PO No">
-                            <h:outputText value="#{dd2.bill.referenceBill.deptId}" />
+                            <h:outputText value="#{dd2.poNo}" />
                         </p:column>
                         <p:column headerText="Supplier">
-                            <h:outputText value="#{dd2.bill.fromInstitution.name}" />
+                            <h:outputText value="#{dd2.supplierName}" />
                         </p:column>
                         <p:column headerText="Item">
-                            <h:outputText value="#{dd2.item.name}" />
+                            <h:outputText value="#{dd2.itemName}" />
                         </p:column>
                         <p:column headerText="Qty">
-                            <h:outputText value="#{dd2.billItemFinanceDetails.quantity}" />
+                            <h:outputText value="#{dd2.quantity}" />
                         </p:column>
                         <p:column headerText="Fr. Qty">
-                            <h:outputText value="#{dd2.billItemFinanceDetails.freeQuantity}" />
+                            <h:outputText value="#{dd2.freeQuantity}" />
                         </p:column>
                         <p:column headerText="Purchase Rate">
-                            <h:outputText value="#{dd2.billItemFinanceDetails.purchaseRate}">
+                            <h:outputText value="#{dd2.purchaseRate}">
                                 <f:convertNumber pattern="#,##0.00" />
                             </h:outputText>
                         </p:column>
                         <p:column headerText="Cost Rate per unit">
-                            <h:outputText value="#{dd2.billItemFinanceDetails.totalCostRate}">
+                            <h:outputText value="#{dd2.totalCostRate}">
                                 <f:convertNumber pattern="#,##0.00" />
                             </h:outputText>
                         </p:column>
                         <p:column headerText="Sale Rate">
-                            <h:outputText value="#{dd2.billItemFinanceDetails.retailSaleRate}">
+                            <h:outputText value="#{dd2.retailSaleRate}">
                                 <f:convertNumber pattern="#,##0.00" />
                             </h:outputText>
                         </p:column>
                         <p:column headerText="Value">
-                            <h:outputText value="#{dd2.billItemFinanceDetails.netTotal}">
+                            <h:outputText value="#{dd2.netTotal}">
                                 <f:convertNumber pattern="#,##0.00" />
                             </h:outputText>
                         </p:column>


### PR DESCRIPTION
## Summary
- add `PharmacyGrnItemDTO` to hold history table data
- build GRN history using billTypeAtomic values
- display GRN history DTOs in history.xhtml
- add block for GRN details

Closes #13457

------
https://chatgpt.com/codex/tasks/task_e_68611c42a160832f912c872392865ca8