### PR TITLE
Improve transfer report UIs

### DIFF
--- a/src/main/webapp/pharmacy/reports/disbursement_reports/pharmacy_report_transfer_issue_bill_dto.xhtml
+++ b/src/main/webapp/pharmacy/reports/disbursement_reports/pharmacy_report_transfer_issue_bill_dto.xhtml
@@ -14,90 +14,123 @@
             <ui:define name="subcontent">
                 <h:form>
 
-                    <p:panel header="Pharmacy Transfer Issue Bills" >
+                    <p:panel header="Pharmacy Transfer Issue Bills"
+                             styleClass="card shadow-sm" >
 
-                        <p:panelGrid columns="5" class="w-100" layout="tabular">
-                            <h:outputLabel value="From" ></h:outputLabel>
-                            <p:calendar
-                                inputStyleClass="w-100"
-                                class="w-100"
-                                value="#{reportsTransfer.fromDate}" 
-                                pattern="#{sessionController.applicationPreference.longDateTimeFormat}"  ></p:calendar>
-                            <p:spacer ></p:spacer>
-                            <h:outputLabel value="To" ></h:outputLabel>
+                        <div id="filters" class="row g-2">
+                            <div class="col-2">
+                                <h:outputLabel for="fromDate" value="From" />
+                            </div>
+                            <div class="col-3">
+                                <p:calendar id="fromDate" class="w-100" inputStyleClass="w-100"
+                                            value="#{reportsTransfer.fromDate}"
+                                            pattern="#{sessionController.applicationPreference.longDateTimeFormat}" />
+                            </div>
+                            <div class="col-2"></div>
+                            <div class="col-2">
+                                <h:outputLabel for="toDate" value="To" />
+                            </div>
+                            <div class="col-3">
+                                <p:calendar id="toDate" class="w-100" inputStyleClass="w-100"
+                                            value="#{reportsTransfer.toDate}"
+                                            pattern="#{sessionController.applicationPreference.longDateTimeFormat}" />
+                            </div>
+                            <div class="col-2">
+                                <h:outputLabel for="fromDept" value="Transfer From" />
+                            </div>
+                            <div class="col-3">
+                                <p:autoComplete id="fromDept" class="w-100" inputStyleClass="w-100"
+                                                completeMethod="#{departmentController.completeDept}" var="dept"
+                                                itemLabel="#{dept.name}" itemValue="#{dept}" forceSelection="true"
+                                                value="#{reportsTransfer.fromDepartment}" />
+                            </div>
+                            <div class="col-2"></div>
+                            <div class="col-2">
+                                <h:outputLabel for="toDept" value="Transfer To" />
+                            </div>
+                            <div class="col-3">
+                                <p:autoComplete id="toDept" class="w-100" inputStyleClass="w-100"
+                                                completeMethod="#{departmentController.completeDept}" var="dept"
+                                                itemLabel="#{dept.name}" itemValue="#{dept}" forceSelection="true"
+                                                value="#{reportsTransfer.toDepartment}" />
+                            </div>
 
-                            <p:calendar 
-                                class="w-100"
-                                inputStyleClass="w-100"
-                                value="#{reportsTransfer.toDate}" pattern="#{sessionController.applicationPreference.longDateTimeFormat}"  ></p:calendar>
-                            <h:outputLabel value="Transfer From" ></h:outputLabel>
-                            <p:autoComplete 
-                                class="w-100"
-                                inputStyleClass="w-100"
-                                completeMethod="#{departmentController.completeDept}" var="dept" 
-                                itemLabel="#{dept.name}" itemValue="#{dept}" forceSelection="true" 
-                                value="#{reportsTransfer.fromDepartment}"  >
-                            </p:autoComplete>
-                            <p:spacer ></p:spacer>
-                            <h:outputLabel value="Transfer To" ></h:outputLabel>
-                            <p:autoComplete
-                                class="w-100"
-                                inputStyleClass="w-100"
-                                completeMethod="#{departmentController.completeDept}" var="dept" 
-                                itemLabel="#{dept.name}" itemValue="#{dept}" forceSelection="true" 
-                                value="#{reportsTransfer.toDepartment}"  >
-                            </p:autoComplete>
+                        </div>
 
-                        </p:panelGrid>
-
-                        <h:panelGrid columns="3" class="my-2">
-                            <p:commandButton 
-                                ajax="false" 
-                                value="Process" 
-                                icon="fas fa-rocket"
-                                class="ui-button-success"
+                        <div class="d-flex flex-wrap gap-2 my-3">
+                            <p:commandButton
+                                ajax="false"
+                                value="Process"
+                                icon="pi pi-play"
+                                class="ui-button-warning"
+                                title="Generate transfer report with current filters"
                                 action="#{reportsTransfer.fillDepartmentTransfersIssueByBillDto}" >
                             </p:commandButton>
-                            <p:commandButton 
-                                ajax="false" 
-                                value="Excel" 
-                                icon="fas fa-file-excel"
-                                class="ui-button-warning mx-2">
+                            <p:commandButton
+                                ajax="false"
+                                value="Export to Excel"
+                                icon="pi pi-file-excel"
+                                class="ui-button-success"
+                                title="Export current data to Excel file">
                                 <p:dataExporter type="xlsx" target="tblScreen" fileName="Detailed_Transfer_Listing_DTO"   />
                             </p:commandButton>
