### PR TITLE
Add extra details to pharmaceutical item list

### DIFF
--- a/src/main/webapp/resources/ezcomp/view/pharmaceutical_bill_item_list_edit.xhtml
+++ b/src/main/webapp/resources/ezcomp/view/pharmaceutical_bill_item_list_edit.xhtml
@@ -80,6 +80,30 @@
                 </p:inputText>
             </p:column>
 
+            <p:column headerText="Wholesale Rate">
+                <p:inputText value="#{bi.wholesaleRate}" styleClass="text-end w-100 m-1">
+                    <f:convertNumber pattern="#,##0.00" />
+                </p:inputText>
+            </p:column>
+
+            <p:column headerText="Last Purchase Rate">
+                <p:inputText value="#{bi.lastPurchaseRate}" styleClass="text-end w-100 m-1">
+                    <f:convertNumber pattern="#,##0.00" />
+                </p:inputText>
+            </p:column>
+
+            <p:column headerText="Remaining Qty">
+                <p:inputText value="#{bi.remainingQty}" styleClass="text-end w-100 m-1">
+                    <f:convertNumber pattern="#,##0.00" />
+                </p:inputText>
+            </p:column>
+
+            <p:column headerText="Remaining Free Qty Pack">
+                <p:inputText value="#{bi.remainingFreeQtyPack}" styleClass="text-end w-100 m-1">
+                    <f:convertNumber pattern="#,##0.00" />
+                </p:inputText>
+            </p:column>
+
             <p:column headerText="Actions">
                 <p:commandButton 
                     value="Fix" 


### PR DESCRIPTION
## Summary
- add columns for wholesale rate, last purchase rate, remaining qty and free qty pack to pharmaceutical bill item list

## Testing
- `mvn -q -DskipTests=true test` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ef70fb920832faf06944bff99ecc4