### PR TITLE
Fix totals row in item movement report

### DIFF
--- a/src/main/java/com/divudi/service/PharmacyAsyncReportService.java
+++ b/src/main/java/com/divudi/service/PharmacyAsyncReportService.java
@@ -391,7 +391,6 @@ public class PharmacyAsyncReportService {
             Cell totalLabel = totalRow.createCell(0);
             totalLabel.setCellValue("Total Net Value");
             totalLabel.setCellStyle(thickValStyle);
-            sheet.addMergedRegion(new CellRangeAddress(r - 1, r - 1, 0, billTypes.size() * 2 + 1));
 
             int tc = 1;
             for (BillTypeAtomic bt : billTypes) {


### PR DESCRIPTION
## Summary
- remove merged region so totals row displays values for each bill type

## Testing
- `mvn -q -DskipTests compile` *(fails: Could not transfer artifact)*

------
https://chatgpt.com/codex/tasks/task_e_6877c73b73a8832fa4fa32eb153e773d