### PR TITLE
Use DTO for item movement summary report

### DIFF
--- a/src/main/java/com/divudi/core/data/dto/ItemMovementSummaryDTO.java
+++ b/src/main/java/com/divudi/core/data/dto/ItemMovementSummaryDTO.java
@@ -1,0 +1,53 @@
+package com.divudi.core.data.dto;
+
+import com.divudi.core.data.BillTypeAtomic;
+import java.io.Serializable;
+
+public class ItemMovementSummaryDTO implements Serializable {
+    private BillTypeAtomic billTypeAtomic;
+    private String itemName;
+    private Double quantity;
+    private Double netValue;
+
+    public ItemMovementSummaryDTO() {
+    }
+
+    public ItemMovementSummaryDTO(BillTypeAtomic billTypeAtomic, String itemName, Double quantity, Double netValue) {
+        this.billTypeAtomic = billTypeAtomic;
+        this.itemName = itemName;
+        this.quantity = quantity;
+        this.netValue = netValue;
+    }
+
+    public BillTypeAtomic getBillTypeAtomic() {
+        return billTypeAtomic;
+    }
+
+    public void setBillTypeAtomic(BillTypeAtomic billTypeAtomic) {
+        this.billTypeAtomic = billTypeAtomic;
+    }
+
+    public String getItemName() {
+        return itemName;
+    }
+
+    public void setItemName(String itemName) {
+        this.itemName = itemName;
+    }
+
+    public Double getQuantity() {
+        return quantity;
+    }
+
+    public void setQuantity(Double quantity) {
+        this.quantity = quantity;
+    }
+
+    public Double getNetValue() {
+        return netValue;
+    }
+
+    public void setNetValue(Double netValue) {
+        this.netValue = netValue;
+    }
+}

--- a/src/main/java/com/divudi/core/facade/PharmaceuticalBillItemFacade.java
+++ b/src/main/java/com/divudi/core/facade/PharmaceuticalBillItemFacade.java
@@ -6,11 +6,16 @@ package com.divudi.core.facade;
 
 import com.divudi.core.entity.Bill;
 import com.divudi.core.entity.pharmacy.PharmaceuticalBillItem;
+import com.divudi.core.data.dto.ItemMovementSummaryDTO;
+import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import javax.ejb.Stateless;
 import javax.persistence.EntityManager;
 import javax.persistence.PersistenceContext;
+import javax.persistence.TemporalType;
+import javax.persistence.TypedQuery;
 
 /**
  *
@@ -44,6 +49,18 @@ public class PharmaceuticalBillItemFacade extends AbstractFacade<PharmaceuticalB
         List<PharmaceuticalBillItem> btm = findByJpql(sql, hm);
 //        System.out.println("btm = " + btm.size());
         return btm;
+    }
+
+    public List<ItemMovementSummaryDTO> findItemMovementSummaryDTOs(String jpql, Map<String, Object> parameters, TemporalType tt) {
+        TypedQuery<ItemMovementSummaryDTO> qry = getEntityManager().createQuery(jpql, ItemMovementSummaryDTO.class);
+        for (Map.Entry<String, Object> e : parameters.entrySet()) {
+            if (e.getValue() instanceof Date) {
+                qry.setParameter(e.getKey(), (Date) e.getValue(), tt);
+            } else {
+                qry.setParameter(e.getKey(), e.getValue());
+            }
+        }
+        return qry.getResultList();
     }
 
 }


### PR DESCRIPTION
## Summary
- add `ItemMovementSummaryDTO` for lean report results
- query item movement summary via new facade method
- use DTO-based query in `PharmacyAsyncReportService`

## Testing
- `mvn -q -DskipTests package` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_68774d1e807c832fa53fc28ebb5aa799