### PR TITLE
13776 improvement of inward final bill

### DIFF
--- a/src/main/webapp/inward/inward_reprint_bill_final.xhtml
+++ b/src/main/webapp/inward/inward_reprint_bill_final.xhtml
@@ -474,7 +474,7 @@
                                                             <p:selectBooleanCheckbox
                                                                 value="#{inwardSearch.withProfessionalFee}"
                                                                 itemLabel="With Professional Fee"
-                                                                rendered="#{!configOptionApplicationController.getBooleanValueByKey('Inward Final Bill - Disable With Professional Fee in Final Bill',false)}"                                                                onchange="#{inwardSearch.showProfessionalFee()}">
+                                                                rendered="#{!configOptionApplicationController.getBooleanValueByKey('Inward Final Bill - Disable With Professional Fee in Final Bill',false)}"
                                                                 onchange="#{inwardSearch.showProfessionalFee()}">
                                                                 <p:ajax process="@this" update="OriginalFinalBillSummaryPriview"/>
                                                             </p:selectBooleanCheckbox>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted visibility of the "With Professional Fee" checkbox in the Final Bill Summary — it now appears when the related "Disable With Professional Fee" configuration is off or not set (default changed so checkbox is shown unless the disable flag is enabled).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->