### PR TITLE
Fix GRN costing net total column

### DIFF
--- a/src/main/webapp/pharmacy/pharmacy_grn_costing.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_grn_costing.xhtml
@@ -229,7 +229,7 @@
                         <h:panelGroup id="total">
                             <h:outputLabel
                                 class="text-end text-secondary w-100"
-                                value="#{bi.billItemFinanceDetails.lineGrossTotal}" >
+                                value="#{bi.billItemFinanceDetails.lineNetTotal}" >
                                 <f:convertNumber pattern="#,##0.00" />
                             </h:outputLabel>
                         </h:panelGroup>
@@ -299,7 +299,10 @@
 
                     </p:column>
 
-                </p:dataTable>  
+                </p:dataTable>
+                <div>
+                    <ph:history/>
+                </div>
                 <p:panel header="Bill Details" class="m-1">
                     <p:panelGrid  id="panelBillDetails" columns="3" class="w-100" >
                         <p:panelGrid columns="2" layout="tabular" class="w-100">


### PR DESCRIPTION
## Summary
- show lineNetTotal instead of lineGrossTotal on GRN costing page
- display history component for GRN costing items

## Testing
- `mvn -q test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_6863737243a0832fb3b61d3fb10a8cbb