### PR TITLE
13607 enable direct result entry

### DIFF
--- a/src/main/java/com/divudi/core/entity/lab/Investigation.java
+++ b/src/main/java/com/divudi/core/entity/lab/Investigation.java
@@ -30,6 +30,11 @@ public class Investigation extends Item implements Serializable {
     @ManyToOne
     Sample sample;
     Double SampleVolume;
+    /**
+     * If true, bypasses sample collection workflow and allows direct result
+     * entry immediately after billing.
+     */
+    boolean bypassSampleWorkflow;
 
     public InvestigationCategory getInvestigationCategory() {
         return investigationCategory;
@@ -61,6 +66,14 @@ public class Investigation extends Item implements Serializable {
 
     public void setSampleVolume(Double SampleVolume) {
         this.SampleVolume = SampleVolume;
+    }
+
+    public boolean isBypassSampleWorkflow() {
+        return bypassSampleWorkflow;
+    }
+
+    public void setBypassSampleWorkflow(boolean bypassSampleWorkflow) {
+        this.bypassSampleWorkflow = bypassSampleWorkflow;
     }
 
     @Enumerated(EnumType.STRING)

--- a/src/main/webapp/admin/lims/investigation.xhtml
+++ b/src/main/webapp/admin/lims/investigation.xhtml
@@ -303,10 +303,20 @@
                                     <div class="col-md-3"><h:outputText value="Report Upload Allowed" ></h:outputText></div>
                                     <div class="col-md-1"><h:outputLabel value=" : " style="text-align: center"/></div>
                                     <div class="col-md-6">
-                                        <p:selectBooleanCheckbox 
-                                            itemLabel="Upload Allowed" 
+                                        <p:selectBooleanCheckbox
+                                            itemLabel="Upload Allowed"
                                             value="#{investigationController.current.canUploadPatinrtReport}" >
                                         </p:selectBooleanCheckbox>
+                                    </div>
+                                </div>
+
+                                <div class="row mt-2">
+                                    <div class="col-md-3"><h:outputText value="Bypass Sample Workflow" /></div>
+                                    <div class="col-md-1"><h:outputLabel value=" : " style="text-align: center"/></div>
+                                    <div class="col-md-6">
+                                        <p:selectBooleanCheckbox
+                                            itemLabel="Bypass"
+                                            value="#{investigationController.current.bypassSampleWorkflow}" />
                                     </div>
                                 </div>
 

--- a/src/main/webapp/opd/opd_batch_bill_print.xhtml
+++ b/src/main/webapp/opd/opd_batch_bill_print.xhtml
@@ -343,6 +343,30 @@
                                     </p:column>
                                 </p:dataTable>
 
+                                <p:dataTable
+                                    value="#{billSearch.fetchPatientInvestigations(opdBillController.batchBill)}"
+                                    var="pi"
+                                    class="mt-2">
+                                    <f:facet name="header" >
+                                        <h:outputLabel value="Investigations" style="font-size: 18px; font-weight: 800;" />
+                                    </f:facet>
+                                    <p:column headerText="Investigation">
+                                        <h:outputText value="#{pi.investigation.name}" />
+                                    </p:column>
+                                    <p:column headerText="Status">
+                                        <h:outputText value="#{pi.status.label}" />
+                                    </p:column>
+                                    <p:column headerText="Actions">
+                                        <p:commandLink id="btnNewReport" ajax="false"
+                                                       disabled="#{!pi.investigation.bypassSampleWorkflow and !pi.received}"
+                                                       action="/lab/patient_report?faces-redirect=true"
+                                                       actionListener="#{patientReportController.createNewReport(pi)}" >
+                                            <f:setPropertyActionListener value="#{pi}" target="#{patientReportController.currentPtIx}" />
+                                            <p:graphicImage library="image" styleClass="standedicon" name="data_entry.png" />
+                                        </p:commandLink>
+                                    </p:column>
+                                </p:dataTable>
+
                                 <p:dataTable 
                                     value="#{billSearch.fetchBillPayments(opdBillController.batchBill)}"
                                     class="mt-2"


### PR DESCRIPTION
## Summary
- add `bypassSampleWorkflow` option to `Investigation`
- expose the option on the Investigation admin form
- list investigations on OPD bill print and allow immediate report access

Closes #13607

------
https://chatgpt.com/codex/tasks/task_e_6865566083b8832f9ac6583f0a926905