### PR TITLE
Enhance transfer request costing controls

### DIFF
--- a/src/main/java/com/divudi/bean/pharmacy/TransferRequestController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/TransferRequestController.java
@@ -736,6 +736,47 @@ public class TransferRequestController implements Serializable {
         }
     }
 
+    // ChatGPT contributed - Populate default rates when an item is selected
+    public void populateRatesOnItemSelect() {
+        BillItem bi = getCurrentBillItem();
+        if (bi == null || bi.getItem() == null) {
+            return;
+        }
+
+        PharmaceuticalBillItem ph = bi.getPharmaceuticalBillItem();
+        if (ph == null) {
+            ph = new PharmaceuticalBillItem();
+            ph.setBillItem(bi);
+            bi.setPharmaceuticalBillItem(ph);
+        }
+
+        ph.setPurchaseRate(pharmacyBean.getLastPurchaseRate(bi.getItem(), sessionController.getDepartment()));
+        ph.setRetailRateInUnit(pharmacyBean.getLastRetailRate(bi.getItem(), sessionController.getDepartment()));
+
+        BillItemFinanceDetails fd = bi.getBillItemFinanceDetails();
+        if (fd == null) {
+            fd = new BillItemFinanceDetails(bi);
+            bi.setBillItemFinanceDetails(fd);
+        }
+
+        fd.setLineCostRate(BigDecimal.valueOf(ph.getPurchaseRate()));
+        fd.setLineGrossRate(determineTransferRate(bi.getItem()));
+
+        pharmacyCostingService.recalculateFinancialsBeforeAddingBillItem(fd);
+        pharmacyCostingService.calculateBillTotalsFromItemsForTransferOuts(getTransferRequestBillPre(), getBillItems());
+    }
+
+    // ChatGPT contributed - Recalculate item totals when gross rate changes
+    public void onLineGrossRateChange(BillItem bi) {
+        if (bi == null || bi.getBillItemFinanceDetails() == null) {
+            return;
+        }
+
+        BillItemFinanceDetails fd = bi.getBillItemFinanceDetails();
+        pharmacyCostingService.recalculateFinancialsBeforeAddingBillItem(fd);
+        pharmacyCostingService.calculateBillTotalsFromItemsForTransferOuts(getTransferRequestBillPre(), getBillItems());
+    }
+
     private BigDecimal determineTransferRate(Item item) {
         boolean byPurchase = configOptionApplicationController.getBooleanValueByKey("Pharmacy Transfer is by Purchase Rate", false);
         boolean byCost = configOptionApplicationController.getBooleanValueByKey("Pharmacy Transfer is by Cost Rate", false);

--- a/src/main/webapp/pharmacy/pharmacy_transfer_request.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_transfer_request.xhtml
@@ -117,7 +117,9 @@
                                                 <p:outputLabel value="1"
                                                                rendered="#{vt.class eq 'class com.divudi.core.entity.pharmacy.Amp'}"/>
                                             </p:column>
-                                            <p:ajax event="itemSelect" update="focusQty" ></p:ajax>
+                                            <p:ajax event="itemSelect"
+                                                    listener="#{transferRequestController.populateRatesOnItemSelect}"
+                                                    update="txtLineCostRate txtLineGrossRate focusQty"/>
                                         </p:autoComplete>
                                     </div>
                                     <div class="col-2">
@@ -127,7 +129,19 @@
                                             <p:ajax event="change" update="focusItem" />
                                         </p:inputText>
                                     </div>
-                                    <div class="col-3">
+                                    <div class="col-2">
+                                        <p:inputText id="txtLineCostRate" class="w-100 text-end"
+                                                     value="#{transferRequestController.currentBillItem.billItemFinanceDetails.lineCostRate}">
+                                            <f:convertNumber pattern="#,##0.00" />
+                                        </p:inputText>
+                                    </div>
+                                    <div class="col-2">
+                                        <p:inputText id="txtLineGrossRate" class="w-100 text-end"
+                                                     value="#{transferRequestController.currentBillItem.billItemFinanceDetails.lineGrossRate}">
+                                            <f:convertNumber pattern="#,##0.00" />
+                                        </p:inputText>
+                                    </div>
+                                    <div class="col-2">
                                         <p:commandButton
                                             value="Add Item"
                                             icon="fas fa-plus"
@@ -184,9 +198,10 @@
                                     </p:column>
 
                                     <p:column headerText="Transfer Rate" class="text-end">
-                                        <h:outputLabel value="#{bi.billItemFinanceDetails.lineGrossRate}">
+                                        <p:inputText value="#{bi.billItemFinanceDetails.lineGrossRate}" class="w-100 text-end">
                                             <f:convertNumber pattern="#,##0.00" />
-                                        </h:outputLabel>
+                                            <p:ajax event="blur" listener="#{transferRequestController.onLineGrossRateChange(bi)}" update="itemList requestTotals"/>
+                                        </p:inputText>
                                     </p:column>
 
                                     <p:column headerText="Transfer Value" class="text-end">


### PR DESCRIPTION
## Summary
- allow editing cost and gross rates when adding items to transfer requests
- compute financials on item select and rate edits

## Testing
- `mvn -q -DskipTests package` *(fails: Could not transfer artifact)*

------
https://chatgpt.com/codex/tasks/task_e_686709e75050832f94ca23460d9f38ea