### PR TITLE
Add report execution logs page

### DIFF
--- a/src/main/java/com/divudi/bean/common/DataAdministrationController.java
+++ b/src/main/java/com/divudi/bean/common/DataAdministrationController.java
@@ -705,6 +705,10 @@ public class DataAdministrationController implements Serializable {
         return "/dataAdmin/name_to_code?faces-redirect=true";
     }
 
+    public String navigateToReportExecutionLogs() {
+        return "/dataAdmin/report_execution_logs?faces-redirect=true";
+    }
+
     public String navigateToListOpdBillsAndBillItemsFields() {
         return "/dataAdmin/opd_bills_and_bill_items?faces-redirect=true";
     }

--- a/src/main/java/com/divudi/bean/common/ReportLogController.java
+++ b/src/main/java/com/divudi/bean/common/ReportLogController.java
@@ -1,0 +1,71 @@
+package com.divudi.bean.common;
+
+import com.divudi.core.entity.report.ReportLog;
+import com.divudi.core.facade.ReportLogFacade;
+import com.divudi.core.util.CommonFunctions;
+
+import javax.ejb.EJB;
+import javax.enterprise.context.SessionScoped;
+import javax.inject.Inject;
+import javax.inject.Named;
+import javax.persistence.TemporalType;
+import java.io.Serializable;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@Named
+@SessionScoped
+public class ReportLogController implements Serializable {
+    private static final long serialVersionUID = 1L;
+
+    @EJB
+    private ReportLogFacade reportLogFacade;
+
+    @Inject
+    SessionController sessionController;
+
+    private Date fromDate;
+    private Date toDate;
+    private List<ReportLog> items;
+
+    public void fillReportLogs() {
+        String jpql = "select rl from ReportLog rl " +
+                "where rl.createdAt between :fd and :td order by rl.startTime desc";
+        Map<String, Object> hm = new HashMap<>();
+        hm.put("fd", getFromDate());
+        hm.put("td", getToDate());
+        items = reportLogFacade.findByJpql(jpql, hm, TemporalType.TIMESTAMP);
+    }
+
+    public Date getFromDate() {
+        if (fromDate == null) {
+            fromDate = CommonFunctions.getStartOfDay();
+        }
+        return fromDate;
+    }
+
+    public void setFromDate(Date fromDate) {
+        this.fromDate = fromDate;
+    }
+
+    public Date getToDate() {
+        if (toDate == null) {
+            toDate = CommonFunctions.getEndOfDay();
+        }
+        return toDate;
+    }
+
+    public void setToDate(Date toDate) {
+        this.toDate = toDate;
+    }
+
+    public List<ReportLog> getItems() {
+        return items;
+    }
+
+    public void setItems(List<ReportLog> items) {
+        this.items = items;
+    }
+}

