### PR TITLE
Bug fix for transfer issue qty calculation

### DIFF
--- a/src/main/java/com/divudi/bean/pharmacy/TransferIssueController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/TransferIssueController.java
@@ -278,8 +278,9 @@ public class TransferIssueController implements Serializable {
             double requestedQty = getPharmacyCalculation().getBilledIssuedByRequestedItem(billItemInRequest, BillType.PharmacyTransferIssue);
             double cancelledIssued = getPharmacyCalculation().getCancelledIssuedByRequestedItem(billItemInRequest, BillType.PharmacyTransferIssue);
 
-            double quantityToIssue = billItemInRequest.getQty()
-                    - (Math.abs(requestedQty) - Math.abs(cancelledIssued));
+            double alreadyIssuedQty = Math.abs(requestedQty) - Math.abs(cancelledIssued);
+            billItemInRequest.setIssuedPhamaceuticalItemQty(alreadyIssuedQty);
+            double quantityToIssue = billItemInRequest.getQty() - alreadyIssuedQty;
 
             System.out.println("=================================================");
             System.out.println("Processing Item: " + billItemInRequest.getItem().getName());
@@ -640,7 +641,8 @@ public class TransferIssueController implements Serializable {
                 }
             }
 
-            if (bi.getReferanceBillItem().getQty() < (bi.getQty() + bi.getIssuedPhamaceuticalItemQty())) {
+            double alreadyIssued = bi.getReferanceBillItem().getIssuedPhamaceuticalItemQty();
+            if (bi.getReferanceBillItem().getQty() < (bi.getQty() + alreadyIssued)) {
                 JsfUtil.addErrorMessage("Issued quantity is higher than requested quantity in " + bi.getItem().getName());
                 return;
             }


### PR DESCRIPTION
## Summary
- calculate already issued quantity when building transfer issue items
- validate remaining qty using requested bill item's issued quantity

## Testing
- `mvn -q test` *(fails: mvn not installed)*

------
https://chatgpt.com/codex/tasks/task_e_686bdcf61b58832fb21ad158c4779449