### PR TITLE
Fix receive bill rebuild when reopening issue

### DIFF
--- a/src/main/java/com/divudi/bean/pharmacy/TransferReceiveController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/TransferReceiveController.java
@@ -244,6 +244,8 @@ public class TransferReceiveController implements Serializable {
             return "";
         }
 
+        generateBillComponent();
+        printPreview = false;
         return "/pharmacy/pharmacy_transfer_receive?faces-redirect=true";
     }
 


### PR DESCRIPTION
## Summary
- rebuild bill component when navigating to pharmacy receive
- reset print preview flag for clean form rendering

## Testing
- `mvn -q test` *(fails: Could not resolve maven-resources-plugin)*

------
https://chatgpt.com/codex/tasks/task_e_686c857bddc0832f88b125b3280434c5