### PR TITLE
Switch fast retail autocomplete to StockDTO

### DIFF
--- a/src/main/webapp/pharmacy/pharmacy_fast_retail_sale.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_fast_retail_sale.xhtml
@@ -101,11 +101,11 @@
                                                     class="w-100"
                                                     forceSelection="true"
                                                     converter="stockDtoConverter"
-                                                    value="#{pharmacyFastRetailSaleController.selectedStockId}"
+                                                    value="#{pharmacyFastRetailSaleController.selectedStockDto}"
                                                     completeMethod="#{pharmacyFastRetailSaleController.completeStockDtos}"
                                                     var="i"
                                                     itemLabel="#{i.itemName}"
-                                                    itemValue="#{i.id}">
+                                                    itemValue="#{i}">
                                                     <p:column headerText="Item" style="padding: 8px;" styleClass="#{commonFunctionsProxy.currentDateTime > i.dateOfExpire ?'ui-messages-fatal': commonFunctionsProxy.dateAfterThreeMonthsCurrentDateTime > i.dateOfExpire ?'ui-messages-warn':''}">
                                                         <h:outputText value="#{i.itemName}"  style="width: 300px!important;">
                                                             &nbsp;<p:tag rendered="#{commonFunctionsProxy.currentDateTime > i.dateOfExpire ?'true': commonFunctionsProxy.dateAfterThreeMonthsCurrentDateTime > i.dateOfExpire ?'true':'false'}" value="#{commonFunctionsProxy.currentDateTime > i.dateOfExpire ?'Expired ': commonFunctionsProxy.dateAfterThreeMonthsCurrentDateTime > i.dateOfExpire ?'Expired Soon':''}" severity="#{commonFunctionsProxy.currentDateTime > i.dateOfExpire ?'danger': commonFunctionsProxy.dateAfterThreeMonthsCurrentDateTime > i.dateOfExpire ?'warning':''}" />


### PR DESCRIPTION
## Summary
- update `PharmacyFastRetailSaleController` to store a StockDTO object and keep a cache of autocomplete results
- update the StockDTO converter to resolve values from the cached list
- adjust `pharmacy_fast_retail_sale.xhtml` autocomplete to use StockDTO

## Testing
- `mvn -q test` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:2.6 could not be resolved)*

------
https://chatgpt.com/codex/tasks/task_e_687fcc65df74832f97b0d2461b286737