### PR TITLE
Add developer docs README

### DIFF
--- a/developer_docs/README.md
+++ b/developer_docs/README.md
@@ -1,0 +1,8 @@
+# Developer Documentation
+
+This directory contains technical guides for developers working on the HMIS project. Use these documents to understand common workflows and system configuration.
+
+## Available Navigation Guides
+
+- [OPD Navigation Guide](navigation/opd_navigation.md)
+- [Channelling Navigation Guide](navigation/channelling_navigation.md)


### PR DESCRIPTION
## Summary
- document purpose of developer docs
- list navigation guides with links

## Testing
- `bash detect-maven.sh -q test` *(fails: Plugin could not be resolved)*

------
https://chatgpt.com/codex/tasks/task_e_688585956018832fb4b65a8715af687c