### PR TITLE
Add generics to params maps

### DIFF
--- a/src/main/java/com/divudi/ejb/PharmacyBean.java
+++ b/src/main/java/com/divudi/ejb/PharmacyBean.java
@@ -658,7 +658,7 @@ public class PharmacyBean {
             return null;
         }
         String jpql;
-        HashMap params = new HashMap();
+        HashMap<String, Object> params = new HashMap<>();
         jpql = "Select s from Stock s where s.itemBatch=:bch and s.department=:dep";
         params.put("bch", pharmaceuticalBillItem.getItemBatch());
         params.put("dep", department);
@@ -772,7 +772,7 @@ public class PharmacyBean {
         }
         String jpql;
         jpql = "Select s from Stock s where s.itemBatch.id = :batchId and s.department.id = :deptId ";
-        Map params = new HashMap();
+        Map<String, Object> params = new HashMap<>();
         params.put("batchId", batch.getId());
         params.put("deptId", department.getId());
         Stock s = getStockFacade().findFirstByJpql(jpql, params, true);
@@ -842,7 +842,7 @@ public class PharmacyBean {
 
     public List<StockQty> getStockByQty(Item item, double qty, Department department) {
         String jpql = "";
-        Map params = new HashMap();
+        Map<String, Object> params = new HashMap<>();
 
         params.put("d", department);
         params.put("q", 1.0);
@@ -885,7 +885,7 @@ public class PharmacyBean {
 
     public List<Stock> getStockByQty(Item item, Department department) {
         String jpql = "";
-        Map params = new HashMap();
+        Map<String, Object> params = new HashMap<>();
 
         params.put("d", department);
         params.put("q", 1.0);
@@ -1247,7 +1247,7 @@ public class PharmacyBean {
             item = ((Ampp) item).getAmp();
         }
         String jpql;
-        Map params = new HashMap();
+        Map<String, Object> params = new HashMap<>();
         jpql = "Select ib from ItemBatch ib where ib.item=:i and ib.dateOfExpire=:doe and ib.batchNo=:batchNo";
         params.put("i", item);
         params.put("batchNo", batchNo);
@@ -1268,7 +1268,7 @@ public class PharmacyBean {
             item = ((Ampp) item).getAmp();
         }
         String jpql;
-        Map params = new HashMap();
+        Map<String, Object> params = new HashMap<>();
         jpql = "Select ib from ItemBatch ib where ib.item=:i and ib.dateOfExpire=:doe and ib.purcahseRate=:pr and ib.retailsaleRate=:rr";
         params.put("i", item);
         params.put("pr", purchasePrice);
@@ -1296,7 +1296,7 @@ public class PharmacyBean {
 
     public Vmpp getVmpp(Ampp ampp, MeasurementUnit packUnit) {
         String jpql;
-        Map params = new HashMap();
+        Map<String, Object> params = new HashMap<>();
         params.put("vmp", ampp.getAmp().getVmp());
         params.put("s", packUnit);
         params.put("d", ampp.getDblValue());

--- a/src/main/java/com/divudi/service/BillService.java
+++ b/src/main/java/com/divudi/service/BillService.java
@@ -530,7 +530,7 @@ public class BillService {
                 + "from BillFee bf "
                 + " where bf.retired=:ret "
                 + " and bf.billItem=:bi";
-        Map params = new HashMap();
+        Map<String, Object> params = new HashMap<>();
         params.put("bi", billItem);
         params.put("ret", false);
         return billFeeFacade.findByJpql(jpql, params);
@@ -548,7 +548,7 @@ public class BillService {
     public List<BillFee> fetchBillFees(Bill bill) {
         List<BillFee> fetchingBillFees;
         String jpql;
-        Map params = new HashMap();
+        Map<String, Object> params = new HashMap<>();
         jpql = "Select bf "
                 + " from BillFee bf "
                 + "where bf.bill=:bill "
@@ -560,7 +560,7 @@ public class BillService {
 
     public List<BillItem> fetchBillItems(Bill b) {
         String jpql;
-        HashMap params = new HashMap();
+        HashMap<String, Object> params = new HashMap<>();
         jpql = "SELECT bi "
                 + " FROM BillItem bi "
                 + " WHERE bi.bill=:bl "
@@ -639,7 +639,7 @@ public class BillService {
 
     public List<PharmaceuticalBillItem> fetchPharmaceuticalBillItems(Bill b) {
         String jpql;
-        HashMap params = new HashMap();
+        HashMap<String, Object> params = new HashMap<>();
         jpql = "SELECT pbi "
                 + " FROM PharmaceuticalBillItem pbi "
                 + " WHERE pbi.billItem.bill=:bl "
@@ -650,7 +650,7 @@ public class BillService {
 
     public Long fetchBillItemCount(Bill b) {
         String jpql;
-        HashMap params = new HashMap();
+        HashMap<String, Object> params = new HashMap<>();
         jpql = "SELECT count(bi) "
                 + " FROM BillItem bi "
                 + " WHERE bi.bill=:bl "
@@ -728,7 +728,7 @@ public class BillService {
     public List<Payment> fetchBillPayments(Bill bill) {
         List<Payment> fetchingBillComponents;
         String jpql;
-        Map params = new HashMap();
+        Map<String, Object> params = new HashMap<>();
         jpql = "Select p "
                 + " from Payment p "
                 + "where p.bill=:bill "
@@ -741,7 +741,7 @@ public class BillService {
     public List<Payment> fetchBillPayments(Bill bill, Bill batchBill) {
         List<Payment> fetchingBillComponents;
         String jpql;
-        Map params = new HashMap();
+        Map<String, Object> params = new HashMap<>();
         jpql = "Select p "
                 + " from Payment p "
                 + "where p.bill=:bill "
@@ -760,7 +760,7 @@ public class BillService {
             return null;
         }
         String jpql;
-        HashMap params = new HashMap();
+        HashMap<String, Object> params = new HashMap<>();
         jpql = "SELECT p "
                 + " FROM Payment p "
                 + " WHERE p.bill=:bl "
@@ -850,7 +850,7 @@ public class BillService {
         ReportTemplateRowBundle outputBundle = new ReportTemplateRowBundle();
         List<ReportTemplateRow> outputRows;
         String jpql;
-        Map params = new HashMap();
+        Map<String, Object> params = new HashMap<>();
 
         jpql = "select new com.divudi.core.data.ReportTemplateRow(b) "
                 + " from Bill b "
@@ -963,7 +963,7 @@ public class BillService {
             AdmissionType admissionType,
             PaymentScheme paymentScheme) {
         String jpql;
-        Map params = new HashMap();
+        Map<String, Object> params = new HashMap<>();
 
         jpql = "select b "
                 + " from Bill b "
@@ -1034,7 +1034,7 @@ public class BillService {
                 + " and b.billTypeAtomic in :billTypesAtomics "
                 + " and b.createdAt between :fromDate and :toDate ";
 
-        Map params = new HashMap();
+        Map<String, Object> params = new HashMap<>();
         params.put("ret", false);
         params.put("billTypesAtomics", billTypeAtomics);
         params.put("fromDate", fromDate);
@@ -1085,7 +1085,7 @@ public class BillService {
             AdmissionType admissionType,
             PaymentScheme paymentScheme) {
         String jpql;
-        Map params = new HashMap();
+        Map<String, Object> params = new HashMap<>();
 
         jpql = "select bi "
                 + " from BillItem bi "
@@ -1144,7 +1144,7 @@ public class BillService {
             AdmissionType admissionType,
             PaymentScheme paymentScheme) {
         String jpql;
-        Map params = new HashMap();
+        Map<String, Object> params = new HashMap<>();
 
         jpql = "select pbi "
                 + " from PharmaceuticalBillItem pbi "
@@ -1291,7 +1291,7 @@ public class BillService {
             String visitType
     ) {
         String jpql;
-        Map params = new HashMap();
+        Map<String, Object> params = new HashMap<>();
 
         jpql = "select b "
                 + " from Bill b "
@@ -1368,7 +1368,7 @@ public class BillService {
             List<BillTypeAtomic> billTypeAtomics,
             PatientEncounter patientEncounter) {
         String jpql;
-        Map params = new HashMap();
+        Map<String, Object> params = new HashMap<>();
 
         jpql = "select bi "
                 + " from BillItem bi "
@@ -1424,7 +1424,7 @@ public class BillService {
             List<BillTypeAtomic> billTypeAtomics,
             PatientEncounter patientEncounter) {
         String jpql;
-        Map params = new HashMap();
+        Map<String, Object> params = new HashMap<>();
 
         jpql = "select bi "
                 + " from BillItem bi "
@@ -1496,7 +1496,7 @@ public class BillService {
                 btas.addAll(BillTypeAtomic.findByCategory(BillCategory.REFUND));
         }
         //
-        Map params = new HashMap();
+        Map<String, Object> params = new HashMap<>();
         jpql = "select b "
                 + " from Bill b "
                 + " where b.retired=:ret "
@@ -1572,7 +1572,7 @@ public class BillService {
                 btas.addAll(BillTypeAtomic.findByCategory(BillCategory.PAYMENTS));
         }
         //
-        Map params = new HashMap();
+        Map<String, Object> params = new HashMap<>();
         jpql = "select bi "
                 + " from BillItem bi"
                 + " join bi.bill b "
@@ -1879,7 +1879,7 @@ public class BillService {
 
     public List<PatientInvestigation> fetchPatientInvestigations(Bill bill) {
         String jpql;
-        HashMap params = new HashMap();
+        HashMap<String, Object> params = new HashMap<>();
         jpql = "SELECT pbi "
                 + " FROM PatientInvestigation pbi "
                 + " WHERE pbi.billItem.bill=:bl "
@@ -1911,7 +1911,7 @@ public class BillService {
             return billItems;
         }
 
-        Map params = new HashMap();
+        Map<String, Object> params = new HashMap<>();
         String jpql = "select bi "
                 + " from BillItem bi"
                 + " where bi.retired=:ret "


### PR DESCRIPTION
## Summary
- parameter Maps use `Map<String, Object>` instead of raw Map types

## Testing
- `mvn -q test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_686638aeaeb4832f90bd0067a709024d