### PR TITLE
Implement store and lab item uploads

### DIFF
--- a/src/main/java/com/divudi/bean/emr/DataUploadController.java
+++ b/src/main/java/com/divudi/bean/emr/DataUploadController.java
@@ -336,6 +336,9 @@ public class DataUploadController implements Serializable {
 
     private int startRow = 1;
 
+    private boolean skipDepartmentTypeColumn;
+    private DepartmentType defaultDepartmentType = DepartmentType.Pharmacy;
+
     public String navigateToRouteUpload() {
         uploadComplete = false;
         return "/admin/institutions/route_upload?faces-redirect=true";
@@ -724,10 +727,13 @@ public class DataUploadController implements Serializable {
 
                 strDistributor = getCellValueAsString(row.getCell(distributorCol));
                 
-                String strDepartmentType = getCellValueAsString(row.getCell(departmentTypeCol));
-                DepartmentType deptType = departmentController.findDepartmentType(strDepartmentType);
+                DepartmentType deptType = null;
+                if (!skipDepartmentTypeColumn) {
+                    String strDepartmentType = getCellValueAsString(row.getCell(departmentTypeCol));
+                    deptType = departmentController.findDepartmentType(strDepartmentType);
+                }
                 if (deptType == null) {
-                    deptType = DepartmentType.Pharmacy;
+                    deptType = defaultDepartmentType != null ? defaultDepartmentType : DepartmentType.Pharmacy;
                 }
 
                 Cell ampCell = row.getCell(ampCol);
@@ -813,6 +819,18 @@ public class DataUploadController implements Serializable {
             default:
                 return "";
         }
+    }
+
+    public String importFromExcelWithoutStockLab() {
+        skipDepartmentTypeColumn = true;
+        defaultDepartmentType = DepartmentType.Lab;
+        return importFromExcelWithoutStock();
+    }
+
+    public String importFromExcelWithoutStockStore() {
+        skipDepartmentTypeColumn = true;
+        defaultDepartmentType = DepartmentType.Store;
+        return importFromExcelWithoutStock();
     }
 
     private double parseDouble(String value) {
@@ -8175,6 +8193,22 @@ public class DataUploadController implements Serializable {
 
     public void setRejecteditemFees(List<ItemLight> rejecteditemFees) {
         this.rejecteditemFees = rejecteditemFees;
+    }
+
+    public boolean isSkipDepartmentTypeColumn() {
+        return skipDepartmentTypeColumn;
+    }
+
+    public void setSkipDepartmentTypeColumn(boolean skipDepartmentTypeColumn) {
+        this.skipDepartmentTypeColumn = skipDepartmentTypeColumn;
+    }
+
+    public DepartmentType getDefaultDepartmentType() {
+        return defaultDepartmentType;
+    }
+
+    public void setDefaultDepartmentType(DepartmentType defaultDepartmentType) {
+        this.defaultDepartmentType = defaultDepartmentType;
     }
 
 }

--- a/src/main/webapp/admin/lims/index.xhtml
+++ b/src/main/webapp/admin/lims/index.xhtml
@@ -218,6 +218,15 @@
                                 </h:panelGroup>
 
                             </p:tab>
+                            <p:tab title="Manage Stocks">
+                                <div class="d-grid gap-2">
+                                    <p:commandButton
+                                        class="w-100"
+                                        ajax="false"
+                                        value="Upload Lab Items"
+                                        action="/admin/lims/upload_lab_items.xhtml?faces-redirect=true" />
+                                </div>
+                            </p:tab>
                             <p:tab title="Developers">
                                 <div class="d-grid gap-2">
                                     <p:commandButton 

--- a/src/main/webapp/admin/lims/upload_lab_items.xhtml
+++ b/src/main/webapp/admin/lims/upload_lab_items.xhtml
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='UTF-8' ?>
 <!DOCTYPE composition PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <ui:composition xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
-                template="/store/store_admin.xhtml"
+                template="/admin/lims/index.xhtml"
                 xmlns:h="http://xmlns.jcp.org/jsf/html"
                 xmlns:p="http://primefaces.org/ui"
                 xmlns:f="http://xmlns.jcp.org/jsf/core">
@@ -11,7 +11,7 @@
             <p:panel>
                 <p:fileUpload value="#{dataUploadController.file}" mode="simple"/>
                 <p:commandButton ajax="false" value="Submit"
-                                 action="#{dataUploadController.importFromExcelWithoutStockStore}"/>
+                                 action="#{dataUploadController.importFromExcelWithoutStockLab}"/>
 
                 <p:panel header="Import Items from Excel (No Stock)" >
                     <h:outputLabel value="Instructions" ></h:outputLabel>
@@ -25,8 +25,6 @@
                     </p:panel>
 
                 </p:panel>
-
-
 
                 <p:panelGrid columns="1" style="border: 1px solid blue;" >
                     <h:outputLabel value ="0. Serial No " ></h:outputLabel>
@@ -47,10 +45,5 @@
 
             </p:panel>
         </h:form>
-
-
-
     </ui:define>
-
-
 </ui:composition>


### PR DESCRIPTION
## Summary
- extend DataUploadController to set default DepartmentType for imports
- use helper methods for lab and store item imports
- update store item import page
- add upload page for lab items
- link new upload page from lab admin index

## Testing
- `mvn -q test` *(fails: Could not resolve Maven dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_687cc5f25c60832fa07001b8403590c5