### PR TITLE
Add remaining qty columns to BillItem list

### DIFF
--- a/src/main/webapp/resources/ezcomp/view/bill_item_list_edit.xhtml
+++ b/src/main/webapp/resources/ezcomp/view/bill_item_list_edit.xhtml
@@ -41,6 +41,14 @@
                 <p:inputText value="#{bi.qty}" rendered="#{cc.attrs.editable}" class="w-100 m-1 text-end" />
                 <p:outputLabel value="#{bi.qty}" rendered="#{!cc.attrs.editable}" class="text-end" />
             </p:column>
+            <p:column headerText="Remaining Qty" class="text-end">
+                <p:inputText value="#{bi.remainingQty}" rendered="#{cc.attrs.editable}" class="w-100 m-1 text-end" />
+                <p:outputLabel value="#{bi.remainingQty}" rendered="#{!cc.attrs.editable}" class="text-end" />
+            </p:column>
+            <p:column headerText="Remaining Free Qty" class="text-end">
+                <p:inputText value="#{bi.pharmaceuticalBillItem.remainingFreeQty}" rendered="#{cc.attrs.editable}" class="w-100 m-1 text-end" />
+                <p:outputLabel value="#{bi.pharmaceuticalBillItem.remainingFreeQty}" rendered="#{!cc.attrs.editable}" class="text-end" />
+            </p:column>
             <p:column headerText="Rate" class="text-end">
                 <p:inputText value="#{bi.rate}" rendered="#{cc.attrs.editable}" class="w-100 m-1 text-end" />
                 <p:outputLabel value="#{bi.rate}" rendered="#{!cc.attrs.editable}" class="text-end" />
@@ -81,6 +89,10 @@
             <p:column headerText="Discount" class="text-end">
                 <p:inputText value="#{bi.discount}" rendered="#{cc.attrs.editable}" class="w-100 m-1 text-end" />
                 <h:outputText value="#{bi.discount}" rendered="#{!cc.attrs.editable}" class="text-end" />
+            </p:column>
+            <p:column headerText="VAT" class="text-end">
+                <p:inputText value="#{bi.vat}" rendered="#{cc.attrs.editable}" class="w-100 m-1 text-end" />
+                <p:outputLabel value="#{bi.vat}" rendered="#{!cc.attrs.editable}" class="text-end" />
             </p:column>
             <p:column headerText="Service Charge" class="text-end">
                 <p:inputText value="#{bi.marginValue}" rendered="#{cc.attrs.editable}" class="w-100 m-1 text-end" />


### PR DESCRIPTION
## Summary
- show remaining quantities and VAT in bill item list edit

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686ef70c9508832f9e6c3ad18e1e4990