### PR TITLE
Fix GRN return quantity calculations

### DIFF
--- a/src/main/java/com/divudi/bean/pharmacy/GrnReturnWithCostingController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/GrnReturnWithCostingController.java
@@ -551,11 +551,11 @@ public class GrnReturnWithCostingController implements Serializable {
             double costRate = pbi.getItemBatch().getCostRate();
 
             pharmacyCostingService.calculateUnitsPerPack(fd);
+            fd.setTotalQuantity(fd.getQuantity().add(fd.getFreeQuantity()));
             pharmacyCostingService.addPharmaceuticalBillItemQuantitiesFromBillItemFinanceDetailQuantities(pbi, fd);
 
             System.out.println("fd.getQuantity() = " + fd.getQuantity());
             System.out.println("fd.getFreeQuantity() = " + fd.getFreeQuantity());
-            fd.setTotalQuantity(fd.getQuantity().add(fd.getFreeQuantity()));
             System.out.println("fd.getTotalQuantity() = " + fd.getTotalQuantity());
             
             fd.setLineNetRate(fd.getLineGrossRate());

--- a/src/main/java/com/divudi/service/pharmacy/PharmacyCostingService.java
+++ b/src/main/java/com/divudi/service/pharmacy/PharmacyCostingService.java
@@ -374,7 +374,7 @@ public class PharmacyCostingService {
 
         bifd.setQuantity(BigDecimal.valueOf(qtyInUnits).divide(upp));
         bifd.setFreeQuantity(BigDecimal.valueOf(freeQtyInUnits).divide(upp));
-        bifd.setTotalQuantity(BigDecimal.valueOf(freeQtyInUnits + freeQtyInUnits).divide(upp));
+        bifd.setTotalQuantity(BigDecimal.valueOf(qtyInUnits + freeQtyInUnits).divide(upp));
 
         bifd.setQuantityByUnits(BigDecimal.valueOf(qtyInUnits));
         bifd.setFreeQuantityByUnits(BigDecimal.valueOf(freeQtyInUnits));


### PR DESCRIPTION
## Summary
- correct total quantity calculation in PharmacyCostingService
- set totalQuantity before calling costing service in GRN return flow

## Testing
- `mvn -q test` *(fails: PluginResolutionException, network unreachable)*
- `mvn -q -DskipTests package` *(fails: PluginResolutionException, network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68708629a994832fa251b3b7284e7b4e