### PR TITLE
Add detailed stock history tabs

### DIFF
--- a/src/main/webapp/analytics/pharmacy/stock_history.xhtml
+++ b/src/main/webapp/analytics/pharmacy/stock_history.xhtml
@@ -137,6 +137,66 @@
                                 </p:panelGrid>
                             </p:tab>
 
+                            <p:tab title="Bill Item Details">
+                                <p:panelGrid columns="2">
+                                    <p:outputLabel value="Quantity"/>
+                                    <p:outputLabel value="#{stockHistoryController.current.pbItem.qty}"/>
+
+                                    <p:outputLabel value="Purchase Rate"/>
+                                    <p:outputLabel value="#{stockHistoryController.current.pbItem.purchaseRate}"/>
+
+                                    <p:outputLabel value="Retail Rate"/>
+                                    <p:outputLabel value="#{stockHistoryController.current.pbItem.retailRate}"/>
+
+                                    <p:outputLabel value="Wholesale Rate"/>
+                                    <p:outputLabel value="#{stockHistoryController.current.pbItem.wholesaleRate}"/>
+
+                                    <p:outputLabel value="Purchase Value"/>
+                                    <p:outputLabel value="#{stockHistoryController.current.pbItem.purchaseValue}"/>
+
+                                    <p:outputLabel value="Bill Type"/>
+                                    <p:outputLabel value="#{stockHistoryController.current.pbItem.billItem.bill.billType.label}"/>
+                                </p:panelGrid>
+                            </p:tab>
+
+                            <p:tab title="Item Batch Details">
+                                <p:panelGrid columns="2">
+                                    <p:outputLabel value="Batch No"/>
+                                    <p:outputLabel value="#{stockHistoryController.current.itemBatch.batchNo}"/>
+
+                                    <p:outputLabel value="Expiry Date"/>
+                                    <p:outputLabel value="#{stockHistoryController.current.itemBatch.dateOfExpire}"/>
+
+                                    <p:outputLabel value="Manufacture Date"/>
+                                    <p:outputLabel value="#{stockHistoryController.current.itemBatch.dateOfManufacture}"/>
+
+                                    <p:outputLabel value="Retail Sale Rate"/>
+                                    <p:outputLabel value="#{stockHistoryController.current.itemBatch.retailsaleRate}"/>
+
+                                    <p:outputLabel value="Wholesale Rate"/>
+                                    <p:outputLabel value="#{stockHistoryController.current.itemBatch.wholesaleRate}"/>
+
+                                    <p:outputLabel value="Manufacturer"/>
+                                    <p:outputLabel value="#{stockHistoryController.current.itemBatch.manufacturer.name}"/>
+                                </p:panelGrid>
+                            </p:tab>
+
+                            <p:tab title="Stock Details">
+                                <p:panelGrid columns="2">
+                                    <p:outputLabel value="Stock ID"/>
+                                    <p:outputLabel value="#{stockHistoryController.current.pbItem.stock.id}"/>
+
+                                    <p:outputLabel value="Department"/>
+                                    <p:outputLabel value="#{stockHistoryController.current.pbItem.stock.department.name}"/>
+
+                                    <p:outputLabel value="Locator"/>
+                                    <p:outputLabel value="#{stockHistoryController.current.pbItem.stock.stockLocator}"/>
+
+                                    <p:outputLabel value="Stock Amount"/>
+                                    <p:outputLabel value="#{stockHistoryController.current.pbItem.stock.stock}"/>
+                                </p:panelGrid>
+                            </p:tab>
+
                             <p:tab title="Audit">
                                 <p:panelGrid columns="2">
                                     <p:outputLabel value="Created At"/>


### PR DESCRIPTION
## Summary
- expand pharmacy stock history with tabs for bill item, item batch, and stock data
- show additional info like qty, rates, expiry dates, and locator info

## Testing
- `mvn -q test` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:2.6 could not be resolved)*

------
https://chatgpt.com/codex/tasks/task_e_686da05cb574832fa83fcaad98cb88ac