### PR TITLE
14001 upgrade pharmacy item import without stock to support optional department type column

### DIFF
--- a/src/main/java/com/divudi/bean/emr/DataUploadController.java
+++ b/src/main/java/com/divudi/bean/emr/DataUploadController.java
@@ -48,6 +48,7 @@ import com.divudi.core.data.CollectingCentrePaymentMethod;
 import com.divudi.core.data.EncounterType;
 import com.divudi.core.data.FeeType;
 import com.divudi.core.data.InstitutionType;
+import com.divudi.core.data.DepartmentType;
 import com.divudi.core.data.Sex;
 import com.divudi.core.data.Title;
 import com.divudi.core.data.inward.InwardChargeType;
@@ -320,6 +321,7 @@ public class DataUploadController implements Serializable {
     private int distributorCol = 11;
     private int manufacturerCol = 12;
     private int importerCol = 13;
+    private int departmentTypeCol = 14;
     private int doeCol = 14;
     private int batchCol = 15;
     private int stockQtyCol = 16;
@@ -745,6 +747,13 @@ public class DataUploadController implements Serializable {
                 strImporter = getCellValueAsString(row.getCell(importerCol));
                 importer = getInstitutionController().getInstitutionByName(strImporter, InstitutionType.Importer);
                 amp.setImporter(importer);
+
+                String strDepartmentType = getCellValueAsString(row.getCell(departmentTypeCol));
+                DepartmentType deptType = departmentController.findDepartmentType(strDepartmentType);
+                if (deptType == null) {
+                    deptType = DepartmentType.Pharmacy;
+                }
+                amp.setDepartmentType(deptType);
 
                 System.out.println("amp = " + amp);
                 System.out.println("rowCount at End of a row= " + rowCount);

--- a/src/main/webapp/pharmacy/pharmacy_item_import_without_stock.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_item_import_without_stock.xhtml
@@ -34,8 +34,8 @@
                     <h:outputLabel value ="2. Product " ></h:outputLabel>
                     <h:outputLabel value ="3. Code" ></h:outputLabel>
                     <h:outputLabel value ="4. Bar Code" ></h:outputLabel>
-                    <h:outputLabel value ="4. Generic Name" ></h:outputLabel>
-                    <h:outputLabel value ="5. Strength" ></h:outputLabel>
+                    <h:outputLabel value ="5. Generic Name" ></h:outputLabel>
+                    <h:outputLabel value ="6. Strength" ></h:outputLabel>
                     <h:outputLabel value ="7. Strength Unit" ></h:outputLabel>
                     <h:outputLabel value ="8. Pack Size" ></h:outputLabel>
                     <h:outputLabel value ="9. Issue Unit" ></h:outputLabel>
@@ -43,11 +43,7 @@
                     <h:outputLabel value ="11. Distributor" ></h:outputLabel>
                     <h:outputLabel value ="12. Manufacturer" ></h:outputLabel>
                     <h:outputLabel value ="13. Importer" ></h:outputLabel>
-                    <h:outputLabel value ="14. Date of Expiry (M/d/yyyy)" ></h:outputLabel>
-                    <h:outputLabel value ="15. Batch" ></h:outputLabel>
-                    <h:outputLabel value ="16. Quentity" ></h:outputLabel>
-                    <h:outputLabel value ="17. Purchase Price" ></h:outputLabel>
-                    <h:outputLabel value ="18. Sale Price" ></h:outputLabel>
+                    <h:outputLabel value ="14. Department Type (Optional)" ></h:outputLabel>
 
                 </p:panelGrid>
 


### PR DESCRIPTION
## Summary
- add optional `departmentType` column when importing items without stock
- document new column order

## Testing
- `mvn -q test` *(fails: Could not resolve Maven dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6879d45bb034832f93b38aef085052a9