### PR TITLE
Add item history button to transfer request save

### DIFF
--- a/src/main/webapp/pharmacy/pharmacy_transfer_request_save.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_transfer_request_save.xhtml
@@ -140,7 +140,17 @@
                                       id="itemList" editable="true" >
 
                             <p:column headerText="Item Name" >
-                                #{bi.item.name}
+                                <h:outputText
+                                    id="item"
+                                    value="#{bi.item.name}" />
+                                <p:commandButton
+                                    icon="pi pi-search"
+                                    id="btnViewSelectedItemDetails"
+                                    title="View Item Details"
+                                    action="#{transferRequestController.displayItemDetails(bi)}"
+                                    update=":#{p:resolveFirstComponentWithId('tab',view).clientId}"
+                                    process="@this"
+                                    class="ui-button-icon-only mx-3"/>
                             </p:column>
 
                             <p:column headerText="Qty" >


### PR DESCRIPTION
## Summary
- show the item details button in transfer request save

## Testing
- `mvn -q test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_68669f2e9354832f95c25f7f802612a6