### PR TITLE
Remove System.out.println debug statements from PR #13962

### DIFF
--- a/src/main/java/com/divudi/bean/pharmacy/DealorPaymentBillSearch.java
+++ b/src/main/java/com/divudi/bean/pharmacy/DealorPaymentBillSearch.java
@@ -188,10 +188,8 @@ public class DealorPaymentBillSearch implements Serializable {
 //        List<Bill> userBills;
 //        if (getUser() == null) {
 //            userBills = new ArrayList<>();
-//            //////// // System.out.println("user is null");
 //        } else {
 //            userBills = getBillBean().billsFromSearchForUser(txtSearch, getFromDate(), getToDate(), getUser(), getSessionController().getInstitution(), BillType.OpdBill);
-//            //////// // System.out.println("user ok");
 //        }
 //        if (userBills == null) {
 //            userBills = new ArrayList<>();
@@ -357,7 +355,6 @@ public class DealorPaymentBillSearch implements Serializable {
 
         rb.setBillType(BillType.GrnPayment);
         rb.setBillTypeAtomic(BillTypeAtomic.SUPPLIER_PAYMENT_RETURNED);
-        System.out.println("BillTypeAtomic set to: " + rb.getBillTypeAtomic());
 
         rb.setBillDate(new Date());
         rb.setBillTime(new Date());
@@ -463,7 +460,6 @@ public class DealorPaymentBillSearch implements Serializable {
             bill.setCancelled(true);
             bill.setCancelledBill(cb);
             JsfUtil.addSuccessMessage("Successfully Cancelled");
-            System.out.println("JsfUtil.addSuccessMessage(Successfully Cancelled);");
             getBilledBillFacade().edit(bill);
 
             WebUser wb = getCashTransactionBean().saveBillCashInTransaction(cb, getSessionController().getLoggedUser());
@@ -509,7 +505,6 @@ public class DealorPaymentBillSearch implements Serializable {
     }
 
     public List<Bill> getBillsToApproveCancellation() {
-        //////// // System.out.println("1");
         billsToApproveCancellation = ejbApplication.getBillsToCancel();
         return billsToApproveCancellation;
     }
@@ -654,13 +649,10 @@ public class DealorPaymentBillSearch implements Serializable {
 
     public List<Bill> getUserBills() {
         List<Bill> userBills;
-        //////// // System.out.println("getting user bills");
         if (getUser() == null) {
             userBills = new ArrayList<>();
-            //////// // System.out.println("user is null");
         } else {
             userBills = getBillBean().billsFromSearchForUser(txtSearch, getFromDate(), getToDate(), getUser(), BillType.OpdBill);
-            //////// // System.out.println("user ok");
         }
         if (userBills == null) {
             userBills = new ArrayList<>();

--- a/src/main/java/com/divudi/bean/pharmacy/ReportsStock.java
+++ b/src/main/java/com/divudi/bean/pharmacy/ReportsStock.java
@@ -192,9 +192,7 @@ public class ReportsStock implements Serializable, ControllerWithReportFilters {
     public void fillDepartmentStocks() {
         List<DepartmentType> availableDepartmentTypes = sessionController.getAvailableDepartmentTypesForPharmacyTransactions();
         reportTimerController.trackReportExecution(() -> {
-            System.out.println("fillDepartmentStocks");
             Date startedAt = new Date();
-            System.out.println("startedAt = " + startedAt);
             Map<String, Object> m = new HashMap<>();
             StringBuilder sql = new StringBuilder("select s from Stock s where s.stock > 0");
 
@@ -213,15 +211,12 @@ public class ReportsStock implements Serializable, ControllerWithReportFilters {
             }
 
             Date beforeJpql = new Date();
-            System.out.println("beforeJpql = " + beforeJpql);
             stocks = getStockFacade().findByJpql(sql.toString(), m);
 
             Date afterJpql = new Date();
-            System.out.println("afterJpql = " + afterJpql);
             stocks.sort(Comparator.comparing(s -> s.getItemBatch().getItem().getName(), String.CASE_INSENSITIVE_ORDER));
 
             Date beforeCal = new Date();
-            System.out.println("beforeCal = " + beforeCal);
             stockPurchaseValue = stocks.stream()
                     .mapToDouble(s -> s.getItemBatch().getPurcahseRate() * s.getStock())
                     .sum();
@@ -237,7 +232,6 @@ public class ReportsStock implements Serializable, ControllerWithReportFilters {
                     })
                     .sum();
             Date afterCal = new Date();
-            System.out.println("afterCal = " + afterCal);
         }, PharmacyReports.STOCK_REPORT_BY_BATCH, sessionController.getLoggedUser());
     }
 
@@ -247,9 +241,7 @@ public class ReportsStock implements Serializable, ControllerWithReportFilters {
 
     public void fillDepartmentStocksForDownload() {
         reportTimerController.trackReportExecution(() -> {
-            System.out.println("fillDepartmentStocks");
             Date startedAt = new Date();
-            System.out.println("startedAt = " + startedAt);
 
             Map<String, Object> parameters = new HashMap<>();
             StringBuilder jpql = new StringBuilder("SELECT s FROM Stock s WHERE 1=1");
@@ -272,7 +264,6 @@ public class ReportsStock implements Serializable, ControllerWithReportFilters {
             jpql.append(" ORDER BY s.id");
 
             Date beforeJpql = new Date();
-            System.out.println("beforeJpql = " + beforeJpql);
 
             stocks = getStockFacade().findByJpql(jpql.toString(), parameters);
 
@@ -361,9 +352,6 @@ public class ReportsStock implements Serializable, ControllerWithReportFilters {
             m.put("d", department);
             m.put("z", 0.0);
         }
-//        //////System.out.println("sql = " + sql);
-//        //////System.out.println("m = " + m);
-//        //////System.out.println("getStockFacade().findObjects(sql, m) = " + getStockFacade().findObjects(sql, m));
         List<PharmacyStockRow> lsts = (List) getStockFacade().findObjects(sql, m);
         stockPurchaseValue = 0.0;
         stockSaleValue = 0.0;
@@ -975,8 +963,6 @@ public class ReportsStock implements Serializable, ControllerWithReportFilters {
         }
         sql += " GROUP BY bi.item";
 
-        //System.out.println("sql = " + sql);
-        //System.out.println("m = " + m);
         Set<Item> bis = new HashSet<>(itemFacade.findByJpql(sql, m));
 
         sql = "SELECT s.itemBatch.item "
@@ -1342,7 +1328,6 @@ public class ReportsStock implements Serializable, ControllerWithReportFilters {
                 + " group by s.itemBatch.item.category "
                 + " order by s.itemBatch.item.category.name";
         List<Object[]> objs = getStockFacade().findAggregates(sql, m);
-        ////System.out.println("sql = " + sql);
         totalPurchaseValue = 0.0;
         stockRecords = new ArrayList<>();
 
@@ -1374,7 +1359,6 @@ public class ReportsStock implements Serializable, ControllerWithReportFilters {
         stockSaleValue = 0.0;
         stockPurchaseValue = 0.0;
         for (Institution i : dealers) {
-            ////////System.out.println("i = " + i);
             m = new HashMap();
             m.put("ins", i);
             m.put("d", department);
@@ -1385,7 +1369,6 @@ public class ReportsStock implements Serializable, ControllerWithReportFilters {
 
             if (objs[0] != null && (Double) objs[0] > 0) {
                 StockReportRecord r = new StockReportRecord();
-                ////////System.out.println("objs = " + objs);
                 r.setInstitution(i);
                 r.setQty((Double) objs[0]);
                 r.setPurchaseValue((Double) objs[1]);
@@ -1412,7 +1395,6 @@ public class ReportsStock implements Serializable, ControllerWithReportFilters {
         stockSaleValue = 0.0;
         stockPurchaseValue = 0.0;
         for (Institution i : dealers) {
-            ////////System.out.println("i = " + i);
             m = new HashMap();
             m.put("ins", i);
             m.put("d", department);
@@ -1424,7 +1406,6 @@ public class ReportsStock implements Serializable, ControllerWithReportFilters {
 
             if (objs[0] != null && (Double) objs[0] > 0) {
                 StockReportRecord r = new StockReportRecord();
-                ////////System.out.println("objs = " + objs);
                 r.setInstitution(i);
                 r.setQty((Double) objs[0]);
                 r.setPurchaseValue((Double) objs[1]);

--- a/src/main/java/com/divudi/bean/pharmacy/ReportsTransfer.java
+++ b/src/main/java/com/divudi/bean/pharmacy/ReportsTransfer.java
@@ -285,12 +285,9 @@ public class ReportsTransfer implements Serializable {
         } else {
             sql += "order by  SUM(bi.pharmaceuticalBillItem.stock.itemBatch.retailsaleRate * bi.pharmaceuticalBillItem.qty) asc";
         }
-        ////System.out.println("sql = " + sql);
-        ////System.out.println("m = " + m);
         List<Object[]> objs = getBillItemFacade().findAggregates(sql, m, TemporalType.TIMESTAMP);
         movementRecords = new ArrayList<>();
         if (objs == null) {
-            ////System.out.println("objs = " + objs);
             return;
         }
         for (Object[] obj : objs) {
@@ -493,9 +490,6 @@ public class ReportsTransfer implements Serializable {
                         + " and b.retired=false "
                         + " order by b.id";
             }
-            System.out.println("jpql = " + jpql);
-            System.out.println("params = " + params);
-            System.out.println("getBillFacade() = " + getBillFacade());
 
             transferBills = getBillFacade().findByJpql(jpql, params, TemporalType.TIMESTAMP);
 
@@ -1287,7 +1281,6 @@ public class ReportsTransfer implements Serializable {
     public void fillItemCountsWithOutMargin(BillType bt) {
 
         List<Object[]> list = fetchBillItemWithOutMargin(bt);
-        ////System.out.println("list = " + list);
         if (list == null) {
             return;
         }
@@ -1812,7 +1805,6 @@ public class ReportsTransfer implements Serializable {
         for (Item i : fetchStockItems()) {
             ItemBHTIssueCountTrancerReciveCount count = new ItemBHTIssueCountTrancerReciveCount();
             count.setI(i);
-            //System.out.println("i.getName() = " + i.getName());
             List<Object[]> object = fetchItemDetails(i);
             double qty;
             try {

--- a/src/main/java/com/divudi/bean/pharmacy/TransferIssueController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/TransferIssueController.java
@@ -122,7 +122,6 @@ public class TransferIssueController implements Serializable {
 //                if (originalItem.getPharmaceuticalBillItem().getItemBatch() == null) {
 //                    continue;
 //                }
-//                System.out.println(originalItem.getIssuedPhamaceuticalItemQty() + " originalItem.getIssuedPhamaceuticalItemQty " + originalItem.getQty() + " originalItem.getQty()");
 //                return true;
 //            }
 //        }
@@ -130,9 +129,6 @@ public class TransferIssueController implements Serializable {
 //        return false;
 //    }
     public boolean isFullyIssued(Bill bill) {
-        System.out.println("isFullyIssued");
-        System.out.println("bill = " + bill);
-        System.out.println(" bill.getBillItems() = " + bill.getBillItems());
         if (bill == null || bill.getBillItems() == null || bill.getBillItems().isEmpty()) {
             return false; // Null or empty bills are not considered fully issued
         }
@@ -285,11 +281,6 @@ public class TransferIssueController implements Serializable {
             billItemInRequest.setIssuedPhamaceuticalItemQty(alreadyIssuedQty);
             double quantityToIssue = billItemInRequest.getQty() - alreadyIssuedQty;
 
-            System.out.println("=================================================");
-            System.out.println("Processing Item: " + billItemInRequest.getItem().getName());
-            System.out.println("Requested Qty (units): " + billItemInRequest.getPharmaceuticalBillItem().getQty());
-            System.out.println("Previously Issued (net units): " + (Math.abs(requestedQty) - Math.abs(cancelledIssued)));
-            System.out.println("Quantity To Issue Now (units): " + quantityToIssue);
 
             Item stockItem = billItemInRequest.getItem();
             double packSize = 1.0;
@@ -310,9 +301,7 @@ public class TransferIssueController implements Serializable {
             List<Stock> availableStocks = pharmacyBean.getStockByQty(stockItem, getSessionController().getDepartment());
 
             if (availableStocks == null || availableStocks.isEmpty()) {
-                System.out.println("No stock entries found in department: " + getSessionController().getDepartment().getName());
             } else {
-                System.out.println("Available stock count: " + availableStocks.size());
             }
 
             Double totalIssuedQtyInUnits = 0.0;
@@ -327,7 +316,6 @@ public class TransferIssueController implements Serializable {
                 String batchNo = issuingStock.getItemBatch().getBatchNo();
                 Date doe = issuingStock.getItemBatch().getDateOfExpire();
 
-                System.out.println("Evaluating batch " + batchNo + " with Qty (units): " + thisTimeIssuingQtyInUnits + ", DOE: " + doe);
 
                 if (totalIssuedQtyInUnits + thisTimeIssuingQtyInUnits > quantityToIssueInUnits) {
                     thisTimeIssuingQtyInUnits = quantityToIssueInUnits - totalIssuedQtyInUnits;
@@ -338,7 +326,6 @@ public class TransferIssueController implements Serializable {
                 }
 
                 if (!userStockController.isStockAvailable(issuingStock, thisTimeIssuingQtyInUnits, getSessionController().getLoggedUser())) {
-                    System.out.println("Stock unavailable or reserved: batch " + batchNo);
                     continue;
                 }
 
@@ -389,7 +376,6 @@ public class TransferIssueController implements Serializable {
                 getBillItems().add(newlyCreatedBillItemInIssueBill);
                 flagStockFound = true;
 
-                System.out.println("Issued " + thisTimeIssuingQtyInUnits + " units from batch " + batchNo);
             }
 
             if (!flagStockFound) {
@@ -399,7 +385,6 @@ public class TransferIssueController implements Serializable {
                 bItem.setReferanceBillItem(billItemInRequest);
                 getBillItems().add(bItem);
 
-                System.out.println("NO stock issued for: " + billItemInRequest.getItem().getName());
             }
         }
     }
@@ -553,17 +538,14 @@ public class TransferIssueController implements Serializable {
                 continue;
             }
 
-//            System.out.println("//Remove Department Stock = ");
             //Remove Department Stock
             boolean returnFlag = pharmacyBean.deductFromStock(i.getPharmaceuticalBillItem().getStock(),
                     Math.abs(i.getPharmaceuticalBillItem().getQtyInUnit()),
                     i.getPharmaceuticalBillItem(),
                     getSessionController().getDepartment());
-//            System.out.println("returnFlag = " + returnFlag);
             if (returnFlag) {
 
 //Addinng Staff
-//                System.out.println("//Addinng Staff = ");
                 Stock staffStock = pharmacyBean.addToStock(i.getPharmaceuticalBillItem(),
                         Math.abs(i.getPharmaceuticalBillItem().getQtyInUnit()), getIssuedBill().getToStaff());
 

--- a/src/main/java/com/divudi/bean/pharmacy/TransferReceiveController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/TransferReceiveController.java
@@ -213,12 +213,10 @@ public class TransferReceiveController implements Serializable {
 
         List<BillItem> issuedBillItems = billService.fetchBillItems(issuedBill);
         for (BillItem issuedBillItem : issuedBillItems) {
-            System.out.println("issuedBillItem = " + issuedBillItem);
             double remainingQty = calculateRemainingQty(issuedBillItem);
             if (remainingQty <= 0) {
                 continue;
             }
-            System.out.println("remainingQty = " + remainingQty);
 
             BillItem newlyCreatedReceivedBillItem = new BillItem();
             newlyCreatedReceivedBillItem.copyWithPharmaceuticalAndFinancialData(issuedBillItem);
@@ -294,7 +292,6 @@ public class TransferReceiveController implements Serializable {
 
         saveBill();
         for (BillItem i : getReceivedBill().getBillItems()) {
-            System.out.println("i.getPharmaceuticalBillItem().getQty() = " + i.getPharmaceuticalBillItem().getQty());
             if (i.getPharmaceuticalBillItem().getQty() == 0.0) {
                 continue;
             }
@@ -358,21 +355,17 @@ public class TransferReceiveController implements Serializable {
 
         double netTotal = 0.0;
 
-        System.out.println("========= Start fillData for Bill ID: " + (inputBill != null ? inputBill.getId() : "null") + " =========");
 
         for (BillItem bi : inputBill.getBillItems()) {
-            System.out.println("Processing BillItem ID: " + (bi != null ? bi.getId() : "null"));
 
             BillItemFinanceDetails bifd = bi.getBillItemFinanceDetails();
             PharmaceuticalBillItem pbi = bi.getPharmaceuticalBillItem();
 
             if (bifd == null) {
-                System.out.println("  -> Skipped: FinanceDetails is null");
                 continue;
             }
 
             if (pbi.getStock() == null || pbi.getStock().getItemBatch() == null) {
-                System.out.println("  -> Skipped: Stock or ItemBatch is null");
                 continue;
             }
 
@@ -381,56 +374,38 @@ public class TransferReceiveController implements Serializable {
             double wholesaleRate = pbi.getStock().getItemBatch().getWholesaleRate() * bifd.getUnitsPerPack().doubleValue();
             double costRate = pbi.getStock().getItemBatch().getCostRate() * bifd.getUnitsPerPack().doubleValue();
 
-            System.out.println("  fd.getQuantity() = " + bifd.getQuantity());
-            System.out.println("  fd.getFreeQuantity() = " + bifd.getFreeQuantity());
-            System.out.println("  fd.getTotalQuantity() = " + bifd.getTotalQuantity());
-            System.out.println("  purchaseRate = " + purchaseRate);
-            System.out.println("  retailRate = " + retailRate);
-            System.out.println("  wholesaleRate = " + wholesaleRate);
-            System.out.println("  costRate = " + costRate);
 
             billTotalAtCostRate += bifd.getTotalCost().doubleValue();
-            System.out.println("  Added to billTotalAtCostRate: " + bifd.getTotalCost().doubleValue() + " -> Current Total: " + billTotalAtCostRate);
 
             double paidQty = pbi.getQty() / bifd.getUnitsPerPack().doubleValue();
             double freeQty = pbi.getFreeQty() / bifd.getUnitsPerPack().doubleValue();
 
-            System.out.println("  freeQty = " + freeQty);
-            System.out.println("  paidQty = " + paidQty);
 
             double tmp;
 
             tmp = freeQty * purchaseRate;
             purchaseFree += tmp;
-            System.out.println("  purchaseFree += " + tmp + " -> " + purchaseFree);
 
             tmp = paidQty * purchaseRate;
             purchaseNonFree += tmp;
-            System.out.println("  purchaseNonFree += " + tmp + " -> " + purchaseNonFree);
 
             tmp = freeQty * retailRate;
             retailFree += tmp;
-            System.out.println("  retailFree += " + tmp + " -> " + retailFree);
 
             tmp = paidQty * retailRate;
             retailNonFree += tmp;
-            System.out.println("  retailNonFree += " + tmp + " -> " + retailNonFree);
 
             tmp = freeQty * wholesaleRate;
             wholesaleFree += tmp;
-            System.out.println("  wholesaleFree += " + tmp + " -> " + wholesaleFree);
 
             tmp = paidQty * wholesaleRate;
             wholesaleNonFree += tmp;
-            System.out.println("  wholesaleNonFree += " + tmp + " -> " + wholesaleNonFree);
 
             tmp = freeQty * costRate;
             costFree += tmp;
-            System.out.println("  costFree += " + tmp + " -> " + costFree);
 
             tmp = paidQty * costRate;
             costNonFree += tmp;
-            System.out.println("  costNonFree += " + tmp + " -> " + costNonFree);
 
             BigDecimal grossTotal = bifd.getGrossTotal();
             if (grossTotal != null) {
@@ -476,15 +451,6 @@ public class TransferReceiveController implements Serializable {
 
         }
 
-        System.out.println("========= Final Aggregated Totals =========");
-        System.out.println("costFree = " + costFree);
-        System.out.println("costNonFree = " + costNonFree);
-        System.out.println("purchaseFree = " + purchaseFree);
-        System.out.println("purchaseNonFree = " + purchaseNonFree);
-        System.out.println("retailFree = " + retailFree);
-        System.out.println("retailNonFree = " + retailNonFree);
-        System.out.println("wholesaleFree = " + wholesaleFree);
-        System.out.println("wholesaleNonFree = " + wholesaleNonFree);
 
         inputBill.getBillFinanceDetails().setTotalCostValue(BigDecimal.valueOf(costFree + costNonFree));
         inputBill.getBillFinanceDetails().setTotalCostValueFree(BigDecimal.valueOf(costFree));
@@ -508,10 +474,7 @@ public class TransferReceiveController implements Serializable {
         inputBill.setGrantTotal(netTotal);
         inputBill.setTotal(netTotal);
 
-        System.out.println("inputBill.setSaleValue = " + inputBill.getSaleValue());
-        System.out.println("inputBill.setFreeValue = " + inputBill.getFreeValue());
 
-        System.out.println("========= End fillData =========");
     }
 
     public void saveRequest() {

--- a/src/main/java/com/divudi/service/pharmacy/PharmacyCostingService.java
+++ b/src/main/java/com/divudi/service/pharmacy/PharmacyCostingService.java
@@ -609,17 +609,14 @@ public class PharmacyCostingService {
             // Fallback: calculate grossTotal if missing or 0
             if (f.getGrossTotal() == null || f.getGrossTotal().compareTo(BigDecimal.ZERO) == 0) {
                 f.setGrossTotal(grossRate.multiply(qty));
-                System.out.println("Set GrossTotal = GrossRate × Qty = " + f.getGrossTotal());
             }
 
             // Fallback net values
             if (f.getNetTotal() == null || f.getNetTotal().compareTo(BigDecimal.ZERO) == 0) {
                 f.setNetTotal(f.getGrossTotal());
-                System.out.println("NetTotal set from GrossTotal: " + f.getNetTotal());
             }
             if (f.getLineNetTotal() == null || f.getLineNetTotal().compareTo(BigDecimal.ZERO) == 0) {
                 f.setLineNetTotal(f.getLineGrossTotal());
-                System.out.println("LineNetTotal set from LineGrossTotal: " + f.getLineNetTotal());
             }
 
             BigDecimal freeQty = Optional.ofNullable(f.getFreeQuantity()).orElse(BigDecimal.ZERO);
@@ -690,7 +687,6 @@ public class PharmacyCostingService {
         bfd.setNetTotal(netTotal);
         bfd.setLineNetTotal(lineNetTotal);
 
-        System.out.println("==== Finished calculateBillTotalsFromItemsForTransferOuts ====");
     }
 
 }


### PR DESCRIPTION
- PharmacyCostingService.java: Removed 4 debug statements from transfer calculations
- TransferReceiveController.java: Removed 34 debug statements from fillData method
- TransferIssueController.java: Removed debug statements from transfer issue processing
- ReportsTransfer.java: Removed debug statements from transfer report generation
- ReportsStock.java: Removed debug statements from stock report calculations
- DealorPaymentBillSearch.java: Removed debug statements from payment processing

These debug statements were added in PR #13962 for "all item movement summary" and are no longer needed in production code.

Fixes #13968

🤖 Generated with [Claude Code](https://claude.ai/code)