-                            <p:commandButton 
-                                value="Print" 
+                            <p:commandButton
+                                value="Print Report"
                                 ajax="false"
-                                icon="fas fa-print"
+                                icon="pi pi-print"
                                 class="ui-button-info"
+                                title="Open print-friendly version"
                                 action="pharmacy_report_transfer_issue_bill_dto_print?faces-redirect=true" >
                             </p:commandButton>
 
-                        </h:panelGrid>
+                        </div>
 
 
                         <h:panelGroup id="gpBillPreviewScreen" styleClass="noBorder summeryBorder screenOnly">
-                            <p:dataTable 
-                                id="tblScreen" 
-                                styleClass="ui-datatable-borderless ui-datatable-sm compact-datatable"
+                            <p:dataTable
+                                id="tblScreen"
+                                styleClass="noBorder normalFont table-responsive"
                                 scrollable="true"
                                 scrollWidth="100%"
                                 value="#{reportsTransfer.transferIssueDtos}"
                                 var="i" >
                                 <f:facet name="header">
-                                    <h:outputLabel value="Transfer List (DTO Mode) - From "/>&nbsp;
-                                    <h:outputLabel style="margin-right: 20px" value="#{reportsTransfer.fromDepartment.name}"/>
-                                    <h:outputLabel value="To "/>&nbsp;
-                                    <h:outputLabel value="#{reportsTransfer.toDepartment.name}"/> 
-                                    <br></br>
-                                    <h:outputLabel value="From  "/>&nbsp;
-                                    <h:outputLabel style="margin-right: 20px" value="#{reportsTransfer.fromDate}">
-                                        <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateTimeFormat}"  />
-                                    </h:outputLabel>
-                                    <h:outputLabel value="To  "/>&nbsp;
-                                    <h:outputLabel value="#{reportsTransfer.toDate}">
-                                        <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateTimeFormat}" />
-                                    </h:outputLabel>
+                                    <div class="table-header-info p-2 bg-light border-bottom">
+                                        <div class="row">
+                                            <div class="col-md-8">
+                                                <h6 class="mb-1 text-primary">
+                                                    <i class="fas fa-exchange-alt mr-2"></i>Transfer Details
+                                                </h6>
+                                                <small class="text-muted">
+                                                    <strong>From:</strong>
+                                                    <span class="badge badge-secondary mr-2">#{reportsTransfer.fromDepartment.name}</span>
+                                                    <strong>To:</strong>
+                                                    <span class="badge badge-secondary">#{reportsTransfer.toDepartment.name}</span>
+                                                </small>
+                                                <br/>
+                                                <small class="text-muted">
+                                                    <i class="fas fa-calendar mr-1"></i>
+                                                    <strong>Period:</strong>
+                                                    <h:outputLabel value="#{reportsTransfer.fromDate}">
+                                                        <f:convertDateTime pattern="#{sessionController.applicationPreference.shortDateFormat}"/>
+                                                    </h:outputLabel>
+                                                    <span class="mx-1">to</span>
+                                                    <h:outputLabel value="#{reportsTransfer.toDate}">
+                                                        <f:convertDateTime pattern="#{sessionController.applicationPreference.shortDateFormat}"/>
+                                                    </h:outputLabel>
+                                                </small>
+                                            </div>
+                                            <div class="col-md-4 text-right">
+                                                <div class="table-record-count">
+                                                    <small class="text-muted">
+                                                        <i class="fas fa-list-ul mr-1"></i>
+                                                        <strong>Total Records:</strong>
+                                                        <span class="badge badge-info">#{reportsTransfer.transferIssueDtos.size()}</span>
+                                                    </small>
+                                                </div>
+                                            </div>
+                                        </div>
+                                    </div>
                                 </f:facet>
 
                                 <p:column headerText="Bill No" sortBy="#{i.deptId}">
@@ -235,25 +268,48 @@
 
 
                         <h:panelGroup id="gpBillPreviewPrinting" styleClass="noBorder summeryBorder" class="printingOnly">
-                            <p:dataTable 
-                                id="tblPrinting" 
-                                styleClass="ui-datatable-borderless ui-datatable-sm compact-datatable"
+                            <p:dataTable
+                                id="tblPrinting"
+                                styleClass="noBorder normalFont table-responsive"
                                 value="#{reportsTransfer.transferIssueDtos}"
                                 var="i" >
                                 <f:facet name="header">
