### PR TITLE
show recent departments on transfer request page

### DIFF
--- a/src/main/webapp/pharmacy/pharmacy_transfer_request.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_transfer_request.xhtml
@@ -26,6 +26,14 @@
                                                  >
                                     <p:ajax process="@this" update="btn"></p:ajax>
                                 </p:autoComplete>
+                                <h:panelGroup rendered="#{not empty transferRequestController.recentToDepartments}">
+                                    <ui:repeat value="#{transferRequestController.recentToDepartments}" var="d">
+                                        <p:commandButton value="#{d.name}" icon="pi pi-building"
+                                                         class="m-1 p-button-sm p-button-outlined"
+                                                         action="#{transferRequestController.selectFromRecentDepartment(d)}"
+                                                         ajax="false"/>
+                                    </ui:repeat>
+                                </h:panelGroup>
                                 <h:panelGroup id="btn">
                                     <p:commandButton
                                         id="btnSelect"


### PR DESCRIPTION
## Summary
- list previously used departments when making pharmacy transfer requests
- add helper methods in TransferRequestController

## Testing
- `mvn -q -DskipTests package` *(fails: Could not transfer artifact maven-resources-plugin)*

------
https://chatgpt.com/codex/tasks/task_e_68671542db84832fa001deebf0e9b0ba