### PR TITLE
Add Excel export to application options list

### DIFF
--- a/src/main/webapp/admin/institutions/admin_mange_application_options.xhtml
+++ b/src/main/webapp/admin/institutions/admin_mange_application_options.xhtml
@@ -16,6 +16,10 @@
                             <!-- Button to List Application Options, with an icon and aligned to the right -->
                             <p:commandButton value="List Application Options" icon="pi pi-list" action="#{configOptionController.listApplicationOptions}"
                                              update="optionsTable" style="float: right;" />
+                            <!-- Excel export button -->
+                            <p:commandButton ajax="false" icon="pi pi-file-excel" title="Export to Excel" style="float: right; margin-right: 0.5em;">
+                                <p:dataExporter type="xlsx" target="optionsTable" fileName="application_options" />
+                            </p:commandButton>
                         </f:facet>
                         <!-- Data Table for Options -->
                         <p:dataTable 


### PR DESCRIPTION
## Summary
- add an Excel export button to `admin_mange_application_options.xhtml`

## Testing
- `git status`

------
https://chatgpt.com/codex/tasks/task_e_688d001d27e8832fab703906bcd2995f