### PR TITLE
Render Manage Procedures panel by default

### DIFF
--- a/src/main/webapp/emr/admin/procedures.xhtml
+++ b/src/main/webapp/emr/admin/procedures.xhtml
@@ -10,7 +10,7 @@
         <h:form >
 
             
-            <p:panel header="Manage Procedures" rendered="false">
+            <p:panel header="Manage Procedures">
                 <p:growl id="msg"/>
                 <p:focus id="selectFocus" context="gpSelect"/>
                 <p:focus id="detailFocus" context="gpDetail"/>


### PR DESCRIPTION
## Summary
- display Manage Procedures panel on page load by removing the rendered flag

## Testing
- No tests were run; JSF-only change per repository guidelines

------
https://chatgpt.com/codex/tasks/task_e_68922ff3d9ec832fb38d247d16c4eb58