### PR TITLE
Pharmacy receive qty recalculates totals

### DIFF
--- a/src/main/webapp/pharmacy/pharmacy_transfer_receive.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_transfer_receive.xhtml
@@ -64,10 +64,14 @@
                                         </h:outputText>
                                     </p:column>  
 
-                                    <p:column headerText="Receiving Qty" style="width:25px!important;">                      
-                                        <p:inputText autocomplete="off" id="qty" value="#{ph.qty}" >
+                                    <p:column headerText="Receiving Qty" style="width:25px!important;">
+                                        <p:inputText autocomplete="off" id="qty" value="#{ph.billItemFinanceDetails.quantity}" >
+                                            <f:convertNumber pattern="#,##0.#" />
+                                            <p:ajax event="keyup" process="@this"
+                                                    update="value txtReceivingNetTotal"
+                                                    listener="#{transferReceiveController.onQuantityChangeForTransferReceive(ph)}"/>
                                         </p:inputText>
-                                    </p:column>  
+                                    </p:column>
 
                                     <p:column headerText="Value"  style="width:25px!important;">  
                                         <h:outputText id="value" value="#{ph.netValue}" >                                   


### PR DESCRIPTION
## Summary
- recalc totals for pharmacy transfer receive when quantity edits occur
- update JSF page to trigger recalculation and show totals

## Testing
- `mvn test` *(fails: mvn not installed)*

------
https://chatgpt.com/codex/tasks/task_e_686c6772353c832fbaa606f9194722e2