### PR TITLE
Improve item movement report formatting

### DIFF
--- a/src/main/java/com/divudi/service/PharmacyAsyncReportService.java
+++ b/src/main/java/com/divudi/service/PharmacyAsyncReportService.java
@@ -7,6 +7,7 @@ import com.divudi.core.entity.Upload;
 import com.divudi.core.data.dto.ItemMovementSummaryDTO;
 import com.divudi.core.facade.HistoricalRecordFacade;
 import com.divudi.core.facade.UploadFacade;
+import com.divudi.core.util.CommonFunctions;
 import java.io.ByteArrayOutputStream;
 import java.util.Arrays;
 import java.util.Comparator;
@@ -21,7 +22,11 @@ import javax.ejb.Asynchronous;
 import javax.ejb.EJB;
 import javax.ejb.Stateless;
 import javax.inject.Inject;
+import org.apache.poi.ss.usermodel.BorderStyle;
+import org.apache.poi.ss.usermodel.Cell;
+import org.apache.poi.ss.usermodel.CellStyle;
 import org.apache.poi.ss.usermodel.Row;
+import org.apache.poi.ss.util.CellRangeAddress;
 import org.apache.poi.xssf.usermodel.XSSFSheet;
 import org.apache.poi.xssf.usermodel.XSSFWorkbook;
 
@@ -55,6 +60,13 @@ public class PharmacyAsyncReportService {
                     types);
             XSSFWorkbook wb = new XSSFWorkbook();
             XSSFSheet sheet = wb.createSheet("Item Movement Summary");
+
+            CellStyle borderStyle = wb.createCellStyle();
+            borderStyle.setBorderBottom(BorderStyle.THIN);
+            borderStyle.setBorderTop(BorderStyle.THIN);
+            borderStyle.setBorderLeft(BorderStyle.THIN);
+            borderStyle.setBorderRight(BorderStyle.THIN);
+
             int r = 0;
             
             //TODO: If institution, Site, Department is not given, it should come as Department: All, Site : All, , Institution: All
