### PR TITLE
Fix NullPointerException in PharmacyCalculation

### DIFF
--- a/src/main/java/com/divudi/ejb/PharmacyCalculation.java
+++ b/src/main/java/com/divudi/ejb/PharmacyCalculation.java
@@ -1006,8 +1006,12 @@ public class PharmacyCalculation implements Serializable {
         double free = 0.0;
 
         for (BillItem i : b.getBillItems()) {
-            sale += (i.getPharmaceuticalBillItem().getQty() + i.getPharmaceuticalBillItem().getFreeQty()) * i.getPharmaceuticalBillItem().getRetailRate();
-            free += i.getPharmaceuticalBillItem().getFreeQty() * i.getPharmaceuticalBillItem().getPurchaseRate();
+            PharmaceuticalBillItem ph = i.getPharmaceuticalBillItem();
+            if (ph == null) {
+                continue;
+            }
+            sale += (ph.getQty() + ph.getFreeQty()) * ph.getRetailRate();
+            free += ph.getFreeQty() * ph.getPurchaseRate();
         }
         if (b.getBillType() == BillType.PharmacyGrnReturn || b.getBillType() == BillType.PurchaseReturn || b.getClass().equals(CancelledBill.class) || b.getClass().equals(RefundBill.class)) {
             b.setSaleValue(0.0 - Math.abs(sale));
@@ -1021,11 +1025,15 @@ public class PharmacyCalculation implements Serializable {
     public boolean checkItemBatch(List<BillItem> list) {
 
         for (BillItem i : list) {
-            if (i.getPharmaceuticalBillItem().getQty() != 0.0) {
-                if (i.getPharmaceuticalBillItem().getDoe() == null || i.getPharmaceuticalBillItem().getStringValue().trim().isEmpty()) {
+            PharmaceuticalBillItem ph = i.getPharmaceuticalBillItem();
+            if (ph == null) {
+                continue;
+            }
+            if (ph.getQty() != 0.0) {
+                if (ph.getDoe() == null || ph.getStringValue().trim().isEmpty()) {
                     return true;
                 }
-                if (i.getPharmaceuticalBillItem().getPurchaseRate() > i.getPharmaceuticalBillItem().getRetailRate()) {
+                if (ph.getPurchaseRate() > ph.getRetailRate()) {
                     return true;
                 }
 

--- a/src/test/java/com/divudi/ejb/PharmacyCalculationTest.java
+++ b/src/test/java/com/divudi/ejb/PharmacyCalculationTest.java
@@ -1,0 +1,43 @@
+package com.divudi.ejb;
+
+import com.divudi.core.entity.Bill;
+import com.divudi.core.entity.BillItem;
+import com.divudi.core.entity.pharmacy.PharmaceuticalBillItem;
+import com.divudi.core.data.BillType;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.Test;
+import static org.junit.Assert.*;
+
+public class PharmacyCalculationTest {
+
+    @Test
+    public void skipsItemsWithoutPharmaceuticalBillItem() {
+        PharmacyCalculation calc = new PharmacyCalculation();
+
+        Bill bill = new Bill();
+        bill.setBillType(BillType.PharmacyGrnBill);
+
+        List<BillItem> items = new ArrayList<>();
+
+        BillItem withPh = new BillItem();
+        PharmaceuticalBillItem ph = new PharmaceuticalBillItem();
+        ph.setBillItem(withPh);
+        ph.setQty(2);
+        ph.setFreeQty(1);
+        ph.setRetailRate(10.0);
+        ph.setPurchaseRate(5.0);
+        withPh.setPharmaceuticalBillItem(ph);
+        items.add(withPh);
+
+        BillItem withoutPh = new BillItem();
+        items.add(withoutPh);
+
+        bill.setBillItems(items);
+
+        calc.calculateRetailSaleValueAndFreeValueAtPurchaseRate(bill);
+
+        assertEquals(30.0, bill.getSaleValue(), 0.001);
+        assertEquals(5.0, bill.getFreeValue(), 0.001);
+    }
+}


### PR DESCRIPTION
## Summary
- handle missing PharmaceuticalBillItem in PharmacyCalculation
- extend checkItemBatch null-safety
- add unit test covering missing PharmaceuticalBillItem

Closes #14112

------
https://chatgpt.com/codex/tasks/task_e_6880e06157b0832fb20247ca58085f5b