### PR TITLE
Implement save/finalize flow for transfer requests

### DIFF
--- a/src/main/java/com/divudi/bean/pharmacy/TransferRequestController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/TransferRequestController.java
@@ -483,10 +483,10 @@ public class TransferRequestController implements Serializable {
         return "/pharmacy/pharmacy_transfer_request_approval?faces-redirect=true";
     }
 
-    public String finalizeTranserRequest() {
+    public void finalizeTranserRequest() {
         if (transerRequestBillPre == null) {
             JsfUtil.addErrorMessage("No Bill! Save the Bill First");
-            return "";
+            return;
         }
         if (transerRequestBillPre.getId() == null) {
             saveTranserRequest();
@@ -529,7 +529,7 @@ public class TransferRequestController implements Serializable {
         JsfUtil.addSuccessMessage("Transfer Request Succesfully Finalized");
 
         searchController.fillSavedTranserRequestBills();
-        return "/pharmacy/pharmacy_transfer_request_list_search_for_approval?faces-redirect=true";
+        printPreview = true;
     }
 
     public String processTransferRequest() {

--- a/src/main/webapp/pharmacy/pharmacy_transfer_request.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_transfer_request.xhtml
@@ -50,23 +50,29 @@
                                 <h:outputLabel value="Transfer Request To #{transferRequestController.toDepartment} From #{sessionController.department}" class="mx-4" />
                             </div>
                             <div>
+                                <p:defaultCommand target="btnSave" />
                                 <p:commandButton
-                                    value="Request"
-                                    action="#{transferRequestController.request}"
+                                    id="btnSave"
+                                    value="Save"
+                                    action="#{transferRequestController.saveTranserRequest()}"
                                     ajax="false"
-                                    icon="fas fa-check"
-                                    class="mx-1 ui-button-success">
-                                </p:commandButton>
+                                    icon="pi pi-save"
+                                    class="mx-1 ui-button-success"/>
+                                <p:commandButton
+                                    value="Finalize"
+                                    action="#{transferRequestController.finalizeTranserRequest()}"
+                                    ajax="false"
+                                    icon="pi pi-check"
+                                    class="mx-1 ui-button-warning"/>
                                 <p:commandButton
                                     value="New Bill"
                                     action="#{transferRequestController.recreate}"
                                     ajax="false"
-                                    icon="fas fa-plus"
-                                    class="ui-button-warning">
-                                </p:commandButton>
+                                    icon="pi pi-plus"
+                                    class="ui-button-danger"/>
 
-                                <p:commandButton value="Change Department" class="ui-button-primary mx-1" ajax="false" icon="fas fa-refresh"
-                                                 action="#{transferRequestController.changeDepartment()}" ></p:commandButton>
+                                <p:commandButton value="Change Department" class="ui-button-primary mx-1" ajax="false" icon="pi pi-refresh"
+                                                 action="#{transferRequestController.changeDepartment()}" />
 
                             </div>
                         </div>


### PR DESCRIPTION
## Summary
- split transfer request actions into Save and Finalize buttons
- call the correct controller methods for each action
- show print preview after finalization

## Testing
- `mvn -q test` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68669f289d60832f94bc6d65484b8826