### PR TITLE
Add item history button to transfer request save page

### DIFF
--- a/src/main/webapp/pharmacy/pharmacy_transfer_request_save.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_transfer_request_save.xhtml
@@ -148,7 +148,7 @@
                                     id="btnViewSelectedItemDetails"
                                     title="View Item Details"
                                     action="#{transferRequestController.displayItemDetails(bi)}"
-                                    update=":#{p:resolveFirstComponentWithId('tab',view).clientId}"
+                                    update="history"
                                     process="@this"
                                     class="ui-button-icon-only mx-3"/>
                             </p:column>
@@ -171,7 +171,7 @@
                         </p:dataTable>
                     </p:panel>
 
-                    <ph:history/>
+                    <ph:history id="history"/>
 
 
                 </p:panel>


### PR DESCRIPTION
## Summary
- show history button in item column with id `btnViewSelectedItemDetails`
- refresh `ph:history` composite when viewing details

## Testing
- `mvn -q test` *(fails: Could not resolve maven-resources-plugin)*

------
https://chatgpt.com/codex/tasks/task_e_6866aabc3100832fa563d378590a173b