### PR TITLE
Remove unused alternatives section

### DIFF
--- a/src/main/java/com/divudi/bean/pharmacy/PharmacySaleController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacySaleController.java
@@ -183,8 +183,6 @@ public class PharmacySaleController implements Serializable, ControllerWithPatie
     @EJB
     BillService billService;
     /////////////////////////
-    Item selectedAvailableAmp;
-    Item selectedAlternative;
     private PreBill preBill;
     private Bill saleBill;
     Bill printBill;
@@ -196,7 +194,6 @@ public class PharmacySaleController implements Serializable, ControllerWithPatie
     Double qty;
     Integer intQty;
     Stock stock;
-    Stock replacableStock;
     private List<ClinicalFindingValue> allergyListOfPatient;
     private boolean billSettlingStarted;
 
@@ -218,11 +215,6 @@ public class PharmacySaleController implements Serializable, ControllerWithPatie
     Institution toInstitution;
     String errorMessage = "";
 
-    /////////////////
-    List<Stock> replaceableStocks;
-    //List<BillItem> billItems;
-    List<Item> itemsWithoutStocks;
-    /////////////////////////
     double cashPaid;
     double netTotal;
     double balance;
@@ -311,7 +303,6 @@ public class PharmacySaleController implements Serializable, ControllerWithPatie
     }
 
     public void clearForNewBill() {
-        selectedAlternative = null;
         preBill = null;
         saleBill = null;
         printBill = null;
@@ -328,8 +319,6 @@ public class PharmacySaleController implements Serializable, ControllerWithPatie
         patientTabId = "tabPt";
         strTenderedValue = "";
         billPreview = false;
-        replaceableStocks = null;
-        itemsWithoutStocks = null;
         paymentMethodData = null;
         cashPaid = 0;
         netTotal = 0;
@@ -339,7 +328,6 @@ public class PharmacySaleController implements Serializable, ControllerWithPatie
     }
 
     public void clearNewBillForMembers() {
-        selectedAlternative = null;
         preBill = null;
         saleBill = null;
         printBill = null;
@@ -357,8 +345,6 @@ public class PharmacySaleController implements Serializable, ControllerWithPatie
         patientSearchTab = 1;
         strTenderedValue = "";
         billPreview = false;
-        replaceableStocks = null;
-        itemsWithoutStocks = null;
         paymentMethodData = null;
         cashPaid = 0;
         netTotal = 0;
@@ -645,10 +631,6 @@ public class PharmacySaleController implements Serializable, ControllerWithPatie
         return Sex.values();
     }
 
-    public List<Stock> getReplaceableStocks() {
-        return replaceableStocks;
-    }
-
     public Integer getIntQty() {
         if (qty == null) {
             return null;
@@ -679,42 +661,6 @@ public class PharmacySaleController implements Serializable, ControllerWithPatie
 
     public void setStock(Stock stock) {
         this.stock = stock;
-    }
-
-    public void setReplaceableStocks(List<Stock> replaceableStocks) {
-        this.replaceableStocks = replaceableStocks;
-    }
-
-    public Item getSelectedAlternative() {
-        return selectedAlternative;
-    }
-
-    public void setSelectedAlternative(Item selectedAlternative) {
-        this.selectedAlternative = selectedAlternative;
-    }
-
-    public void selectReplaceableStocks() {
-        if (selectedAlternative == null || !(selectedAlternative instanceof Amp)) {
-            replaceableStocks = new ArrayList<>();
-            return;
-        }
-        String sql;
-        Map m = new HashMap();
-        double d = 0.0;
-        Amp amp = (Amp) selectedAlternative;
-        m.put("d", getSessionController().getLoggedUser().getDepartment());
-        m.put("s", d);
-        m.put("vmp", amp.getVmp());
-        sql = "select i from Stock i join treat(i.itemBatch.item as Amp) amp where i.stock >:s and i.department=:d and amp.vmp=:vmp order by i.itemBatch.item.name";
-        replaceableStocks = getStockFacade().findByJpql(sql, m);
-    }
-
-    public List<Item> getItemsWithoutStocks() {
-        return itemsWithoutStocks;
-    }
-
-    public void setItemsWithoutStocks(List<Item> itemsWithoutStocks) {
-        this.itemsWithoutStocks = itemsWithoutStocks;
     }
 
     public String newSaleBillWithoutReduceStock() {
@@ -901,8 +847,6 @@ public class PharmacySaleController implements Serializable, ControllerWithPatie
             sql = "select i from Stock i where i.stock >:s and i.department=:d and ((i.itemBatch.item.name) like :n or (i.itemBatch.item.code) like :n)  order by i.itemBatch.item.name, i.itemBatch.dateOfExpire";
         }
         stockList = getStockFacade().findByJpql(sql, m, 20);
-//        itemsWithoutStocks = completeRetailSaleItems(qry);
-        //////System.out.println("selectedSaleitems = " + itemsWithoutStocks);
         return stockList;
     }
 
@@ -921,8 +865,6 @@ public class PharmacySaleController implements Serializable, ControllerWithPatie
             sql = "select i from Stock i where i.stock >:s and i.department=:d and ((i.itemBatch.item.name) like :n or (i.itemBatch.item.code) like :n)  order by i.itemBatch.item.name, i.itemBatch.dateOfExpire";
         }
         stockList = getStockFacade().findByJpql(sql, m, 20);
