### PR TITLE
14098 date of birth calculation in pharmacy retail sale is wrong when the age is given

### DIFF
--- a/src/main/java/com/divudi/bean/pharmacy/PharmacySaleController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacySaleController.java
@@ -3417,4 +3417,14 @@ public class PharmacySaleController implements Serializable, ControllerWithPatie
         this.billSettlingStarted = billSettlingStarted;
     }
 
+    public void calculateDobFromAge() {
+        if (patient == null) {
+            return;
+        }
+        if (patient.getPerson() == null) {
+            return;
+        }
+        patient.getPerson().calDobFromAge();
+    }
+
 }

--- a/src/main/webapp/pharmacy/pharmacy_bill_retail_sale.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_bill_retail_sale.xhtml
@@ -743,7 +743,7 @@
 
                                                                                     value="#{pharmacySaleController.patient.person.ageYearsComponent}"
                                                                                     class="form-control">
-                                                                                    <f:ajax event="keyup" execute="@this" render="dpDob" />
+    <f:ajax event="keyup" execute="@this" render="dpDob" listener="#{pharmacySaleController.calculateDobFromAge}" />
                                                                                 </p:inputText>
                                                                             </div>
                                                                             <div class="col-md-2">
@@ -752,7 +752,7 @@
                                                                                     autocomplete="off" id="month" placeholder="Months"
                                                                                     value="#{pharmacySaleController.patient.person.ageMonthsComponent}"
                                                                                     class="form-control">
-                                                                                    <f:ajax event="keyup" execute="@this"  render="dpDob"  />
+    <f:ajax event="keyup" execute="@this"  render="dpDob"  listener="#{pharmacySaleController.calculateDobFromAge}" />
                                                                                 </p:inputText>
                                                                             </div>
                                                                             <div class="col-md-2">
@@ -761,7 +761,7 @@
                                                                                     autocomplete="off" id="day" placeholder="Days"
                                                                                     value="#{pharmacySaleController.patient.person.ageDaysComponent}"
                                                                                     class="form-control">
-                                                                                    <f:ajax event="keyup" execute="@this"  render="dpDob" />
+    <f:ajax event="keyup" execute="@this"  render="dpDob" listener="#{pharmacySaleController.calculateDobFromAge}" />
                                                                                 </p:inputText>
                                                                             </div>
                                                                             <div class="col-md-6">

--- a/src/main/webapp/pharmacy/pharmacy_bill_retail_sale_for_cashier.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_bill_retail_sale_for_cashier.xhtml
@@ -348,7 +348,8 @@
                                 <div class="col-md-5">
                                     <common:patient_details
                                         editable="true"
-                                        controller="#{pharmacySaleController}">
+                                        controller="#{pharmacySaleController}"
+                                        ageListener="#{pharmacySaleController.calculateDobFromAge}">
                                     </common:patient_details>
 
                                     <p:panel class="m-1 w-100">

--- a/src/main/webapp/resources/ezcomp/common/patient_details.xhtml
+++ b/src/main/webapp/resources/ezcomp/common/patient_details.xhtml
@@ -14,6 +14,7 @@
         <cc:attribute name="searchable" type="java.lang.Boolean" default="true" />
         <cc:attribute name="controller" type="com.divudi.bean.common.ControllerWithPatient"/>
         <cc:attribute name="focus" type="java.lang.Boolean"  />
+        <cc:attribute name="ageListener" method-signature="void action()"/>
     </cc:interface>
 
     <!-- IMPLEMENTATION -->
@@ -184,7 +185,7 @@
                                                     onfocus="this.select();"
                                                     value="#{cc.attrs.controller.patient.person.ageYearsComponent}"
                                                     class="form-control">
-                                                    <f:ajax event="keyup" execute="@this" render="dpDob" />
+                                                    <f:ajax event="keyup" execute="@this" render="dpDob" listener="#{cc.attrs.ageListener}" />
                                                 </p:inputText>
                                             </div>
                                             <div class="col-md-2">
@@ -193,7 +194,7 @@
                                                     autocomplete="off" id="month" placeholder="Months"
                                                     value="#{cc.attrs.controller.patient.person.ageMonthsComponent}"
                                                     class="form-control">
-                                                    <f:ajax event="keyup" execute="@this"  render="dpDob"  />
+                                                    <f:ajax event="keyup" execute="@this"  render="dpDob" listener="#{cc.attrs.ageListener}" />
                                                 </p:inputText>
                                             </div>
                                             <div class="col-md-2">
@@ -202,7 +203,7 @@
                                                     autocomplete="off" id="day" placeholder="Days"
                                                     value="#{cc.attrs.controller.patient.person.ageDaysComponent}"
                                                     class="form-control">
-                                                    <f:ajax event="keyup" execute="@this"  render="dpDob" />
+                                                    <f:ajax event="keyup" execute="@this"  render="dpDob" listener="#{cc.attrs.ageListener}" />
                                                 </p:inputText>
                                             </div>
                                             <div class="col-md-6">


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The date of birth field now updates automatically based on entered age (years, months, days) in patient details during pharmacy retail sales.
  * Age input fields trigger an immediate recalculation of date of birth as you type, enhancing accuracy and user experience.

* **Enhancements**
  * Improved integration between age input and date of birth calculation for both regular and cashier pharmacy sale interfaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->