### PR TITLE
Add department item fee page

### DIFF
--- a/src/main/java/com/divudi/bean/common/FeeValueController.java
+++ b/src/main/java/com/divudi/bean/common/FeeValueController.java
@@ -85,9 +85,19 @@ public class FeeValueController implements Serializable {
         return feeValue != null ? feeValue.getTotalValueForLocals() : 0.0;
     }
 
+    public Double getFeeForLocals(Item item, Department department) {
+        FeeValue feeValue = getFeeValue(item, department);
+        return feeValue != null ? feeValue.getTotalValueForLocals() : 0.0;
+    }
+
     public Double getFeeForForeigners(Item item, Institution institution) {
         FeeValue feeValue = getFeeValue(item, institution);
         return feeValue != null ? feeValue.getTotalValueForLocals() : 0.0;
+    }
+
+    public Double getFeeForForeigners(Item item, Department department) {
+        FeeValue feeValue = getFeeValue(item, department);
+        return feeValue != null ? feeValue.getTotalValueForForeigners() : 0.0;
     }
 
     public FeeValue getFeeValue(Item item, Department department) {

--- a/src/main/java/com/divudi/bean/common/ItemFeeManager.java
+++ b/src/main/java/com/divudi/bean/common/ItemFeeManager.java
@@ -62,6 +62,7 @@ public class ItemFeeManager implements Serializable {
     ItemFee removingFee;
     private Institution collectingCentre;
     private Institution forSite;
+    private Department forDepartment;
     private Category feeListType;
 
     List<ItemFee> itemFees;
@@ -339,6 +340,16 @@ public class ItemFeeManager implements Serializable {
         }
     }
 
+    public void fillForDepartmentItemFees() {
+        itemFees = fillFees(null, forDepartment);
+    }
+
+    public void updateFeesForDepartmentItemFees() {
+        for (ItemFee tif : itemFees) {
+            updateDepartmentFeeValues(tif.getItem(), forDepartment);
+        }
+    }
+
     public void updateFeesForListFees() {
         for (ItemFee tif : itemFees) {
             updateListFeeValues(tif.getItem(), feeListType);
@@ -440,6 +451,21 @@ public class ItemFeeManager implements Serializable {
         JsfUtil.addSuccessMessage("Removed. Reload Items");
     }
 
+    public void removeFeeForDepartmentFees() {
+        if (removingFee == null) {
+            JsfUtil.addErrorMessage("Select a fee");
+            return;
+        }
+        removingFee.setRetired(true);
+        removingFee.setRetiredAt(new Date());
+        removingFee.setRetirer(sessionController.getLoggedUser());
+        itemFeeFacade.edit(removingFee);
+        itemFees = null;
+        updateTotal();
+        feeValueController.updateFeeValue(item, forDepartment, totalItemFee, totalItemFeeForForeigners);
+        JsfUtil.addSuccessMessage("Removed. Reload Items");
+    }
+
     public void fillDepartments() {
         ////// // System.out.println("fill dept");
         String jpql;
@@ -494,6 +520,14 @@ public class ItemFeeManager implements Serializable {
         feeListType = null;
         fillForCollectingCentreFees();
         return "/admin/pricing/manage_for_site_item_fees?faces-redirect=true";
+    }
+
+    public String navigateToForDepartmentItemFees() {
+        collectingCentre = null;
+        item = null;
+        feeListType = null;
+        fillForCollectingCentreFees();
+        return "/admin/pricing/manage_for_department_item_fees?faces-redirect=true";
     }
 
     public String navigateToFeeListFees() {
@@ -587,6 +621,19 @@ public class ItemFeeManager implements Serializable {
         feeValueController.updateFeeValue(ti, si, tlf, tfff);
     }
 
+    public void updateDepartmentFeeValues(Item ti, Department dept) {
+        List<ItemFee> tfs = fillFees(ti, dept);
+        double tlf = tfs.stream()
+                .filter(Objects::nonNull)
+                .mapToDouble(ItemFee::getFee)
+                .sum();
+        double tfff = tfs.stream()
+                .filter(Objects::nonNull)
+                .mapToDouble(ItemFee::getFfee)
+                .sum();
+        feeValueController.updateFeeValue(ti, dept, tlf, tfff);
+    }
+
     public void updateCcFeeValues(Item ti, Institution cc) {
         List<ItemFee> tfs = fillFees(ti, cc);
         double tlf = tfs.stream()
@@ -625,6 +672,18 @@ public class ItemFeeManager implements Serializable {
         calculateFeesForSitesByProvidingFees();
     }
 
+    public void updateItemAndDepartmentFees() {
+        itemFees = new ArrayList<>();
+        if (item == null) {
+            return;
+        }
+        if (forDepartment == null) {
+            return;
+        }
+        itemFees = fillFees(item, forDepartment);
+        calculateFeesForDepartmentsByProvidingFees();
+    }
+
     public void calculateFeesForSitesByProvidingFees() {
         totalItemFee = itemFees.stream()
                 .filter(Objects::nonNull)
@@ -635,6 +694,18 @@ public class ItemFeeManager implements Serializable {
                 .mapToDouble(ItemFee::getFfee)
                 .sum();
         feeValueController.updateFeeValue(item, forSite, totalItemFee, totalItemFeeForForeigners);
+    }
+
+    public void calculateFeesForDepartmentsByProvidingFees() {
+        totalItemFee = itemFees.stream()
+                .filter(Objects::nonNull)
+                .mapToDouble(ItemFee::getFee)
+                .sum();
+        totalItemFeeForForeigners = itemFees.stream()
+                .filter(Objects::nonNull)
+                .mapToDouble(ItemFee::getFfee)
+                .sum();
+        feeValueController.updateFeeValue(item, forDepartment, totalItemFee, totalItemFeeForForeigners);
     }
 
     public void updateItemAndFeeListees() {
@@ -735,6 +806,26 @@ public class ItemFeeManager implements Serializable {
 
     public List<ItemFee> fillFees(Item i, Institution ins) {
         return fillFees(i, ins, null);
+    }
+
+    public List<ItemFee> fillFees(Item i, Department dept) {
+        String jpql = "select f from ItemFee f where 1=1";
+        Map<String, Object> m = new HashMap<>();
+        jpql += " and f.retired=:ret";
+        m.put("ret", false);
+        if (i != null) {
+            jpql += " and f.item=:i";
+            m.put("i", i);
+        }
+        if (dept != null) {
+            jpql += " and f.department=:d";
+            m.put("d", dept);
+        } else {
+            jpql += " and f.department is null";
+        }
+        jpql += " and f.forInstitution is null";
+        jpql += " and f.forCategory is null";
+        return itemFeeFacade.findByJpql(jpql, m);
     }
 
     public List<ItemFee> fillFees(Item i, Category cat) {
@@ -1023,6 +1114,51 @@ public class ItemFeeManager implements Serializable {
         JsfUtil.addSuccessMessage("New Fee Added for Collecting Centre");
     }
 
+    public void addNewDepartmentFee() {
+        if (forDepartment == null) {
+            JsfUtil.addErrorMessage("Select a Department ?");
+            return;
+        }
+        if (item == null) {
+            JsfUtil.addErrorMessage("Select an Item ?");
+            return;
+        }
+        if (itemFee == null) {
+            JsfUtil.addErrorMessage("Select Item Fee");
+            return;
+        }
+        if (itemFee.getName() == null || itemFee.getName().trim().equals("")) {
+            JsfUtil.addErrorMessage("Please Fill Fee Name");
+            return;
+        }
+
+        if (itemFee.getFeeType() == null) {
+            JsfUtil.addErrorMessage("Please Fill Fee Type");
+            return;
+        }
+
+        if (itemFee.getFee() == 0.00) {
+            JsfUtil.addErrorMessage("Please Enter Local Fee Value");
+            return;
+        }
+
+        if (itemFee.getFfee() == 0.00) {
+            JsfUtil.addErrorMessage("Please Enter Foreign Fee Value");
+            return;
+        }
+        getItemFee().setCreatedAt(new Date());
+        getItemFee().setCreater(sessionController.getLoggedUser());
+        getItemFee().setDepartment(forDepartment);
+        itemFeeFacade.create(itemFee);
+        getItemFee().setItem(item);
+        itemFeeFacade.edit(itemFee);
+        itemFee = new ItemFee();
+        itemFees = null;
+
+        updateItemAndDepartmentFees();
+        JsfUtil.addSuccessMessage("New Fee Added for Department");
+    }
+
     public void addNewFeeForFeeListType() {
         if (feeListType == null) {
             JsfUtil.addErrorMessage("Select Collecting Centre ?");
@@ -1123,6 +1259,22 @@ public class ItemFeeManager implements Serializable {
         feeValueController.updateFeeValue(item, forSite, totalItemFee, totalItemFeeForForeigners);
     }
 
+    public void fillForDepartmentFees() {
+        if (forDepartment == null) {
+            itemFees = null;
+            totalItemFee = 0.0;
+            totalItemFeeForForeigners = 0.0;
+            return;
+        }
+        itemFees = fillFees(item, forDepartment);
+    }
+
+    public void updateFeeForDepartments(ItemFee f) {
+        itemFeeFacade.edit(f);
+        calculateFeesForDepartmentsByProvidingFees();
+        feeValueController.updateFeeValue(item, forDepartment, totalItemFee, totalItemFeeForForeigners);
+    }
+
     public void updateFee() {
         if (item == null) {
             return;
@@ -1220,6 +1372,14 @@ public class ItemFeeManager implements Serializable {
 
     public void setForSite(Institution forSite) {
         this.forSite = forSite;
+    }
+
+    public Department getForDepartment() {
+        return forDepartment;
+    }
+
+    public void setForDepartment(Department forDepartment) {
+        this.forDepartment = forDepartment;
     }
 
 }

--- a/src/main/webapp/admin/pricing/index.xhtml
+++ b/src/main/webapp/admin/pricing/index.xhtml
@@ -32,11 +32,19 @@
                                                 action="#{categoryController.navigateToManageFeeListTypes()}">
                                             </p:commandButton>
 
-                                            <p:commandButton 
+                                            <p:commandButton
                                                 class="w-100"
-                                                ajax="false" 
+                                                ajax="false"
+                                                value="Item Fees for Departments"
+                                                icon="fa fa-sitemap"
+                                                action="#{itemFeeManager.navigateToForDepartmentItemFees()}">
+                                            </p:commandButton>
+
+                                            <p:commandButton
+                                                class="w-100"
+                                                ajax="false"
                                                 value="Item Fees for Sites"
-                                                icon="fa fa-building" 
+                                                icon="fa fa-building"
                                                 action="#{itemFeeManager.navigateToForSiteItemFees()}">
                                             </p:commandButton>
 

--- a/src/main/webapp/admin/pricing/manage_for_department_item_fees.xhtml
+++ b/src/main/webapp/admin/pricing/manage_for_department_item_fees.xhtml
@@ -1,0 +1,305 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
+      xmlns:p="http://primefaces.org/ui"
+      xmlns:h="http://xmlns.jcp.org/jsf/html"
+      xmlns:f="http://xmlns.jcp.org/jsf/core">
+
+    <h:head>
+    </h:head>
+    <h:body>
+        <ui:composition template="/admin/pricing/index.xhtml">
+            <ui:define name="subcontent">
+                <h:form>
+                    <p:growl id="msg"/>
+                    <p:panel>
+                        <f:facet name="header">
+                            <h:outputText styleClass="fa fa-fw fa-money-bill-wave"></h:outputText>
+                            <p:outputLabel class="m-2">Manage For Department Items Fees</p:outputLabel>
+                        </f:facet>
+
+                        <p:panelGrid columns="2" class="w-100" >
+                            <p:outputLabel value="Select Department" />
+                            <p:autoComplete
+                                value="#{itemFeeManager.forDepartment}"
+                                forceSelection="true"
+                                id="acDept"
+                                completeMethod="#{itemFeeManager.compelteDepartments}"
+                                var="vt"
+                                itemLabel="#{vt.name}"
+                                itemValue="#{vt}"
+                                maxResults="10"
+                                class="w-100 mb-1"
+                                inputStyleClass="form-control">
+                                <p:ajax
+                                    event="itemSelect"
+                                    process="@this"
+                                    update="gpFees localFee foreignerFee"
+                                    listener="#{itemFeeManager.updateItemAndDepartmentFees()}">
+                                </p:ajax>
+                            </p:autoComplete>
+
+                            <p:outputLabel value="Select Item" />
+                            <p:autoComplete 
+                                widgetVar="aIx" 
+                                id="acIx" 
+                                forceSelection="true" 
+                                value="#{itemFeeManager.item}"
+                                completeMethod="#{itemController.completeInwardItems}" 
+                                var="ix" 
+                                itemLabel="#{ix.name}" 
+                                itemValue="#{ix}" 
+                                size="30"  
+                                class="w-100"
+                                maxResults="10"
+                                inputStyleClass="w-100">
+                                <p:column  headerText="Code" style="padding: 6px; margin: 0px; width: 8em;">
+                                    <h:outputText value="#{ix.code}"></h:outputText>
+                                </p:column>
+                                <p:column rendered="#{webUserController.hasPrivilege('Developers')}" headerText="Type" style="padding: 6px; margin: 0px; width: 8em;">
+                                    <h:outputText value="#{ix.itemType}"></h:outputText>
+                                </p:column>
+                                <p:column  headerText="Name" style="padding: 6px; margin: 0px;">
+                                    <h:outputText value="#{ix.name}"></h:outputText>
+                                </p:column>
+                                <p:ajax 
+                                    event="itemSelect" 
+                                    process="@this" 
+                                    update="gpFees localFee foreignerFee"
+                                    listener="#{itemFeeManager.updateItemAndDepartmentFees()}">
+                                </p:ajax>
+                            </p:autoComplete>
+
+                            <h:panelGroup  id="localFee">
+                                <h:panelGroup rendered="#{itemFeeManager.item ne null and itemFeeManager.forDepartment ne null}" >
+                                    <p:outputLabel value="Local Fee" />
+                                    <p:outputLabel 
+                                        value="#{feeValueController.getFeeForLocals(itemFeeManager.item,itemFeeManager.forDepartment)}"
+                                        class="w-100">
+                                        <f:convertNumber pattern="#,##0.00" />
+                                    </p:outputLabel>
+                                </h:panelGroup>
+                            </h:panelGroup>
+
+                            <h:panelGroup id="foreignerFee"  >
+                                <h:panelGroup rendered="#{itemFeeManager.item ne null and itemFeeManager.forDepartment ne null}" >
+                                    <p:outputLabel value="Foreigner Fee" />
+                                    <p:outputLabel 
+                                        value="#{feeValueController.getFeeForForeigners(itemFeeManager.item, itemFeeManager.forDepartment)}"
+                                        class="w-100">
+                                        <f:convertNumber pattern="#,##0.00" />
+                                    </p:outputLabel>
+                                </h:panelGroup>
+                            </h:panelGroup>
+                        </p:panelGrid>
+
+                        <div class="row">
+                            <div class="col-md-2">
+                                <p:commandButton 
+                                    id="btnAddNewFee"
+                                    value="Add New Fee" 
+                                    process="btnAddNewFee acIx" 
+                                    onclick="PF('dlg').show();" 
+                                    class="w-100 my-2 ui-button-success" icon="fa fa-plus">   
+                                </p:commandButton>
+                            </div>
+                        </div>
+
+                        <p:dialog id="dlg"  widgetVar="dlg" modal="true" height="30em" width="50em" >
+                            <f:facet name="header" >
+                                <p:outputLabel value="Adding a new Fee" class="mr-5"></p:outputLabel>
+                                <p:commandButton
+                                    value="Save"
+                                    action="#{itemFeeManager.addNewDepartmentFee()}"
+                                    style="margin-left: 30px;"
+                                    update="gpFees dlg msg tblFees localFee foreignerFee "
+                                    process="gpDetail @this"
+                                    oncomplete="PF('dlg').hide();">
+                                </p:commandButton>
+                            </f:facet>
+                            <p:panelGrid columns="2" id="gpDetail" class="w-100">
+                                <p:outputLabel value="Fee Name" ></p:outputLabel>
+                                <p:inputText value="#{itemFeeManager.itemFee.name}"   class="w-100">
+                                    <f:ajax event="keyup" execute="@this" ></f:ajax>
+                                </p:inputText>
+
+                                <p:outputLabel value="Fee Type" ></p:outputLabel>
+                                <p:selectOneMenu 
+                                    filter="true"
+                                    filterMatchMode="contains"
+                                    value="#{itemFeeManager.itemFee.feeType}" 
+                                    class="w-100">
+                                    <f:selectItem itemLabel="Select Fee Type" ></f:selectItem>
+                                    <f:selectItems value="#{enumController.feeTypes}" var="ft" itemLabel="#{ft.label}" itemValue="#{ft}" />                                        
+                                    <p:ajax process="@this" update="gpDetail" ></p:ajax>
+                                </p:selectOneMenu>
+
+                                <p:outputLabel value="Discounts Allowed" ></p:outputLabel>
+                                <p:selectBooleanButton 
+                                    class="w-100"
+                                    value="#{itemFeeManager.itemFee.discountAllowed}" offLabel="Discounts NOT Allowed" onLabel="Discounts Allowed" >
+                                </p:selectBooleanButton>
+
+                                <h:panelGroup id="gpLblIns" rendered="#{itemFeeManager.itemFee.feeType eq 'OtherInstitution' or itemFeeManager.itemFee.feeType eq 'OwnInstitution'  or itemFeeManager.itemFee.feeType eq 'Referral' }" >
+                                    <p:outputLabel value="Institution" ></p:outputLabel>
+                                </h:panelGroup>
+
+                                <h:panelGroup id="gpAcIns" rendered="#{itemFeeManager.itemFee.feeType eq 'OtherInstitution' or itemFeeManager.itemFee.feeType eq 'OwnInstitution'  or itemFeeManager.itemFee.feeType eq 'Referral' }" >
+                                    <p:autoComplete 
+                                        id="acIns" 
+                                        value="#{itemFeeManager.itemFee.institution}" 
+                                        completeMethod="#{institutionController.completeIns}"
+                                        var="ins" 
+                                        class="w-100"
+                                        inputStyleClass="w-100"
+                                        itemLabel="#{ins.name}" 
+                                        itemValue="#{ins}" 
+                                        >
+                                        <p:ajax event="itemSelect" process="acIns" update="gpSomDepartment" listener="#{itemFeeManager.fillDepartments()}" ></p:ajax>
+                                    </p:autoComplete>
+                                </h:panelGroup>
+
+                                <h:panelGroup id="gpLblDep" rendered="#{itemFeeManager.itemFee.feeType eq 'OtherInstitution' or itemFeeManager.itemFee.feeType eq 'OwnInstitution'  or itemFeeManager.itemFee.feeType eq 'Referral' }" >
+                                    <p:outputLabel value="Department" ></p:outputLabel>
+                                </h:panelGroup>
+                                <h:panelGroup id="gpSomDepartment" rendered="#{itemFeeManager.itemFee.feeType eq 'OtherInstitution' or itemFeeManager.itemFee.feeType eq 'OwnInstitution'  or itemFeeManager.itemFee.feeType eq 'Referral' }" >
+                                    <p:selectOneMenu 
+                                        id="somDepartment"
+                                        class="w-100"
+                                        filter="true"
+                                        filterMatchMode="contains"
+                                        value="#{itemFeeManager.itemFee.department}" >
+                                        <f:selectItem itemLabel="Select" ></f:selectItem>
+                                        <f:selectItems value="#{itemFeeManager.departments}" var="dept" itemLabel="#{dept.name}" itemValue="#{dept}" ></f:selectItems>
+                                    </p:selectOneMenu>
+                                </h:panelGroup>
+
+                                <h:panelGroup id="gpLblSpe" rendered="#{itemFeeManager.itemFee.feeType eq 'Staff'}" >
+                                    <p:outputLabel value="Speciality" ></p:outputLabel>
+                                </h:panelGroup>
+
+                                <h:panelGroup id="gpAcSpe" rendered="#{itemFeeManager.itemFee.feeType eq 'Staff' }" >
+                                    <p:autoComplete 
+                                        value="#{itemFeeManager.itemFee.speciality}" 
+                                        completeMethod="#{specialityController.completeSpeciality}"
+                                        var="spe" 
+                                        class="w-100"
+                                        inputStyleClass="w-100"
+                                        itemLabel="#{spe.name}" 
+                                        itemValue="#{spe}" 
+                                        >
+                                        <p:ajax event="itemSelect" process="@this" update="somEmployee" listener="#{itemFeeManager.fillStaff()}" ></p:ajax>
+                                    </p:autoComplete>
+                                </h:panelGroup>
+
+                                <h:panelGroup id="gpLblEmp" rendered="#{itemFeeManager.itemFee.feeType eq 'Staff'}" >
+                                    <p:outputLabel value="Doctor / Staff" ></p:outputLabel>
+                                </h:panelGroup>
+                                <h:panelGroup id="gpSomEmp" rendered="#{itemFeeManager.itemFee.feeType eq 'Staff'}" >
+                                    <p:selectOneMenu 
+                                        id="somEmployee"
+                                        filter="true"
+                                        filterMatchMode="contains"
+                                        value="#{itemFeeManager.itemFee.staff}"   
+                                        class="w-100">
+                                        <f:selectItem itemLabel="Select" ></f:selectItem>
+                                        <f:selectItems value="#{itemFeeManager.staffs}" var="staff" itemLabel="#{staff.person.nameWithTitle}" itemValue="#{staff}" ></f:selectItems>
+                                    </p:selectOneMenu>
+                                </h:panelGroup>
+
+                                <p:outputLabel value="Fee" ></p:outputLabel>
+                                <p:inputText value="#{itemFeeManager.itemFee.fee}"  onfocus="this.select();"   class="w-100"></p:inputText>
+
+                                <p:outputLabel value="Foreigner Fee" ></p:outputLabel>
+                                <p:inputText value="#{itemFeeManager.itemFee.ffee}"  onfocus="this.select();"  class="w-100"></p:inputText>
+                            </p:panelGrid>
+                        </p:dialog>
+
+                        <p:panel header="Current Fees" id="gpFees" class="m-1">
+                            <p:dataTable id="tblFees" value="#{itemFeeManager.itemFees}" var="f" rowIndexVar="n" rowKey="#{f.id}" >
+                                <p:column headerText="Fee ID" width="5em;" >
+                                    <p:outputLabel id="txtFee" value="#{f}" />
+                                </p:column>
+                                <p:column headerText="Name" >
+                                    <p:inputText id="txtFeeName" value="#{f.name}" class="w-100" >
+                                        <p:ajax process="txtFeeName" event="blur" listener="#{itemFeeManager.updateFee(f)}" update=":#{p:resolveFirstComponentWithId('localFee',view).clientId} :#{p:resolveFirstComponentWithId('foreignerFee',view).clientId}" ></p:ajax>
+                                    </p:inputText>
+                                </p:column>
+                                <p:column headerText="Type" >
+                                    <p:outputLabel id="txtFeeType" value="#{f.feeType.label}" >
+                                    </p:outputLabel>
+                                </p:column>
+                                <p:column headerText="Created At" >
+                                    <p:outputLabel id="txt" value="#{f.createdAt}" >
+                                        <f:convertDateTime pattern="YYYY MM dd HH:mm:ss"/>
+                                    </p:outputLabel>
+                                </p:column>
+                                <p:column headerText="Discount Allowed" >
+                                    <p:selectBooleanButton 
+                                        value="#{f.discountAllowed}" 
+                                        offLabel="Discounts NOT Allowed" 
+                                        onLabel="Discounts Allowed" 
+                                        onIcon="pi pi-check" 
+                                        offIcon="pi pi-times"
+                                        styleClass="#{f.discountAllowed ? 'ui-button-success' : 'ui-button-danger'}">
+                                        <p:ajax process="@this" listener="#{itemFeeManager.updateFeeForDepartments(f)}" />
+                                    </p:selectBooleanButton>
+                                </p:column>
+                                <p:column headerText="For" >
+                                    <h:panelGroup rendered="#{f.institution ne null}" >
+                                        <p:outputLabel value="#{f.institution.name}" >
+                                        </p:outputLabel>
+                                        <p:spacer height="1" width="2" ></p:spacer>
+
+                                    </h:panelGroup>
+                                    <h:panelGroup rendered="#{f.speciality ne null}" >
+                                        <p:outputLabel value="#{f.speciality.name}" >
+                                        </p:outputLabel>
+                                        <p:spacer height="1" width="2" ></p:spacer>
+                                    </h:panelGroup>
+
+                                    <h:panelGroup rendered="#{f.department ne null}" >
+                                        <p:outputLabel value=" - " ></p:outputLabel>
+                                        <p:outputLabel value="#{f.department.name}" >
+                                        </p:outputLabel>
+                                    </h:panelGroup>
+
+                                    <h:panelGroup rendered="#{f.staff ne null}" >
+                                        <p:outputLabel value=" - " ></p:outputLabel>
+                                        <p:outputLabel value="#{f.staff.person.nameWithTitle}" >
+                                        </p:outputLabel>
+                                    </h:panelGroup>
+                                </p:column>
+                                <p:column headerText="Value" >
+                                    <p:inputText id="txtFeeVal" value="#{f.fee}" class="w-100" >
+                                        <f:convertNumber pattern="#,##0.00" />
+                                        <p:ajax process="txtFeeVal" event="blur" listener="#{itemFeeManager.updateFeeForDepartments(f)}" update=":#{p:resolveFirstComponentWithId('localFee',view).clientId} :#{p:resolveFirstComponentWithId('foreignerFee',view).clientId}" ></p:ajax>
+                                    </p:inputText>
+                                </p:column>
+                                <p:column headerText="Value for Foreigners" >
+                                    <p:inputText id="txtFfeeVal" value="#{f.ffee}"  class="w-100" >
+                                        <f:convertNumber pattern="#,##0.00" />
+                                        <p:ajax process="txtFfeeVal" event="blur" listener="#{itemFeeManager.updateFeeForDepartments(f)}"  update=":#{p:resolveFirstComponentWithId('foreignerFee',view).clientId} :#{p:resolveFirstComponentWithId('foreignerFee',view).clientId}"></p:ajax>
+                                    </p:inputText>
+                                </p:column>
+                                <p:column headerText="Actions" width="6em;" >
+                                    <p:commandButton 
+                                        id="cmdRemove" 
+                                        value="Remove" 
+                                        class="ui-button-danger"
+                                        icon="fas fa-trash"
+                                        ajax="false" 
+                                        action="#{itemFeeManager.removeFeeForDepartmentFees()}" >
+                                        <f:setPropertyActionListener value="#{f}" target="#{itemFeeManager.removingFee}" ></f:setPropertyActionListener>
+                                    </p:commandButton>
+                                </p:column>
+                            </p:dataTable>
+                        </p:panel>
+                    </p:panel>
+                    
+                </h:form>
+            </ui:define>
+        </ui:composition>
+    </h:body>
+</html>


### PR DESCRIPTION
## Summary
- add ability to manage item fees by department
- include new page with department autocomplete and fee actions
- expose helper methods to fetch department fee values
- wire new page into pricing navigation

## Testing
- `mvn test` *(fails: mvn not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6870382cf864832f9dabe28c31b39fb9