-//        itemsWithoutStocks = completeRetailSaleItems(qry);
-        //////System.out.println("selectedSaleitems = " + itemsWithoutStocks);
         return stockList;
     }
 
@@ -951,8 +893,6 @@ public class PharmacySaleController implements Serializable, ControllerWithPatie
         if (qry.length() > 5 && items.size() == 1) {
             stock = items.get(0);
             handleSelectAction();
-        } else if (!qry.trim().isEmpty() && qry.length() > 4) {
-            itemsWithoutStocks = completeRetailSaleItemsWithoutStocks(qry);
         }
         return items;
     }
@@ -1068,53 +1008,6 @@ public class PharmacySaleController implements Serializable, ControllerWithPatie
         calculateRates(billItem);
         pharmacyService.addBillItemInstructions(billItem);
 
-        boolean findAlternatives = configOptionApplicationController.getBooleanValueByKey("Show alternative medicines available during retail sale", false);
-        if (findAlternatives) {
-            if (stock != null && stock.getItemBatch() != null) {
-                fillReplaceableStocksForAmp((Amp) stock.getItemBatch().getItem());
-            }
-        }
-    }
-
-    public List<Item> completeRetailSaleItemsWithoutStocks(String qry) {
-        Map m = new HashMap<>();
-        List<Item> items;
-        String sql;
-
-        if (qry.length() > 4) {
-            sql = "select i from Amp i "
-                    + "where i.retired=false and "
-                    + "((i.name) like :n or (i.code) like :n  or (i.barcode) like :n  or (i.vmp.name) like :n) and "
-                    + "i.id not in(select ibs.itemBatch.item.id from Stock ibs where ibs.stock >:s and ibs.department=:d and ((ibs.itemBatch.item.name) like :n or (ibs.itemBatch.item.code) like :n  or (ibs.itemBatch.item.barcode) like :n  or (ibs.itemBatch.item.vmp.name) like :n )  ) "
-                    + "order by i.name ";
-
-        } else {
-
-            sql = "select i from Amp i "
-                    + "where i.retired=false and "
-                    + "((i.name) like :n or (i.code) like :n or (i.vmp.name) like :n) and "
-                    + "i.id not in(select ibs.itemBatch.item.id from Stock ibs where ibs.stock >:s and ibs.department=:d and ((ibs.itemBatch.item.name) like :n or (ibs.itemBatch.item.code) like :n or (ibs.itemBatch.item.vmp.name) like :n )  ) "
-                    + "order by i.name ";
-
-        }
-
-//        if (qry.length() > 4) {
-//            sql = "select i from Stock i where i.stock >:s and i.department=:d and ((i.itemBatch.item.name) like :n or (i.itemBatch.item.code) like :n or (i.itemBatch.item.barcode) like :n or (i.itemBatch.item.vmp.name) like :n) order by i.itemBatch.item.name, i.itemBatch.dateOfExpire";
-//        } else {
-//            sql = "select i from Stock i where i.stock >:s and i.department=:d and ((i.itemBatch.item.name) like :n or (i.itemBatch.item.code) like :n or (i.itemBatch.item.vmp.name) like :n)  order by i.itemBatch.item.name, i.itemBatch.dateOfExpire";
-//        }
-//
-//        sql = "select i from Amp i "
-//                + "where i.retired=false and "
-//                + "(i.name) like :n and "
-//                + "i.id not in(select ibs.itemBatch.item.id from Stock ibs where ibs.stock >:s and ibs.department=:d and ibs.itemBatch.item.name like :n) "
-//                + "order by i.name ";
-        m.put("d", getSessionController().getLoggedUser().getDepartment());
-        m.put("n", "%" + qry + "%");
-        double s = 0.0;
-        m.put("s", s);
-        items = getItemFacade().findByJpql(sql, m, 10);
-        return items;
     }
 
     public void handleSelect(SelectEvent event) {
@@ -1149,38 +1042,6 @@ public class PharmacySaleController implements Serializable, ControllerWithPatie
 //        bi.setNetRate(bi.getRate() - bi.getDiscount());
 //        //  ////System.err.println("Net "+bi.getNetRate());
 //    }
-    public void fillReplaceableStocksForAmp(Amp ampIn) {
-        String sql;
-        Map m = new HashMap();
-        double d = 0.0;
-        Amp amp = ampIn;
-        m.put("d", getSessionController().getLoggedUser().getDepartment());
-        m.put("s", d);
-        m.put("vmp", amp.getVmp());
-        m.put("a", amp);
-        sql = "select i from Stock i join treat(i.itemBatch.item as Amp) amp "
-                + "where i.stock >:s and "
-                + "i.department=:d and "
-                + "amp.vmp=:vmp "
-                + "and amp<>:a "
-                + "order by i.itemBatch.item.name";
-        replaceableStocks = getStockFacade().findByJpql(sql, m);
-    }
-
-    public void makeStockAsBillItemStock() {
-        ////System.out.println("replacableStock = " + replacableStock);
-        setStock(replacableStock);
-        ////System.out.println("getStock() = " + getStock());
-    }
-
-    public void selectReplaceableStocksNew() {
-        if (selectedAvailableAmp == null || !(selectedAvailableAmp instanceof Amp)) {
-            replaceableStocks = new ArrayList<>();
-            return;
-        }
-        fillReplaceableStocksForAmp((Amp) selectedAvailableAmp);
-    }
-
     public void calculateBillItemListner(AjaxBehaviorEvent event) {
         calculateBillItem();
     }
@@ -3069,7 +2930,6 @@ public class PharmacySaleController implements Serializable, ControllerWithPatie
     }
 
     private void clearBillItem() {
-        replaceableStocks = null;
         billItem = null;
         editingBillItem = null;
         qty = null;
@@ -3417,21 +3277,6 @@ public class PharmacySaleController implements Serializable, ControllerWithPatie
         this.errorMessage = errorMessage;
     }
 
