### PR TITLE
Fix bin card DTO null handling

### DIFF
--- a/src/main/java/com/divudi/core/data/dto/PharmacyBinCardDTO.java
+++ b/src/main/java/com/divudi/core/data/dto/PharmacyBinCardDTO.java
@@ -16,12 +16,12 @@ public class PharmacyBinCardDTO implements Serializable {
     private BillTypeAtomic billTypeAtomic;
     private String itemName;
     private String itemClass;
-    private double qty;
-    private double freeQty;
-    private double qtyPacks;
-    private double freeQtyPacks;
-    private double itemDblValue;
-    private double itemStock;
+    private Double qty;
+    private Double freeQty;
+    private Double qtyPacks;
+    private Double freeQtyPacks;
+    private Double itemDblValue;
+    private Double itemStock;
 
     public PharmacyBinCardDTO(Long id,
                               Date createdAt,
@@ -29,12 +29,12 @@ public class PharmacyBinCardDTO implements Serializable {
                               BillTypeAtomic billTypeAtomic,
                               String itemName,
                               Class<?> itemClass,
-                              double qty,
-                              double freeQty,
-                              double qtyPacks,
-                              double freeQtyPacks,
-                              double itemDblValue,
-                              double itemStock) {
+                              Double qty,
+                              Double freeQty,
+                              Double qtyPacks,
+                              Double freeQtyPacks,
+                              Double itemDblValue,
+                              Double itemStock) {
         this.id = id;
         this.createdAt = createdAt;
         this.billType = billType;
@@ -100,57 +100,59 @@ public class PharmacyBinCardDTO implements Serializable {
         this.itemClass = itemClass;
     }
 
-    public double getQty() {
+    public Double getQty() {
         return qty;
     }
 
-    public void setQty(double qty) {
+    public void setQty(Double qty) {
         this.qty = qty;
     }
 
-    public double getFreeQty() {
+    public Double getFreeQty() {
         return freeQty;
     }
 
-    public void setFreeQty(double freeQty) {
+    public void setFreeQty(Double freeQty) {
         this.freeQty = freeQty;
     }
 
-    public double getQtyPacks() {
+    public Double getQtyPacks() {
         return qtyPacks;
     }
 
-    public void setQtyPacks(double qtyPacks) {
+    public void setQtyPacks(Double qtyPacks) {
         this.qtyPacks = qtyPacks;
     }
 
-    public double getFreeQtyPacks() {
+    public Double getFreeQtyPacks() {
         return freeQtyPacks;
     }
 
-    public void setFreeQtyPacks(double freeQtyPacks) {
+    public void setFreeQtyPacks(Double freeQtyPacks) {
         this.freeQtyPacks = freeQtyPacks;
     }
 
-    public double getItemDblValue() {
+    public Double getItemDblValue() {
         return itemDblValue;
     }
 
-    public void setItemDblValue(double itemDblValue) {
+    public void setItemDblValue(Double itemDblValue) {
         this.itemDblValue = itemDblValue;
     }
 
-    public double getItemStock() {
+    public Double getItemStock() {
         return itemStock;
     }
 
-    public void setItemStock(double itemStock) {
+    public void setItemStock(Double itemStock) {
         this.itemStock = itemStock;
     }
 
     // Derived helper properties
     public double getTransQtyPlusFreeQty() {
-        return qty + freeQty;
+        double q = qty == null ? 0.0 : qty;
+        double fq = freeQty == null ? 0.0 : freeQty;
+        return q + fq;
     }
 
     public double getTransAbsoluteQtyPlusFreeQty() {


### PR DESCRIPTION
## Summary
- prevent argument type mismatch when bin card rows have null numeric fields

## Testing
- `mvn test` *(fails: mvn not installed)*

------
https://chatgpt.com/codex/tasks/task_e_687148718b00832fb7cb7be5ba27bca2