### PR TITLE
Remove duplicated history column and unify prefix

### DIFF
--- a/src/main/webapp/pharmacy/pharmacy_transfer_request.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_transfer_request.xhtml
@@ -5,8 +5,7 @@
                 xmlns:h="http://xmlns.jcp.org/jsf/html"
                 xmlns:p="http://primefaces.org/ui"
                 xmlns:f="http://xmlns.jcp.org/jsf/core"
-                xmlns:ph="http://xmlns.jcp.org/jsf/composite/pharmacy"
-                xmlns:phi="http://xmlns.jcp.org/jsf/composite/pharmacy">
+                xmlns:ph="http://xmlns.jcp.org/jsf/composite/pharmacy">
 
     <ui:define name="content">
         <h:form>
@@ -204,7 +203,7 @@
                     <p:printer target="gpBillPreview"></p:printer>
                 </p:commandButton>
                 <h:panelGroup id="gpBillPreview">
-                    <phi:pharmacy_transfer_request_receipt id="pharmacy_transfer_request_receipt" bill="#{transferRequestController.bill}" />
+                    <ph:pharmacy_transfer_request_receipt id="pharmacy_transfer_request_receipt" bill="#{transferRequestController.bill}" />
                 </h:panelGroup>
             </p:panel>
 

--- a/src/main/webapp/resources/pharmacy/history.xhtml
+++ b/src/main/webapp/resources/pharmacy/history.xhtml
@@ -79,11 +79,6 @@
                                             <f:convertNumber integerOnly="true" />
                                         </h:outputLabel> 
                                     </p:column>
-                                    <p:column style="text-align: right;">
-                                        <h:outputLabel value="#{dep.stock}">       
-                                            <f:convertNumber integerOnly="true" />
-                                        </h:outputLabel> 
-                                    </p:column>
                                     <p:columnGroup type="footer">
                                         <p:row>
                                             <p:column footerText="Total Stock"></p:column>

--- a/src/main/webapp/resources/pharmacy/pharmacy_transfer_request_receipt.xhtml
+++ b/src/main/webapp/resources/pharmacy/pharmacy_transfer_request_receipt.xhtml
@@ -108,10 +108,10 @@
                             </h:column>
                             <h:column>
                                 <f:facet name="header">Pack Size</f:facet>
-                                <h:outputText value="#{bip.item.dblValue}" rendered="#{bip.item.class eq 'class com.divudi.core.entity.pharmacy.Ampp'}">
+                                <h:outputText value="#{bip.item.dblValue}" rendered="#{bip.item.class.simpleName eq 'Ampp'}">
                                     <f:convertNumber pattern="0.#" />
                                 </h:outputText>
-                                <h:outputText value="1" rendered="#{bip.item.class eq 'class com.divudi.core.entity.pharmacy.Amp'}" />
+                                <h:outputText value="1" rendered="#{bip.item.class.simpleName eq 'Amp'}" />
                             </h:column>
                             <h:column>
                                 <f:facet name="header">Qty</f:facet>


### PR DESCRIPTION
## Summary
- fix table structure in history.xhtml by removing duplicate column
- simplify transfer request receipt prefix usage
- clean up namespace declarations in pharmacy_transfer_request.xhtml

## Testing
- `mvn -q test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6861da5c8514832fa1797af2a6d73f38