-    public Stock getReplacableStock() {
-        return replacableStock;
-    }
-
-    public void setReplacableStock(Stock replacableStock) {
-        this.replacableStock = replacableStock;
-    }
-
-    public Item getSelectedAvailableAmp() {
-        return selectedAvailableAmp;
-    }
-
-    public void setSelectedAvailableAmp(Item selectedAvailableAmp) {
-        this.selectedAvailableAmp = selectedAvailableAmp;
-    }
 
     public UserStockContainerFacade getUserStockContainerFacade() {
         return userStockContainerFacade;

--- a/src/main/webapp/pharmacy/pharmacy_fast_retail_sale.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_fast_retail_sale.xhtml
@@ -180,8 +180,7 @@
                                                             </h:outputLabel>
                                                         </p:column>
                                                         <p:ajax event="focus" process="acStock :#{p:resolveFirstComponentWithId('cmbPs',view).clientId} :#{p:resolveFirstComponentWithId('cmbPaymentScheme',view).clientId}"  ></p:ajax>
-                                                        <p:ajax event="itemSelect" listener="#{pharmacySaleController.handleSelect}" update="txtQty txtRate focusQty txtItemInstructions :#{p:resolveFirstComponentWithId('lstReplaceableBatch',view).clientId}" ></p:ajax>
-                                                        <p:ajax event="query" update=":#{p:resolveFirstComponentWithId('tabI',view).clientId}" process="acStock"></p:ajax>
+                                                        <p:ajax event="itemSelect" listener="#{pharmacySaleController.handleSelect}" update="txtQty txtRate focusQty txtItemInstructions" ></p:ajax>
                                                     </p:autoComplete>
                                                     <p:autoComplete
                                                         accesskey="i"
@@ -228,8 +227,7 @@
                                                             </h:outputLabel>
                                                         </p:column>
                                                         <p:ajax event="focus" process="acStock :#{p:resolveFirstComponentWithId('cmbPs',view).clientId} :#{p:resolveFirstComponentWithId('cmbPaymentScheme',view).clientId}"  ></p:ajax>
-                                                        <p:ajax event="itemSelect" listener="#{pharmacySaleController.handleSelect}" update="txtQty txtRate focusQty txtItemInstructions :#{p:resolveFirstComponentWithId('lstReplaceableBatch',view).clientId}" ></p:ajax>
-                                                        <p:ajax event="query" update=":#{p:resolveFirstComponentWithId('tabI',view).clientId}" process="acStock"></p:ajax>
+                                                        <p:ajax event="itemSelect" listener="#{pharmacySaleController.handleSelect}" update="txtQty txtRate focusQty txtItemInstructions" ></p:ajax>
                                                     </p:autoComplete>
                                                 </h:panelGroup>
 
@@ -263,7 +261,7 @@
                                                             styleClass="ui-button-success"
                                                             action="#{pharmacySaleController.addBillItem()}"
                                                             process="@this acStock txtQty :#{p:resolveFirstComponentWithId('cmbPs',view).clientId} :#{p:resolveFirstComponentWithId('cmbPaymentScheme',view).clientId} focusForAcIx"
-                                                            update=":#{p:resolveFirstComponentWithId('netTotal',view).clientId} :#{p:resolveFirstComponentWithId('dis',view).clientId} :#{p:resolveFirstComponentWithId('total',view).clientId} :#{p:resolveFirstComponentWithId('panelBillDetails',view).clientId} :#{p:resolveFirstComponentWithId('tblBillItem',view).clientId} txtRate txtQty acStock focusItem :#{p:resolveFirstComponentWithId('tabI',view).clientId} :#{p:resolveFirstComponentWithId('panelError',view).clientId} txtItemInstructions" >
+                                                            update=":#{p:resolveFirstComponentWithId('netTotal',view).clientId} :#{p:resolveFirstComponentWithId('dis',view).clientId} :#{p:resolveFirstComponentWithId('total',view).clientId} :#{p:resolveFirstComponentWithId('panelBillDetails',view).clientId} :#{p:resolveFirstComponentWithId('tblBillItem',view).clientId} txtRate txtQty acStock focusItem :#{p:resolveFirstComponentWithId('panelError',view).clientId} txtItemInstructions" >
                                                         </p:commandButton>
 
                                                     </div>
@@ -593,55 +591,6 @@
 
 
                                         </p:dataTable>
-                                    </p:panel>
-                                    <p:panel id="tabI" class="my-1 ">
-                                        <f:facet name="header" >
-                                            <h:outputText styleClass="fas fa-check-circle" />
-                                            <h:outputLabel value="Alternatives" class="mx-4"></h:outputLabel>
-                                        </f:facet>
-                                        <p:dataTable
-                                            class="w-100"
-                                            id="lstReplaceableBatch"
-                                            selection="#{pharmacySaleController.replacableStock}"
-                                            value="#{pharmacySaleController.replaceableStocks}"
-                                            var="ri"
-                                            selectionMode="single"
-                                            rowKey="#{ri.id}"
-                                            emptyMessage="System can not detect suitable replacements.">
-                                            <p:ajax event="rowSelect" process="@this" update=":#{p:resolveFirstComponentWithId('acStock',view).clientId}" listener="#{pharmacySaleController.makeStockAsBillItemStock()}" ></p:ajax>
-                                            <p:ajax event="rowUnselect" process="@this" update=":#{p:resolveFirstComponentWithId('acStock',view).clientId}" listener="#{pharmacySaleController.makeStockAsBillItemStock()}" ></p:ajax>
-                                            <p:column headerText="Item">
-                                                #{ri.itemBatch.item.name}
-                                            </p:column>
-                                            <p:column headerText="Code">
-                                                #{ri.itemBatch.item.code}
-                                            </p:column>
-                                            <p:column headerText="Rate"  style="text-align: right;">
-                                                <p:outputLabel value="#{ri.itemBatch.retailsaleRate}">
-                                                    <f:convertNumber pattern="#,##0.00" ></f:convertNumber>
-                                                </p:outputLabel>
-                                            </p:column>
-                                            <p:column headerText="Stocks" style="text-align: right;">
-                                                <p:outputLabel value="#{ri.stock}"  style="width: 50px!important;">
-                                                    <f:convertNumber pattern="#,###" ></f:convertNumber>
-                                                </p:outputLabel>
-                                            </p:column>
-                                            <p:column headerText="Expiry">
-                                                <h:panelGroup rendered="#{commonFunctionsProxy.currentDateTime > ri.itemBatch.dateOfExpire}" >
-                                                    <p:outputLabel value="#{ri.itemBatch.dateOfExpire}" styleClass="ui-messages-fatal"  >
-                                                        <f:convertDateTime pattern="#{sessionController.applicationPreference.shortDateFormat}" ></f:convertDateTime>
-                                                    </p:outputLabel>
-                                                </h:panelGroup>
-                                                <h:panelGroup rendered="#{ri.itemBatch.dateOfExpire > commonFunctionsProxy.currentDateTime}" >
-                                                    <p:outputLabel value="#{ri.itemBatch.dateOfExpire}" >
-                                                        <f:convertDateTime pattern="#{sessionController.applicationPreference.shortDateFormat}" ></f:convertDateTime>
-                                                    </p:outputLabel>
-                                                </h:panelGroup>
-                                            </p:column>
-                                        </p:dataTable>
-
-
-
                                     </p:panel>
 
 


### PR DESCRIPTION
## Summary
- clean up pharmacy_fast_retail_sale.xhtml by removing the unused "Alternatives" table
- drop update hooks and queries that referenced the removed panel
- remove alternative item logic from PharmacySaleController
- remove leftover `itemsWithoutStocks` handling from PharmacySaleController

## Testing
- `mvn -q -DskipTests install` *(fails: could not resolve Maven plugin due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_687e4fd8ea40832f927cb158dbf68f00