-                                    <h:outputLabel value="Transfer List (DTO Mode) - From "/>&nbsp;
-                                    <h:outputLabel style="margin-right: 20px" value="#{reportsTransfer.fromDepartment.name}"/>
-                                    <h:outputLabel value="To "/>&nbsp;
-                                    <h:outputLabel value="#{reportsTransfer.toDepartment.name}"/> 
-                                    <br></br>
-                                    <h:outputLabel value="From  "/>&nbsp;
-                                    <h:outputLabel style="margin-right: 20px" value="#{reportsTransfer.fromDate}">
-                                        <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateTimeFormat}"  ></f:convertDateTime>
-                                    </h:outputLabel>
-                                    <h:outputLabel value="To  "/>&nbsp;
-                                    <h:outputLabel value="#{reportsTransfer.toDate}">
-                                        <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateTimeFormat}"  ></f:convertDateTime>
-                                    </h:outputLabel>
+                                    <div class="table-header-info p-2 bg-light border-bottom">
+                                        <div class="row">
+                                            <div class="col-md-8">
+                                                <h6 class="mb-1 text-primary">
+                                                    <i class="fas fa-exchange-alt mr-2"></i>Transfer Details
+                                                </h6>
+                                                <small class="text-muted">
+                                                    <strong>From:</strong>
+                                                    <span class="badge badge-secondary mr-2">#{reportsTransfer.fromDepartment.name}</span>
+                                                    <strong>To:</strong>
+                                                    <span class="badge badge-secondary">#{reportsTransfer.toDepartment.name}</span>
+                                                </small>
+                                                <br/>
+                                                <small class="text-muted">
+                                                    <i class="fas fa-calendar mr-1"></i>
+                                                    <strong>Period:</strong>
+                                                    <h:outputLabel value="#{reportsTransfer.fromDate}">
+                                                        <f:convertDateTime pattern="#{sessionController.applicationPreference.shortDateFormat}"  />
+                                                    </h:outputLabel>
+                                                    <span class="mx-1">to</span>
+                                                    <h:outputLabel value="#{reportsTransfer.toDate}">
+                                                        <f:convertDateTime pattern="#{sessionController.applicationPreference.shortDateFormat}"  />
+                                                    </h:outputLabel>
+                                                </small>
+                                            </div>
+                                            <div class="col-md-4 text-right">
+                                                <div class="table-record-count">
+                                                    <small class="text-muted">
+                                                        <i class="fas fa-list-ul mr-1"></i>
+                                                        <strong>Total Records:</strong>
+                                                        <span class="badge badge-info">#{reportsTransfer.transferIssueDtos.size()}</span>
+                                                    </small>
+                                                </div>
+                                            </div>
+                                        </div>
+                                    </div>
                                 </f:facet>
 
                                 <p:column headerText="Bill No" sortBy="#{i.deptId}">

--- a/src/main/webapp/pharmacy/reports/disbursement_reports/pharmacy_report_transfer_issue_bill_summery.xhtml
+++ b/src/main/webapp/pharmacy/reports/disbursement_reports/pharmacy_report_transfer_issue_bill_summery.xhtml
@@ -13,11 +13,12 @@
 
             <ui:define name="subcontent">
                 <h:form>
-                    <p:panel header="Pharmacy Transfer Issue Summary Report" >
+                    <p:panel header="Pharmacy Transfer Issue Summary Report"
+                             styleClass="card shadow-sm" >
                         
                         
                         
-                        <div class="row">
+                        <div id="filters" class="row g-2">
                             <div class="col-4 ">
                                 <h:outputLabel value="Issue From" />
                                 <p:autoComplete completeMethod="#{departmentController.completeDept}" var="dept" 
@@ -36,47 +37,74 @@
                             </div>
                         </div>
 
-                        <h:panelGrid columns="3" class="my-2">
+                        <div class="d-flex flex-wrap gap-2 my-3">
                             <p:commandButton 
                                 ajax="false" 
-                                value="Fill" 
-                                icon="fas fa-fill"
+                                value="Process"
+                                icon="pi pi-play"
                                 class="ui-button-warning"
+                                title="Generate transfer summary with current filters"
                                 action="#{reportsTransfer.createTransferIssueBillSummery}" >
                             </p:commandButton>
-                            <p:commandButton 
-                                ajax="false" 
-                                value="Excel" 
-                                icon="fas fa-file-excel"
-                                class="ui-button-success mx-2">
+                            <p:commandButton
+                                ajax="false"
+                                value="Export to Excel"
+                                icon="pi pi-file-excel"
+                                class="ui-button-success"
+                                title="Export current data to Excel file">
                                 <p:dataExporter type="xlsx" target="tbl" fileName="Pharmacy_Transfer_Issue_Summery_Report"  />
                             </p:commandButton>
-                            <p:commandButton 
-                                value="Print" 
+                            <p:commandButton
+                                value="Print Report"
                                 ajax="false"
-                                icon="fas fa-print"
+                                icon="pi pi-print"
                                 class="ui-button-info"
+                                title="Open print-friendly version"
                                 action="pharmacy_report_transfer_issue_bill_summery_print?faces-redirect=true" >
                             </p:commandButton>
-                            
-                           
-                        </h:panelGrid>
+
+
+                        </div>
 
                         <h:panelGroup id="gpBillPreview" styleClass="noBorder summeryBorder">
                             
-                            <p:dataTable id="tbl" value="#{reportsTransfer.listz}" var="i">
+                            <p:dataTable id="tbl" value="#{reportsTransfer.listz}" var="i"
+                                         styleClass="noBorder normalFont table-responsive">
                                 <f:facet name="header">
