### PR TITLE
Fix already returned quantity display in GRN return with costing

### DIFF
--- a/src/main/java/com/divudi/bean/pharmacy/GrnReturnWithCostingController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/GrnReturnWithCostingController.java
@@ -824,11 +824,11 @@ public class GrnReturnWithCostingController implements Serializable {
             BillItemFinanceDetails newBillItemFinanceDetailsInReturnBill = new BillItemFinanceDetails();
             newBillItemFinanceDetailsInReturnBill.setBillItem(newBillItemInReturnBill);
             newBillItemInReturnBill.setBillItemFinanceDetails(newBillItemFinanceDetailsInReturnBill);
+            addDataToReturningBillItem(newBillItemInReturnBill);
             pharmacyCostingService.calculateUnitsPerPack(newBillItemFinanceDetailsInReturnBill);
             pharmacyCostingService.addBillItemFinanceDetailQuantitiesFromPharmaceuticalBillItem(newPharmaceuticalBillItemInReturnBill, newBillItemFinanceDetailsInReturnBill);
             newBillItemFinanceDetailsInReturnBill.setLineGrossRate(getReturnRateForUnits(pbiOfBilledBill.getBillItem()).multiply(newBillItemFinanceDetailsInReturnBill.getUnitsPerPack()));
             calculateLineTotalByLineGrossRate(newBillItemInReturnBill);
-            addDataToReturningBillItem(newBillItemInReturnBill);
             getBillItems().add(newBillItemInReturnBill);
         }
         calculateTotalReturnByLineNetTotals();


### PR DESCRIPTION
## Summary
- call `addDataToReturningBillItem` earlier in `prepareBillItems`

## Testing
- `mvn clean compile` *(fails: PluginResolutionException)*

------
https://chatgpt.com/codex/tasks/task_e_6871dcb0c860832f95db5d821e582fab