### PR TITLE
Implement GRN return with costing

### DIFF
--- a/src/main/java/com/divudi/bean/common/BillSearch.java
+++ b/src/main/java/com/divudi/bean/common/BillSearch.java
@@ -54,7 +54,8 @@ import com.divudi.core.facade.WebUserFacade;
 import com.divudi.core.util.JsfUtil;
 import com.divudi.bean.opd.OpdBillController;
 import com.divudi.bean.pharmacy.BhtIssueReturnController;
-import com.divudi.bean.pharmacy.DirectPurchaseReturnController;
+import com.divudi.bean.pharmacy.
+import com.divudi.bean.pharmacy.GrnReturnWithCostingController;
 import com.divudi.bean.pharmacy.GoodsReturnController;
 import com.divudi.bean.pharmacy.IssueReturnController;
 import com.divudi.bean.pharmacy.PharmacyBillSearch;
@@ -239,6 +240,9 @@ public class BillSearch implements Serializable {
     PurchaseReturnController purchaseReturnController;
     @Inject
     DirectPurchaseReturnController directPurchaseReturnController;
+
+    @Inject
+    GrnReturnWithCostingController grnReturnWithCostingController;
     @Inject
     PharmacyReturnwithouttresing pharmacyReturnwithouttresing;
     @Inject
@@ -4257,9 +4261,18 @@ public class BillSearch implements Serializable {
             return null;
         }
         loadBillDetails(bill);
-        goodsReturnController.setReturnBill(bill);
-        goodsReturnController.setPrintPreview(true);
-        return "/pharmacy/pharmacy_return_good";
+        grnReturnWithCostingController.resetValuesForReturn();
+        boolean manageCosting = configOptionApplicationController.getBooleanValueByKey("Manage Costing", true);
+        if (manageCosting) {
+            grnReturnWithCostingController.setBill(bill);
+            grnReturnWithCostingController.prepareReturnBill();
+            grnReturnWithCostingController.setPrintPreview(false);
+            return "/pharmacy/grn_return_with_costing?faces-redirect=true";
+        } else {
+            goodsReturnController.setReturnBill(bill);
+            goodsReturnController.setPrintPreview(true);
+            return "/pharmacy/pharmacy_return_good";
+        }
     }
 
     public String navigateToPharmacyIssue() {

--- a/src/main/java/com/divudi/bean/pharmacy/GrnReturnWithCostingController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/GrnReturnWithCostingController.java
@@ -1,0 +1,947 @@
+/*
+ * Dr M H B Ariyaratne
+ * buddhika.ari@gmail.com
+ */
+package com.divudi.bean.pharmacy;
+
+import com.divudi.bean.common.SessionController;
+import com.divudi.core.util.JsfUtil;
+import com.divudi.bean.common.ConfigOptionApplicationController;
+import com.divudi.core.data.BillClassType;
+import com.divudi.core.data.BillNumberSuffix;
+import com.divudi.core.data.BillType;
+import com.divudi.core.data.BillTypeAtomic;
+import com.divudi.core.data.PaymentMethod;
+import com.divudi.core.data.dataStructure.PharmacyItemData;
+import com.divudi.ejb.BillNumberGenerator;
+import com.divudi.ejb.PharmacyBean;
+import com.divudi.ejb.PharmacyCalculation;
+import com.divudi.core.entity.Bill;
+import com.divudi.core.entity.BillFee;
+import com.divudi.core.entity.BillFeePayment;
+import com.divudi.core.entity.BillItem;
+import com.divudi.core.entity.BilledBill;
+import com.divudi.core.entity.Payment;
+import com.divudi.core.entity.pharmacy.PharmaceuticalBillItem;
+import com.divudi.core.facade.BillFacade;
+import com.divudi.core.facade.BillFeeFacade;
+import com.divudi.core.facade.BillFeePaymentFacade;
+import com.divudi.core.facade.BillItemFacade;
+import com.divudi.core.facade.PaymentFacade;
+import com.divudi.core.facade.PharmaceuticalBillItemFacade;
+import com.divudi.core.entity.BillItemFinanceDetails;
+import com.divudi.core.entity.pharmacy.Ampp;
+import com.divudi.core.entity.BillFinanceDetails;
+import com.divudi.service.pharmacy.PharmacyCostingService;
+import java.math.BigDecimal;
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Calendar;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import javax.ejb.EJB;
+import javax.enterprise.context.SessionScoped;
+import javax.inject.Inject;
+import javax.inject.Named;
+
+/**
+ *
+ * @author safrin
+ */
+@Named
+@SessionScoped
+public class GrnReturnWithCostingController implements Serializable {
+
+    /**
+     * EJBs
+     */
+    @EJB
+    private PharmaceuticalBillItemFacade pharmaceuticalBillItemFacade;
+    @EJB
+    private BillNumberGenerator billNumberBean;
+    @EJB
+    private BillFacade billFacade;
+    @EJB
+    private PharmacyBean pharmacyBean;
+    @EJB
+    private BillItemFacade billItemFacade;
+    @EJB
+    BillFeePaymentFacade billFeePaymentFacade;
+    @EJB
+    BillFeeFacade billFeeFacade;
+    @EJB
+    PaymentFacade paymentFacade;
+    @EJB
+    PharmacyCostingService pharmacyCostingService;
+
+    /**
+     * Controllers
+     */
+    @Inject
+    PharmacyCalculation pharmacyCalculation;
+    @Inject
+    private PharmaceuticalItemController pharmaceuticalItemController;
+    @Inject
+    private PharmacyController pharmacyController;
+    @Inject
+    private SessionController sessionController;
+    @Inject
+    private ConfigOptionApplicationController configOptionApplicationController;
+    /**
+     * Properties
+     *
+     */
+
+    private Bill bill;
+    private Bill returnBill;
+    private boolean printPreview;
+    private List<BillItem> billItems;
+
+    public Bill getBill() {
+        return bill;
+    }
+
+    public void setBill(Bill bill) {
+        this.bill = bill;
+    }
+
+    public Bill getReturnBill() {
+        if (returnBill == null) {
+            returnBill = new BilledBill();
+            returnBill.setBillType(BillType.PharmacyGrnReturn);
+            returnBill.setBillTypeAtomic(BillTypeAtomic.PHARMACY_GRN_RETURN);
+        }
+        return returnBill;
+    }
+
+    public void setReturnBill(Bill returnBill) {
+        this.returnBill = returnBill;
+    }
+
+    public boolean isPrintPreview() {
+        return printPreview;
+    }
+
+    public void setPrintPreview(boolean printPreview) {
+        this.printPreview = printPreview;
+    }
+
+    @Inject
+    private PharmacyCalculation pharmacyRecieveBean;
+
+    private double getRemainingQty(BillItem bilItem) {
+        if (configOptionApplicationController.getBooleanValueByKey("Direct Purchase Return by Total Quantity", false)) {
+            double originalQty = bilItem.getQty();
+            double originalFreeQty = 0.0;
+            if (bilItem.getPharmaceuticalBillItem() != null) {
+                originalFreeQty = bilItem.getPharmaceuticalBillItem().getFreeQty();
+            }
+            double returnedTotal = getPharmacyRecieveBean().getTotalQtyWithFreeQty(bilItem, BillType.PharmacyGrnReturn, new BilledBill());
+            return originalQty + originalFreeQty - Math.abs(returnedTotal);
+        } else {
+            String sql = "Select sum(p.pharmaceuticalBillItem.qty) from BillItem p where"
+                    + "   p.creater is not null and"
+                    + " p.referanceBillItem=:bt and p.bill.billType=:btp";
+
+            HashMap hm = new HashMap();
+            hm.put("bt", bilItem);
+            hm.put("btp", BillType.PharmacyGrnReturn);
+
+            return bilItem.getQty() + getPharmaceuticalBillItemFacade().findDoubleByJpql(sql, hm);
+        }
+    }
+
+    private void addDataToReturningBillItem(BillItem returningBillItem) {
+        if (returningBillItem == null) {
+            return;
+        }
+        BillItem originalBillItem = returningBillItem.getReferanceBillItem();
+        if (originalBillItem == null) {
+            return;
+        }
+        BillItemFinanceDetails bifdOriginal = originalBillItem.getBillItemFinanceDetails();
+        if (bifdOriginal == null) {
+            return;
+        }
+        PharmaceuticalBillItem pbiOriginal = originalBillItem.getPharmaceuticalBillItem();
+        if (pbiOriginal == null) {
+            return;
+        }
+        BillItemFinanceDetails bifdReturning = returningBillItem.getBillItemFinanceDetails();
+        if (bifdReturning == null) {
+            return;
+        }
+        PharmaceuticalBillItem pbiReturning = returningBillItem.getPharmaceuticalBillItem();
+        if (pbiReturning == null) {
+            return;
+        }
+
+        BigDecimal alreadyReturnQuentity = BigDecimal.ZERO;
+        BigDecimal alreadyReturnedFreeQuentity = BigDecimal.ZERO;
+        BigDecimal allreadyReturnedTotalQuentity = BigDecimal.ZERO;
+
+        BigDecimal returningRate = BigDecimal.ZERO;
+
+        String sql = "Select sum(b.billItemFinanceDetails.quantity), sum(b.billItemFinanceDetails.freeQuantity) "
+                + " from BillItem b "
+                + " where b.retired=false "
+                + " and b.bill.retired=false "
+                + " and b.referanceBillItem=:obi "
+                + " and b.bill.billTypeAtomic=:bta";
+
+        Map<String, Object> params = new HashMap<>();
+        params.put("obi", originalBillItem);
+        params.put("bta", BillTypeAtomic.PHARMACY_GRN_RETURN);
+
+        Object[] returnedValues = getBillItemFacade().findSingleAggregate(sql, params);
+
+        if (returnedValues != null) {
+            alreadyReturnQuentity = returnedValues[0] == null ? BigDecimal.ZERO : new BigDecimal(returnedValues[0].toString());
+            alreadyReturnedFreeQuentity = returnedValues[1] == null ? BigDecimal.ZERO : new BigDecimal(returnedValues[1].toString());
+            allreadyReturnedTotalQuentity = alreadyReturnQuentity.add(alreadyReturnedFreeQuentity);
+        }
+
+        bifdOriginal.setReturnQuantity(alreadyReturnQuentity);
+        bifdOriginal.setReturnFreeQuantity(alreadyReturnedFreeQuentity);
+
+        if (configOptionApplicationController.getBooleanValueByKey("Direct Purchase Return by Total Quantity", false)) {
+            // Returning free quantity is not tracked separately.
+            // The total return covers both original quantity and free quantity.
+            // Here, free quantity being returned is considered zero.
+            // Need to subtract already returned total (qty + free) from original total (qty + free)
+            BigDecimal originalTotal = bifdOriginal.getQuantity().add(bifdOriginal.getFreeQuantity());
+            BigDecimal returnedTotal = alreadyReturnQuentity.add(alreadyReturnedFreeQuentity);
+            BigDecimal remaining = originalTotal.subtract(returnedTotal);
+            bifdReturning.setQuantity(remaining);
+            bifdReturning.setFreeQuantity(BigDecimal.ZERO);
+        } else {
+            // Returning quantity and free quantity are managed separately.
+            // Subtract already returned quantity and free quantity from respective originals.
+            bifdReturning.setQuantity(bifdOriginal.getQuantity().subtract(alreadyReturnQuentity));
+            bifdReturning.setFreeQuantity(bifdOriginal.getFreeQuantity().subtract(alreadyReturnedFreeQuentity));
+        }
+
+        returningRate = getReturnRate(originalBillItem);
+        bifdReturning.setLineGrossRate(returningRate);
+
+        billItemFacade.edit(originalBillItem);
+    }
+
+    private double getRemainingFreeQty(BillItem bilItem) {
+        String sql = "Select sum(p.pharmaceuticalBillItem.freeQty) from BillItem p where"
+                + "   p.creater is not null and"
+                + " p.referanceBillItem=:bt and p.bill.billType=:btp";
+
+        HashMap hm = new HashMap();
+        hm.put("bt", bilItem);
+        hm.put("btp", BillType.PharmacyGrnReturn);
+
+        double originalFreeQty = 0.0;
+        if (bilItem.getPharmaceuticalBillItem() != null) {
+            originalFreeQty = bilItem.getPharmaceuticalBillItem().getFreeQty();
+        }
+
+        return originalFreeQty + getPharmaceuticalBillItemFacade().findDoubleByJpql(sql, hm);
+    }
+
+    public void onEdit(BillItem tmp) {
+        //    PharmaceuticalBillItem tmp = (PharmaceuticalBillItem) event.getObject();
+
+        double remain = getRemainingQty(tmp.getReferanceBillItem());
+        if (tmp.getQty() > remain) {
+            tmp.setQty(remain);
+            JsfUtil.addErrorMessage("You cant return over than ballanced Qty ");
+        }
+
+        if (!configOptionApplicationController.getBooleanValueByKey("Direct Purchase Return by Total Quantity", false)) {
+            double remainFree = getRemainingFreeQty(tmp.getReferanceBillItem());
+            if (tmp.getPharmaceuticalBillItem().getFreeQty() > remainFree) {
+                tmp.getPharmaceuticalBillItem().setFreeQty(remainFree);
+                JsfUtil.addErrorMessage("You cant return over than ballanced Free Qty ");
+            }
+        }
+
+        calculateBillItemDetails(tmp);
+        callculateBillDetails();
+        calTotal();
+        getPharmacyController().setPharmacyItem(tmp.getPharmaceuticalBillItem().getBillItem().getItem());
+    }
+
+    public void resetValuesForReturn() {
+        bill = null;
+        returnBill = null;
+        printPreview = false;
+        billItems = null;
+    }
+
+    private void saveReturnBill() {
+        getReturnBill().setBillTypeAtomic(BillTypeAtomic.PHARMACY_GRN_RETURN);
+        getReturnBill().setInvoiceDate(getBill().getInvoiceDate());
+        getReturnBill().setReferenceBill(getBill());
+        getReturnBill().setToInstitution(getBill().getFromInstitution());
+        getReturnBill().setToDepartment(getBill().getFromDepartment());
+        getReturnBill().setFromInstitution(getBill().getToInstitution());
+        String deptId = getBillNumberBean().departmentBillNumberGeneratorYearly(sessionController.getDepartment(), BillTypeAtomic.PHARMACY_GRN_RETURN);
+        getReturnBill().setDeptId(deptId);
+        getReturnBill().setInsId(deptId); // for insId also dept Id is used intentionally
+
+        getReturnBill().setInstitution(getSessionController().getInstitution());
+        getReturnBill().setDepartment(getSessionController().getDepartment());
+        // getReturnBill().setReferenceBill(getBill());
+        getReturnBill().setCreater(getSessionController().getLoggedUser());
+        getReturnBill().setCreatedAt(Calendar.getInstance().getTime());
+
+        if (getReturnBill().getId() == null) {
+            getBillFacade().create(getReturnBill());
+        }
+
+    }
+
+    public BigDecimal getReturnRate(BillItem originalBillItem) {
+        BillItemFinanceDetails fd = originalBillItem.getBillItemFinanceDetails();
+        if (fd == null) {
+            return BigDecimal.ZERO;
+        }
+
+        BigDecimal rate = fd.getGrossRate();
+        if (configOptionApplicationController.getBooleanValueByKey("Direct Purchase Return Based On Line Cost Rate", false)
+                && fd.getLineCostRate() != null) {
+            rate = fd.getLineCostRate();
+        } else if (configOptionApplicationController.getBooleanValueByKey("Direct Purchase Return Based On Total Cost Rate", false)
+                && fd.getTotalCostRate() != null) {
+            rate = fd.getTotalCostRate();
+        }
+
+        if (originalBillItem.getItem() instanceof Ampp) {
+            BigDecimal upp = Optional.ofNullable(fd.getUnitsPerPack()).orElse(BigDecimal.ONE);
+            if (upp.compareTo(BigDecimal.ZERO) > 0) {
+                rate = rate.multiply(upp);
+            }
+        }
+
+        return rate;
+    }
+
+    public String getReturnRateLabel() {
+        if (configOptionApplicationController.getBooleanValueByKey("Direct Purchase Return Based On Line Cost Rate", false)) {
+            return "Line Cost Rate";
+        }
+        if (configOptionApplicationController.getBooleanValueByKey("Direct Purchase Return Based On Total Cost Rate", false)) {
+            return "Total Cost Rate";
+        }
+        return "Purchase Rate";
+    }
+
+//    private void saveComponent() {
+//        for (BillItem i : getBillItems()) {
+//            i.getPharmaceuticalBillItem().setQtyInUnit(0 - i.getQty());
+//
+//            if (i.getPharmaceuticalBillItem().getQtyInUnit() == 0.0) {
+//                continue;
+//            }
+//
+//            double rate = getReturnRate(i).doubleValue();
+//            i.setNetValue(i.getPharmaceuticalBillItem().getQtyInUnit() * rate);
+//            i.setCreatedAt(Calendar.getInstance().getTime());
+//            i.setCreater(getSessionController().getLoggedUser());
+//
+//            PharmaceuticalBillItem tmpPharmaceuticalBillItem = i.getPharmaceuticalBillItem();
+//            i.setPharmaceuticalBillItem(null);
+//
+//            if (i.getId() == null) {
+//                getBillItemFacade().create(i);
+//            }
+//
+//            tmpPharmaceuticalBillItem.setBillItem(i);
+//
+//            if (tmpPharmaceuticalBillItem.getId() == null) {
+//                getPharmaceuticalBillItemFacade().create(tmpPharmaceuticalBillItem);
+//            }
+//
+//            i.setPharmaceuticalBillItem(tmpPharmaceuticalBillItem);
+//            getBillItemFacade().edit(i);
+//
+//            boolean returnFlag = getPharmacyBean().deductFromStock(i.getPharmaceuticalBillItem().getStock(), Math.abs(i.getPharmaceuticalBillItem().getQtyInUnit()), i.getPharmaceuticalBillItem(), getSessionController().getDepartment());
+//
+//            if (!returnFlag) {
+//                i.setTmpQty(0);
+//                getPharmaceuticalBillItemFacade().edit(i.getPharmaceuticalBillItem());
+//                getBillItemFacade().edit(i);
+//            }
+//
+//            getReturnBill().getBillItems().add(i);
+//        }
+//
+//    }
+    // ChatGPT Contribution
+    private void saveBillItems() {
+        for (BillItem i : getBillItems()) {
+            BillItemFinanceDetails fd = i.getBillItemFinanceDetails();
+            BillItem ref = i.getReferanceBillItem();
+            BillItemFinanceDetails refFd = ref != null ? ref.getBillItemFinanceDetails() : null;
+
+            if (fd == null || refFd == null) {
+                continue; // Skip if finance details are missing
+            }
+
+            PharmaceuticalBillItem pbi = i.getPharmaceuticalBillItem();
+
+            double qty = fd.getQuantity().doubleValue();
+            double freeQty = fd.getFreeQuantity().doubleValue();
+            double unitsPerPack = fd.getUnitsPerPack().doubleValue();
+            double rate = fd.getLineGrossRate().doubleValue();
+
+            if (i.getItem() instanceof Ampp) {
+                pbi.setQty(-qty * unitsPerPack);
+                pbi.setFreeQty(-freeQty * unitsPerPack);
+            } else {
+                pbi.setQty(-qty);
+                pbi.setFreeQty(-freeQty);
+            }
+
+
+            i.setNetValue(pbi.getQty() * rate);
+            i.setCreatedAt(Calendar.getInstance().getTime());
+            i.setCreater(getSessionController().getLoggedUser());
+
+            i.setPharmaceuticalBillItem(null);
+
+            if (i.getId() == null) {
+                getBillItemFacade().create(i);
+            }
+
+            pbi.setBillItem(i);
+
+            if (pbi.getId() == null) {
+                getPharmaceuticalBillItemFacade().create(pbi);
+            }
+
+            i.setPharmaceuticalBillItem(pbi);
+            getBillItemFacade().edit(i);
+
+            boolean returnFlag = getPharmacyBean().deductFromStock(
+                    pbi.getStock(),
+                    Math.abs(fd.getTotalQuantityByUnits().doubleValue()),
+                    pbi,
+                    getSessionController().getDepartment()
+            );
+
+            if (!returnFlag) {
+                getPharmaceuticalBillItemFacade().edit(pbi);
+                getBillItemFacade().edit(i);
+                // TODO: Log error
+            }
+
+            saveBillFee(i);
+            getBillItemFacade().editAndCommit(ref);
+
+            BillItemFinanceDetails savedFd = ref.getBillItemFinanceDetails();
+
+            getReturnBill().getBillItems().add(i);
+        }
+    }
+
+    private void fillData() {
+        for (BillItem bi : getBillItems()) {
+            PharmaceuticalBillItem pbi = bi.getPharmaceuticalBillItem();
+            BillItemFinanceDetails fd = bi.getBillItemFinanceDetails();
+            if (bi.getItem() instanceof Ampp) {
+                pbi.setQty(fd.getQuantity().doubleValue() * fd.getUnitsPerPack().doubleValue());
+                pbi.setFreeQty(fd.getFreeQuantity().doubleValue() * fd.getUnitsPerPack().doubleValue());
+            } else {
+                pbi.setQty(fd.getQuantity().doubleValue());
+                pbi.setFreeQty(fd.getFreeQuantity().doubleValue());
+            }
+        }
+    }
+
+    private void applyPendingReturnTotals() {
+        for (BillItem i : getBillItems()) {
+            BillItemFinanceDetails fd = i.getBillItemFinanceDetails();
+            BillItem ref = i.getReferanceBillItem();
+            BillItemFinanceDetails refFd = ref != null ? ref.getBillItemFinanceDetails() : null;
+
+            if (fd == null || refFd == null) {
+                continue;
+            }
+
+            refFd.setReturnQuantity(refFd.getReturnQuantity().add(fd.getQuantity()));
+            refFd.setReturnFreeQuantity(refFd.getReturnFreeQuantity().add(fd.getFreeQuantity()));
+        }
+    }
+
+    private void revertPendingReturnTotals() {
+        for (BillItem i : getBillItems()) {
+            BillItemFinanceDetails fd = i.getBillItemFinanceDetails();
+            BillItem ref = i.getReferanceBillItem();
+            BillItemFinanceDetails refFd = ref != null ? ref.getBillItemFinanceDetails() : null;
+
+            if (fd == null || refFd == null) {
+                continue;
+            }
+
+            refFd.setReturnQuantity(refFd.getReturnQuantity().subtract(fd.getQuantity()));
+            refFd.setReturnFreeQuantity(refFd.getReturnFreeQuantity().subtract(fd.getFreeQuantity()));
+        }
+    }
+
+    public void settle() {
+        fillData();
+        applyPendingReturnTotals();
+        if (getPharmacyBean().isInsufficientStockForReturn(getBillItems())) {
+            revertPendingReturnTotals();
+            JsfUtil.addErrorMessage("Insufficient stock available to return these items.");
+            return;
+        }
+        if (getPharmacyBean().isReturingMoreThanPurchased(getBillItems())) {
+            revertPendingReturnTotals();
+            JsfUtil.addErrorMessage("Returning more than purchased.");
+            return;
+        }
+        pharmacyCalculation.calculateRetailSaleValueAndFreeValueAtPurchaseRate(getBill());
+        saveReturnBill();
+        saveBillItems();
+        Payment p = createPayment(getReturnBill(), getReturnBill().getPaymentMethod());
+
+        getBillFacade().edit(getReturnBill());
+        getBillFacade().edit(getBill());
+
+        printPreview = true;
+        JsfUtil.addSuccessMessage("Successfully Returned");
+
+    }
+
+    private void calTotal() {
+        double grossTotal = 0.0;
+
+        for (BillItem p : getBillItems()) {
+            double rate = getReturnRate(p).doubleValue();
+            grossTotal += rate * p.getQty();
+
+        }
+
+        getReturnBill().setTotal(grossTotal);
+        getReturnBill().setNetTotal(grossTotal);
+
+        //  return grossTotal;
+    }
+
+    public void prepareReturnBill() {
+        if (bill == null) {
+            JsfUtil.addErrorMessage("No GRN is selected to return");
+            return;
+        }
+        if (bill.getBillTypeAtomic() == null) {
+            JsfUtil.addErrorMessage("No Bill Type for the selected Bill to return. Its a system error. Please contact Developers");
+            return;
+        }
+        if (bill.getBillTypeAtomic() != BillTypeAtomic.PHARMACY_GRN) {
+            JsfUtil.addErrorMessage("Wrong Bill Type for the selected Bill to return. Its a system error. Please contact Developers");
+            return;
+        }
+        getReturnBill();
+        getReturnBill().setBilledBill(bill);
+        // Reset inherited financial values
+        getReturnBill().setDiscount(0.0);
+        getReturnBill().setExpenseTotal(0.0);
+        getReturnBill().setTax(0.0);
+        if (getReturnBill().getBillFinanceDetails() == null) {
+            getReturnBill().setBillFinanceDetails(new BillFinanceDetails(getReturnBill()));
+        } else {
+            BillFinanceDetails bfd = getReturnBill().getBillFinanceDetails();
+            bfd.setBillDiscount(BigDecimal.ZERO);
+            bfd.setBillExpense(BigDecimal.ZERO);
+            bfd.setBillTaxValue(BigDecimal.ZERO);
+            bfd.setTotalDiscount(BigDecimal.ZERO);
+            bfd.setTotalExpense(BigDecimal.ZERO);
+            bfd.setTotalTaxValue(BigDecimal.ZERO);
+            bfd.setLineDiscount(BigDecimal.ZERO);
+            bfd.setLineExpense(BigDecimal.ZERO);
+            bfd.setItemTaxValue(BigDecimal.ZERO);
+            bfd.setBillCostValue(BigDecimal.ZERO);
+            bfd.setLineCostValue(BigDecimal.ZERO);
+            bfd.setTotalCostValue(BigDecimal.ZERO);
+        }
+        prepareBillItems(bill);
+    }
+
+    private void prepareBillItems(Bill bill) {
+        if (bill == null) {
+            JsfUtil.addErrorMessage("There is a system error. Please contact Developers");
+            return;
+        }
+        if (bill.getId() == null) {
+            JsfUtil.addErrorMessage("There is a system error. Please contact Developers");
+            return;
+        }
+        String jpql = "Select p from PharmaceuticalBillItem p where p.billItem.bill.id = :billId";
+        Map<String, Object> params = new HashMap<>();
+        params.put("billId", bill.getId());
+        List<PharmaceuticalBillItem> pbisOfBilledBill = getPharmaceuticalBillItemFacade().findByJpql(jpql, params);
+        for (PharmaceuticalBillItem pbiOfBilledBill : pbisOfBilledBill) {
+            BillItem newBillItemInReturnBill = new BillItem();
+            // Copy basic item data but ignore any financial values
+            newBillItemInReturnBill.copyWithoutFinancialData(pbiOfBilledBill.getBillItem());
+            newBillItemInReturnBill.setQty(0.0);
+            newBillItemInReturnBill.setBill(getReturnBill());
+            newBillItemInReturnBill.setItem(pbiOfBilledBill.getBillItem().getItem());
+            newBillItemInReturnBill.setReferanceBillItem(pbiOfBilledBill.getBillItem());
+            newBillItemInReturnBill.setBill(returnBill);
+
+            BigDecimal alreadyReturnQuentity = BigDecimal.ZERO;
+            BigDecimal alreadyReturnedFreeQuentity = BigDecimal.ZERO;
+            BigDecimal allreadyReturnedTotalQuentity = BigDecimal.ZERO;
+
+            BigDecimal availableToReturnQuentity = BigDecimal.ZERO;
+            BigDecimal availableToReturnFreeQuentity = BigDecimal.ZERO;
+            BigDecimal availableToReturnTotalQuentity = BigDecimal.ZERO;
+
+            BigDecimal returningRate = BigDecimal.ZERO;
+            BigDecimal returningValue = BigDecimal.ZERO;
+            BigDecimal returningFreeValue = BigDecimal.ZERO;
+            BigDecimal returningTotalValue = BigDecimal.ZERO;
+
+            PharmaceuticalBillItem newPharmaceuticalBillItemInReturnBill = new PharmaceuticalBillItem();
+            newPharmaceuticalBillItemInReturnBill.copy(pbiOfBilledBill);
+            newPharmaceuticalBillItemInReturnBill.setBillItem(newBillItemInReturnBill);
+
+            double originalQty = pbiOfBilledBill.getQty();
+            double originalFreeQty = pbiOfBilledBill.getFreeQty();
+
+            if (configOptionApplicationController.getBooleanValueByKey("Direct Purchase Return by Total Quantity", false)) {
+                double returnedTotal = getPharmacyRecieveBean().getTotalQtyWithFreeQty(pbiOfBilledBill.getBillItem(), BillType.PharmacyGrnReturn, new BilledBill());
+                newPharmaceuticalBillItemInReturnBill.setQty(originalQty + originalFreeQty - Math.abs(returnedTotal));
+                newPharmaceuticalBillItemInReturnBill.setFreeQty(0.0);
+            } else {
+                double returnedQty = getPharmacyRecieveBean().getTotalQty(pbiOfBilledBill.getBillItem(), BillType.PharmacyGrnReturn, new BilledBill());
+                double returnedFreeQty = getPharmacyRecieveBean().getTotalFreeQty(pbiOfBilledBill.getBillItem(), BillType.PharmacyGrnReturn, new BilledBill());
+                newPharmaceuticalBillItemInReturnBill.setQty(originalQty - Math.abs(returnedQty));
+                newPharmaceuticalBillItemInReturnBill.setFreeQty(originalFreeQty - Math.abs(returnedFreeQty));
+            }
+
+            newBillItemInReturnBill.setPharmaceuticalBillItem(newPharmaceuticalBillItemInReturnBill);
+
+            BillItemFinanceDetails fd = null;
+            BillItemFinanceDetails originalFd = pbiOfBilledBill.getBillItem().getBillItemFinanceDetails();
+            if (originalFd != null) {
+                fd = originalFd.clone();
+                fd.setBillItem(newBillItemInReturnBill);
+                // Remove any previously calculated discounts, taxes or expenses
+                fd.setLineDiscountRate(BigDecimal.ZERO);
+                fd.setBillDiscountRate(BigDecimal.ZERO);
+                fd.setTotalDiscountRate(BigDecimal.ZERO);
+                fd.setLineDiscount(BigDecimal.ZERO);
+                fd.setBillDiscount(BigDecimal.ZERO);
+                fd.setTotalDiscount(BigDecimal.ZERO);
+
+                fd.setLineExpenseRate(BigDecimal.ZERO);
+                fd.setBillExpenseRate(BigDecimal.ZERO);
+                fd.setTotalExpenseRate(BigDecimal.ZERO);
+                fd.setLineExpense(BigDecimal.ZERO);
+                fd.setBillExpense(BigDecimal.ZERO);
+                fd.setTotalExpense(BigDecimal.ZERO);
+
+                fd.setBillTaxRate(BigDecimal.ZERO);
+                fd.setLineTaxRate(BigDecimal.ZERO);
+                fd.setTotalTaxRate(BigDecimal.ZERO);
+                fd.setBillTax(BigDecimal.ZERO);
+                fd.setLineTax(BigDecimal.ZERO);
+                fd.setTotalTax(BigDecimal.ZERO);
+
+                fd.setBillCostRate(BigDecimal.ZERO);
+                fd.setLineCostRate(BigDecimal.ZERO);
+                fd.setTotalCostRate(BigDecimal.ZERO);
+                fd.setBillCost(BigDecimal.ZERO);
+                fd.setLineCost(BigDecimal.ZERO);
+                fd.setTotalCost(BigDecimal.ZERO);
+            } else {
+                fd = new BillItemFinanceDetails(newBillItemInReturnBill);
+            }
+            fd.setQuantity(BigDecimal.valueOf(newPharmaceuticalBillItemInReturnBill.getQty()));
+            fd.setFreeQuantity(BigDecimal.valueOf(newPharmaceuticalBillItemInReturnBill.getFreeQty()));
+            newBillItemInReturnBill.setBillItemFinanceDetails(fd);
+            if (pharmacyCostingService != null) {
+                pharmacyCostingService.recalculateFinancialsBeforeAddingBillItem(fd);
+            }
+
+            addDataToReturningBillItem(newBillItemInReturnBill);
+
+            getBillItems().add(newBillItemInReturnBill);
+            calculateBillItemDetails(newBillItemInReturnBill);
+        }
+    }
+
+    private void calculateBillItemDetails(BillItem returningBillItem) {
+        if (returningBillItem == null) {
+            return;
+        }
+
+        BillItemFinanceDetails f = returningBillItem.getBillItemFinanceDetails();
+        PharmaceuticalBillItem pbi = returningBillItem.getPharmaceuticalBillItem();
+
+        if (f == null || pbi == null) {
+            return;
+        }
+
+        if (pharmacyCostingService != null) {
+            pharmacyCostingService.recalculateFinancialsBeforeAddingBillItem(f);
+        }
+
+        BigDecimal qty = Optional.ofNullable(f.getQuantity()).orElse(BigDecimal.ZERO);
+        BigDecimal freeQty = Optional.ofNullable(f.getFreeQuantity()).orElse(BigDecimal.ZERO);
+
+        if (returningBillItem.getItem() instanceof Ampp) {
+            pbi.setQtyPacks(qty.doubleValue());
+            pbi.setQty(f.getQuantityByUnits().doubleValue());
+            pbi.setFreeQtyPacks(freeQty.doubleValue());
+            pbi.setFreeQty(f.getFreeQuantityByUnits().doubleValue());
+            pbi.setPurchaseRatePack(f.getLineGrossRate().doubleValue());
+            pbi.setPurchaseRate(f.getLineGrossRate().doubleValue());
+            pbi.setRetailRate(f.getRetailSaleRate().doubleValue());
+            pbi.setRetailRatePack(f.getRetailSaleRate().doubleValue());
+            pbi.setRetailRateInUnit(f.getRetailSaleRatePerUnit().doubleValue());
+        } else {
+            pbi.setQty(qty.doubleValue());
+            pbi.setQtyPacks(qty.doubleValue());
+            pbi.setFreeQty(freeQty.doubleValue());
+            pbi.setFreeQtyPacks(freeQty.doubleValue());
+            pbi.setPurchaseRate(f.getLineGrossRate().doubleValue());
+            pbi.setPurchaseRatePack(f.getLineGrossRate().doubleValue());
+            f.setRetailSaleRate(f.getRetailSaleRatePerUnit());
+            double rr = Optional.ofNullable(f.getRetailSaleRatePerUnit()).orElse(BigDecimal.ZERO).doubleValue();
+            pbi.setRetailRate(rr);
+            pbi.setRetailRatePack(rr);
+            pbi.setRetailRateInUnit(rr);
+        }
+
+        returningBillItem.setQty(f.getQuantityByUnits().doubleValue());
+        returningBillItem.setRate(f.getLineGrossRate().doubleValue());
+    }
+
+    private void callculateBillDetails() {
+        if (returnBill == null) {
+            return;
+        }
+
+        if (billItems != null) {
+            for (BillItem bi : billItems) {
+                calculateBillItemDetails(bi);
+            }
+        }
+
+        if (pharmacyCostingService != null) {
+            pharmacyCostingService.distributeProportionalBillValuesToItems(getBillItems(), getReturnBill());
+            pharmacyCostingService.calculateBillTotalsFromItemsForPurchases(getReturnBill(), getBillItems());
+        }
+
+        if (pharmacyCalculation != null) {
+            pharmacyCalculation.calculateRetailSaleValueAndFreeValueAtPurchaseRate(getReturnBill());
+        }
+    }
+
+    public void onReturnRateChange(BillItem bi) {
+        calculateBillItemDetails(bi);
+        callculateBillDetails();
+    }
+
+    public void onReturningTotalQtyChange(BillItem bi) {
+        onEdit(bi);
+    }
+
+    public void onReturningQtyChange(BillItem bi) {
+        onEdit(bi);
+    }
+
+    public void onReturningFreeQtyChange(BillItem bi) {
+        onEdit(bi);
+    }
+
+    // Have to have onedit methods for the following components in the  page direct_purchase_return
+    // txtReturnRate, txtReturningTotalQty, txtReturningQty, txtReturningFreeQty
+    // These should update bill item lelvel txtLineReturnValue and Bill Level panelReturnBillDetails
+    // have to prefil 
+    public void onEditItem(PharmacyItemData tmp) {
+        double pur = getPharmacyBean().getLastPurchaseRate(tmp.getPharmaceuticalBillItem().getBillItem().getItem(), tmp.getPharmaceuticalBillItem().getBillItem().getReferanceBillItem().getBill().getDepartment());
+        double ret = getPharmacyBean().getLastRetailRate(tmp.getPharmaceuticalBillItem().getBillItem().getItem(), tmp.getPharmaceuticalBillItem().getBillItem().getReferanceBillItem().getBill().getDepartment());
+
+        tmp.getPharmaceuticalBillItem().setPurchaseRateInUnit(pur);
+        tmp.getPharmaceuticalBillItem().setRetailRateInUnit(ret);
+        tmp.getPharmaceuticalBillItem().setLastPurchaseRateInUnit(pur);
+
+        // onEdit(tmp);
+    }
+
+    public Payment createPayment(Bill bill, PaymentMethod pm) {
+        Payment p = new Payment();
+        p.setBill(bill);
+        setPaymentMethodData(p, pm);
+        return p;
+    }
+
+    public void setPaymentMethodData(Payment p, PaymentMethod pm) {
+
+        p.setInstitution(getSessionController().getInstitution());
+        p.setDepartment(getSessionController().getDepartment());
+        p.setCreatedAt(new Date());
+        p.setCreater(getSessionController().getLoggedUser());
+        p.setPaymentMethod(pm);
+
+        p.setPaidValue(p.getBill().getNetTotal());
+
+        if (p.getId() == null) {
+            getPaymentFacade().create(p);
+        }
+
+    }
+
+    public void saveBillFee(BillItem bi) {
+        BillFee bf = new BillFee();
+        bf.setCreatedAt(Calendar.getInstance().getTime());
+        bf.setCreater(getSessionController().getLoggedUser());
+        bf.setBillItem(bi);
+        bf.setPatienEncounter(bi.getBill().getPatientEncounter());
+        bf.setPatient(bi.getBill().getPatient());
+        bf.setFeeValue(bi.getNetValue());
+        bf.setFeeGrossValue(bi.getGrossValue());
+        bf.setSettleValue(bi.getNetValue());
+        bf.setCreatedAt(new Date());
+        bf.setDepartment(getSessionController().getDepartment());
+        bf.setInstitution(getSessionController().getInstitution());
+        bf.setBill(bi.getBill());
+
+        if (bf.getId() == null) {
+            getBillFeeFacade().create(bf);
+        }
+//        createBillFeePaymentAndPayment(bf, p); // Retired Concept. No Loger Used
+    }
+
+//    public void createBillFeePaymentAndPayment(BillFee bf, Payment p) {
+//        BillFeePayment bfp = new BillFeePayment();
+//        bfp.setBillFee(bf);
+//        bfp.setAmount(bf.getSettleValue());
+//        bfp.setInstitution(getSessionController().getInstitution());
+//        bfp.setDepartment(getSessionController().getDepartment());
+//        bfp.setCreater(getSessionController().getLoggedUser());
+//        bfp.setCreatedAt(new Date());
+//        bfp.setPayment(p);
+//        getBillFeePaymentFacade().create(bfp);
+//    }
+    public PharmaceuticalBillItemFacade getPharmaceuticalBillItemFacade() {
+        return pharmaceuticalBillItemFacade;
+    }
+
+    public void setPharmaceuticalBillItemFacade(PharmaceuticalBillItemFacade pharmaceuticalBillItemFacade) {
+        this.pharmaceuticalBillItemFacade = pharmaceuticalBillItemFacade;
+    }
+
+    public PharmaceuticalItemController getPharmaceuticalItemController() {
+        return pharmaceuticalItemController;
+    }
+
+    public void setPharmaceuticalItemController(PharmaceuticalItemController pharmaceuticalItemController) {
+        this.pharmaceuticalItemController = pharmaceuticalItemController;
+    }
+
+    public PharmacyController getPharmacyController() {
+        return pharmacyController;
+    }
+
+    public void setPharmacyController(PharmacyController pharmacyController) {
+        this.pharmacyController = pharmacyController;
+    }
+
+    public SessionController getSessionController() {
+        return sessionController;
+    }
+
+    public void setSessionController(SessionController sessionController) {
+        this.sessionController = sessionController;
+    }
+
+    public ConfigOptionApplicationController getConfigOptionApplicationController() {
+        return configOptionApplicationController;
+    }
+
+    public void setConfigOptionApplicationController(ConfigOptionApplicationController configOptionApplicationController) {
+        this.configOptionApplicationController = configOptionApplicationController;
+    }
+
+    public BillNumberGenerator getBillNumberBean() {
+        return billNumberBean;
+    }
+
+    public void setBillNumberBean(BillNumberGenerator billNumberBean) {
+        this.billNumberBean = billNumberBean;
+    }
+
+    public BillFacade getBillFacade() {
+        return billFacade;
+    }
+
+    public void setBillFacade(BillFacade billFacade) {
+        this.billFacade = billFacade;
+    }
+
+    public PharmacyBean getPharmacyBean() {
+        return pharmacyBean;
+    }
+
+    public void setPharmacyBean(PharmacyBean pharmacyBean) {
+        this.pharmacyBean = pharmacyBean;
+    }
+
+    public BillItemFacade getBillItemFacade() {
+        return billItemFacade;
+    }
+
+    public void setBillItemFacade(BillItemFacade billItemFacade) {
+        this.billItemFacade = billItemFacade;
+    }
+
+    public PharmacyCalculation getPharmacyRecieveBean() {
+        return pharmacyRecieveBean;
+    }
+
+    public void setPharmacyRecieveBean(PharmacyCalculation pharmacyRecieveBean) {
+        this.pharmacyRecieveBean = pharmacyRecieveBean;
+    }
+
+    public List<BillItem> getBillItems() {
+        if (billItems == null) {
+            billItems = new ArrayList<>();
+        }
+        return billItems;
+    }
+
+    public void setBillItems(List<BillItem> billItems) {
+        this.billItems = billItems;
+    }
+
+    public BillFeePaymentFacade getBillFeePaymentFacade() {
+        return billFeePaymentFacade;
+    }
+
+    public void setBillFeePaymentFacade(BillFeePaymentFacade billFeePaymentFacade) {
+        this.billFeePaymentFacade = billFeePaymentFacade;
+    }
+
+    public BillFeeFacade getBillFeeFacade() {
+        return billFeeFacade;
+    }
+
+    public void setBillFeeFacade(BillFeeFacade billFeeFacade) {
+        this.billFeeFacade = billFeeFacade;
+    }
+
+    public PaymentFacade getPaymentFacade() {
+        return paymentFacade;
+    }
+
+    public void setPaymentFacade(PaymentFacade paymentFacade) {
+        this.paymentFacade = paymentFacade;
+    }
+
+}

--- a/src/main/webapp/pharmacy/grn_return_with_costing.xhtml
+++ b/src/main/webapp/pharmacy/grn_return_with_costing.xhtml
@@ -1,0 +1,264 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<!DOCTYPE composition PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<ui:composition xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
+                template="/resources/template/template.xhtml"
+                xmlns:h="http://xmlns.jcp.org/jsf/html"
+                xmlns:p="http://primefaces.org/ui"
+                xmlns:f="http://xmlns.jcp.org/jsf/core"
+                xmlns:ph="http://xmlns.jcp.org/jsf/composite/pharmacy">
+
+    <ui:define name="content">
+        <h:form>
+
+            <h:panelGroup rendered="#{!grnReturnWithCostingController.printPreview}" styleClass="alignTop" >
+
+                <p:panel 
+                    header="Pharmacy GRN Return" 
+                    class="w-100 m-1">
+
+                    <div class="row" >
+                        <div class="col-7" >
+                            <p:dataTable 
+                                var="ph" 
+                                value="#{grnReturnWithCostingController.billItems}"
+                                id="itemList" >
+
+                                <f:facet name="header">
+                                    <h:outputText value="Returning Items" ></h:outputText>
+                                </f:facet>
+
+                                <p:column headerText="Item Name"  >
+                                    <h:outputLabel value="#{ph.item.name}"/>
+                                </p:column>
+
+                                <p:column
+                                    width="5em" 
+                                    headerText="Purchased Quantity" >
+                                    <h:outputLabel  value="#{ph.referanceBillItem.billItemFinanceDetails.quantity}" />
+                                </p:column>
+                                <p:column
+                                    width="5em" 
+                                    headerText="Free Quantity" >
+                                    <h:outputLabel  value="#{ph.referanceBillItem.billItemFinanceDetails.freeQuantity}" />
+                                </p:column>
+                                <p:column 
+                                    width="5em" 
+                                    headerText="Already Returned Qty" >
+                                    <h:outputLabel  value="#{ph.referanceBillItem.billItemFinanceDetails.returnQuantity}" />
+                                </p:column>
+                                <p:column 
+                                    width="5em" 
+                                    headerText="Already Returned Free Qty" 
+                                    rendered="#{configOptionApplicationController.getBooleanValueByKey('Direct Purchase Return by Quantity and Free Quantity')}">
+                                    <h:outputLabel  value="#{ph.referanceBillItem.billItemFinanceDetails.returnFreeQuantity}" />
+                                </p:column>
+                                <p:column 
+                                    width="5em" 
+                                    headerText="Purchased Rate" >
+                                    <h:outputLabel value="#{ph.referanceBillItem.billItemFinanceDetails.lineGrossRate}" >
+                                        <f:convertNumber pattern="#,##0.00##" ></f:convertNumber>
+                                    </h:outputLabel>
+                                </p:column>
+                                <p:column 
+                                    width="5em" 
+                                    headerText="Cost Rate (Per Unit)" >
+                                    <h:outputText value="#{ph.referanceBillItem.billItemFinanceDetails.totalCostRate}" >
+                                        <f:convertNumber pattern="#,##0.00##" ></f:convertNumber>
+                                    </h:outputText>
+                                </p:column>
+
+                                <p:column
+                                    width="5em" 
+                                    headerText="Return rate (#{grnReturnWithCostingController.returnRateLabel})" >
+                                    <h:panelGroup id="purchase" >
+                                        <h:outputText  
+                                            value="#{ph.billItemFinanceDetails.lineGrossRate}" 
+                                            rendered="#{!configOptionApplicationController.getBooleanValueByKey('Direct Purchase Return - Changing Return Rate is allowed')}">
+                                            <f:convertNumber pattern="#,##0.00##" />
+                                        </h:outputText>
+                                        <p:inputText
+                                            id="txtReturnRate"
+                                            class="w-100 text-end"
+                                            value="#{ph.billItemFinanceDetails.lineGrossRate}"
+                                            rendered="#{configOptionApplicationController.getBooleanValueByKey('Direct Purchase Return - Changing Return Rate is allowed')}">
+                                            <f:convertNumber pattern="#,##0.00##" ></f:convertNumber>
+                                            <f:ajax event="blur" render="@this txtLineReturnValue :#{p:resolveFirstComponentWithId('panelReturnBillDetails',view).clientId}" listener="#{grnReturnWithCostingController.onReturnRateChange(ph)}" />
+                                        </p:inputText>
+                                        <h:outputText value="&nbsp;per Pack" rendered="#{ph.item.class eq 'class com.divudi.core.entity.pharmacy.Ampp'}" />
+                                    </h:panelGroup>
+                                </p:column>
+                                <!--                                <p:column headerText="Batch No" >
+                                                                    <h:outputText value="#{ph.pharmaceuticalBillItem.stringValue}" />
+                                                                </p:column>-->
+                                <p:column 
+                                    headerText="Date of Expirey" 
+                                    width="5em" >
+                                    <h:outputText value="#{ph.pharmaceuticalBillItem.doe}" >
+                                        <f:convertDateTime pattern="#{sessionController.applicationPreference.shortDateFormat}" ></f:convertDateTime>
+                                    </h:outputText>
+                                </p:column>
+                                <p:column 
+                                    width="5em" 
+                                    headerText="Returning Total Qty"
+                                    rendered="#{configOptionApplicationController.getBooleanValueByKey('Direct Purchase Return by Total Quantity')}">
+                                    <p:inputText
+                                        id="txtReturningTotalQty"
+                                        autocomplete="off"
+                                        class="w-100 text-end"
+                                        onfocus="this.select()"
+                                        value="#{ph.billItemFinanceDetails.quantity}">
+                                        <f:convertNumber pattern="#,##0.00##" ></f:convertNumber>
+                                        <p:ajax 
+                                            event="keyup" 
+                                            process="@this"
+                                            update="txtLineReturnValue :#{p:resolveFirstComponentWithId('panelReturnBillDetails',view).clientId}" 
+                                            listener="#{grnReturnWithCostingController.onReturningTotalQtyChange(ph)}" />
+                                    </p:inputText>
+                                    <h:outputText value="&nbsp;Packs" rendered="#{ph.item.class eq 'class com.divudi.core.entity.pharmacy.Ampp'}" />
+                                </p:column>
+
+                                <p:column
+                                    width="5em" 
+                                    headerText="Returning Qty"
+                                    rendered="#{configOptionApplicationController.getBooleanValueByKey('Direct Purchase Return by Quantity and Free Quantity')}">
+                                    <p:inputText
+                                        id="txtReturningQty"
+                                        autocomplete="off"
+                                        onfocus="this.select()"
+                                        class="w-100 text-end"
+                                        value="#{ph.billItemFinanceDetails.quantity}">
+                                        <p:ajax 
+                                            process="@this"
+                                            event="keyup" 
+                                            update="txtLineReturnValue :#{p:resolveFirstComponentWithId('panelReturnBillDetails',view).clientId}" 
+                                            listener="#{grnReturnWithCostingController.onReturningQtyChange(ph)}" 
+                                            />
+                                    </p:inputText>
+                                </p:column>
+
+                                <p:column
+                                    headerText="Returning Free Qty"
+                                    width="5em" 
+                                    rendered="#{configOptionApplicationController.getBooleanValueByKey('Direct Purchase Return by Quantity and Free Quantity')}">
+                                    <p:inputText
+                                        class="w-100 text-end"
+                                        id="txtReturningFreeQty"
+                                        autocomplete="off" value="#{ph.billItemFinanceDetails.freeQuantity}">
+                                        <p:ajax
+                                            event="blur" 
+                                            process="@this txtLineReturnValue :#{p:resolveFirstComponentWithId('panelReturnBillDetails',view).clientId}" 
+                                            listener="#{grnReturnWithCostingController.onReturningFreeQtyChange(ph)}" />
+                                    </p:inputText>
+                                </p:column>
+
+                                <p:column headerText="Return Value" width="5em" >
+                                    <h:outputText id="txtLineReturnValue" value="#{ph.billItemFinanceDetails.lineGrossTotal}" >
+                                        <f:convertNumber pattern="#,##0.00##" ></f:convertNumber>
+                                    </h:outputText>
+                                </p:column>
+
+                            </p:dataTable>
+
+                        </div>
+                        <div class="col-5" >
+                            <p:panel 
+                                class="w-100 m-1"
+                                >
+                                <f:facet name="header" >
+                                    <h:outputText value="Return Details" ></h:outputText>
+                                    <p:commandButton  
+                                        value="Return"
+                                        action="#{grnReturnWithCostingController.settle}"
+                                        ajax="false"  
+                                        style="float: right;"
+                                        class="ui-button-warning"
+                                        >
+                                    </p:commandButton>
+                                </f:facet>
+
+                                <p:panelGrid 
+                                    columns="2"
+                                    id="panelReturnBillDetails"
+                                    layout="tabular"
+                                    class="w-100">
+                                    <h:outputLabel value="Supplier : " />
+                                    <h:outputLabel value="#{grnReturnWithCostingController.bill.fromInstitution.name}" />
+                                    <p:outputLabel  value="Receivable Amount : " />
+                                    <p:outputLabel 
+                                        id="total" 
+                                        class="h1"
+                                        value="#{0-grnReturnWithCostingController.returnBill.netTotal}" >
+                                        <f:convertNumber pattern="#,##0.00" />
+                                    </p:outputLabel>
+
+                                    <h:outputLabel value="Payment Received as : " />
+                                    <p:selectOneMenu id="cmbPs" value="#{grnReturnWithCostingController.returnBill.paymentMethod}">
+                                        <f:selectItems value="#{enumController.paymentMethods}"/>
+                                        <p:ajax process="cmbPs"  event="change" />
+                                    </p:selectOneMenu>
+                                </p:panelGrid>
+
+
+
+
+                            </p:panel>
+                            <p:panel class="w-100 m-1">
+                                <f:facet name="header" >
+                                    <h:outputText value="GRN Details" ></h:outputText>
+                                    <p:commandButton 
+                                        value="View Bill" 
+                                        ajax="false" 
+                                        class="ui-button-info" 
+                                        icon="fa fa-eye"
+                                        style="float: right;"
+                                        action="pharmacy_reprint_purchase?faces-redirect=true">
+                                        <f:setPropertyActionListener target="#{pharmacyBillSearch.bill}" value="#{grnReturnWithCostingController.bill}"/>
+                                    </p:commandButton>
+                                </f:facet>
+                                <p:panelGrid columns="2" class="w-100">
+                                    <h:outputLabel value="GRN Bill No :"/>
+                                    <h:outputLabel value="#{grnReturnWithCostingController.bill.deptId}"/>
+                                    <h:outputLabel value="GRN Net Total :"/>
+                                    <h:outputLabel value="#{grnReturnWithCostingController.bill.netTotal}">
+                                        <f:convertNumber pattern="#,##0.00" ></f:convertNumber>
+                                    </h:outputLabel>
+                                    <h:outputLabel value="GRN Date :"/>
+                                    <h:outputLabel value="#{grnReturnWithCostingController.bill.invoiceDate}">
+                                        <f:convertDateTime timeZone="Asia/Colombo" pattern="#{sessionController.applicationPreference.shortDateFormat}"/>
+                                    </h:outputLabel>
+                                </p:panelGrid>
+
+
+                            </p:panel>
+                            <p:panel header="Invoice Details" >
+                                <p:panelGrid columns="2" class="poDetail">
+                                    <h:outputLabel value="Invoice No :"/>
+                                    <h:outputLabel value="#{grnReturnWithCostingController.bill.deptId}"/>
+                                    <h:outputLabel value="Invoice Date :"/>
+                                    <h:outputLabel value="#{grnReturnWithCostingController.bill.invoiceDate}">
+                                        <f:convertDateTime timeZone="Asia/Colombo" pattern="#{sessionController.applicationPreference.shortDateFormat}"/>
+                                    </h:outputLabel>
+                                </p:panelGrid>
+                            </p:panel>
+
+                        </div>
+                    </div>
+
+                </p:panel>
+
+
+            </h:panelGroup>
+
+            <p:panel rendered="#{grnReturnWithCostingController.printPreview}">
+                <p:commandButton value="Print" ajax="false" action="#" >
+                    <p:printer target="gpBillPreview" ></p:printer>
+                </p:commandButton>
+                <p:panel   id="gpBillPreview">
+                    <ph:grn_return_receipt_with_costing bill="#{grnReturnWithCostingController.returnBill}"/>
+                </p:panel>
+            </p:panel>
+
+        </h:form>
+    </ui:define>
+
+</ui:composition>

--- a/src/main/webapp/pharmacy/pharmacy_grn_list_for_return.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_grn_list_for_return.xhtml
@@ -152,14 +152,14 @@
                                     <f:setPropertyActionListener target="#{goodsReturnController.bill}" value="#{p}"/>
                                 </p:commandButton>
 
-                                <p:commandButton 
-                                    ajax="false" 
-                                    value="Return" 
-                                    action="pharmacy_return_good?faces-redirect=true" 
-                                    disabled="#{p.cancelled}" 
-                                    icon="pi pi-undo" 
+                                <p:commandButton
+                                    ajax="false"
+                                    value="Return"
+                                    action="#{billSearch.navigateToPharmacyGrnReturnBillView()}"
+                                    disabled="#{p.cancelled}"
+                                    icon="pi pi-undo"
                                     styleClass="ui-button-warning mx-1">
-                                    <f:setPropertyActionListener target="#{goodsReturnController.bill}" value="#{p}"/>
+                                    <f:setPropertyActionListener target="#{billSearch.bill}" value="#{p}"/>
                                 </p:commandButton>
 
                             </p:column>

--- a/src/main/webapp/resources/pharmacy/grn_return_receipt_with_costing.xhtml
+++ b/src/main/webapp/resources/pharmacy/grn_return_receipt_with_costing.xhtml
@@ -1,0 +1,177 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:cc="http://xmlns.jcp.org/jsf/composite"
+      xmlns:h="http://xmlns.jcp.org/jsf/html"
+      xmlns:p="http://primefaces.org/ui"
+      xmlns:f="http://xmlns.jcp.org/jsf/core">
+
+    <!-- INTERFACE -->
+    <cc:interface>
+        <cc:attribute name="bill" />
+    </cc:interface>
+    <!-- IMPLEMENTATION -->
+    <cc:implementation>
+        <div class="purhcaseBill"
+             style="font-family: sans-serif!important;
+             border: none!important;
+             margin-top: 10px;
+             height: 210mm;">
+
+            <div class=" mt-3" style="
+                 text-align: center!important;
+                 font-weight: bold!important;
+                 font-size: 23px!important;
+                 font-weight: bolder;
+                 font-family: monospace;
+                 text-transform: capitalize!important;">
+                <h:outputLabel value="#{cc.attrs.bill.creater.department.printingName}"/>
+            </div>
+
+            <div style="position: relative!important;
+                 text-align: center!important;
+                 font-size: 16px!important;
+                 font-family:monospace;" >
+                <div>
+                    <h:outputLabel value="#{cc.attrs.bill.creater.department.address}"/>
+                </div>
+                <div >
+                    <h:outputLabel value="#{cc.attrs.bill.creater.department.telephone1} "/>
+                    <h:outputLabel value="#{cc.attrs.bill.creater.department.telephone2}"/>
+                </div>
+                <div >
+                    <h:outputLabel value="#{cc.attrs.bill.creater.department.fax}"/>
+                </div>
+                <div >
+                    <h:outputLabel value="#{cc.attrs.bill.department.email}"/>
+                </div>
+            </div>
+
+            <div style="text-align: center!important;
+                 font-weight: bold!important;
+                 font-size: 18px!important;
+                 font-weight: bold;">
+                <h:outputLabel value="GRN Return Note"   />
+            </div>
+
+            <div style="margin-left: 3%; margin-right: 3%; margin-top: 6px;">
+                <h:panelGrid columns="4" style="font-size: 16px; font-family: sans; min-width: 100%!important;">
+                    <h:outputLabel value="GRN" class="billDetailsFiveFive"/>
+                    <h:outputLabel value="#{cc.attrs.bill.deptId}" class="billDetailsFiveFive"/>
+                    <h:outputLabel value="GRN No" class="billDetailsFiveFive"/>
+                    <h:outputLabel value="#{cc.attrs.bill.referenceBill.deptId}" class="billDetailsFiveFive"/>
+
+                    <h:outputLabel value="GRN Return Date" class="billDetailsFiveFive"/>
+                    <h:outputLabel value="#{cc.attrs.bill.createdAt}" class="billDetailsFiveFive">
+                        <f:convertDateTime  timeZone="Asia/Colombo" pattern="#{sessionController.applicationPreference.shortDateFormat}"  />
+                    </h:outputLabel>
+                    <h:outputLabel value="GRN Date" class="billDetailsFiveFive"/>
+                    <h:outputLabel value="#{cc.attrs.bill.referenceBill.createdAt}" class="billDetailsFiveFive">
+                        <f:convertDateTime  timeZone="Asia/Colombo" pattern="#{sessionController.applicationPreference.shortDateFormat}"  />
+                    </h:outputLabel>
+
+                    <h:outputLabel value="Invoice No" class="billDetailsFiveFive"/>
+                    <h:outputLabel value="#{cc.attrs.bill.invoiceNumber}" class="billDetailsFiveFive"/>
+                    <h:outputLabel value="Return By" class="billDetailsFiveFive"/>
+                    <h:outputLabel value="#{cc.attrs.bill.creater.staff.code}" class="billDetailsFiveFive"/>
+
+                    <h:outputLabel value="Supplier" class="billDetailsFiveFive"/>
+                    <h:outputLabel value="#{cc.attrs.bill.toInstitution.name}" class="billDetailsFiveFive"/>
+                    <h:outputLabel value="Location" class="billDetailsFiveFive"/>
+                    <h:outputLabel value="#{cc.attrs.bill.referenceBill.referenceBill.creater.department.name}" class="billDetailsFiveFive"/>
+                </h:panelGrid>
+            </div>
+
+            <p:spacer height="15px"/>
+            <div>
+                <p:dataTable
+                        rowIndexVar="rowIndex"
+                        value="#{cc.attrs.bill.billItems}"
+                        var="bip"
+                        style="font-size: 16px; margin-left: 3%; margin-right: 3%;">
+
+                    <p:column style="padding: 4px; width: 2em;">
+                        <f:facet name="header">No</f:facet>
+                        <h:outputLabel value="#{rowIndex+1}"/>
+                    </p:column>
+
+                    <p:column style="padding: 4px;">
+                        <f:facet name="header">Item</f:facet>
+                        <h:outputLabel value="#{bip.item.name}"/>
+                    </p:column>
+
+                    <p:column style="padding: 4px; width: 7em;" class="text-end">
+                        <f:facet name="header">Expiry</f:facet>
+                        <h:outputLabel value="#{bip.referanceBillItem.pharmaceuticalBillItem.doe}" >
+                            <f:convertDateTime  timeZone="Asia/Colombo" pattern="#{sessionController.applicationPreference.shortDateFormat}"  />
+                        </h:outputLabel>
+                    </p:column>
+
+                    <p:column style="padding: 4px; width: 7em;" class="text-end">
+                        <f:facet name="header">Batch No</f:facet>
+                        <h:outputLabel value="#{bip.referanceBillItem.pharmaceuticalBillItem.stringValue}"/>
+                    </p:column>
+
+                    <p:column
+                            style="padding: 4px; width: 7em;" class="text-end"
+                            rendered="#{configOptionApplicationController.getBooleanValueByKey('Direct Purchase Return by Total Quantity', false)}">
+                        <f:facet name="header">Return Total QTY</f:facet>
+                        <h:outputLabel value="#{bip.billItemFinanceDetails.quantity + bip.billItemFinanceDetails.freeQuantity}"/>
+                    </p:column>
+
+                    <p:column
+                            style="padding: 4px; width: 7em;" class="text-end"
+                            rendered="#{!configOptionApplicationController.getBooleanValueByKey('Direct Purchase Return by Total Quantity', false)}">
+                        <f:facet name="header">Return QTY</f:facet>
+                        <h:outputLabel value="#{bip.billItemFinanceDetails.quantity}"/>
+                    </p:column>
+
+                    <p:column
+                            style="padding: 4px; width: 7em;" class="text-end"
+                            rendered="#{!configOptionApplicationController.getBooleanValueByKey('Direct Purchase Return by Total Quantity', false)}">
+                        <f:facet name="header">Free QTY</f:facet>
+                        <h:outputLabel value="#{bip.billItemFinanceDetails.freeQuantity}"/>
+                    </p:column>
+
+                    <p:column style="padding: 4px; width: 7em;" class="text-end">
+                        <f:facet name="header">Rate</f:facet>
+                        <h:outputLabel value="#{bip.billItemFinanceDetails.lineGrossRate}" >
+                            <f:convertNumber pattern="#,##0.00" />
+                        </h:outputLabel>
+                    </p:column>
+
+                    <p:column style="padding: 4px; width: 7em;" class="text-end">
+                        <f:facet name="header">Amount</f:facet>
+                        <h:outputLabel value="#{bip.billItemFinanceDetails.lineGrossRate*(bip.billItemFinanceDetails.quantity + bip.billItemFinanceDetails.freeQuantity)}" >
+                            <f:convertNumber pattern="#,##0.00" />
+                        </h:outputLabel>
+                    </p:column>
+
+                    <p:columnGroup type="footer">
+                        <p:row>
+                            <p:column style="padding: 4px;" colspan="#{configOptionApplicationController.getBooleanValueByKey('Direct Purchase Return by Total Quantity', false) ? 7 : 7}" footerText="Total"/>
+                            <p:column style="padding: 4px; width: 7em;" footerText="#{0-cc.attrs.bill.total}" class="text-end">
+                                <f:facet name="footer" >
+                                    <h:outputLabel value="#{0-cc.attrs.bill.total}" >
+                                        <f:convertNumber pattern="#,##0.00" />
+                                    </h:outputLabel>
+                                </f:facet>
+                            </p:column>
+                        </p:row>
+                    </p:columnGroup>
+                </p:dataTable>
+            </div>
+
+            <p:spacer height="5px"/>
+
+            <div class="preparedBy" style="margin-left: 3%; margin-right: 3%;">
+                <h:outputLabel value="Prepared By : #{cc.attrs.bill.creater.webUserPerson.nameWithTitle}"/>
+            </div>
+
+            <div style="margin-left: 3%; margin-right: 3%;">
+                <h:outputLabel value="Authorized By : "/>
+            </div>
+
+        </div>
+    </cc:implementation>
+</html>


### PR DESCRIPTION
## Summary
- add `GrnReturnWithCostingController`
- create GRN return pages with costing
- add receipt template for GRN return with costing
- integrate controller with `BillSearch.navigateToPharmacyGrnReturnBillView`
- update GRN list to use navigation method

## Testing
- `mvn -q -DskipTests package` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686e99a04970832fb05f165b24871943