### PR TITLE
Add channelling navigation guide

### DIFF
--- a/developer_docs/navigation/channelling_navigation.md
+++ b/developer_docs/navigation/channelling_navigation.md
@@ -1,0 +1,50 @@
+# Channelling Navigation Guide
+
+This document lists all pages reachable from the **Channelling** menu and its related index screens. Each entry shows how to navigate from the main screen, the target page path, required user privilege and any relevant configuration keys.
+
+| Menu steps | Page path | Privilege | Configuration notes |
+|------------|-----------|-----------|---------------------|
+| **Channel → Channel Scheduling → Channel Schedule Management** | `/channel/channel_shedule.xhtml` | `Channelling` | |
+| **Channel → Channel Scheduling → Channel Session Management** | `/channel/session_instance_management.xhtml` | `Channelling` | |
+| **Channel → Channel Scheduling → Channel Activity Management** | `/channel/channel_scheduling/appointment_activity_management.xhtml` | `Channelling` | |
+| **Channel → Channel Scheduling → Retired Channel Schedules** | `/channel/retired_channel_shedules.xhtml` | `Channelling` | |
+| **Channel → Channel Management → Agency → Agencies** | `/channel/institutions.xhtml` | `Channelling` | |
+| **Channel → Channel Management → Agency → Agency Credit Limit Update** | `/channel/institutions_udate_credit_limit.xhtml` | `Channelling` | |
+| **Channel → Channel Management → Agency → Agency Credit Limit Update (Bulk)** | `/channel/channel_agent_credit_bulk_update.xhtml` | `Channelling` | |
+| **Channel → Channel Management → Agency → Add Channel Book to Agency** | `/channel/channel_agent_referece_book.xhtml` | `Channelling` | |
+| **Channel → Channel Management → Staff → Manage Specialities** | `/channel/maintanance/doctorSpeciality/List.xhtml` | `Channelling` | |
+| **Channel → Channel Management → Staff → Manage Consultants** | `/admin/staff/admin_doctor_consultant.xhtml` | `Channelling` | |
+| **Channel → Channel Management → Channeling → Editing Appointment Count** | `/channel/channel_booking_editing_appoinment_count.xhtml` | `Channelling` | |
+| **Channel → Channel Management → Consultants → Add Channelling Consultants to Institutions** | `/admin/staff/person_institution.xhtml` | `Channelling` | |
+| **Channel → Channel Management → Schedule → Channel Fee Update** | `/channel/channel_fee_change.xhtml` | `Channelling` | |
+| **Financial Transaction Manager → Start Shift** | `/cashier/initial_fund_bill.xhtml` | `Cashier` | |
+| **Financial Transaction Manager → End Shift** | `/cashier/shift_end_summery_bill.xhtml` | `Cashier` | |
+| **Financial Transaction Manager → My Drawer** | `/cashier/my_drawer.xhtml` | `Cashier` | |
+| **Financial Transaction Manager → My Drawer History** | `/cashier/my_drawer_entry_history.xhtml` | `Cashier` | |
+| **Financial Transaction Manager → Record Shift End Cash in Hand** | `/cashier/shift_end_cash_in_hand.xhtml` | `Cashier` | |
+| **Financial Transaction Manager → Handover Current Shift** | `/cashier/handover_start.xhtml` | `Cashier` | |
+| **Financial Transaction Manager → Handover By Period** | `/cashier/handover_start_for_period.xhtml` | `Cashier` | |
+| **Financial Transaction Manager → My Shifts** | `/cashier/my_shifts.xhtml` | `Cashier` | |
+| **Financial Transaction Manager → Record Shift Shortage** | `/cashier/record_shift_shortage.xhtml` | `Cashier` | |
+| **Financial Transaction Manager → Record Shift Excess** | `/cashier/record_shift_excess.xhtml` | `Cashier` | |
+| **Financial Transaction Manager → Shift Shortage Bill Search** | `/cashier/cashier_shift_bill_search.xhtml` | `Cashier` | |
+| **Financial Transaction Manager → Float Transfer** | `/cashier/fund_transfer_bill.xhtml` | `Cashier` | |
+| **Financial Transaction Manager → Receive Float Transfer Bills** | `/cashier/fund_transfer_bills_for_me_to_receive.xhtml` | `Cashier` | |
+| **Financial Transaction Manager → Transfer Bill Payment Method** | `/cashier/transfer_payment_method.xhtml` | `Cashier` | |
+| **Financial Transaction Manager → Add Supplimantary Income** | `/cashier/income_bill.xhtml` | `Cashier` | |
+| **Financial Transaction Manager → Add Expenses** | `/cashier/expense_bill.xhtml` | `Cashier` | |
+| **Financial Transaction Manager → Trace Income & Expense** | `/cashier/trace_income_expenses.xhtml` | `Cashier` | |
+| **Financial Transaction Manager → Shift Handovers to Accept** | `/cashier/handover_bills_for_me_to_receive.xhtml` | `Cashier` | |
+| **Financial Transaction Manager → My Handovers** | `/cashier/handover_bills_from_me.xhtml` | `Cashier` | |
+| **Financial Transaction Manager → Payment Recording** | `/cashier/payment_recording.xhtml` | `Cashier` | |
+| **Financial Transaction Manager → Withdrawals** | `/cashier/fund_withdrawal_bill.xhtml` | `Cashier` | |
+| **Financial Transaction Manager → Deposit to Safe/Bank** | `/cashier/deposit_funds.xhtml` | `Cashier` | |
+| **Financial Transaction Manager → Site Cashbook Daily Summary** | `/cashier/cash_book_summery_site.xhtml` | `Cashier` | |
+| **Financial Transaction Manager → Cash Book Entries** | `/cashier/cash_book_entry.xhtml` | `Cashier` | |
+| **Financial Transaction Manager → My Shift Summary** | `/cashier/my_cashier_summary.xhtml` | `Cashier` | |
+| **Financial Transaction Manager → My Department All Cashier Summary** | `/cashier/my_department_all_cashier_summary.xhtml` | `Cashier` | |
+| **Financial Transaction Manager → My Service Department Revenue Report** | `/cashier/my_service_department_revenue_report_by_period.xhtml` | `Cashier` | |
+| **Financial Transaction Manager → My Professional Payments** | `/cashier/my_professional_payments.xhtml` | `Cashier` | |
+| **Financial Transaction Manager → Cashier Summary** | `/cashier/cashier_summary.xhtml` | `Cashier` | |
+| **Financial Transaction Manager → Cashier Summary Breakdown** | `/cashier/shift_end_summary_breakdown.xhtml` | `Cashier` | |
+| **Financial Transaction Manager → Cashier Bill List** | `/cashier/shift_end_summary_bill_list.xhtml` | `Cashier` | |


### PR DESCRIPTION
## Summary
- document every linked page from channel scheduling, management, and cashier index pages

## Testing
- `bash detect-maven.sh -q test` *(fails: Plugin resolution error)*

------
https://chatgpt.com/codex/tasks/task_e_6885841741b4832fb5491676d85832e7