### PR TITLE
Add patient name capitalization options

### DIFF
--- a/src/main/java/com/divudi/bean/common/ConfigOptionApplicationController.java
+++ b/src/main/java/com/divudi/bean/common/ConfigOptionApplicationController.java
@@ -107,6 +107,7 @@ public class ConfigOptionApplicationController implements Serializable {
         loadPharmacyTransferIssueReceiptConfigurationDefaults();
         loadPharmacyTransferRequestReceiptConfigurationDefaults();
         loadPharmacyDirectPurchaseWithoutCostingConfigurationDefaults();
+        loadPatientNameConfigurationDefaults();
     }
 
     private void loadEmailGatewayConfigurationDefaults() {
@@ -407,6 +408,11 @@ public class ConfigOptionApplicationController implements Serializable {
                 + "  }\n"
                 + "}"
         );
+    }
+
+    private void loadPatientNameConfigurationDefaults() {
+        getBooleanValueByKey("Capitalize Entire Patient Name", false);
+        getBooleanValueByKey("Capitalize Each Word in Patient Name", false);
     }
 
     public ConfigOption getApplicationOption(String key) {

--- a/src/main/java/com/divudi/bean/common/PatientController.java
+++ b/src/main/java/com/divudi/bean/common/PatientController.java
@@ -3058,6 +3058,18 @@ public class PatientController implements Serializable, ControllerWithPatient {
                 return false;
             }
         }
+
+        boolean capitalizeAll = configOptionApplicationController.getBooleanValueByKey("Capitalize Entire Patient Name", false);
+        boolean capitalizeEach = configOptionApplicationController.getBooleanValueByKey("Capitalize Each Word in Patient Name", false);
+        String personName = p.getPerson().getName();
+        if (personName != null) {
+            if (capitalizeAll) {
+                personName = personName.toUpperCase();
+            } else if (capitalizeEach) {
+                personName = CommonFunctions.capitalizeFirstLetter(personName);
+            }
+            p.getPerson().setName(personName);
+        }
 //        if (p.getPerson().getId() == null) {
 //            p.getPerson().setCreatedAt(Calendar.getInstance().getTime());
 //            p.getPerson().setCreater(getSessionController().getLoggedUser());

--- a/src/main/java/com/divudi/bean/inward/AdmissionController.java
+++ b/src/main/java/com/divudi/bean/inward/AdmissionController.java
@@ -1124,10 +1124,10 @@ public class AdmissionController implements Serializable, ControllerWithPatient 
         String tc = sessionController.getApplicationPreference().getChangeTextCasesPatientName();
         String updatedPersonName = CommonFunctions.changeTextCases(getPatient().getPerson().getName(), tc);
         String updatedAddress = CommonFunctions.changeTextCases(getPatient().getPerson().getAddress(), tc);
-        if (updatedPersonName == null) {
+        if (updatedPersonName != null) {
             getPatient().getPerson().setName(updatedPersonName);
         }
-        if (updatedAddress == null) {
+        if (updatedAddress != null) {
             getPatient().getPerson().setAddress(updatedAddress);
         }
         Person person = getPatient().getPerson();


### PR DESCRIPTION
## Summary
- add patient name capitalization defaults
- apply capitalization logic before saving a patient
- save transformed name and address in AdmissionController

## Testing
- `mvn -q test` *(fails: Could not resolve dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6865c8ddf300832f852e85a63ce5bda6