### PR TITLE
12875-incorrect-grn-billitem-quantity-ampp

### DIFF
--- a/src/main/java/com/divudi/bean/pharmacy/GrnCostingController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/GrnCostingController.java
@@ -1294,43 +1294,54 @@ public class GrnCostingController implements Serializable {
         if (bi.getItem() instanceof com.divudi.core.entity.pharmacy.Ampp) {
             BigDecimal unitsPerPack = Optional.ofNullable(f.getUnitsPerPack())
                     .orElse(BigDecimal.ONE);
-            BigDecimal qtyUnits = Optional.ofNullable(f.getQuantity())
-                    .orElse(BigDecimal.ZERO)
-                    .multiply(unitsPerPack);
-            BigDecimal freeQtyUnits = Optional.ofNullable(f.getFreeQuantity())
-                    .orElse(BigDecimal.ZERO)
-                    .multiply(unitsPerPack);
+            BigDecimal qtyPacks = Optional.ofNullable(f.getQuantity())
+                    .orElse(BigDecimal.ZERO);
+            BigDecimal qtyUnits = qtyPacks.multiply(unitsPerPack);
+            BigDecimal freeQtyPacks = Optional.ofNullable(f.getFreeQuantity())
+                    .orElse(BigDecimal.ZERO);
+            BigDecimal freeQtyUnits = freeQtyPacks.multiply(unitsPerPack);
 
             pbi.setQty(qtyUnits.doubleValue());
             pbi.setQtyInUnit(pbi.getQty());
-            pbi.setQtyPacks(Optional.ofNullable(f.getQuantity()).orElse(BigDecimal.ZERO).doubleValue());
+            pbi.setQtyPacks(qtyPacks.doubleValue());
 
             pbi.setFreeQty(freeQtyUnits.doubleValue());
             pbi.setFreeQtyInUnit(pbi.getFreeQty());
-            pbi.setFreeQtyPacks(Optional.ofNullable(f.getFreeQuantity()).orElse(BigDecimal.ZERO).doubleValue());
+            pbi.setFreeQtyPacks(freeQtyPacks.doubleValue());
 
-            pbi.setPurchaseRate(java.util.Optional.ofNullable(f.getNetRate()).orElse(java.math.BigDecimal.ZERO).doubleValue());
+            pbi.setPurchaseRate(Optional.ofNullable(f.getNetRate()).orElse(BigDecimal.ZERO).doubleValue());
             pbi.setPurchaseRatePack(pbi.getPurchaseRate());
 
-            pbi.setRetailRate(java.util.Optional.ofNullable(f.getRetailSaleRate()).orElse(java.math.BigDecimal.ZERO).doubleValue());
+            pbi.setRetailRate(Optional.ofNullable(f.getRetailSaleRate()).orElse(BigDecimal.ZERO).doubleValue());
             pbi.setRetailRatePack(pbi.getRetailRate());
-            pbi.setRetailRateInUnit(java.util.Optional.ofNullable(f.getRetailSaleRatePerUnit()).orElse(java.math.BigDecimal.ZERO).doubleValue());
+            pbi.setRetailRateInUnit(Optional.ofNullable(f.getRetailSaleRatePerUnit()).orElse(BigDecimal.ZERO).doubleValue());
+
+            // Update BillItem quantity and rate in packs
+            bi.setQty(qtyPacks.doubleValue());
+            bi.setRate(pbi.getPurchaseRatePack());
         } else {
-            pbi.setQty(java.util.Optional.ofNullable(f.getQuantityByUnits()).orElse(java.math.BigDecimal.ZERO).doubleValue());
+            BigDecimal qty = Optional.ofNullable(f.getQuantityByUnits()).orElse(BigDecimal.ZERO);
+            BigDecimal freeQty = Optional.ofNullable(f.getFreeQuantityByUnits()).orElse(BigDecimal.ZERO);
+
+            pbi.setQty(qty.doubleValue());
             pbi.setQtyInUnit(pbi.getQty());
             pbi.setQtyPacks(pbi.getQty());
 
-            pbi.setFreeQty(java.util.Optional.ofNullable(f.getFreeQuantityByUnits()).orElse(java.math.BigDecimal.ZERO).doubleValue());
+            pbi.setFreeQty(freeQty.doubleValue());
             pbi.setFreeQtyInUnit(pbi.getFreeQty());
             pbi.setFreeQtyPacks(pbi.getFreeQty());
 
-            pbi.setPurchaseRate(java.util.Optional.ofNullable(f.getNetRate()).orElse(java.math.BigDecimal.ZERO).doubleValue());
+            pbi.setPurchaseRate(Optional.ofNullable(f.getNetRate()).orElse(BigDecimal.ZERO).doubleValue());
             pbi.setPurchaseRatePack(pbi.getPurchaseRate());
 
-            double r = java.util.Optional.ofNullable(f.getRetailSaleRatePerUnit()).orElse(java.math.BigDecimal.ZERO).doubleValue();
+            double r = Optional.ofNullable(f.getRetailSaleRatePerUnit()).orElse(BigDecimal.ZERO).doubleValue();
             pbi.setRetailRate(r);
             pbi.setRetailRatePack(r);
             pbi.setRetailRateInUnit(r);
+
+            // Update BillItem quantity and rate in units
+            bi.setQty(qty.doubleValue());
+            bi.setRate(pbi.getPurchaseRate());
         }
     }
 


### PR DESCRIPTION
## Summary
- ensure BillItem quantity & rate are updated when processing GRN costing

## Testing
- `mvn -q test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d199b0f08832f8f7833c3197d4f89