### PR TITLE
13830-add-null-safety-checks-in-pharmacycostingservice-addpharmaceuticalbillitemquantitiesfrombillitemfinancedetailquantities

### DIFF
--- a/src/main/java/com/divudi/service/pharmacy/PharmacyCostingService.java
+++ b/src/main/java/com/divudi/service/pharmacy/PharmacyCostingService.java
@@ -326,9 +326,11 @@ public class PharmacyCostingService {
         pbi.setQtyPacks(qty.doubleValue());
         pbi.setFreeQtyPacks(freeQty.doubleValue());
 
-        bifd.setQuantityByUnits(bifd.getQuantity().multiply(bifd.getUnitsPerPack()));
-        bifd.setFreeQuantityByUnits(bifd.getFreeQuantity().multiply(bifd.getUnitsPerPack()));
-        bifd.setTotalQuantityByUnits(bifd.getTotalQuantity().multiply(bifd.getUnitsPerPack()));
+        BigDecimal totalQty = Optional.ofNullable(bifd.getTotalQuantity()).orElse(BigDecimal.ZERO);
+
+        bifd.setQuantityByUnits(qty.multiply(upp));
+        bifd.setFreeQuantityByUnits(freeQty.multiply(upp));
+        bifd.setTotalQuantityByUnits(totalQty.multiply(upp));
 
     }
 


### PR DESCRIPTION
## Summary
- add null safety checks to `PharmacyCostingService`

Closes #13830

------
https://chatgpt.com/codex/tasks/task_e_6870ffeccc8c832fa69ce8a015db18b4