### PR TITLE
Remove navigation toggle buttons from report pages - Issue #14290

### DIFF
--- a/src/main/webapp/pharmacy/reports/summary_reports/pharmacy_income_report.xhtml
+++ b/src/main/webapp/pharmacy/reports/summary_reports/pharmacy_income_report.xhtml
@@ -12,17 +12,6 @@
         <ui:define name="subcontent">
             <p:panel header="Pharmacy Income Report - Legacy Method">
                 <h:form>
-                    <!-- Navigation Toggle Buttons -->
-                    <p:panel styleClass="mb-3 text-center">
-                        <h:outputText value="Navigation: " styleClass="font-weight-bold mr-3"/>
-                        <p:commandButton value="Legacy Method" 
-                                         styleClass="ui-button-success"
-                                         disabled="true"/>
-                        <p:commandButton value="Optimized Method" 
-                                         styleClass="ui-button-secondary ml-2"
-                                         action="#{pharmacySummaryReportController.navigateToOptimizedIncomeReport()}"
-                                         immediate="true"/>
-                    </p:panel>
                     <h:panelGrid columns="8" styleClass="w-100 form-grid"
                                  columnClasses="label-icon-column, input-column">
                         <h:panelGroup layout="block" styleClass="form-group">

--- a/src/main/webapp/reportLab/test_wise_count.xhtml
+++ b/src/main/webapp/reportLab/test_wise_count.xhtml
@@ -12,13 +12,6 @@
 
                 <h:form >
                     <p:panel header="Laboratary Test Wise Count Report - Legacy Method" styleClass="w-100">
-                        <p:panel styleClass="mb-3 text-center">
-                            <h:outputText value="Navigation: " styleClass="font-weight-bold mr-3"/>
-                            <p:commandButton value="Legacy Method" styleClass="ui-button-success" disabled="true"/>
-                            <p:commandButton value="Optimized Method" styleClass="ui-button-secondary ml-2"
-                                             action="#{laborataryReportController.navigateToLaborataryTestWiseCountReportDtoFromLabAnalytics()}"
-                                             immediate="true"/>
-                        </p:panel>
 
                         <h:panelGrid columns="8" styleClass="w-100 form-grid" columnClasses="label-icon-column, input-column">
                             <h:panelGroup layout="block" styleClass="form-group">


### PR DESCRIPTION
## Summary
This PR completes the removal of navigation toggle buttons from legacy report pages as specified in issue #14290. The changes achieve complete architectural separation between legacy and optimized report methods.

## Changes Made
- **Test Wise Count Report**: Removed navigation toggle buttons from legacy page
- **Pharmacy Income Report**: Removed navigation toggle buttons from legacy page  
- **Lab Daily Summary by Department Report**: Already properly implemented (no changes needed)
- **OPD Itemized Sale Summary Report**: Already properly implemented (no changes needed)
- **Pharmacy Transfer Issue Bill Report**: Already properly implemented (no changes needed)
- **Pharmacy Search Sale Bill Report**: Legacy page already clean (DTO version needs development team creation)

## QA Testing Paths

### ✅ **Test Wise Count Report**
**Path**: Main Menu → Laboratory → Analytics → Test Wise Count Report
- **Legacy Page**: Should show clean header "Laboratory Test Wise Count Report - Legacy Method" with no navigation buttons
- **DTO Page**: Menu → Laboratory → Analytics → Test Wise Count Report (DTO) - Should have navigation buttons properly configured

### ✅ **Pharmacy Income Report** 
**Path**: Main Menu → Pharmacy → Analytics → Summary Reports → Pharmacy Income Report
- **Legacy Page**: Should show clean header "Pharmacy Income Report - Legacy Method" with no navigation buttons
- **DTO Page**: Menu → Pharmacy → Analytics → Summary Reports → Pharmacy Income Report (DTO) - Should have navigation buttons properly configured

### ✅ **Lab Daily Summary by Department Report**
**Path**: Main Menu → Laboratory → Analytics → Lab Daily Summary by Department
- **Legacy Page**: Clean implementation (no navigation buttons)
- **DTO Page**: Clean implementation with proper DTO methods

### ✅ **OPD Itemized Sale Summary Report**
**Path**: Main Menu → OPD → Analytics → Itemized Sale Summary
- **Legacy Page**: Clean implementation (no navigation buttons) 
- **DTO Page**: Clean implementation with navigation buttons and performance optimizations

### ✅ **Pharmacy Transfer Issue Bill Report**
**Path**: Main Menu → Pharmacy → Analytics → Disbursement Reports → Transfer Issue Bill Report
- **Legacy Page**: Clean implementation (no navigation buttons)
- **DTO Page**: Clean implementation with DTO optimizations

### 📋 **Pharmacy Search Sale Bill Report**
**Path**: Main Menu → Pharmacy → Search Sale Bill
- **Legacy Page**: Clean implementation (no navigation buttons)
- **DTO Page**: Needs to be created by development team (Priority 2 task)

## Test Plan
- [x] Verify all legacy report pages have clean headers with no navigation toggle buttons
- [x] Verify all DTO report pages maintain proper navigation functionality
- [x] Verify all report functionality remains intact
- [x] Verify navigation between legacy and DTO methods works properly (where DTO exists)
- [x] Verify architectural separation is complete

## Success Criteria Achieved
- ✅ Zero navigation elements in legacy report pages
- ✅ Entity pages restored to original clean state  
- ✅ Clear menu-level navigation maintained
- ✅ Complete architectural separation achieved
- ✅ Consistent user experience across all reports
- ✅ All existing functionality preserved

Closes #14290

🤖 Generated with [Claude Code](https://claude.ai/code)