### PR TITLE
Fix converter name for LabAmpController

### DIFF
--- a/src/main/java/com/divudi/bean/lab/LabAmpController.java
+++ b/src/main/java/com/divudi/bean/lab/LabAmpController.java
@@ -251,7 +251,7 @@ public class LabAmpController implements Serializable {
     /**
      *
      */
-    @FacesConverter("stoAmpCon")
+    @FacesConverter("labAmpCon")
     public static class AmpControllerConverter implements Converter {
 
         @Override


### PR DESCRIPTION
## Summary
- rename FacesConverter annotation on `LabAmpController` from `stoAmpCon` to `labAmpCon`

## Testing
- `mvn -q test` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:2.6 or one of its dependencies could not be resolved)*

------
https://chatgpt.com/codex/tasks/task_e_687ce58b6e24832fbbf06458fdba5c54