### PR TITLE
Fix equality checks when fetching summary report history

### DIFF
--- a/src/main/java/com/divudi/bean/pharmacy/PharmacySummaryReportController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacySummaryReportController.java
@@ -665,12 +665,12 @@ public class PharmacySummaryReportController implements Serializable {
         }
 
         if (fromDate != null) {
-            jpql.append(" and hr.fromDateTime >= :fd ");
+            jpql.append(" and hr.fromDateTime = :fd ");
             params.put("fd", fromDate);
         }
 
         if (toDate != null) {
-            jpql.append(" and hr.toDateTime <= :td ");
+            jpql.append(" and hr.toDateTime = :td ");
             params.put("td", toDate);
         }
 


### PR DESCRIPTION
## Summary
- use exact equality on `fromDateTime` and `toDateTime` when loading existing all-item movement summaries

## Testing
- `mvn -q test` *(fails: PluginResolutionException)*

------
https://chatgpt.com/codex/tasks/task_e_6877609377a4832fa9546842eb092838