### PR TITLE
Add DTO totals to transfer issue item report

### DIFF
--- a/src/main/java/com/divudi/core/data/dto/PharmacyTransferIssueBillItemDTO.java
+++ b/src/main/java/com/divudi/core/data/dto/PharmacyTransferIssueBillItemDTO.java
@@ -1,0 +1,150 @@
+package com.divudi.core.data.dto;
+
+import java.io.Serializable;
+import java.util.Date;
+
+/**
+ * DTO for Pharmacy Transfer Issue Bill Items
+ */
+public class PharmacyTransferIssueBillItemDTO implements Serializable {
+    private String deptId;
+    private Date createdAt;
+    private String itemName;
+    private String itemCode;
+    private Double qty;
+    private Double costRate;
+    private Double costValue;
+    private Double retailRate;
+    private Double retailValue;
+    private Double purchaseRate;
+    private Double purchaseValue;
+    private Double transferRate;
+    private Double transferValue;
+
+    public PharmacyTransferIssueBillItemDTO() {
+    }
+
+    public PharmacyTransferIssueBillItemDTO(String deptId, Date createdAt, String itemName, String itemCode,
+                                            Double qty, Double costRate, Double costValue,
+                                            Double retailRate, Double retailValue,
+                                            Double purchaseRate, Double purchaseValue,
+                                            Double transferRate, Double transferValue) {
+        this.deptId = deptId;
+        this.createdAt = createdAt;
+        this.itemName = itemName;
+        this.itemCode = itemCode;
+        this.qty = qty;
+        this.costRate = costRate;
+        this.costValue = costValue;
+        this.retailRate = retailRate;
+        this.retailValue = retailValue;
+        this.purchaseRate = purchaseRate;
+        this.purchaseValue = purchaseValue;
+        this.transferRate = transferRate;
+        this.transferValue = transferValue;
+    }
+
+    public String getDeptId() {
+        return deptId;
+    }
+
+    public void setDeptId(String deptId) {
+        this.deptId = deptId;
+    }
+
+    public Date getCreatedAt() {
+        return createdAt;
+    }
+
+    public void setCreatedAt(Date createdAt) {
+        this.createdAt = createdAt;
+    }
+
+    public String getItemName() {
+        return itemName;
+    }
+
+    public void setItemName(String itemName) {
+        this.itemName = itemName;
+    }
+
+    public String getItemCode() {
+        return itemCode;
+    }
+
+    public void setItemCode(String itemCode) {
+        this.itemCode = itemCode;
+    }
+
+    public Double getQty() {
+        return qty;
+    }
+
+    public void setQty(Double qty) {
+        this.qty = qty;
+    }
+
+    public Double getCostRate() {
+        return costRate;
+    }
+
+    public void setCostRate(Double costRate) {
+        this.costRate = costRate;
+    }
+
+    public Double getCostValue() {
+        return costValue;
+    }
+
+    public void setCostValue(Double costValue) {
+        this.costValue = costValue;
+    }
+
+    public Double getRetailRate() {
+        return retailRate;
+    }
+
+    public void setRetailRate(Double retailRate) {
+        this.retailRate = retailRate;
+    }
+
+    public Double getRetailValue() {
+        return retailValue;
+    }
+
+    public void setRetailValue(Double retailValue) {
+        this.retailValue = retailValue;
+    }
+
+    public Double getPurchaseRate() {
+        return purchaseRate;
+    }
+
+    public void setPurchaseRate(Double purchaseRate) {
+        this.purchaseRate = purchaseRate;
+    }
+
+    public Double getPurchaseValue() {
+        return purchaseValue;
+    }
+
+    public void setPurchaseValue(Double purchaseValue) {
+        this.purchaseValue = purchaseValue;
+    }
+
+    public Double getTransferRate() {
+        return transferRate;
+    }
+
+    public void setTransferRate(Double transferRate) {
+        this.transferRate = transferRate;
+    }
+
+    public Double getTransferValue() {
+        return transferValue;
+    }
+
+    public void setTransferValue(Double transferValue) {
+        this.transferValue = transferValue;
+    }
+}

--- a/src/main/webapp/pharmacy/reports/disbursement_reports/pharmacy_report_transfer_issue_bill_item.xhtml
+++ b/src/main/webapp/pharmacy/reports/disbursement_reports/pharmacy_report_transfer_issue_bill_item.xhtml
@@ -64,8 +64,8 @@
 
 
                         <h:panelGroup id="gpBillPreview">
-                            <p:dataTable id="tbl" styleClass="noBorder normalFont" 
-                                         value="#{reportsTransfer.transferItems}" var="i"  
+                            <p:dataTable id="tbl" styleClass="noBorder normalFont"
+                                         value="#{reportsTransfer.transferIssueBillItemDtos}" var="i"
                                          >
                                 <f:facet name="header">
                                     <h:outputLabel value="Transfer List From "/>&nbsp;
