### PR TITLE
Add stock column to item movement report

### DIFF
--- a/src/main/java/com/divudi/core/data/dto/ItemMovementSummaryDTO.java
+++ b/src/main/java/com/divudi/core/data/dto/ItemMovementSummaryDTO.java
@@ -5,6 +5,7 @@ import java.io.Serializable;
 
 public class ItemMovementSummaryDTO implements Serializable {
     private BillTypeAtomic billTypeAtomic;
+    private Long itemId;
     private String itemName;
     private Double quantity;
     private Double netValue;
@@ -12,8 +13,9 @@ public class ItemMovementSummaryDTO implements Serializable {
     public ItemMovementSummaryDTO() {
     }
 
-    public ItemMovementSummaryDTO(BillTypeAtomic billTypeAtomic, String itemName, Double quantity, Double netValue) {
+    public ItemMovementSummaryDTO(BillTypeAtomic billTypeAtomic, Long itemId, String itemName, Double quantity, Double netValue) {
         this.billTypeAtomic = billTypeAtomic;
+        this.itemId = itemId;
         this.itemName = itemName;
         this.quantity = quantity;
         this.netValue = netValue;
@@ -25,6 +27,14 @@ public class ItemMovementSummaryDTO implements Serializable {
 
     public void setBillTypeAtomic(BillTypeAtomic billTypeAtomic) {
         this.billTypeAtomic = billTypeAtomic;
+    }
+
+    public Long getItemId() {
+        return itemId;
+    }
+
+    public void setItemId(Long itemId) {
+        this.itemId = itemId;
     }
 
     public String getItemName() {

--- a/src/main/java/com/divudi/service/BillService.java
+++ b/src/main/java/com/divudi/service/BillService.java
@@ -1110,7 +1110,7 @@ public class BillService {
             Department department,
             List<BillTypeAtomic> billTypeAtomics) {
         String jpql = "select new com.divudi.core.data.dto.ItemMovementSummaryDTO(" +
-                " b.billTypeAtomic, bi.item.name, sum(pbi.qty + pbi.freeQty), sum(bi.netValue))" +
+                " b.billTypeAtomic, bi.item.id, bi.item.name, sum(pbi.qty + pbi.freeQty), sum(bi.netValue))" +
                 " from PharmaceuticalBillItem pbi" +
                 " join pbi.billItem bi" +
                 " join bi.bill b" +
@@ -1137,7 +1137,7 @@ public class BillService {
             params.put("site", site);
         }
 
-        jpql += " group by b.billTypeAtomic, bi.item.name" +
+        jpql += " group by b.billTypeAtomic, bi.item.id, bi.item.name" +
                 " order by b.billTypeAtomic, bi.item.name";
 
         return pharmaceuticalBillItemFacade.findItemMovementSummaryDTOs(jpql, params, TemporalType.TIMESTAMP);


### PR DESCRIPTION
## Summary
- show current stock levels in async item movement report
- fetch stock values using `StockController`
- use item ID instead of name when looking up stock

## Testing
- `mvn -q -DskipTests package` *(fails: Plugin artifact could not be resolved)*

------
https://chatgpt.com/codex/tasks/task_e_687775585f6c832f9796445e9f027559