### PR TITLE
Refactor report timer tracking method

### DIFF
--- a/src/main/java/com/divudi/bean/common/ReportTimerController.java
+++ b/src/main/java/com/divudi/bean/common/ReportTimerController.java
@@ -22,27 +22,7 @@ public class ReportTimerController implements Serializable {
     private ReportLogAsyncService reportLogAsyncService;
 
     public void trackReportExecution(Runnable reportGenerationLogic, IReportType reportType, WebUser loggedUser) {
-        final Date startTime = new Date();
-
-        final ReportLog reportLog = new ReportLog(reportType, loggedUser, startTime, null);
-
-        ReportLog savedLog = null;
-
-        try {
-            Future<ReportLog> futureLog = reportLogAsyncService.logReport(reportLog);
-            savedLog = futureLog.get();
-
-            reportGenerationLogic.run();
-        } catch (Exception e) {
-            LOGGER.log(Level.SEVERE, "Error occurred while generating the report", e);
-        }
-
-        final Date endTime = new Date();
-
-        if (savedLog != null) {
-            savedLog.setEndTime(endTime);
-            reportLogAsyncService.logReport(savedLog);
-        }
+        trackReportExecution(reportGenerationLogic, reportType, reportType.getReportName(), loggedUser);
     }
 
     public void trackReportExecution(Runnable reportGenerationLogic, IReportType reportType, String reportName, WebUser loggedUser) {


### PR DESCRIPTION
## Summary
- delegate `trackReportExecution(Runnable, IReportType, WebUser)` to the overloaded method to remove duplicate logic

## Testing
- `mvn -q test` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6869107d37d8832f940b46252022cdbe