### PR TITLE
Fix #13826 Use DTOs for BinCard

### DIFF
--- a/src/main/java/com/divudi/bean/pharmacy/PharmacyErrorChecking.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacyErrorChecking.java
@@ -23,6 +23,7 @@ import com.divudi.core.entity.Item;
 import com.divudi.core.entity.PreBill;
 import com.divudi.core.entity.RefundBill;
 import com.divudi.core.entity.pharmacy.StockHistory;
+import com.divudi.core.data.dto.PharmacyBinCardDTO;
 import com.divudi.core.facade.BillFacade;
 import com.divudi.core.util.CommonFunctions;
 import java.io.Serializable;
@@ -54,6 +55,7 @@ public class PharmacyErrorChecking implements Serializable {
 
     List<BillItem> billItems;
     private List<StockHistory> stockHistories;
+    private List<PharmacyBinCardDTO> binCardEntries;
     //private ReportTimerController reportTimerController;
     Date fromDate;
     Date toDate;
@@ -106,20 +108,17 @@ public class PharmacyErrorChecking implements Serializable {
 
     public void processBinCard() {
         reportTimerController.trackReportExecution(() -> {
-            stockHistories = stockHistoryController.findStockHistories(fromDate, toDate, null, department, item);
+            binCardEntries = stockHistoryController.findBinCardDTOs(fromDate, toDate, null, department, item);
 
             if (configOptionApplicationController.getBooleanValueByKey("Pharmacy Bin Card - Hide Adjustment Bills in Bin Card",true)) {
                 List<BillType> bts = new ArrayList<>();
                 bts.add(BillType.PharmacyAdjustmentSaleRate);
 
-                Iterator<StockHistory> iterator = stockHistories.iterator();
+                Iterator<PharmacyBinCardDTO> iterator = binCardEntries.iterator();
                 while (iterator.hasNext()) {
-                    StockHistory sh = iterator.next();
-                    if (sh.getPbItem() != null
-                            && sh.getPbItem().getBillItem() != null
-                            && sh.getPbItem().getBillItem().getBill() != null
-                            && bts.contains(sh.getPbItem().getBillItem().getBill().getBillType())) {
-                        iterator.remove(); // modifies the original list safely
+                    PharmacyBinCardDTO dto = iterator.next();
+                    if (dto.getBillType() != null && bts.contains(dto.getBillType())) {
+                        iterator.remove();
                     }
                 }
             }
@@ -537,6 +536,14 @@ public class PharmacyErrorChecking implements Serializable {
 
     public void setStockHistories(List<StockHistory> stockHistories) {
         this.stockHistories = stockHistories;
+    }
+
+    public List<PharmacyBinCardDTO> getBinCardEntries() {
+        return binCardEntries;
+    }
+
+    public void setBinCardEntries(List<PharmacyBinCardDTO> binCardEntries) {
+        this.binCardEntries = binCardEntries;
     }
 
 }

--- a/src/main/java/com/divudi/bean/pharmacy/StockHistoryController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/StockHistoryController.java
@@ -11,6 +11,7 @@ import com.divudi.core.data.HistoryType;
 import com.divudi.ejb.StockHistoryRecorder;
 import com.divudi.core.entity.Department;
 import com.divudi.core.entity.pharmacy.StockHistory;
+import com.divudi.core.data.dto.PharmacyBinCardDTO;
 import com.divudi.core.facade.StockHistoryFacade;
 import com.divudi.core.util.JsfUtil;
 import com.divudi.core.entity.Item;
@@ -87,6 +88,23 @@ public class StockHistoryController implements Serializable {
         return "/analytics/pharmacy/stock_history?faces-redirect=true";
     }
 
+    /**
+     * Helper navigation method when only the id of the stock history is
+     * available. This is used when bin card rows are represented by DTOs.
+     */
+    public String navigateToViewStockHistoryById(Long id) {
+        if (id == null) {
+            JsfUtil.addErrorMessage("Nothing selected");
+            return null;
+        }
+        current = facade.find(id);
+        if (current == null) {
+            JsfUtil.addErrorMessage("Nothing found");
+            return null;
+        }
+        return "/analytics/pharmacy/stock_history?faces-redirect=true";
+    }
+
     // </editor-fold>
     // <editor-fold defaultstate="collapsed" desc="Functions">
     public void fillHistoryAvailableDays() {
@@ -140,6 +158,41 @@ public class StockHistoryController implements Serializable {
         if (shxs != null) {
         }
         return shxs;
+    }
+
+    /**
+     * Returns lightweight DTOs for the bin card view to reduce memory usage.
+     */
+    public List<PharmacyBinCardDTO> findBinCardDTOs(Date fd, Date td, HistoryType ht, Department dep, Item i) {
+        StringBuilder jpql = new StringBuilder();
+        jpql.append("select new com.divudi.core.data.dto.PharmacyBinCardDTO(")
+                .append("s.id, s.createdAt, ")
+                .append("s.pbItem.billItem.bill.billType, ")
+                .append("s.pbItem.billItem.bill.billTypeAtomic, ")
+                .append("s.pbItem.billItem.item.name, ")
+                .append("TYPE(s.pbItem.billItem.item), ")
+                .append("s.pbItem.qty, s.pbItem.freeQty, ")
+                .append("s.pbItem.qtyPacks, s.pbItem.freeQtyPacks, ")
+                .append("s.pbItem.billItem.item.dblValue, s.itemStock")
+                .append(") from StockHistory s ")
+                .append("where s.createdAt between :fd and :td ");
+        Map<String, Object> m = new HashMap<>();
+        m.put("fd", fd);
+        m.put("td", td);
+        if (ht != null) {
+            jpql.append(" and s.historyType=:ht ");
+            m.put("ht", ht);
+        }
+        if (dep != null) {
+            jpql.append(" and s.department=:dep ");
+            m.put("dep", dep);
+        }
+        if (i != null) {
+            jpql.append(" and s.item=:i ");
+            m.put("i", i);
+        }
+        jpql.append(" order by s.createdAt");
+        return (List<PharmacyBinCardDTO>) facade.findLightsByJpql(jpql.toString(), m, TemporalType.TIMESTAMP);
     }
 
     public void fillStockHistories(boolean withoutZeroStock) {

--- a/src/main/java/com/divudi/core/data/dto/PharmacyBinCardDTO.java
+++ b/src/main/java/com/divudi/core/data/dto/PharmacyBinCardDTO.java
@@ -1,0 +1,171 @@
+package com.divudi.core.data.dto;
+
+import com.divudi.core.data.BillType;
+import com.divudi.core.data.BillTypeAtomic;
+import java.io.Serializable;
+import java.util.Date;
+
+/**
+ * Lightweight projection used for the pharmacy bin card to avoid loading full
+ * entity graphs.
+ */
+public class PharmacyBinCardDTO implements Serializable {
+    private Long id;
+    private Date createdAt;
+    private BillType billType;
+    private BillTypeAtomic billTypeAtomic;
+    private String itemName;
+    private String itemClass;
+    private double qty;
+    private double freeQty;
+    private double qtyPacks;
+    private double freeQtyPacks;
+    private double itemDblValue;
+    private double itemStock;
+
+    public PharmacyBinCardDTO(Long id,
+                              Date createdAt,
+                              BillType billType,
+                              BillTypeAtomic billTypeAtomic,
+                              String itemName,
+                              Class<?> itemClass,
+                              double qty,
+                              double freeQty,
+                              double qtyPacks,
+                              double freeQtyPacks,
+                              double itemDblValue,
+                              double itemStock) {
+        this.id = id;
+        this.createdAt = createdAt;
+        this.billType = billType;
+        this.billTypeAtomic = billTypeAtomic;
+        this.itemName = itemName;
+        this.itemClass = itemClass == null ? null : itemClass.getSimpleName();
+        this.qty = qty;
+        this.freeQty = freeQty;
+        this.qtyPacks = qtyPacks;
+        this.freeQtyPacks = freeQtyPacks;
+        this.itemDblValue = itemDblValue;
+        this.itemStock = itemStock;
+    }
+
+    public PharmacyBinCardDTO() {
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public Date getCreatedAt() {
+        return createdAt;
+    }
+
+    public void setCreatedAt(Date createdAt) {
+        this.createdAt = createdAt;
+    }
+
+    public BillType getBillType() {
+        return billType;
+    }
+
+    public void setBillType(BillType billType) {
+        this.billType = billType;
+    }
+
+    public BillTypeAtomic getBillTypeAtomic() {
+        return billTypeAtomic;
+    }
+
+    public void setBillTypeAtomic(BillTypeAtomic billTypeAtomic) {
+        this.billTypeAtomic = billTypeAtomic;
+    }
+
+    public String getItemName() {
+        return itemName;
+    }
+
+    public void setItemName(String itemName) {
+        this.itemName = itemName;
+    }
+
+    public String getItemClass() {
+        return itemClass;
+    }
+
+    public void setItemClass(String itemClass) {
+        this.itemClass = itemClass;
+    }
+
+    public double getQty() {
+        return qty;
+    }
+
+    public void setQty(double qty) {
+        this.qty = qty;
+    }
+
+    public double getFreeQty() {
+        return freeQty;
+    }
+
+    public void setFreeQty(double freeQty) {
+        this.freeQty = freeQty;
+    }
+
+    public double getQtyPacks() {
+        return qtyPacks;
+    }
+
+    public void setQtyPacks(double qtyPacks) {
+        this.qtyPacks = qtyPacks;
+    }
+
+    public double getFreeQtyPacks() {
+        return freeQtyPacks;
+    }
+
+    public void setFreeQtyPacks(double freeQtyPacks) {
+        this.freeQtyPacks = freeQtyPacks;
+    }
+
+    public double getItemDblValue() {
+        return itemDblValue;
+    }
+
+    public void setItemDblValue(double itemDblValue) {
+        this.itemDblValue = itemDblValue;
+    }
+
+    public double getItemStock() {
+        return itemStock;
+    }
+
+    public void setItemStock(double itemStock) {
+        this.itemStock = itemStock;
+    }
+
+    // Derived helper properties
+    public double getTransQtyPlusFreeQty() {
+        return qty + freeQty;
+    }
+
+    public double getTransAbsoluteQtyPlusFreeQty() {
+        return Math.abs(getTransQtyPlusFreeQty());
+    }
+
+    public boolean isTransThisIsStockIn() {
+        return getTransQtyPlusFreeQty() > 0;
+    }
+
+    public boolean isTransThisIsStockOut() {
+        return getTransQtyPlusFreeQty() < 0;
+    }
+
+    public boolean isAmpp() {
+        return "Ampp".equals(itemClass);
+    }
+}

--- a/src/main/webapp/pharmacy/bin_card.xhtml
+++ b/src/main/webapp/pharmacy/bin_card.xhtml
@@ -85,7 +85,7 @@
 
                 </h:panelGrid>
 
-                <p:dataTable value="#{pharmacyErrorChecking.stockHistories}"
+                <p:dataTable value="#{pharmacyErrorChecking.binCardEntries}"
                              var="sh"
                              rowIndexVar="i"
                              rows="10"
@@ -101,10 +101,10 @@
                         headerText="Stock Hx ID"
                         rendered="#{webUserController.hasPrivilege('Developers')}"
                         width="10rem">
-                        <p:commandLink 
+                        <p:commandLink
                             ajax="false"
-                            action="#{stockHistoryController.navigateToViewStockHistory(sh)}"
-                            value="#{sh.id}" 
+                            action="#{stockHistoryController.navigateToViewStockHistoryById(sh.id)}"
+                            value="#{sh.id}"
                             ></p:commandLink>
                         <f:facet name="footer">
                             <h:outputText value="Total"/>
@@ -120,50 +120,50 @@
 
                     <!-- Bill Type -->
                     <p:column headerText="Bill Type">
-                        <h:outputText value="#{sh.pbItem.billItem.bill.billType.label}" rendered="#{sh.pbItem.billItem.bill.billTypeAtomic eq null}"/>
-                        <h:outputText value="#{sh.pbItem.billItem.bill.billTypeAtomic.label}" rendered="#{sh.pbItem.billItem.bill.billTypeAtomic ne null}"/>
+                        <h:outputText value="#{sh.billType.label}" rendered="#{sh.billTypeAtomic eq null}"/>
+                        <h:outputText value="#{sh.billTypeAtomic.label}" rendered="#{sh.billTypeAtomic ne null}"/>
                     </p:column>
 
                     <!-- Item -->
                     <p:column headerText="Item">
-                        <h:outputText value="#{sh.pbItem.billItem.item.name}" />
+                        <h:outputText value="#{sh.itemName}" />
                     </p:column>
 
                     <p:column headerText="Qty In" styleClass="text-end">
 
                         <!-- Grouped rendering for Ampp items -->
-                        <h:panelGroup rendered="#{sh.pbItem.transThisIsStockIn and sh.pbItem.billItem.item.class.simpleName eq 'Ampp'}">
+                        <h:panelGroup rendered="#{sh.transThisIsStockIn and sh.ampp}">
 
-                            <h:outputText 
-                                value="(" 
-                                styleClass="#{sh.pbItem.qty gt 0 ? 'text-primary' : ''}" />
+                            <h:outputText
+                                value="("
+                                styleClass="#{sh.qty gt 0 ? 'text-primary' : ''}" />
 
-                            <h:outputText 
-                                value="#{sh.pbItem.qtyPacks + sh.pbItem.freeQtyPacks}" 
-                                styleClass="#{sh.pbItem.qty gt 0 ? 'text-primary' : ''}">
+                            <h:outputText
+                                value="#{sh.qtyPacks + sh.freeQtyPacks}"
+                                styleClass="#{sh.qty gt 0 ? 'text-primary' : ''}">
                                 <f:convertNumber pattern="#.#"/>
                             </h:outputText>
 
-                            <h:outputText 
-                                value="  X  " 
-                                styleClass="#{sh.pbItem.qty gt 0 ? 'text-primary' : ''}" />
+                            <h:outputText
+                                value="  X  "
+                                styleClass="#{sh.qty gt 0 ? 'text-primary' : ''}" />
 
-                            <h:outputText 
-                                value="#{sh.pbItem.billItem.item.dblValue}" 
-                                styleClass="#{sh.pbItem.qty gt 0 ? 'text-primary' : ''}">
+                            <h:outputText
+                                value="#{sh.itemDblValue}"
+                                styleClass="#{sh.qty gt 0 ? 'text-primary' : ''}">
                                 <f:convertNumber pattern="#.#"/>
                             </h:outputText>
 
-                            <h:outputText 
-                                value=")    " 
-                                styleClass="#{sh.pbItem.qty gt 0 ? 'text-primary' : ''}" />
+                            <h:outputText
+                                value=")    "
+                                styleClass="#{sh.qty gt 0 ? 'text-primary' : ''}" />
                         </h:panelGroup>
 
                         <!-- Total quantity display -->
-                        <h:outputText 
-                            value="#{sh.pbItem.transAbsoluteQtyPlusFreeQty}" 
-                            rendered="#{sh.pbItem.transThisIsStockIn}"
-                            styleClass="#{sh.pbItem.qty gt 0 ? 'text-success' : ''}">
+                        <h:outputText
+                            value="#{sh.transAbsoluteQtyPlusFreeQty}"
+                            rendered="#{sh.transThisIsStockIn}"
+                            styleClass="#{sh.qty gt 0 ? 'text-success' : ''}">
                             <f:convertNumber pattern="#.#"/>
                         </h:outputText>
 
@@ -173,37 +173,37 @@
                     <p:column headerText="Qty Out" styleClass="text-end">
 
                         <!-- Grouped rendering for Ampp items -->
-                        <h:panelGroup rendered="#{sh.pbItem.transThisIsStockOut and sh.pbItem.billItem.item.class.simpleName eq 'Ampp'}">
-                            <h:outputText 
-                                value="(" 
-                                styleClass="#{sh.pbItem.qty lt 0 ? 'text-danger' : ''}" />
+                        <h:panelGroup rendered="#{sh.transThisIsStockOut and sh.ampp}">
+                            <h:outputText
+                                value="("
+                                styleClass="#{sh.qty lt 0 ? 'text-danger' : ''}" />
 #
-                            <h:outputText 
-                                value="#{sh.pbItem.qtyPacks + sh.pbItem.freeQtyPacks}" 
-                                styleClass="#{sh.pbItem.qty lt 0 ? 'text-danger' : ''}">
+                            <h:outputText
+                                value="#{sh.qtyPacks + sh.freeQtyPacks}"
+                                styleClass="#{sh.qty lt 0 ? 'text-danger' : ''}">
                                 <f:convertNumber pattern="#.#"/>
                             </h:outputText>
 ##
-                            <h:outputText 
-                                value="  X  " 
-                                styleClass="#{sh.pbItem.qty lt 0 ? 'text-danger' : ''}" />
+                            <h:outputText
+                                value="  X  "
+                                styleClass="#{sh.qty lt 0 ? 'text-danger' : ''}" />
 ###
-                            <h:outputText 
-                                value="#{sh.pbItem.billItem.item.dblValue}" 
-                                styleClass="#{sh.pbItem.qty lt 0 ? 'text-danger' : ''}">
+                            <h:outputText
+                                value="#{sh.itemDblValue}"
+                                styleClass="#{sh.qty lt 0 ? 'text-danger' : ''}">
                                 <f:convertNumber pattern="#.#"/>
                             </h:outputText>
 
-                            <h:outputText 
-                                value=")    " 
-                                styleClass="#{sh.pbItem.qty lt 0 ? 'text-danger' : ''}" />
+                            <h:outputText
+                                value=")    "
+                                styleClass="#{sh.qty lt 0 ? 'text-danger' : ''}" />
                         </h:panelGroup>
 
                         <!-- Total quantity display -->
-                        <h:outputText 
-                            value="#{sh.pbItem.transAbsoluteQtyPlusFreeQty}" 
-                            rendered="#{sh.pbItem.transThisIsStockOut}"
-                            styleClass="#{sh.pbItem.qty lt 0 ? 'text-danger' : ''}">
+                        <h:outputText
+                            value="#{sh.transAbsoluteQtyPlusFreeQty}"
+                            rendered="#{sh.transThisIsStockOut}"
+                            styleClass="#{sh.qty lt 0 ? 'text-danger' : ''}">
                             <f:convertNumber pattern="#.#"/>
                         </h:outputText>
 


### PR DESCRIPTION
## Summary
- add `PharmacyBinCardDTO` for lightweight bin card rows
- query DTOs from `StockHistoryController`
- update `PharmacyErrorChecking` to use DTOs
- adjust `bin_card.xhtml` for new DTO
- allow navigation by StockHistory id

Closes #13826

------
https://chatgpt.com/codex/tasks/task_e_6870ec4031f4832fab01c6a954c8e1f9