### PR TITLE
feat: add transfer receive reprint navigation by id

### DIFF
--- a/src/main/java/com/divudi/bean/pharmacy/PharmacyBillSearch.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacyBillSearch.java
@@ -294,6 +294,23 @@ public class PharmacyBillSearch implements Serializable {
     }
 
     /**
+     * Used by DTO reports where only the bill id is available.
+     */
+    public String navigateToReprintPharmacyTransferReceiveById() {
+        if (billId == null) {
+            JsfUtil.addErrorMessage("No Bill Selected");
+            return null;
+        }
+        Bill tb = billBean.fetchBillWithItemsAndFees(billId);
+        if (tb == null) {
+            JsfUtil.addErrorMessage("Bill not found");
+            return null;
+        }
+        bill = tb;
+        return "/pharmacy/pharmacy_reprint_transfer_receive?faces-redirect=true";
+    }
+
+    /**
      * Used by DTO reports where the bill id is passed as a parameter.
      * This avoids potential ViewExpiredException issues with f:setPropertyActionListener.
      */


### PR DESCRIPTION
## Summary
- add navigateToReprintPharmacyTransferReceiveById to fetch and reprint transfer receive bills using bill id

## Testing
- `mvn -e -DskipTests package` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:3.3.1 or one of its dependencies could not be resolved: Could not transfer artifact... Network is unreachable)*
- `mvn -e test` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:3.3.1 or one of its dependencies could not be resolved: Could not transfer artifact... Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6890bb2270fc832fb3cfb46441c4c599