### PR TITLE
Remove legacy/DTO toggles from lab income report

### DIFF
--- a/src/main/java/com/divudi/bean/lab/LaborataryReportController.java
+++ b/src/main/java/com/divudi/bean/lab/LaborataryReportController.java
@@ -215,14 +215,6 @@ public class LaborataryReportController implements Serializable {
     }
 
 
-    public String navigateToOptimizedLaboratoryIncomeReport() {
-        return "/reportLab/laboratary_income_report_dto.xhtml?faces-redirect=true";
-    }
-
-    public String navigateToLegacyLaboratoryIncomeReport() {
-        return "/reportLab/laboratary_income_report.xhtml?faces-redirect=true";
-    }
-
     public boolean isOptimizedMethodEnabled() {
         return configController.getBooleanValueByKey("Laboratory Income Report - Optimized Method", false);
     }

--- a/src/main/webapp/reportLab/laboratary_income_report.xhtml
+++ b/src/main/webapp/reportLab/laboratary_income_report.xhtml
@@ -12,14 +12,6 @@
 
                 <h:form >
                     <p:panel header="Laboratory Income Report - Legacy Method">
-                        <p:panel styleClass="mb-3 text-center">
-                            <h:outputText value="Navigation: " styleClass="font-weight-bold mr-3"/>
-                            <p:commandButton value="Legacy Method" styleClass="ui-button-success" disabled="true"/>
-                            <p:commandButton value="Optimized Method"
-                                             styleClass="ui-button-secondary ml-2"
-                                             action="#{laborataryReportController.navigateToOptimizedLaboratoryIncomeReport()}"
-                                             immediate="true"/>
-                        </p:panel>
                         <h:panelGrid columns="8" styleClass="w-100 form-grid" columnClasses="label-icon-column, input-column">
                             <h:panelGroup layout="block" styleClass="form-group">
                                 <h:outputText value="&#xf073;" styleClass="fa ml-5" /> <!-- FontAwesome calendar icon -->

--- a/src/main/webapp/reportLab/laboratary_income_report_dto.xhtml
+++ b/src/main/webapp/reportLab/laboratary_income_report_dto.xhtml
@@ -11,16 +11,6 @@
         <ui:define name="subcontent">
             <p:panel header="Laboratory Income Report - Optimized Method">
                 <h:form>
-                    <p:panel styleClass="mb-3 text-center">
-                        <h:outputText value="Navigation: " styleClass="font-weight-bold mr-3"/>
-                        <p:commandButton value="Legacy Method"
-                                         styleClass="ui-button-secondary mr-2"
-                                         action="#{laborataryReportController.navigateToLegacyLaboratoryIncomeReport()}"
-                                         immediate="true"/>
-                        <p:commandButton value="Optimized Method"
-                                         styleClass="ui-button-success"
-                                         disabled="true"/>
-                    </p:panel>
 
                     <h:panelGrid columns="8" styleClass="w-100 form-grid"
                                  columnClasses="label-icon-column, input-column">


### PR DESCRIPTION
## Summary
- clean up Laboratory Income Report pages
- drop DTO/legacy navigation panel
- remove now-unused internal navigation methods

## Testing
- `./detect-maven.sh -q test -Dtest=CommonFunctionsTest` *(fails: Plugin could not be resolved)*

------
https://chatgpt.com/codex/tasks/task_e_68876f38cf60832f8d705989eef48349