### PR TITLE
Optimize OPD Income Report with DTO queries

### DIFF
--- a/src/main/java/com/divudi/core/data/IncomeBundle.java
+++ b/src/main/java/com/divudi/core/data/IncomeBundle.java
@@ -2,6 +2,7 @@ package com.divudi.core.data;
 
 import com.divudi.core.data.dto.PharmacyIncomeBillDTO;
 import com.divudi.core.data.dto.PharmacyIncomeBillItemDTO;
+import com.divudi.core.data.dto.OpdIncomeReportDTO;
 import com.divudi.core.entity.*;
 import com.divudi.core.entity.channel.SessionInstance;
 import com.divudi.core.entity.pharmacy.PharmaceuticalBillItem;
@@ -297,6 +298,15 @@ public class IncomeBundle implements Serializable {
                         rows.add(ir);
                     }
                 }
+            } else if (firstElement instanceof OpdIncomeReportDTO) {
+                // Process list as IncomeRows
+                for (Object obj : entries) {
+                    if (obj instanceof OpdIncomeReportDTO) {
+                        OpdIncomeReportDTO dto = (OpdIncomeReportDTO) obj;
+                        IncomeRow ir = new IncomeRow(dto);
+                        rows.add(ir);
+                    }
+                }
             } else if (firstElement instanceof PharmacyIncomeBillItemDTO) {
                 // Process list as IncomeRows
                 for (Object obj : entries) {
@@ -314,6 +324,15 @@ public class IncomeBundle implements Serializable {
         this();
         if (dtos != null) {
             for (PharmacyIncomeCostBillDTO dto : dtos) {
+                rows.add(new IncomeRow(dto));
+            }
+        }
+    }
+
+    public IncomeBundle(List<OpdIncomeReportDTO> dtos) {
+        this();
+        if (dtos != null) {
+            for (OpdIncomeReportDTO dto : dtos) {
                 rows.add(new IncomeRow(dto));
             }
         }

--- a/src/main/java/com/divudi/core/data/IncomeRow.java
+++ b/src/main/java/com/divudi/core/data/IncomeRow.java
@@ -3,6 +3,7 @@ package com.divudi.core.data;
 import com.divudi.core.data.dto.PharmacyIncomeCostBillDTO;
 import com.divudi.core.data.dto.PharmacyIncomeBillDTO;
 import com.divudi.core.data.dto.PharmacyIncomeBillItemDTO;
+import com.divudi.core.data.dto.OpdIncomeReportDTO;
 import com.divudi.core.entity.*;
 import com.divudi.core.entity.channel.SessionInstance;
 import com.divudi.core.entity.inward.AdmissionType;
@@ -280,6 +281,33 @@ public class IncomeRow implements Serializable {
         billFinanceDetails.setTotalRetailSaleValue(dto.getTotalRetailSaleValue());
         billFinanceDetails.setTotalPurchaseValue(dto.getTotalPurchaseValue());
         bill.setBillFinanceDetails(billFinanceDetails);
+
+        this.bill = bill;
+    }
+
+    public IncomeRow(OpdIncomeReportDTO dto) {
+        this();
+
+        Bill bill = new Bill();
+        bill.setId(dto.getBillId());
+        bill.setDeptId(dto.getDeptId());
+        if (dto.getPatientName() != null) {
+            Patient patient = new Patient();
+            Person person = new Person();
+            person.setName(dto.getPatientName());
+            patient.setPerson(person);
+            bill.setPatient(patient);
+        }
+        bill.setBillTypeAtomic(dto.getBillTypeAtomic());
+        bill.setCreatedAt(dto.getCreatedAt());
+        bill.setNetTotal(dto.getNetTotal());
+        bill.setPaymentMethod(dto.getPaymentMethod());
+        bill.setTotal(dto.getTotal());
+        bill.setPatientEncounter(dto.getPatientEncounter());
+        bill.setDiscount(dto.getDiscount() != null ? dto.getDiscount() : 0.0);
+        bill.setMargin(dto.getMargin() != null ? dto.getMargin() : 0.0);
+        bill.setServiceCharge(dto.getServiceCharge() != null ? dto.getServiceCharge() : 0.0);
+        bill.setPaymentScheme(dto.getPaymentScheme());
 
         this.bill = bill;
     }

--- a/src/main/java/com/divudi/core/data/dto/OpdIncomeReportDTO.java
+++ b/src/main/java/com/divudi/core/data/dto/OpdIncomeReportDTO.java
@@ -1,0 +1,169 @@
+package com.divudi.core.data.dto;
+
+import com.divudi.core.data.BillTypeAtomic;
+import com.divudi.core.data.PaymentMethod;
+import com.divudi.core.entity.PatientEncounter;
+import com.divudi.core.entity.PaymentScheme;
+
+import java.io.Serializable;
+import java.util.Date;
+
+public class OpdIncomeReportDTO implements Serializable {
+    private Long billId;
+    private String deptId;
+    private String patientName;
+    private BillTypeAtomic billTypeAtomic;
+    private Date createdAt;
+    private Double netTotal;
+    private PaymentMethod paymentMethod;
+    private Double total;
+    private PatientEncounter patientEncounter;
+    private Double discount;
+    private Double margin;
+    private Double serviceCharge;
+    private PaymentScheme paymentScheme;
+
+    public OpdIncomeReportDTO() {
+    }
+
+    // Basic fields constructor
+    public OpdIncomeReportDTO(Long billId, String deptId, String patientName,
+                              BillTypeAtomic billTypeAtomic, Date createdAt,
+                              Double netTotal, PaymentMethod paymentMethod,
+                              Double total) {
+        this.billId = billId;
+        this.deptId = deptId;
+        this.patientName = patientName;
+        this.billTypeAtomic = billTypeAtomic;
+        this.createdAt = createdAt;
+        this.netTotal = netTotal;
+        this.paymentMethod = paymentMethod;
+        this.total = total;
+    }
+
+    // Detailed constructor
+    public OpdIncomeReportDTO(Long billId, String deptId, String patientName,
+                              BillTypeAtomic billTypeAtomic, Date createdAt,
+                              Double netTotal, PaymentMethod paymentMethod,
+                              Double total, PatientEncounter patientEncounter,
+                              Double discount, Double margin, Double serviceCharge,
+                              PaymentScheme paymentScheme) {
+        this.billId = billId;
+        this.deptId = deptId;
+        this.patientName = patientName;
+        this.billTypeAtomic = billTypeAtomic;
+        this.createdAt = createdAt;
+        this.netTotal = netTotal;
+        this.paymentMethod = paymentMethod;
+        this.total = total;
+        this.patientEncounter = patientEncounter;
+        this.discount = discount;
+        this.margin = margin;
+        this.serviceCharge = serviceCharge;
+        this.paymentScheme = paymentScheme;
+    }
+
+    public Long getBillId() {
+        return billId;
+    }
+
+    public void setBillId(Long billId) {
+        this.billId = billId;
+    }
+
+    public String getDeptId() {
+        return deptId;
+    }
+
+    public void setDeptId(String deptId) {
+        this.deptId = deptId;
+    }
+
+    public String getPatientName() {
+        return patientName;
+    }
+
+    public void setPatientName(String patientName) {
+        this.patientName = patientName;
+    }
+
+    public BillTypeAtomic getBillTypeAtomic() {
+        return billTypeAtomic;
+    }
+
+    public void setBillTypeAtomic(BillTypeAtomic billTypeAtomic) {
+        this.billTypeAtomic = billTypeAtomic;
+    }
+
+    public Date getCreatedAt() {
+        return createdAt;
+    }
+
+    public void setCreatedAt(Date createdAt) {
+        this.createdAt = createdAt;
+    }
+
+    public Double getNetTotal() {
+        return netTotal;
+    }
+
+    public void setNetTotal(Double netTotal) {
+        this.netTotal = netTotal;
+    }
+
+    public PaymentMethod getPaymentMethod() {
+        return paymentMethod;
+    }
+
+    public void setPaymentMethod(PaymentMethod paymentMethod) {
+        this.paymentMethod = paymentMethod;
+    }
+
+    public Double getTotal() {
+        return total;
+    }
+
+    public void setTotal(Double total) {
+        this.total = total;
+    }
+
+    public PatientEncounter getPatientEncounter() {
+        return patientEncounter;
+    }
+
+    public void setPatientEncounter(PatientEncounter patientEncounter) {
+        this.patientEncounter = patientEncounter;
+    }
+
+    public Double getDiscount() {
+        return discount;
+    }
+
+    public void setDiscount(Double discount) {
+        this.discount = discount;
+    }
+
+    public Double getMargin() {
+        return margin;
+    }
+
+    public void setMargin(Double margin) {
+        this.margin = margin;
+    }
+
+    public Double getServiceCharge() {
+        return serviceCharge;
+    }
+
+    public void setServiceCharge(Double serviceCharge) {
+        this.serviceCharge = serviceCharge;
+    }
+
+    public PaymentScheme getPaymentScheme() {
+        return paymentScheme;
+    }
+
+    public void setPaymentScheme(PaymentScheme paymentScheme) {
+        this.paymentScheme = paymentScheme;
+    }
+}

--- a/src/main/java/com/divudi/service/BillService.java
+++ b/src/main/java/com/divudi/service/BillService.java
@@ -35,6 +35,7 @@ import com.divudi.core.data.dataStructure.SearchKeyword;
 import com.divudi.core.data.dto.OpdSaleSummaryDTO;
 import com.divudi.core.data.dto.PharmacyIncomeBillDTO;
 import com.divudi.core.data.dto.PharmacyIncomeBillItemDTO;
+import com.divudi.core.data.dto.OpdIncomeReportDTO;
 import com.divudi.core.entity.Bill;
 import com.divudi.core.entity.BillFee;
 import com.divudi.core.entity.BillFinanceDetails;
@@ -1180,6 +1181,72 @@ public class BillService {
 
         System.out.println("=== DEBUG: fetchBillsAsPharmacyIncomeBillDTOs END ===");
         return results;
+    }
+
+    public List<OpdIncomeReportDTO> fetchOpdIncomeReportDTOs(Date fromDate,
+            Date toDate,
+            Institution institution,
+            Institution site,
+            Department department,
+            WebUser webUser,
+            List<BillTypeAtomic> billTypeAtomics,
+            AdmissionType admissionType,
+            PaymentScheme paymentScheme) {
+
+        if (fromDate == null || toDate == null) {
+            throw new IllegalArgumentException("fromDate and toDate cannot be null");
+        }
+        if (fromDate.after(toDate)) {
+            throw new IllegalArgumentException("fromDate cannot be after toDate");
+        }
+
+        String jpql = "select new com.divudi.core.data.dto.OpdIncomeReportDTO(" +
+                " b.id, b.deptId, coalesce(pers.name,'N/A'), b.billTypeAtomic, b.createdAt, " +
+                " coalesce(b.netTotal,0.0), b.paymentMethod, coalesce(b.total,0.0), " +
+                " pe, coalesce(b.discount,0.0), coalesce(b.margin,0.0), " +
+                " coalesce(b.serviceCharge,0.0), b.paymentScheme ) " +
+                " from Bill b " +
+                " left join b.patient pat " +
+                " left join pat.person pers " +
+                " left join b.patientEncounter pe " +
+                " where b.retired=:ret " +
+                " and b.billTypeAtomic in :billTypesAtomics " +
+                " and b.createdAt between :fromDate and :toDate";
+
+        Map<String, Object> params = new HashMap<>();
+        params.put("ret", false);
+        params.put("billTypesAtomics", billTypeAtomics);
+        params.put("fromDate", fromDate);
+        params.put("toDate", toDate);
+
+        if (institution != null) {
+            jpql += " and b.institution=:ins";
+            params.put("ins", institution);
+        }
+        if (webUser != null) {
+            jpql += " and b.creater=:user";
+            params.put("user", webUser);
+        }
+        if (department != null) {
+            jpql += " and b.department=:dep";
+            params.put("dep", department);
+        }
+        if (site != null) {
+            jpql += " and b.department.site=:site";
+            params.put("site", site);
+        }
+        if (admissionType != null) {
+            jpql += " and b.patientEncounter.admissionType=:admissionType";
+            params.put("admissionType", admissionType);
+        }
+        if (paymentScheme != null) {
+            jpql += " and b.paymentScheme=:paymentScheme";
+            params.put("paymentScheme", paymentScheme);
+        }
+
+        jpql += " order by b.createdAt desc";
+
+        return (List<OpdIncomeReportDTO>) billFacade.findLightsByJpql(jpql, params, TemporalType.TIMESTAMP);
     }
 
     public List<BillItem> fetchBillItems(Date fromDate,

--- a/src/main/webapp/opd/analytics/summary_reports/opd_income_report_dto.xhtml
+++ b/src/main/webapp/opd/analytics/summary_reports/opd_income_report_dto.xhtml
@@ -9,21 +9,21 @@
     <h:body>
         <ui:composition template="/opd/analytics/index.xhtml">
             <ui:define name="subcontent">
-                <p:panel header="OPD Income Report - Legacy Method">
+                <p:panel header="OPD Income Report - Optimized Method">
                     <h:form>
                         <!-- Navigation Toggle Buttons -->
                         <p:panel styleClass="mb-3 text-center">
                             <h:outputText value="Navigation: " styleClass="font-weight-bold mr-3"/>
                             <p:commandButton value="Legacy Method"
+                                             styleClass="ui-button-secondary mr-2"
+                                             action="#{opdReportController.navigateToLegacyOpdIncomeReport()}"
+                                             immediate="true"/>
+                            <p:commandButton value="Optimized Method"
                                              styleClass="ui-button-success"
                                              disabled="true"/>
-                            <p:commandButton value="Optimized Method"
-                                             styleClass="ui-button-secondary ml-2"
-                                             action="#{opdReportController.navigateToOptimizedOpdIncomeReport()}"
-                                             immediate="true"/>
                         </p:panel>
 
-                    <h:panelGrid columns="8" styleClass="w-100 form-grid" columnClasses="label-icon-column, input-column">
+                        <h:panelGrid columns="8" styleClass="w-100 form-grid" columnClasses="label-icon-column, input-column">
                         <h:panelGroup layout="block" styleClass="form-group">
                             <h:outputText value="&#xf073;" styleClass="fa ml-5" /> <!-- FontAwesome calendar icon -->
                             <h:outputLabel value="From" for="fromDate" class="mx-3"/>

--- a/src/test/java/com/divudi/service/BillServiceOpdIncomeReportDtoTest.java
+++ b/src/test/java/com/divudi/service/BillServiceOpdIncomeReportDtoTest.java
@@ -1,0 +1,82 @@
+package com.divudi.service;
+
+import com.divudi.core.data.BillTypeAtomic;
+import com.divudi.core.data.dto.OpdIncomeReportDTO;
+import com.divudi.core.entity.Department;
+import com.divudi.core.entity.Institution;
+import com.divudi.core.entity.WebUser;
+import com.divudi.core.facade.BillFacade;
+import org.junit.jupiter.api.Test;
+
+import javax.persistence.TemporalType;
+import java.lang.reflect.Field;
+import java.util.*;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class BillServiceOpdIncomeReportDtoTest {
+
+    private static class DummyBillFacade extends BillFacade {
+        String jpql;
+        Map<String, Object> params;
+        @Override
+        public List<?> findLightsByJpql(String jpql, java.util.Map<String, Object> parameters, TemporalType tt) {
+            this.jpql = jpql;
+            this.params = new HashMap<>(parameters);
+            return Collections.emptyList();
+        }
+    }
+
+    @Test
+    public void verifyQueryAndParamsPassedToFacade() throws Exception {
+        BillService service = new BillService();
+        DummyBillFacade facade = new DummyBillFacade();
+        Field f = BillService.class.getDeclaredField("billFacade");
+        f.setAccessible(true);
+        f.set(service, facade);
+
+        Institution institution = new Institution();
+        institution.setId(1L);
+        Institution site = new Institution();
+        site.setId(2L);
+        Department dep = new Department();
+        dep.setId(3L);
+        WebUser user = new WebUser();
+
+        Date from = new Date(0);
+        Date to = new Date();
+        List<BillTypeAtomic> bts = Collections.singletonList(BillTypeAtomic.OPD_BILL_WITH_PAYMENT);
+
+        service.fetchOpdIncomeReportDTOs(from, to, institution, site, dep, user, bts, null, null);
+
+        assertNotNull(facade.jpql);
+        assertTrue(facade.jpql.contains("b.createdAt between :fromDate and :toDate"));
+        assertTrue(facade.jpql.contains("b.billTypeAtomic in :billTypesAtomics"));
+
+        assertEquals(from, facade.params.get("fromDate"));
+        assertEquals(to, facade.params.get("toDate"));
+        assertEquals(institution, facade.params.get("ins"));
+        assertEquals(site, facade.params.get("site"));
+        assertEquals(dep, facade.params.get("dep"));
+        assertEquals(user, facade.params.get("user"));
+    }
+
+    @Test
+    public void testNullParameterValidation() {
+        BillService service = new BillService();
+
+        assertThrows(IllegalArgumentException.class, () -> {
+            service.fetchOpdIncomeReportDTOs(null, new Date(), null, null, null, null, new ArrayList<>(), null, null);
+        });
+
+        assertThrows(IllegalArgumentException.class, () -> {
+            service.fetchOpdIncomeReportDTOs(new Date(), null, null, null, null, null, new ArrayList<>(), null, null);
+        });
+
+        Date from = new Date(System.currentTimeMillis() + 86400000);
+        Date to = new Date();
+        assertThrows(IllegalArgumentException.class, () -> {
+            service.fetchOpdIncomeReportDTOs(from, to, null, null, null, null, new ArrayList<>(), null, null);
+        });
+    }
+}


### PR DESCRIPTION
## Summary
- add `OpdIncomeReportDTO` with basic and detailed constructors
- extend `IncomeRow` and `IncomeBundle` for new DTO
- implement `BillService.fetchOpdIncomeReportDTOs`
- support optimized navigation in `OpdReportController`
- add DTO-based page `opd_income_report_dto.xhtml`
- include navigation toggle on legacy page
- add unit tests for DTO query method

Navigation Path for QA Testing:
1. OPD → Analytics → Summary Reports → **OPD Income Report**
2. Toggle between Legacy/Optimized pages using buttons
3. Configuration key `OPD Income Report - Optimized Method` enables optimized page by default

Closes #0

------
https://chatgpt.com/codex/tasks/task_e_68863a3d9138832f81b137eb92008883