### PR TITLE
Modify UserIcon form handling

### DIFF
--- a/src/main/java/com/divudi/bean/common/UserIconController.java
+++ b/src/main/java/com/divudi/bean/common/UserIconController.java
@@ -95,6 +95,8 @@ public class UserIconController implements Serializable {
             JsfUtil.addSuccessMessage("Save Success ");
             fillDepartmentIcon();
             reOrderUserIcons();
+            // Clear selected icon after successful addition
+            icon = null;
         } else {
             JsfUtil.addErrorMessage("Icon already exists at this position");
         }

--- a/src/main/webapp/admin/users/user_icons.xhtml
+++ b/src/main/webapp/admin/users/user_icons.xhtml
@@ -15,8 +15,8 @@
                     <na:not_authorize />
                 </h:panelGroup>
 
-                <h:form >
-                    <p:panel class="w-100" rendered="#{webUserController.hasPrivilege('AdminManagingUsers') or sessionController.firstLogin}" >
+                <!-- Use outer form from user_list.xhtml -->
+                <p:panel class="w-100" rendered="#{webUserController.hasPrivilege('AdminManagingUsers') or sessionController.firstLogin}" >
                         <f:facet name="header">
                             <i class="fa fa-icons" />
                             <h:outputLabel class="mx-2" value="Manage User Icons"/>
@@ -72,8 +72,8 @@
                                 ajax="false"
                                 class="w-100 mx-2"
                                 icon="fa fa-plus" 
-                                action="#{userIconController.addUserIcon}" 
-                                update="userIcon" 
+                                action="#{userIconController.addUserIcon}"
+                                update="iconAutoComplete tbl"
                                 />
                         </h:panelGrid>
 
@@ -140,7 +140,6 @@
                             </p:column>
                         </p:dataTable>
                     </p:panel>
-                </h:form>
             </ui:define>
         </ui:composition>
     </h:body>


### PR DESCRIPTION
## Summary
- remove nested `<h:form>` from `user_icons.xhtml`
- reset the selected icon after adding a user icon
- refresh autocomplete and table when adding icons

## Testing
- `mvn -q test` *(fails: Could not download maven dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_686da04d092c832fafdb5ddd0d68c025