### PR TITLE
Add configurable transfer request receipt

### DIFF
--- a/src/main/java/com/divudi/bean/common/ConfigOptionApplicationController.java
+++ b/src/main/java/com/divudi/bean/common/ConfigOptionApplicationController.java
@@ -105,6 +105,7 @@ public class ConfigOptionApplicationController implements Serializable {
         loadPharmacyConfigurationDefaults();
         loadPharmacyIssueReceiptConfigurationDefaults();
         loadPharmacyTransferIssueReceiptConfigurationDefaults();
+        loadPharmacyTransferRequestReceiptConfigurationDefaults();
         loadPharmacyDirectPurchaseWithoutCostingConfigurationDefaults();
     }
 
@@ -206,6 +207,65 @@ public class ConfigOptionApplicationController implements Serializable {
 
     private void loadPharmacyTransferIssueReceiptConfigurationDefaults() {
         getLongTextValueByKey("Pharmacy Transfer Issue Receipt CSS",
+                ".receipt-container {\n"
+                + "    font-family: Verdana, sans-serif;\n"
+                + "    font-size: 12px;\n"
+                + "    color: #000;\n"
+                + "}\n"
+                + ".receipt-header, .receipt-title, .receipt-separator, .receipt-summary {\n"
+                + "    margin-bottom: 10px;\n"
+                + "}\n"
+                + ".receipt-institution-name {\n"
+                + "    font-weight: bold;\n"
+                + "    font-size: 16px;\n"
+                + "    text-align: center;\n"
+                + "}\n"
+                + ".receipt-institution-contact {\n"
+                + "    text-align: center;\n"
+                + "    font-size: 11px;\n"
+                + "}\n"
+                + ".receipt-title {\n"
+                + "    text-align: center;\n"
+                + "    font-size: 14px;\n"
+                + "    font-weight: bold;\n"
+                + "    text-decoration: underline;\n"
+                + "}\n"
+                + ".receipt-details-table, .receipt-items-table, .receipt-summary-table {\n"
+                + "    width: 100%;\n"
+                + "    border-collapse: collapse;\n"
+                + "}\n"
+                + ".receipt-items-header {\n"
+                + "    font-weight: bold;\n"
+                + "    border-bottom: 1px solid #ccc;\n"
+                + "}\n"
+                + ".item-name, .item-qty, .item-rate, .item-value {\n"
+                + "    padding: 4px;\n"
+                + "    text-align: left;\n"
+                + "}\n"
+                + ".item-qty, .item-rate, .item-value {\n"
+                + "    text-align: right;\n"
+                + "}\n"
+                + ".summary-label {\n"
+                + "    font-weight: bold;\n"
+                + "}\n"
+                + ".summary-value {\n"
+                + "    text-align: right;\n"
+                + "    font-weight: bold;\n"
+                + "}\n"
+                + ".total-amount {\n"
+                + "    font-size: 14px;\n"
+                + "    font-weight: bold;\n"
+                + "}\n"
+                + ".receipt-cashier {\n"
+                + "    margin-top: 20px;\n"
+                + "    text-align: right;\n"
+                + "    text-decoration: overline;\n"
+                + "}"
+        );
+    }
+
+    private void loadPharmacyTransferRequestReceiptConfigurationDefaults() {
+        getLongTextValueByKey("Pharmacy Transfer Request Receipt CSS",
                 ".receipt-container {\n"
                 + "    font-family: Verdana, sans-serif;\n"
                 + "    font-size: 12px;\n"

--- a/src/main/webapp/pharmacy/pharmacy_transfer_request.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_transfer_request.xhtml
@@ -5,7 +5,8 @@
                 xmlns:h="http://xmlns.jcp.org/jsf/html"
                 xmlns:p="http://primefaces.org/ui"
                 xmlns:f="http://xmlns.jcp.org/jsf/core"
-                xmlns:ph="http://xmlns.jcp.org/jsf/composite/pharmacy">
+                xmlns:ph="http://xmlns.jcp.org/jsf/composite/pharmacy"
+                xmlns:phi="http://xmlns.jcp.org/jsf/composite/pharmacy">
 
     <ui:define name="content">
         <h:form>
@@ -203,7 +204,7 @@
                     <p:printer target="gpBillPreview"></p:printer>
                 </p:commandButton>
                 <h:panelGroup id="gpBillPreview">
-                    <ph:transferRequest id="pharmacy_transfer_request_receipt" bill="#{transferRequestController.bill}" />
+                    <phi:pharmacy_transfer_request_receipt id="pharmacy_transfer_request_receipt" bill="#{transferRequestController.bill}" />
                 </h:panelGroup>
             </p:panel>
 

--- a/src/main/webapp/resources/pharmacy/pharmacy_transfer_request_receipt.xhtml
+++ b/src/main/webapp/resources/pharmacy/pharmacy_transfer_request_receipt.xhtml
@@ -1,0 +1,128 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:cc="http://xmlns.jcp.org/jsf/composite"
+      xmlns:f="http://xmlns.jcp.org/jsf/core"
+      xmlns:h="http://xmlns.jcp.org/jsf/html"
+      xmlns:ui="http://xmlns.jcp.org/jsf/facelets">
+
+    <!-- INTERFACE -->
+    <cc:interface>
+        <cc:attribute name="bill" type="com.divudi.core.entity.Bill"/>
+    </cc:interface>
+
+    <!-- IMPLEMENTATION -->
+    <cc:implementation>
+
+        <style>
+            <h:outputText escape="false"
+                          value="#{configOptionApplicationController.getLongTextValueByKey('Pharmacy Transfer Request Receipt CSS')}"/>
+        </style>
+
+        <h:outputText escape="false"
+                      value="#{configOptionApplicationController.getLongTextValueByKey('Pharmacy Transfer Request Receipt Header')}"/>
+
+        <div class="receipt-container">
+            <div class="receipt-header">
+                <div class="receipt-institution-name">
+                    <h:outputLabel value="#{cc.attrs.bill.institution.name}" />
+                </div>
+            </div>
+
+            <div class="receipt-title">
+                <h:outputLabel value="Pharmacy Transfer Request Receipt" />
+            </div>
+
+            <div class="receipt-separator"><hr /></div>
+
+            <div class="receipt-bill-details">
+                <table class="receipt-details-table">
+                    <tr>
+                        <td><h:outputLabel value="Request From" /></td>
+                        <td><h:outputLabel value=":" /></td>
+                        <td colspan="4"><h:outputLabel value="#{cc.attrs.bill.fromDepartment.name}  (#{cc.attrs.bill.fromDepartment.institution.name})" /></td>
+                    </tr>
+                    <tr>
+                        <td><h:outputLabel value="Request To" /></td>
+                        <td><h:outputLabel value=":" /></td>
+                        <td colspan="4"><h:outputLabel value="#{cc.attrs.bill.toDepartment.name}  (#{cc.attrs.bill.toDepartment.institution.name})" /></td>
+                    </tr>
+                    <tr>
+                        <td><h:outputLabel value="Req No" /></td>
+                        <td><h:outputLabel value=":" /></td>
+                        <td colspan="4"><h:outputLabel value="#{cc.attrs.bill.deptId}" /></td>
+                    </tr>
+                    <tr>
+                        <td><h:outputLabel value="Req Person" /></td>
+                        <td><h:outputLabel value=":" /></td>
+                        <td colspan="4"><h:outputLabel value="#{cc.attrs.bill.creater.webUserPerson.name}" /></td>
+                    </tr>
+                    <tr>
+                        <td><h:outputLabel value="Req Date" /></td>
+                        <td><h:outputLabel value=":" /></td>
+                        <td colspan="4">
+                            <h:outputLabel value="#{cc.attrs.bill.createdAt}">
+                                <f:convertDateTime timeZone="Asia/Colombo" pattern="#{sessionController.applicationPreference.longDateFormat}" />
+                            </h:outputLabel>
+                        </td>
+                    </tr>
+                    <tr>
+                        <td><h:outputLabel value="Req Time" /></td>
+                        <td><h:outputLabel value=":" /></td>
+                        <td colspan="4">
+                            <h:outputLabel value="#{cc.attrs.bill.createdAt}">
+                                <f:convertDateTime pattern="#{sessionController.applicationPreference.longTimeFormat}" />
+                            </h:outputLabel>
+                        </td>
+                    </tr>
+                </table>
+            </div>
+
+            <div class="receipt-separator"><hr /></div>
+
+            <div class="receipt-items-section">
+                <table class="receipt-items-table">
+                    <thead>
+                        <tr class="receipt-items-header">
+                            <th>No</th>
+                            <th class="item-name">Item Name</th>
+                            <th>Item Code</th>
+                            <th>Pack Size</th>
+                            <th class="item-qty">Qty</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <ui:repeat value="#{cc.attrs.bill.billItems}" var="bip" rowIndexVar="rowIndex">
+                            <tr>
+                                <td><h:outputLabel value="#{rowIndex+1}" /></td>
+                                <td class="item-name"><h:outputLabel value="#{bip.item.name}" /></td>
+                                <td><h:outputLabel value="#{bip.item.code}" /></td>
+                                <td>
+                                    <p:outputLabel value="#{bip.item.dblValue}" rendered="#{bip.item.class eq 'class com.divudi.core.entity.pharmacy.Ampp'}">
+                                        <f:convertNumber pattern="0.#" />
+                                    </p:outputLabel>
+                                    <p:outputLabel value="1" rendered="#{bip.item.class eq 'class com.divudi.core.entity.pharmacy.Amp'}" />
+                                </td>
+                                <td class="item-qty">
+                                    <h:outputLabel value="#{bip.qty}">
+                                        <f:convertNumber integerOnly="true" />
+                                    </h:outputLabel>
+                                </td>
+                            </tr>
+                        </ui:repeat>
+                    </tbody>
+                </table>
+            </div>
+
+            <div class="receipt-separator"><hr /></div>
+
+            <div style="#{configOptionApplicationController.getLongTextValueByKey('Pharmacy Transfer Request Bill Footer CSS')}">
+                <h:outputText value="#{configOptionApplicationController.getLongTextValueByKey('Pharmacy Transfer Request Bill Footer Text')}" escape="false" />
+            </div>
+        </div>
+
+        <h:outputText escape="false"
+                      value="#{configOptionApplicationController.getLongTextValueByKey('Pharmacy Transfer Request Receipt Footer')}"/>
+
+    </cc:implementation>
+</html>


### PR DESCRIPTION
## Summary
- add default configuration for Pharmacy Transfer Request Receipt
- implement a new composite receipt `pharmacy_transfer_request_receipt.xhtml`
- use new receipt on pharmacy transfer request page

## Testing
- `mvn test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686128089220832f9881076664a9d84f