### PR TITLE
fix: adjust discount calculation for cancelled and refund bills #14330

### DIFF
--- a/src/main/java/com/divudi/bean/report/ServiceSummery.java
+++ b/src/main/java/com/divudi/bean/report/ServiceSummery.java
@@ -7,11 +7,8 @@ package com.divudi.bean.report;
 
 import com.divudi.bean.common.ServiceSubCategoryController;
 import com.divudi.bean.common.SessionController;
+import com.divudi.core.data.*;
 import com.divudi.core.util.JsfUtil;
-import com.divudi.core.data.BillType;
-import com.divudi.core.data.BillTypeAtomic;
-import com.divudi.core.data.FeeType;
-import com.divudi.core.data.PaymentMethod;
 import com.divudi.core.data.dataStructure.BillItemWithFee;
 import com.divudi.core.data.table.String1Value5;
 
@@ -995,8 +992,11 @@ public class ServiceSummery implements Serializable {
             double proportion = paidValue / billNetTotal;
 
             // Proportionally allocate total and discount
+            boolean isCancelledBill = bill.getBillClassType().equals(BillClassType.CancelledBill) || bill.getBillClassType().equals(BillClassType.RefundBill);
+            double billProportionalDiscount = billDiscount * proportion;
+
             totalBill += billTotal * proportion;
-            discountBill += billDiscount * proportion;
+            discountBill += isCancelledBill ? (billProportionalDiscount > 0 ? -billProportionalDiscount:billProportionalDiscount) : billProportionalDiscount;
             netTotalBill += paidValue; // The payment amount is already the proportional net
         }
     }

--- a/src/main/webapp/reportInstitution/report_opd_pharmacy_staff_welfare.xhtml
+++ b/src/main/webapp/reportInstitution/report_opd_pharmacy_staff_welfare.xhtml
@@ -112,7 +112,12 @@
 
                         <p:column headerText="Discount" style="text-align: right">
                             <f:facet name="header"><p:outputLabel value="Discount"/></f:facet>
-                            <p:outputLabel value="#{p.discountValue}">
+                            <p:outputLabel rendered="#{p.bill.billClassType ne 'CancelledBill' and p.bill.billClassType ne 'RefundBill' }"
+                                           value="#{p.discountValue}">
+                                <f:convertNumber pattern="#,##0.00"/>
+                            </p:outputLabel>
+                            <p:outputLabel rendered="#{p.bill.billClassType eq 'CancelledBill' or p.bill.billClassType eq 'RefundBill' }"
+                                           value="#{p.discountValue > 0 ? -p.discountValue : p.discountValue}">
                                 <f:convertNumber pattern="#,##0.00"/>
                             </p:outputLabel>
                             <f:facet name="footer">


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the display and calculation of discounts for cancelled and refunded bills, ensuring that positive discounts are shown as negative values in these cases.
* **Style**
  * Improved the conditional rendering of discount values in reports for better clarity and accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->