@@ -70,27 +82,27 @@ public class PharmacyAsyncReportService {
             if (hr.getFromDateTime() != null) {
                 Row fr = sheet.createRow(r++);
                 fr.createCell(0).setCellValue("From");
-                fr.createCell(1).setCellValue(hr.getFromDateTime());
+                fr.createCell(1).setCellValue(CommonFunctions.getDateFormat(hr.getFromDateTime(), sessionController.getApplicationPreference().getLongDateFormat()));
             }
             if (hr.getToDateTime() != null) {
                 Row tr = sheet.createRow(r++);
                 tr.createCell(0).setCellValue("To");
-                tr.createCell(1).setCellValue(hr.getToDateTime());
+                tr.createCell(1).setCellValue(CommonFunctions.getDateFormat(hr.getToDateTime(), sessionController.getApplicationPreference().getLongDateFormat()));
             }
-            if (hr.getInstitution() != null) {
+            {
                 Row ir = sheet.createRow(r++);
                 ir.createCell(0).setCellValue("Institution");
-                ir.createCell(1).setCellValue(hr.getInstitution().getName());
+                ir.createCell(1).setCellValue(hr.getInstitution() != null ? hr.getInstitution().getName() : "All");
             }
-            if (hr.getSite() != null) {
+            {
                 Row sr = sheet.createRow(r++);
                 sr.createCell(0).setCellValue("Site");
-                sr.createCell(1).setCellValue(hr.getSite().getName());
+                sr.createCell(1).setCellValue(hr.getSite() != null ? hr.getSite().getName() : "All");
             }
-            if (hr.getDepartment() != null) {
+            {
                 Row dr = sheet.createRow(r++);
                 dr.createCell(0).setCellValue("Department");
-                dr.createCell(1).setCellValue(hr.getDepartment().getName());
+                dr.createCell(1).setCellValue(hr.getDepartment() != null ? hr.getDepartment().getName() : "All");
             }
             r++; // blank line
 // ChatGPT contribution: One row per item, with Qty and Net Value as adjacent columns under each Bill Type
@@ -106,42 +118,90 @@ public class PharmacyAsyncReportService {
 
 // First header row: Bill type names
             Row header1 = sheet.createRow(r++);
-            header1.createCell(0).setCellValue("Item");
+            Cell hItem = header1.createCell(0);
+            hItem.setCellValue("Item");
+            hItem.setCellStyle(borderStyle);
             int col = 1;
             for (BillTypeAtomic bt : billTypes) {
-                header1.createCell(col).setCellValue(bt.getLabel());
-                header1.createCell(col + 1).setCellValue(""); // Placeholder for merge visual
+                Cell c = header1.createCell(col);
+                c.setCellValue(bt.getLabel());
+                c.setCellStyle(borderStyle);
+                header1.createCell(col + 1).setCellStyle(borderStyle);
+                sheet.addMergedRegion(new CellRangeAddress(r - 1, r - 1, col, col + 1));
                 col += 2;
             }
+            Cell totalHeadQty = header1.createCell(col);
+            totalHeadQty.setCellValue("Total Qty");
+            totalHeadQty.setCellStyle(borderStyle);
+            Cell totalHeadVal = header1.createCell(col + 1);
+            totalHeadVal.setCellValue("Total Value");
+            totalHeadVal.setCellStyle(borderStyle);
 
 // Second header row: Qty / Net Value
             Row header2 = sheet.createRow(r++);
-            header2.createCell(0).setCellValue("");
+            Cell hb = header2.createCell(0);
+            hb.setCellStyle(borderStyle);
             col = 1;
             for (int i = 0; i < billTypes.size(); i++) {
-                header2.createCell(col++).setCellValue("Total Qty");
-                header2.createCell(col++).setCellValue("Net Value");
+                Cell q = header2.createCell(col++);
+                q.setCellValue("Qty");
+                q.setCellStyle(borderStyle);
+                Cell v = header2.createCell(col++);
+                v.setCellValue("Net Value");
+                v.setCellStyle(borderStyle);
             }
+            Cell tQty = header2.createCell(col++);
+            tQty.setCellValue("Qty");
+            tQty.setCellStyle(borderStyle);
+            Cell tVal = header2.createCell(col++);
+            tVal.setCellValue("Net Value");
+            tVal.setCellStyle(borderStyle);
 
 // Data rows: One row per item
+            double grandTotal = 0.0;
             for (Map.Entry<String, Map<BillTypeAtomic, ItemMovementSummaryDTO>> entry : grouped.entrySet()) {
                 Row dataRow = sheet.createRow(r++);
-                dataRow.createCell(0).setCellValue(entry.getKey());
+                Cell itemCell = dataRow.createCell(0);
+                itemCell.setCellValue(entry.getKey());
+                itemCell.setCellStyle(borderStyle);
                 Map<BillTypeAtomic, ItemMovementSummaryDTO> itemMap = entry.getValue();
+
+                double rowQty = 0.0;
+                double rowVal = 0.0;
 
                 col = 1;
                 for (BillTypeAtomic bt : billTypes) {
                     ItemMovementSummaryDTO dto = itemMap.get(bt);
+                    Cell qCell = dataRow.createCell(col);
+                    Cell vCell = dataRow.createCell(col + 1);
                     if (dto != null) {
-                        dataRow.createCell(col).setCellValue(dto.getQuantity());
-                        dataRow.createCell(col + 1).setCellValue(dto.getNetValue());
-                    } else {
-                        dataRow.createCell(col).setCellValue("");
-                        dataRow.createCell(col + 1).setCellValue("");
+                        qCell.setCellValue(dto.getQuantity());
+                        vCell.setCellValue(dto.getNetValue());
+                        rowQty += dto.getQuantity() != null ? dto.getQuantity() : 0;
+                        rowVal += dto.getNetValue() != null ? dto.getNetValue() : 0;
                     }
+                    qCell.setCellStyle(borderStyle);
+                    vCell.setCellStyle(borderStyle);
                     col += 2;
                 }
+                Cell tq = dataRow.createCell(col);
+                tq.setCellValue(rowQty);
+                tq.setCellStyle(borderStyle);
+                Cell tv = dataRow.createCell(col + 1);
+                tv.setCellValue(rowVal);
+                tv.setCellStyle(borderStyle);
+
+                grandTotal += rowVal;
             }
+
+            Row totalRow = sheet.createRow(r++);
+            Cell totalLabel = totalRow.createCell(0);
+            totalLabel.setCellValue("Total Net Value");
+            totalLabel.setCellStyle(borderStyle);
+            sheet.addMergedRegion(new CellRangeAddress(r - 1, r - 1, 0, billTypes.size()*2));
+            Cell totalValueCell = totalRow.createCell(billTypes.size()*2 + 1);
+            totalValueCell.setCellValue(grandTotal);
+            totalValueCell.setCellStyle(borderStyle);
 
             ByteArrayOutputStream baos = new ByteArrayOutputStream();
             wb.write(baos);


### PR DESCRIPTION
## Summary
- enhance `generateAllItemMovementReport` with date formatting
- provide defaults when institution/site/department are not specified
- add cell borders and merged headers
- compute per-item totals and an overall total row

## Testing
- `mvn -q -DskipTests package` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6877595662b4832fb7897cf430c1a0b6