### PR TITLE
Fix duplicate items on transfer finalization

### DIFF
--- a/src/main/java/com/divudi/bean/pharmacy/TransferRequestController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/TransferRequestController.java
@@ -414,7 +414,10 @@ public class TransferRequestController implements Serializable {
             b.setPharmaceuticalBillItem(tmpPh);
             getPharmaceuticalBillItemFacade().edit(tmpPh);
             getBillItemFacade().edit(b);
-            getTransferRequestBillPre().getBillItems().add(b);
+
+            if (b.getId() == null || !getTransferRequestBillPre().getBillItems().contains(b)) {
+                getTransferRequestBillPre().getBillItems().add(b);
+            }
         }
         getTransferRequestBillPre().setBillTypeAtomic(BillTypeAtomic.PHARMACY_TRANSFER_REQUEST_PRE);
         LOGGER.log(Level.FINE, "Finalizing transfer request with {0} items", getBillItems().size());


### PR DESCRIPTION
## Summary
- avoid repeated additions when finalizing saved pharmacy transfer requests

## Testing
- `mvn -q test` *(fails: PluginResolutionException)*

------
https://chatgpt.com/codex/tasks/task_e_6866c7587424832fa36f20ca961066eb