### PR TITLE
Add details to stock history quantities tab

### DIFF
--- a/src/main/webapp/analytics/pharmacy/stock_history.xhtml
+++ b/src/main/webapp/analytics/pharmacy/stock_history.xhtml
@@ -132,10 +132,29 @@
 
 
                                     <p:outputLabel value="Purchase Value"/>
+                                    <p:outputLabel value="#{stockHistoryController.current.pbItem.purchaseValue}"/>
+                                    <p:outputLabel value=""/>
+                                    <p:outputLabel value=""/>
+
                                     <p:outputLabel value="Retail Value"/>
-                                    <p:outputLabel value="Whoelsale Value"/>
+                                    <p:outputLabel value="#{stockHistoryController.current.pbItem.retailValue}"/>
+                                    <p:outputLabel value=""/>
+                                    <p:outputLabel value=""/>
+
+                                    <p:outputLabel value="Wholesale Value"/>
+                                    <p:outputLabel value="#{stockHistoryController.current.pbItem.wholesaleRate * stockHistoryController.current.pbItem.qty}"/>
+                                    <p:outputLabel value=""/>
+                                    <p:outputLabel value=""/>
+
                                     <p:outputLabel value="Gross Value"/>
+                                    <p:outputLabel value=""/>
+                                    <p:outputLabel value="#{stockHistoryController.current.pbItem.billItem.grossValue}"/>
+                                    <p:outputLabel value="#{stockHistoryController.current.pbItem.billItem.billItemFinanceDetails.lineGrossTotal}"/>
+
                                     <p:outputLabel value="Net Value"/>
+                                    <p:outputLabel value=""/>
+                                    <p:outputLabel value="#{stockHistoryController.current.pbItem.billItem.netValue}"/>
+                                    <p:outputLabel value="#{stockHistoryController.current.pbItem.billItem.billItemFinanceDetails.lineNetTotal}"/>
 
                                 </p:panelGrid>
                             </p:tab>


### PR DESCRIPTION
## Summary
- extend pharmacy stock history view with values for purchase, retail, wholesale, gross and net

## Testing
- `mvn -q -DskipTests package` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_686dac9bc798832f9cb19f7f504ffe81