### PR TITLE
Add edit workflow for AMPP management

### DIFF
--- a/src/main/java/com/divudi/bean/pharmacy/AmppController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/AmppController.java
@@ -55,6 +55,7 @@ public class AmppController implements Serializable {
     PharmacyBean pharmacyBean;
     MeasurementUnit packUnit;
     private String selectText = "";
+    private boolean editable;
 
     public MeasurementUnit getPackUnit() {
         return packUnit;
@@ -103,6 +104,20 @@ public class AmppController implements Serializable {
         current = new Ampp();
         current.setVmpp(new Vmpp());
         dblValue = 0.0;
+        editable = true;
+    }
+
+    public void edit() {
+        if (current == null) {
+            JsfUtil.addErrorMessage("Select one to edit");
+            return;
+        }
+        editable = true;
+    }
+
+    public void cancel() {
+        current = null;
+        editable = false;
     }
 
     private void recreateModel() {
@@ -135,6 +150,7 @@ public class AmppController implements Serializable {
 
         recreateModel();
         getItems();
+        editable = false;
     }
 
     public AmppFacade getEjbFacade() {
@@ -184,6 +200,7 @@ public class AmppController implements Serializable {
         getItems();
         current = null;
         getCurrent();
+        editable = false;
     }
 
     private AmppFacade getFacade() {
@@ -223,6 +240,14 @@ public class AmppController implements Serializable {
 
     public void setSelectText(String selectText) {
         this.selectText = selectText;
+    }
+
+    public boolean isEditable() {
+        return editable;
+    }
+
+    public void setEditable(boolean editable) {
+        this.editable = editable;
     }
 
     /**

--- a/src/main/webapp/pharmacy/admin/ampp.xhtml
+++ b/src/main/webapp/pharmacy/admin/ampp.xhtml
@@ -17,29 +17,44 @@
                     <div class="row">
                         <div class="col-md-6">
                             <p:commandButton
-                                id="btnAdd" 
-                                value="Add" 
-                                action="#{amppController.prepareAdd()}" 
-                                class=" m-1 ui-button-success w-25" 
-                                update="lstSelect gpDetail" 
-                                process="btnAdd">
+                                id="btnAdd"
+                                value="Add"
+                                icon="fa fa-plus"
+                                action="#{amppController.prepareAdd()}"
+                                class=" m-1 ui-button-success w-25"
+                                update="lstSelect gpDetail"
+                                process="btnAdd"
+                                disabled="#{amppController.editable}">
                             </p:commandButton>
-                            <p:commandButton 
-                                id="btnDelete" 
+                            <p:commandButton
+                                id="btnEdit"
+                                value="Edit"
+                                icon="fas fa-edit"
+                                action="#{amppController.edit()}"
+                                class=" m-1 ui-button-info w-25"
+                                update="gpDetail"
+                                process="btnEdit"
+                                disabled="#{amppController.editable or amppController.current.id eq null}">
+                            </p:commandButton>
+                            <p:commandButton
+                                id="btnDelete"
                                 onclick="if (!confirm('Are you sure you want to delete this record?'))
-                                            return false;" 
-                                action="#{amppController.delete()}"  
-                                value="Delete"  
-                                class=" m-1 ui-button-danger w-25" 
-                                update="lstSelect gpDetail msg" 
-                                process="btnDelete">
+                                            return false;"
+                                action="#{amppController.delete()}"
+                                value="Delete"
+                                icon="fas fa-trash"
+                                class=" m-1 ui-button-danger w-25"
+                                update="lstSelect gpDetail msg"
+                                process="btnDelete"
+                                disabled="#{amppController.editable}">
                             </p:commandButton>
                             <div class="w-100">
-                                <p:autoComplete 
-                                    id="lstSelect" 
+                                <p:autoComplete
+                                    id="lstSelect"
                                     value="#{amppController.current}"
-                                    completeMethod="#{amppController.completeAmpp}" 
-                                    forceSelection="true" 
+                                    completeMethod="#{amppController.completeAmpp}"
+                                    forceSelection="true"
+                                    disabled="#{amppController.editable}"
                                     var="i"
                                     itemLabel="#{i.name}" 
                                     itemValue="#{i}" 
@@ -65,36 +80,40 @@
                                         <h:outputText
                                             id="lblName" 
                                             value="Pack Name" ></h:outputText>
-                                        <p:inputText 
-                                            autocomplete="off" 
+                                        <p:inputText
+                                            autocomplete="off"
                                             id="txtName"
-                                            value="#{amppController.current.name}" 
-                                            class="w-100"></p:inputText>
+                                            value="#{amppController.current.name}"
+                                            class="w-100"
+                                            disabled="#{!amppController.editable}"></p:inputText>
                                         <h:outputText 
                                             value="Select AMP" ></h:outputText>
-                                        <p:autoComplete 
-                                            completeMethod="#{ampController.completeAmp}" 
+                                        <p:autoComplete
+                                            completeMethod="#{ampController.completeAmp}"
                                             var="pta"
                                             class="w-100"
                                             inputStyleClass="w-100"
-                                            itemLabel="#{pta.name}" 
+                                            itemLabel="#{pta.name}"
                                             itemValue="#{pta}"
-                                            forceSelection="true" 
-                                            value="#{amppController.current.amp}" 
+                                            forceSelection="true"
+                                            value="#{amppController.current.amp}"
                                             scrollHeight="300"
-                                            size="45"></p:autoComplete>
+                                            size="45"
+                                            disabled="#{!amppController.editable}"></p:autoComplete>
                                         <h:outputText  
                                             value="Size" ></h:outputText>
-                                        <p:inputText 
+                                        <p:inputText
                                             autocomplete="off"
                                             onfocus="this.select()"
-                                            value="#{amppController.current.dblValue}"  
-                                            class="w-100"></p:inputText>
+                                            value="#{amppController.current.dblValue}"
+                                            class="w-100"
+                                            disabled="#{!amppController.editable}"></p:inputText>
                                         <h:outputText  
                                             value="Pack Unit" ></h:outputText>
-                                        <p:selectOneMenu 
-                                            value="#{amppController.packUnit}" 
-                                            class="w-100">
+                                        <p:selectOneMenu
+                                            value="#{amppController.packUnit}"
+                                            class="w-100"
+                                            disabled="#{!amppController.editable}">
                                             <f:selectItem 
                                                 itemLabel="Select pack"/>
                                             <f:selectItems 
@@ -107,22 +126,36 @@
                                             for="txtComments" 
                                             value="Description" 
                                             class="form-label"></p:outputLabel>
-                                        <h:inputTextarea 
-                                            id="txtComments" 
-                                            value="#{ampController.current.comments}" 
-                                            required="false" 
-                                            class="form-control" ></h:inputTextarea>
+                                        <h:inputTextarea
+                                            id="txtComments"
+                                            value="#{ampController.current.comments}"
+                                            required="false"
+                                            class="form-control"
+                                            disabled="#{!amppController.editable}" ></h:inputTextarea>
                                     </p:panelGrid>
 
-                                    <p:commandButton 
-                                        id="btnSave" 
-                                        value="Save" 
-                                        action="#{amppController.saveSelected()}" 
-                                        class=" m-1 ui-button-warning w-25" 
-                                        process="btnSave gpDetail" 
-                                        update="lstSelect msg">
+                                    <p:commandButton
+                                        id="btnSave"
+                                        value="Save"
+                                        icon="fas fa-save"
+                                        action="#{amppController.saveSelected()}"
+                                        class=" m-1 ui-button-warning w-25"
+                                        process="btnSave gpDetail"
+                                        update="lstSelect gpDetail msg"
+                                        onclick="if(!confirm('Are you sure you want to save changes?')) return false;"
+                                        disabled="#{!amppController.editable}">
                                     </p:commandButton>
-                                    <p:defaultCommand 
+                                    <p:commandButton
+                                        id="btnCancel"
+                                        value="Cancel"
+                                        icon="fas fa-times"
+                                        action="#{amppController.cancel()}"
+                                        class=" m-1 ui-button-secondary w-25"
+                                        process="btnCancel"
+                                        update="lstSelect gpDetail"
+                                        disabled="#{!amppController.editable}">
+                                    </p:commandButton>
+                                    <p:defaultCommand
                                         target="btnSave"/>
 
                                 </p:panelGrid>


### PR DESCRIPTION
## Summary
- allow enabling/disabling of AMPP fields through a new `editable` flag
- support edit and cancel operations on AMPPs
- disable left controls while editing and show icons on buttons

## Testing
- `mvn -q test` *(fails: Plugin resolution due to network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68713c2a3bec832f8db47d2670655a3b