### PR TITLE
Add qty and rate recalculation

### DIFF
--- a/src/main/java/com/divudi/bean/pharmacy/TransferRequestController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/TransferRequestController.java
@@ -746,6 +746,38 @@ public class TransferRequestController implements Serializable {
         pharmacyCostingService.calculateBillTotalsFromItemsForTransferOuts(getTransferRequestBillPre(), getBillItems());
     }
 
+    // ************************************
+    // Newly added helper methods
+    // ************************************
+
+    public void onCurrentQtyChange() {
+        if (currentBillItem == null) {
+            return;
+        }
+
+        BillItemFinanceDetails fd = currentBillItem.getBillItemFinanceDetails();
+        if (fd == null) {
+            return;
+        }
+
+        pharmacyCostingService.recalculateFinancialsBeforeAddingBillItem(fd);
+        pharmacyCostingService.calculateBillTotalsFromItemsForTransferOuts(getTransferRequestBillPre(), getBillItems());
+    }
+
+    public void onCurrentLineGrossRateChange() {
+        if (currentBillItem == null) {
+            return;
+        }
+
+        BillItemFinanceDetails fd = currentBillItem.getBillItemFinanceDetails();
+        if (fd == null) {
+            return;
+        }
+
+        pharmacyCostingService.recalculateFinancialsBeforeAddingBillItem(fd);
+        pharmacyCostingService.calculateBillTotalsFromItemsForTransferOuts(getTransferRequestBillPre(), getBillItems());
+    }
+
     private BigDecimal determineTransferRate(Item item) {
         boolean byPurchase = configOptionApplicationController.getBooleanValueByKey("Pharmacy Transfer is by Purchase Rate", false);
         boolean byCost = configOptionApplicationController.getBooleanValueByKey("Pharmacy Transfer is by Cost Rate", false);

--- a/src/main/webapp/pharmacy/pharmacy_transfer_request.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_transfer_request.xhtml
@@ -118,7 +118,7 @@
                                             </p:column>
                                             <p:ajax event="itemSelect"
                                                     listener="#{transferRequestController.populateRatesOnItemSelect}"
-                                                    update="txtLineCostRate txtLineGrossRate focusQty"/>
+                                                    update="txtLineCostRate txtLineGrossRate txtLineNetValue requestTotals focusQty"/>
                                         </p:autoComplete>
                                     </div>
                                     <div class="col-1">
@@ -127,6 +127,7 @@
                                                      value="#{transferRequestController.currentBillItem.qty}"
                                                      onfocus="this.select();">
                                             <p:ajax event="change" update="focusItem" />
+                                            <p:ajax event="blur" listener="#{transferRequestController.onCurrentQtyChange}" update="txtLineNetValue requestTotals" />
                                         </p:inputText>
                                     </div>
                                     <div class="col-1">
@@ -134,6 +135,7 @@
                                         <p:inputText id="txtLineGrossRate" class="w-100 text-end"
                                                      value="#{transferRequestController.currentBillItem.billItemFinanceDetails.lineGrossRate}">
                                             <f:convertNumber pattern="#,##0.00" />
+                                            <p:ajax event="blur" listener="#{transferRequestController.onCurrentLineGrossRateChange}" update="txtLineNetValue requestTotals"/>
                                         </p:inputText>
                                     </div>
                                     <div class="col-1">


### PR DESCRIPTION
## Summary
- recalc net values when quantity or rate edited in transfer request
- refresh totals when adding item, quantity or rate changes

## Testing
- `mvn -q -DskipTests package` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6867133a5e58832fac57d356946196dd