### PR TITLE
13993 add a button to rates visible during inward billing in edit features of multiple item for multiple edit

### DIFF
--- a/src/main/java/com/divudi/bean/common/ItemController.java
+++ b/src/main/java/com/divudi/bean/common/ItemController.java
@@ -1833,6 +1833,30 @@ public class ItemController implements Serializable {
         }
         JsfUtil.addSuccessMessage("All Unmarked for Request For Quentity");
     }
+    
+    public void markSelectedItemsForRatesvisibleduringInwardBilling() {
+        if (selectedList == null || selectedList.isEmpty()) {
+            JsfUtil.addErrorMessage("Nothing is selected");
+            return;
+        }
+        for (Item i : selectedList) {
+            i.setChargesVisibleForInward(true);
+            itemFacade.edit(i);
+        }
+        JsfUtil.addSuccessMessage("All Marked for Rates visible during Inward Billing");
+    }
+
+    public void unMarkSelectedItemsForRatesvisibleduringInwardBilling() {
+        if (selectedList == null || selectedList.isEmpty()) {
+            JsfUtil.addErrorMessage("Nothing is selected");
+            return;
+        }
+        for (Item i : selectedList) {
+            i.setChargesVisibleForInward(false);
+            itemFacade.edit(i);
+        }
+        JsfUtil.addSuccessMessage("All Unmarked for Rates visible during Inward Billing");
+    }
 
     public void addSessionNumberType() {
         if (selectedList == null || selectedList.isEmpty()) {

--- a/src/main/webapp/admin/items/multiple_item_edit.xhtml
+++ b/src/main/webapp/admin/items/multiple_item_edit.xhtml
@@ -20,83 +20,107 @@
                     <h:panelGrid columns="1" styleClass="alignTop" >
                         <h:panelGrid columns="4" >
                             <!-- Make Selected Items' Fees Changeable at Billing -->
-                            <p:commandButton ajax="false" 
-                                             value="Make Selected Items' Fees Changable at Billing"
-                                             action="#{itemController.markSelectedItemsFeesChangableAtBilling}"
-                                             icon="pi pi-check-circle" 
-                                             styleClass="ui-button-success">
+                            <p:commandButton 
+                                ajax="false" 
+                                value="Make Selected Items' Fees Changable at Billing"
+                                action="#{itemController.markSelectedItemsFeesChangableAtBilling}"
+                                icon="pi pi-check-circle" 
+                                styleClass="ui-button-success">
                             </p:commandButton>
 
                             <!-- Unmark Selected Items' Fees Changable at Billing -->
-                            <p:commandButton ajax="false" 
-                                             value="Unmark Selected Items' Fees Changable at Billing"
-                                             action="#{itemController.unmarkSelectedItemsFeesChangableAtBilling}"
-                                             icon="pi pi-times-circle" 
-                                             styleClass="ui-button-danger">
+                            <p:commandButton 
+                                ajax="false" 
+                                value="Unmark Selected Items' Fees Changable at Billing"
+                                action="#{itemController.unmarkSelectedItemsFeesChangableAtBilling}"
+                                icon="pi pi-times-circle" 
+                                styleClass="ui-button-danger">
                             </p:commandButton>
 
                             <!-- Make Selected Items Discountable at Billing -->
-                            <p:commandButton ajax="false" 
-                                             value="Make Selected Items Discountable at Billing"
-                                             action="#{itemController.markSelectedItemsAsDiscountableAtBilling}"
-                                             icon="pi pi-check-square" 
-                                             styleClass="ui-button-success">
+                            <p:commandButton 
+                                ajax="false" 
+                                value="Make Selected Items Discountable at Billing"
+                                action="#{itemController.markSelectedItemsAsDiscountableAtBilling}"
+                                icon="pi pi-check-square" 
+                                styleClass="ui-button-success">
                             </p:commandButton>
 
                             <!-- Unmark Selected Items Discountable at Billing -->
-                            <p:commandButton ajax="false" 
-                                             value="Unmark Selected Items Discountable at Billing"
-                                             action="#{itemController.unmarkSelectedItemsAsDiscountableAtBilling}"
-                                             icon="pi pi-times-circle" 
-                                             styleClass="ui-button-danger">
+                            <p:commandButton 
+                                ajax="false" 
+                                value="Unmark Selected Items Discountable at Billing"
+                                action="#{itemController.unmarkSelectedItemsAsDiscountableAtBilling}"
+                                icon="pi pi-times-circle" 
+                                styleClass="ui-button-danger">
                             </p:commandButton>
 
 
                             <!-- Make Selected Items Discountable at Billing -->
-                            <p:commandButton ajax="false" 
-                                             value="Make Selected Items To Print Session Numbers"
-                                             action="#{itemController.markSelectedItemsAsPrintSessionNumber}"
-                                             icon="pi pi-check-square" 
-                                             styleClass="ui-button-success">
+                            <p:commandButton 
+                                ajax="false" 
+                                value="Make Selected Items To Print Session Numbers"
+                                action="#{itemController.markSelectedItemsAsPrintSessionNumber}"
+                                icon="pi pi-check-square" 
+                                styleClass="ui-button-success">
                             </p:commandButton>
 
                             <!-- Unmark Selected Items Discountable at Billing -->
-                            <p:commandButton ajax="false" 
-                                             value="Unmark Selected Items Not to Print SessionNumbers"
-                                             action="#{itemController.unmarkSelectedItemsAsNotToPrintSessionNumber}"
-                                             icon="pi pi-times-circle" 
-                                             styleClass="ui-button-danger">
+                            <p:commandButton 
+                                ajax="false" 
+                                value="Unmark Selected Items Not to Print SessionNumbers"
+                                action="#{itemController.unmarkSelectedItemsAsNotToPrintSessionNumber}"
+                                icon="pi pi-times-circle" 
+                                styleClass="ui-button-danger">
                             </p:commandButton>
 
-
-                            <p:commandButton ajax="false" 
-                                             value="Mark Selected Items for Print Separate Fees"
-                                             action="#{itemController.markSelectedItemsForPrintSeparateFees()}"
-                                             icon="pi pi-check-square" 
-                                             styleClass="ui-button-success">
+                            <p:commandButton 
+                                ajax="false" 
+                                value="Mark Selected Items for Print Separate Fees"
+                                action="#{itemController.markSelectedItemsForPrintSeparateFees()}"
+                                icon="pi pi-check-square" 
+                                styleClass="ui-button-success">
                             </p:commandButton>
 
-                            <p:commandButton ajax="false" 
-                                             value="Unmark Selected Items for Print Separate Fees"
-                                             action="#{itemController.unMarkSelectedItemsForPrintSeparateFees()}"
-                                             icon="pi pi-times-circle"  
-                                             styleClass="ui-button-danger">
-                            </p:commandButton>
-                            
-                            <p:commandButton ajax="false" 
-                                             value="Mark Selected Items for Request for Quantity"
-                                             action="#{itemController.markSelectedItemsForRequestForQuentity()}"
-                                             icon="pi pi-check-square" 
-                                             styleClass="ui-button-success">
+                            <p:commandButton 
+                                ajax="false" 
+                                value="Unmark Selected Items for Print Separate Fees"
+                                action="#{itemController.unMarkSelectedItemsForPrintSeparateFees()}"
+                                icon="pi pi-times-circle"  
+                                styleClass="ui-button-danger">
                             </p:commandButton>
 
-                            <p:commandButton ajax="false" 
-                                             value="Unmark Selected Items for Request for Quantity"
-                                             action="#{itemController.unMarkSelectedItemsForRequestForQuentity()}"
-                                             icon="pi pi-times-circle"  
-                                             styleClass="ui-button-danger">
+                            <p:commandButton 
+                                ajax="false" 
+                                value="Mark Selected Items for Request for Quantity"
+                                action="#{itemController.markSelectedItemsForRequestForQuentity()}"
+                                icon="pi pi-check-square" 
+                                styleClass="ui-button-success">
                             </p:commandButton>
 
+                            <p:commandButton 
+                                ajax="false" 
+                                value="Unmark Selected Items for Request for Quantity"
+                                action="#{itemController.unMarkSelectedItemsForRequestForQuentity()}"
+                                icon="pi pi-times-circle"  
+                                styleClass="ui-button-danger">
+                            </p:commandButton>
+
+                            <p:commandButton 
+                                ajax="false" 
+                                value="Mark Selected Items for Rates visible during Inward Billing"
+                                action="#{itemController.markSelectedItemsForRatesvisibleduringInwardBilling()}"
+                                icon="pi pi-check-square" 
+                                styleClass="ui-button-success">
+                            </p:commandButton>
+
+                            <p:commandButton 
+                                ajax="false" 
+                                value="Unmark Selected Items for Rates visible during Inward Billing"
+                                action="#{itemController.unMarkSelectedItemsForRatesvisibleduringInwardBilling()}"
+                                icon="pi pi-times-circle"  
+                                styleClass="ui-button-danger">
+                            </p:commandButton>
 
                             <p:commandButton 
                                 ajax="false" 
@@ -105,9 +129,6 @@
                                 icon="pi pi-times-circle"  
                                 styleClass="ui-button-danger">
                             </p:commandButton>
-
-
-
 
                         </h:panelGrid>
 
@@ -141,13 +162,12 @@
                                 var="i"   
                                 rowKey="#{i.id}" 
                                 rowIndexVar="s"
-                                rows="20"
+                                rows="50"
                                 selectionMode="multiple"
                                 paginator="true"
                                 selection="#{itemController.selectedList}"
                                 paginatorTemplate="{CurrentPageReport}  {FirstPageLink} {PreviousPageLink} {PageLinks} {NextPageLink} {LastPageLink} {RowsPerPageDropdown}"
-                                rowsPerPageTemplate="20,50,100,500,1000,1500"
-                                >
+                                rowsPerPageTemplate="50,100,250,500,1000">
 
                                 <p:column selectionBox="true"  exportable="false" style="width: 10px;"> 
                                 </p:column>
@@ -161,7 +181,7 @@
                                     </f:facet>
                                     <h:outputLabel value="#{i.id}"/>
                                 </p:column>
-                                
+
                                 <p:column  
                                     sortBy="#{i.code}" width="80"
                                     filterMatchMode="contains" filterBy="#{i.code}" >  
@@ -247,7 +267,7 @@
                                     <h:outputLabel value="#{i.printFeesForBills?'Yes':'No'}" >
                                     </h:outputLabel>
                                 </p:column>
-                                
+
                                 <p:column sortBy="#{i.requestForQuentity}" width="10"
                                           filterMatchMode="contains" filterBy="#{i.requestForQuentity}">
                                     <f:facet name="header">
@@ -268,9 +288,15 @@
                                     </h:outputLabel>
                                 </p:column>
 
-
-
-
+                                <p:column sortBy="#{i.chargesVisibleForInward}" width="10"
+                                          filterMatchMode="contains" filterBy="#{i.chargesVisibleForInward}">
+                                    <f:facet name="header">
+                                        <h:outputLabel value="Rates visible during Inward Billing" >
+                                        </h:outputLabel>
+                                    </f:facet>
+                                    <h:outputLabel value="#{i.chargesVisibleForInward ?'Yes':'No'}" >
+                                    </h:outputLabel>
+                                </p:column>
 
                             </p:dataTable>
                         </p:panel>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added batch actions to mark or unmark selected items for "Rates visible during Inward Billing" from the item management interface.
  * Introduced a new column to display the "Rates visible during Inward Billing" status for each item.

* **Enhancements**
  * Increased the default and selectable number of rows displayed in the item list for improved data navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->