### PR TITLE
Implement multi-batch purchase rate adjustments

### DIFF
--- a/src/main/java/com/divudi/bean/pharmacy/PharmacyAdjustmentController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacyAdjustmentController.java
@@ -1323,6 +1323,52 @@ public class PharmacyAdjustmentController implements Serializable {
 
     }
 
+    public void adjustPurchaseRates() {
+        if (ampStock == null || ampStock.isEmpty()) {
+            JsfUtil.addErrorMessage("No Stocks");
+            return;
+        }
+
+        if ((comment == null) || (comment.trim().isEmpty())) {
+            JsfUtil.addErrorMessage("Add the Comment..");
+            return;
+        }
+
+        savePurchaseRateAdjustmentBill();
+
+        boolean any = false;
+        for (StockDTO dto : ampStock) {
+            if (dto.getNewPurchaseRate() == null) {
+                continue;
+            }
+            any = true;
+            Stock s = stockFacade.find(dto.getId());
+            if (s == null) {
+                continue;
+            }
+            stock = s;
+
+            double oldPurchaseRate = s.getItemBatch().getPurcahseRate();
+            double newPurchaseRate = dto.getNewPurchaseRate();
+            double purchaseRateChange = newPurchaseRate - oldPurchaseRate;
+            double changeValue = s.getStock() * purchaseRateChange;
+
+            savePrAdjustmentBillItems(oldPurchaseRate, newPurchaseRate, purchaseRateChange, changeValue);
+
+            s.getItemBatch().setPurcahseRate(newPurchaseRate);
+            itemBatchFacade.edit(s.getItemBatch());
+        }
+
+        if (!any) {
+            JsfUtil.addErrorMessage("Enter at least one new purchase rate");
+            return;
+        }
+
+        deptAdjustmentPreBill = billFacade.find(getDeptAdjustmentPreBill().getId());
+        printPreview = true;
+        JsfUtil.addSuccessMessage("Purchase Rate Adjustment Successfully");
+    }
+
     public void adjustExDate() {
         if (errorCheck()) {
             return;

--- a/src/main/java/com/divudi/core/data/dto/StockDTO.java
+++ b/src/main/java/com/divudi/core/data/dto/StockDTO.java
@@ -14,6 +14,8 @@ public class StockDTO implements Serializable {
     private String batchNo;
     private Double purchaseRate;
     private Double wholesaleRate;
+    // Temporary holder for purchase rate adjustments on the UI
+    private Double newPurchaseRate;
 
     public StockDTO() {
     }
@@ -121,5 +123,13 @@ public class StockDTO implements Serializable {
 
     public void setWholesaleRate(Double wholesaleRate) {
         this.wholesaleRate = wholesaleRate;
+    }
+
+    public Double getNewPurchaseRate() {
+        return newPurchaseRate;
+    }
+
+    public void setNewPurchaseRate(Double newPurchaseRate) {
+        this.newPurchaseRate = newPurchaseRate;
     }
 }

--- a/src/main/webapp/pharmacy/adjustments/pharmacy_adjustment_purchase_rate.xhtml
+++ b/src/main/webapp/pharmacy/adjustments/pharmacy_adjustment_purchase_rate.xhtml
@@ -59,9 +59,6 @@
                                         rows="10"
                                         paginator="true"
                                         paginatorAlwaysVisible="false"
-                                        selectionMode="single"
-                                        rowKey="#{i.id}"
-                                        selection="#{pharmacyAdjustmentController.selectedStockDto}"
                                         emptyMessage="No Stocks">
 
                                         <f:facet name="header">
@@ -101,6 +98,9 @@
                                             </h:outputText>
                                         </p:column>
 
+                                        <p:column headerText="New Purchase Rate" styleClass="text-end">
+                                            <p:inputText value="#{i.newPurchaseRate}" styleClass="w-100"/>
+                                        </p:column>
                                         <p:column
                                             headerText="Cost Rate"
                                             sortBy="#{i.retailRate}"
@@ -129,104 +129,25 @@
                                         </p:column>
 
 
-                                        <p:ajax event="rowSelect" update=":#{p:resolveFirstComponentWithId('det',view).clientId}" />
-                                        <p:ajax event="rowUnselect" update=":#{p:resolveFirstComponentWithId('det',view).clientId}" />
                                     </p:dataTable>
                                 </p:panel>
 
                             </div>
                             <div class="col-md-6">
-                                <p:panel class="w-100" id="det">
-                                    <f:facet name="header">
-                                        <h:outputText styleClass="fa-solid fa-file-invoice"></h:outputText>
-                                        <h:outputLabel value="Item Details" class="mx-4"></h:outputLabel>
-                                    </f:facet>
-                                    <div>
-                                        <div class="row">
-                                            <div class="col-md-3">
-                                                <h:outputLabel value="Stock ID"/>
-                                            </div>
-                                            <div class="col-md-2">
-                                                <h:outputLabel value=":"/>
-                                            </div>
-                                            <div class="col-md-7">
-                                                <h:outputLabel value="#{pharmacyAdjustmentController.selectedStockDto.id}" ></h:outputLabel>
-                                            </div>
-                                        </div>
-
-                                        <div class="row">
-                                            <div class="col-md-3"><h:outputLabel value="Item ID"/></div>
-                                            <div class="col-md-2"><h:outputLabel value=":"/></div>
-                                            <div class="col-md-7"><h:outputLabel value="#{pharmacyAdjustmentController.selectedStockDto.id}" ></h:outputLabel></div>
-                                        </div>
-                                        <div class="row">
-                                            <div class="col-md-3"><h:outputLabel value="Name"/></div>
-                                            <div class="col-md-2"><h:outputLabel value=":"/></div>
-                                            <div class="col-md-7"><h:outputLabel value="#{pharmacyAdjustmentController.selectedStockDto.itemName}" ></h:outputLabel></div>
-                                        </div>
-                                        <div class="row">
-                                            <div class="col-md-3"><h:outputLabel value="Code"/></div>
-                                            <div class="col-md-2"><h:outputLabel value=":"/></div>
-                                            <div class="col-md-7"><h:outputLabel value="#{pharmacyAdjustmentController.selectedStockDto.code}" ></h:outputLabel></div>
-                                        </div>
-                                        <div class="row">
-                                            <div class="col-md-3"><h:outputLabel value="Purchase Rate"/></div>
-                                            <div class="col-md-2"><h:outputLabel value=":"/></div>
-                                            <div class="col-md-7"><h:outputLabel value="#{pharmacyAdjustmentController.selectedStockDto.purchaseRate}" >
-                                                    <f:convertNumber pattern="#,##0.00" ></f:convertNumber>
-                                                </h:outputLabel></div>
-                                        </div>
-                                        <div class="row">
-                                            <div class="col-md-3"> <h:outputLabel value="Retail Sale Rate"/></div>
-                                            <div class="col-md-2"><h:outputLabel value=":"/></div>
-                                            <div class="col-md-7"><h:outputLabel value="#{pharmacyAdjustmentController.selectedStockDto.retailRate}" >
-                                                    <f:convertNumber pattern="#,##0.00" ></f:convertNumber>
-                                                </h:outputLabel></div>
-                                        </div>
-                                        <div class="row">
-                                            <div class="col-md-3"> <h:outputLabel value="Wholesale Rate"/></div>
-                                            <div class="col-md-2"><h:outputLabel value=":"/></div>
-                                            <div class="col-md-7"><h:outputLabel value="#{pharmacyAdjustmentController.selectedStockDto.wholesaleRate}" >
-                                                    <f:convertNumber pattern="#,##0.00" ></f:convertNumber>
-                                                </h:outputLabel></div>
-                                        </div>
-                                        <div class="row">
-                                            <div class="col-md-3"><h:outputLabel value="Stocks"/></div>
-                                            <div class="col-md-2"><h:outputLabel value=":"/></div>
-                                            <div class="col-md-7"><h:outputLabel value="#{pharmacyAdjustmentController.selectedStockDto.stockQty}" >
-                                                    <f:convertNumber pattern="#,###" ></f:convertNumber>
-                                                </h:outputLabel></div>
-                                        </div>
-
-                                        <div class="row">
-                                            <div class="col-md-3"> <h:outputLabel value="Expiry"/></div>
-                                            <div class="col-md-2"><h:outputLabel value=":"/></div>
-                                            <div class="col-md-7 align-items-center"><h:outputLabel value="#{pharmacyAdjustmentController.selectedStockDto.dateOfExpire}" >
-                                                    <f:convertDateTime pattern="MMM yyyy" ></f:convertDateTime>
-                                                    &nbsp;<p:tag rendered="#{commonFunctionsProxy.currentDateTime > pharmacyAdjustmentController.selectedStockDto.dateOfExpire ?'true': commonFunctionsProxy.dateAfterThreeMonthsCurrentDateTime > pharmacyAdjustmentController.selectedStockDto.dateOfExpire ?'true':'false'}" value="#{commonFunctionsProxy.currentDateTime > pharmacyAdjustmentController.selectedStockDto.dateOfExpire ?'Expired ':
-                                                                             commonFunctionsProxy.dateAfterThreeMonthsCurrentDateTime > pharmacyAdjustmentController.selectedStockDto.dateOfExpire ?'Expired Soon':''}"
-                                                                 severity="#{commonFunctionsProxy.currentDateTime > pharmacyAdjustmentController.selectedStockDto.dateOfExpire ?'danger': commonFunctionsProxy.dateAfterThreeMonthsCurrentDateTime > pharmacyAdjustmentController.selectedStockDto.dateOfExpire ?'warning':''}" />
-                                                </h:outputLabel></div>
-                                        </div>
-                                    </div>
-
-                                </p:panel>
-                                <p:panel >
+                                <p:panel>
                                     <f:facet name="header" >
                                         <h:outputLabel value="Adjust" ></h:outputLabel>
                                     </f:facet>
-                                    <h:outputLabel value="New Purchase Rate" ></h:outputLabel>
-                                    <p:inputText autocomplete="off" value="#{pharmacyAdjustmentController.pr}"  class="w-100"></p:inputText>
                                     <h:outputLabel value="Comment" ></h:outputLabel>
                                     <p:inputTextarea value="#{pharmacyAdjustmentController.comment}"  class="w-100"></p:inputTextarea>
 
                                     <p:commandButton
                                         id="btnAdjust"
-                                        value="Make Adjustment"
+                                        value="Adjust the Purchase Rates"
                                         ajax="false"
                                         class="mt-2 ui-button-warning"
                                         icon="fa-solid fa-sliders"
-                                        action="#{pharmacyAdjustmentController.adjustPurchaseRate()}" >
+                                        action="#{pharmacyAdjustmentController.adjustPurchaseRates()}" >
                                     </p:commandButton>
                                     <p:defaultCommand target="btnAdjust"/>
                                 </p:panel>


### PR DESCRIPTION
## Summary
- allow entering new purchase rate per batch
- add newPurchaseRate field to `StockDTO`
- update purchase rate adjustment page for multiple entries
- iterate selected batches in controller and update rates

## Testing
- `./detect-maven.sh -q test -DskipTests` *(fails: plugin resolution blocked)*

------
https://chatgpt.com/codex/tasks/task_e_6883bef136d8832faf906c283866265b