### PR TITLE
12799-disable-transfer-request-approve-after-use

### DIFF
--- a/src/main/java/com/divudi/bean/pharmacy/TransferRequestController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/TransferRequestController.java
@@ -281,6 +281,16 @@ public class TransferRequestController implements Serializable {
             }
             bill.getBillItems().add(newBillItem);
         }
+
+        if (transferRequestBillPre != null) {
+            transferRequestBillPre.setForwardReferenceBill(bill);
+            transferRequestBillPre.setApproveUser(sessionController.getLoggedUser());
+            transferRequestBillPre.setApproveAt(new Date());
+            transferRequestBillPre.setReferenceBill(bill);
+            billFacade.edit(transferRequestBillPre);
+            bill.setReferenceBill(transferRequestBillPre);
+        }
+
         billFacade.edit(bill);
         printPreview = true;
     }


### PR DESCRIPTION
## Summary
- set approval user & date for transfer request pre-bill
- link approved bill with its pre-bill so the list detects approval

## Testing
- `mvn -q -DskipTests package` *(fails: Could not transfer artifact org.apache.maven.plugins:maven-resources-plugin)*

------
https://chatgpt.com/codex/tasks/task_e_6868707fd170832f894c437579401dda