### PR TITLE
Fix site filtering for JPQL queries

### DIFF
--- a/src/main/java/com/divudi/bean/common/SearchController.java
+++ b/src/main/java/com/divudi/bean/common/SearchController.java
@@ -11452,7 +11452,7 @@ public class SearchController implements Serializable {
 
         if (site != null) {
             params.put("site", site);
-            jpql.append(" and b.department = :site ");
+            jpql.append(" and b.department.site = :site ");
         }
 
         if (webUser != null) {

--- a/src/main/java/com/divudi/bean/opd/OpdReportController.java
+++ b/src/main/java/com/divudi/bean/opd/OpdReportController.java
@@ -331,7 +331,7 @@ public class OpdReportController implements Serializable {
 
         if (site != null) {
             params.put("site", site);
-            jpql.append(" and b.department = :site ");
+            jpql.append(" and b.department.site = :site ");
         }
 
         if (webUser != null) {

--- a/src/main/java/com/divudi/bean/pharmacy/PharmacySummaryReportController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacySummaryReportController.java
@@ -436,7 +436,7 @@ public class PharmacySummaryReportController implements Serializable {
 
             if (site != null) {
                 params.put("site", site);
-                jpql.append(" and b.department = :site ");
+                jpql.append(" and b.department.site = :site ");
             }
 
             if (webUser != null) {


### PR DESCRIPTION
## Summary
- fix site filtering logic in OpdReportController
- fix site filtering logic in PharmacySummaryReportController
- fix site filtering logic in SearchController

## Testing
- `./detect-maven.sh -q test` *(fails: Maven could not download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6885c35b2c18832facbc1fad180772b9