### PR TITLE
Implement optimized pharmacy retail sale page

### DIFF
--- a/src/main/java/com/divudi/bean/pharmacy/PharmacyFastRetailSaleController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacyFastRetailSaleController.java
@@ -1,0 +1,31 @@
+package com.divudi.bean.pharmacy;
+
+import javax.enterprise.context.SessionScoped;
+import javax.inject.Named;
+import java.io.Serializable;
+
+@Named
+@SessionScoped
+public class PharmacyFastRetailSaleController extends PharmacySaleController implements Serializable {
+
+    public PharmacyFastRetailSaleController() {
+    }
+
+    public String navigateToPharmacyFastRetailSale() {
+        if (sessionController.getPharmacyBillingAfterShiftStart()) {
+            financialTransactionController.findNonClosedShiftStartFundBillIsAvailable();
+            if (financialTransactionController.getNonClosedShiftStartFundBill() != null) {
+                resetAll();
+                setBillSettlingStarted(false);
+                return "/pharmacy/pharmacy_fast_retail_sale?faces-redirect=true";
+            } else {
+                JsfUtil.addErrorMessage("Start Your Shift First !");
+                return "/cashier/index?faces-redirect=true";
+            }
+        } else {
+            resetAll();
+            setBillSettlingStarted(false);
+            return "/pharmacy/pharmacy_fast_retail_sale?faces-redirect=true";
+        }
+    }
+}

