### PR TITLE
Add prevent password reuse config option

### DIFF
--- a/src/main/java/com/divudi/bean/common/ConfigOptionApplicationController.java
+++ b/src/main/java/com/divudi/bean/common/ConfigOptionApplicationController.java
@@ -113,6 +113,7 @@ public class ConfigOptionApplicationController implements Serializable {
         loadPharmacyCommonBillConfigurationDefaults();
         loadPharmacyAdjustmentReceiptConfigurationDefaults();
         loadPatientNameConfigurationDefaults();
+        loadSecurityConfigurationDefaults();
     }
 
     private void loadEmailGatewayConfigurationDefaults() {
@@ -607,6 +608,10 @@ public class ConfigOptionApplicationController implements Serializable {
         getBooleanValueByKey("Capitalize Each Word in Patient Name", false);
     }
 
+    private void loadSecurityConfigurationDefaults() {
+        getBooleanValueByKey("prevent_password_reuse", false);
+    }
+
     private void loadPharmacyAnalyticsConfigurationDefaults() {
         List<String> tabOptions = Arrays.asList(
                 "Pharmacy Analytics - Show Pharmacy Analytics Summary Reports Tab",
@@ -1039,6 +1044,18 @@ public class ConfigOptionApplicationController implements Serializable {
         option.setOptionValue(Boolean.toString(value));
         optionFacade.edit(option);
         loadApplicationOptions();
+    }
+
+    public boolean isPreventPasswordReuse() {
+        return getBooleanValueByKey("prevent_password_reuse", false);
+    }
+
+    public void setPreventPasswordReuse(boolean value) {
+        setBooleanValueByKey("prevent_password_reuse", value);
+    }
+
+    public ConfigOption getPreventPasswordReuseOption() {
+        return getApplicationOption("prevent_password_reuse");
     }
 
     public List<ConfigOption> getAllOptions(Object entity) {

--- a/src/main/java/com/divudi/bean/common/ConfigOptionController.java
+++ b/src/main/java/com/divudi/bean/common/ConfigOptionController.java
@@ -551,11 +551,20 @@ public class ConfigOptionController implements Serializable {
     }
 
     public void listApplicationOptions() {
+        configOptionApplicationController.isPreventPasswordReuse();
         options = getApplicationOptions();
     }
 
     public void listWebUserOptions() {
         options = getWebUserOptions(webUser);
+    }
+
+    public boolean isPreventPasswordReuse() {
+        return configOptionApplicationController.isPreventPasswordReuse();
+    }
+
+    public void setPreventPasswordReuse(boolean value) {
+        configOptionApplicationController.setPreventPasswordReuse(value);
     }
 
     private ConfigOptionFacade getFacade() {


### PR DESCRIPTION
## Summary
- add `prevent_password_reuse` application option with default false
- expose helpers to get/set this option
- allow configuration UI to list and toggle the option

## Testing
- `mvn -q -e test` *(fails: PluginResolutionException: maven-resources-plugin:3.3.1, Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_688e9fc4e0d8832f952378a0ddc964ea