### PR TITLE
Add finalize transfer requests list

### DIFF
--- a/src/main/java/com/divudi/bean/common/SearchController.java
+++ b/src/main/java/com/divudi/bean/common/SearchController.java
@@ -5233,6 +5233,29 @@ public class SearchController implements Serializable {
 
     }
 
+    public void fillOnlySavedPharmacyTransferRequest() {
+        bills = null;
+        HashMap tmp = new HashMap();
+        String sql;
+        sql = "Select b From Bill b where "
+                + " b.checkedBy is null "
+                + " and b.institution = :ins "
+                + " and b.fromDepartment = :fromDep "
+                + " and b.createdAt between :fromDate and :toDate "
+                + " and b.retired=false "
+                + " and b.billType= :bTp";
+
+        sql += " order by b.createdAt desc  ";
+        tmp.put("toDate", getToDate());
+        tmp.put("fromDate", getFromDate());
+        tmp.put("ins", sessionController.getInstitution());
+        tmp.put("fromDep", sessionController.getDepartment());
+        tmp.put("bTp", BillType.PharmacyTransferRequest);
+
+        bills = getBillFacade().findByJpql(sql, tmp, TemporalType.TIMESTAMP, maxResult);
+
+    }
+
     public void createNotApprovedStore() {
         Date startTime = new Date();
 
@@ -14367,6 +14390,11 @@ public class SearchController implements Serializable {
     public String navigateToPurchaseOrderFinalize() {
         makeNull();
         return "/pharmacy/pharmacy_purhcase_order_list_to_finalize?faces-redirect=true";
+    }
+
+    public String navigateToTransferRequestFinalize() {
+        makeNull();
+        return "/pharmacy/pharmacy_transfer_request_list_to_finalize?faces-redirect=true";
     }
 
     // ToDo: TO Be Linked to command buttons where the file name is used without calling a backend method

--- a/src/main/webapp/pharmacy/pharmacy_transfer_request_list_to_finalize.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_transfer_request_list_to_finalize.xhtml
@@ -1,0 +1,86 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<!DOCTYPE composition PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<ui:composition xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
+                template="/resources/template/template.xhtml"
+                xmlns:h="http://xmlns.jcp.org/jsf/html"
+                xmlns:p="http://primefaces.org/ui"
+                xmlns:f="http://xmlns.jcp.org/jsf/core">
+
+    <ui:define name="content">
+        <h:form>
+            <p:panel>
+                <f:facet name="header">
+                    <p:outputLabel value="Finalize Transfer Requests"/>
+                </f:facet>
+                <div class="row">
+                    <div class="col-md-2">
+                        <h:outputLabel value="From Date"/>
+                        <p:calendar class="w-100" inputStyleClass="form-control" id="fromDate"
+                                    value="#{searchController.fromDate}" navigator="false"
+                                    pattern="#{sessionController.applicationPreference.longDateTimeFormat}"/>
+                        <h:outputLabel class="mb-2" value="To Date"/>
+                        <p:calendar class="w-100" inputStyleClass="form-control" id="toDate"
+                                    value="#{searchController.toDate}" navigator="false"
+                                    pattern="#{sessionController.applicationPreference.longDateTimeFormat}"/>
+                        <p:commandButton id="btnSearch" ajax="false" value="Search"
+                                         icon="fas fa-search" class="ui-button-warning w-100 my-2"
+                                         action="#{searchController.fillOnlySavedPharmacyTransferRequest()}"/>
+                        <h:outputLabel value="Request No"/>
+                        <p:inputText class="w-100" autocomplete="off" value="#{searchController.searchKeyword.billNo}"/>
+                        <h:outputLabel value="To Department"/>
+                        <p:inputText class="w-100" autocomplete="off" value="#{searchController.searchKeyword.department}"/>
+                    </div>
+                    <div class="col-md-10">
+                        <p:dataTable value="#{searchController.bills}" var="b" rows="10"
+                                     paginator="true"
+                                     paginatorTemplate="{CurrentPageReport}  {FirstPageLink} {PreviousPageLink} {PageLinks} {NextPageLink} {LastPageLink} {RowsPerPageDropdown}"
+                                     rowsPerPageTemplate="5,10,15" paginatorPosition="bottom">
+                            <p:column headerText="Request No" width="100px">
+                                <h:outputLabel value="#{b.deptId}"/>
+                            </p:column>
+                            <p:column headerText="To Department" width="150px">
+                                <h:outputLabel value="#{b.toDepartment.name}"/>
+                            </p:column>
+                            <p:column headerText="Requested At" width="130px">
+                                <h:outputLabel value="#{b.createdAt}">
+                                    <f:convertDateTime timeZone="Asia/Colombo" pattern="#{sessionController.applicationPreference.longDateTimeFormat}"/>
+                                </h:outputLabel>
+                                <br/>
+                                <h:panelGroup rendered="#{b.cancelled}">
+                                    <h:outputLabel style="color: red;" value="Cancelled at "/>
+                                    <h:outputLabel style="color: red;" rendered="#{b.cancelled}"
+                                                   value="#{b.cancelledBill.createdAt}">
+                                        <f:convertDateTime timeZone="Asia/Colombo" pattern="#{sessionController.applicationPreference.longDateTimeFormat}"/>
+                                    </h:outputLabel>
+                                </h:panelGroup>
+                            </p:column>
+                            <p:column headerText="Requested By" width="150px">
+                                <h:outputLabel value="#{b.creater.webUserPerson.name}"/>
+                                <br/>
+                                <h:panelGroup rendered="#{b.cancelled}">
+                                    <h:outputLabel style="color: red;" value="Cancelled By "/>
+                                    <h:outputLabel style="color: red;" rendered="#{b.cancelled}"
+                                                   value="#{b.cancelledBill.creater.webUserPerson.name}"/>
+                                </h:panelGroup>
+                            </p:column>
+                            <p:column headerText="Requested Value">
+                                <h:outputLabel value="#{b.netTotal}">
+                                    <f:convertNumber pattern="#,##0.00"/>
+                                </h:outputLabel>
+                            </p:column>
+                            <p:column headerText="Actions" width="9em">
+                                <p:commandButton id="finalize" ajax="false" title="Edit and Finalize Request"
+                                                 icon="fas fa-check-circle" class="ui-button-success mx-2"
+                                                 action="#{transferRequestController.navigateToEditRequest}"
+                                                 disabled="#{b.checkedBy ne null or b.cancelled eq true}">
+                                    <f:setPropertyActionListener target="#{transferRequestController.transerRequestBillPre}" value="#{b}"/>
+                                </p:commandButton>
+                            </p:column>
+                        </p:dataTable>
+                    </div>
+                </div>
+            </p:panel>
+        </h:form>
+    </ui:define>
+
+</ui:composition>

--- a/src/main/webapp/resources/ezcomp/menu.xhtml
+++ b/src/main/webapp/resources/ezcomp/menu.xhtml
@@ -1000,11 +1000,17 @@
                                     rendered="#{webUserController.hasPrivilege('PharmacyDisbursementRequest') and configOptionApplicationController.getBooleanValueByKey('Pharmacy Transer Request With Approval')}" 
                                     icon="fas fa-hand-holding-medical"></p:menuitem>
                         <p:menuitem ajax="false" 
-                                    action="/pharmacy/pharmacy_transfer_request_list_search_for_approval?faces-redirect=true"  
-                                    value="Search Transer Request" 
-                                    actionListener="#{searchController.makeListNull()}" 
-                                    rendered="#{webUserController.hasPrivilege('PharmacyDisbursementRequest') and configOptionApplicationController.getBooleanValueByKey('Pharmacy Transer Request With Approval')}" 
+                                    action="/pharmacy/pharmacy_transfer_request_list_search_for_approval?faces-redirect=true"
+                                    value="Search Transer Request"
+                                    actionListener="#{searchController.makeListNull()}"
+                                    rendered="#{webUserController.hasPrivilege('PharmacyDisbursementRequest') and configOptionApplicationController.getBooleanValueByKey('Pharmacy Transer Request With Approval')}"
                                     icon="fas fa-hand-holding-medical"></p:menuitem>
+
+                        <p:menuitem ajax="false"
+                                    action="#{searchController.navigateToTransferRequestFinalize}"
+                                    value="Finalize Transer Requests"
+                                    icon="fas fa-tasks"
+                                    rendered="#{webUserController.hasPrivilege('PharmacyDisbursementRequest')}"></p:menuitem>
 
                         <p:menuitem ajax="false" 
                                     action="#{transferIssueController.navigateToListPharmacyIssueRequests}"  


### PR DESCRIPTION
## Summary
- add a finalize list view for pharmacy transfer requests
- query saved transfer requests in `SearchController`
- add navigation method and menu link

## Testing
- `mvn -q test -DskipTests` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68669f2cbdc0832fb161481ae480999c