### PR TITLE
14220 optimize laboratory income report using dtos

### DIFF
--- a/src/main/java/com/divudi/bean/common/ConfigOptionApplicationController.java
+++ b/src/main/java/com/divudi/bean/common/ConfigOptionApplicationController.java
@@ -94,6 +94,7 @@ public class ConfigOptionApplicationController implements Serializable {
     public void init() {
         loadApplicationOptions();
         loadPharmacyAnalyticsConfigurationDefaults();
+        loadReportMethodConfigurationDefaults();
     }
 
     public void loadApplicationOptions() {
@@ -745,6 +746,11 @@ public class ConfigOptionApplicationController implements Serializable {
         );
 
         buttonOptions.forEach(k -> getBooleanValueByKey(k, true));
+    }
+
+    private void loadReportMethodConfigurationDefaults() {
+        getBooleanValueByKey("Laboratory Income Report - Legacy Method", true);
+        getBooleanValueByKey("Laboratory Income Report - Optimized Method", false);
     }
 
     public ConfigOption getApplicationOption(String key) {

--- a/src/main/java/com/divudi/bean/lab/LaborataryReportController.java
+++ b/src/main/java/com/divudi/bean/lab/LaborataryReportController.java
@@ -29,6 +29,8 @@ import com.divudi.core.entity.inward.AdmissionType;
 import com.divudi.core.entity.lab.Investigation;
 import com.divudi.core.facade.BillItemFacade;
 import com.divudi.core.util.CommonFunctions;
+import com.divudi.core.data.dto.LabIncomeReportDTO;
+import com.divudi.bean.common.ConfigOptionApplicationController;
 import com.divudi.service.BillService;
 import com.divudi.service.PaymentService;
 import javax.enterprise.context.SessionScoped;
@@ -73,6 +75,8 @@ public class LaborataryReportController implements Serializable {
     BillItemFacade billItemFacade;
     @EJB
     PaymentService paymentService;
+    @Inject
+    ConfigOptionApplicationController configController;
 
     // </editor-fold>
 
@@ -143,6 +147,7 @@ public class LaborataryReportController implements Serializable {
 
     private StreamedContent downloadingExcel;
     private UploadedFile file;
+    private List<LabIncomeReportDTO> labIncomeReportDtos;
 
     // Numeric variables
     private int maxResult = 50;
@@ -204,6 +209,22 @@ public class LaborataryReportController implements Serializable {
         setToInstitution(sessionController.getInstitution());
         setToDepartment(sessionController.getDepartment());
         return "/reportLab/test_wise_count?faces-redirect=true";
+    }
+
+    public String navigateToOptimizedLaboratoryIncomeReport() {
+        return "/reportLab/laboratary_income_report_dto.xhtml?faces-redirect=true";
+    }
+
+    public String navigateToLegacyLaboratoryIncomeReport() {
+        return "/reportLab/laboratary_income_report.xhtml?faces-redirect=true";
+    }
+
+    public boolean isOptimizedMethodEnabled() {
+        return configController.getBooleanValueByKey("Laboratory Income Report - Optimized Method", false);
+    }
+
+    public boolean isLegacyMethodEnabled() {
+        return configController.getBooleanValueByKey("Laboratory Income Report - Legacy Method", true);
     }
 
     // </editor-fold>
@@ -341,6 +362,36 @@ public class LaborataryReportController implements Serializable {
             }
         }
         bundle.generatePaymentDetailsForBills();
+    }
+
+    public void processLaboratoryIncomeReportDto() {
+        List<BillTypeAtomic> billTypeAtomics = new ArrayList<>();
+        billTypeAtomics.add(BillTypeAtomic.OPD_BILL_CANCELLATION);
+        billTypeAtomics.add(BillTypeAtomic.OPD_BILL_CANCELLATION_DURING_BATCH_BILL_CANCELLATION);
+        billTypeAtomics.add(BillTypeAtomic.OPD_BILL_PAYMENT_COLLECTION_AT_CASHIER);
+        billTypeAtomics.add(BillTypeAtomic.OPD_BILL_REFUND);
+        billTypeAtomics.add(BillTypeAtomic.OPD_BILL_TO_COLLECT_PAYMENT_AT_CASHIER);
+        billTypeAtomics.add(BillTypeAtomic.OPD_BILL_WITH_PAYMENT);
+
+        billTypeAtomics.add(BillTypeAtomic.INWARD_SERVICE_BILL);
+        billTypeAtomics.add(BillTypeAtomic.INWARD_SERVICE_BILL_CANCELLATION);
+        billTypeAtomics.add(BillTypeAtomic.INWARD_SERVICE_BILL_CANCELLATION_DURING_BATCH_BILL_CANCELLATION);
+        billTypeAtomics.add(BillTypeAtomic.INWARD_SERVICE_BILL_REFUND);
+
+        billTypeAtomics.add(BillTypeAtomic.PACKAGE_OPD_BILL_CANCELLATION);
+        billTypeAtomics.add(BillTypeAtomic.PACKAGE_OPD_BILL_CANCELLATION_DURING_BATCH_BILL_CANCELLATION);
+        billTypeAtomics.add(BillTypeAtomic.PACKAGE_OPD_BILL_PAYMENT_COLLECTION_AT_CASHIER);
+        billTypeAtomics.add(BillTypeAtomic.PACKAGE_OPD_BILL_REFUND);
+        billTypeAtomics.add(BillTypeAtomic.PACKAGE_OPD_BILL_TO_COLLECT_PAYMENT_AT_CASHIER);
+        billTypeAtomics.add(BillTypeAtomic.PACKAGE_OPD_BILL_WITH_PAYMENT);
+
+        billTypeAtomics.add(BillTypeAtomic.CC_BILL);
+        billTypeAtomics.add(BillTypeAtomic.CC_BILL_CANCELLATION);
+        billTypeAtomics.add(BillTypeAtomic.CC_BILL_REFUND);
+
+        labIncomeReportDtos = billService.fetchBillsAsLabIncomeReportDTOs(fromDate,
+                toDate, institution, site, department, webUser, billTypeAtomics,
+                admissionType, paymentScheme, toInstitution, toDepartment, visitType);
     }
 
     public void processLaboratoryOrderReport() {
@@ -1092,6 +1143,14 @@ public class LaborataryReportController implements Serializable {
 
     public void setPayments(List<Payment> payments) {
         this.payments = payments;
+    }
+
+    public List<LabIncomeReportDTO> getLabIncomeReportDtos() {
+        return labIncomeReportDtos;
+    }
+
+    public void setLabIncomeReportDtos(List<LabIncomeReportDTO> labIncomeReportDtos) {
+        this.labIncomeReportDtos = labIncomeReportDtos;
     }
 
 }

--- a/src/main/java/com/divudi/core/data/dto/LabIncomeReportDTO.java
+++ b/src/main/java/com/divudi/core/data/dto/LabIncomeReportDTO.java
@@ -1,0 +1,90 @@
+package com.divudi.core.data.dto;
+
+import java.io.Serializable;
+import java.math.BigDecimal;
+import java.util.Date;
+
+/**
+ * DTO for Laboratory Income Report optimization
+ */
+public class LabIncomeReportDTO implements Serializable {
+
+    private Long billId;
+    private String billNumber;
+    private Date billDate;
+    private String departmentName;
+    private String institutionName;
+    private BigDecimal netTotal;
+    private BigDecimal total;
+
+    public LabIncomeReportDTO() {
+    }
+
+    public LabIncomeReportDTO(Long billId, String billNumber, Date billDate,
+                              String departmentName, String institutionName,
+                              BigDecimal netTotal, BigDecimal total) {
+        this.billId = billId;
+        this.billNumber = billNumber;
+        this.billDate = billDate;
+        this.departmentName = departmentName;
+        this.institutionName = institutionName;
+        this.netTotal = netTotal;
+        this.total = total;
+    }
+
+    public Long getBillId() {
+        return billId;
+    }
+
+    public void setBillId(Long billId) {
+        this.billId = billId;
+    }
+
+    public String getBillNumber() {
+        return billNumber;
+    }
+
+    public void setBillNumber(String billNumber) {
+        this.billNumber = billNumber;
+    }
+
+    public Date getBillDate() {
+        return billDate;
+    }
+
+    public void setBillDate(Date billDate) {
+        this.billDate = billDate;
+    }
+
+    public String getDepartmentName() {
+        return departmentName;
+    }
+
+    public void setDepartmentName(String departmentName) {
+        this.departmentName = departmentName;
+    }
+
+    public String getInstitutionName() {
+        return institutionName;
+    }
+
+    public void setInstitutionName(String institutionName) {
+        this.institutionName = institutionName;
+    }
+
+    public BigDecimal getNetTotal() {
+        return netTotal;
+    }
+
+    public void setNetTotal(BigDecimal netTotal) {
+        this.netTotal = netTotal;
+    }
+
+    public BigDecimal getTotal() {
+        return total;
+    }
+
+    public void setTotal(BigDecimal total) {
+        this.total = total;
+    }
+}

--- a/src/main/java/com/divudi/service/BillService.java
+++ b/src/main/java/com/divudi/service/BillService.java
@@ -1022,6 +1022,83 @@ public class BillService {
         return fetchedBills;
     }
 
+    public List<LabIncomeReportDTO> fetchBillsAsLabIncomeReportDTOs(Date fromDate,
+                                                                    Date toDate,
+                                                                    Institution institution,
+                                                                    Institution site,
+                                                                    Department department,
+                                                                    WebUser webUser,
+                                                                    List<BillTypeAtomic> billTypeAtomics,
+                                                                    AdmissionType admissionType,
+                                                                    PaymentScheme paymentScheme,
+                                                                    Institution toInstitution,
+                                                                    Department toDepartment,
+                                                                    String visitType) {
+
+        String jpql = "select new com.divudi.core.data.dto.LabIncomeReportDTO(" +
+                " b.id, b.deptId, b.createdAt, b.department.name, b.institution.name," +
+                " coalesce(b.netTotal,0.0), coalesce(b.total,0.0)) " +
+                " from Bill b " +
+                " where b.retired=:ret " +
+                " and b.billTypeAtomic in :billTypesAtomics " +
+                " and b.createdAt between :fromDate and :toDate ";
+
+        Map<String, Object> params = new HashMap<>();
+        params.put("ret", false);
+        params.put("billTypesAtomics", billTypeAtomics);
+        params.put("fromDate", fromDate);
+        params.put("toDate", toDate);
+
+        if (institution != null) {
+            jpql += " and b.institution=:ins ";
+            params.put("ins", institution);
+        }
+
+        if (webUser != null) {
+            jpql += " and b.creater=:user ";
+            params.put("user", webUser);
+        }
+
+        if (department != null) {
+            jpql += " and b.department=:dep ";
+            params.put("dep", department);
+        }
+
+        if (site != null) {
+            jpql += " and b.department.site=:site ";
+            params.put("site", site);
+        }
+
+        if (admissionType != null) {
+            jpql += " and b.patientEncounter.admissionType=:admissionType ";
+            params.put("admissionType", admissionType);
+        }
+
+        if (paymentScheme != null) {
+            jpql += " and b.paymentScheme=:paymentScheme ";
+            params.put("paymentScheme", paymentScheme);
+        }
+
+        if (toInstitution != null) {
+            jpql += " and b.toInstitution=:toIns ";
+            params.put("toIns", toInstitution);
+        }
+
+        if (toDepartment != null) {
+            jpql += " and b.toDepartment=:toDep ";
+            params.put("toDep", toDepartment);
+        }
+
+        if (visitType != null && !visitType.trim().isEmpty()) {
+            jpql += " and b.ipOpOrCc=:type ";
+            params.put("type", visitType.trim());
+        }
+
+        jpql += " order by b.createdAt desc";
+
+        return (List<LabIncomeReportDTO>) billFacade.findLightsByJpql(jpql, params, TemporalType.TIMESTAMP);
+    }
+
     public List<PharmacyIncomeCostBillDTO> fetchBillIncomeCostDtos(Date fromDate,
                                                                    Date toDate,
                                                                    Institution institution,

--- a/src/main/webapp/reportLab/laboratary_income_report.xhtml
+++ b/src/main/webapp/reportLab/laboratary_income_report.xhtml
@@ -11,7 +11,15 @@
             <ui:define name="subcontent">
 
                 <h:form >
-                    <p:panel header="Laboratory Income Report">
+                    <p:panel header="Laboratory Income Report - Legacy Method">
+                        <p:panel styleClass="mb-3 text-center">
+                            <h:outputText value="Navigation: " styleClass="font-weight-bold mr-3"/>
+                            <p:commandButton value="Legacy Method" styleClass="ui-button-success" disabled="true"/>
+                            <p:commandButton value="Optimized Method"
+                                             styleClass="ui-button-secondary ml-2"
+                                             action="#{laborataryReportController.navigateToOptimizedLaboratoryIncomeReport()}"
+                                             immediate="true"/>
+                        </p:panel>
                         <h:panelGrid columns="8" styleClass="w-100 form-grid" columnClasses="label-icon-column, input-column">
                             <h:panelGroup layout="block" styleClass="form-group">
                                 <h:outputText value="&#xf073;" styleClass="fa ml-5" /> <!-- FontAwesome calendar icon -->

--- a/src/main/webapp/reportLab/laboratary_income_report_dto.xhtml
+++ b/src/main/webapp/reportLab/laboratary_income_report_dto.xhtml
@@ -1,0 +1,147 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
+      xmlns:h="http://xmlns.jcp.org/jsf/html"
+      xmlns:p="http://primefaces.org/ui"
+      xmlns:f="http://xmlns.jcp.org/jsf/core">
+
+<h:body>
+    <ui:composition template="/reportLab/lab_summeries_index.xhtml">
+        <ui:define name="subcontent">
+            <p:panel header="Laboratory Income Report - Optimized Method">
+                <h:form>
+                    <p:panel styleClass="mb-3 text-center">
+                        <h:outputText value="Navigation: " styleClass="font-weight-bold mr-3"/>
+                        <p:commandButton value="Legacy Method"
+                                         styleClass="ui-button-secondary mr-2"
+                                         action="#{laborataryReportController.navigateToLegacyLaboratoryIncomeReport()}"
+                                         immediate="true"/>
+                        <p:commandButton value="Optimized Method"
+                                         styleClass="ui-button-success"
+                                         disabled="true"/>
+                    </p:panel>
+
+                    <h:panelGrid columns="8" styleClass="w-100 form-grid"
+                                 columnClasses="label-icon-column, input-column">
+                        <h:panelGroup layout="block" styleClass="form-group">
+                            <h:outputText value="&#xf073;" styleClass="fa ml-5"/>
+                            <h:outputLabel value="From" for="fromDate" class="mx-3"/>
+                        </h:panelGroup>
+                        <p:calendar styleClass="w-100"
+                                    inputStyleClass="w-100 form-control"
+                                    id="fromDate"
+                                    value="#{laborataryReportController.fromDate}"
+                                    pattern="#{sessionController.applicationPreference.longDateTimeFormat}"/>
+
+                        <p:spacer width="50"/>
+
+                        <h:panelGroup layout="block" styleClass="form-group">
+                            <h:outputText value="&#xf073;" styleClass="fa mr-2"/>
+                            <h:outputLabel value="To" for="toDate" class="mx-3"/>
+                        </h:panelGroup>
+                        <p:calendar styleClass="w-100"
+                                    inputStyleClass="w-100 form-control"
+                                    id="toDate"
+                                    value="#{laborataryReportController.toDate}"
+                                    navigator="false"
+                                    pattern="#{sessionController.applicationPreference.longDateTimeFormat}"/>
+
+                        <p:spacer width="50"/>
+                        <p:spacer width="50"/>
+                        <p:spacer width="50"/>
+
+                        <h:panelGroup layout="block" styleClass="form-group">
+                            <h:outputText value="&#xf19c;" styleClass="fa mr-2"/>
+                            <h:outputLabel value="Institution" for="cmbIns" class="mx-3"/>
+                        </h:panelGroup>
+                        <p:selectOneMenu id="cmbIns"
+                                         styleClass="w-100 form-control"
+                                         value="#{laborataryReportController.institution}"
+                                         converter="#{institutionConverter}">
+                            <f:selectItem itemLabel="All Institutions" itemValue="#{null}"/>
+                            <f:selectItems value="#{institutionController.institutions}" var="ins" itemLabel="#{ins.name}" itemValue="#{ins}"/>
+                        </p:selectOneMenu>
+
+                        <p:spacer width="50"/>
+
+                        <h:panelGroup layout="block" styleClass="form-group">
+                            <h:outputText value="&#xf0f7;" styleClass="fa mr-2"/>
+                            <h:outputLabel value="Department" for="cmbDept" class="mx-3"/>
+                        </h:panelGroup>
+                        <p:selectOneMenu id="cmbDept"
+                                         styleClass="w-100 form-control"
+                                         value="#{laborataryReportController.department}"
+                                         converter="#{departmentConverter}">
+                            <f:selectItem itemLabel="All Departments" itemValue="#{null}"/>
+                            <f:selectItems value="#{departmentController.departments}" var="dept" itemLabel="#{dept.name}" itemValue="#{dept}"/>
+                        </p:selectOneMenu>
+
+                        <p:spacer width="50"/>
+                        <p:spacer width="50"/>
+                        <p:spacer width="50"/>
+
+                        <h:panelGroup layout="block" styleClass="form-group">
+                            <p:commandButton value="Generate Report (DTO)"
+                                             action="#{laborataryReportController.processLaboratoryIncomeReportDto()}"
+                                             styleClass="btn btn-primary"
+                                             update="@form"
+                                             icon="pi pi-search"/>
+                        </h:panelGroup>
+                    </h:panelGrid>
+                </h:form>
+
+                <h:panelGroup rendered="#{not empty laborataryReportController.labIncomeReportDtos}">
+                    <div class="alert alert-success mt-3" role="alert">
+                        <h:outputText value="&#xf058;" styleClass="fa mr-2"/>
+                        <strong>Performance Optimized:</strong> Using DTO-based queries for improved memory usage and load times.
+                    </div>
+                </h:panelGroup>
+
+                <h:panelGroup rendered="#{not empty laborataryReportController.labIncomeReportDtos}">
+                    <p:dataTable value="#{laborataryReportController.labIncomeReportDtos}"
+                                var="dto" styleClass="table table-striped" id="dtoResultsTable">
+                        <f:facet name="header">
+                            <h:outputText value="Laboratory Income Report Results (DTO Method)"/>
+                        </f:facet>
+
+                        <p:column headerText="Bill Date">
+                            <h:outputText value="#{dto.billDate}">
+                                <f:convertDateTime pattern="#{sessionController.applicationPreference.shortDateFormat}"/>
+                            </h:outputText>
+                        </p:column>
+
+                        <p:column headerText="Bill Number">
+                            <h:outputText value="#{dto.billNumber}"/>
+                        </p:column>
+
+                        <p:column headerText="Department">
+                            <h:outputText value="#{dto.departmentName}"/>
+                        </p:column>
+
+                        <p:column headerText="Institution">
+                            <h:outputText value="#{dto.institutionName}"/>
+                        </p:column>
+
+                        <p:column headerText="Net Total" styleClass="text-right">
+                            <h:outputText value="#{dto.netTotal}">
+                                <f:convertNumber type="currency" currencySymbol=""/>
+                            </h:outputText>
+                        </p:column>
+
+                        <p:column headerText="Total" styleClass="text-right">
+                            <h:outputText value="#{dto.total}">
+                                <f:convertNumber type="currency" currencySymbol=""/>
+                            </h:outputText>
+                        </p:column>
+
+                        <f:facet name="footer">
+                            <h:outputText value="Total Records: #{laborataryReportController.labIncomeReportDtos.size()}"/>
+                        </f:facet>
+                    </p:dataTable>
+                </h:panelGroup>
+            </p:panel>
+        </ui:define>
+    </ui:composition>
+</h:body>
+</html>


### PR DESCRIPTION
## Summary
- add configuration defaults for lab income report
- implement LabIncomeReportDTO and service method
- update Lab report controller with DTO generation and navigation methods
- add optimized DTO page and navigation toggle

Navigation Path for QA Testing:
1. Navigate to Reports → Lab → Income Reports
2. Select "Laboratory Income Report"
3. Use navigation buttons to switch between Legacy and Optimized methods

Closes #14220

------
https://chatgpt.com/codex/tasks/task_e_6885fa8ebe38832fac4647a4d6442a92