### PR TITLE
Add rate calculations on transfer request page

### DIFF
--- a/src/main/webapp/pharmacy/pharmacy_transfer_request.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_transfer_request.xhtml
@@ -177,7 +177,20 @@
 
                             <p:column headerText="Qty" >
                                 <p:inputText autocomplete="off"  id="qty" value="#{bi.tmpQty}" label="Qty">
+                                    <p:ajax event="blur" update="itemList requestTotals" listener="#{transferRequestController.onEdit(bi)}"/>
                                 </p:inputText>
+                            </p:column>
+
+                            <p:column headerText="Transfer Rate" class="text-end">
+                                <h:outputLabel value="#{bi.billItemFinanceDetails.lineGrossRate}">
+                                    <f:convertNumber pattern="#,##0.00" />
+                                </h:outputLabel>
+                            </p:column>
+
+                            <p:column headerText="Transfer Value" class="text-end">
+                                <h:outputLabel value="#{bi.billItemFinanceDetails.lineGrossTotal}">
+                                    <f:convertNumber pattern="#,##0.00" />
+                                </h:outputLabel>
                             </p:column>
 
                             <p:column>
@@ -189,6 +202,26 @@
                                     action="#{transferRequestController.remove(bi)}"/>
                             </p:column>
                         </p:dataTable>
+                    </p:panel>
+
+                    <p:panel id="requestTotals" class="my-2">
+                        <f:facet name="header" >
+                            <h:outputLabel styleClass="fas fa-list" />
+                            <h:outputLabel value="Request Details" class="mx-4" />
+                        </f:facet>
+                        <h:panelGrid columns="3" class="w-100">
+                            <h:outputLabel value="Transfer Value" />
+                            <h:outputLabel value=": &nbsp;"/>
+                            <h:outputLabel class="w-100 text-end" value="#{transferRequestController.transferRequestBillPre.netTotal}">
+                                <f:convertNumber pattern="#,##0.00" />
+                            </h:outputLabel>
+
+                            <h:outputLabel value="Transfer Cost Value" />
+                            <h:outputLabel value=": &nbsp;"/>
+                            <h:outputLabel class="w-100 text-end" value="#{transferRequestController.transferRequestBillPre.billFinanceDetails.totalCostValue}">
+                                <f:convertNumber pattern="#,##0.00" />
+                            </h:outputLabel>
+                        </h:panelGrid>
                     </p:panel>
 
                     <ph:history/>


### PR DESCRIPTION
## Summary
- compute transfer rates for request bill items based on config options
- recalc totals when adding, editing or removing items
- display rate/value columns and bill totals on `pharmacy_transfer_request.xhtml`

## Testing
- `mvn -q -DskipTests package` *(fails: mvn not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6866fe4d5b4c832facf5691982972438