-                                    <h:outputLabel value="Pharmacy Transfer Issue Summary Report - "/>
-                                    <h:outputLabel value="#{reportsTransfer.fromDepartment.name}"/>
-                                    <br/>
-                                    <h:outputLabel value="From "/>
-                                    <h:outputLabel value="#{reportsTransfer.fromDate}">
-                                        <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateFormat}"/>
-                                    </h:outputLabel>
-                                    <h:outputLabel value=" To "/>
-                                    <h:outputLabel value="#{reportsTransfer.toDate}">
-                                        <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateFormat}"/>
-                                    </h:outputLabel>
+                                    <div class="table-header-info p-2 bg-light border-bottom">
+                                        <div class="row">
+                                            <div class="col-md-8">
+                                                <h6 class="mb-1 text-primary">
+                                                    <i class="fas fa-exchange-alt mr-2"></i>Transfer Summary
+                                                </h6>
+                                                <small class="text-muted">
+                                                    <strong>From:</strong>
+                                                    <span class="badge badge-secondary mr-2">#{reportsTransfer.fromDepartment.name}</span>
+                                                </small>
+                                                <br/>
+                                                <small class="text-muted">
+                                                    <i class="fas fa-calendar mr-1"></i>
+                                                    <strong>Period:</strong>
+                                                    <h:outputLabel value="#{reportsTransfer.fromDate}">
+                                                        <f:convertDateTime pattern="#{sessionController.applicationPreference.shortDateFormat}"/>
+                                                    </h:outputLabel>
+                                                    <span class="mx-1">to</span>
+                                                    <h:outputLabel value="#{reportsTransfer.toDate}">
+                                                        <f:convertDateTime pattern="#{sessionController.applicationPreference.shortDateFormat}"/>
+                                                    </h:outputLabel>
+                                                </small>
+                                            </div>
+                                            <div class="col-md-4 text-right">
+                                                <div class="table-record-count">
+                                                    <small class="text-muted">
+                                                        <i class="fas fa-list-ul mr-1"></i>
+                                                        <strong>Total Records:</strong>
+                                                        <span class="badge badge-info">#{reportsTransfer.listz.size()}</span>
+                                                    </small>
+                                                </div>
+                                            </div>
+                                        </div>
+                                    </div>
                                 </f:facet>
 
                                 <p:column headerText="Department">

--- a/src/main/webapp/pharmacy/reports/disbursement_reports/pharmacy_report_transfer_receive_bill.xhtml
+++ b/src/main/webapp/pharmacy/reports/disbursement_reports/pharmacy_report_transfer_receive_bill.xhtml
@@ -11,90 +11,124 @@
         <ui:composition template="/pharmacy/pharmacy_analytics.xhtml">
             <ui:define name="subcontent">
                 <h:form>
-                    <p:panel header="Pharmacy Transfer Received Bills" >
-                        <p:panelGrid columns="5" class="w-100" layout="tabular">
-                            <h:outputLabel value="From" ></h:outputLabel>
-                            <p:calendar
-                                inputStyleClass="w-100"
-                                class="w-100"
-                                value="#{reportsTransfer.fromDate}" 
-                                pattern="#{sessionController.applicationPreference.longDateTimeFormat}"  ></p:calendar>
-                            <p:spacer ></p:spacer>
-                            <h:outputLabel value="To" ></h:outputLabel>
+                    <p:panel header="Pharmacy Transfer Received Bills"
+                             styleClass="card shadow-sm" >
+                        <div id="filters" class="row g-2">
+                            <div class="col-2">
+                                <h:outputLabel for="fromDate" value="From" />
+                            </div>
+                            <div class="col-3">
+                                <p:calendar id="fromDate" class="w-100" inputStyleClass="w-100"
+                                            value="#{reportsTransfer.fromDate}"
+                                            pattern="#{sessionController.applicationPreference.longDateTimeFormat}"  ></p:calendar>
+                            </div>
+                            <div class="col-2"></div>
+                            <div class="col-2">
+                                <h:outputLabel for="toDate" value="To" />
+                            </div>
+                            <div class="col-3">
+                                <p:calendar id="toDate" class="w-100" inputStyleClass="w-100"
+                                            value="#{reportsTransfer.toDate}" pattern="#{sessionController.applicationPreference.longDateTimeFormat}"  ></p:calendar>
+                            </div>
+                            <div class="col-2">
+                                <h:outputLabel for="fromDept" value="Transfer From" />
+                            </div>
+                            <div class="col-3">
+                                <p:autoComplete id="fromDept" class="w-100" inputStyleClass="w-100"
+                                                completeMethod="#{departmentController.completeDept}" var="dept"
+                                                itemLabel="#{dept.name}" itemValue="#{dept}" forceSelection="true"
+                                                value="#{reportsTransfer.fromDepartment}"  >
+                                </p:autoComplete>
+                            </div>
+                            <div class="col-2"></div>
+                            <div class="col-2">
+                                <h:outputLabel for="toDept" value="Transfer To" />
+                            </div>
+                            <div class="col-3">
+                                <p:autoComplete id="toDept" class="w-100" inputStyleClass="w-100"
+                                                completeMethod="#{departmentController.completeDept}" var="dept"
+                                                itemLabel="#{dept.name}" itemValue="#{dept}" forceSelection="true"
+                                                value="#{reportsTransfer.toDepartment}"  >
+                                </p:autoComplete>
+                            </div>
 
