### PR TITLE
Add Transfer Request finalization flow

### DIFF
--- a/src/main/java/com/divudi/bean/common/SearchController.java
+++ b/src/main/java/com/divudi/bean/common/SearchController.java
@@ -14369,6 +14369,11 @@ public class SearchController implements Serializable {
         return "/pharmacy/pharmacy_purhcase_order_list_to_finalize?faces-redirect=true";
     }
 
+    public String navigateToTransferRequestFinalize() {
+        makeNull();
+        return "/pharmacy/pharmacy_transfer_request_list_to_finalize?faces-redirect=true";
+    }
+
     // ToDo: TO Be Linked to command buttons where the file name is used without calling a backend method
     /**
      * Samples of places to be updated as follows

--- a/src/main/java/com/divudi/bean/pharmacy/TransferRequestController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/TransferRequestController.java
@@ -453,14 +453,9 @@ public class TransferRequestController implements Serializable {
             JsfUtil.addErrorMessage("Please select a bill");
             return "";
         }
-
-        billItems = new ArrayList<>();
-        billItems.addAll(getTranserRequestBillPre().getBillItems());
-        System.out.println("line 401");
-        System.out.println(billItems.size());
+        billItems = fetchBillItems(transerRequestBillPre);
         for (BillItem bi : billItems) {
             bi.setTmpQty(bi.getQty());
-            billItemFacade.edit(bi);
         }
         setToDepartment(getTranserRequestBillPre().getToDepartment());
         return "/pharmacy/pharmacy_transfer_request_save?faces-redirect=true";
@@ -551,6 +546,14 @@ public class TransferRequestController implements Serializable {
             bi.setSearialNo(serialNo++);
         }
 
+    }
+
+    private List<BillItem> fetchBillItems(Bill bill) {
+        String jpql = "select bi from BillItem bi where bi.retired=:retired and bi.bill=:bill";
+        Map m = new HashMap();
+        m.put("bill", bill);
+        m.put("retired", false);
+        return billItemFacade.findByJpql(jpql, m);
     }
 
     public TransferRequestController() {

--- a/src/main/webapp/pharmacy/pharmacy_transfer_request_list_to_finalize.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_transfer_request_list_to_finalize.xhtml
@@ -1,0 +1,81 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<!DOCTYPE composition PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<ui:composition xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
+                template="/resources/template/template.xhtml"
+                xmlns:h="http://xmlns.jcp.org/jsf/html"
+                xmlns:p="http://primefaces.org/ui"
+                xmlns:f="http://xmlns.jcp.org/jsf/core">
+
+    <ui:define name="content">
+        <h:form>
+            <p:panel>
+                <f:facet name="header">
+                    <p:outputLabel value="Finalize Transfer Requests"/>
+                </f:facet>
+                <div class="row">
+                    <div class="col-md-2">
+                        <h:outputLabel value="From Date"/>
+                        <p:calendar class="w-100" inputStyleClass="form-control" id="fromDate"
+                                    value="#{searchController.fromDate}" navigator="false"
+                                    pattern="#{sessionController.applicationPreference.longDateTimeFormat}"/>
+                        <h:outputLabel value="To Date"/>
+                        <p:calendar class="w-100" inputStyleClass="form-control" id="toDate"
+                                    value="#{searchController.toDate}" navigator="true"
+                                    pattern="#{sessionController.applicationPreference.longDateTimeFormat}"/>
+                        <p:commandButton id="btnSearch" ajax="false" value="Search" icon="fas fa-search"
+                                         class="ui-button-warning w-100 my-2"
+                                         action="#{searchController.fillSavedTranserRequestBills()}"
+                                         actionListener="#{transferIssueController.makeNull()}"/>
+                        <h:outputLabel value="Request No"/>
+                        <p:inputText class="w-100" autocomplete="off"
+                                     value="#{searchController.searchKeyword.billNo}"/>
+                        <h:outputLabel value="From Department"/>
+                        <p:inputText class="w-100" autocomplete="off"
+                                     value="#{searchController.searchKeyword.department}"/>
+                    </div>
+                    <div class="col-md-10">
+                        <p:dataTable value="#{searchController.bills}" var="b" rows="10" paginator="true"
+                                     paginatorTemplate="{CurrentPageReport}  {FirstPageLink} {PreviousPageLink} {PageLinks} {NextPageLink} {LastPageLink} {RowsPerPageDropdown}"
+                                     rowsPerPageTemplate="5,10,15" paginatorPosition="bottom">
+                            <p:column headerText="Request No" width="100px">
+                                <h:outputLabel value="#{b.deptId}"/>
+                            </p:column>
+                            <p:column headerText="From Department" width="150px">
+                                <h:outputLabel value="#{b.department.name}"/>
+                            </p:column>
+                            <p:column headerText="Requested At" width="100px">
+                                <h:outputLabel value="#{b.createdAt}">
+                                    <f:convertDateTime timeZone="Asia/Colombo" pattern="#{sessionController.applicationPreference.longDateTimeFormat}"/>
+                                </h:outputLabel>
+                                <br/>
+                                <h:panelGroup rendered="#{b.cancelled}">
+                                    <h:outputLabel style="color: red;" value="Cancelled at "/>
+                                    <h:outputLabel style="color: red;" rendered="#{b.cancelled}"
+                                                   value="#{b.cancelledBill.createdAt}">
+                                        <f:convertDateTime timeZone="Asia/Colombo" pattern="#{sessionController.applicationPreference.longDateTimeFormat}"/>
+                                    </h:outputLabel>
+                                </h:panelGroup>
+                            </p:column>
+                            <p:column headerText="Requested By" width="100px">
+                                <h:outputLabel value="#{b.creater.webUserPerson.name}"/>
+                                <br/>
+                                <h:panelGroup rendered="#{b.cancelled}">
+                                    <h:outputLabel style="color: red;" value="Cancelled By "/>
+                                    <h:outputLabel style="color: red;" rendered="#{b.cancelled}"
+                                                   value="#{b.cancelledBill.creater.webUserPerson.name}"/>
+                                </h:panelGroup>
+                            </p:column>
+                            <p:column width="8em" headerText="Action">
+                                <p:commandButton id="finalize" ajax="false" title="Edit and Finalize"
+                                                 icon="fas fa-check-circle" class="ui-button-success mx-2"
+                                                 action="#{transferRequestController.navigateToEditRequest}">
+                                    <f:setPropertyActionListener target="#{transferRequestController.transerRequestBillPre}" value="#{b}"/>
+                                </p:commandButton>
+                            </p:column>
+                        </p:dataTable>
+                    </div>
+                </div>
+            </p:panel>
+        </h:form>
+    </ui:define>
+</ui:composition>

--- a/src/main/webapp/resources/ezcomp/menu.xhtml
+++ b/src/main/webapp/resources/ezcomp/menu.xhtml
@@ -1000,11 +1000,18 @@
                                     rendered="#{webUserController.hasPrivilege('PharmacyDisbursementRequest') and configOptionApplicationController.getBooleanValueByKey('Pharmacy Transer Request With Approval')}" 
                                     icon="fas fa-hand-holding-medical"></p:menuitem>
                         <p:menuitem ajax="false" 
-                                    action="/pharmacy/pharmacy_transfer_request_list_search_for_approval?faces-redirect=true"  
-                                    value="Search Transer Request" 
-                                    actionListener="#{searchController.makeListNull()}" 
-                                    rendered="#{webUserController.hasPrivilege('PharmacyDisbursementRequest') and configOptionApplicationController.getBooleanValueByKey('Pharmacy Transer Request With Approval')}" 
+                                    action="/pharmacy/pharmacy_transfer_request_list_search_for_approval?faces-redirect=true"
+                                    value="Search Transer Request"
+                                    actionListener="#{searchController.makeListNull()}"
+                                    rendered="#{webUserController.hasPrivilege('PharmacyDisbursementRequest') and configOptionApplicationController.getBooleanValueByKey('Pharmacy Transer Request With Approval')}"
                                     icon="fas fa-hand-holding-medical"></p:menuitem>
+
+                        <p:menuitem ajax="false"
+                                    action="#{searchController.navigateToTransferRequestFinalize}"
+                                    value="To Finalize Transfer Requests"
+                                    actionListener="#{searchController.makeListNull()}"
+                                    rendered="#{webUserController.hasPrivilege('PharmacyDisbursementRequest')}"
+                                    icon="fas fa-tasks"></p:menuitem>
 
                         <p:menuitem ajax="false" 
                                     action="#{transferIssueController.navigateToListPharmacyIssueRequests}"  


### PR DESCRIPTION
## Summary
- add page to list transfer requests pending finalization
- allow navigating to transfer request save page from the new list
- load bill items correctly when editing transfer requests
- expose navigation method and menu link for the finalize list

## Testing
- `mvn -q test` *(fails: mvn not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68669f2d6ea0832fb928e14756db8425