### PR TITLE
Add date validation to generateAllItemMovementReport method

### DIFF
--- a/src/main/java/com/divudi/bean/pharmacy/PharmacySummaryReportController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacySummaryReportController.java
@@ -644,6 +644,15 @@ public class PharmacySummaryReportController implements Serializable {
     }
 
     public void generateAllItemMovementReport() {
+        if (fromDate == null || toDate == null) {
+            JsfUtil.addErrorMessage("Please select both from and to dates");
+            return;
+        }
+        if (fromDate.after(toDate)) {
+            JsfUtil.addErrorMessage("From date must be before or equal to to date");
+            return;
+        }
+        
         HistoricalRecord hr = new HistoricalRecord();
         hr.setHistoricalRecordType(HistoricalRecordType.ASYNC_REPORT);
         hr.setVariableName("AllItemMovementSummary");


### PR DESCRIPTION
Implement input validation to prevent invalid report generation:
- Check that both fromDate and toDate are not null
- Validate that fromDate is before or equal to toDate
- Provide clear error messages to users via JsfUtil

This prevents:
- Generating reports with null dates
- Creating reports with invalid date ranges
- Unnecessary resource consumption
- Poor user experience

Fixes #13966

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added validation to ensure both start and end dates are selected and that the start date is not after the end date when generating item movement reports. Clear error messages are now shown for invalid or incomplete date selections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->