### PR TITLE
Add download option for async excel

### DIFF
--- a/src/main/webapp/pharmacy/reports/summary_reports/all_item_movement_summary.xhtml
+++ b/src/main/webapp/pharmacy/reports/summary_reports/all_item_movement_summary.xhtml
@@ -187,6 +187,16 @@
                             <p:column headerText="Completed">
                                 <h:outputText value="#{rec.completed ? 'Yes' : 'No'}" />
                             </p:column>
+                            <p:column headerText="Download" exportable="false">
+                                <p:commandButton
+                                    rendered="#{rec.completed}"
+                                    ajax="false"
+                                    styleClass="ui-button-warning"
+                                    icon="pi pi-download"
+                                    value="Download">
+                                    <p:fileDownload value="#{pharmacySummaryReportController.downloadHistoricalRecordFile(rec)}" />
+                                </p:commandButton>
+                            </p:column>
                         </p:dataTable>
 
                     </h:form>


### PR DESCRIPTION
## Summary
- inject `UploadFacade` and add file download helper
- expose file download in All Item Movement Summary page

## Testing
- `mvn -q -DskipTests package` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68774a226134832f90338c69eab36ab6