--- a/src/main/java/com/divudi/core/data/Icon.java
+++ b/src/main/java/com/divudi/core/data/Icon.java
@@ -131,7 +131,8 @@ public enum Icon {
     Financial_Transaction_Manager("Financial Transaction Manager"),
     Channel_Booking_by_Dates("Channel Booking by Dates"),
     Channel_Scheduling("Channel Scheduling"),
-    Goods_Receipt_Costing("Goods Receipt Costing");
+    Goods_Receipt_Costing("Goods Receipt Costing"),
+    Report_Execution_Logs("Report Execution Logs");
 
     private final String label;
 

--- a/src/main/webapp/dataAdmin/admin_data_administration.xhtml
+++ b/src/main/webapp/dataAdmin/admin_data_administration.xhtml
@@ -257,8 +257,15 @@
 
                                             <p:commandButton
                                                 ajax="false" 
-                                                action="#{dataAdministrationController.navigateToDownloadLogFiles()}" 
-                                                value="To Download Log Files"  
+                                            action="#{dataAdministrationController.navigateToDownloadLogFiles()}"
+                                            value="To Download Log Files"
+                                            class="w-100 m-1"
+                                            />
+
+                                            <p:commandButton
+                                                ajax="false"
+                                                action="#{dataAdministrationController.navigateToReportExecutionLogs()}"
+                                                value="Report Execution Logs"
                                                 class="w-100 m-1"
                                                 />
 

--- a/src/main/webapp/dataAdmin/report_execution_logs.xhtml
+++ b/src/main/webapp/dataAdmin/report_execution_logs.xhtml
@@ -1,0 +1,77 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
+      xmlns:p="http://primefaces.org/ui"
+      xmlns:h="http://xmlns.jcp.org/jsf/html"
+      xmlns:f="http://xmlns.jcp.org/jsf/core">
+
+    <h:body>
+        <ui:composition template="/dataAdmin/admin_data_administration.xhtml">
+            <ui:define name="subcontent">
+                <h:form>
+                    <p:panel>
+                        <f:facet name="header">
+                            <h:outputText value="Report Execution Logs" />
+                        </f:facet>
+
+                        <h:panelGrid columns="2" class="my-2">
+                            <h:outputLabel value="From Date" />
+                            <p:datePicker class="w-100 mx-4" inputStyleClass="w-100"
+                                          id="fromDate"
+                                          value="#{reportLogController.fromDate}"
+                                          showTime="true"
+                                          pattern="#{sessionController.applicationPreference.longDateTimeFormat}" />
+                            <h:outputLabel value="To Date" />
+                            <p:datePicker class="w-100 mx-4" inputStyleClass="w-100"
+                                          id="toDate"
+                                          value="#{reportLogController.toDate}"
+                                          showTime="true"
+                                          pattern="#{sessionController.applicationPreference.longDateTimeFormat}" />
+                        </h:panelGrid>
+
+                        <h:panelGrid columns="3" class="my-2">
+                            <p:commandButton id="btnSearch"
+                                             class="ui-button-warning"
+                                             icon="pi pi-search"
+                                             ajax="false"
+                                             value="Search"
+                                             action="#{reportLogController.fillReportLogs}" />
+                        </h:panelGrid>
+
+                        <p:dataTable id="tblLogs" value="#{reportLogController.items}"
+                                     var="rl" rowIndexVar="i" style="min-width:100%;"
+                                     paginator="true" paginatorPosition="bottom"
+                                     rows="10"
+                                     paginatorTemplate="{CurrentPageReport} {FirstPageLink} {PreviousPageLink} {PageLinks} {NextPageLink} {LastPageLink} {RowsPerPageDropdown}"
+                                     rowsPerPageTemplate="5,10,15">
+                            <p:column headerText="User">
+                                <h:outputText value="#{webUserController.findWebUserNameWithTitleById(rl.generatedById)}" />
+                            </p:column>
+
+                            <p:column headerText="Report">
+                                <h:outputText value="#{rl.reportName}" />
+                            </p:column>
+
+                            <p:column headerText="Start Time">
+                                <h:outputText value="#{rl.startTime}">
+                                    <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateTimeFormat}" />
+                                </h:outputText>
+                            </p:column>
+
+                            <p:column headerText="End Time">
+                                <h:outputText value="#{rl.endTime}">
+                                    <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateTimeFormat}" />
+                                </h:outputText>
+                            </p:column>
+
+                            <p:column headerText="Duration (ms)">
+                                <h:outputText value="#{rl.executionTimeInMillis}" />
+                            </p:column>
+                        </p:dataTable>
+                    </p:panel>
+                </h:form>
+            </ui:define>
+        </ui:composition>
+    </h:body>
+</html>

--- a/src/main/webapp/home.xhtml
+++ b/src/main/webapp/home.xhtml
@@ -1620,6 +1620,21 @@
                     </h:form>
                 </h:panelGroup>
 
+                <!-- Report Execution Logs -->
+                <h:panelGroup rendered="#{ui.icon eq 'Report_Execution_Logs'}" layout="block" class="col-1 p-1" >
+                    <h:form>
+                        <p:tooltip for="report_execution_logs" value="Report Execution Logs" showDelay="0" hideDelay="0"></p:tooltip>
+                        <p:commandLink
+                            id="report_execution_logs"
+                            ajax="false"
+                            action="/dataAdmin/report_execution_logs?faces-redirect=true"
+                            styleClass="svg-link" >
+                            <p:graphicImage class="img-thumbnail"  library="images" name="home/report-execution-logs.svg" style="cursor: pointer;" width="80" height="80"/>
+                            <h:outputText style="display: none;" value="Report Execution Logs" />
+                        </p:commandLink>
+                    </h:form>
+                </h:panelGroup>
+
                 <!-- Channel Booking by Dates -->
                 <h:panelGroup rendered="#{ui.icon eq 'Channel_Booking_by_Dates' and webUserController.hasPrivilege('ChannellingChannelBooking')}" layout="block" class="col-1 p-1" >
                     <h:form>

--- a/src/main/webapp/resources/images/home/report-execution-logs.svg
+++ b/src/main/webapp/resources/images/home/report-execution-logs.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48" fill="currentColor">
+  <rect x="6" y="8" width="36" height="32" rx="2" ry="2" stroke="currentColor" fill="none"/>
+  <path d="M14 16h20M14 24h20M14 32h12" stroke="currentColor" stroke-width="2" fill="none" stroke-linecap="round"/>
+</svg>


### PR DESCRIPTION
## Summary
- allow navigating to report execution logs
- implement `ReportLogController`
- expose new icon and UI entrypoint
- add `report_execution_logs.xhtml` page

## Testing
- `mvn -q -DskipTests=true package` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6868c0d37ad0832fb64acaa4ae60098e