### PR TITLE
Fix already returned quantity display in GRN return with costing

### DIFF
--- a/src/main/java/com/divudi/bean/pharmacy/GrnReturnWithCostingController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/GrnReturnWithCostingController.java
@@ -828,6 +828,7 @@ public class GrnReturnWithCostingController implements Serializable {
             pharmacyCostingService.addBillItemFinanceDetailQuantitiesFromPharmaceuticalBillItem(newPharmaceuticalBillItemInReturnBill, newBillItemFinanceDetailsInReturnBill);
             newBillItemFinanceDetailsInReturnBill.setLineGrossRate(getReturnRateForUnits(pbiOfBilledBill.getBillItem()).multiply(newBillItemFinanceDetailsInReturnBill.getUnitsPerPack()));
             calculateLineTotalByLineGrossRate(newBillItemInReturnBill);
+            addDataToReturningBillItem(newBillItemInReturnBill);
             getBillItems().add(newBillItemInReturnBill);
         }
         calculateTotalReturnByLineNetTotals();


### PR DESCRIPTION
## Summary
- add missing addDataToReturningBillItem call

## Testing
- `mvn -q -DskipTests package` *(fails: Plugin could not be resolved due to network)*

------
https://chatgpt.com/codex/tasks/task_e_6871b824d934832fa53ab3a9e44f3b3d