--- a/src/main/java/com/divudi/core/data/Privileges.java
+++ b/src/main/java/com/divudi/core/data/Privileges.java
@@ -477,6 +477,7 @@ public enum Privileges {
     PharmacyRetailTransactionMenue("Pharmacy Retail Transaction Menu"),
     PharmacyRetailTransaction("Pharmacy Retail Transaction"),
     PharmacySale("Pharmacy Sale"),
+    PharmacySaleQuick("Pharmacy Sale Quick"),
     PharmacySaleForCashier("Pharmacy Sale for Cashier"),
     PharmacySaleWithOutStock("Pharmacy Sale without Stock"),
     PharmacySearchSaleBill("Pharmacy Search Sale Bill"),
@@ -818,6 +819,7 @@ public enum Privileges {
             // Retail Transactions
             case PharmacyRetailTransaction:
             case PharmacySale:
+            case PharmacySaleQuick:
             case PharmacySaleForCashier:
             case PharmacySaleWithOutStock:
             case PharmacySearchSaleBill:

--- a/src/main/webapp/pharmacy/pharmacy_fast_retail_sale.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_fast_retail_sale.xhtml
@@ -1,0 +1,1388 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
+      xmlns:h="http://xmlns.jcp.org/jsf/html"
+      xmlns:p="http://primefaces.org/ui"
+      xmlns:f="http://xmlns.jcp.org/jsf/core"
+      xmlns:bil="http://xmlns.jcp.org/jsf/composite/bill"
+      xmlns:phi="http://xmlns.jcp.org/jsf/composite/pharmacy"
+      xmlns:pa="http://xmlns.jcp.org/jsf/composite/paymentMethod"
+      xmlns:pat="http://xmlns.jcp.org/jsf/composite/patient"
+      xmlns:common="http://xmlns.jcp.org/jsf/composite/ezcomp/common">
+    <h:body>
+        <ui:composition template="/resources/template/template.xhtml">
+            <ui:define name="content">
+                <h:form id="bill" >
+                    <script>
+                        window.onload = function () {
+                            document.getElementById("acStock").focus();
+                        };
+                    </script>
+                    <p:growl id="panelError" />
+                    <p:defaultCommand  target="btnAdd" />
+                    <p:panel rendered="#{!pharmacySaleController.billPreview}">
+                        <i
+                            type="button"
+                            class="fas fa-shopping-cart rounded-circle shadow-lg"
+                            onclick="PF('findAMP').show()"
+                            style="font-size: 60px; right:5%; color: purple; padding: 20px; background-color: #A9CCE3; position: absolute;">
+                        </i>
+                        <p:panel>
+                            <p:commandButton icon="fas fa-file-invoice" disabled="true" value="Sale 1" action="/pharmacy/pharmacy_fast_retail_sale?faces-redirect=true" rendered="#{webUserController.hasPrivilege('PharmacySaleQuick')}" actionListener="#{pharmacyFastRetailSaleController.navigateToPharmacyFastRetailSale()}" />
+
+                            <p:dialog
+                                rendered="#{configOptionApplicationController.getBooleanValueByKey('Find Last Sale Rate of Medicines in Retail Sale',false)}"
+                                header="Search Any Medicine..."
+                                widgetVar="findAMP"
+                                minHeight="300"
+                                width="1100"
+                                position="top"
+                                modal="true"
+
+                                closeOnEscape="true">
+                                <p:autoComplete
+                                    id="exItem"
+                                    forceSelection="true"
+                                    class="w-100 formgrid grid"
+                                    placeholder="Search Any Medicine..."
+                                    maxResults="20"
+                                    minQueryLength="3"
+                                    inputStyleClass="w-100"
+                                    completeMethod="#{itemController.completeAmpItem}"
+                                    var="vt"
+                                    onfocus="this.select()"
+                                    itemLabel="#{vt.name}"
+                                    itemValue="#{vt}" >
+                                    <p:column headerText="Code" style="padding: 6px;width: 4em;">
+                                        <h:outputLabel value="#{vt.code}"></h:outputLabel>
+                                    </p:column>
+
+                                    <p:column headerText="Item" style="width: 350px; padding: 6px;">
+                                        <h:outputLabel value="#{vt.name}"></h:outputLabel>
+                                    </p:column>
+
+                                    <p:column headerText="Dept. Stock" style="padding: 6px; text-align: center;width: 5em;">
+                                        <p:outputLabel value="#{stockController.departmentItemStock(sessionController.department , vt)}">
+                                            <f:convertNumber pattern="#,###" ></f:convertNumber>
+                                        </p:outputLabel>
+                                    </p:column>
+
+                                    <p:column headerText="Price" style="padding: 6px; text-align: right;width: 6em;">
+                                        <p:outputLabel value="#{pharmacyPurchaseController.findLastRetailRate(vt)}">
+                                            <f:convertNumber pattern="#,##0.00" ></f:convertNumber>
+                                        </p:outputLabel>
+                                    </p:column>
+                                </p:autoComplete>
+                            </p:dialog>
+
+                        </p:panel>
+
+
+                        <p:panel class="w-100">
+                            <f:facet name="header" >
+                                <h:outputText styleClass="fas fa-mortar-pestle" />
+                                <h:outputLabel value="Pharmacy Retail Bill (Sale 1)" class="mx-4"></h:outputLabel>
+                                <p:commandButton
+                                    accesskey="n"
+                                    icon="fa fa-plus"
+                                    value="New Bill"
+                                    style="float: right;"
+                                    ajax="false" action="pharmacy_bill_retail_sale"
+                                    class="mx-1 ui-button-warning"
+                                    actionListener="#{pharmacySaleController.resetAll()}"  >
+                                </p:commandButton>
+                                <p:commandButton
+                                    ajax="false"
+                                    accesskey="s"
+                                    value="Settle"
+                                    icon="fa fa-check"
+                                    style="float: right;"
+                                    class="ui-button-success mx-1"
+                                    onclick="if (!confirm('Are you sure?'))
+                                                return false"
+                                    action="#{pharmacySaleController.settleBillWithPay}" >
+                                </p:commandButton>
+                            </f:facet>
+
+                            <style>
+                                @keyframes slideInFromButton {
+                                    0% {
+                                        transform: scale(0) translate(50, 50);
+                                        opacity: 0;
+                                    }
+                                    100% {
+                                        transform: scale(1) translate(50, 50);
+                                        opacity: 1;
+                                    }
+                                }
+
+                                .custom-dialog {
+                                    animation: slideInFromButton 0.3s ease-out;
+                                }
+                            </style>
+
+                            <div class="row">
+                                <div class="col-md-7" >
+                                    <p:panel>
+                                        <f:facet name="header" >
+                                            <h:outputText styleClass="fa-solid fa-circle-plus" />
+                                            <h:outputText value="Add New Items" class="mx-4"></h:outputText>
+                                        </f:facet>
+                                        <div class="row w-100 m-1 p-1 boder-1">
+                                            <div class="col-md-5">
+                                                <p:focus id="focusForAcIx" for="acStock" ></p:focus>
+                                                <p:outputLabel
+                                                    class="w-100"
+                                                    for="acStock">Medicines or Devices</p:outputLabel>
+                                                <h:panelGroup id="acStock" >
+                                                    <p:autoComplete
+                                                        accesskey="i"
+                                                        rendered="#{not configOptionApplicationController.getBooleanValueByKey('Display Total Stock when listing medicines for Retail Sale',true)}"
+                                                        id="acStockWithoutTotalStock"
+                                                        inputStyleClass="w-100"
+                                                        minQueryLength="3"
+                                                        maxResults="10"
+                                                        class="w-100"
+                                                        forceSelection="true"
+                                                        value="#{pharmacySaleController.stock}"
+                                                        completeMethod="#{pharmacySaleController.completeAvailableStockOptimized}"
+                                                        var="i"
+                                                        itemLabel="#{i.itemBatch.item.name}"
+                                                        itemValue="#{i}">
+                                                        <p:column headerText="Item" style="padding: 8px;" styleClass="#{commonFunctionsProxy.currentDateTime > i.itemBatch.dateOfExpire ?'ui-messages-fatal': commonFunctionsProxy.dateAfterThreeMonthsCurrentDateTime > i.itemBatch.dateOfExpire ?'ui-messages-warn':''}">
+                                                            <h:outputText value="#{i.itemBatch.item.name}"  style="width: 300px!important;">
+                                                                &nbsp;<p:tag rendered="#{commonFunctionsProxy.currentDateTime > i.itemBatch.dateOfExpire ?'true': commonFunctionsProxy.dateAfterThreeMonthsCurrentDateTime > i.itemBatch.dateOfExpire ?'true':'false'}" value="#{commonFunctionsProxy.currentDateTime > i.itemBatch.dateOfExpire ?'Expired ': commonFunctionsProxy.dateAfterThreeMonthsCurrentDateTime > i.itemBatch.dateOfExpire ?'Expired Soon':''}" severity="#{commonFunctionsProxy.currentDateTime > i.itemBatch.dateOfExpire ?'danger': commonFunctionsProxy.dateAfterThreeMonthsCurrentDateTime > i.itemBatch.dateOfExpire ?'warning':''}" />
+                                                            </h:outputText>
+                                                        </p:column>
+                                                        <p:column
+                                                            rendered="#{configOptionApplicationController.getBooleanValueByKey('Medicine Identification Codes Used',true)}"
+                                                            headerText="Code" style="padding: 8px;" styleClass="#{commonFunctionsProxy.currentDateTime > i.itemBatch.dateOfExpire ?'ui-messages-fatal': commonFunctionsProxy.dateAfterThreeMonthsCurrentDateTime > i.itemBatch.dateOfExpire ?'ui-messages-warn':''}">
+                                                            <h:outputText value="#{i.itemBatch.item.code}" style="width: 50px!important;"></h:outputText>
+                                                        </p:column>
+                                                        <p:column headerText="Generic" style="padding: 8px;" styleClass="#{commonFunctionsProxy.currentDateTime > i.itemBatch.dateOfExpire ?'ui-messages-fatal': commonFunctionsProxy.dateAfterThreeMonthsCurrentDateTime > i.itemBatch.dateOfExpire ?'ui-messages-warn':''}">
+                                                            <h:outputText value="#{i.itemBatch.item.vmp.name}" style="width: 150px!important;"></h:outputText>
+                                                        </p:column>
+                                                        <p:column
+                                                            headerText="Rate" style="padding: 8px;" styleClass="text-end #{commonFunctionsProxy.currentDateTime > i.itemBatch.dateOfExpire ?'ui-messages-fatal': commonFunctionsProxy.dateAfterThreeMonthsCurrentDateTime > i.itemBatch.dateOfExpire ?'ui-messages-warn':''}">
+                                                            <h:outputLabel value="#{i.itemBatch.retailsaleRate}" style="width: 80px!important;">
+                                                                <f:convertNumber pattern="#,##0.00" ></f:convertNumber>
+                                                            </h:outputLabel>
+                                                        </p:column>
+                                                        <p:column headerText="Stocks" style="padding: 8px;" styleClass="text-end #{commonFunctionsProxy.currentDateTime > i.itemBatch.dateOfExpire ?'ui-messages-fatal': commonFunctionsProxy.dateAfterThreeMonthsCurrentDateTime > i.itemBatch.dateOfExpire ?'ui-messages-warn':''}">
+                                                            <h:outputLabel value="#{i.stock}" >
+                                                                <f:convertNumber pattern="#,###" ></f:convertNumber>
+                                                            </h:outputLabel>
+                                                        </p:column>
+                                                        <p:column headerText="Expiry" style="padding: 8px;" class="w-100" styleClass="text-end #{commonFunctionsProxy.currentDateTime > i.itemBatch.dateOfExpire ?'ui-messages-fatal': commonFunctionsProxy.dateAfterThreeMonthsCurrentDateTime > i.itemBatch.dateOfExpire ?'ui-messages-warn':''}">
+                                                            <h:outputLabel value="#{i.itemBatch.dateOfExpire}" style="width: 100px!important;" >
+                                                                <f:convertDateTime pattern="#{sessionController.applicationPreference.shortDateFormat}" ></f:convertDateTime>
+                                                            </h:outputLabel>
+                                                        </p:column>
+                                                        <p:ajax event="focus" process="acStock :#{p:resolveFirstComponentWithId('cmbPs',view).clientId} :#{p:resolveFirstComponentWithId('cmbPaymentScheme',view).clientId}"  ></p:ajax>
+                                                        <p:ajax event="itemSelect" listener="#{pharmacySaleController.handleSelect}" update="txtQty txtRate focusQty txtItemInstructions :#{p:resolveFirstComponentWithId('lstReplaceableBatch',view).clientId}" ></p:ajax>
+                                                        <p:ajax event="query" update=":#{p:resolveFirstComponentWithId('tabI',view).clientId}" process="acStock"></p:ajax>
+                                                    </p:autoComplete>
+                                                    <p:autoComplete
+                                                        accesskey="i"
+                                                        rendered="#{configOptionApplicationController.getBooleanValueByKey('Display Total Stock when listing medicines for Retail Sale',true)}"
+                                                        id="acStockWithTotalStock"
+                                                        inputStyleClass="w-100"
+                                                        minQueryLength="3"
+                                                        maxResults="20"
+                                                        class="w-100"
+                                                        forceSelection="true"
+                                                        value="#{pharmacySaleController.stock}"
+                                                        completeMethod="#{stockController.completeAvailableStocksWithItemStock}"
+                                                        scrollHeight="400"
+                                                        var="i"
+                                                        itemLabel="#{i.itemBatch.item.name}"
+                                                        itemValue="#{i}">
+                                                        <p:column headerText="Item" style="padding: 8px;" styleClass="#{commonFunctionsProxy.currentDateTime > i.itemBatch.dateOfExpire ?'ui-messages-fatal': commonFunctionsProxy.dateAfterThreeMonthsCurrentDateTime > i.itemBatch.dateOfExpire ?'ui-messages-warn':''}">
+                                                            <h:outputText value="#{i.itemBatch.item.name}"  style="width: 300px!important;">
+                                                                &nbsp;<p:tag rendered="#{commonFunctionsProxy.currentDateTime > i.itemBatch.dateOfExpire ?'true': commonFunctionsProxy.dateAfterThreeMonthsCurrentDateTime > i.itemBatch.dateOfExpire ?'true':'false'}" value="#{commonFunctionsProxy.currentDateTime > i.itemBatch.dateOfExpire ?'Expired ': commonFunctionsProxy.dateAfterThreeMonthsCurrentDateTime > i.itemBatch.dateOfExpire ?'Expired Soon':''}" severity="#{commonFunctionsProxy.currentDateTime > i.itemBatch.dateOfExpire ?'danger': commonFunctionsProxy.dateAfterThreeMonthsCurrentDateTime > i.itemBatch.dateOfExpire ?'warning':''}" />
+                                                            </h:outputText>
+                                                            <h:outputLabel value=" (" ></h:outputLabel>
+                                                            <h:outputText value="#{i.itemBatch.item.code}" style="width: 50px!important;"></h:outputText>
+                                                            <h:outputLabel value=") - " ></h:outputLabel>
+                                                            <h:outputText value="#{i.itemBatch.item.vmp.name}" style="width: 150px!important;"></h:outputText>
+                                                        </p:column>
+                                                        <p:column headerText="Rate" style="padding: 8px;" styleClass="#{commonFunctionsProxy.currentDateTime > i.itemBatch.dateOfExpire ?'ui-messages-fatal': commonFunctionsProxy.dateAfterThreeMonthsCurrentDateTime > i.itemBatch.dateOfExpire ?'ui-messages-warn':''}">
+                                                            <h:outputLabel value="#{i.itemBatch.retailsaleRate}" style="width: 80px!important;">
+                                                                <f:convertNumber pattern="#,##0.00" ></f:convertNumber>
+                                                            </h:outputLabel>
+                                                        </p:column>
+                                                        <p:column headerText="Stocks" style="padding: 8px;" styleClass="#{commonFunctionsProxy.currentDateTime > i.itemBatch.dateOfExpire ?'ui-messages-fatal': commonFunctionsProxy.dateAfterThreeMonthsCurrentDateTime > i.itemBatch.dateOfExpire ?'ui-messages-warn':''}">
+                                                            <h:outputLabel value="#{i.stock}" >
+                                                                <f:convertNumber pattern="#,###" ></f:convertNumber>
+                                                            </h:outputLabel>
+                                                        </p:column>
+                                                        <p:column headerText="Total Stock" style="padding: 8px;" styleClass="#{commonFunctionsProxy.currentDateTime > i.itemBatch.dateOfExpire ?'ui-messages-fatal': commonFunctionsProxy.dateAfterThreeMonthsCurrentDateTime > i.itemBatch.dateOfExpire ?'ui-messages-warn':''}">
+                                                            <h:outputLabel value="#{i.transItemStockQty}" >
+                                                                <f:convertNumber pattern="#,###" ></f:convertNumber>
+                                                            </h:outputLabel>
+                                                        </p:column>
+                                                        <p:column headerText="Expiry" style="padding: 8px;" class="w-100" styleClass="#{commonFunctionsProxy.currentDateTime > i.itemBatch.dateOfExpire ?'ui-messages-fatal': commonFunctionsProxy.dateAfterThreeMonthsCurrentDateTime > i.itemBatch.dateOfExpire ?'ui-messages-warn':''}">
+                                                            <h:outputLabel value="#{i.itemBatch.dateOfExpire}" style="width: 100px!important;" >
+                                                                <f:convertDateTime pattern="#{sessionController.applicationPreference.shortDateFormat}" ></f:convertDateTime>
+                                                            </h:outputLabel>
+                                                        </p:column>
+                                                        <p:ajax event="focus" process="acStock :#{p:resolveFirstComponentWithId('cmbPs',view).clientId} :#{p:resolveFirstComponentWithId('cmbPaymentScheme',view).clientId}"  ></p:ajax>
+                                                        <p:ajax event="itemSelect" listener="#{pharmacySaleController.handleSelect}" update="txtQty txtRate focusQty txtItemInstructions :#{p:resolveFirstComponentWithId('lstReplaceableBatch',view).clientId}" ></p:ajax>
+                                                        <p:ajax event="query" update=":#{p:resolveFirstComponentWithId('tabI',view).clientId}" process="acStock"></p:ajax>
+                                                    </p:autoComplete>
+                                                </h:panelGroup>
+
+
+                                            </div>
+                                            <div class="col-md-2">
+                                                <p:outputLabel
+                                                    class="w-100"
+                                                    for="txtQty">Quantity</p:outputLabel>
+                                                <p:inputText
+                                                    id="txtQty"
+                                                    accesskey="q"
+                                                    autocomplete="off"
+                                                    class="w-100"
+                                                    style="text-align: right;"
+                                                    value="#{pharmacySaleController.intQty}">
+                                                    <p:ajax event="keyup" listener="#{pharmacySaleController.calculateBillItemListner}" process="acStock txtQty :#{p:resolveFirstComponentWithId('cmbPs',view).clientId} :#{p:resolveFirstComponentWithId('cmbPaymentScheme',view).clientId}" update="txtRate txtVal"></p:ajax>
+                                                    <p:ajax event="blur" listener="#{pharmacySaleController.calculateBillItemListner}" process="acStock txtQty :#{p:resolveFirstComponentWithId('cmbPs',view).clientId} :#{p:resolveFirstComponentWithId('cmbPaymentScheme',view).clientId}" update="txtRate txtVal"></p:ajax>
+                                                </p:inputText>
+
+                                            </div>
+                                            <div class="col-md-5">
+                                                <div class="row" >
+                                                    <div class="col-md-4">
+                                                        <p:outputLabel value="&nbsp;" class="w-100" ></p:outputLabel>
+                                                        <p:commandButton
+                                                            id="btnAdd"
+                                                            accesskey="a"
+                                                            icon="fa fa-plus"
+                                                            value="Add"
+                                                            styleClass="ui-button-success"
+                                                            action="#{pharmacySaleController.addBillItem()}"
+                                                            process="@this acStock txtQty :#{p:resolveFirstComponentWithId('cmbPs',view).clientId} :#{p:resolveFirstComponentWithId('cmbPaymentScheme',view).clientId} focusForAcIx"
+                                                            update=":#{p:resolveFirstComponentWithId('netTotal',view).clientId} :#{p:resolveFirstComponentWithId('dis',view).clientId} :#{p:resolveFirstComponentWithId('total',view).clientId} :#{p:resolveFirstComponentWithId('panelBillDetails',view).clientId} :#{p:resolveFirstComponentWithId('tblBillItem',view).clientId} txtRate txtQty acStock focusItem :#{p:resolveFirstComponentWithId('tabI',view).clientId} :#{p:resolveFirstComponentWithId('panelError',view).clientId} txtItemInstructions" >
+                                                        </p:commandButton>
+
+                                                    </div>
+                                                    <div class="col-md-4">
+                                                        <p:outputLabel class="w-100" for="txtRate">Rate</p:outputLabel>
+                                                        <p:inputText
+                                                            id="txtRate"
+                                                            style="text-align: right;"
+                                                            class="w-100"
+                                                            readonly="true"
+                                                            value="#{pharmacySaleController.billItem.netRate}">
+                                                            <f:convertNumber pattern="#,##0.00" />
+                                                        </p:inputText>
+                                                    </div>
+                                                    <div class="col-md-4">
+                                                        <p:outputLabel
+                                                            class="w-100"
+                                                            value="Value"
+                                                            for="txtVal">
+                                                        </p:outputLabel>
+                                                        <p:inputText
+                                                            readonly="true"
+                                                            id="txtVal"
+                                                            class="w-100"
+                                                            style="text-align: right;"
+                                                            value="#{pharmacySaleController.billItem.netValue}">
+                                                            <f:convertNumber pattern="#,##0.00" />
+                                                        </p:inputText>
+                                                    </div>
+                                                </div>
+                                            </div>
+                                        </div>
+                                        <div class="row w-100 m-1 p-1 boder-1">
+                                            <div class="col-12" >
+                                                <h:panelGroup id="txtItemInstructions" style="display: #{pharmacySaleController.billItem != null and not empty pharmacySaleController.billItem.instructions ? 'block' : 'none'}">
+                                                    <h:outputLabel style="font-weight: bold" value="Instructions : " for="instructionText"></h:outputLabel>
+                                                    <h:outputText id="instructionText" class=" text-muted" value=" #{pharmacySaleController.billItem.instructions}" ></h:outputText>
+                                                </h:panelGroup>
+                                            </div>
+                                        </div>
+                                        <p:focus id="focusQty" for="txtQty"></p:focus>
+                                        <p:focus id="focusItem" for="acStock"></p:focus>
+                                    </p:panel>
+
+                                    <p:panel id="pBis">
+                                        <f:facet name="header" >
+                                            <h:outputText styleClass="fas fa-money-bill" />
+                                            <h:outputLabel value="Bill Items" class="mx-4"></h:outputLabel>
+                                        </f:facet>
+
+                                        <p:dataTable id="tblBillItem" value="#{pharmacySaleController.preBill.billItems}"
+                                                     var="bi" rowIndexVar="s" editable="true" sortBy="#{bi.searialNo}" class="w-100">
+
+                                            <p:ajax event="rowEdit" listener="#{pharmacySaleController.onEdit}" update="@this gros :#{p:resolveFirstComponentWithId('panelBillDetails',view).clientId}" />
+                                            <p:ajax event="rowEditCancel" listener="#{pharmacySaleController.onEdit}" update="@this gros :#{p:resolveFirstComponentWithId('panelBillDetails',view).clientId}" />
+
+                                            <p:column headerText="No" style="width: 2em; padding: 6px;">
+                                                <h:outputLabel value="#{s+1}" >
+                                                    <f:convertNumber pattern="#,##0" />
+                                                </h:outputLabel>
+                                            </p:column>
+
+                                            <p:column headerText="Item" style="padding: 6px;">
+                                                <h:outputLabel value="#{bi.pharmaceuticalBillItem.itemBatch.item.name}" />
+                                                <p:commandLink id="showDetails" type="button" value="&nbsp;(+)" oncomplete="PF('dlg').show();" process="showDetails" update="#{p:resolveFirstComponentWithId('panDoc',view).clientId}" />
+
+                                                <p:dialog
+                                                    id="panDoc"
+                                                    widgetVar="dlg"
+                                                    resizable="false"
+                                                    modal="true"
+                                                    onShow="$('.ui-dialog').addClass('custom-dialog')"
+                                                    class="w-50">
+                                                    <p:panelGrid
+                                                        columns="2"
+                                                        class="table table-striped"
+                                                        >
+                                                        <f:facet name="header" >
+                                                            <h:outputLabel value="Item Details" ></h:outputLabel>
+                                                        </f:facet>
+
+                                                        <p:outputLabel value="Code" style="font-weight: bold;"/>
+                                                        <p:outputLabel value="#{bi.pharmaceuticalBillItem.itemBatch.item.code}"/>
+
+                                                        <p:outputLabel value="Name" style="font-weight: bold;"/>
+                                                        <p:outputLabel value="#{bi.pharmaceuticalBillItem.itemBatch.item.name}"/>
+
+                                                        <p:outputLabel value="Type" style="font-weight: bold;"/>
+                                                        <p:outputLabel value="#{bi.pharmaceuticalBillItem.itemBatch.item.class.simpleName}"/>
+
+                                                        <p:outputLabel value="Product" style="font-weight: bold;"/>
+                                                        <p:outputLabel value="#{bi.pharmaceuticalBillItem.itemBatch.item.vmp.name}"/>
+
+
+                                                        <p:outputLabel value="Stock Quentity" style="font-weight: bold;"/>
+                                                        <p:outputLabel value="#{bi.pharmaceuticalBillItem.stock.stock}"/>
+
+                                                        <p:outputLabel value="Expiry" style="font-weight: bold;"/>
+                                                        <p:outputLabel value="#{bi.pharmaceuticalBillItem.itemBatch.dateOfExpire}">
+                                                            <f:convertDateTime  pattern="#{sessionController.applicationPreference.shortDateFormat}" />
+                                                        </p:outputLabel>
+
+                                                        <p:outputLabel value="Batch No" style="font-weight: bold;"/>
+                                                        <p:outputLabel value="#{bi.pharmaceuticalBillItem.itemBatch.batchNo}"/>
+
+                                                        <p:outputLabel value="Sale Rate" style="font-weight: bold;"/>
+                                                        <p:outputLabel value="#{bi.pharmaceuticalBillItem.itemBatch.retailsaleRate}"/>
+                                                    </p:panelGrid>
+
+
+                                                </p:dialog>
+                                            </p:column>
+
+                                            <p:column headerText="Instructions" style="text-align: center" rendered="#{configOptionApplicationController.getBooleanValueByKey('Enable label printing for pharmacy medicines', false)}">
+                                                <p:commandButton style="font-size: small; margin: auto; border-radius: 10px" actionListener="#{pharmacySaleController.addPrescriptionToBillitem(bi)}" id="processInstructions" class="ui-button-info" value="Add" oncomplete="PF('instructions').show();" process="processInstructions" update="#{p:resolveFirstComponentWithId('instructionDetials',view).clientId}"></p:commandButton>
+
+                                                <p:dialog
+                                                    id="instructionDetials"
+                                                    widgetVar="instructions"
+                                                    resizable="false"
+                                                    closable="false"
+                                                    modal="true"
+                                                    onShow="$('.ui-dialog').addClass('custom-dialog')"
+
+                                                    >
+                                                    <p:panel>
+                                                        <f:facet name="header" class="align-items-center">
+                                                            <h:outputText styleClass="fas fa-pills"/>
+                                                            <p:outputLabel class="mx-4" value="Instruction for the #{bi.item.name}" />
+
+                                                            <p:commandButton value="Close" process="@this" class='ui-button-warning' style="float: right;" oncomplete="PF('instructions').hide()"/>
+
+                                                        </f:facet>
+                                                        <div>
+
+                                                            <!-- Dose Group -->
+                                                            <div class="row align-items-center text-left text-start">
+                                                                <div class="col-md-3">
+                                                                    <label>Dose:</label>
+                                                                </div>
+
+                                                                <div class="col-3">
+                                                                    <p:inputText
+                                                                        id="txtDose"
+                                                                        class="w-100"
+                                                                        value="#{bi.prescription.dose}"
+                                                                        placeholder="Dose"/>
+
+                                                                </div>
+                                                                <div class="col-md-3">
+                                                                    <p:selectOneMenu id="cmbDose"
+                                                                                     value="#{bi.prescription.doseUnit}">
+                                                                        <f:selectItem itemLabel="Select" />
+                                                                        <f:selectItems value="#{measurementUnitController.getDoseUnitsForMedicine(patientEncounterController.encounterMedicine.prescription.item)}"
+                                                                                       var="du" itemLabel="#{du.name}" itemValue="#{du}" />
+                                                                    </p:selectOneMenu>
+                                                                </div>
+                                                            </div>
+
+                                                            <!-- Frequency Selection -->
+                                                            <div class="row my-3 text-start align-items-center">
+                                                                <div class="col-md-3">
+                                                                    <label for="cmbFrequency">Frequency:</label>
+                                                                </div>
+
+                                                                <div class="col-md-6">
+                                                                    <p:selectOneMenu id="cmbFrequency"
+                                                                                     class="w-100"
+                                                                                     value="#{bi.prescription.frequencyUnit}">
+                                                                        <f:selectItem itemLabel="Select" />
+                                                                        <f:selectItems value="#{measurementUnitController.frequencyUnits}"
+                                                                                       var="du"
+                                                                                       itemLabel="#{du.name}"
+                                                                                       itemValue="#{du}" />
+                                                                    </p:selectOneMenu>
+                                                                </div>
+
+                                                            </div>
+
+                                                            <!-- Duration Group -->
+                                                            <div class="row text-start align-items-center">
+                                                                <div class="col-md-3">
+                                                                    <label>Duration:</label>
+                                                                </div>
+
+                                                                <div class="col-md-3">
+                                                                    <p:inputText style="width: 6em;"
+                                                                                 id="txtDuration"
+                                                                                 value="#{bi.prescription.duration}"
+                                                                                 placeholder="Duration"/>
+
+                                                                </div>
+
+                                                                <div class="col-md-3">
+                                                                    <p:selectOneMenu id="cmbDuration"
+                                                                                     value="#{bi.prescription.durationUnit}">
+                                                                        <f:selectItem itemLabel="Select" />
+                                                                        <f:selectItems value="#{measurementUnitController.durationUnits}"
+                                                                                       var="du"
+                                                                                       itemLabel="#{du.name}"
+                                                                                       itemValue="#{du}" />
+                                                                    </p:selectOneMenu>
+                                                                </div>
+                                                            </div>
+
+                                                            <div class="row text-start my-3">
+                                                                <div class="col-md-3">
+                                                                    <label for="instructionText" class="w-100">Comment :</label>
+                                                                </div>
+
+                                                                <div class="col-md-9">
+                                                                    <p:inputTextarea value="#{bi.prescription.comment}" id="instructionText" rows="6" cols="33"/>
+                                                                </div>
+
+
+                                                            </div>
+
+                                                            <!-- Add Prescription Button -->
+                                                            <div class="row">
+                                                                <div class="col-md-6">
+                                                                    <p:commandButton value="Print Label"
+                                                                                     class="ui-button-info w-100"
+                                                                                     action="#{pharmacySaleController.enableLabelPrint(bi.prescription)}"
+                                                                                     ajax="true"
+                                                                                     update="printLabelSection"
+                                                                                     oncomplete="PF('printLabelSectionView').show()"
+
+                                                                                     >
+
+                                                                    </p:commandButton>
+
+
+                                                                </div>
+                                                                <div class="col-md-6">
+                                                                    <p:commandButton value="Add Instructions"
+                                                                                     class="ui-button-success w-100"
+                                                                                     id="btnAddRx"
+                                                                                     icon="pi pi-plus"
+                                                                                     process="btnAddRx instructionDetials "
+                                                                                     update="tblBillItem"
+                                                                                     action="#{pharmacySaleController.addPrescriptionToBillitem(bi)}" />
+                                                                </div>
+                                                            </div>
+                                                        </div>
+                                                    </p:panel>
+
+                                                </p:dialog>
+
+                                                <p:dialog
+                                                    id="printLabelDialog"
+                                                    widgetVar="printLabelSectionView"
+                                                    resizable="false"
+                                                    closable="true"
+                                                    modal="true"
+                                                    onShow="$('.ui-dialog').addClass('custom-dialog')"
+
+                                                    >
+
+                                                    <h:panelGroup id="printLabelSection">
+                                                        <phi:pharmacy_instruction_label billItem="#{bi}" controller="#{pharmacySaleController}"/>
+                                                    </h:panelGroup>
+
+                                                    <p:commandButton value="Print Label"
+                                                                     class="ui-button-info w-100 my-4"
+                                                                     action="#{pharmacySaleController.enableLabelPrint(bi.prescription)}"
+                                                                     ajax="false"
+                                                                     update="printLabelSection instructionDetials"
+                                                                     oncomplete="PF('printLabelSectionView').show()"
+                                                                     process="@this"
+                                                                     >
+                                                        <p:printer target="printLabelSection"></p:printer>
+
+                                                    </p:commandButton>
+                                                </p:dialog>
+
+                                            </p:column>
+
+                                            <p:column headerText="Rate" style="width: 5em; padding: 6px;">
+                                                <h:outputLabel id="rate" value="#{bi.rate}" >
+                                                    <f:convertNumber pattern="#,##0.00" />
+                                                </h:outputLabel>
+                                            </p:column>
+                                            <p:column headerText="Value" style="width: 5em; padding: 6px;">
+                                                <h:outputLabel value="#{bi.grossValue}" id="gros">
+                                                    <f:convertNumber pattern="#,##0.00" />
+                                                </h:outputLabel>
+                                            </p:column>
+                                            <p:column headerText="Expiry" style="width: 7em; padding: 6px;">
+                                                <h:outputLabel value="#{bi.pharmaceuticalBillItem.itemBatch.dateOfExpire}" >
+                                                    <f:convertDateTime  timeZone="Asia/Colombo" pattern="#{sessionController.applicationPreference.shortDateFormat}"  ></f:convertDateTime>
+                                                </h:outputLabel>
+
+                                            </p:column>
+                                            <p:column headerText="Qty" style="width: 3em; padding: 6px;">
+                                                <p:cellEditor>
+                                                    <f:facet name="output">
+                                                        <h:outputText value="#{bi.qty}">
+                                                            <f:convertNumber integerOnly="true" pattern="#,##0"/>
+                                                        </h:outputText>
+                                                    </f:facet>
+                                                    <f:facet name="input">
+                                                        <p:inputText
+                                                            autocomplete="off"
+                                                            id="ipTblQty"
+                                                            value="#{bi.qty}"
+                                                            style="width:96%"
+                                                            converterMessage="Please enter a valid integer value.">
+                                                            <f:convertNumber integerOnly="true" pattern="#,##0"/>
+                                                        </p:inputText>
+                                                    </f:facet>
+                                                </p:cellEditor>
+                                            </p:column>
+
+
+                                            <p:column style="width: 10em; padding: 6px;">
+                                                <p:rowEditor style="display: inline-block; margin-right: 10px;"/>
+                                                <p:commandButton
+                                                    id="btnDelete"
+                                                    icon="fas fa-trash"
+                                                    action="#{pharmacySaleController.removeBillItem(bi)}"
+                                                    class="ui-button-danger"
+                                                    process="btnDelete"
+                                                    update="tblBillItem :#{p:resolveFirstComponentWithId('panelBillDetails',view).clientId} :#{p:resolveFirstComponentWithId('panelPayment',view).clientId}"
+                                                    style="display: inline-block;">
+                                                </p:commandButton>
+                                            </p:column>
+
+
+                                        </p:dataTable>
+                                    </p:panel>
+                                    <p:panel id="tabI" class="my-1 ">
+                                        <f:facet name="header" >
+                                            <h:outputText styleClass="fas fa-check-circle" />
+                                            <h:outputLabel value="Alternatives" class="mx-4"></h:outputLabel>
+                                        </f:facet>
+                                        <p:dataTable
+                                            class="w-100"
+                                            id="lstReplaceableBatch"
+                                            selection="#{pharmacySaleController.replacableStock}"
+                                            value="#{pharmacySaleController.replaceableStocks}"
+                                            var="ri"
+                                            selectionMode="single"
+                                            rowKey="#{ri.id}"
+                                            emptyMessage="System can not detect suitable replacements.">
+                                            <p:ajax event="rowSelect" process="@this" update=":#{p:resolveFirstComponentWithId('acStock',view).clientId}" listener="#{pharmacySaleController.makeStockAsBillItemStock()}" ></p:ajax>
+                                            <p:ajax event="rowUnselect" process="@this" update=":#{p:resolveFirstComponentWithId('acStock',view).clientId}" listener="#{pharmacySaleController.makeStockAsBillItemStock()}" ></p:ajax>
+                                            <p:column headerText="Item">
+                                                #{ri.itemBatch.item.name}
+                                            </p:column>
+                                            <p:column headerText="Code">
+                                                #{ri.itemBatch.item.code}
+                                            </p:column>
+                                            <p:column headerText="Rate"  style="text-align: right;">
+                                                <p:outputLabel value="#{ri.itemBatch.retailsaleRate}">
+                                                    <f:convertNumber pattern="#,##0.00" ></f:convertNumber>
+                                                </p:outputLabel>
+                                            </p:column>
+                                            <p:column headerText="Stocks" style="text-align: right;">
+                                                <p:outputLabel value="#{ri.stock}"  style="width: 50px!important;">
+                                                    <f:convertNumber pattern="#,###" ></f:convertNumber>
+                                                </p:outputLabel>
+                                            </p:column>
+                                            <p:column headerText="Expiry">
+                                                <h:panelGroup rendered="#{commonFunctionsProxy.currentDateTime > ri.itemBatch.dateOfExpire}" >
+                                                    <p:outputLabel value="#{ri.itemBatch.dateOfExpire}" styleClass="ui-messages-fatal"  >
+                                                        <f:convertDateTime pattern="#{sessionController.applicationPreference.shortDateFormat}" ></f:convertDateTime>
+                                                    </p:outputLabel>
+                                                </h:panelGroup>
+                                                <h:panelGroup rendered="#{ri.itemBatch.dateOfExpire > commonFunctionsProxy.currentDateTime}" >
+                                                    <p:outputLabel value="#{ri.itemBatch.dateOfExpire}" >
+                                                        <f:convertDateTime pattern="#{sessionController.applicationPreference.shortDateFormat}" ></f:convertDateTime>
+                                                    </p:outputLabel>
+                                                </h:panelGroup>
+                                            </p:column>
+                                        </p:dataTable>
+
+
+
+                                    </p:panel>
+
+
+
+
+
+
+
+                                </div>
+                                <div class="col-md-5"  >
+                                    <h:panelGrid id="sale" columns="1" class="alignTop w-100"  >
+                                        <p:panel id="panelPatient">
+                                            <p:growl id="msg"/>
+                                            <f:facet name="header">
+                                                <h:panelGroup layout="block" styleClass="d-flex justify-content-between align-items-center">
+                                                    <h:panelGroup id="headerFacet">
+                                                        <h:outputText value="Select a Patient" rendered="#{pharmacySaleController.patient eq null}"></h:outputText>
+                                                        <h:outputText styleClass="fas fa-user" />
+                                                        <h:panelGroup
+                                                            rendered="#{patientController.quickSearchPatientList eq null or empty patientController.quickSearchPatientList}">
+                                                            <h:outputText
+                                                                rendered="#{pharmacySaleController.patient.id eq null}"
+                                                                value="Patient"
+                                                                class="mx-4"
+                                                                >
+                                                            </h:outputText>
+                                                            <h:outputText
+                                                                rendered="#{pharmacySaleController.patient.id ne null}"
+                                                                value="Searched Patient Details"
+                                                                class="mx-2"
+                                                                ></h:outputText>
+                                                            <h:panelGroup rendered="#{cc.attrs.editable}" id="edit" >
+                                                                <p:selectBooleanButton
+                                                                    value="#{pharmacySaleController.patientDetailsEditable}"
+                                                                    offIcon="pi pi-pencil"
+                                                                    onIcon="pi pi-eye"
+                                                                    class="mx-2"
+                                                                    >
+                                                                    <p:ajax
+                                                                        process="@this"
+                                                                        update="viewPatient editPatient btnDone edit" />
+                                                                </p:selectBooleanButton>
+                                                                <p:commandButton id="btnDone" alt="Save Patient Details" class="ui-button-success" icon="fas fa-check" action="#{patientController.saveSelected(pharmacySaleController.patient)}" rendered="#{pharmacySaleController.patientDetailsEditable}" update=":#{p:resolveFirstComponentWithId('panelPatient',view).clientId} " />
+                                                            </h:panelGroup>
+
+                                                        </h:panelGroup>
+                                                    </h:panelGroup>
+                                                    <h:panelGroup id="quickSearch" >
+                                                        <h:panelGroup layout="block"  styleClass="form-inline">
+                                                            <p:inputText
+                                                                autocomplete="off"
+                                                                id="txtQuickSearchPhoneNumber"
+                                                                value="#{patientController.quickSearchPhoneNumber}"
+                                                                placeholder="Phone Number"
+                                                                class="form-control-sm mx-1"
+                                                                onfocus="this.select()"
+                                                                />
+                                                            <p:commandButton
+                                                                id="btnSearchbyPhoneNo"
+                                                                icon="fa fa-search"
+                                                                title="Quick Search from Phone Number"
+                                                                action="#{patientController.quickSearchPatientLongPhoneNumber(pharmacySaleController)}"
+                                                                process="btnSearchbyPhoneNo txtQuickSearchPhoneNumber panelPayment"
+                                                                update="panelPatient selectPatient editPatient viewPatient panelPayment panelBillDetails"
+                                                                styleClass="btn-sm mx-1"/>
+                                                            <p:defaultCommand target="btnSearchbyPhoneNo"> </p:defaultCommand>
+                                                            <p:commandButton
+                                                                id="btnAddNewPatient"
+                                                                icon="fa fa-plus-circle"
+                                                                title="Add New Patient"
+                                                                action="#{patientController.quickSearchNewPatient(pharmacySaleController)}"
+                                                                process="btnAddNewPatient"
+                                                                update="panelPatient selectPatient editPatient viewPatient panelPayment panelBillDetails"
+                                                                styleClass="btn-sm mx-1"/>
+                                                        </h:panelGroup>
+                                                    </h:panelGroup>
+                                                </h:panelGroup>
+                                            </f:facet>
+                                            <h:panelGroup id="selectPatient" >
+                                                <h:panelGroup rendered="#{patientController.quickSearchPatientList ne null and not empty patientController.quickSearchPatientList}">
+                                                    <p:dataTable id="tblPatients" value="#{patientController.quickSearchPatientList}" var="ps">
+                                                        <p:column headerText="Name">
+                                                            #{ps.person.name}
+                                                        </p:column>
+                                                        <p:column headerText="Phone Number">
+                                                            #{ps.person.phone}
+                                                        </p:column>
+                                                        <p:column headerText="Mobile Number">
+                                                            #{ps.person.mobile}
+                                                        </p:column>
+                                                        <p:column>
+                                                            <p:commandButton
+                                                                action="#{patientController.selectQuickOneFromQuickSearchPatient(pharmacySaleController)}"
+                                                                id="btnSelectPt"
+                                                                process="btnSelectPt panelPayment"
+                                                                update=":#{p:resolveFirstComponentWithId('panelPatient',view).clientId} :#{p:resolveFirstComponentWithId('panelPayment',view).clientId} :#{p:resolveFirstComponentWithId('panelBillDetails',view).clientId}"
+                                                                value="Select">
+                                                                <f:setPropertyActionListener value="#{ps}" target="#{patientController.current}" />
+                                                            </p:commandButton>
+                                                        </p:column>
+                                                    </p:dataTable>
+                                                </h:panelGroup>
+                                            </h:panelGroup>
+                                            <h:panelGroup id="editPatient" >
+                                                <h:panelGroup rendered="#{pharmacySaleController.patientDetailsEditable}" >
+                                                    <h:panelGroup rendered="#{patientController.quickSearchPatientList eq null or empty patientController.quickSearchPatientList}">
+                                                        <h:panelGroup class="mb-1 w-100" id="panelPatientEdit" >
+                                                            <h:panelGroup id="gpPatient" >
+                                                                <div class="row">
+                                                                    <div class="col-md-3 p-1">
+                                                                        <p:selectOneMenu
+                                                                            id="cmbTitle"
+                                                                            class="form-control w-100"
+                                                                            value="#{pharmacySaleController.patient.person.title}">
+                                                                            <f:selectItem itemLabel="Select Title" />
+                                                                            <f:selectItems value="#{opdBillController.title}" var="i"
+                                                                                           itemLabel="#{i.label}" itemValue="#{i}"/>
+                                                                            <p:ajax event="change" process="cmbTitle" update="cmbSex" ></p:ajax>
+                                                                        </p:selectOneMenu>
+                                                                    </div>
+                                                                    <div class="col-md-9 p-1">
+                                                                        <p:inputText
+                                                                            autocomplete="off"
+                                                                            id="txtNewPtName"
+                                                                            placeholder="Enter the Name of the patient"
+                                                                            value="#{pharmacySaleController.patient.person.name}"
+                                                                            validatorMessage="Please enter only letters and spaces."
+                                                                            class="form-control" >
+                                                                        </p:inputText>
+                                                                    </div>
+                                                                </div>
+
+                                                                <div class="row">
+                                                                    <div class="col-md-3 p-1">
+                                                                        <p:selectOneMenu
+                                                                            id="cmbSex"
+                                                                            value="#{pharmacySaleController.patient.person.sex}"
+                                                                            class="form-control w-100">
+                                                                            <f:selectItem itemLabel="Select Gender"/>
+                                                                            <f:selectItems value="#{opdBillController.sex}"/>
+                                                                        </p:selectOneMenu>
+                                                                    </div>
+                                                                    <div class="col-md-9 p-1">
+                                                                        <div class="row">
+                                                                            <div class="col-md-2">
+                                                                                <p:inputText
+                                                                                    autocomplete="off"
+                                                                                    id="year"
+                                                                                    placeholder="Years"
+
+                                                                                    value="#{pharmacySaleController.patient.person.ageYearsComponent}"
+                                                                                    class="form-control">
+                                                                                    <f:ajax event="keyup" execute="@this" render="dpDob" />
+                                                                                </p:inputText>
+                                                                            </div>
+                                                                            <div class="col-md-2">
+                                                                                <p:inputText
+
+                                                                                    autocomplete="off" id="month" placeholder="Months"
+                                                                                    value="#{pharmacySaleController.patient.person.ageMonthsComponent}"
+                                                                                    class="form-control">
+                                                                                    <f:ajax event="keyup" execute="@this"  render="dpDob"  />
+                                                                                </p:inputText>
+                                                                            </div>
+                                                                            <div class="col-md-2">
+                                                                                <p:inputText
+
+                                                                                    autocomplete="off" id="day" placeholder="Days"
+                                                                                    value="#{pharmacySaleController.patient.person.ageDaysComponent}"
+                                                                                    class="form-control">
+                                                                                    <f:ajax event="keyup" execute="@this"  render="dpDob" />
+                                                                                </p:inputText>
+                                                                            </div>
+                                                                            <div class="col-md-6">
+                                                                                <p:datePicker
+                                                                                    value="#{pharmacySaleController.patient.person.dob}"
+                                                                                    id="dpDob"
+                                                                                    class="w-100"
+                                                                                    yearNavigator="true"
+                                                                                    monthNavigator="true"
+                                                                                    inputStyleClass="form-control"
+                                                                                    pattern="#{sessionController.applicationPreference.longDateFormat}"
+                                                                                    placeholder="Date of Birth (dd/mm/yyyy)"
+                                                                                    >
+                                                                                    <p:ajax event="dateSelect" process="@this" update="year month day" />
+                                                                                </p:datePicker>
+                                                                            </div>
+                                                                        </div>
+                                                                    </div>
+                                                                </div>
+
+                                                                <div class="row">
+                                                                    <div class="col-md-3 p-1">
+                                                                        <p:inputText
+                                                                            id="txtMobile"
+                                                                            autocomplete="off"
+                                                                            placeholder="Mobile Number"
+                                                                            value="#{pharmacySaleController.patient.mobileNumberStringTransient}"
+                                                                            class="form-control"
+                                                                            validatorMessage="Please enter valid Number">
+                                                                        </p:inputText>
+                                                                    </div>
+                                                                    <div class="col-md-3 p-1">
+                                                                        <p:inputText
+                                                                            id="txtPhone"
+                                                                            autocomplete="off"
+                                                                            placeholder="Phone Number"
+                                                                            value="#{pharmacySaleController.patient.phoneNumberStringTransient}"
+                                                                            class="form-control" validatorMessage="Please enter valid Number">
+                                                                        </p:inputText>
+                                                                    </div>
+                                                                    <div class="col-md-3 p-1">
+                                                                        <p:inputText
+                                                                            autocomplete="off" id="txtEmail" placeholder="Enter Email here"
+                                                                            value="#{pharmacySaleController.patient.person.email}"
+                                                                            class="form-control"
+                                                                            >
+                                                                        </p:inputText>
+                                                                    </div>
+                                                                    <div class="col-md-3 p-1">
+                                                                        <p:inputText
+                                                                            id="txtNic"
+                                                                            autocomplete="off"
+                                                                            placeholder="National ID Number"
+                                                                            value="#{pharmacySaleController.patient.person.nic}"
+                                                                            class="form-control"/>
+                                                                    </div>
+                                                                </div>
+
+                                                                <div class="row">
+                                                                    <div class="col-md-8 p-1">
+                                                                        <p:inputText
+                                                                            id="txtAddress"
+                                                                            autocomplete="off"
+                                                                            placeholder="Address"
+                                                                            value="#{pharmacySaleController.patient.person.address}"
+                                                                            class="form-control"/>
+                                                                    </div>
+                                                                    <div class="col-md-4 p-1">
+                                                                        <p:autoComplete
+                                                                            id="acNewPtArea"
+                                                                            placeholder="Search &amp; Select Area"
+                                                                            completeMethod="#{areaController.completeArea}"
+                                                                            var="pta" itemLabel="#{pta.name}"
+                                                                            itemValue="#{pta}" forceSelection="true"
+                                                                            value="#{pharmacySaleController.patient.person.area}"
+                                                                            inputStyleClass="form-control"
+                                                                            class="w-100"/>
+                                                                    </div>
+                                                                </div>
+
+                                                                <p:tooltip for="txtNewPtName" value="Patient Name"  showDelay="0" hideDelay="0"></p:tooltip>
+                                                                <p:tooltip for="txtNic" value="NIC / Passport No"  showDelay="0" hideDelay="0"></p:tooltip>
+                                                                <p:tooltip for="dpDob" value="Date Of Birth"  showDelay="0" hideDelay="0"></p:tooltip>
+                                                                <p:tooltip for="txtAddress" value="Address"  showDelay="0" hideDelay="0"></p:tooltip>
+                                                                <p:tooltip for="txtMobile" value="Mobile Number"  showDelay="0" hideDelay="0"></p:tooltip>
+                                                                <p:tooltip for="txtPhone" value="Home Phone Number"  showDelay="0" hideDelay="0"></p:tooltip>
+                                                                <p:tooltip for="cmbSex" value="Sex"  showDelay="0" hideDelay="0"></p:tooltip>
+                                                                <p:tooltip for="cmbTitle" value="Title"  showDelay="0" hideDelay="0"></p:tooltip>
+                                                                <p:tooltip for="acNewPtArea" value="Area"  showDelay="0" hideDelay="0"></p:tooltip>
+                                                                <p:tooltip for="txtEmail" value="Email"  showDelay="0" hideDelay="0"></p:tooltip>
+
+                                                                <p:tooltip for="year" value="Age- Years Component"  showDelay="0" hideDelay="0"></p:tooltip>
+                                                                <p:tooltip for="month" value="Age- Month Component"  showDelay="0" hideDelay="0"></p:tooltip>
+                                                                <p:tooltip for="day" value="Age- Days Component"  showDelay="0" hideDelay="0"></p:tooltip>
+
+
+                                                            </h:panelGroup>
+                                                        </h:panelGroup>
+                                                    </h:panelGroup>
+                                                </h:panelGroup>
+                                            </h:panelGroup>
+                                            <h:panelGroup id="viewPatient" >
+                                                <h:panelGroup  rendered="#{not pharmacySaleController.patientDetailsEditable}"  >
+                                                    <h:panelGroup  rendered="#{patientController.quickSearchPatientList eq null}" >
+                                                        <h:panelGrid columns="3" class="my-1" id="panelPatientDisplay" rendered="#{pharmacySaleController.patient ne null}" >
+                                                            <h:outputLabel value="Name " class="mx-3"/>
+                                                            <h:outputLabel value=" : " class="mx-3"/>
+                                                            <h:outputText value="#{pharmacySaleController.patient.person.nameWithTitle}" />
+
+                                                            <h:outputLabel value="Gender " class="mx-3"/>
+                                                            <h:outputLabel value=" : " class="mx-3"/>
+                                                            <h:outputText value="#{pharmacySaleController.patient.person.sex}" />
+
+                                                            <h:outputLabel value="Date of Birth " class="mx-3"/>
+                                                            <h:outputLabel value=" : " class="mx-3"/>
+                                                            <h:outputText value="#{pharmacySaleController.patient.person.dob}" >
+                                                                <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateFormat}" ></f:convertDateTime>
+                                                            </h:outputText>
+
+                                                            <h:outputLabel value="Age  " class="mx-3"/>
+                                                            <h:outputLabel value=" : " class="mx-3"/>
+                                                            <h:outputText value="#{pharmacySaleController.patient.person.ageAsString}" />
+
+                                                            <h:outputLabel value="Mobile No. " class="mx-3"/>
+                                                            <h:outputLabel value=" : " class="mx-3"/>
+                                                            <h:outputText value="#{pharmacySaleController.patient.person.mobile}" />
+
+                                                            <h:outputLabel value="Phone No. " class="mx-3"/>
+                                                            <h:outputLabel value=" : " class="mx-3"/>
+                                                            <h:outputText value="#{pharmacySaleController.patient.person.phone}" />
+
+                                                            <h:outputLabel value="Email " class="mx-3"/>
+                                                            <h:outputLabel value=" : " class="mx-3"/>
+                                                            <h:outputText value="#{pharmacySaleController.patient.person.email}" />
+
+                                                            <h:outputLabel value="National ID No. " class="mx-3"/>
+                                                            <h:outputLabel value=" : " class="mx-3"/>
+                                                            <h:outputText value="#{pharmacySaleController.patient.person.nic}" />
+
+                                                            <h:outputLabel value="Address " class="mx-3"/>
+                                                            <h:outputLabel value=" : " class="mx-3"/>
+                                                            <h:outputText value="#{pharmacySaleController.patient.person.address}" />
+
+                                                            <h:outputLabel value="Area " class="mx-3"/>
+                                                            <h:outputLabel value=" : " class="mx-3"/>
+                                                            <h:outputText value="#{pharmacySaleController.patient.person.area.name}" />
+
+                                                        </h:panelGrid>
+                                                    </h:panelGroup>
+                                                </h:panelGroup>
+                                            </h:panelGroup>
+                                        </p:panel>
+                                        <div class="row">
+                                            <div class="col">
+                                                <p:panel id="panelPayment"  class="w-100">
+                                                    <f:facet name="header" >
+                                                        <h:outputText styleClass="fas fa-money-bill-wave" />
+                                                        <h:outputLabel value="Payment Details" class="mx-4"></h:outputLabel>
+                                                    </f:facet>
+                                                    <div class="row" >
+                                                        <div class="col-md-5" >
+                                                            <p:selectOneMenu   id="pay"
+                                                                               value="#{pharmacySaleController.paymentMethod}">
+                                                                <f:selectItems value="#{enumController.paymentMethodsForPharmacyBilling}" var="p" itemLabel="#{p.label}"
+                                                                               itemValue="#{p}"/>
+                                                                <p:ajax process="@this cmbPs cmbPaymentScheme"
+                                                                        update="panelBillDetails panelPaymentDetails"
+                                                                        event="change"
+                                                                        listener="#{pharmacySaleController.listnerForPaymentMethodChange()}"/>
+                                                            </p:selectOneMenu>
+
+                                                            <p:selectOneMenu   id="cmbPaymentScheme" value="#{pharmacySaleController.paymentScheme}" rendered="#{sessionController.loggedPreference.checkPaymentSchemeValidation eq true}">
+                                                                <f:selectItems value="#{paymentSchemeController.items}" var="i" itemLabel="#{i.name}" itemValue="#{i}"/>
+                                                                <p:ajax process="@this pay "
+                                                                        update="panelBillDetails panelPaymentDetails"
+                                                                        event="change"
+                                                                        listener="#{pharmacySaleController.listnerForPaymentMethodChange()}"/>
+                                                            </p:selectOneMenu>
+                                                        </div>
+                                                    </div>
+                                                    <div class="row" >
+                                                        <div class="my-1">
+                                                            <h:panelGroup id="panelPaymentDetails" class="row">
+                                                                <div class="col" >
+                                                                    <h:panelGroup
+                                                                        class="row"
+                                                                        layout="block"
+                                                                        rendered="#{pharmacySaleController.paymentMethod eq 'Credit'}" >
+                                                                        <div class="my-1" id="credit">
+                                                                            <div class="row">
+                                                                                <div class="col-12 d-flex ">
+                                                                                    <p:autoComplete
+                                                                                        id="creditCompany"
+                                                                                        class="w-100 -mx-2"
+                                                                                        inputStyleClass="form-control"
+                                                                                        forceSelection="true"
+                                                                                        value="#{pharmacySaleController.toInstitution}"
+                                                                                        completeMethod="#{institutionController.completeCreditCompany}"
+                                                                                        var="ix"
+                                                                                        minQueryLength="2"
+                                                                                        placeholder="Company (Type at least 4 letters to search)"
+                                                                                        itemLabel="#{ix.name}"
+                                                                                        itemValue="#{ix}"
+                                                                                        size="10"  >
+
+                                                                                        <f:ajax
+                                                                                            event="itemSelect"
+                                                                                            listener="#{pharmacySaleController.calTotal()}"
+                                                                                            execute="@this"
+                                                                                            render=":#{p:resolveFirstComponentWithId('panelBillDetails',view).clientId}"/>
+                                                                                    </p:autoComplete>
+                                                                                    <p:commandLink
+                                                                                        id="btnAddNewCreditCom"
+                                                                                        value="(+)"
+                                                                                        class="mx-3 mt-1"
+                                                                                        title="Add New Credit Company"
+                                                                                        ajax="false"
+                                                                                        action="#{navigationController.navigateToCreditCompany()}"
+                                                                                        actionListener="#{creditCompanyController.prepareAdd()}" />
+                                                                                </div>
+                                                                            </div>
+                                                                        </div>
+                                                                    </h:panelGroup>
+                                                                    <h:panelGroup
+                                                                        class="row"
+                                                                        layout="block"
+                                                                        rendered="#{pharmacySaleController.paymentMethod eq 'Staff'}" >
+                                                                        <div class="my-1" id="staffCredit">
+                                                                            <div class="row mt-1">
+                                                                                <div class="col-12">
+                                                                                    <p:autoComplete
+                                                                                        minQueryLength="2"
+                                                                                        forceSelection="true"
+                                                                                        value="#{pharmacySaleController.toStaff}"
+                                                                                        id="creditStaff"
+                                                                                        completeMethod="#{staffController.completeStaff}"
+                                                                                        var="mys"
+                                                                                        class="w-100"
+                                                                                        placeholder="Staff (Type at least 4 letters to search)"
+                                                                                        inputStyleClass="form-control"
+                                                                                        itemLabel="#{mys.person.name}"
+                                                                                        itemValue="#{mys}"
+                                                                                        size="10">
+                                                                                        <p:column headerText="Name" style="padding: 2px;">
+                                                                                            <h:outputText value="#{mys.person.nameWithTitle}" ></h:outputText>
+                                                                                        </p:column>
+                                                                                        <p:column headerText="EPF" style="padding: 2px;">
+                                                                                            <h:outputText value="#{mys.epfNo}" ></h:outputText>
+                                                                                        </p:column>
+                                                                                        <p:column headerText="Credit Entitlement" style="padding: 2px;">
+                                                                                            <h:outputText value="#{mys.creditLimitQualified}" >
+                                                                                                <f:convertNumber pattern="#,##0.00" ></f:convertNumber>
+                                                                                            </h:outputText>
+                                                                                        </p:column>
+                                                                                        <p:column  headerText="Credit Utilized" style="padding: 2px;">
+                                                                                            <h:outputText value="#{mys.currentCreditValue}" >
+                                                                                                <f:convertNumber pattern="#,##0.00" ></f:convertNumber>
+                                                                                            </h:outputText>
+                                                                                        </p:column>
+                                                                                        <p:ajax process="@this"
+                                                                                                update=":#{p:resolveFirstComponentWithId('panelBillDetails',view).clientId}"
+                                                                                                event="itemSelect"
+                                                                                                listener="#{pharmacySaleController.calTotal()}" />
+                                                                                    </p:autoComplete>
+                                                                                </div>
+                                                                            </div>
+                                                                        </div>
+                                                                    </h:panelGroup>
+                                                                    <h:panelGroup
+                                                                        class="row"
+                                                                        layout="block"
+                                                                        rendered="#{pharmacySaleController.paymentMethod eq 'Staff_Welfare'}" >
+                                                                        <div class="my-1" id="credit">
+                                                                            <div class="row mt-1">
+                                                                                <div class="col-12">
+                                                                                    <p:autoComplete
+                                                                                        minQueryLength="1"
+                                                                                        forceSelection="true"
+                                                                                        value="#{pharmacySaleController.toStaff}"
+                                                                                        id="welfareStaff"
+                                                                                        completeMethod="#{staffController.completeStaff}"
+                                                                                        var="mys"
+                                                                                        class="w-100"
+                                                                                        placeholder="Staff (Type Name, Code or EPF No to search)"
+                                                                                        inputStyleClass="form-control"
+                                                                                        itemLabel="#{mys.person.name}"
+                                                                                        itemValue="#{mys}"
+                                                                                        size="10">
+                                                                                        <p:column headerText="Name" style="padding: 2px;">
+                                                                                            <h:outputText value="#{mys.person.nameWithTitle}" ></h:outputText>
+                                                                                        </p:column>
+                                                                                        <p:column headerText="Code" style="padding: 2px;">
+                                                                                            <h:outputText value="#{mys.staffCode}" ></h:outputText>
+                                                                                        </p:column>
+                                                                                        <p:column headerText="EPF" style="padding: 2px;">
+                                                                                            <h:outputText value="#{mys.epfNo}" ></h:outputText>
+                                                                                        </p:column>
+                                                                                        <p:column headerText="Welfare Entitlement" style="padding: 2px;">
+                                                                                            <h:outputText value="#{mys.annualWelfareQualified}" >
+                                                                                                <f:convertNumber pattern="#,##0.00" ></f:convertNumber>
+                                                                                            </h:outputText>
+                                                                                        </p:column>
+                                                                                        <p:column  headerText="Welfare Utilized" style="padding: 2px;">
+                                                                                            <h:outputText value="#{mys.annualWelfareUtilized}" >
+                                                                                                <f:convertNumber pattern="#,##0.00" ></f:convertNumber>
+                                                                                            </h:outputText>
+                                                                                        </p:column>
+                                                                                        <p:ajax process="@this"
+                                                                                                update=":#{p:resolveFirstComponentWithId('panelBillDetails',view).clientId}"
+                                                                                                event="itemSelect"
+                                                                                                listener="#{pharmacySaleController.calTotal()}" />
+                                                                                    </p:autoComplete>
+                                                                                </div>
+                                                                            </div>
+                                                                        </div>
+                                                                    </h:panelGroup>
+                                                                    <h:panelGroup id="creditCard" rendered="#{pharmacySaleController.paymentMethod eq 'Card'}">
+                                                                        <pa:creditCard paymentMethodData="#{pharmacySaleController.paymentMethodData}"/>
+                                                                    </h:panelGroup>
+
+                                                                    <h:panelGroup id="ptdeposit" rendered="#{pharmacySaleController.paymentMethod eq 'PatientDeposit'}">
+                                                                        <pa:patient_deposit paymentMethodData="#{pharmacySaleController.paymentMethodData}"/>
+                                                                    </h:panelGroup>
+
+                                                                    <h:panelGroup id="ewallet" rendered="#{pharmacySaleController.paymentMethod eq 'ewallet'}" >
+                                                                        <pa:ewallet paymentMethodData="#{pharmacySaleController.paymentMethodData}"/>
+                                                                    </h:panelGroup>
+
+
+                                                                    <h:panelGroup id="cheque" rendered="#{pharmacySaleController.paymentMethod eq 'Cheque'}" >
+                                                                        <pa:cheque paymentMethodData="#{pharmacySaleController.paymentMethodData}"/>
+                                                                    </h:panelGroup>
+
+                                                                    <h:panelGroup id="slip" rendered="#{pharmacySaleController.paymentMethod eq 'Slip'}">
+                                                                        <pa:slip paymentMethodData="#{pharmacySaleController.paymentMethodData}"/>
+                                                                    </h:panelGroup>
+
+
+                                                                    <h:panelGroup
+                                                                        class="row my-1 w-100"
+                                                                        layout="block"
+                                                                        id="multiplePaymentMethods"  rendered="#{pharmacySaleController.paymentMethod eq 'MultiplePaymentMethods'}"
+                                                                        >
+                                                                        <pa:multiple_payment_methods class="w-100" controller="#{pharmacySaleController}" paymentMethods="#{enumController.paymentMethodsForMultiplePaymentMethod}"/>
+
+                                                                    </h:panelGroup>
+
+                                                                </div>
+
+                                                            </h:panelGroup>
+                                                        </div>
+                                                    </div>
+
+                                                    <div class="col-5">
+                                                        <p:selectOneMenu   id="cmbPs" value="#{pharmacySaleController.paymentScheme}" rendered="#{sessionController.loggedPreference.checkPaymentSchemeValidation eq false}" class="my-1">
+                                                            <f:selectItem itemLabel="Discount Scheme"/>
+                                                            <f:selectItems value="#{paymentSchemeController.paymentSchemesForPharmacy}" var="i" itemLabel="#{i.name}" itemValue="#{i}"/>
+                                                            <p:ajax process="@this pay "
+                                                                    update="panelBillDetails panelPaymentDetails"
+                                                                    event="change"
+                                                                    listener="#{pharmacySaleController.listnerForPaymentMethodChange()}"/>
+                                                        </p:selectOneMenu>
+                                                    </div>
+
+                                                    <h:panelGrid columns="2" class="my-2">
+                                                        <p:outputLabel value="Referring Doctor" ></p:outputLabel>
+                                                        <p:autoComplete forceSelection="true" id="cmbDoc" value="#{pharmacySaleController.preBill.referredBy}"
+                                                                        completeMethod="#{doctorController.completeDoctor}"
+                                                                        var="ix" itemLabel="#{ix.person.name}"
+                                                                        itemValue="#{ix}" size="40"
+                                                                        class="mx-4 w-100 mt-1"
+                                                                        inputStyleClass="form-control">
+                                                        </p:autoComplete>
+                                                        <p:outputLabel value="Comments" ></p:outputLabel>
+                                                        <p:inputTextarea class="w-100 mx-4" value="#{pharmacySaleController.comment}" id="comment"/>
+
+
+
+                                                    </h:panelGrid>
+
+                                                </p:panel>
+
+                                                <p:panel  id="panelBillDetails" class="my-1">
+                                                    <f:facet name="header" >
+                                                        <h:outputText styleClass="fas fa-list" />
+                                                        <h:outputLabel value="Bill Details" class="mx-4"></h:outputLabel>
+                                                    </f:facet>
+                                                    <h:panelGrid columns="2" columnClasses="numberCol, textCol">
+                                                        <h:outputLabel value="Total" />
+                                                        <h:panelGroup layout="block" class="text-end mx-4 my-1">
+                                                            <h:outputLabel id="total" value="#{pharmacySaleController.preBill.total}">
+                                                                <f:convertNumber pattern="#,##0.00" />
+                                                            </h:outputLabel>
+                                                        </h:panelGroup>
+
+                                                        <h:outputLabel value="Discount" />
+                                                        <h:panelGroup layout="block" class="text-end mx-4 my-1">
+                                                            <h:outputLabel id="dis" value="#{pharmacySaleController.preBill.discount}">
+                                                                <f:convertNumber pattern="#,##0.00" />
+                                                            </h:outputLabel>
+                                                        </h:panelGroup>
+
+                                                        <h:outputLabel value="Net Total" />
+                                                        <h:panelGroup layout="block" class="text-end mx-4 my-1">
+                                                            <h:outputLabel id="netTotal" value="#{pharmacySaleController.preBill.netTotal}">
+                                                                <f:convertNumber pattern="#,##0.00" />
+                                                            </h:outputLabel>
+                                                        </h:panelGroup>
+
+                                                        <h:outputLabel value="Tendered" />
+                                                        <h:panelGroup layout="block" class="text-end mx-4 my-1">
+                                                            <p:inputText
+                                                                id="paid"
+                                                                value="#{pharmacySaleController.cashPaid}"
+                                                                class="form-control text-end"
+                                                                autocomplete="off"
+                                                                accesskey="t"
+                                                                onfocus="this.select()">
+                                                                <p:ajax process="total dis netTotal paid" update="balance netTotal" event="keyup" />
+                                                            </p:inputText>
+                                                        </h:panelGroup>
+
+                                                        <h:outputLabel value="Balance" />
+                                                        <h:panelGroup layout="block" class="text-end mx-4 my-1">
+                                                            <h:outputLabel id="balance" value="#{pharmacySaleController.balance}">
+                                                                <f:convertNumber pattern="#,##0.00" />
+                                                            </h:outputLabel>
+                                                        </h:panelGroup>
+                                                    </h:panelGrid>
+
+
+                                                </p:panel>
+
+                                            </div>
+                                        </div>
+                                    </h:panelGrid>
+                                </div>
+                            </div>
+                        </p:panel>
+                    </p:panel>
+                </h:form>
+                <h:form>
+
+                    <p:panel  rendered="#{pharmacySaleController.billPreview}" >
+
+                        <p:commandButton id="nullButton3" value="No Action"
+                                         action="#" style="display: none;" ></p:commandButton>
+                        <!--<p:defaultCommand  target="btnPrint" />-->
+
+                        <div   >
+                            <div>
+                                <p:commandButton
+                                    accesskey="p"
+                                    id="btnPrint"
+                                    value="Print Bill"
+                                    style="width: 10em;"
+                                    class="ui-button-info"
+                                    rendered="#{!configOptionApplicationController.getBooleanValueByKey('Pharmacy Bill Support for Native Printers')}"
+                                    ajax="false"  >
+                                    <p:printer target="gpBillPreview" ></p:printer>
+                                </p:commandButton>
+                                <p:commandButton
+
+                                    id="btnLabelPrint"
+                                    value="Print Labels"
+                                    style="width: 10em;"
+                                    oncomplete="PF('PrintLables').show()"
+                                    class="ui-button-info mx-3"
+                                    rendered="#{configOptionApplicationController.getBooleanValueByKey('Enable label printing for pharmacy medicines', false)}"
+                                    >
+
+                                </p:commandButton>
+
+                                <p:dialog
+                                    id="PrintLableSectionAfterSettleBill"
+                                    widgetVar="PrintLables"
+                                    resizable="false"
+                                    closable="true"
+                                    modal="true"
+                                    onShow="$('.ui-dialog').addClass('custom-dialog')"
+
+                                    >
+                                    <p:outputLabel for="@next" value="Select Bill Item : " class="m-2"/>
+                                    <p:selectOneMenu id="group" value="#{pharmacySaleController.billItem}">
+                                        <f:selectItem itemLabel="Select One" itemValue=""/>
+                                        <f:selectItems value="#{pharmacySaleController.printBill.billItems}" var="item" itemLabel="#{item.pharmaceuticalBillItem.itemBatch.item.name}" itemValue="#{item}"/>
+
+                                        <p:ajax event="change" process="group" update="printLabelSectionAfterSettle"></p:ajax>
+
+                                    </p:selectOneMenu>
+
+                                    <h:panelGroup id="printLabelSectionAfterSettle" class="my-3" rendered="#{pharmacySaleController.billItem ne null}">
+                                        <phi:pharmacy_instruction_label billItem="#{pharmacySaleController.billItem}" controller="#{pharmacySaleController}"/>
+                                    </h:panelGroup>
+
+                                    <p:commandButton value="Print Label"
+                                                     class="ui-button-info w-100 my-4"
+                                                     action="#{pharmacySaleController.enableLabelPrint(pharmacySaleController.billItem.prescription)}"
+                                                     ajax="false"
+                                                     update="PrintLableSectionAfterSettleBill"
+                                                     oncomplete="PF('printLabelSectionView').show()"
+                                                     process="@this"
+                                                     >
+                                        <p:printer target="printLabelSectionAfterSettle"></p:printer>
+
+                                    </p:commandButton>
+                                </p:dialog>
+
+                                <p:commandButton
+                                    accesskey="n"
+                                    value="New Bill"
+                                    icon="fa fa-plus"
+                                    ajax="false"
+                                    action="pharmacy_bill_retail_sale"
+                                    class="ui-button-warning mx-2"
+                                    actionListener="#{pharmacySaleController.resetAll()}" ></p:commandButton>
+                                <p:outputLabel value="Paper Type" class="m-2"></p:outputLabel>
+                                <p:selectOneMenu value="#{sessionController.departmentPreference.pharmacyBillPaperType}" class="m-1" id='ph' style="width: 13em;">
+                                    <f:selectItem itemLabel="Please Select Paper Type" />
+                                    <f:selectItems value="#{enumController.paperTypes}" />
+                                </p:selectOneMenu>
+                                <p:commandButton ajax="false" icon="fa fa-sync-alt" class="ui-button" title="Redraw Bill"></p:commandButton>
+                                <p:spacer width="20em" ></p:spacer>
+                                <p:commandButton class="m-1" icon="fas fa-file-invoice" disabled="true" value="Sale 1"  action="pharmacy_fast_retail_sale?faces-redirect=true" rendered="#{webUserController.hasPrivilege('PharmacySaleQuick')}" actionListener="#{pharmacyFastRetailSaleController.navigateToPharmacyFastRetailSale()}" />
+
+                            </div>
+
+                            <div>
+                                <br/>
+                                <br/>
+                                <br/>
+                            </div>
+                        </div>
+
+                        <h:panelGroup id="gpBillPreview" >
+                            <h:panelGroup   id="gpBillWithOutItem" rendered="#{configOptionApplicationController.getBooleanValueByKey('Pharmacy Retail Sale Bill is PosPaper',true)}">
+                                <div style="page-break-inside: avoid;">
+                                    <phi:saleBill_without_item bill="#{pharmacySaleController.printBill}"></phi:saleBill_without_item>
+                                </div>
+                                <br/>
+                                <div style="page-break-inside: avoid;">
+                                    <phi:saleBill bill="#{pharmacySaleController.printBill}"></phi:saleBill>
+                                </div>
+                            </h:panelGroup>
+
+                            <h:panelGroup   id="gpBillWithItem" rendered="#{configOptionApplicationController.getBooleanValueByKey('Pharmacy Retail Sale Bill with Items is PosPaper',true)}">
+                                <div style="page-break-inside: avoid;">
+                                    <phi:saleBill bill="#{pharmacySaleController.printBill}"></phi:saleBill>
+                                </div>
+                            </h:panelGroup>
+
+                            <h:panelGroup id="gpBillPreviewDouble" rendered="#{configOptionApplicationController.getBooleanValueByKey('Pharmacy Retail Sale Bill is PosPaper(prabodha)',true)}">
+                                <phi:saleBill_prabodha bill="#{pharmacySaleController.printBill}"></phi:saleBill_prabodha>
+                            </h:panelGroup>
+
+                            <h:panelGroup id="gpBillPreviewFiveFive" rendered="#{configOptionApplicationController.getBooleanValueByKey('Pharmacy Retail Sale Bill is FiveFivePaper',true)}">
+                                <phi:saleBill_five_five bill="#{pharmacySaleController.printBill}"></phi:saleBill_five_five>
+                            </h:panelGroup>
+
+                            <h:panelGroup id="gpBillPreviewPosHeader" rendered="#{configOptionApplicationController.getBooleanValueByKey('Pharmacy Retail Sale Bill is PosHeaderPaper',true)}">
+                                <phi:saleBill_Header bill="#{pharmacySaleController.printBill}"></phi:saleBill_Header>
+                            </h:panelGroup>
+                            <h:panelGroup id="gpBillPreviewFiveFiveCustom3" rendered="#{configOptionApplicationController.getBooleanValueByKey('Pharmacy Retail Sale Bill is FiveFiveCustom3',true)}">
+                                <phi:sale_bill_five_five_custom_3 bill="#{pharmacySaleController.printBill}"/>
+                            </h:panelGroup>
+                        </h:panelGroup>
+                    </p:panel>
+                </h:form>
+            </ui:define>
+        </ui:composition>
+
+    </h:body>
+</html>

--- a/src/main/webapp/resources/ezcomp/menu.xhtml
+++ b/src/main/webapp/resources/ezcomp/menu.xhtml
@@ -756,6 +756,12 @@
                             rendered="#{webUserController.hasPrivilege('PharmacySale')}" ></p:menuitem>
                         <p:menuitem
                             ajax="false"
+                            action="#{pharmacyFastRetailSaleController.navigateToPharmacyFastRetailSale()}"
+                            value="Sale (Fast)"
+                            icon="fas fa-bolt"
+                            rendered="#{webUserController.hasPrivilege('PharmacySaleQuick')}" ></p:menuitem>
+                        <p:menuitem
+                            ajax="false"
                             action="#{pharmacySaleController.navigateToPharmacyBillForCashier()}"
                             value="Sale for cashier"
                             icon="fas fa-cash-register"


### PR DESCRIPTION
## Summary
- add `PharmacySaleFastRetailSaleController` extending the existing sale controller
- introduce `PharmacySaleQuick` privilege
- create new page `pharmacy_fast_retail_sale.xhtml` without other sale buttons
- link the new page from menu as *Sale (Fast)*

## Testing
- `mvn -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687e464da218832f9591a3a1672e8439