### PR TITLE
Allow measurement units to appear in multiple unit lists

### DIFF
--- a/src/main/java/com/divudi/bean/pharmacy/MeasurementUnitController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/MeasurementUnitController.java
@@ -102,24 +102,32 @@ public class MeasurementUnitController implements Serializable {
         if (allUnits == null) {
             return;
         }
+        Set<MeasurementUnit> doseUnitSet = new HashSet<>();
+        Set<MeasurementUnit> durationUnitSet = new HashSet<>();
         for (MeasurementUnit mu : allUnits) {
             if (mu.isIssueUnit()) {
                 issueUnits.add(mu);
-                doseUnits.add(mu);
-                durationUnits.add(mu);
-            } else if (mu.isPackUnit()) {
-                doseUnits.add(mu);
+                doseUnitSet.add(mu);
+                durationUnitSet.add(mu);
+            }
+            if (mu.isPackUnit()) {
                 packUnits.add(mu);
-                durationUnits.add(mu);
-            } else if (mu.isStrengthUnit()) {
+                doseUnitSet.add(mu);
+                durationUnitSet.add(mu);
+            }
+            if (mu.isStrengthUnit()) {
                 strengthUnits.add(mu);
-                doseUnits.add(mu);
-            } else if (mu.isDurationUnit()) {
-                durationUnits.add(mu);
-            } else if (mu.isFrequencyUnit()) {
+                doseUnitSet.add(mu);
+            }
+            if (mu.isDurationUnit()) {
+                durationUnitSet.add(mu);
+            }
+            if (mu.isFrequencyUnit()) {
                 frequencyUnits.add(mu);
             }
         }
+        doseUnits.addAll(doseUnitSet);
+        durationUnits.addAll(durationUnitSet);
     }
 
     public MeasurementUnit findAndSaveMeasurementUnitByName(String name) {


### PR DESCRIPTION
## Summary
- Refactor MeasurementUnitController.fillAllUnits to add units to all applicable lists using independent conditionals
- Ensure patient profile dropdowns can show units flagged for multiple categories

## Testing
- `mvn -q -e test` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:3.3.1 could not be resolved: Network is unreachable)*
- `mvn -q -e -o package -DskipTests` *(fails: Cannot access central in offline mode and the artifact maven-resources-plugin has not been downloaded)*

------
https://chatgpt.com/codex/tasks/task_e_68923350267c832f83d5960dd7ffc0a6