### PR TITLE
Implement audit tracking for bill dept ID updates

### DIFF
--- a/src/main/java/com/divudi/bean/common/BillDeptIdEditorController.java
+++ b/src/main/java/com/divudi/bean/common/BillDeptIdEditorController.java
@@ -9,6 +9,7 @@ import com.divudi.core.data.ReportViewType;
 import com.divudi.core.facade.BillFacade;
 import com.divudi.core.util.CommonFunctions;
 import com.divudi.core.util.JsfUtil;
+import com.divudi.service.AuditService;
 import java.io.Serializable;
 import java.util.*;
 import javax.ejb.EJB;
@@ -25,6 +26,9 @@ public class BillDeptIdEditorController implements Serializable, ControllerWithR
 
     @EJB
     private BillFacade billFacade;
+
+    @EJB
+    private AuditService auditService;
 
     @Inject
     private SessionController sessionController;
@@ -87,8 +91,19 @@ public class BillDeptIdEditorController implements Serializable, ControllerWithR
             if (original == null) {
                 continue;
             }
+            String beforeDeptId = original.getDeptId();
             original.setDeptId(b.getDeptId());
             billFacade.edit(original);
+
+            Map<String, String> before = new HashMap<>();
+            before.put("billId", String.valueOf(original.getId()));
+            before.put("deptId", beforeDeptId);
+
+            Map<String, String> after = new HashMap<>();
+            after.put("billId", String.valueOf(original.getId()));
+            after.put("deptId", original.getDeptId());
+
+            auditService.logAudit(before, after, sessionController.getLoggedUser(), Bill.class.getSimpleName(), "Update Bill DeptId");
         }
         JsfUtil.addSuccessMessage("Bill DeptIds updated");
     }

--- a/src/main/webapp/audit/all_audit_events.xhtml
+++ b/src/main/webapp/audit/all_audit_events.xhtml
@@ -1,0 +1,76 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
+      xmlns:p="http://primefaces.org/ui"
+      xmlns:h="http://xmlns.jcp.org/jsf/html"
+      xmlns:f="http://xmlns.jcp.org/jsf/core">
+
+    <h:body>
+        <ui:composition template="/dataAdmin/admin_data_administration.xhtml">
+            <ui:define name="subcontent">
+                <h:form>
+                    <p:panel>
+                        <f:facet name="header">
+                            <h:outputText value="Audit Event History" />
+                        </f:facet>
+
+                        <h:panelGrid columns="2" class="my-2">
+                            <h:outputLabel value="From Date"/>
+                            <p:datePicker class="w-100 mx-4" inputStyleClass="w-100"
+                                          id="fromDate"
+                                          value="#{auditEventController.fromDate}"
+                                          showTime="true"
+                                          pattern="#{sessionController.applicationPreference.longDateTimeFormat}" />
+                            <h:outputLabel value="To Date"/>
+                            <p:datePicker class="w-100 mx-4" inputStyleClass="w-100"
+                                          id="toDate"
+                                          value="#{auditEventController.toDate}"
+                                          showTime="true"
+                                          pattern="#{sessionController.applicationPreference.longDateTimeFormat}" />
+                        </h:panelGrid>
+
+                        <h:panelGrid columns="3" class="my-2">
+                            <p:commandButton id="btnSearch"
+                                             class="ui-button-warning"
+                                             icon="pi pi-search"
+                                             ajax="false"
+                                             value="Search"
+                                             action="#{auditEventController.fillAllAuditEvents}" />
+                        </h:panelGrid>
+
+                        <p:dataTable rowIndexVar="i" id="tblEvents"
+                                     value="#{auditEventController.items}"
+                                     var="ae"
+                                     style="min-width:100%;"
+                                     paginator="true"
+                                     paginatorPosition="bottom"
+                                     rows="10"
+                                     paginatorTemplate="{CurrentPageReport} {FirstPageLink} {PreviousPageLink} {PageLinks} {NextPageLink} {LastPageLink} {RowsPerPageDropdown}"
+                                     rowsPerPageTemplate="5,10,15">
+
+                            <p:column headerText="User">
+                                <h:outputText value="#{webUserController.findWebUserNameWithTitleById(ae.webUserId)}" />
+                            </p:column>
+
+                            <p:column headerText="Time">
+                                <h:outputText value="#{ae.eventDataTime}">
+                                    <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateTimeFormat}" />
+                                </h:outputText>
+                            </p:column>
+
+                            <p:column headerText="Event">
+                                <h:outputText value="#{ae.eventTrigger}" />
+                            </p:column>
+
+                            <p:column headerText="Differences">
+                                <h:outputText value="#{ae.difference}" style="white-space: pre-line;" />
+                            </p:column>
+
+                        </p:dataTable>
+                    </p:panel>
+                </h:form>
+            </ui:define>
+        </ui:composition>
+    </h:body>
+</html>

--- a/src/main/webapp/dataAdmin/admin_data_administration.xhtml
+++ b/src/main/webapp/dataAdmin/admin_data_administration.xhtml
@@ -233,8 +233,14 @@
                                             </p:commandButton>
                                             <p:commandButton
                                                 ajax="false"
-                                                action="/audit/config_option_events?faces-redirect=true"
-                                                value="Config Option Events"
+                                            action="/audit/config_option_events?faces-redirect=true"
+                                            value="Config Option Events"
+                                            icon="pi pi-history" >
+                                            </p:commandButton>
+                                            <p:commandButton
+                                                ajax="false"
+                                                action="/audit/all_audit_events?faces-redirect=true"
+                                                value="All Audit Events"
                                                 icon="pi pi-history" >
                                             </p:commandButton>
                                         </div>


### PR DESCRIPTION
## Summary
- track before/after deptId values when editing bills
- list all audit events from a new page in the Audit tab
- add navigation to new page

## Testing
- `mvn -q test` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6865e5cd79a0832fa9993526fdd2c105