### PR TITLE
Fix image deletion in OPD visit

### DIFF
--- a/src/main/java/com/divudi/bean/clinical/PastPatientEncounterController.java
+++ b/src/main/java/com/divudi/bean/clinical/PastPatientEncounterController.java
@@ -2485,6 +2485,9 @@ public class PastPatientEncounterController implements Serializable {
 
     public void setRemovingClinicalFindingValue(ClinicalFindingValue removingClinicalFindingValue) {
         this.removingClinicalFindingValue = removingClinicalFindingValue;
+        if (removingClinicalFindingValue == null) {
+            this.removingCfv = null;
+        }
     }
 
     public Patient getPatient() {

--- a/src/main/java/com/divudi/bean/clinical/PatientEncounterController.java
+++ b/src/main/java/com/divudi/bean/clinical/PatientEncounterController.java
@@ -2677,6 +2677,9 @@ public class PatientEncounterController implements Serializable {
 
     public void setRemovingClinicalFindingValue(ClinicalFindingValue removingClinicalFindingValue) {
         this.removingClinicalFindingValue = removingClinicalFindingValue;
+        if (removingClinicalFindingValue == null) {
+            this.removingCfv = null;
+        }
     }
 
     public Patient getPatient() {

--- a/src/main/java/com/divudi/bean/inward/InpatientClinicalDataController.java
+++ b/src/main/java/com/divudi/bean/inward/InpatientClinicalDataController.java
@@ -2688,6 +2688,9 @@ public class InpatientClinicalDataController implements Serializable {
 
     public void setRemovingClinicalFindingValue(ClinicalFindingValue removingClinicalFindingValue) {
         this.removingClinicalFindingValue = removingClinicalFindingValue;
+        if (removingClinicalFindingValue == null) {
+            this.removingCfv = null;
+        }
     }
 
     public Patient getPatient() {

--- a/src/main/webapp/emr/opd_visit.xhtml
+++ b/src/main/webapp/emr/opd_visit.xhtml
@@ -1003,7 +1003,7 @@
                                                         <p:commandButton id="btnRemoveImage" action="#{patientEncounterController.removeEncounterImage()}"
                                                                          process="@this" update="imageSwitcher" icon="pi pi-trash"
                                                                          style="position: absolute; top: 5px; left: 5px;" >
-                                                            <f:setPropertyActionListener value="#{photo}" target="#{patientEncounterController.removingClinicalFindingValue}" ></f:setPropertyActionListener>
+                                                            <f:setPropertyActionListener value="#{photo}" target="#{patientEncounterController.removingCfv}" ></f:setPropertyActionListener>
                                                         </p:commandButton>
 
                                                         <p:graphicImage value="#{patientEncounterController.image}" cache="false" style="width: 100%; height: 100%; object-fit: cover;">

--- a/src/main/webapp/emr/opd_visit_view.xhtml
+++ b/src/main/webapp/emr/opd_visit_view.xhtml
@@ -558,7 +558,7 @@
                                                         <p:commandButton id="btnRemoveImage" action="#{pastPatientEncounterController.removeEncounterImage()}"
                                                                          process="@this" update="imageSwitcher" icon="pi pi-trash"
                                                                          style="position: absolute; top: 5px; left: 5px;" >
-                                                            <f:setPropertyActionListener value="#{photo}" target="#{pastPatientEncounterController.removingClinicalFindingValue}" ></f:setPropertyActionListener>
+                                                            <f:setPropertyActionListener value="#{photo}" target="#{pastPatientEncounterController.removingCfv}" ></f:setPropertyActionListener>
                                                         </p:commandButton>
 
                                                         <p:graphicImage value="#{pastPatientEncounterController.image}" cache="false" style="width: 100%; height: 100%; object-fit: cover;">

--- a/src/main/webapp/inward/clinical_data_diagnosis_card.xhtml
+++ b/src/main/webapp/inward/clinical_data_diagnosis_card.xhtml
@@ -612,7 +612,7 @@
                                                         <p:commandButton id="btnRemoveImage" action="#{inpatientClinicalDataController.removeEncounterImage()}"
                                                                          process="@this" update="imageSwitcher" icon="pi pi-trash"
                                                                          style="position: absolute; top: 5px; left: 5px;" >
-                                                            <f:setPropertyActionListener value="#{photo}" target="#{inpatientClinicalDataController.removingClinicalFindingValue}" ></f:setPropertyActionListener>
+                                                            <f:setPropertyActionListener value="#{photo}" target="#{inpatientClinicalDataController.removingCfv}" ></f:setPropertyActionListener>
                                                         </p:commandButton>
 
                                                         <p:graphicImage value="#{inpatientClinicalDataController.image}" cache="false" style="width: 100%; height: 100%; object-fit: cover;">

--- a/src/main/webapp/inward/clinical_data_drug_chart.xhtml
+++ b/src/main/webapp/inward/clinical_data_drug_chart.xhtml
@@ -612,7 +612,7 @@
                                                         <p:commandButton id="btnRemoveImage" action="#{inpatientClinicalDataController.removeEncounterImage()}"
                                                                          process="@this" update="imageSwitcher" icon="pi pi-trash"
                                                                          style="position: absolute; top: 5px; left: 5px;" >
-                                                            <f:setPropertyActionListener value="#{photo}" target="#{inpatientClinicalDataController.removingClinicalFindingValue}" ></f:setPropertyActionListener>
+                                                            <f:setPropertyActionListener value="#{photo}" target="#{inpatientClinicalDataController.removingCfv}" ></f:setPropertyActionListener>
                                                         </p:commandButton>
 
                                                         <p:graphicImage value="#{inpatientClinicalDataController.image}" cache="false" style="width: 100%; height: 100%; object-fit: cover;">

--- a/src/main/webapp/inward/clinical_data_images.xhtml
+++ b/src/main/webapp/inward/clinical_data_images.xhtml
@@ -612,7 +612,7 @@
                                                         <p:commandButton id="btnRemoveImage" action="#{inpatientClinicalDataController.removeEncounterImage()}"
                                                                          process="@this" update="imageSwitcher" icon="pi pi-trash"
                                                                          style="position: absolute; top: 5px; left: 5px;" >
-                                                            <f:setPropertyActionListener value="#{photo}" target="#{inpatientClinicalDataController.removingClinicalFindingValue}" ></f:setPropertyActionListener>
+                                                            <f:setPropertyActionListener value="#{photo}" target="#{inpatientClinicalDataController.removingCfv}" ></f:setPropertyActionListener>
                                                         </p:commandButton>
 
                                                         <p:graphicImage value="#{inpatientClinicalDataController.image}" cache="false" style="width: 100%; height: 100%; object-fit: cover;">

--- a/src/main/webapp/inward/clinical_data_investigations.xhtml
+++ b/src/main/webapp/inward/clinical_data_investigations.xhtml
@@ -612,7 +612,7 @@
                                                         <p:commandButton id="btnRemoveImage" action="#{inpatientClinicalDataController.removeEncounterImage()}"
                                                                          process="@this" update="imageSwitcher" icon="pi pi-trash"
                                                                          style="position: absolute; top: 5px; left: 5px;" >
-                                                            <f:setPropertyActionListener value="#{photo}" target="#{inpatientClinicalDataController.removingClinicalFindingValue}" ></f:setPropertyActionListener>
+                                                            <f:setPropertyActionListener value="#{photo}" target="#{inpatientClinicalDataController.removingCfv}" ></f:setPropertyActionListener>
                                                         </p:commandButton>
 
                                                         <p:graphicImage value="#{inpatientClinicalDataController.image}" cache="false" style="width: 100%; height: 100%; object-fit: cover;">

--- a/src/main/webapp/optician/opd_visit.xhtml
+++ b/src/main/webapp/optician/opd_visit.xhtml
@@ -998,7 +998,7 @@
                                                         <p:commandButton id="btnRemoveImage" action="#{patientEncounterController.removeEncounterImage()}"
                                                                          process="@this" update="imageSwitcher" icon="pi pi-trash"
                                                                          style="position: absolute; top: 5px; left: 5px;" >
-                                                            <f:setPropertyActionListener value="#{photo}" target="#{patientEncounterController.removingClinicalFindingValue}" ></f:setPropertyActionListener>
+                                                            <f:setPropertyActionListener value="#{photo}" target="#{patientEncounterController.removingCfv}" ></f:setPropertyActionListener>
                                                         </p:commandButton>
 
                                                         <p:graphicImage value="#{patientEncounterController.image}" cache="false" style="width: 100%; height: 100%; object-fit: cover;">

--- a/src/main/webapp/optician/opd_visit_view.xhtml
+++ b/src/main/webapp/optician/opd_visit_view.xhtml
@@ -558,7 +558,7 @@
                                                         <p:commandButton id="btnRemoveImage" action="#{pastPatientEncounterController.removeEncounterImage()}"
                                                                          process="@this" update="imageSwitcher" icon="pi pi-trash"
                                                                          style="position: absolute; top: 5px; left: 5px;" >
-                                                            <f:setPropertyActionListener value="#{photo}" target="#{pastPatientEncounterController.removingClinicalFindingValue}" ></f:setPropertyActionListener>
+                                                            <f:setPropertyActionListener value="#{photo}" target="#{pastPatientEncounterController.removingCfv}" ></f:setPropertyActionListener>
                                                         </p:commandButton>
 
                                                         <p:graphicImage value="#{pastPatientEncounterController.image}" cache="false" style="width: 100%; height: 100%; object-fit: cover;">


### PR DESCRIPTION
## Summary
- Use a dedicated `removingCfv` property for deleting clinical finding images
- Update image delete buttons across OPD, past-encounter, and inpatient views to reference `removingCfv`

## Testing
- `mvn -q -e -DskipTests=true compile` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:pom:3.3.1 could not be resolved)*

Closes #14713

------
https://chatgpt.com/codex/tasks/task_e_6892342ca038832f87645161f0c64ab6