### PR TITLE
Add report log tracking for billing pages

### DIFF
--- a/src/main/java/com/divudi/bean/collectingCentre/CollectingCentreBillController.java
+++ b/src/main/java/com/divudi/bean/collectingCentre/CollectingCentreBillController.java
@@ -18,6 +18,8 @@ import com.divudi.core.data.dataStructure.YearMonthDay;
 import com.divudi.ejb.BillEjb;
 import com.divudi.ejb.BillNumberGenerator;
 import com.divudi.ejb.CashTransactionBean;
+import com.divudi.bean.common.ReportTimerController;
+import com.divudi.core.data.reports.CommonReports;
 
 import com.divudi.service.StaffService;
 import com.divudi.core.entity.AgentHistory;
@@ -156,6 +158,8 @@ public class CollectingCentreBillController implements Serializable, ControllerW
     private EnumController enumController;
     @Inject
     DepartmentController departmentController;
+    @Inject
+    ReportTimerController reportTimerController;
     @EJB
     StaffService staffBean;
     @Inject
@@ -356,6 +360,14 @@ public class CollectingCentreBillController implements Serializable, ControllerW
 //        searchController.createTablePharmacyCreditToPayBills();
 //    }
     public void saveBillOPDCredit() {
+        reportTimerController.trackReportExecution(
+                () -> saveBillOPDCreditInternal(),
+                CommonReports.COLLECTING_CENTRE_BILL,
+                "CollectingCentreBillController.saveBillOPDCredit",
+                sessionController.getLoggedUser());
+    }
+
+    private void saveBillOPDCreditInternal() {
 
         BilledBill temp = new BilledBill();
 

--- a/src/main/java/com/divudi/bean/common/BillPackageController.java
+++ b/src/main/java/com/divudi/bean/common/BillPackageController.java
@@ -18,6 +18,8 @@ import com.divudi.core.data.dataStructure.PaymentMethodData;
 import com.divudi.core.data.dataStructure.YearMonthDay;
 import com.divudi.ejb.BillNumberGenerator;
 import com.divudi.ejb.CashTransactionBean;
+import com.divudi.bean.common.ReportTimerController;
+import com.divudi.core.data.reports.CommonReports;
 
 import com.divudi.ejb.ServiceSessionBean;
 import com.divudi.core.entity.Bill;
@@ -146,6 +148,8 @@ public class BillPackageController implements Serializable, ControllerWithPatien
     ApplicationController applicationController;
     @Inject
     PatientDepositController patientDepositController;
+    @Inject
+    ReportTimerController reportTimerController;
     //</editor-fold>
     // <editor-fold defaultstate="collapsed" desc="Class Variables">
     private List<Item> malePackaes;
@@ -1045,6 +1049,14 @@ public class BillPackageController implements Serializable, ControllerWithPatien
     }
 
     public void settleBill() {
+        reportTimerController.trackReportExecution(
+                () -> settleBillInternal(),
+                CommonReports.OPD_BILL_PACKAGE,
+                "BillPackageController.settleBill",
+                sessionController.getLoggedUser());
+    }
+
+    private void settleBillInternal() {
 //        if (validatePaymentMethodDeta()) {
 //            return;
 //        }

--- a/src/main/java/com/divudi/bean/common/OpdPreBillController.java
+++ b/src/main/java/com/divudi/bean/common/OpdPreBillController.java
@@ -18,6 +18,9 @@ import com.divudi.core.data.DepartmentType;
 import com.divudi.core.data.FeeType;
 import com.divudi.core.data.ItemLight;
 import com.divudi.core.data.PaymentMethod;
+import com.divudi.bean.common.ReportTimerController;
+import com.divudi.core.data.reports.CommonReports;
+import com.divudi.bean.common.ReportTimerController;
 import com.divudi.core.data.Sex;
 import com.divudi.core.data.Title;
 import com.divudi.core.data.dataStructure.PaymentMethodData;
@@ -129,6 +132,8 @@ public class OpdPreBillController implements Serializable, ControllerWithPatient
     ConfigOptionApplicationController configOptionApplicationController;
     @Inject
     DepartmentController departmentController;
+    @Inject
+    ReportTimerController reportTimerController;
 
     // </editor-fold>
     // <editor-fold defaultstate="collapsed" desc="Class Variables">
@@ -743,6 +748,14 @@ public class OpdPreBillController implements Serializable, ControllerWithPatient
     }
 
     public String settleBill() {
+        return reportTimerController.trackReportExecution(
+                () -> settleBillInternal(),
+                CommonReports.OPD_PRE_BILL,
+                "OpdPreBillController.settleBill",
+                sessionController.getLoggedUser());
+    }
+
+    private String settleBillInternal() {
         if (errorCheck()) {
             return null;
         }

--- a/src/main/java/com/divudi/bean/opd/OpdBillController.java
+++ b/src/main/java/com/divudi/bean/opd/OpdBillController.java
@@ -189,6 +189,8 @@ public class OpdBillController implements Serializable, ControllerWithPatient, C
     @Inject
     DrawerController drawerController;
     @Inject
+    ReportTimerController reportTimerController;
+    @Inject
     PatientInvestigationController patientInvestigationController;
     /**
      * Class Variables
@@ -1830,6 +1832,14 @@ public class OpdBillController implements Serializable, ControllerWithPatient, C
     }
 
     public String settleOpdBill() {
+        return reportTimerController.trackReportExecution(
+                () -> settleOpdBillInternal(),
+                CommonReports.OPD_BILL,
+                "OpdBillController.settleOpdBill",
+                sessionController.getLoggedUser());
+    }
+
+    private String settleOpdBillInternal() {
         AuditEvent audirEvent = auditEventController.createNewAuditEvent("Settle OPD Bill");
         if (billSettlingStarted) {
             auditEventController.failAuditEvent(audirEvent, "Failed due to already started OPD Bill Settling Process.");

--- a/src/main/java/com/divudi/bean/pharmacy/PharmacySaleController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacySaleController.java
@@ -16,7 +16,9 @@ import com.divudi.bean.common.PriceMatrixController;
 import com.divudi.bean.common.SearchController;
 import com.divudi.bean.common.SessionController;
 import com.divudi.bean.common.TokenController;
+import com.divudi.bean.common.ReportTimerController;
 import com.divudi.core.util.JsfUtil;
+import com.divudi.core.data.reports.CommonReports;
 import com.divudi.bean.membership.MembershipSchemeController;
 import com.divudi.bean.membership.PaymentSchemeController;
 import com.divudi.core.data.BillClassType;
@@ -140,6 +142,8 @@ public class PharmacySaleController implements Serializable, ControllerWithPatie
     TokenController tokenController;
     @Inject
     DrawerController drawerController;
+    @Inject
+    ReportTimerController reportTimerController;
 
     ////////////////////////
     @EJB
@@ -2368,6 +2372,14 @@ public class PharmacySaleController implements Serializable, ControllerWithPatie
     }
 
     public void settleBillWithPay() {
+        reportTimerController.trackReportExecution(
+                () -> settleBillWithPayInternal(),
+                CommonReports.PHARMACY_BILL_RETAIL_SALE,
+                "PharmacySaleController.settleBillWithPay",
+                sessionController.getLoggedUser());
+    }
+
+    private void settleBillWithPayInternal() {
         editingQty = null;
 
         if (billSettlingStarted) {

--- a/src/main/java/com/divudi/bean/pharmacy/PurchaseOrderRequestController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PurchaseOrderRequestController.java
@@ -9,6 +9,8 @@ import com.divudi.bean.common.ItemController;
 import com.divudi.bean.common.EnumController;
 import com.divudi.bean.common.NotificationController;
 import com.divudi.bean.common.SessionController;
+import com.divudi.bean.common.ReportTimerController;
+import com.divudi.core.data.reports.CommonReports;
 
 import com.divudi.core.data.BillType;
 import com.divudi.core.data.PaymentMethod;
@@ -83,6 +85,8 @@ public class PurchaseOrderRequestController implements Serializable {
 
     @Inject
     NotificationController notificationController;
+    @Inject
+    ReportTimerController reportTimerController;
 
     public void removeSelected() {
         if (selectedBillItems == null) {
@@ -225,6 +229,14 @@ public class PurchaseOrderRequestController implements Serializable {
     }
 
     public void saveBill() {
+        reportTimerController.trackReportExecution(
+                () -> saveBillInternal(),
+                CommonReports.PHARMACY_PURCHASE_ORDER_REQUEST,
+                "PurchaseOrderRequestController.saveBill",
+                sessionController.getLoggedUser());
+    }
+
+    private void saveBillInternal() {
 
         String deptId = billNumberBean.departmentBillNumberGeneratorYearly(getSessionController().getDepartment(), BillTypeAtomic.PHARMACY_ORDER_PRE);
 

--- a/src/main/java/com/divudi/core/data/reports/CommonReports.java
+++ b/src/main/java/com/divudi/core/data/reports/CommonReports.java
@@ -4,7 +4,17 @@ package com.divudi.core.data.reports;
  * Generic report type used for miscellaneous report logging.
  */
 public enum CommonReports implements IReportType {
-    LAB_DASHBOARD("Lab Dashboard");
+    LAB_DASHBOARD("Lab Dashboard"),
+    OPD_BILL("OPD Bill"),
+    OPD_BILL_PACKAGE("OPD Bill Package"),
+    OPD_PRE_BILL("OPD Pre Bill"),
+    COLLECTING_CENTRE_BILL("Collecting Centre Bill"),
+    PHARMACY_SEARCH_PRE_BILL("Pharmacy Search Pre Bill"),
+    OPD_BILL_SEARCH("OPD Bill Search"),
+    PHARMACY_BILL_RETAIL_SALE("Pharmacy Bill Retail Sale"),
+    PHARMACY_BILL_RETAIL_SALE_FOR_CASHIER("Pharmacy Bill Retail Sale For Cashier"),
+    PHARMACY_PURCHASE_ORDER_REQUEST("Pharmacy Purchase Order Request"),
+    PHARMACY_PURCHASE_ORDER_LIST_FOR_RECEIVE("Pharmacy Purchase Order List For Receive");
 
     private final String displayName;
 


### PR DESCRIPTION
## Summary
- extend `CommonReports` with new types
- support Supplier logging in `ReportTimerController`
- inject `ReportTimerController` into billing controllers
- wrap key billing actions with execution logging

## Testing
- `mvn test` *(fails: PluginResolutionException)*

------
https://chatgpt.com/codex/tasks/task_e_68691547be2c832f85f796c98262342c