### PR TITLE
Add privilege checks to All Item Movement Summary report

### DIFF
--- a/src/main/webapp/pharmacy/reports/summary_reports/all_item_movement_summary.xhtml
+++ b/src/main/webapp/pharmacy/reports/summary_reports/all_item_movement_summary.xhtml
@@ -9,8 +9,9 @@
     <h:body>
         <ui:composition template="/pharmacy/pharmacy_analytics.xhtml">
             <ui:define name="subcontent">
-
-                <p:panel header="All Item Movement Summary" >
+                
+                <h:panelGroup rendered="#{webUserController.hasPrivilege('PharmacyReports') or webUserController.hasPrivilege('PharmacyAdministration')}">
+                    <p:panel header="All Item Movement Summary" >
 
                     <h:form >
                         <h:panelGrid columns="8" styleClass="w-100 form-grid" columnClasses="label-icon-column, input-column">
@@ -211,6 +212,19 @@
                     </h:form>
 
                 </p:panel>
+                </h:panelGroup>
+                
+                <h:panelGroup rendered="#{not (webUserController.hasPrivilege('PharmacyReports') or webUserController.hasPrivilege('PharmacyAdministration'))}">
+                    <p:panel header="Access Denied">
+                        <p:messages autoUpdate="true" closable="true" />
+                        <div class="alert alert-warning" role="alert">
+                            <h4 class="alert-heading">Access Denied</h4>
+                            <p>You do not have sufficient privileges to access this report. Please contact your system administrator to request access.</p>
+                            <hr />
+                            <p class="mb-0">Required privileges: <strong>Pharmacy Reports</strong> or <strong>Pharmacy Administration</strong></p>
+                        </div>
+                    </p:panel>
+                </h:panelGroup>
 
             </ui:define>
         </ui:composition>


### PR DESCRIPTION
This change adds security checks to restrict access to the All Item Movement Summary report page. Users now need either 'PharmacyReports' or 'PharmacyAdministration' privileges to access this sensitive pharmacy reporting data.

Changes:
- Wrap main content in privilege verification block
- Add access denied message for unauthorized users
- Maintain existing page structure and functionality
- No breaking changes to current functionality

Closes #13967

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added access control to the "All Item Movement Summary" report, displaying the panel only to users with the appropriate privileges.
  * Introduced an "Access Denied" message for users without the required privileges, specifying which privileges are needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->