### PR TITLE
Fix incorrect success message in addNewForSiteFee

### DIFF
--- a/src/main/java/com/divudi/bean/common/ItemFeeManager.java
+++ b/src/main/java/com/divudi/bean/common/ItemFeeManager.java
@@ -1133,7 +1133,7 @@ public class ItemFeeManager implements Serializable {
         itemFees = null;
 
         updateItemAndSiteFees();
-        JsfUtil.addSuccessMessage("New Fee Added for Collecting Centre");
+        JsfUtil.addSuccessMessage("New Fee Added for Site");
     }
 
     public void addNewForDepartmentFee() {


### PR DESCRIPTION
## Summary
- correct success message in ItemFeeManager for site fee creation

Closes #13870

------
https://chatgpt.com/codex/tasks/task_e_6872e6fe8254832fb94cab09d8334e44