### PR TITLE
fix: round balance to two decimal places in cashier bill

### DIFF
--- a/src/main/webapp/resources/pharmacy/sale_for_cashier_bill_five_five_custom_3_.xhtml
+++ b/src/main/webapp/resources/pharmacy/sale_for_cashier_bill_five_five_custom_3_.xhtml
@@ -169,7 +169,7 @@
                             <td >Balance :</td>
                             <td style="text-align: right;">
                                 <h:outputLabel value="#{cc.attrs.bill.balance}">
-                                    <f:convertNumber integerOnly="true" />
+                                    <f:convertNumber pattern="#,##0.00" />
                                 </h:outputLabel>
                             </td>
                         </tr>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the "Balance" field in the cash payment section to display values with two decimal places and thousands separators for improved readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->