### PR TITLE
Add department-aware pharmacy item completion

### DIFF
--- a/src/main/java/com/divudi/bean/common/ItemController.java
+++ b/src/main/java/com/divudi/bean/common/ItemController.java
@@ -2267,6 +2267,42 @@ public class ItemController implements Serializable {
         return suggestions;
     }
 
+    public List<Item> completeAmpItemForLoggedDepartment(String query) {
+        List<Item> suggestions = new ArrayList<>();
+        if (query == null || query.trim().isEmpty()) {
+            return suggestions;
+        } else {
+            String[] words = query.split("\\s+");
+            String sql = "SELECT c FROM Item c WHERE c.retired = false AND type(c) = :amp AND c.departmentType in :dts AND ";
+
+            StringBuilder nameConditions = new StringBuilder();
+            for (int i = 0; i < words.length; i++) {
+                if (i > 0) {
+                    nameConditions.append(" AND ");
+                }
+                nameConditions.append("LOWER(c.name) LIKE :nameStr").append(i);
+            }
+
+            sql += "(" + nameConditions + ") OR LOWER(c.code) LIKE :codeStr "
+                    + "OR LOWER(c.barcode) LIKE :barcodeStr OR c.barcode = :exactBarcodeStr) "
+                    + "ORDER BY c.name";
+
+            HashMap<String, Object> tmpMap = new HashMap<>();
+            tmpMap.put("amp", Amp.class);
+            tmpMap.put("dts", sessionController.getAvailableDepartmentTypesForPharmacyTransactions());
+            tmpMap.put("codeStr", "%" + query.toLowerCase() + "%");
+            tmpMap.put("barcodeStr", "%" + query.toLowerCase() + "%");
+            tmpMap.put("exactBarcodeStr", query);
+
+            for (int i = 0; i < words.length; i++) {
+                tmpMap.put("nameStr" + i, "%" + words[i].toLowerCase() + "%");
+            }
+
+            suggestions = getFacade().findByJpql(sql, tmpMap, TemporalType.TIMESTAMP, 30);
+        }
+        return suggestions;
+    }
+
 //    @Deprecated(forRemoval = true)
 //    public List<Item> completeAmps(String query) {
 //        // Please use Amp Controller completeAmps
@@ -2551,6 +2587,56 @@ public class ItemController implements Serializable {
         parameters.put("ampp", Ampp.class);
         parameters.put("vmp", Vmp.class);
         parameters.put("vmpp", Vmpp.class);
+        parameters.put("q", "%" + q + "%");
+
+        results = getFacade().findByJpql(jpql, parameters, TemporalType.TIMESTAMP, maxResults);
+
+        return results;
+    }
+
+    public List<Item> completeAmpAmppVmpVmppItemsForLoggedDepartment(String query) {
+        List<Item> results;
+        String jpql;
+        Map<String, Object> parameters = new HashMap<>();
+
+        if (query == null || query.trim().isEmpty()) {
+            return new ArrayList<>();
+        }
+
+        String q = query.trim().toUpperCase();
+
+        int barcodeMinLength = 8; // fallback default
+        int maxResults = 30; // fallback default
+
+        try {
+            barcodeMinLength = configOptionApplicationController.getIntegerValueByKey("BarcodeMinLength", 8);
+        } catch (Exception e) {
+            // Use default
+        }
+
+        try {
+            maxResults = configOptionApplicationController.getIntegerValueByKey("PharmaceuticalAutocompleteMaxResults", 30);
+        } catch (Exception e) {
+            // Use default
+        }
+
+        boolean includeBarcode = q.length() >= barcodeMinLength;
+
+        jpql = "SELECT i FROM Item i "
+                + "WHERE i.retired = false "
+                + "AND TYPE(i) IN (:amp, :ampp, :vmp, :vmpp) "
+                + "AND i.departmentType in :dts "
+                + "AND (UPPER(i.name) LIKE :q "
+                + "OR UPPER(i.code) LIKE :q "
+                + (includeBarcode ? "OR UPPER(i.barcode) LIKE :q " : "")
+                + ") "
+                + "ORDER BY i.name";
+
+        parameters.put("amp", Amp.class);
+        parameters.put("ampp", Ampp.class);
+        parameters.put("vmp", Vmp.class);
+        parameters.put("vmpp", Vmpp.class);
+        parameters.put("dts", sessionController.getAvailableDepartmentTypesForPharmacyTransactions());
         parameters.put("q", "%" + q + "%");
 
         results = getFacade().findByJpql(jpql, parameters, TemporalType.TIMESTAMP, maxResults);

--- a/src/main/webapp/pharmacy/direct_purchase.xhtml
+++ b/src/main/webapp/pharmacy/direct_purchase.xhtml
@@ -70,7 +70,7 @@
                                         id="acItem"
                                         value="#{pharmacyDirectPurchaseController.currentBillItem.item}"
                                         forceSelection="true"
-                                        completeMethod="#{itemController.completeAmpAndAmppItem}"
+                                        completeMethod="#{itemController.completeAmpAndAmppItemForLoggedDepartment}"
                                         var="vt"
                                         maxResults="20"
                                         itemLabel="#{vt.name}"

--- a/src/main/webapp/pharmacy/pharmacy_purchase.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_purchase.xhtml
@@ -157,7 +157,7 @@
                                         id="acItem"
                                         value="#{pharmacyPurchaseController.currentBillItem.item}"
                                         forceSelection="true"
-                                        completeMethod="#{itemController.completeAmpAndAmppItem}"
+                                        completeMethod="#{itemController.completeAmpAndAmppItemForLoggedDepartment}"
                                         var="vt"
                                         maxResults="20"
                                         itemLabel="#{vt.name}"
@@ -294,7 +294,7 @@
                                     id="exItem"
                                     value="#{pharmacyPurchaseController.currentBillItem.item}"
                                     forceSelection="true"
-                                    completeMethod="#{itemController.completeAmpItem}"
+                                    completeMethod="#{itemController.completeAmpItemForLoggedDepartment}"
                                     var="vt"
                                     itemLabel="#{vt.name}"
                                     itemValue="#{vt}" >

--- a/src/main/webapp/pharmacy/pharmacy_transfer_request.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_transfer_request.xhtml
@@ -125,7 +125,7 @@
                                             forceSelection="true"
                                             class="w-100"
                                             inputStyleClass="w-100"
-                                            completeMethod="#{itemController.completeAmpAmppVmpVmppItems}"
+                                            completeMethod="#{itemController.completeAmpAmppVmpVmppItemsForLoggedDepartment}"
                                             var="vt"
                                             itemLabel="#{vt.name}"
                                             itemValue="#{vt}"


### PR DESCRIPTION
## Summary
- restrict autocomplete suggestions by department when selecting pharmacy items
- update item selection on several pharmacy pages

## Testing
- `mvn test` *(fails: mvn not installed)*

------
https://chatgpt.com/codex/tasks/task_e_687c74c7f7a8832faa7eb2e0c241d953