### PR TITLE
Add finance details tabs to bill admin view

### DIFF
--- a/src/main/webapp/opd/view/bill_admin.xhtml
+++ b/src/main/webapp/opd/view/bill_admin.xhtml
@@ -5,7 +5,8 @@
       xmlns:p="http://primefaces.org/ui"
       xmlns:h="http://xmlns.jcp.org/jsf/html"
       xmlns:f="http://xmlns.jcp.org/jsf/core"
-      xmlns:view="http://xmlns.jcp.org/jsf/composite/ezcomp/view">
+      xmlns:view="http://xmlns.jcp.org/jsf/composite/ezcomp/view"
+      xmlns:ph="http://xmlns.jcp.org/jsf/composite/ezcomp/pharmacy">
 
     <h:body>
         <ui:composition template="/resources/template/template.xhtml">
@@ -158,8 +159,22 @@
                                                         target="#{billSearch.payment}" ></f:setPropertyActionListener>
                                                 </p:commandButton>
                                             </p:column>
-                                        </p:dataTable>
+                                    </p:dataTable>
                                     </p:tab>
+
+                                    <p:tab title="Finance Summary" >
+                                        <p:panel id="billFinanceDetails">
+                                            <ph:bill_finance_details bill="#{billSearch.viewingBill}"/>
+                                        </p:panel>
+                                    </p:tab>
+
+                                    <p:tab title="Item Finance Details" >
+                                        <ui:repeat value="#{billSearch.viewingBillItems}" var="bi" >
+                                            <ph:bill_item_finance_details pbi="#{bi}"/>
+                                            <p:separator />
+                                        </ui:repeat>
+                                    </p:tab>
+
                                     <p:tab title="Cancellations" >
                                         <h:panelGroup rendered="#{not billSearch.viewingBill.cancelled}" >
                                             <p:outputLabel value="Not Cancelled" class="ui-message-error m-2 p-2 b-1 w-100 text-center" ></p:outputLabel>


### PR DESCRIPTION
## Summary
- add pharmacy namespace to bill admin page
- show finance summary tab
- show item finance details for each bill item

## Testing
- `mvn -q -DskipTests package` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ef52aebb0832fb858a5d304204056