### PR TITLE
Fix audit logging when Bill deptId unchanged

### DIFF
--- a/src/main/java/com/divudi/bean/common/BillDeptIdEditorController.java
+++ b/src/main/java/com/divudi/bean/common/BillDeptIdEditorController.java
@@ -92,7 +92,14 @@ public class BillDeptIdEditorController implements Serializable, ControllerWithR
                 continue;
             }
             String beforeDeptId = original.getDeptId();
-            original.setDeptId(b.getDeptId());
+            String newDeptId = b.getDeptId();
+
+            if (Objects.equals(beforeDeptId, newDeptId)) {
+                // No change in department id; skip persisting and auditing
+                continue;
+            }
+
+            original.setDeptId(newDeptId);
             billFacade.edit(original);
 
             Map<String, String> before = new HashMap<>();


### PR DESCRIPTION
## Summary
- skip saving and auditing bills when the department ID is unchanged

## Testing
- `mvn -q test` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6865eb6e2588832fafd06721591fb745