-                            <p:calendar 
-                                class="w-100"
-                                inputStyleClass="w-100"
-                                value="#{reportsTransfer.toDate}" pattern="#{sessionController.applicationPreference.longDateTimeFormat}"  ></p:calendar>
-                            <h:outputLabel value="Transfer From" ></h:outputLabel>
-                            <p:autoComplete 
-                                class="w-100"
-                                inputStyleClass="w-100"
-                                completeMethod="#{departmentController.completeDept}" var="dept" 
-                                itemLabel="#{dept.name}" itemValue="#{dept}" forceSelection="true" 
-                                value="#{reportsTransfer.fromDepartment}"  >
-                            </p:autoComplete>
-                            <p:spacer ></p:spacer>
-                            <h:outputLabel value="Transfer To" ></h:outputLabel>
-                            <p:autoComplete
-                                class="w-100"
-                                inputStyleClass="w-100"
-                                completeMethod="#{departmentController.completeDept}" var="dept" 
-                                itemLabel="#{dept.name}" itemValue="#{dept}" forceSelection="true" 
-                                value="#{reportsTransfer.toDepartment}"  >
-                            </p:autoComplete>
+                        </div>
 
-                        </p:panelGrid>
-
-                        <h:panelGrid columns="3" class="my-2">
-                            <p:commandButton 
-                                ajax="false" 
-                                value="Fill" 
-                                icon="fas fa-rocket"
-                                class="ui-button-success"
+                        <div class="d-flex flex-wrap gap-2 my-3">
+                            <p:commandButton
+                                ajax="false"
+                                value="Process"
+                                icon="pi pi-play"
+                                class="ui-button-warning"
+                                title="Generate transfer report with current filters"
                                 action="#{reportsTransfer.fillDepartmentTransfersReceiveByBillDto}" >
                             </p:commandButton>
-                            <p:commandButton 
-                                ajax="false" 
-                                value="Excel" 
-                                icon="fas fa-file-excel"
-                                class="ui-button-warning mx-2">
+                            <p:commandButton
+                                ajax="false"
+                                value="Export to Excel"
+                                icon="pi pi-file-excel"
+                                class="ui-button-success"
+                                title="Export current data to Excel file">
                                 <p:dataExporter type="xlsx" target="tblScreen" fileName="Detailed_Transfer_Receive_Listing_DTO"   />
                             </p:commandButton>
-                            <p:commandButton 
-                                value="Print" 
+                            <p:commandButton
+                                value="Print Report"
                                 ajax="false"
-                                icon="fas fa-print"
+                                icon="pi pi-print"
                                 class="ui-button-info"
+                                title="Open print-friendly version"
                                 action="pharmacy_report_transfer_receive_bill_print?faces-redirect=true" >
                             </p:commandButton>
 
 
-                        </h:panelGrid>
+                        </div>
 
 
                         <h:panelGroup id="gpBillPreviewScreen" styleClass="noBorder summeryBorder screenOnly">
                             <p:dataTable 
                                 id="tblScreen" 
-                                styleClass="ui-datatable-borderless ui-datatable-sm compact-datatable"
+                                styleClass="noBorder normalFont table-responsive"
                                 scrollable="true"
                                 scrollWidth="100%"
                                 value="#{reportsTransfer.transferReceiveDtos}"
                                 var="i" >
                                 <f:facet name="header">
-                                    <h:outputLabel value="Transfer Receive List (DTO Mode) - From "/>&nbsp;
-                                    <h:outputLabel style="margin-right: 20px" value="#{reportsTransfer.fromDepartment != null ? reportsTransfer.fromDepartment.name : 'All Departments'}"/>
-                                    <h:outputLabel value="To "/>&nbsp;
-                                    <h:outputLabel value="#{reportsTransfer.toDepartment != null ? reportsTransfer.toDepartment.name : 'All Departments'}"/> 
-                                    <br></br>
-                                    <h:outputLabel value="From  "/>&nbsp;
-                                    <h:outputLabel style="margin-right: 20px" value="#{reportsTransfer.fromDate}">
-                                        <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateTimeFormat}"  />
-                                    </h:outputLabel>
-                                    <h:outputLabel value="To  "/>&nbsp;
-                                    <h:outputLabel value="#{reportsTransfer.toDate}">
-                                        <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateTimeFormat}" />
-                                    </h:outputLabel>
+                                    <div class="table-header-info p-2 bg-light border-bottom">
+                                        <div class="row">
+                                            <div class="col-md-8">
+                                                <h6 class="mb-1 text-primary">
+                                                    <i class="fas fa-exchange-alt mr-2"></i>Transfer Receive Details
+                                                </h6>
+                                                <small class="text-muted">
+                                                    <strong>From:</strong>
+                                                    <span class="badge badge-secondary mr-2">#{reportsTransfer.fromDepartment != null ? reportsTransfer.fromDepartment.name : 'All Departments'}</span>
+                                                    <strong>To:</strong>
+                                                    <span class="badge badge-secondary">#{reportsTransfer.toDepartment != null ? reportsTransfer.toDepartment.name : 'All Departments'}</span>
+                                                </small>
+                                                <br/>
+                                                <small class="text-muted">
+                                                    <i class="fas fa-calendar mr-1"></i>
+                                                    <strong>Period:</strong>
+                                                    <h:outputLabel value="#{reportsTransfer.fromDate}">
+                                                        <f:convertDateTime pattern="#{sessionController.applicationPreference.shortDateFormat}"  />
+                                                    </h:outputLabel>
+                                                    <span class="mx-1">to</span>
+                                                    <h:outputLabel value="#{reportsTransfer.toDate}">
+                                                        <f:convertDateTime pattern="#{sessionController.applicationPreference.shortDateFormat}"  />
+                                                    </h:outputLabel>
+                                                </small>
+                                            </div>
+                                            <div class="col-md-4 text-right">
+                                                <div class="table-record-count">
+                                                    <small class="text-muted">
+                                                        <i class="fas fa-list-ul mr-1"></i>
+                                                        <strong>Total Records:</strong>
+                                                        <span class="badge badge-info">#{reportsTransfer.transferReceiveDtos.size()}</span>
+                                                    </small>
+                                                </div>
+                                            </div>
+                                        </div>
+                                    </div>
                                 </f:facet>
 
                                 <p:column headerText="Bill No" sortBy="#{i.deptId}">
