### PR TITLE
Add purchase value metrics for BillFinanceDetails

### DIFF
--- a/src/main/java/com/divudi/core/entity/BillFinanceDetails.java
+++ b/src/main/java/com/divudi/core/entity/BillFinanceDetails.java
@@ -87,17 +87,41 @@ public class BillFinanceDetails implements Serializable {
     @Column(precision = 18, scale = 4)
     private BigDecimal totalPurchaseValue = BigDecimal.ZERO;
 
+    @Column(precision = 18, scale = 4)
+    private BigDecimal totalPurchaseValueFree = BigDecimal.ZERO;
+
+    @Column(precision = 18, scale = 4)
+    private BigDecimal totalPurchaseValueNonFree = BigDecimal.ZERO;
+
     // Estimated value of items given free of charge
     @Column(precision = 18, scale = 4)
     private BigDecimal totalOfFreeItemValues = BigDecimal.ZERO;
+
+    @Column(precision = 18, scale = 4)
+    private BigDecimal totalOfFreeItemValuesFree = BigDecimal.ZERO;
+
+    @Column(precision = 18, scale = 4)
+    private BigDecimal totalOfFreeItemValuesNonFree = BigDecimal.ZERO;
 
     // Expected total if all items sold at retail rate
     @Column(precision = 18, scale = 4)
     private BigDecimal totalRetailSaleValue = BigDecimal.ZERO;
 
+    @Column(precision = 18, scale = 4)
+    private BigDecimal totalRetailSaleValueFree = BigDecimal.ZERO;
+
+    @Column(precision = 18, scale = 4)
+    private BigDecimal totalRetailSaleValueNonFree = BigDecimal.ZERO;
+
     // Expected total if all items sold at wholesale rate
     @Column(precision = 18, scale = 4)
     private BigDecimal totalWholesaleValue = BigDecimal.ZERO;
+
+    @Column(precision = 18, scale = 4)
+    private BigDecimal totalWholesaleValueFree = BigDecimal.ZERO;
+
+    @Column(precision = 18, scale = 4)
+    private BigDecimal totalWholesaleValueNonFree = BigDecimal.ZERO;
 
     // ------------------ QUANTITIES ------------------
     // Total quantity of all BillItems (excluding free)
@@ -186,9 +210,17 @@ public class BillFinanceDetails implements Serializable {
 
         // ------------------ VALUES ------------------
         clone.setTotalPurchaseValue(this.totalPurchaseValue);
+        clone.setTotalPurchaseValueFree(this.totalPurchaseValueFree);
+        clone.setTotalPurchaseValueNonFree(this.totalPurchaseValueNonFree);
         clone.setTotalOfFreeItemValues(this.totalOfFreeItemValues);
+        clone.setTotalOfFreeItemValuesFree(this.totalOfFreeItemValuesFree);
+        clone.setTotalOfFreeItemValuesNonFree(this.totalOfFreeItemValuesNonFree);
         clone.setTotalRetailSaleValue(this.totalRetailSaleValue);
+        clone.setTotalRetailSaleValueFree(this.totalRetailSaleValueFree);
+        clone.setTotalRetailSaleValueNonFree(this.totalRetailSaleValueNonFree);
         clone.setTotalWholesaleValue(this.totalWholesaleValue);
+        clone.setTotalWholesaleValueFree(this.totalWholesaleValueFree);
+        clone.setTotalWholesaleValueNonFree(this.totalWholesaleValueNonFree);
 
         // ------------------ QUANTITIES ------------------
         clone.setTotalQuantity(this.totalQuantity);
@@ -315,6 +347,22 @@ public class BillFinanceDetails implements Serializable {
         this.totalOfFreeItemValues = totalOfFreeItemValues;
     }
 
+    public BigDecimal getTotalOfFreeItemValuesFree() {
+        return totalOfFreeItemValuesFree;
+    }
+
+    public void setTotalOfFreeItemValuesFree(BigDecimal totalOfFreeItemValuesFree) {
+        this.totalOfFreeItemValuesFree = totalOfFreeItemValuesFree;
+    }
+
+    public BigDecimal getTotalOfFreeItemValuesNonFree() {
+        return totalOfFreeItemValuesNonFree;
+    }
+
+    public void setTotalOfFreeItemValuesNonFree(BigDecimal totalOfFreeItemValuesNonFree) {
+        this.totalOfFreeItemValuesNonFree = totalOfFreeItemValuesNonFree;
+    }
+
     public BigDecimal getTotalCostValue() {
         return totalCostValue;
     }
@@ -329,6 +377,22 @@ public class BillFinanceDetails implements Serializable {
 
     public void setTotalPurchaseValue(BigDecimal totalPurchaseValue) {
         this.totalPurchaseValue = totalPurchaseValue;
+    }
+
+    public BigDecimal getTotalPurchaseValueFree() {
+        return totalPurchaseValueFree;
+    }
+
+    public void setTotalPurchaseValueFree(BigDecimal totalPurchaseValueFree) {
+        this.totalPurchaseValueFree = totalPurchaseValueFree;
+    }
+
+    public BigDecimal getTotalPurchaseValueNonFree() {
+        return totalPurchaseValueNonFree;
+    }
+
+    public void setTotalPurchaseValueNonFree(BigDecimal totalPurchaseValueNonFree) {
+        this.totalPurchaseValueNonFree = totalPurchaseValueNonFree;
     }
 
     public BigDecimal getTotalQuantity() {
@@ -363,12 +427,44 @@ public class BillFinanceDetails implements Serializable {
         this.totalRetailSaleValue = totalRetailSaleValue;
     }
 
+    public BigDecimal getTotalRetailSaleValueFree() {
+        return totalRetailSaleValueFree;
+    }
+
+    public void setTotalRetailSaleValueFree(BigDecimal totalRetailSaleValueFree) {
+        this.totalRetailSaleValueFree = totalRetailSaleValueFree;
+    }
+
+    public BigDecimal getTotalRetailSaleValueNonFree() {
+        return totalRetailSaleValueNonFree;
+    }
+
+    public void setTotalRetailSaleValueNonFree(BigDecimal totalRetailSaleValueNonFree) {
+        this.totalRetailSaleValueNonFree = totalRetailSaleValueNonFree;
+    }
+
     public BigDecimal getTotalWholesaleValue() {
         return totalWholesaleValue;
     }
 
     public void setTotalWholesaleValue(BigDecimal totalWholesaleValue) {
         this.totalWholesaleValue = totalWholesaleValue;
+    }
+
+    public BigDecimal getTotalWholesaleValueFree() {
+        return totalWholesaleValueFree;
+    }
+
+    public void setTotalWholesaleValueFree(BigDecimal totalWholesaleValueFree) {
+        this.totalWholesaleValueFree = totalWholesaleValueFree;
+    }
+
+    public BigDecimal getTotalWholesaleValueNonFree() {
+        return totalWholesaleValueNonFree;
+    }
+
+    public void setTotalWholesaleValueNonFree(BigDecimal totalWholesaleValueNonFree) {
+        this.totalWholesaleValueNonFree = totalWholesaleValueNonFree;
     }
 
     public BigDecimal getTotalQuantityInAtomicUnitOfMeasurement() {


### PR DESCRIPTION
## Summary
- expand `BillFinanceDetails` entity with detailed purchase value fields for free/non-free items
- clone method and accessors updated accordingly

## Testing
- `mvn -q -DskipTests package` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68702364c330832fa3bf010ef923d6a0