### PR TITLE
feat: track web user password history

### DIFF
--- a/src/main/java/com/divudi/bean/common/WebUserController.java
+++ b/src/main/java/com/divudi/bean/common/WebUserController.java
@@ -28,6 +28,7 @@ import com.divudi.core.facade.WebUserDashboardFacade;
 import com.divudi.core.facade.WebUserFacade;
 import com.divudi.core.facade.WebUserPrivilegeFacade;
 import com.divudi.core.facade.WebUserRoleFacade;
+import com.divudi.core.facade.WebUserPasswordHistoryFacade;
 import com.divudi.core.util.JsfUtil;
 import com.divudi.bean.hr.StaffImageController;
 import com.divudi.core.data.LoginPage;
@@ -76,6 +77,8 @@ public class WebUserController implements Serializable {
     private StaffFacade staffFacade;
     @EJB
     private WebUserDashboardFacade webUserDashboardFacade;
+    @EJB
+    private WebUserPasswordHistoryFacade webUserPasswordHistoryFacade;
 
     /**
      * Controllers
@@ -1195,6 +1198,14 @@ public class WebUserController implements Serializable {
 
     public WebUserDashboardFacade getWebUserDashboardFacade() {
         return webUserDashboardFacade;
+    }
+
+    public WebUserPasswordHistoryFacade getWebUserPasswordHistoryFacade() {
+        return webUserPasswordHistoryFacade;
+    }
+
+    public void setWebUserPasswordHistoryFacade(WebUserPasswordHistoryFacade webUserPasswordHistoryFacade) {
+        this.webUserPasswordHistoryFacade = webUserPasswordHistoryFacade;
     }
 
     public List<Department> getDepartmentsOfSelectedUsersInstitution() {

--- a/src/main/java/com/divudi/core/entity/WebUserPasswordHistory.java
+++ b/src/main/java/com/divudi/core/entity/WebUserPasswordHistory.java
@@ -1,0 +1,147 @@
+package com.divudi.core.entity;
+
+import java.io.Serializable;
+import java.util.Date;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.ManyToOne;
+import javax.persistence.Temporal;
+
+/**
+ *
+ * @author OpenAI
+ */
+@Entity
+public class WebUserPasswordHistory implements Serializable, RetirableEntity {
+
+    private static final long serialVersionUID = 1L;
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO)
+    private Long id;
+
+    @ManyToOne
+    private WebUser webUser;
+    private String password;
+
+    //Created Properties
+    @ManyToOne
+    private WebUser creater;
+    @Temporal(javax.persistence.TemporalType.TIMESTAMP)
+    private Date createdAt;
+    //Retairing properties
+    private boolean retired;
+    @ManyToOne
+    private WebUser retirer;
+    @Temporal(javax.persistence.TemporalType.TIMESTAMP)
+    private Date retiredAt;
+    private String retireComments;
+
+    public WebUserPasswordHistory() {
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public WebUser getWebUser() {
+        return webUser;
+    }
+
+    public void setWebUser(WebUser webUser) {
+        this.webUser = webUser;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+
+    public void setPassword(String password) {
+        this.password = password;
+    }
+
+    public WebUser getCreater() {
+        return creater;
+    }
+
+    public void setCreater(WebUser creater) {
+        this.creater = creater;
+    }
+
+    public Date getCreatedAt() {
+        return createdAt;
+    }
+
+    public void setCreatedAt(Date createdAt) {
+        this.createdAt = createdAt;
+    }
+
+    @Override
+    public boolean isRetired() {
+        return retired;
+    }
+
+    @Override
+    public void setRetired(boolean retired) {
+        this.retired = retired;
+    }
+
+    @Override
+    public Date getRetiredAt() {
+        return retiredAt;
+    }
+
+    @Override
+    public void setRetiredAt(Date retiredAt) {
+        this.retiredAt = retiredAt;
+    }
+
+    @Override
+    public WebUser getRetirer() {
+        return retirer;
+    }
+
+    @Override
+    public void setRetirer(WebUser retirer) {
+        this.retirer = retirer;
+    }
+
+    @Override
+    public String getRetireComments() {
+        return retireComments;
+    }
+
+    @Override
+    public void setRetireComments(String retireComments) {
+        this.retireComments = retireComments;
+    }
+
+    @Override
+    public int hashCode() {
+        int hash = 0;
+        hash += (id != null ? id.hashCode() : 0);
+        return hash;
+    }
+
+    @Override
+    public boolean equals(Object object) {
+        if (!(object instanceof WebUserPasswordHistory)) {
+            return false;
+        }
+        WebUserPasswordHistory other = (WebUserPasswordHistory) object;
+        if ((this.id == null && other.id != null) || (this.id != null && !this.id.equals(other.id))) {
+            return false;
+        }
+        return true;
+    }
+
+    @Override
+    public String toString() {
+        return "com.divudi.core.entity.WebUserPasswordHistory[ id=" + id + " ]";
+    }
+}

--- a/src/main/java/com/divudi/core/facade/WebUserPasswordHistoryFacade.java
+++ b/src/main/java/com/divudi/core/facade/WebUserPasswordHistoryFacade.java
@@ -1,0 +1,29 @@
+/*
+ * Author : WebUserPasswordHistoryFacade
+ */
+package com.divudi.core.facade;
+
+import com.divudi.core.entity.WebUserPasswordHistory;
+import javax.ejb.Stateless;
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+
+/**
+ *
+ * @author OpenAI
+ */
+@Stateless
+public class WebUserPasswordHistoryFacade extends AbstractFacade<WebUserPasswordHistory> {
+    @PersistenceContext(unitName = "hmisPU")
+    private EntityManager em;
+
+    @Override
+    protected EntityManager getEntityManager() {
+        if(em == null){}return em;
+    }
+
+    public WebUserPasswordHistoryFacade() {
+        super(WebUserPasswordHistory.class);
+    }
+
+}


### PR DESCRIPTION
## Summary
- add WebUserPasswordHistory entity to log password changes with metadata
- create WebUserPasswordHistoryFacade for persistence operations
- wire new facade into WebUserController for dependency injection

## Testing
- `mvn -q -e test` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:3.3.1 or one of its dependencies could not be resolved: Could not transfer artifact org.apache.maven.plugins:maven-resources-plugin:pom:3.3.1 from/to central (https://repo.maven.apache.org/maven2): Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_688e9e4c35cc832f9879bfc6dd5f1851