@@ -204,25 +238,48 @@
                         </h:panelGroup>
                         
                         <h:panelGroup id="gpBillPreviewPrinting" styleClass="noBorder summeryBorder" class="printingOnly">
-                            <p:dataTable 
-                                id="tblPrinting" 
-                                styleClass="ui-datatable-borderless ui-datatable-sm compact-datatable"
+                            <p:dataTable
+                                id="tblPrinting"
+                                styleClass="noBorder normalFont table-responsive"
                                 value="#{reportsTransfer.transferReceiveDtos}"
                                 var="i" >
                                 <f:facet name="header">
-                                    <h:outputLabel value="Transfer Receive List (DTO Mode) - From "/>&nbsp;
-                                    <h:outputLabel style="margin-right: 20px" value="#{reportsTransfer.fromDepartment != null ? reportsTransfer.fromDepartment.name : 'All Departments'}"/>
-                                    <h:outputLabel value="To "/>&nbsp;
-                                    <h:outputLabel value="#{reportsTransfer.toDepartment != null ? reportsTransfer.toDepartment.name : 'All Departments'}"/> 
-                                    <br></br>
-                                    <h:outputLabel value="From  "/>&nbsp;
-                                    <h:outputLabel style="margin-right: 20px" value="#{reportsTransfer.fromDate}">
-                                        <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateTimeFormat}"  ></f:convertDateTime>
-                                    </h:outputLabel>
-                                    <h:outputLabel value="To  "/>&nbsp;
-                                    <h:outputLabel value="#{reportsTransfer.toDate}">
-                                        <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateTimeFormat}"  ></f:convertDateTime>
-                                    </h:outputLabel>
+                                    <div class="table-header-info p-2 bg-light border-bottom">
+                                        <div class="row">
+                                            <div class="col-md-8">
+                                                <h6 class="mb-1 text-primary">
+                                                    <i class="fas fa-exchange-alt mr-2"></i>Transfer Receive Details
+                                                </h6>
+                                                <small class="text-muted">
+                                                    <strong>From:</strong>
+                                                    <span class="badge badge-secondary mr-2">#{reportsTransfer.fromDepartment != null ? reportsTransfer.fromDepartment.name : 'All Departments'}</span>
+                                                    <strong>To:</strong>
+                                                    <span class="badge badge-secondary">#{reportsTransfer.toDepartment != null ? reportsTransfer.toDepartment.name : 'All Departments'}</span>
+                                                </small>
+                                                <br/>
+                                                <small class="text-muted">
+                                                    <i class="fas fa-calendar mr-1"></i>
+                                                    <strong>Period:</strong>
+                                                    <h:outputLabel value="#{reportsTransfer.fromDate}">
+                                                        <f:convertDateTime pattern="#{sessionController.applicationPreference.shortDateFormat}"  ></f:convertDateTime>
+                                                    </h:outputLabel>
+                                                    <span class="mx-1">to</span>
+                                                    <h:outputLabel value="#{reportsTransfer.toDate}">
+                                                        <f:convertDateTime pattern="#{sessionController.applicationPreference.shortDateFormat}"  ></f:convertDateTime>
+                                                    </h:outputLabel>
+                                                </small>
+                                            </div>
+                                            <div class="col-md-4 text-right">
+                                                <div class="table-record-count">
+                                                    <small class="text-muted">
+                                                        <i class="fas fa-list-ul mr-1"></i>
+                                                        <strong>Total Records:</strong>
+                                                        <span class="badge badge-info">#{reportsTransfer.transferReceiveDtos.size()}</span>
+                                                    </small>
+                                                </div>
+                                            </div>
+                                        </div>
+                                    </div>
                                 </f:facet>
 
                                 <p:column headerText="Bill No" sortBy="#{i.deptId}">

--- a/src/main/webapp/pharmacy/reports/disbursement_reports/pharmacy_report_transfer_receive_bill_item.xhtml
+++ b/src/main/webapp/pharmacy/reports/disbursement_reports/pharmacy_report_transfer_receive_bill_item.xhtml
@@ -18,45 +18,67 @@
                              styleClass="card shadow-sm"
                              >
 
