### PR TITLE
Fix Amp JPQL queries in lab controller

### DIFF
--- a/src/main/java/com/divudi/bean/lab/LabAmpController.java
+++ b/src/main/java/com/divudi/bean/lab/LabAmpController.java
@@ -169,7 +169,7 @@ public class LabAmpController implements Serializable {
         if (items == null) {
             Map m = new HashMap();
             m.put("dt", DepartmentType.Lab);
-            String sql = "Select a from Item a where a.retired=false and a.departmentType=:dt order by a.name";
+            String sql = "Select a from Amp a where a.retired=false and a.departmentType=:dt order by a.name";
             items = getFacade().findByJpql(sql, m);
         }
         return items;
@@ -181,7 +181,7 @@ public class LabAmpController implements Serializable {
         itemsAll.addAll(items);
         Map m = new HashMap();
         m.put("dt", DepartmentType.Lab);
-        String sql = "Select a from Item a where a.retired=true and a.departmentType=:dt order by a.name";
+        String sql = "Select a from Amp a where a.retired=true and a.departmentType=:dt order by a.name";
         itemsAll.addAll(getFacade().findByJpql(sql, m));
     }
 


### PR DESCRIPTION
## Summary
- query `Amp` directly in `LabAmpController` when loading items
- keep same query structure for retired items

## Testing
- `mvn -q test` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_687cd9eb1770832fbd442732d83c0499