### PR TITLE
Add department field to payment scheme page

### DIFF
--- a/src/main/java/com/divudi/core/entity/PaymentScheme.java
+++ b/src/main/java/com/divudi/core/entity/PaymentScheme.java
@@ -5,6 +5,7 @@
 package com.divudi.core.entity;
 
 import com.divudi.core.data.CliantType;
+import com.divudi.core.entity.Department;
 import java.io.Serializable;
 import java.util.Date;
 import javax.persistence.Column;
@@ -38,6 +39,8 @@ public class PaymentScheme implements Serializable {
     Institution institution;
     @ManyToOne
     Person person;
+    @ManyToOne
+    Department department;
     //Created Properties
     @ManyToOne
     WebUser creater;
@@ -145,6 +148,14 @@ public class PaymentScheme implements Serializable {
 
     public void setPerson(Person person) {
         this.person = person;
+    }
+
+    public Department getDepartment() {
+        return department;
+    }
+
+    public void setDepartment(Department department) {
+        this.department = department;
     }
 
     public WebUser getCreater() {

--- a/src/main/webapp/admin/pricing/payment_scheme.xhtml
+++ b/src/main/webapp/admin/pricing/payment_scheme.xhtml
@@ -96,6 +96,14 @@
                                                 <p:selectBooleanCheckbox value="#{paymentSchemeController.current.validForBilledBills}" />
                                                 <h:outputLabel value="Valid for Channeling" />
                                                 <p:selectBooleanCheckbox value="#{paymentSchemeController.current.validForChanneling}" />
+                                                <h:outputLabel value="Department" />
+                                                <p:autoComplete value="#{paymentSchemeController.current.department}"
+                                                               completeMethod="#{departmentController.completeDept}"
+                                                               var="d"
+                                                               itemLabel="#{d.name}"
+                                                               itemValue="#{d}"
+                                                               forceSelection="true"
+                                                               class="w-100" />
                                             </p:panelGrid>
                                         </p:tab>
 


### PR DESCRIPTION
## Summary
- allow specifying a `Department` for a discount scheme
- show department autocomplete under **Availability** on `/admin/pricing/payment_scheme.xhtml`

## Testing
- `mvn -q test` *(fails: Could not resolve Maven dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68737726af70832f90d28f14c19a2bb3