### PR TITLE
Fix for issue #14181

### DIFF
--- a/src/main/java/com/divudi/core/data/dto/StockDTO.java
+++ b/src/main/java/com/divudi/core/data/dto/StockDTO.java
@@ -19,6 +19,10 @@ public class StockDTO implements Serializable {
     private Double wholesaleRate;
     // Temporary holder for purchase rate adjustments on the UI
     private Double newPurchaseRate;
+    // Fields for retail rate adjustment
+    private Double newRetailRate;
+    private Double retailRateChange;
+    private Double beforeRetailAdjustmentValue;
 
     public StockDTO() {
     }
@@ -49,8 +53,8 @@ public class StockDTO implements Serializable {
     }
 
     // Constructor for pharmacy adjustment with Stock ID and ItemBatch ID
-    public StockDTO(Long id, Long stockId, Long itemBatchId, String itemName, String code, 
-                    Double retailRate, Double stockQty, Date dateOfExpire, String batchNo, 
+    public StockDTO(Long id, Long stockId, Long itemBatchId, String itemName, String code,
+                    Double retailRate, Double stockQty, Date dateOfExpire, String batchNo,
                     Double purchaseRate, Double wholesaleRate) {
         this.id = id;
         this.stockId = stockId;
@@ -63,6 +67,14 @@ public class StockDTO implements Serializable {
         this.batchNo = batchNo;
         this.purchaseRate = purchaseRate;
         this.wholesaleRate = wholesaleRate;
+    }
+
+    // Constructor including field for retail rate adjustments
+    public StockDTO(Long id, Long stockId, Long itemBatchId, String itemName, String code,
+                    Double retailRate, Double stockQty, Date dateOfExpire, String batchNo,
+                    Double purchaseRate, Double wholesaleRate, Double beforeRetailAdjustmentValue) {
+        this(id, stockId, itemBatchId, itemName, code, retailRate, stockQty, dateOfExpire, batchNo, purchaseRate, wholesaleRate);
+        this.beforeRetailAdjustmentValue = beforeRetailAdjustmentValue;
     }
 
     public Long getId() {
@@ -167,5 +179,29 @@ public class StockDTO implements Serializable {
 
     public void setNewPurchaseRate(Double newPurchaseRate) {
         this.newPurchaseRate = newPurchaseRate;
+    }
+
+    public Double getNewRetailRate() {
+        return newRetailRate;
+    }
+
+    public void setNewRetailRate(Double newRetailRate) {
+        this.newRetailRate = newRetailRate;
+    }
+
+    public Double getRetailRateChange() {
+        return retailRateChange;
+    }
+
+    public void setRetailRateChange(Double retailRateChange) {
+        this.retailRateChange = retailRateChange;
+    }
+
+    public Double getBeforeRetailAdjustmentValue() {
+        return beforeRetailAdjustmentValue;
+    }
+
+    public void setBeforeRetailAdjustmentValue(Double beforeRetailAdjustmentValue) {
+        this.beforeRetailAdjustmentValue = beforeRetailAdjustmentValue;
     }
 }

--- a/src/main/java/com/divudi/service/pharmacy/StockSearchService.java
+++ b/src/main/java/com/divudi/service/pharmacy/StockSearchService.java
@@ -3,6 +3,7 @@ package com.divudi.service.pharmacy;
 import com.divudi.bean.common.ConfigOptionApplicationController;
 import com.divudi.core.entity.Department;
 import com.divudi.core.entity.pharmacy.Stock;
+import com.divudi.core.entity.pharmacy.Amp;
 import com.divudi.core.data.dto.StockDTO;
 import com.divudi.core.facade.StockFacade;
 import java.util.Collections;
@@ -100,5 +101,32 @@ public class StockSearchService {
         }
         sql.append(") ORDER BY s.itemBatch.item.name, s.itemBatch.dateOfExpire");
         return (List<StockDTO>) stockFacade.findLightsByJpql(sql.toString(), params, javax.persistence.TemporalType.TIMESTAMP, 20);
+    }
+
+    public List<StockDTO> findRetailRateStockDtos(Amp amp, Department department) {
+        if (amp == null || department == null) {
+            return Collections.emptyList();
+        }
+        Map<String, Object> params = new HashMap<>();
+        params.put("d", department);
+        params.put("amp", amp);
+        String sql = "SELECT new com.divudi.core.data.dto.StockDTO(" +
+                "s.id, " +
+                "s.id, " +
+                "s.itemBatch.id, " +
+                "s.itemBatch.item.name, " +
+                "s.itemBatch.item.code, " +
+                "s.itemBatch.retailsaleRate, " +
+                "s.stock, " +
+                "s.itemBatch.dateOfExpire, " +
+                "s.itemBatch.batchNo, " +
+                "s.itemBatch.purcahseRate, " +
+                "s.itemBatch.wholesaleRate, " +
+                "s.itemBatch.retailsaleRate) " +
+                "FROM Stock s " +
+                "WHERE s.department = :d " +
+                "AND s.itemBatch.item = :amp " +
+                "ORDER BY s.stock DESC";
+        return (List<StockDTO>) stockFacade.findLightsByJpql(sql, params);
     }
 }

--- a/src/main/webapp/pharmacy/adjustments/pharmacy_adjustment_retail_sale_rate.xhtml
+++ b/src/main/webapp/pharmacy/adjustments/pharmacy_adjustment_retail_sale_rate.xhtml
@@ -25,69 +25,56 @@
                                     </f:facet>
                                     <p:panelGrid columns="1" class="w-100">
                                         <h:outputLabel value="Item" ></h:outputLabel>
-                                        <p:autoComplete
-                                            id="acAmp"
-                                            class="w-100"
-                                            inputStyleClass="w-100"
-                                            completeMethod="#{ampController.completeAmp}"
-                                            var="amp"
-                                            itemLabel="#{amp.name}"
-                                            itemValue="#{amp}"
-                                            value="#{pharmacyAdjustmentController.amp}"
-                                            maxResults="10"
-                                            minQueryLength="3"
-                                            >
-                                            <p:ajax
-                                                process="acAmp"
-                                                listener="#{pharmacyAdjustmentController.fillAmpStocks}"
-                                                update="tblStocks" ></p:ajax>
-                                            <p:column headerText="Item"  style="padding: 3px;" >
-                                                <h:outputText value="#{amp.name}" ></h:outputText>
+                                        <p:autoComplete id="acAmp" class="w-100" inputStyleClass="w-100"
+                                                       completeMethod="#{ampController.completeAmp}"
+                                                       var="amp" itemLabel="#{amp.name}" itemValue="#{amp}"
+                                                       value="#{pharmacyAdjustmentController.amp}"
+                                                       maxResults="10" minQueryLength="3">
+                                            <p:ajax process="acAmp"
+                                                    listener="#{pharmacyAdjustmentController.fillRetailRateStockDtos}"
+                                                    update="tblStocks" />
+                                            <p:column headerText="Item" style="padding: 3px;">
+                                                <h:outputText value="#{amp.name}" />
                                             </p:column>
-                                            <p:column headerText="Code"  style="padding: 3px;" >
-                                                <h:outputText value="#{amp.code}" ></h:outputText>
-                                            </p:column>
-                                            <p:column headerText="Stock" style="padding: 3px;" >
-                                                <h:outputText value="#{stockController.departmentItemStock(sessionController.getLoggedUser().getDepartment(), amp)}" ></h:outputText>
+                                            <p:column headerText="Code" style="padding: 3px;">
+                                                <h:outputText value="#{amp.code}" />
                                             </p:column>
                                         </p:autoComplete>
 
-                                        <h:outputLabel value="Batches" ></h:outputLabel>
-                                        <p:dataTable
-                                            id="tblStocks"
-                                            value="#{pharmacyAdjustmentController.ampStock}"
-                                            var="i"
-                                            rows="10"
-                                            selectionMode="single"
-                                            rowKey="#{i.id}"
-                                            selection="#{pharmacyAdjustmentController.stock}">
-                                            <p:column
-                                                headerText="Rate"
-                                                sortBy="#{i.itemBatch.retailsaleRate}"
-                                                styleClass="#{commonFunctionsProxy.currentDateTime > i.itemBatch.dateOfExpire ?'ui-messages-fatal': commonFunctionsProxy.dateAfterThreeMonthsCurrentDateTime > i.itemBatch.dateOfExpire ?'ui-messages-warn':''}">
-                                                <h:outputText value="#{i.itemBatch.retailsaleRate}" >
-                                                    <f:convertNumber pattern="#,##0.00" ></f:convertNumber>
-                                                </h:outputText>
-                                            </p:column>
-                                            <p:column
-                                                sortBy="#{i.stock}"
-                                                headerText="Stocks"
-                                                styleClass="#{commonFunctionsProxy.currentDateTime > i.itemBatch.dateOfExpire ?'ui-messages-fatal': commonFunctionsProxy.dateAfterThreeMonthsCurrentDateTime > i.itemBatch.dateOfExpire ?'ui-messages-warn':''}">
-                                                <h:outputText value="#{i.stock}" >
-                                                    <f:convertNumber pattern="#,###" ></f:convertNumber>
-                                                </h:outputText>
-                                            </p:column>
-                                            <p:column
-                                                headerText="Expiry"
-                                                sortBy="#{i.itemBatch.dateOfExpire}"
-                                                styleClass="#{commonFunctionsProxy.currentDateTime > i.itemBatch.dateOfExpire ?'ui-messages-fatal': commonFunctionsProxy.dateAfterThreeMonthsCurrentDateTime > i.itemBatch.dateOfExpire ?'ui-messages-warn':''}">
-                                                <h:outputText value="#{i.itemBatch.dateOfExpire}" style="width: 100px!important;" >
-                                                    <f:convertDateTime pattern="MMM yyyy" ></f:convertDateTime>
+                                        <p:dataTable id="tblStocks"
+                                                     value="#{pharmacyAdjustmentController.retailRateStockDtos}"
+                                                     var="i" rows="10"
+                                                     paginator="true" paginatorAlwaysVisible="false"
+                                                     emptyMessage="No Stocks">
+                                            <f:facet name="header">
+                                                Batches
+                                            </f:facet>
 
+                                            <p:column headerText="Expiry" sortBy="#{i.dateOfExpire}"
+                                                      styleClass="#{commonFunctionsProxy.currentDateTime > i.dateOfExpire ?'ui-messages-fatal': commonFunctionsProxy.dateAfterThreeMonthsCurrentDateTime > i.dateOfExpire ?'ui-messages-warn':''}">
+                                                <h:outputText value="#{i.dateOfExpire}">
+                                                    <f:convertDateTime pattern="MMM yyyy" />
                                                 </h:outputText>
                                             </p:column>
-                                            <p:ajax event="rowSelect" update=":#{p:resolveFirstComponentWithId('det',view).clientId}" />
-                                            <p:ajax event="rowUnselect" update=":#{p:resolveFirstComponentWithId('det',view).clientId}" />
+                                            <p:column headerText="Batch No." sortBy="#{i.batchNo}"
+                                                      styleClass="#{commonFunctionsProxy.currentDateTime > i.dateOfExpire ?'ui-messages-fatal': commonFunctionsProxy.dateAfterThreeMonthsCurrentDateTime > i.dateOfExpire ?'ui-messages-warn':''}">
+                                                <h:outputText value="#{i.batchNo}"/>
+                                            </p:column>
+                                            <p:column sortBy="#{i.stockQty}" headerText="Stock"
+                                                      styleClass="text-end #{commonFunctionsProxy.currentDateTime > i.dateOfExpire ?'ui-messages-fatal': commonFunctionsProxy.dateAfterThreeMonthsCurrentDateTime > i.dateOfExpire ?'ui-messages-warn':''}">
+                                                <h:outputText value="#{i.stockQty}">
+                                                    <f:convertNumber pattern="#,###" />
+                                                </h:outputText>
+                                            </p:column>
+                                            <p:column headerText="Current Retail Rate" sortBy="#{i.retailRate}"
+                                                      styleClass="text-end fw-bold #{commonFunctionsProxy.currentDateTime > i.dateOfExpire ?'ui-messages-fatal': commonFunctionsProxy.dateAfterThreeMonthsCurrentDateTime > i.dateOfExpire ?'ui-messages-warn':''}">
+                                                <h:outputText value="#{i.retailRate}" styleClass="fw-bold">
+                                                    <f:convertNumber pattern="#,##0.00" />
+                                                </h:outputText>
+                                            </p:column>
+                                            <p:column headerText="New Retail Rate" styleClass="text-end">
+                                                <p:inputText value="#{i.newRetailRate}" styleClass="w-100"/>
+                                            </p:column>
                                         </p:dataTable>
 
                                     </p:panelGrid>
@@ -177,13 +164,11 @@
                                     <f:facet name="header" >
                                         <h:outputLabel value="Adjust" ></h:outputLabel>
                                     </f:facet>
-                                    <h:outputLabel value="New Sale Rate" ></h:outputLabel>
-                                    <p:inputText autocomplete="off" value="#{pharmacyAdjustmentController.rsr}" rendered="true" requiredMessage="Enter New Sale Rate" class="w-100"></p:inputText>
                                     <h:outputLabel value="Comment" ></h:outputLabel>
                                     <p:inputTextarea value="#{pharmacyAdjustmentController.comment}"  class="w-100"></p:inputTextarea>
 
-                                    <p:commandButton id="btnAdjust" value="Make Adjustment" ajax="false"  class="mt-2 ui-button-warning" icon="fa-solid fa-sliders"
-                                                     action="#{pharmacyAdjustmentController.adjustRetailRate()}" ></p:commandButton>
+                                    <p:commandButton id="btnAdjust" value="Adjust the Retail Rates" ajax="false"  class="mt-2 ui-button-warning" icon="fa-solid fa-sliders"
+                                                     action="#{pharmacyAdjustmentController.adjustRetailRates()}" ></p:commandButton>
                                     <p:defaultCommand target="btnAdjust"/>
                                 </p:panel>
                             </div>

--- a/src/main/webapp/resources/pharmacy/adjustmentBill_sale_price.xhtml
+++ b/src/main/webapp/resources/pharmacy/adjustmentBill_sale_price.xhtml
@@ -70,7 +70,7 @@
                             <h:outputLabel value="Rate Difference" style="font-weight: bold!important;" />
                         </f:facet>
                         <h:outputLabel value="#{bip.pharmaceuticalBillItem.stock.itemBatch.retailsaleRate - bip.pharmaceuticalBillItem.beforeAdjustmentValue}">
-                            <f:convertNumber pattern="#00.00"/>
+                            <f:convertNumber pattern="+#,##0.00;-#,##0.00"/>
                         </h:outputLabel>
                     </p:column>
 


### PR DESCRIPTION
## Summary
- add fields for retail rate adjustments to `StockDTO`
- extend `StockSearchService` with retail-rate DTO search
- modernize `PharmacyAdjustmentController` with DTO-based retail rate logic
- update retail rate adjustment page to use DTO data table
- improve number formatting in sale rate print component

Closes #14181

------
https://chatgpt.com/codex/tasks/task_e_68847603f1f0832f8e29438c8764e656

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the ability to adjust retail sale rates for pharmacy stock batches in bulk.
  * Introduced a new interface to view and edit retail rates for multiple stock batches at once.

* **Enhancements**
  * Improved display of rate differences with clearer formatting, including plus and minus signs and thousand separators.

* **Bug Fixes**
  * Improved error handling when no items are selected or required fields are missing during retail rate adjustment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->