-                        <h:panelGrid columns="4" class="w-100" >
-                            <h:outputLabel value="From" ></h:outputLabel>
-                            <p:calendar value="#{reportsTransfer.fromDate}" pattern="#{sessionController.applicationPreference.longDateTimeFormat}"  ></p:calendar>
-                            <h:outputLabel value="To" ></h:outputLabel>
-                            <p:calendar value="#{reportsTransfer.toDate}" pattern="#{sessionController.applicationPreference.longDateTimeFormat}"  ></p:calendar>
-                            <h:outputLabel value="Transfer From" ></h:outputLabel>
-                            <p:autoComplete completeMethod="#{departmentController.completeDept}" var="dept" 
-                                            itemLabel="#{dept.name}" itemValue="#{dept}" forceSelection="true" 
-                                            value="#{reportsTransfer.fromDepartment}"  >
-                            </p:autoComplete>
-                            <h:outputLabel value="Transfer To" ></h:outputLabel>
-                            <p:autoComplete completeMethod="#{departmentController.completeDept}" var="dept" 
-                                            itemLabel="#{dept.name}" itemValue="#{dept}" forceSelection="true" 
-                                            value="#{reportsTransfer.toDepartment}"  >
-                            </p:autoComplete>
+                        <div id="filters" class="row g-2">
+                            <div class="col-2">
+                                <h:outputLabel for="fromDate" value="From" />
+                            </div>
+                            <div class="col-3">
+                                <p:calendar id="fromDate" class="w-100" inputStyleClass="w-100"
+                                            value="#{reportsTransfer.fromDate}"
+                                            pattern="#{sessionController.applicationPreference.longDateTimeFormat}"  />
+                            </div>
+                            <div class="col-2"></div>
+                            <div class="col-2">
+                                <h:outputLabel for="toDate" value="To" />
+                            </div>
+                            <div class="col-3">
+                                <p:calendar id="toDate" class="w-100" inputStyleClass="w-100"
+                                            value="#{reportsTransfer.toDate}"
+                                            pattern="#{sessionController.applicationPreference.longDateTimeFormat}"  />
+                            </div>
+                            <div class="col-2">
+                                <h:outputLabel for="fromDept" value="Transfer From" />
+                            </div>
+                            <div class="col-3">
+                                <p:autoComplete id="fromDept" class="w-100" inputStyleClass="w-100"
+                                                completeMethod="#{departmentController.completeDept}" var="dept"
+                                                itemLabel="#{dept.name}" itemValue="#{dept}" forceSelection="true"
+                                                value="#{reportsTransfer.fromDepartment}"  />
+                            </div>
+                            <div class="col-2"></div>
+                            <div class="col-2">
+                                <h:outputLabel for="toDept" value="Transfer To" />
+                            </div>
+                            <div class="col-3">
+                                <p:autoComplete id="toDept" class="w-100" inputStyleClass="w-100"
+                                                completeMethod="#{departmentController.completeDept}" var="dept"
+                                                itemLabel="#{dept.name}" itemValue="#{dept}" forceSelection="true"
+                                                value="#{reportsTransfer.toDepartment}"  />
+                            </div>
 
-                        </h:panelGrid>
+                        </div>
 
                         <div class="d-flex flex-wrap gap-2 my-3">
-                            <p:commandButton 
-                                ajax="false" 
-                                value="Fill Report" 
-                                icon="fas fa-search"
+                            <p:commandButton
+                                ajax="false"
+                                value="Process"
+                                icon="pi pi-play"
                                 class="ui-button-warning"
                                 title="Generate transfer report with current filters"
                                 action="#{reportsTransfer.fillDepartmentTransfersReceiveByBillItem()}" >
                             </p:commandButton>
-                            <p:commandButton 
-                                ajax="false" 
-                                value="Export to Excel" 
-                                icon="fas fa-file-excel"
+                            <p:commandButton
+                                ajax="false"
+                                value="Export to Excel"
+                                icon="pi pi-file-excel"
                                 class="ui-button-success"
                                 title="Export current data to Excel file">
                                 <p:dataExporter type="xlsx" target="tblScreen" fileName="Detailed_Transfer_Receive_Listing_#{reportsTransfer.fromDate}_#{reportsTransfer.toDate}"  />
                             </p:commandButton>
-                            <p:commandButton 
-                                value="Print Report" 
+                            <p:commandButton
+                                value="Print Report"
                                 ajax="false"
-                                icon="fas fa-print"
+                                icon="pi pi-print"
                                 class="ui-button-info"
                                 title="Open print-friendly version"
                                 action="pharmacy_report_transfer_receive_bill_item_report_print?faces-redirect=true" >

--- a/src/main/webapp/pharmacy/reports/disbursement_reports/pharmacy_report_transfer_receive_bill_summery.xhtml
+++ b/src/main/webapp/pharmacy/reports/disbursement_reports/pharmacy_report_transfer_receive_bill_summery.xhtml
@@ -14,9 +14,10 @@
             <ui:define name="subcontent">
                 <h:form>
 
