### PR TITLE
Fix ambiguous null overloads

### DIFF
--- a/src/main/java/com/divudi/ejb/BillNumberGenerator.java
+++ b/src/main/java/com/divudi/ejb/BillNumberGenerator.java
@@ -1766,7 +1766,7 @@ public class BillNumberGenerator {
                 = configOptionApplicationController.getBooleanValueByKey("Bill Number Generation Strategy - Separate Bill Number for Bill Types Only", false);
 
         if (commonBillNumberForAllDepartmentsInstitutionsBillTypeAtomic) {
-            billNumber = fetchLastBillNumberForYear(dep.getInstitution(), null, null);
+            billNumber = fetchLastBillNumberForYear(dep.getInstitution(), null, (BillTypeAtomic) null);
         } else if (separateBillNumberForAllDepartmentsInstitutionsBillTypeAtomic) {
             billNumber = fetchLastBillNumberForYear(dep.getInstitution(), dep, billType);
         } else if (separateBillNumberForInstitutionsOnly) {
@@ -1908,7 +1908,7 @@ public class BillNumberGenerator {
 
         
         if (commonBillNumberForAllDepartmentsInstitutionsBillTypeAtomic) {
-            billNumber = fetchLastBillNumberForYear(null, null, null);
+            billNumber = fetchLastBillNumberForYear(null, null, (BillTypeAtomic) null);
         } else if (separateBillNumberForAllDepartmentsInstitutionsBillTypeAtomic) {
             billNumber = fetchLastBillNumberForYear(dep.getInstitution(), dep, billType);
         } else if (separateBillNumberForInstitutionsOnly) {


### PR DESCRIPTION
## Summary
- clear null overload call in `BillNumberGenerator#departmentBillNumberGeneratorYearly`
- compile project to ensure no ambiguities

## Testing
- `mvn -q -DskipTests=true package` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6863f68e1a14832f9acb882f08ba15bc