### PR TITLE
13824-fix-incorrect-column-span-calculation-in-grn-return-receipt-footer

### DIFF
--- a/src/main/webapp/resources/pharmacy/grn_return_receipt_with_costing.xhtml
+++ b/src/main/webapp/resources/pharmacy/grn_return_receipt_with_costing.xhtml
@@ -149,7 +149,7 @@
 
                     <p:columnGroup type="footer">
                         <p:row>
-                            <p:column style="padding: 4px;" colspan="#{configOptionApplicationController.getBooleanValueByKey('Direct Purchase Return by Total Quantity', false) ? 7 : 7}" footerText="Total"/>
+                            <p:column style="padding: 4px;" colspan="#{configOptionApplicationController.getBooleanValueByKey('Direct Purchase Return by Total Quantity', false) ? 6 : 7}" footerText="Total"/>
                             <p:column style="padding: 4px; width: 7em;" footerText="#{0-cc.attrs.bill.total}" class="text-end">
                                 <f:facet name="footer" >
                                     <h:outputLabel value="#{0-cc.attrs.bill.total}" >


### PR DESCRIPTION
## Summary
- fix column span for grn return receipt footer

Closes #13824

------
https://chatgpt.com/codex/tasks/task_e_6870ed19e2c4832f989152642ee64949