### PR TITLE
Add stock autocomplete colour toggle

### DIFF
--- a/developer_docs/navigation/pharmacy_navigation.md
+++ b/developer_docs/navigation/pharmacy_navigation.md
@@ -33,7 +33,7 @@ This document lists key pages reachable from the **Pharmacy** menu. Each entry s
 | **Pharmacy → Purchase → GRN** | `/faces/pharmacy/pharmacy_grn.xhtml` | `PharmacyGoodReceive` | |
 | **Pharmacy → Purchase → Purchase Order** | `/faces/pharmacy/pharmacy_purhcase_order_list.xhtml` | `PharmacyOrderCreation` | |
 | **Pharmacy → Stock → Transfer Request** | `/faces/pharmacy/pharmacy_transfer_request.xhtml` | `PharmacyTransferRequest` | |
-| **Pharmacy → Stock → Issue Stock** | `/faces/pharmacy/pharmacy_transfer_issue.xhtml` | `PharmacyTransferIssue` | |
+| **Pharmacy → Stock → Issue Stock** | `/faces/pharmacy/pharmacy_transfer_issue.xhtml` | `PharmacyTransferIssue` | Colour-coded autocomplete when `Display Colours for Stock Autocomplete Items` is true |
 | **Pharmacy → Stock → Receive Stock** | `/faces/pharmacy/pharmacy_transfer_receive.xhtml` | `PharmacyTransferRecive` | |
 | **Pharmacy → Stock → Bin Card** | `/faces/pharmacy/bin_card.xhtml` | `Pharmacy` | |
 | **Pharmacy → Reports → Sale by Date Summary** | `/faces/pharmacy/pharmacy_report_sale_by_date_summery.xhtml` | `ReportsSearchCashCardOwn` | |

--- a/src/main/java/com/divudi/bean/common/ConfigOptionApplicationController.java
+++ b/src/main/java/com/divudi/bean/common/ConfigOptionApplicationController.java
@@ -150,6 +150,7 @@ public class ConfigOptionApplicationController implements Serializable {
         getBooleanValueByKey("Direct Purchase Return by Quantity and Free Quantity", true);
         getBooleanValueByKey("Direct Purchase Return by Total Quantity", false);
         getBooleanValueByKey("Show Profit Percentage in GRN", true);
+        getBooleanValueByKey("Display Colours for Stock Autocomplete Items", true);
     }
 
     private void loadPharmacyIssueReceiptConfigurationDefaults() {


### PR DESCRIPTION
## Summary
- load `Display Colours for Stock Autocomplete Items` in pharmacy config defaults
- document option in Pharmacy navigation guide

## Testing
- `bash detect-maven.sh test -q` *(fails: could not resolve maven-resources-plugin)*

------
https://chatgpt.com/codex/tasks/task_e_688d00033564832f9006b128db0b0089