### PR TITLE
Fix typo in PharmacyCostingService method names

### DIFF
--- a/src/main/java/com/divudi/bean/pharmacy/GrnReturnWithCostingController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/GrnReturnWithCostingController.java
@@ -474,7 +474,7 @@ public class GrnReturnWithCostingController implements Serializable {
 
             PharmaceuticalBillItem pbi = i.getPharmaceuticalBillItem();
             System.out.println("pbi.getQty() = " + pbi.getQty());
-            pharmacyCostingService.makeAllQuentityValuesNegative(pbi);
+            pharmacyCostingService.makeAllQuantityValuesNegative(pbi);
             if (i.getId() == null) {
                 i.setCreatedAt(new Date());
                 i.setCreater(sessionController.getLoggedUser());

--- a/src/main/java/com/divudi/service/pharmacy/PharmacyCostingService.java
+++ b/src/main/java/com/divudi/service/pharmacy/PharmacyCostingService.java
@@ -30,7 +30,7 @@ public class PharmacyCostingService {
      *
      * @param pbi PharmaceuticalBillItem to update
      */
-    public void makeAllQuentityValuesNegative(PharmaceuticalBillItem pbi) {
+    public void makeAllQuantityValuesNegative(PharmaceuticalBillItem pbi) {
         if (pbi == null) {
             return;
         }
@@ -52,7 +52,7 @@ public class PharmacyCostingService {
      *
      * @param pbi PharmaceuticalBillItem to update
      */
-    public void makeAllQuentityValuesPositive(PharmaceuticalBillItem pbi) {
+    public void makeAllQuantityValuesPositive(PharmaceuticalBillItem pbi) {
         if (pbi == null) {
             return;
         }


### PR DESCRIPTION
## Summary
- rename makeAllQuentityValues* methods to makeAllQuantityValues*
- update call site in GrnReturnWithCostingController

Closes #13827

------
https://chatgpt.com/codex/tasks/task_e_687100636ad0832fa79e7b9c66c52ed9