### PR TITLE
Fix stock retrieval for VMP items

### DIFF
--- a/src/main/java/com/divudi/ejb/PharmacyBean.java
+++ b/src/main/java/com/divudi/ejb/PharmacyBean.java
@@ -926,7 +926,9 @@ public class PharmacyBean {
         }
         for (Amp a : amps) {
             List<StockQty> sq = getStockByQty(a, qty, department);
-
+            if (sq != null) {
+                stocks.addAll(sq);
+            }
         }
         return stocks;
     }


### PR DESCRIPTION
## Summary
- append fetched StockQty results for each AMP when retrieving VMP stock quantities

## Testing
- `mvn -q test` *(fails: mvn not installed)*

------
https://chatgpt.com/codex/tasks/task_e_686638a370c4832f89e8b5fcc3c6a2ec