### PR TITLE
Fix pharmacy bills settled at cashier not appearing in cashier reports

### DIFF
--- a/src/main/java/com/divudi/bean/common/SearchController.java
+++ b/src/main/java/com/divudi/bean/common/SearchController.java
@@ -582,6 +582,7 @@ public class SearchController implements Serializable {
         billTypeAtomic.add(BillTypeAtomic.CC_BILL_REFUND);
         //Pharmacy Types
         billTypeAtomic.add(BillTypeAtomic.PHARMACY_RETAIL_SALE);
+        billTypeAtomic.add(BillTypeAtomic.PHARMACY_RETAIL_SALE_PREBILL_SETTLED_AT_CASHIER);
 //        billTypeAtomic.add(BillTypeAtomic.PHARMACY_RETAIL_SALE_CANCELLED);
         billTypeAtomic.add(BillTypeAtomic.PHARMACY_RETAIL_SALE_RETURN_ITEMS_AND_PAYMENTS);
         billTypeAtomic.add(BillTypeAtomic.PHARMACY_RETAIL_SALE_REFUND);
@@ -733,6 +734,7 @@ public class SearchController implements Serializable {
         billTypeAtomic.add(BillTypeAtomic.CC_BILL_REFUND);
         //Pharmacy Types
         billTypeAtomic.add(BillTypeAtomic.PHARMACY_RETAIL_SALE);
+        billTypeAtomic.add(BillTypeAtomic.PHARMACY_RETAIL_SALE_PREBILL_SETTLED_AT_CASHIER);
 //        billTypeAtomic.add(BillTypeAtomic.PHARMACY_RETAIL_SALE_CANCELLED);
         billTypeAtomic.add(BillTypeAtomic.PHARMACY_RETAIL_SALE_RETURN_ITEMS_AND_PAYMENTS);
         billTypeAtomic.add(BillTypeAtomic.PHARMACY_RETAIL_SALE_REFUND);
@@ -14811,7 +14813,11 @@ public class SearchController implements Serializable {
             collectionForTheDay += getSafeTotal(opdServiceRefundsCredit);
 
             // Generate Pharmacy Collection and add to the main bundle
-            List<BillTypeAtomic> pharmacyCollectionBillTypes = BillTypeAtomic.findByServiceTypeAndFinanceType(ServiceType.PHARMACY, BillFinanceType.CASH_IN);
+            List<BillTypeAtomic> pharmacyCollectionBillTypes = new ArrayList<>();
+            pharmacyCollectionBillTypes.add(BillTypeAtomic.PHARMACY_RETAIL_SALE);
+            pharmacyCollectionBillTypes.add(BillTypeAtomic.PHARMACY_RETAIL_SALE_PREBILL_SETTLED_AT_CASHIER);
+            pharmacyCollectionBillTypes.add(BillTypeAtomic.PHARMACY_WHOLESALE);
+            pharmacyCollectionBillTypes.add(BillTypeAtomic.PHARMACY_SALE_WITHOUT_STOCK);
             ReportTemplateRowBundle pharmacyCollection = generateTotalPaymentColumnByDepartment(pharmacyCollectionBillTypes, nonCreditPaymentMethods);
             pharmacyCollection.setBundleType("pharmacyCollection");
             pharmacyCollection.setName("Pharmacy Collection");
@@ -15161,6 +15167,7 @@ public class SearchController implements Serializable {
             // Generate Pharmacy Bills and add to the main bundle
             List<BillTypeAtomic> pharmacyCollectionBillTypes = new ArrayList<>();
             pharmacyCollectionBillTypes.add(BillTypeAtomic.PHARMACY_RETAIL_SALE);
+            pharmacyCollectionBillTypes.add(BillTypeAtomic.PHARMACY_RETAIL_SALE_PREBILL_SETTLED_AT_CASHIER);
             pharmacyCollectionBillTypes.add(BillTypeAtomic.PHARMACY_WHOLESALE);
             ReportTemplateRowBundle pharmacyCollection = generatePaymentMethodColumnsByBills(pharmacyCollectionBillTypes, nonCreditPaymentMethods);
             pharmacyCollection.setBundleType("pharmacyNonCreditBills");
@@ -17031,6 +17038,7 @@ public class SearchController implements Serializable {
         btas.add(BillTypeAtomic.OPD_BILL_CANCELLATION);
         btas.add(BillTypeAtomic.OPD_BILL_REFUND);
         btas.add(BillTypeAtomic.PHARMACY_RETAIL_SALE);
+        btas.add(BillTypeAtomic.PHARMACY_RETAIL_SALE_PREBILL_SETTLED_AT_CASHIER);
 
         ap = reportTemplateController.generateBillReport(
                 btas,
@@ -17055,6 +17063,7 @@ public class SearchController implements Serializable {
         btas.add(BillTypeAtomic.OPD_BILL_CANCELLATION);
         btas.add(BillTypeAtomic.OPD_BILL_REFUND);
         btas.add(BillTypeAtomic.PHARMACY_RETAIL_SALE);
+        btas.add(BillTypeAtomic.PHARMACY_RETAIL_SALE_PREBILL_SETTLED_AT_CASHIER);
         ap = reportTemplateController.generateBillReportWithoutProfessionalFees(
                 btas,
                 fromDate,


### PR DESCRIPTION
## Summary
- Fixes issue where `PHARMACY_RETAIL_SALE_PREBILL_SETTLED_AT_CASHIER` bills were missing from cashier reports
- Ensures pharmacy bills settled at cashier appear consistently across all cashier reporting functions
- Updates 6 methods in SearchController to include the missing bill type

## Problem
Pharmacy bills with bill type `PHARMACY_RETAIL_SALE_PREBILL_SETTLED_AT_CASHIER` were not appearing in cashier reports because they were missing from explicit bill type lists in several reporting methods, even though they should be treated the same as regular `PHARMACY_RETAIL_SALE` bills.

## Solution
Added `BillTypeAtomic.PHARMACY_RETAIL_SALE_PREBILL_SETTLED_AT_CASHIER` to all relevant bill type lists:

### Cashier Reports (Primary Fix)
- **generateCashierSummary()** - Updated pharmacy collection filtering for consistency
- **generateCashierDetailed()** - Added missing bill type to pharmacy bills (non-credit) section

### Related Functions (Consistency Fix)  
- **findBillcountUsingBills()** - Bill count analytics
- **findBillcountUsingBillItem()** - Bill count analytics
- **generateCreditBills()** - Credit bill reports
- **generateCreditBillsWithoutProfessionalFees()** - Credit bill reports

## Files Changed
- `src/main/java/com/divudi/bean/common/SearchController.java` - Updated 6 methods to include missing bill type

## Test Plan
- [ ] Verify pharmacy bills settled at cashier now appear in All Cashier Summary report
- [ ] Verify pharmacy bills settled at cashier now appear in Cashier Summary report  
- [ ] Verify pharmacy bills settled at cashier now appear in Cashier Detailed report
- [ ] Confirm bill counts and credit reports include these bills consistently
- [ ] Test with existing pharmacy retail sale bills to ensure no regression

🤖 Generated with [Claude Code](https://claude.ai/code)