### PR TITLE
14219 optimize test wise count report using dto

### DIFF
--- a/src/main/java/com/divudi/bean/common/ConfigOptionApplicationController.java
+++ b/src/main/java/com/divudi/bean/common/ConfigOptionApplicationController.java
@@ -94,6 +94,7 @@ public class ConfigOptionApplicationController implements Serializable {
     public void init() {
         loadApplicationOptions();
         loadPharmacyAnalyticsConfigurationDefaults();
+        loadReportMethodConfigurationDefaults();
     }
 
     public void loadApplicationOptions() {
@@ -745,6 +746,30 @@ public class ConfigOptionApplicationController implements Serializable {
         );
 
         buttonOptions.forEach(k -> getBooleanValueByKey(k, true));
+    }
+
+    private void loadReportMethodConfigurationDefaults() {
+        // Lab Reports
+        getBooleanValueByKey("Lab Daily Summary Report - Legacy Method", true);
+        getBooleanValueByKey("Lab Daily Summary Report - Optimized Method", false);
+        getBooleanValueByKey("Test Wise Count Report - Legacy Method", true);
+        getBooleanValueByKey("Test Wise Count Report - Optimized Method", false);
+        getBooleanValueByKey("Laboratory Income Report - Legacy Method", true);
+        getBooleanValueByKey("Laboratory Income Report - Optimized Method", false);
+
+        // OPD Reports
+        getBooleanValueByKey("OPD Itemized Sale Summary - Legacy Method", true);
+        getBooleanValueByKey("OPD Itemized Sale Summary - Optimized Method", false);
+        getBooleanValueByKey("OPD Income Report - Legacy Method", true);
+        getBooleanValueByKey("OPD Income Report - Optimized Method", false);
+
+        // Pharmacy Reports
+        getBooleanValueByKey("Pharmacy Transfer Issue Bill Report - Legacy Method", true);
+        getBooleanValueByKey("Pharmacy Transfer Issue Bill Report - Optimized Method", false);
+        getBooleanValueByKey("Pharmacy Income Report - Legacy Method", true);
+        getBooleanValueByKey("Pharmacy Income Report - Optimized Method", false);
+        getBooleanValueByKey("Pharmacy Search Sale Bill - Legacy Method", true);
+        getBooleanValueByKey("Pharmacy Search Sale Bill - Optimized Method", false);
     }
 
     public ConfigOption getApplicationOption(String key) {

--- a/src/main/java/com/divudi/core/data/dto/TestCountDTO.java
+++ b/src/main/java/com/divudi/core/data/dto/TestCountDTO.java
@@ -1,0 +1,124 @@
+package com.divudi.core.data.dto;
+
+import java.io.Serializable;
+
+public class TestCountDTO implements Serializable {
+    private Long testId;
+    private String testCode;
+    private String testName;
+    private Long count;
+    private Double hosFee;
+    private Double ccFee;
+    private Double proFee;
+    private Double reagentFee;
+    private Double otherFee;
+    private Double discount;
+    private Double total;
+
+    public TestCountDTO() {
+    }
+
+    public TestCountDTO(Long testId, String testCode, String testName,
+                        Long count, Double hosFee, Double ccFee, Double proFee,
+                        Double reagentFee, Double otherFee, Double discount, Double total) {
+        this.testId = testId;
+        this.testCode = testCode;
+        this.testName = testName;
+        this.count = count;
+        this.hosFee = hosFee;
+        this.ccFee = ccFee;
+        this.proFee = proFee;
+        this.reagentFee = reagentFee;
+        this.otherFee = otherFee;
+        this.discount = discount;
+        this.total = total;
+    }
+
+    public Long getTestId() {
+        return testId;
+    }
+
+    public void setTestId(Long testId) {
+        this.testId = testId;
+    }
+
+    public String getTestCode() {
+        return testCode;
+    }
+
+    public void setTestCode(String testCode) {
+        this.testCode = testCode;
+    }
+
+    public String getTestName() {
+        return testName;
+    }
+
+    public void setTestName(String testName) {
+        this.testName = testName;
+    }
+
+    public Long getCount() {
+        return count;
+    }
+
+    public void setCount(Long count) {
+        this.count = count;
+    }
+
+    public Double getHosFee() {
+        return hosFee;
+    }
+
+    public void setHosFee(Double hosFee) {
+        this.hosFee = hosFee;
+    }
+
+    public Double getCcFee() {
+        return ccFee;
+    }
+
+    public void setCcFee(Double ccFee) {
+        this.ccFee = ccFee;
+    }
+
+    public Double getProFee() {
+        return proFee;
+    }
+
+    public void setProFee(Double proFee) {
+        this.proFee = proFee;
+    }
+
+    public Double getReagentFee() {
+        return reagentFee;
+    }
+
+    public void setReagentFee(Double reagentFee) {
+        this.reagentFee = reagentFee;
+    }
+
+    public Double getOtherFee() {
+        return otherFee;
+    }
+
+    public void setOtherFee(Double otherFee) {
+        this.otherFee = otherFee;
+    }
+
+    public Double getDiscount() {
+        return discount;
+    }
+
+    public void setDiscount(Double discount) {
+        this.discount = discount;
+    }
+
+    public Double getTotal() {
+        return total;
+    }
+
+    public void setTotal(Double total) {
+        this.total = total;
+    }
+}

--- a/src/main/webapp/reportLab/lab_summeries_index.xhtml
+++ b/src/main/webapp/reportLab/lab_summeries_index.xhtml
@@ -104,11 +104,17 @@
                                     <h:form>
                                         <div class="d-grid gap-2">
                                             <p:commandButton
-                                                class="w-100"  
-                                                ajax="false" 
-                                                value="Test Wise Count Report" 
-                                                action="#{laborataryReportController.navigateToLaborataryTestWiseCountReportFromLabAnalytics()}" >
-                                            </p:commandButton>
+                                                class="w-100"
+                                                ajax="false"
+                                                value="Test Wise Count Report"
+                                                rendered="#{laborataryReportController.testWiseCountLegacyEnabled}"
+                                                action="#{laborataryReportController.navigateToLaborataryTestWiseCountReportFromLabAnalytics()}" />
+                                            <p:commandButton
+                                                class="w-100 ui-button-secondary mt-1"
+                                                ajax="false"
+                                                value="Test Wise Count Report - Optimized"
+                                                rendered="#{laborataryReportController.testWiseCountOptimizedEnabled}"
+                                                action="#{laborataryReportController.navigateToLaborataryTestWiseCountReportDtoFromLabAnalytics()}" />
 
                                             <p:commandButton
                                                 ajax="false" 

--- a/src/main/webapp/reportLab/test_wise_count_dto.xhtml
+++ b/src/main/webapp/reportLab/test_wise_count_dto.xhtml
@@ -11,13 +11,13 @@
             <ui:define name="subcontent">
 
                 <h:form >
-                    <p:panel header="Laboratary Test Wise Count Report - Legacy Method" styleClass="w-100">
+                    <p:panel header="Laboratary Test Wise Count Report - Optimized Method" styleClass="w-100">
                         <p:panel styleClass="mb-3 text-center">
                             <h:outputText value="Navigation: " styleClass="font-weight-bold mr-3"/>
-                            <p:commandButton value="Legacy Method" styleClass="ui-button-success" disabled="true"/>
-                            <p:commandButton value="Optimized Method" styleClass="ui-button-secondary ml-2"
-                                             action="#{laborataryReportController.navigateToLaborataryTestWiseCountReportDtoFromLabAnalytics()}"
+                            <p:commandButton value="Legacy Method" styleClass="ui-button-secondary mr-2"
+                                             action="#{laborataryReportController.navigateToLaborataryTestWiseCountReportFromLabAnalytics()}"
                                              immediate="true"/>
+                            <p:commandButton value="Optimized Method" styleClass="ui-button-success" disabled="true"/>
                         </p:panel>
 
                         <h:panelGrid columns="8" styleClass="w-100 form-grid" columnClasses="label-icon-column, input-column">
@@ -259,7 +259,7 @@
                                     style="width: 150px"
                                     icon="fas fa-cogs"
                                     class="mx-2 ui-button-warning m-1"
-                                    action="#{laborataryReportController.processLabTestWiseCountReport()}" >
+                                    action="#{laborataryReportController.processLabTestWiseCountReportDto()}" >
                                 </p:commandButton>
 
                                 <p:commandButton 
@@ -292,8 +292,8 @@
                             </p:commandButton>
                         </div>
 
-                        <p:dataTable 
-                            value="#{laborataryReportController.testWiseCounts}" 
+                        <p:dataTable
+                            value="#{laborataryReportController.testWiseCountDtos}"
                             id="tblExport" 
                             var="c" 
                             rowIndexVar="rowIndex">


### PR DESCRIPTION
## Summary
- add TestCountDTO for DTO-based lab test count results
- configure report method defaults
- support optimized Test Wise Count report in `LaborataryReportController`
- add navigation buttons for optimized/legacy Test Wise Count reports
- create `test_wise_count_dto.xhtml` with DTO logic

Navigation Path for QA Testing:
1. Reports → Lab → Test Reports → Test Wise Count
2. Use navigation buttons to switch between Legacy and Optimized methods

Closes #14219

------
https://chatgpt.com/codex/tasks/task_e_6885f999d6b4832fb69bbaf5196941e4