### PR TITLE
Fix item fee setter for foreigners

### DIFF
--- a/src/main/java/com/divudi/service/ItemFeeService.java
+++ b/src/main/java/com/divudi/service/ItemFeeService.java
@@ -58,7 +58,7 @@ public class ItemFeeService {
             feeValue.setCreatedAt(new Date());
         }
         feeValue.setTotalValueForLocals(feeValueForLocals);
-        feeValue.setTotalValueForLocals(feeValueForForeigners);
+        feeValue.setTotalValueForForeigners(feeValueForForeigners);
         save(feeValue);
     }
 


### PR DESCRIPTION
## Summary
- ensure `updateFeeValue(Item, Department, …)` saves the foreigners total correctly

## Testing
- `mvn -q test` *(fails: PluginResolutionException)*

------
https://chatgpt.com/codex/tasks/task_e_68722c88087c832fbad6e2437b4ea706