### PR TITLE
Fix image deletion in OPD visit

### DIFF
--- a/src/main/java/com/divudi/bean/clinical/PastPatientEncounterController.java
+++ b/src/main/java/com/divudi/bean/clinical/PastPatientEncounterController.java
@@ -2485,6 +2485,7 @@ public class PastPatientEncounterController implements Serializable {
 
     public void setRemovingClinicalFindingValue(ClinicalFindingValue removingClinicalFindingValue) {
         this.removingClinicalFindingValue = removingClinicalFindingValue;
+        this.removingCfv = removingClinicalFindingValue;
     }
 
     public Patient getPatient() {

--- a/src/main/java/com/divudi/bean/clinical/PatientEncounterController.java
+++ b/src/main/java/com/divudi/bean/clinical/PatientEncounterController.java
@@ -2677,6 +2677,7 @@ public class PatientEncounterController implements Serializable {
 
     public void setRemovingClinicalFindingValue(ClinicalFindingValue removingClinicalFindingValue) {
         this.removingClinicalFindingValue = removingClinicalFindingValue;
+        this.removingCfv = removingClinicalFindingValue;
     }
 
     public Patient getPatient() {

--- a/src/main/java/com/divudi/bean/inward/InpatientClinicalDataController.java
+++ b/src/main/java/com/divudi/bean/inward/InpatientClinicalDataController.java
@@ -2688,6 +2688,7 @@ public class InpatientClinicalDataController implements Serializable {
 
     public void setRemovingClinicalFindingValue(ClinicalFindingValue removingClinicalFindingValue) {
         this.removingClinicalFindingValue = removingClinicalFindingValue;
+        this.removingCfv = removingClinicalFindingValue;
     }
 
     public Patient getPatient() {


### PR DESCRIPTION
## Summary
- Sync `removingClinicalFindingValue` with internal `removingCfv` to enable deleting encounter images
- Apply the same binding fix across encounter controllers for consistent removal behavior

## Testing
- `mvn -q -e -DskipTests=true compile` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:pom:3.3.1 could not be resolved)*

Closes #14713

------
https://chatgpt.com/codex/tasks/task_e_6892342ca038832f87645161f0c64ab6