### PR TITLE
Fix discount rate preservation in pharmacy reports

### DIFF
--- a/src/main/java/com/divudi/bean/pharmacy/PharmacySummaryReportController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacySummaryReportController.java
@@ -1101,7 +1101,9 @@ public class PharmacySummaryReportController implements Serializable {
         bifd.setBillNetRate(rateOfTaxPortionFromBill.add(rateOfExpensePortionFromBill).subtract(rateOfDiscountPortionFromBill));
         bifd.setNetRate(bifd.getLineNetRate().add(bifd.getBillNetRate()));
 
-        BigDecimal lineDiscountRate = BigDecimal.valueOf(bi.getDiscountRate());
+        BigDecimal lineDiscountRate = Optional.ofNullable(bifd.getLineDiscountRate())
+                .filter(r -> r.compareTo(BigDecimal.ZERO) != 0)
+                .orElse(BigDecimal.valueOf(bi.getDiscountRate()));
         bifd.setLineDiscountRate(lineDiscountRate);
         bifd.setBillDiscountRate(rateOfDiscountPortionFromBill);
         bifd.setTotalDiscountRate(lineDiscountRate.add(rateOfDiscountPortionFromBill));


### PR DESCRIPTION
## Summary
- improve `addMissingDataToBillItemFinanceDetailsWhenPharmaceuticalBillItemsAreAvailableForPharmacySale` to keep existing discount rate when present

## Testing
- `mvn -q test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68742baf7510832f82f899b761f51f6c