### PR TITLE
Enable inline bill editing

### DIFF
--- a/src/main/webapp/opd/view/bill_admin.xhtml
+++ b/src/main/webapp/opd/view/bill_admin.xhtml
@@ -92,7 +92,7 @@
                                                 <h:outputText styleClass="fa-solid fa-file-invoice"></h:outputText>
                                                 <h:outputLabel value="Bill Details" class="mx-4"></h:outputLabel>
                                             </f:facet>
-                                            <view:out bill="#{billSearch.viewingBill}"/>
+                                            <view:bill_edit bill="#{billSearch.viewingBill}" editable="true"/>
                                         </p:panel>
                                     </p:tab>
                                     <p:tab title="Bill Items" >

--- a/src/main/webapp/opd/view/cc_deposit_bill_admin.xhtml
+++ b/src/main/webapp/opd/view/cc_deposit_bill_admin.xhtml
@@ -67,7 +67,7 @@
                                                 <h:outputText styleClass="fa-solid fa-file-invoice"></h:outputText>
                                                 <h:outputLabel value="Bill Details" class="mx-4"></h:outputLabel>
                                             </f:facet>
-                                            <view:out bill="#{billSearch.viewingBill}"/>
+                                            <view:bill_edit bill="#{billSearch.viewingBill}" editable="true"/>
                                         </p:panel>
                                     </p:tab>
                                     <p:tab title="Bill Items" >

--- a/src/main/webapp/opd/view/opd_bill_admin.xhtml
+++ b/src/main/webapp/opd/view/opd_bill_admin.xhtml
@@ -67,7 +67,7 @@
                                                 <h:outputText styleClass="fa-solid fa-file-invoice"></h:outputText>
                                                 <h:outputLabel value="Bill Details" class="mx-4"></h:outputLabel>
                                             </f:facet>
-                                            <view:out bill="#{billSearch.viewingBill}"/>
+                                            <view:bill_edit bill="#{billSearch.viewingBill}" editable="true"/>
                                         </p:panel>
                                     </p:tab>
                                     <p:tab title="Bill Items" >

--- a/src/main/webapp/opd/view/opd_cancellation_bill_admin.xhtml
+++ b/src/main/webapp/opd/view/opd_cancellation_bill_admin.xhtml
@@ -32,7 +32,7 @@
                                                 <h:outputText styleClass="fa-solid fa-file-invoice"></h:outputText>
                                                 <h:outputLabel value="Bill Details" class="mx-4"></h:outputLabel>
                                             </f:facet>
-                                            <view:out bill="#{billSearch.viewingBill}"/>
+                                            <view:bill_edit bill="#{billSearch.viewingBill}" editable="true"/>
                                             <p:splitter ></p:splitter>
                                             <common:patient patient="#{billSearch.viewingBill.patient}" class="w-100"/>
                                         </p:panel>

--- a/src/main/webapp/opd/view/opd_refund_bill_admin.xhtml
+++ b/src/main/webapp/opd/view/opd_refund_bill_admin.xhtml
@@ -32,7 +32,7 @@
                                                 <h:outputText styleClass="fa-solid fa-file-invoice"></h:outputText>
                                                 <h:outputLabel value="Bill Details" class="mx-4"></h:outputLabel>
                                             </f:facet>
-                                            <view:out bill="#{billSearch.viewingBill}"/>
+                                            <view:bill_edit bill="#{billSearch.viewingBill}" editable="true"/>
                                             <p:splitter ></p:splitter>
                                             <common:patient patient="#{billSearch.viewingBill.patient}" class="w-100"/>
                                         </p:panel>


### PR DESCRIPTION
## Summary
- allow editing bill details inline in bill_admin.xhtml
- swap to editing view in OPD-related admin pages for consistency

## Testing
- `mvn -q test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_68637808bf20832fa784ef35d9df8404