-                    <p:panel header="Pharmacy Transfer Receive Summary Report" >
+                    <p:panel header="Pharmacy Transfer Receive Summary Report"
+                             styleClass="card shadow-sm" >
                         
-                        <div class="row">
+                        <div id="filters" class="row g-2">
                             <div class="col-4 ">
                                 <h:outputLabel value="Recive From" ></h:outputLabel>&nbsp;
                             <p:autoComplete completeMethod="#{departmentController.completeDept}" var="dept" 
@@ -34,50 +35,75 @@
                             </div>
                         </div>
 
-                        <h:panelGrid columns="3" class="my-2">
-                            <p:commandButton 
-                                ajax="false" 
-                                value="Fill" 
-                                icon="fas fa-fill"
+                        <div class="d-flex flex-wrap gap-2 my-3">
+                            <p:commandButton
+                                ajax="false"
+                                value="Process"
+                                icon="pi pi-play"
                                 class="ui-button-warning"
+                                title="Generate transfer summary with current filters"
                                 action="#{reportsTransfer.createTransferReciveBillSummery}">
                             </p:commandButton>
-                            <p:commandButton 
-                                ajax="false" 
-                                value="Excel" 
-                                icon="fas fa-file-excel"
-                                class="ui-button-success mx-2">
+                            <p:commandButton
+                                ajax="false"
+                                value="Export to Excel"
+                                icon="pi pi-file-excel"
+                                class="ui-button-success"
+                                title="Export current data to Excel file">
                                 <p:dataExporter type="xlsx" target="tbl" fileName="Pharmacy_Transfer_Receive_Summery_Report"  />
                             </p:commandButton>
-                            <p:commandButton 
-                                value="Print" 
+                            <p:commandButton
+                                value="Print Report"
                                 ajax="false"
-                                icon="fas fa-print"
+                                icon="pi pi-print"
                                 class="ui-button-info"
+                                title="Open print-friendly version"
                                 action="#" >
                                 <p:printer target="gpBillPreview" ></p:printer>
                             </p:commandButton>
-                        
-                        </h:panelGrid>
+
+                        </div>
 
 
                         <h:panelGroup id="gpBillPreview" styleClass="noBorder summeryBorder">
                             <p:dataTable id="tbl"
-                                         value="#{reportsTransfer.listz}" var="i"  >
+                                         value="#{reportsTransfer.listz}" var="i"
+                                         styleClass="noBorder normalFont table-responsive"  >
                                 <f:facet name="header">
-                                    <h:outputLabel value="Pharmacy Transfer Receive Summary Report"/>
-                                    <h:outputLabel value="#{reportsTransfer.fromDepartment.name}"/> 
-                                    <br/>
-                                    <!--<h:panelGrid columns="4">-->
-                                    <h:outputLabel value="From  "/>&nbsp;
-                                    <h:outputLabel value="#{reportsTransfer.fromDate}">&nbsp;&nbsp;
-                                            <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateFormat}" ></f:convertDateTime>
-                                        </h:outputLabel>
-                                    <h:outputLabel value="To  "/>&nbsp;
-                                        <h:outputLabel value="#{reportsTransfer.toDate}">
-                                            <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateFormat}" ></f:convertDateTime>
-                                        </h:outputLabel>
-                                    <!--</h:panelGrid>-->
+                                    <div class="table-header-info p-2 bg-light border-bottom">
+                                        <div class="row">
+                                            <div class="col-md-8">
+                                                <h6 class="mb-1 text-primary">
+                                                    <i class="fas fa-exchange-alt mr-2"></i>Transfer Receive Summary
+                                                </h6>
+                                                <small class="text-muted">
+                                                    <strong>From:</strong>
+                                                    <span class="badge badge-secondary mr-2">#{reportsTransfer.fromDepartment.name}</span>
+                                                </small>
+                                                <br/>
+                                                <small class="text-muted">
+                                                    <i class="fas fa-calendar mr-1"></i>
+                                                    <strong>Period:</strong>
+                                                    <h:outputLabel value="#{reportsTransfer.fromDate}">
+                                                        <f:convertDateTime pattern="#{sessionController.applicationPreference.shortDateFormat}" ></f:convertDateTime>
+                                                    </h:outputLabel>
+                                                    <span class="mx-1">to</span>
+                                                    <h:outputLabel value="#{reportsTransfer.toDate}">
+                                                        <f:convertDateTime pattern="#{sessionController.applicationPreference.shortDateFormat}" ></f:convertDateTime>
+                                                    </h:outputLabel>
+                                                </small>
+                                            </div>
+                                            <div class="col-md-4 text-right">
+                                                <div class="table-record-count">
+                                                    <small class="text-muted">
+                                                        <i class="fas fa-list-ul mr-1"></i>
+                                                        <strong>Total Records:</strong>
+                                                        <span class="badge badge-info">#{reportsTransfer.listz.size()}</span>
+                                                    </small>
+                                                </div>
+                                            </div>
+                                        </div>
+                                    </div>
                                 </f:facet>
 s
                                 <p:column headerText="Department">


### PR DESCRIPTION
## Summary
- unify styling across transfer report pages
- use Bootstrap grid for filters
- standardize command button icons and labels
- update table headers and styling

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688d15feba8c832f8a255f218330c13d