### PR TITLE
feat: add expense removal actions

### DIFF
--- a/src/main/java/com/divudi/bean/pharmacy/GrnCostingController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/GrnCostingController.java
@@ -1733,6 +1733,26 @@ public class GrnCostingController implements Serializable {
 
     }
 
+    public void removeExpense(BillItem expense) {
+        if (expense == null) {
+            return;
+        }
+
+        if (billExpenses != null) {
+            billExpenses.remove(expense);
+            int index = 0;
+            for (BillItem be : billExpenses) {
+                be.setSearialNo(index++);
+            }
+        }
+
+        if (getBill().getBillExpenses() != null) {
+            getBill().getBillExpenses().remove(expense);
+        }
+
+        calTotal();
+    }
+
     public double calExpenses() {
         double tot = 0.0;
         for (BillItem be : billExpenses) {

--- a/src/main/java/com/divudi/bean/pharmacy/PharmacyDirectPurchaseController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacyDirectPurchaseController.java
@@ -658,6 +658,32 @@ public class PharmacyDirectPurchaseController implements Serializable {
 
     }
 
+    public void removeExpense(BillItem expense) {
+        if (expense == null) {
+            return;
+        }
+
+        if (billExpenses != null) {
+            billExpenses.remove(expense);
+            int index = 0;
+            for (BillItem be : billExpenses) {
+                be.setSearialNo(index++);
+            }
+        }
+
+        if (getBill().getBillExpenses() != null) {
+            getBill().getBillExpenses().remove(expense);
+        }
+
+        recalculateExpenseTotals();
+        calculateBillTotalsFromItems();
+        pharmacyCostingService.distributeProportionalBillValuesToItems(getBillItems(), getBill());
+
+        if (getBill().getId() != null) {
+            billFacade.edit(getBill());
+        }
+    }
+
     public void settleDirectPurchaseBillFinally() {
         if (getBill().getPaymentMethod() == null) {
             JsfUtil.addErrorMessage("Select Payment Method");

--- a/src/main/webapp/pharmacy/direct_purchase.xhtml
+++ b/src/main/webapp/pharmacy/direct_purchase.xhtml
@@ -565,10 +565,21 @@
                                     </p:column>
                                     <p:column headerText="Considered for Costing" >
                                         <p:selectBooleanCheckbox value="#{be.consideredForCosting}" >
-                                            <p:ajax event="change" 
+                                            <p:ajax event="change"
                                                     listener="#{pharmacyDirectPurchaseController.updateExpenseCosting(be)}"
                                                     update="@parent" />
                                         </p:selectBooleanCheckbox>
+                                    </p:column>
+                                    <p:column headerText="Delete" >
+                                        <p:commandButton
+                                            id="btnRemoveExpense"
+                                            title="Delete expense"
+                                            styleClass="ui-button-danger"
+                                            action="#{pharmacyDirectPurchaseController.removeExpense(be)}"
+                                            process="@this"
+                                            update="tblExpenses :#{p:resolveFirstComponentWithId('billExpenseGrid',view).clientId} :#{p:resolveFirstComponentWithId('tot',view).clientId} :#{p:resolveFirstComponentWithId('billFinanceDetails',view).clientId}">
+                                            <p:graphicImage library="images" name="icons/trash.svg" width="20" height="20" style="fill: currentColor;"/>
+                                        </p:commandButton>
                                     </p:column>
                                 </p:dataTable>
                             </p:panel>

--- a/src/main/webapp/pharmacy/pharmacy_grn_costing.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_grn_costing.xhtml
@@ -364,6 +364,17 @@
                                     <p:column headerText="Description" >
                                         <h:outputLabel value="#{be.descreption}" ></h:outputLabel>
                                     </p:column>
+                                    <p:column headerText="Delete" >
+                                        <p:commandButton
+                                            id="btnRemoveExpense"
+                                            title="Delete expense"
+                                            styleClass="ui-button-danger"
+                                            action="#{grnCostingController.removeExpense(be)}"
+                                            process="@this"
+                                            update="tblExpenses :#{p:resolveFirstComponentWithId('billExpenseGrid',view).clientId} :#{p:resolveFirstComponentWithId('grn',view).clientId} :#{p:resolveFirstComponentWithId('billFinanceDetails',view).clientId}">
+                                            <p:graphicImage library="images" name="icons/trash.svg" width="20" height="20" style="fill: currentColor;"/>
+                                        </p:commandButton>
+                                    </p:column>
                                 </p:dataTable>
                             </p:panel>
 

--- a/src/main/webapp/resources/images/icons/trash.svg
+++ b/src/main/webapp/resources/images/icons/trash.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="80" height="80" viewBox="0 0 24 24" fill="currentColor">
+  <path d="M9 2v2H4v2h16V4h-5V2H9zm10 7H5l1 12a2 2 0 0 0 2 2h8a2 2 0 0 0 2-2l1-12z"/>
+</svg>


### PR DESCRIPTION
## Summary
- allow removing individual expenses from direct purchase bills with recalc of totals
- enable deleting expenses on GRN costing with total recalculation
- add shared trash icon for expense delete actions

## Testing
- `mvn -q test` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:3.3.1: Could not transfer artifact ... Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_688f8da03158832fbe56bb2d8b5142ca