### PR TITLE
Add report execution logs audit page

### DIFF
--- a/src/main/webapp/audit/report_execution_logs.xhtml
+++ b/src/main/webapp/audit/report_execution_logs.xhtml
@@ -1,0 +1,84 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
+      xmlns:p="http://primefaces.org/ui"
+      xmlns:h="http://xmlns.jcp.org/jsf/html"
+      xmlns:f="http://xmlns.jcp.org/jsf/core">
+
+    <h:body>
+        <ui:composition template="/dataAdmin/admin_data_administration.xhtml">
+            <ui:define name="subcontent">
+                <h:form>
+                    <p:panel>
+                        <f:facet name="header">
+                            <h:outputText value="Execution Logs" />
+                        </f:facet>
+
+                        <h:panelGrid columns="2" class="my-2">
+                            <h:outputLabel value="From Date" />
+                            <p:datePicker class="w-100 mx-4" inputStyleClass="w-100"
+                                          id="fromDate"
+                                          value="#{reportLogController.fromDate}"
+                                          showTime="true"
+                                          pattern="#{sessionController.applicationPreference.longDateTimeFormat}" />
+                            <h:outputLabel value="To Date" />
+                            <p:datePicker class="w-100 mx-4" inputStyleClass="w-100"
+                                          id="toDate"
+                                          value="#{reportLogController.toDate}"
+                                          showTime="true"
+                                          pattern="#{sessionController.applicationPreference.longDateTimeFormat}" />
+                        </h:panelGrid>
+
+                        <h:panelGrid columns="3" class="my-2">
+                            <p:commandButton id="btnSearch"
+                                             class="ui-button-warning"
+                                             icon="pi pi-search"
+                                             ajax="false"
+                                             value="Search"
+                                             action="#{reportLogController.fillReportLogs}" />
+                            <p:commandButton id="btnDownload"
+                                             class="ui-button-warning"
+                                             icon="fa fa-download"
+                                             ajax="false"
+                                             value="Download">
+                                <p:dataExporter fileName="Exeution Logs" target="tblLogs" type="xlsx" ></p:dataExporter>
+                            </p:commandButton>
+
+                        </h:panelGrid>
+
+                        <p:dataTable
+                            id="tblLogs" 
+                            value="#{reportLogController.items}"
+                            var="rl" rowIndexVar="i" style="min-width:100%;"
+                            paginator="true" paginatorPosition="bottom"
+                            rows="10"
+                            paginatorTemplate="{CurrentPageReport} {FirstPageLink} {PreviousPageLink} {PageLinks} {NextPageLink} {LastPageLink} {RowsPerPageDropdown}"
+                            rowsPerPageTemplate="5,10,15">
+
+                            <p:column headerText="Report">
+                                <h:outputText value="#{rl.report != null ? rl.report.displayName : rl.reportName}" />
+                            </p:column>
+
+                            <p:column headerText="Start Time" width="8em" class="text-end">
+                                <h:outputText value="#{rl.startTime}">
+                                    <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateTimeFormat}" />
+                                </h:outputText>
+                            </p:column>
+
+                            <p:column headerText="End Time" width="8em" class="text-end">
+                                <h:outputText value="#{rl.endTime}" >
+                                    <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateTimeFormat}" />
+                                </h:outputText>
+                            </p:column>
+
+                            <p:column headerText="Duration (ms)" width="8em" class="text-end">
+                                <h:outputText value="#{rl.executionTimeInMillis}" />
+                            </p:column>
+                        </p:dataTable>
+                    </p:panel>
+                </h:form>
+            </ui:define>
+        </ui:composition>
+    </h:body>
+</html>

--- a/src/main/webapp/dataAdmin/admin_data_administration.xhtml
+++ b/src/main/webapp/dataAdmin/admin_data_administration.xhtml
@@ -239,6 +239,12 @@
                                             </p:commandButton>
                                             <p:commandButton
                                                 ajax="false"
+                                                action="/audit/report_execution_logs?faces-redirect=true"
+                                                value="Report Execution Logs"
+                                                icon="pi pi-history" >
+                                            </p:commandButton>
+                                            <p:commandButton
+                                                ajax="false"
                                                 action="/audit/all_audit_events?faces-redirect=true"
                                                 value="All Audit Events"
                                                 icon="pi pi-history" >


### PR DESCRIPTION
## Summary
- expose report execution logs under the audit section
- link new page from the Audit tab

## Testing
- `mvn -q -DskipTests package` *(fails: Could not resolve Maven dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6887a1fe03b4832fbabd21e5a89fd6a0