### PR TITLE
Add batch details dialog to receive page

### DIFF
--- a/src/main/java/com/divudi/bean/pharmacy/TransferReceiveController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/TransferReceiveController.java
@@ -93,6 +93,7 @@ public class TransferReceiveController implements Serializable {
     private PharmacyCalculation pharmacyCalculation;
     private List<Bill> bills;
     private SearchKeyword searchKeyword;
+    private BillItem selectedBillItem;
 
     public void onFocus(BillItem tmp) {
         getPharmacyController().setPharmacyItem(tmp.getItem());
@@ -761,6 +762,22 @@ public class TransferReceiveController implements Serializable {
             tot += Math.abs(b.getNetValue());
         }
         return tot;
+    }
+
+    public void displayItemDetails(BillItem bi) {
+        getPharmacyController().fillItemDetails(bi.getItem());
+    }
+
+    public void prepareBatchDetails(BillItem bi) {
+        selectedBillItem = bi;
+    }
+
+    public BillItem getSelectedBillItem() {
+        return selectedBillItem;
+    }
+
+    public void setSelectedBillItem(BillItem selectedBillItem) {
+        this.selectedBillItem = selectedBillItem;
     }
 
 }

--- a/src/main/webapp/pharmacy/pharmacy_transfer_receive.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_transfer_receive.xhtml
@@ -38,10 +38,26 @@
                                              id="itemList" scrollable="true" scrollHeight="250" sortBy="#{ph.searialNo}"
                                              editable="true">  
 
-                                    <p:column headerText="Item Name"  style="width:25px!important;">  
-                                        <h:outputText id="item" value="#{ph.item.name}" >                                   
-                                        </h:outputText>
-                                    </p:column>  
+                                    <p:column headerText="Item Name"  style="width:25px!important;">
+                                        <h:outputText id="item" value="#{ph.item.name}" />
+                                        <p:commandButton
+                                            icon="pi pi-search"
+                                            id="btnViewSelectedItemDetails"
+                                            title="View Item Details"
+                                            action="#{transferReceiveController.displayItemDetails(ph)}"
+                                            update=":#{p:resolveFirstComponentWithId('tab',view).clientId}"
+                                            process="@this"
+                                            class="ui-button-icon-only mx-3"/>
+                                        <p:commandButton
+                                            icon="pi pi-info-circle"
+                                            id="btnViewBatchDetails"
+                                            title="View Batch Details"
+                                            actionListener="#{transferReceiveController.prepareBatchDetails(ph)}"
+                                            update=":#{p:resolveFirstComponentWithId('batchDetailsForm',view).clientId}"
+                                            oncomplete="PF('batchDetailsDialog').show();"
+                                            process="@this"
+                                            class="ui-button-info ui-button-icon-only mx-1"/>
+                                    </p:column>
 
                                     <p:column headerText="Batch No"  style="width:25px!important;">  
                                         <h:outputText id="batchNo" value="#{ph.pharmaceuticalBillItem.itemBatch.batchNo}" >                                   
@@ -122,6 +138,50 @@
 
 
                     <ph:history/>
+
+                    <p:dialog
+                        widgetVar="batchDetailsDialog"
+                        modal="true"
+                        position="top"
+                        fitViewport="true"
+                        appendTo="@(body)"
+                        header="Batch Details"
+                        width="40%">
+                        <p:panelGrid
+                            id="batchDetailsForm"
+                            layout="tabular"
+                            columns="2" class="table table-striped" >
+                            <f:facet name="header" >
+                                <h:outputLabel value="Batch Details" styleClass="fw-bold"/>
+                            </f:facet>
+                            <h:outputLabel value="Item" styleClass="fw-bold"/>
+                            <h:outputText value="#{transferReceiveController.selectedBillItem.item.name}"/>
+
+                            <h:outputLabel value="Batch No" styleClass="fw-bold"/>
+                            <h:outputText value="#{transferReceiveController.selectedBillItem.pharmaceuticalBillItem.itemBatch.batchNo}"/>
+
+                            <h:outputLabel value="Expiry Date" styleClass="fw-bold"/>
+                            <h:outputText value="#{transferReceiveController.selectedBillItem.pharmaceuticalBillItem.itemBatch.dateOfExpire}">
+                                <f:convertDateTime pattern="#{sessionController.applicationPreference.shortDateFormat}"/>
+                            </h:outputText>
+
+                            <h:outputLabel value="Purchase Price" styleClass="fw-bold"/>
+                            <h:outputText value="#{transferReceiveController.selectedBillItem.pharmaceuticalBillItem.itemBatch.purcahseRate}">
+                                <f:convertNumber pattern="#,##0.00"/>
+                            </h:outputText>
+
+                            <h:outputLabel value="Retail Rate" styleClass="fw-bold"/>
+                            <h:outputText value="#{transferReceiveController.selectedBillItem.pharmaceuticalBillItem.itemBatch.retailsaleRate}">
+                                <f:convertNumber pattern="#,##0.00"/>
+                            </h:outputText>
+
+                            <h:outputLabel value="Cost" styleClass="fw-bold"/>
+                            <h:outputText value="#{transferReceiveController.selectedBillItem.pharmaceuticalBillItem.itemBatch.costRate}">
+                                <f:convertNumber pattern="#,##0.00"/>
+                            </h:outputText>
+                        </p:panelGrid>
+
+                    </p:dialog>
                 </p:panel>
             </p:panel>
             <p:panel rendered="#{transferReceiveController.printPreview}">


### PR DESCRIPTION
## Summary
- support batch detail viewing in transfer receive page
- expose controller methods to show selected item details and batch info

## Testing
- `mvn -q test` *(fails: mvn not installed)*

------
https://chatgpt.com/codex/tasks/task_e_686cd7fe0c7c832f99b9bfd35742b67f