### PR TITLE
Enable historical record deletion from summary reports

### DIFF
--- a/src/main/java/com/divudi/bean/pharmacy/PharmacySummaryReportController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacySummaryReportController.java
@@ -2101,4 +2101,31 @@ public class PharmacySummaryReportController implements Serializable {
         this.historicalRecords = historicalRecords;
     }
 
+    public void retireHistoricalRecord(HistoricalRecord hr) {
+        if (hr == null) {
+            JsfUtil.addErrorMessage("Nothing to delete");
+            return;
+        }
+        hr.setRetired(true);
+        hr.setRetiredAt(new Date());
+        hr.setRetiredBy(sessionController.getLoggedUser());
+        historicalRecordFacade.edit(hr);
+
+        String jpql = "select u from Upload u where u.retired=false and u.historicalRecord=:hr";
+        Map<String, Object> params = new HashMap<>();
+        params.put("hr", hr);
+        List<Upload> uploads = uploadFacade.findByJpql(jpql, params);
+        if (uploads != null) {
+            for (Upload u : uploads) {
+                u.setRetired(true);
+                u.setRetiredAt(new Date());
+                u.setRetirer(sessionController.getLoggedUser());
+                uploadFacade.edit(u);
+            }
+        }
+
+        JsfUtil.addSuccessMessage("Deleted");
+        viewAlreadyAvailableAllItemMovementSummaryReports();
+    }
+
 }

--- a/src/main/webapp/pharmacy/reports/summary_reports/all_item_movement_summary.xhtml
+++ b/src/main/webapp/pharmacy/reports/summary_reports/all_item_movement_summary.xhtml
@@ -197,6 +197,15 @@
                                     <p:fileDownload value="#{pharmacySummaryReportController.downloadHistoricalRecordFile(rec)}" />
                                 </p:commandButton>
                             </p:column>
+                            <p:column headerText="Delete" exportable="false">
+                                <p:commandButton
+                                    icon="pi pi-trash"
+                                    styleClass="ui-button-danger"
+                                    value="Delete"
+                                    action="#{pharmacySummaryReportController.retireHistoricalRecord(rec)}"
+                                    update="tblReports"
+                                    onclick="if (!confirm('Are you sure you want to delete this record?')) return false;" />
+                            </p:column>
                         </p:dataTable>
 
                     </h:form>


### PR DESCRIPTION
## Summary
- allow retiring of `HistoricalRecord` entities via a new method
- retire linked uploads when deleting a record
- add a delete button in All Item Movement summary table

## Testing
- `mvn -q test` *(fails: Could not transfer artifact maven-resources-plugin due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_6877609a4070832f9c6738a4e7f97d4a