### PR TITLE
Improve pharmacy transfer report layouts with configurable columns

### DIFF
--- a/src/main/webapp/resources/pharmacy/transferIssue.xhtml
+++ b/src/main/webapp/resources/pharmacy/transferIssue.xhtml
@@ -229,6 +229,7 @@
                     </p:column>
                     
                      <p:column  
+                        rendered="#{configOptionApplicationController.getBooleanValueByKey('Report Columns - Transfer Rate is required in Pharmacy Disbursement Reports', false)}"
                         width="4em" 
                         class="text-end">
                         <f:facet name="header">
@@ -245,6 +246,7 @@
                     </p:column>
 
                     <p:column  
+                        rendered="#{configOptionApplicationController.getBooleanValueByKey('Report Columns - Transfer Value is required in Pharmacy Disbursement Reports', false)}"
                         width="4em" 
                         class="text-end">
                         <f:facet name="header">

--- a/src/main/webapp/resources/pharmacy/transferReceive.xhtml
+++ b/src/main/webapp/resources/pharmacy/transferReceive.xhtml
@@ -109,8 +109,8 @@
                 <p:dataTable
                     rowIndexVar="rowIndex"
                     styleClass="no-border-table"
-                    style="border: none !important; font-size: #{configOptionApplicationController.getShortTextValueByKey('Report Font Size of Item List in Pharmacy Disbursement Reports', '10pt')}!Important;"
-                    class="my-4"
+                    style="border: none !important; font-size: #{configOptionApplicationController.getShortTextValueByKey('Report Font Size of Item List in Pharmacy Disbursement Reports', '10pt')}!Important; line-height: 1.2;"
+                    class="my-2"
                     value="#{cc.attrs.bill.billItems}" sortBy="#{bip.searialNo}" var="bip">
 
                     <p:column
@@ -133,15 +133,6 @@
                         </f:facet>
                     </p:column>
 
-                    <p:column style="margin: 0px; padding: 0px;" width="5em"
-                              rendered="#{configOptionApplicationController.getBooleanValueByKey('Report Columns - Date of Expiary is required in Pharmacy Disbursement Reports', true)}">
-                        <f:facet name="header">
-                            <h:outputLabel value="D O E"/>
-                        </f:facet>
-                        <h:outputLabel value="#{bip.pharmaceuticalBillItem.doe}">
-                            <f:convertDateTime pattern="#{sessionController.applicationPreference.shortDateFormat}"/>
-                        </h:outputLabel>
-                    </p:column>
 
                     <p:column
                         rendered="#{configOptionApplicationController.getBooleanValueByKey('Report Columns - Code is required in Pharmacy Disbursement Reports', true)}"
@@ -220,6 +211,7 @@
                     </p:column>
 
                     <p:column
+                        rendered="#{configOptionApplicationController.getBooleanValueByKey('Report Columns - Transfer Rate is required in Pharmacy Disbursement Reports', false)}"
                         width="4em" class="text-end">
                         <f:facet name="header">
                             <h:outputLabel value="Transfer Rate"/>
@@ -228,10 +220,9 @@
                             <f:convertNumber pattern="#,##0.00"/>
                         </h:outputLabel>
                     </p:column>
-                    
 
                     <p:column
-                        rendered="#{configOptionApplicationController.getBooleanValueByKey('Report Columns - Retail Value is required in Pharmacy Disbursement Reports', false)}"
+                        rendered="#{configOptionApplicationController.getBooleanValueByKey('Report Columns - Transfer Value is required in Pharmacy Disbursement Reports', false)}"
                         width="4em" class="text-end">
                         <f:facet name="header">
                             <h:outputLabel value="Transfer Value"/>
@@ -246,6 +237,17 @@
                             </h:outputLabel>
                         </f:facet>
                     </p:column>
+
+                    <p:column style="margin: 0px; padding: 0px;" width="5em"
+                              rendered="#{configOptionApplicationController.getBooleanValueByKey('Report Columns - Date of Expiary is required in Pharmacy Disbursement Reports', true)}">
+                        <f:facet name="header">
+                            <h:outputLabel value="D O E"/>
+                        </f:facet>
+                        <h:outputLabel value="#{bip.pharmaceuticalBillItem.doe}">
+                            <f:convertDateTime pattern="#{sessionController.applicationPreference.shortDateFormat}"/>
+                        </h:outputLabel>
+                    </p:column>
+
 
 
 


### PR DESCRIPTION
## Summary
- Add config options to control Transfer Rate and Transfer Value column visibility in both transfer issue and transfer receive reports
- Reposition DOE column after retail value column in transfer receive report as requested
- Reduce row spacing by adjusting line-height and Bootstrap class

## Config Options Added
- `Report Columns - Transfer Rate is required in Pharmacy Disbursement Reports` (default: false)
- `Report Columns - Transfer Value is required in Pharmacy Disbursement Reports` (default: false)

## Test Plan
- [ ] Verify Transfer Rate and Transfer Value columns are hidden by default in both transfer issue and receive reports
- [ ] Test enabling the config options shows the columns correctly
- [ ] Verify DOE column appears after retail value column in transfer receive report
- [ ] Check that row spacing is reduced appropriately

🤖 Generated with [Claude Code](https://claude.ai/code)