### PR TITLE
Fix PropertyNotFoundException in pharmacy transfer issue page

### DIFF
--- a/src/main/webapp/resources/pharmacy/transferIssue.xhtml
+++ b/src/main/webapp/resources/pharmacy/transferIssue.xhtml
@@ -254,7 +254,7 @@
                             <f:convertNumber pattern="#0.00" />
                         </h:outputLabel>
                         <f:facet name="footer">
-                            <h:outputLabel value="#{cc.attrs.bill.billFinanceDetails.totalTransferValue}">
+                            <h:outputLabel value="#{cc.attrs.bill.billFinanceDetails.billGrossTotal}">
                                 <f:convertNumber pattern="#0.00" />
                             </h:outputLabel>
                         </f:facet>


### PR DESCRIPTION
Replace non-existent totalTransferValue property with billGrossTotal in transferIssue.xhtml footer. The billGrossTotal property contains the calculated transfer value based on pharmacy transfer configuration (cost rate, purchase rate, or retail rate).

Fixes #14375
Fixes #14372

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the "Transfer Value" column footer to display the correct total value in the data table.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->