### PR TITLE
Implement editable modes for pharmacy controllers

### DIFF
--- a/src/main/java/com/divudi/bean/pharmacy/AmpController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/AmpController.java
@@ -107,6 +107,7 @@ public class AmpController implements Serializable {
     private ItemController itemController;
 
     private boolean duplicateCode;
+    private boolean editable;
 
     private UploadedFile file;
 
@@ -528,6 +529,20 @@ public class AmpController implements Serializable {
         current = new Amp();
         current.setItemType(ItemType.Amp);
         current.setDepartmentType(DepartmentType.Pharmacy);
+        editable = true;
+    }
+
+    public void edit() {
+        if (current == null) {
+            JsfUtil.addErrorMessage("Select one to edit");
+            return;
+        }
+        editable = true;
+    }
+
+    public void cancel() {
+        current = null;
+        editable = false;
     }
 
     public void listnerCategorySelect() {
@@ -891,6 +906,7 @@ public class AmpController implements Serializable {
         }
         recreateModel();
         // getItems();
+        editable = false;
     }
 
     public void saveAmp(Amp amp) {
@@ -955,6 +971,7 @@ public class AmpController implements Serializable {
         getItems();
         current = null;
         getCurrent();
+        editable = false;
     }
 
     private AmpFacade getFacade() {
@@ -1085,6 +1102,14 @@ public class AmpController implements Serializable {
 
     public void setDuplicateCode(boolean duplicateCode) {
         this.duplicateCode = duplicateCode;
+    }
+
+    public boolean isEditable() {
+        return editable;
+    }
+
+    public void setEditable(boolean editable) {
+        this.editable = editable;
     }
 
     /**

--- a/src/main/java/com/divudi/bean/pharmacy/AtmController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/AtmController.java
@@ -47,6 +47,7 @@ public class AtmController implements Serializable {
     private List<Atm> items;
     List<Atm> atmList;
     String selectText;
+    private boolean editable;
 
     public String navigateToListAllAtms() {
         String jpql = "Select atm "
@@ -157,6 +158,20 @@ public class AtmController implements Serializable {
 
     public void prepareAdd() {
         current = new Atm();
+        editable = true;
+    }
+
+    public void edit() {
+        if (current == null) {
+            JsfUtil.addErrorMessage("Select one to edit");
+            return;
+        }
+        editable = true;
+    }
+
+    public void cancel() {
+        current = null;
+        editable = false;
     }
 
     public void setSelectedItems(List<Atm> selectedItems) {
@@ -184,6 +199,7 @@ public class AtmController implements Serializable {
         }
         recreateModel();
         getItems();
+        editable = false;
     }
 
     public void saveAtm(Atm atm) {
@@ -244,6 +260,7 @@ public class AtmController implements Serializable {
         getItems();
         current = null;
         getCurrent();
+        editable = false;
     }
 
     private AtmFacade getFacade() {
@@ -261,6 +278,14 @@ public class AtmController implements Serializable {
 
     public void setItems(List<Atm> items) {
         this.items = items;
+    }
+
+    public boolean isEditable() {
+        return editable;
+    }
+
+    public void setEditable(boolean editable) {
+        this.editable = editable;
     }
 
     /**

--- a/src/main/java/com/divudi/bean/pharmacy/VmpController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/VmpController.java
@@ -80,6 +80,7 @@ public class VmpController implements Serializable {
 
     @EJB
     VmpFacade vmpFacade;
+    private boolean editable;
 
     public String navigateToListAllVmps() {
         String jpql = "Select vmp "
@@ -541,6 +542,20 @@ public class VmpController implements Serializable {
     public void prepareAdd() {
         current = new Vmp();
         addingVtmInVmp = new VirtualProductIngredient();
+        editable = true;
+    }
+
+    public void edit() {
+        if (current == null) {
+            JsfUtil.addErrorMessage("Select one to edit");
+            return;
+        }
+        editable = true;
+    }
+
+    public void cancel() {
+        current = null;
+        editable = false;
     }
 
     public void bulkUpload() {
@@ -583,6 +598,7 @@ public class VmpController implements Serializable {
         }
         recreateModel();
         getItems();
+        editable = false;
     }
 
     public void save() {
@@ -647,6 +663,7 @@ public class VmpController implements Serializable {
         getItems();
         current = null;
         getCurrent();
+        editable = false;
     }
 
     private VmpFacade getFacade() {
@@ -671,6 +688,14 @@ public class VmpController implements Serializable {
 
     public void setSpecialityFacade(SpecialityFacade specialityFacade) {
         this.specialityFacade = specialityFacade;
+    }
+
+    public boolean isEditable() {
+        return editable;
+    }
+
+    public void setEditable(boolean editable) {
+        this.editable = editable;
     }
 
     /**

--- a/src/main/java/com/divudi/bean/pharmacy/VmppController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/VmppController.java
@@ -43,6 +43,7 @@ public class VmppController implements Serializable {
     private VmppFacade ejbFacade;
     private Vmpp current;
     private List<Vmpp> items = null;
+    private boolean editable;
 
     @Deprecated
     public String navigateToListAllVmpps() {
@@ -84,6 +85,20 @@ public class VmppController implements Serializable {
 
     public void prepareAdd() {
         current = new Vmpp();
+        editable = true;
+    }
+
+    public void edit() {
+        if (current == null) {
+            JsfUtil.addErrorMessage("Select one to edit");
+            return;
+        }
+        editable = true;
+    }
+
+    public void cancel() {
+        current = null;
+        editable = false;
     }
 
     private void recreateModel() {
@@ -100,6 +115,7 @@ public class VmppController implements Serializable {
         }
         recreateModel();
         getItems();
+        editable = false;
     }
 
     public void save() {
@@ -156,6 +172,7 @@ public class VmppController implements Serializable {
         getItems();
         current = null;
         getCurrent();
+        editable = false;
     }
 
     private VmppFacade getFacade() {
@@ -182,6 +199,14 @@ public class VmppController implements Serializable {
         }
 
         return vmpps;
+    }
+
+    public boolean isEditable() {
+        return editable;
+    }
+
+    public void setEditable(boolean editable) {
+        this.editable = editable;
     }
 
     /**

--- a/src/main/java/com/divudi/bean/pharmacy/VtmController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/VtmController.java
@@ -60,6 +60,7 @@ public class VtmController implements Serializable {
     boolean billedAs;
     boolean reportedAs;
     List<Vtm> vtmList;
+    private boolean editable;
 
     public String navigateToListAllVtms() {
         String jpql = "Select vtm "
@@ -246,6 +247,20 @@ public class VtmController implements Serializable {
 
     public void prepareAdd() {
         current = new Vtm();
+        editable = true;
+    }
+
+    public void edit() {
+        if (current == null) {
+            JsfUtil.addErrorMessage("Select one to edit");
+            return;
+        }
+        editable = true;
+    }
+
+    public void cancel() {
+        current = null;
+        editable = false;
     }
 
     public void bulkUpload() {
@@ -308,6 +323,7 @@ public class VtmController implements Serializable {
         }
         recreateModel();
         getItems();
+        editable = false;
     }
 
     public void save() {
@@ -388,6 +404,7 @@ public class VtmController implements Serializable {
         getItems();
         current = null;
         getCurrent();
+        editable = false;
     }
 
     private VtmFacade getFacade() {
@@ -409,6 +426,14 @@ public class VtmController implements Serializable {
 
     public void setSpecialityFacade(SpecialityFacade specialityFacade) {
         this.specialityFacade = specialityFacade;
+    }
+
+    public boolean isEditable() {
+        return editable;
+    }
+
+    public void setEditable(boolean editable) {
+        this.editable = editable;
     }
 
     /**

--- a/src/main/webapp/pharmacy/admin/atm.xhtml
+++ b/src/main/webapp/pharmacy/admin/atm.xhtml
@@ -1,122 +1,69 @@
 <?xml version='1.0' encoding='UTF-8' ?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml"
-      xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
-      xmlns:p="http://primefaces.org/ui"
-      xmlns:h="http://xmlns.jcp.org/jsf/html"
-      xmlns:f="http://xmlns.jcp.org/jsf/core"
-      xmlns:se="http://xmlns.jcp.org/jsf/composite/pharmacy/search">
-    <h:body>
-        <ui:composition template="/pharmacy/admin/index.xhtml">
-            <ui:define name="subcontent">
-                <h:form>
-                    <p:growl id="msg"/>
-                    <p:focus id="selectFocus" for="lstSelect" />
-                    <p:focus id="detailFocus" for="gpDetail" />
-                    <p:panel >
-                        <f:facet name="header" >
-                            <h:outputText value="Manage ATMs" ></h:outputText>
-                        </f:facet>
-
-
-                        <div class="row" >
-                            <div class="col-6" >
-                                <p:commandButton 
-                                    id="btnAdd" 
-                                    value="Add" 
-                                    action="#{atmController.prepareAdd()}" 
-                                    class="ui-button-success m-1 w-25" 
-                                    update="lstSelect gpDetail" 
-                                    icon="fa fa-plus"
-                                    process="btnAdd">
-                                </p:commandButton>
-                                <p:commandButton 
-                                    id="btnDelete" 
-                                    icon="fa fa-trash"
-                                    update="lstSelect gpDetail msg" process="btnDelete"
-
-                                    onclick="if (!confirm('Are you sure you want to delete this record?'))
-                                                return false;" 
-                                    action="#{atmController.delete()}"  
-                                    value="Delete" 
-                                    class="ui-button-danger m-1 w-25" >
-                                </p:commandButton>
-                                <p:selectOneListbox id="lstSelect" 
-                                                    filter="true"
-                                                    filterMatchMode="contains"
-                                                    value="#{atmController.current}">
-                                    <f:selectItems value="#{atmController.items}" 
-                                                   var="myItem" 
-                                                   itemValue="#{myItem}" 
-                                                   itemLabel="#{myItem.name}"></f:selectItems>
-                                    <p:ajax update="gpDetail" process="lstSelect" >
-                                    </p:ajax>
-                                </p:selectOneListbox>
-
-                            </div>
-                            <div class="col-6" >
-                                <p:panel header="Manage ATM">
-                                    <h:panelGrid columns="2" id="gpDetail" class="w-100" >
-                                        <p:outputLabel for="txtName" class="form-label w-100">Name</p:outputLabel>
-                                        <h:inputText 
-                                            autocomplete="off" 
-                                            id="txtName" 
-                                            value="#{atmController.current.name}" 
-                                            required="true" 
-                                            class="form-control" 
-                                            requiredMessage="Name is required"
-                                            ></h:inputText>
-
-                                        <p:outputLabel
-                                            for="acVtm" 
-                                            class="form-label w-100">VTM</p:outputLabel>
-
-
-                                        <p:autoComplete
-                                            id="acVtm"
-                                            class="w-100"
-                                            inputStyleClass="w-100"
-                                            completeMethod="#{vtmController.completeVtm}" 
-                                            value="#{atmController.current.vtm}" 
-                                            var="v" 
-                                            itemLabel="#{v.name}" 
-                                            itemValue="#{v}"
-                                            required="true"
-                                            requiredMessage="VTM is needed"></p:autoComplete>
-
-
-                                        <p:outputLabel for="txtDes" class="form-label w-100">Description</p:outputLabel>
-                                        <h:inputTextarea 
-                                            id="txtDes" 
-                                            value="#{atmController.current.descreption}" 
-                                            required="false" 
-                                            class="form-control" 
-                                            ></h:inputTextarea>
-                                    </h:panelGrid>
-
-
-                                    <p:commandButton
-                                        id="btnSave" 
-                                        value="Save"  
-                                        action="#{atmController.saveSelected()}" 
-                                        class=" m-1 ui-button-warning w-25"
-                                        icon="fas fa-save"
-                                        process="gpDetail btnSave" 
-                                        update="lstSelect msg"
-                                        >
-                                    </p:commandButton>
-                                </p:panel>
-                            </div>
+<!DOCTYPE composition PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<ui:composition xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
+                template="/pharmacy/admin/index.xhtml"
+                xmlns:h="http://xmlns.jcp.org/jsf/html"
+                xmlns:f="http://xmlns.jcp.org/jsf/core"
+                xmlns="http://www.w3.org/1999/xhtml"
+                xmlns:p="http://primefaces.org/ui">
+    <ui:define name="subcontent">
+        <h:panelGroup>
+            <h:form>
+                <p:growl id="msg" />
+                <p:focus id="selectFocus" context="lstSelect" />
+                <p:focus id="detailFocus" context="gpDetail" />
+                <p:panel header="Manage ATMs">
+                    <div class="row">
+                        <div class="col-md-5">
+                            <p:commandButton id="btnAdd" value="Add" icon="fa fa-plus" action="#{atmController.prepareAdd()}"
+                                             class=" m-1 ui-button-success w-25" update="lstSelect gpDetail btnEdit btnDelete"
+                                             process="btnAdd" disabled="#{atmController.editable}" />
+                            <p:commandButton id="btnEdit" value="Edit" icon="fas fa-edit" action="#{atmController.edit()}"
+                                             class=" m-1 ui-button-info w-25" update="lstSelect gpDetail btnAdd btnDelete"
+                                             process="btnEdit" disabled="#{atmController.editable or atmController.current.id eq null}" />
+                            <p:commandButton id="btnDelete" value="Delete" icon="fas fa-trash"
+                                             onclick="if (!confirm('Are you sure you want to delete this record?')) return false;"
+                                             action="#{atmController.delete()}" class=" m-1 ui-button-danger w-25"
+                                             update="lstSelect gpDetail msg" process="btnDelete" disabled="#{atmController.editable}" />
+                            <p:selectOneListbox id="lstSelect" value="#{atmController.current}" filter="true" filterMatchMode="contains"
+                                                class="w-100" disabled="#{atmController.editable}">
+                                <f:selectItems value="#{atmController.items}" var="myItem" itemValue="#{myItem}" itemLabel="#{myItem.name}" />
+                                <p:ajax update="gpDetail btnEdit" process="lstSelect" />
+                            </p:selectOneListbox>
                         </div>
-
-                    </p:panel>
-
-                </h:form>
-
-
-
-
-            </ui:define>
-        </ui:composition>
-    </h:body>
-</html>
+                        <div class="col-md-7">
+                            <p:panel>
+                                <p:panelGrid id="gpDetail" columns="1" class="w-100">
+                                    <p:panelGrid id="gpDetailText" columns="2" columnClasses="w-25 , w-75" class="w-100">
+                                        <p:outputLabel for="txtName" class="form-label">Name</p:outputLabel>
+                                        <h:inputText id="txtName" autocomplete="off" value="#{atmController.current.name}" required="true"
+                                                     class="form-control" requiredMessage="Name is required"
+                                                     disabled="#{!atmController.editable}" />
+                                        <p:outputLabel for="acVtm" class="form-label">VTM</p:outputLabel>
+                                        <p:autoComplete id="acVtm" class="w-100" inputStyleClass="w-100"
+                                                        completeMethod="#{vtmController.completeVtm}" value="#{atmController.current.vtm}"
+                                                        var="v" itemLabel="#{v.name}" itemValue="#{v}" required="true"
+                                                        requiredMessage="VTM is needed" disabled="#{!atmController.editable}" />
+                                        <p:outputLabel for="txtDes" class="form-label">Description</p:outputLabel>
+                                        <h:inputTextarea id="txtDes" value="#{atmController.current.descreption}" required="false"
+                                                         class="form-control" disabled="#{!atmController.editable}" />
+                                    </p:panelGrid>
+                                    <h:panelGroup layout="block" class="text-end">
+                                        <div>
+                                            <p:commandButton id="btnSave" value="Save" icon="fas fa-save" action="#{atmController.saveSelected()}"
+                                                             class=" m-1 ui-button-warning w-25" process="gpDetail btnSave"
+                                                             update="lstSelect gpDetail msg btnEdit btnDelete btnAdd" disabled="#{!atmController.editable}" />
+                                            <p:commandButton id="btnCancel" value="Cancel" icon="fas fa-times" action="#{atmController.cancel()}"
+                                                             class=" m-1 ui-button-secondary w-25" process="btnCancel"
+                                                             update="lstSelect gpDetail btnEdit btnDelete btnAdd" disabled="#{!atmController.editable}" />
+                                        </div>
+                                    </h:panelGroup>
+                                </p:panelGrid>
+                            </p:panel>
+                        </div>
+                    </div>
+                </p:panel>
+            </h:form>
+        </h:panelGroup>
+    </ui:define>
+</ui:composition>

--- a/src/main/webapp/pharmacy/admin/vtm.xhtml
+++ b/src/main/webapp/pharmacy/admin/vtm.xhtml
@@ -13,41 +13,52 @@
                     <p:focus id="selectFocus" for="lstSelect" />
                     <p:focus id="detailFocus" for="gpDetail" />
 
-                    <f:facet name="header" >
-                        <p:outputLabel value="Manage VTMs" ></p:outputLabel>
-                    </f:facet>
+                    <p:panel header="Manage VTMs" styleClass="w-100 mb-2" rendered="false" />
                     <div class="row">
                         <div class="col-md-5">
 
-                            <p:commandButton 
-                                id="btnAdd" 
-                                value="Add" 
-                                action="#{vtmController.prepareAdd()}" 
-                                class="w-25 ui-button-success"
-                                update="lstSelect gpDetail" 
+                            <p:commandButton
+                                id="btnAdd"
+                                value="Add"
                                 icon="fa fa-plus"
+                                action="#{vtmController.prepareAdd()}"
+                                class=" m-1 ui-button-success w-25"
+                                update="lstSelect gpDetail btnEdit btnDelete"
                                 process="btnAdd"
-                                >
+                                disabled="#{vtmController.editable}">
                             </p:commandButton>
-                            <p:commandButton 
-                                id="btnDelete" 
+                            <p:commandButton
+                                id="btnEdit"
+                                value="Edit"
+                                icon="fas fa-edit"
+                                action="#{vtmController.edit()}"
+                                class=" m-1 ui-button-info w-25"
+                                update="lstSelect gpDetail btnAdd btnDelete"
+                                process="btnEdit"
+                                disabled="#{vtmController.editable or vtmController.current.id eq null}">
+                            </p:commandButton>
+                            <p:commandButton
+                                id="btnDelete"
                                 onclick="if (!confirm('Are you sure you want to delete this record?'))
-                                            return false;" 
-                                action="#{vtmController.delete()}" 
+                                            return false;"
+                                action="#{vtmController.delete()}"
+                                value="Delete"
+                                icon="fas fa-trash"
+                                class=" m-1 ui-button-danger w-25"
+                                update="lstSelect gpDetail msg"
                                 process="btnDelete"
-                                update="gpDetail lstSelect msg"
-                                icon="fa fa-trash"
-                                value="Delete" 
-                                class="ui-button-danger w-25 mx-1" />
-                            <p:selectOneListbox  
+                                disabled="#{vtmController.editable}">
+                            </p:commandButton>
+                            <p:selectOneListbox
                                 class="w-100"
-                                id="lstSelect" 
+                                id="lstSelect"
                                 value="#{vtmController.current}"
-                                filter="true">
-                                <f:selectItems  
+                                filter="true"
+                                disabled="#{vtmController.editable}">
+                                <f:selectItems
                                     value="#{vtmController.items}"
-                                    var="myItem" 
-                                    itemValue="#{myItem}" 
+                                    var="myItem"
+                                    itemValue="#{myItem}"
                                     itemLabel="#{myItem.name}" ></f:selectItems>
                                 <p:ajax event="change"   update="gpDetail" process="lstSelect" >
                                 </p:ajax>
@@ -60,42 +71,65 @@
                         </div>
                         <div class="col-md-7">
                             <p:panel header="Manage VTM Details">
-                                <h:panelGroup id="gpDetail" >
-                                    <label for="txtName" class="form-label">Name</label>
-                                    <h:inputText 
-                                        autocomplete="off" 
-                                        id="txtName" 
-                                        value="#{vtmController.current.name}" 
-                                        required="true" 
-                                        requiredMessage="Enter a name for VTM"
-                                        class="form-control" ></h:inputText>
+                                <p:panelGrid
+                                    id="gpDetail"
+                                    columns="1"
+                                    class="w-100">
+                                    <p:panelGrid
+                                        id="gpDetailText"
+                                        columns="2"
+                                        columnClasses="w-25 , w-75"
+                                        class="w-100">
+                                        <h:outputText value="Name" />
+                                        <p:inputText
+                                            autocomplete="off"
+                                            id="txtName"
+                                            value="#{vtmController.current.name}"
+                                            required="true"
+                                            requiredMessage="Enter a name for VTM"
+                                            class="w-100"
+                                            disabled="#{!vtmController.editable}" />
 
-                                    <label for="txtDes" class="form-label">Description</label>
-                                    <h:inputTextarea 
-                                        id="txtDes" 
-                                        value="#{vtmController.current.descreption}" 
-                                        required="false" 
-                                        class="form-control" ></h:inputTextarea>
+                                        <h:outputText value="Description" />
+                                        <h:inputTextarea
+                                            id="txtDes"
+                                            value="#{vtmController.current.descreption}"
+                                            required="false"
+                                            class="form-control"
+                                            disabled="#{!vtmController.editable}" />
 
+                                        <p:outputLabel for="txtIns" value="Instructions" class="form-label"/>
+                                        <h:inputTextarea
+                                            id="txtIns"
+                                            value="#{vtmController.current.instructions}"
+                                            required="false"
+                                            class="form-control"
+                                            disabled="#{!vtmController.editable}" />
+                                    </p:panelGrid>
 
-                                    <p:outputLabel for="txtIns" value="Instructions" class="form-label"></p:outputLabel>
-                                    <h:inputTextarea 
-                                        id="txtIns" 
-                                        value="#{vtmController.current.instructions}" 
-                                        required="false" 
-                                        class="form-control" ></h:inputTextarea>
-                                    <p:commandButton 
-                                        id="btnSave" 
-                                        value="Save"  
-                                        action="#{vtmController.save}"
-                                        process="btnSave gpDetail" 
-                                        update="lstSelect msg" 
-                                        class=" m-1 ui-button-warning w-25"
-                                        icon="fas fa-save"
-                                        >
-                                    </p:commandButton>
-                                    <p:defaultCommand target="btnSave"/>
-                                </h:panelGroup>
+                                    <h:panelGroup layout="block" class="text-end">
+                                        <div>
+                                            <p:commandButton
+                                                id="btnSave"
+                                                value="Save"
+                                                icon="fas fa-save"
+                                                action="#{vtmController.save}"
+                                                class=" m-1 ui-button-warning w-25"
+                                                process="btnSave gpDetail"
+                                                update="lstSelect gpDetail msg btnEdit btnDelete btnAdd"
+                                                disabled="#{!vtmController.editable}" />
+                                            <p:commandButton
+                                                id="btnCancel"
+                                                value="Cancel"
+                                                icon="fas fa-times"
+                                                action="#{vtmController.cancel()}"
+                                                class=" m-1 ui-button-secondary w-25"
+                                                process="btnCancel"
+                                                update="lstSelect gpDetail btnEdit btnDelete btnAdd"
+                                                disabled="#{!vtmController.editable}" />
+                                        </div>
+                                    </h:panelGroup>
+                                </p:panelGrid>
                             </p:panel>
                         </div>
                     </div>


### PR DESCRIPTION
## Summary
- add `editable` flag to item controllers
- toggle editability in CRUD methods
- revamp ATM and VTM admin pages with new layout

## Testing
- `mvn -q test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_6871b80a869c832fa6372435d99d5a7b