### PR TITLE
Inactive suppliers not working #14310

### DIFF
--- a/src/main/java/com/divudi/bean/emr/DataUploadController.java
+++ b/src/main/java/com/divudi/bean/emr/DataUploadController.java
@@ -5470,8 +5470,9 @@ public class DataUploadController implements Serializable {
             }
 
             Cell activeCell = row.getCell(3);
-            if (activeCell != null && activeCell.getCellType() == CellType.BOOLEAN) {
-                active = activeCell.getBooleanCellValue();
+            if (activeCell != null && activeCell.getCellType() == CellType.STRING) {
+                String cellValue = activeCell.getStringCellValue();
+                active = cellValue.equalsIgnoreCase("Active");
             }
             if (active == null) {
                 active = false;
@@ -5564,7 +5565,7 @@ public class DataUploadController implements Serializable {
             supplier.setCode(code);
             supplier.setInstitutionCode(code);
             supplier.setName(supplierName);
-            supplier.setInactive(active);
+            supplier.setInactive(!active);
             supplier.setMobile(mobilenumber);
             supplier.setFax(fax);
             supplier.setPhone(phone);

--- a/src/main/java/com/divudi/bean/pharmacy/DealerController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/DealerController.java
@@ -66,6 +66,20 @@ public class DealerController implements Serializable {
         return institutionList;
     }
 
+    public List<Institution> completeActiveDealor(String query) {
+
+        String sql;
+        Map m = new HashMap();
+
+        sql = "select c from Institution c where c.retired=false and c.inactive=false and "
+                + " c.institutionType =:t and (c.name) like :q order by c.name ";
+        m.put("t", InstitutionType.Dealer);
+        m.put("q", "%" + query.toUpperCase() + "%");
+        institutionList = getEjbFacade().findByJpql(sql, m);
+
+        return institutionList;
+    }
+
     public List<Institution> findAllDealors() {
 
         String sql;

--- a/src/main/webapp/admin/institutions/supplier_upload_extended.xhtml
+++ b/src/main/webapp/admin/institutions/supplier_upload_extended.xhtml
@@ -75,7 +75,7 @@
                             <tr>
                                 <td>D</td>
                                 <td>Active</td>
-                                <td>True or False</td>
+                                <td>Active or InActive, Required</td>
                             </tr>
                             <tr>
                                 <td>E</td>

--- a/src/main/webapp/pharmacy/direct_purchase.xhtml
+++ b/src/main/webapp/pharmacy/direct_purchase.xhtml
@@ -481,7 +481,7 @@
                                     converter="deal"
                                     value="#{pharmacyDirectPurchaseController.bill.fromInstitution}"
                                     forceSelection="true"
-                                    completeMethod="#{dealerController.completeDealor}"
+                                    completeMethod="#{dealerController.completeActiveDealor}"
                                     var="vt"
                                     maxResults="10"
                                     itemLabel="#{vt.name}"

--- a/src/main/webapp/pharmacy/pharmacy_purhcase_order_request.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_purhcase_order_request.xhtml
@@ -195,7 +195,7 @@
                                     class="w-100"
                                     inputStyleClass="w-100"
                                     requiredMessage="Supplier is Required"
-                                    completeMethod="#{dealerController.completeDealor}"
+                                    completeMethod="#{dealerController.completeActiveDealor}"
                                     var="vt" itemLabel="#{vt.name}" itemValue="#{vt}" >
                                     <f:ajax
                                         event="itemSelect" 

--- a/src/main/webapp/store/store_purchase.xhtml
+++ b/src/main/webapp/store/store_purchase.xhtml
@@ -33,7 +33,7 @@
                                 <p:outputLabel value="Select Supplier"/>
                                 <p:autoComplete class=" w-100" inputStyleClass="w-100" converter="deal" value="#{storePurchaseController.bill.fromInstitution}"
                                                 forceSelection="true"
-                                                completeMethod="#{dealerController.completeDealor}" var="vt" itemLabel="#{vt.name}" itemValue="#{vt}" />
+                                                completeMethod="#{dealerController.completeActiveDealor}" var="vt" itemLabel="#{vt.name}" itemValue="#{vt}" />
                                 <h:outputLabel value="Purchasing Institution"/>
                                 <p:autoComplete class=" w-100" inputStyleClass="w-100" value="#{storePurchaseController.bill.referenceInstitution}"
                                                 completeMethod="#{institutionController.completeCompany}"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added improved supplier autocomplete to display only active dealers when selecting suppliers in purchasing and order forms.

* **Bug Fixes**
  * Updated supplier upload to correctly interpret "Active" or "Inactive" status from the template.

* **Documentation**
  * Clarified instructions in the supplier upload template to require "Active" or "Inactive" as input for supplier status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->