@@ -214,15 +214,30 @@
 
                                 <p:columnGroup type="footer">
                                     <p:row>
-                                        <p:column colspan="5"/>
-                                        <p:column style="text-align: right;" >
+                                        <p:column colspan="6"/>
+                                        <p:column style="text-align: right;">
                                             <f:facet name="footer">
-                                                <h:outputLabel value="#{reportsTransfer.purchaseValue}" >
-                                                    <f:convertNumber pattern="#,##0.00" ></f:convertNumber>
+                                                <h:outputLabel value="#{reportsTransfer.costValue}">
+                                                    <f:convertNumber pattern="#,##0.00"/>
                                                 </h:outputLabel>
                                             </f:facet>
                                         </p:column>
-                                        <p:column colspan="6"/>
+                                        <p:column colspan="3"/>
+                                        <p:column style="text-align: right;">
+                                            <f:facet name="footer">
+                                                <h:outputLabel value="#{reportsTransfer.purchaseValue}">
+                                                    <f:convertNumber pattern="#,##0.00"/>
+                                                </h:outputLabel>
+                                            </f:facet>
+                                        </p:column>
+                                        <p:column colspan="1"/>
+                                        <p:column style="text-align: right;">
+                                            <f:facet name="footer">
+                                                <h:outputLabel value="#{reportsTransfer.transferValue}">
+                                                    <f:convertNumber pattern="#,##0.00"/>
+                                                </h:outputLabel>
+                                            </f:facet>
+                                        </p:column>
                                     </p:row>
                                 </p:columnGroup>
 

--- a/src/main/webapp/pharmacy/reports/disbursement_reports/pharmacy_report_transfer_issue_bill_item_report_print.xhtml
+++ b/src/main/webapp/pharmacy/reports/disbursement_reports/pharmacy_report_transfer_issue_bill_item_report_print.xhtml
@@ -178,34 +178,34 @@
                                             </tr>
                                         </thead>
                                         <tbody>
-                                            <ui:repeat value="#{reportsTransfer.transferItems}" var="i">
+                                            <ui:repeat value="#{reportsTransfer.transferIssueBillItemDtos}" var="i">
                                                 <tr>
                                                     <td style="width: 8mm;" >
-                                                        <h:outputText value="#{i.bill.deptId}" style="margin-left: 1mm;"/>
+                                                        <h:outputText value="#{i.deptId}" style="margin-left: 1mm;"/>
                                                     </td>
                                                     <td style="width: 25mm; text-align: left;">
-                                                        <h:outputText value="#{i.bill.createdAt}" style="margin-left: 1mm;">
+                                                        <h:outputText value="#{i.createdAt}" style="margin-left: 1mm;">
                                                             <f:convertDateTime pattern="#{sessionController.applicationPreference.shortDateFormat}"/>
                                                         </h:outputText>
                                                     </td>
                                                     <td style="width: 67mm; text-align: left;">
-                                                        <h:outputText value="#{i.item.name}" style="margin-left: 1mm;"/>
+                                                        <h:outputText value="#{i.itemName}" style="margin-left: 1mm;"/>
                                                     </td>
                                                     <td style="width: 17mm; text-align: left;">
-                                                        <h:outputText value="#{i.item.code}" style="margin-left: 1mm;"/>
+                                                        <h:outputText value="#{i.itemCode}" style="margin-left: 1mm;"/>
                                                     </td>
                                                     <td style="width: 17mm; text-align: right;">
-                                                        <h:outputText value="#{i.pharmaceuticalBillItem.qty}" style="margin-right: 1mm;">
+                                                        <h:outputText value="#{i.qty}" style="margin-right: 1mm;">
                                                             <f:convertNumber pattern="#,##0.00" />
                                                         </h:outputText>
                                                     </td>
                                                     <td style="width: 17mm; text-align: right;">
-                                                        <h:outputText value="#{i.pharmaceuticalBillItem.itemBatch.purcahseRate}" style="margin-right: 1mm;">
+                                                        <h:outputText value="#{i.purchaseRate}" style="margin-right: 1mm;">
                                                             <f:convertNumber pattern="#,##0.00"/>
                                                         </h:outputText>
                                                     </td>
                                                     <td style="width: 17mm; text-align: right;">
-                                                        <h:outputText value="#{i.pharmaceuticalBillItem.itemBatch.purcahseRate * i.pharmaceuticalBillItem.qty}" style="margin-right: 1mm;">
+                                                        <h:outputText value="#{i.purchaseValue}" style="margin-right: 1mm;">
                                                             <f:convertNumber pattern="#,##0.00" />
                                                         </h:outputText>
                                                     </td>


### PR DESCRIPTION
## Summary
- add `PharmacyTransferIssueBillItemDTO` for lightweight item data
- fetch transfer issue items using DTOs in `ReportsTransfer`
- show totals for cost and transfer values in transfer issue item report
- adjust print view and datatable bindings

## Testing
- `mvn -q -DskipTests package` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_688920c4f208832f984508df16ed8fc3