### PR TITLE
13698 add report execution log capturing to lab dashboard

### DIFF
--- a/src/main/java/com/divudi/bean/common/ReportTimerController.java
+++ b/src/main/java/com/divudi/bean/common/ReportTimerController.java
@@ -44,4 +44,28 @@ public class ReportTimerController implements Serializable {
             reportLogAsyncService.logReport(savedLog);
         }
     }
+
+    public void trackReportExecution(Runnable reportGenerationLogic, IReportType reportType, String reportName, WebUser loggedUser) {
+        final Date startTime = new Date();
+
+        final ReportLog reportLog = new ReportLog(reportType, reportName, loggedUser, startTime, null);
+
+        ReportLog savedLog = null;
+
+        try {
+            Future<ReportLog> futureLog = reportLogAsyncService.logReport(reportLog);
+            savedLog = futureLog.get();
+
+            reportGenerationLogic.run();
+        } catch (Exception e) {
+            LOGGER.log(Level.SEVERE, "Error occurred while generating the report", e);
+        }
+
+        final Date endTime = new Date();
+
+        if (savedLog != null) {
+            savedLog.setEndTime(endTime);
+            reportLogAsyncService.logReport(savedLog);
+        }
+    }
 }

--- a/src/main/java/com/divudi/core/data/reports/CommonReports.java
+++ b/src/main/java/com/divudi/core/data/reports/CommonReports.java
@@ -1,0 +1,29 @@
+package com.divudi.core.data.reports;
+
+/**
+ * Generic report type used for miscellaneous report logging.
+ */
+public enum CommonReports implements IReportType {
+    LAB_DASHBOARD("Lab Dashboard");
+
+    private final String displayName;
+
+    CommonReports(String displayName) {
+        this.displayName = displayName;
+    }
+
+    @Override
+    public String getDisplayName() {
+        return displayName;
+    }
+
+    @Override
+    public String getReportType() {
+        return this.getClass().getSimpleName();
+    }
+
+    @Override
+    public String getReportName() {
+        return this.name();
+    }
+}

--- a/src/main/java/com/divudi/core/entity/report/ReportLog.java
+++ b/src/main/java/com/divudi/core/entity/report/ReportLog.java
@@ -55,6 +55,15 @@ public class ReportLog implements Serializable {
         this.executionTimeInMillis = endTime != null && startTime != null ? endTime.getTime() - startTime.getTime() : null;
     }
 
+    public ReportLog(IReportType reportType, String reportName, WebUser generatedBy, Date startTime, Date endTime) {
+        this.generatedById = generatedBy.getId();
+        this.startTime = startTime;
+        this.endTime = endTime;
+        this.reportType = reportType.getReportType();
+        this.reportName = reportName;
+        this.executionTimeInMillis = endTime != null && startTime != null ? endTime.getTime() - startTime.getTime() : null;
+    }
+
     public ReportLog() {
     }
 

--- a/src/main/webapp/dataAdmin/report_execution_logs.xhtml
+++ b/src/main/webapp/dataAdmin/report_execution_logs.xhtml
@@ -50,7 +50,7 @@
                             </p:column>
 
                             <p:column headerText="Report">
-                                <h:outputText value="#{rl.reportName}" />
+                                <h:outputText value="#{rl.report != null ? rl.report.displayName : rl.reportName}" />
                             </p:column>
 
                             <p:column headerText="Start Time">


### PR DESCRIPTION
## Summary
- add `CommonReports` enum for generic logging
- support custom report name in `ReportLog`
- allow specifying custom name in `ReportTimerController`
- show readable report name in execution logs page
- log execution of lab dashboard actions

## Testing
- `mvn -q -DskipTests compile` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_686908b5e3b4832f9184698d70010362