### PR TITLE
feat: add consignment flag to pharmacy bills

### DIFF
--- a/db/migration/04_add_consignment_column_to_bill.sql
+++ b/db/migration/04_add_consignment_column_to_bill.sql
@@ -1,0 +1,6 @@
+-- Migration Script: Add consignment flag to Bill
+-- Adds boolean column 'consignment' to table Bill with default false.
+-- Author: ChatGPT
+-- Date: 2025-08-01
+
+ALTER TABLE Bill ADD COLUMN consignment BOOLEAN DEFAULT FALSE;

--- a/src/main/java/com/divudi/bean/common/ConfigOptionApplicationController.java
+++ b/src/main/java/com/divudi/bean/common/ConfigOptionApplicationController.java
@@ -152,6 +152,7 @@ public class ConfigOptionApplicationController implements Serializable {
         getBooleanValueByKey("Direct Purchase Return by Total Quantity", false);
         getBooleanValueByKey("Show Profit Percentage in GRN", true);
         getBooleanValueByKey("Display Colours for Stock Autocomplete Items", true);
+        getBooleanValueByKey("Enable Consignment in Pharmacy Purchasing", true);
     }
 
     private void loadPharmacyIssueReceiptConfigurationDefaults() {

--- a/src/main/java/com/divudi/bean/pharmacy/GrnCostingController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/GrnCostingController.java
@@ -1931,6 +1931,7 @@ public class GrnCostingController implements Serializable {
             grnBill = new BilledBill();
             grnBill.setBillType(BillType.PharmacyGrnBill);
             grnBill.setBillTypeAtomic(BillTypeAtomic.PHARMACY_GRN);
+            grnBill.setConsignment(getApproveBill().isConsignment());
             grnBill.setBillFinanceDetails(new BillFinanceDetails(grnBill));
         }
         return grnBill;
@@ -2125,6 +2126,7 @@ public class GrnCostingController implements Serializable {
             currentGrnBillPre = new BilledBill();
             currentGrnBillPre.setBillType(BillType.PharmacyGrnBill);
             currentGrnBillPre.setBillTypeAtomic(BillTypeAtomic.PHARMACY_GRN_PRE);
+            currentGrnBillPre.setConsignment(getApproveBill().isConsignment());
         }
         return currentGrnBillPre;
     }

--- a/src/main/java/com/divudi/bean/pharmacy/PharmacyDirectPurchaseController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacyDirectPurchaseController.java
@@ -929,6 +929,8 @@ public class PharmacyDirectPurchaseController implements Serializable {
             bill.setBillType(BillType.PharmacyPurchaseBill);
             bill.setBillTypeAtomic(BillTypeAtomic.PHARMACY_DIRECT_PURCHASE);
             bill.setReferenceInstitution(getSessionController().getInstitution());
+            boolean consignmentEnabled = configOptionApplicationController.getBooleanValueByKey("Enable Consignment in Pharmacy Purchasing", true);
+            bill.setConsignment(consignmentEnabled);
         }
         return bill;
     }

--- a/src/main/java/com/divudi/bean/pharmacy/PurchaseOrderController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PurchaseOrderController.java
@@ -350,6 +350,7 @@ public class PurchaseOrderController implements Serializable {
             aprovedBill = new BilledBill();
             aprovedBill.setBillType(BillType.PharmacyOrderApprove);
             aprovedBill.setBillTypeAtomic(BillTypeAtomic.PHARMACY_ORDER_APPROVAL);
+            aprovedBill.setConsignment(getRequestedBill() != null && getRequestedBill().isConsignment());
         }
         return aprovedBill;
     }

--- a/src/main/java/com/divudi/bean/pharmacy/PurchaseOrderRequestController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PurchaseOrderRequestController.java
@@ -649,6 +649,8 @@ public class PurchaseOrderRequestController implements Serializable {
             PaymentMethod pm = enumController.getEnumValue(PaymentMethod.class, strEnumValue);
 
             currentBill.setPaymentMethod(pm);
+            boolean consignmentEnabled = configOptionApplicationController.getBooleanValueByKey("Enable Consignment in Pharmacy Purchasing", true);
+            currentBill.setConsignment(consignmentEnabled);
         }
         return currentBill;
     }

--- a/src/main/java/com/divudi/core/entity/Bill.java
+++ b/src/main/java/com/divudi/core/entity/Bill.java
@@ -120,6 +120,7 @@ public class Bill implements Serializable, RetirableEntity {
     private String creditCardRefNo;
     private String chequeRefNo;
     private boolean creditBill;
+    private boolean consignment;
     private int creditDuration;
     @ManyToOne(fetch = FetchType.LAZY)
     private Institution bank;
@@ -464,6 +465,7 @@ public class Bill implements Serializable, RetirableEntity {
         reactivated = false;
         refunded = false;
         cancelled = false;
+        consignment = false;
         billDate = new Date();
         billTime = new Date();
         createdAt = new Date();
@@ -995,6 +997,7 @@ public class Bill implements Serializable, RetirableEntity {
         this.tax = bill.getTax();
         this.billTotal = bill.getBillTotal();
         this.vatPlusNetTotal = bill.getVatPlusNetTotal();
+        this.consignment = bill.isConsignment();
         this.settledAmountByPatient = bill.getSettledAmountByPatient();
         this.settledAmountBySponsor = bill.getSettledAmountBySponsor();
         if (this.getPharmacyBill() != null && bill.getPharmacyBill() != null) {
@@ -1045,6 +1048,7 @@ public class Bill implements Serializable, RetirableEntity {
         sessionId = bill.getSessionId();
         ipOpOrCc = bill.getIpOpOrCc();
         chequeRefNo = bill.getChequeRefNo();
+        consignment = bill.isConsignment();
         settledAmountByPatient = bill.getSettledAmountByPatient();
         settledAmountBySponsor = bill.getSettledAmountBySponsor();
         qty = bill.getQty();
@@ -2649,6 +2653,14 @@ public class Bill implements Serializable, RetirableEntity {
 
     public void setCreditBill(boolean creditBill) {
         this.creditBill = creditBill;
+    }
+
+    public boolean isConsignment() {
+        return consignment;
+    }
+
+    public void setConsignment(boolean consignment) {
+        this.consignment = consignment;
     }
 
     public boolean isCompleted() {

--- a/src/main/webapp/pharmacy/direct_purchase.xhtml
+++ b/src/main/webapp/pharmacy/direct_purchase.xhtml
@@ -642,6 +642,9 @@
                                         <f:selectItems value="#{enumController.paymentMethodsForPharmacyPurchase}" />
                                         <p:ajax event="change" process="cmbPs" ></p:ajax>
                                     </p:selectOneMenu>
+                                    <h:panelGroup rendered="#{configOptionApplicationController.getBooleanValueByKey('Enable Consignment in Pharmacy Purchasing', true)}">
+                                        <p:selectBooleanCheckbox value="#{pharmacyDirectPurchaseController.bill.consignment}" itemLabel="Consignment"/>
+                                    </h:panelGroup>
 
                                 </h:panelGrid>
                             </p:panel>

--- a/src/main/webapp/pharmacy/pharmacy_grn_costing.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_grn_costing.xhtml
@@ -432,6 +432,9 @@
                                         <p:ajax process="@this" update="grn" event="change"/>
                                         <p:ajax process="@this" update="duration" event="itemSelect" />
                                     </p:selectOneMenu>
+                                    <h:panelGroup rendered="#{configOptionApplicationController.getBooleanValueByKey('Enable Consignment in Pharmacy Purchasing', true)}">
+                                        <p:selectBooleanCheckbox value="#{grnCostingController.grnBill.consignment}" itemLabel="Consignment"/>
+                                    </h:panelGroup>
                                     <h:panelGroup rendered="#{grnCostingController.grnBill.paymentMethod eq 'Credit'}" id="duration" >
                                         <p:inputText  
                                             value="#{grnCostingController.grnBill.creditDuration}"

--- a/src/main/webapp/pharmacy/pharmacy_purchase_order_list_for_recieve.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_purchase_order_list_for_recieve.xhtml
@@ -116,6 +116,10 @@
                                     <f:setPropertyActionListener target="#{pharmacyBillSearch.bill}" value="#{p}"/>
                                 </h:commandLink>
                             </p:column>
+                            <p:column headerText="Consignment" width="5em">
+                                <h:outputText value="#{p.consignment ? 'Yes' : 'No'}" />
+                            </p:column>
+
                             <p:column 
                                 headerText="Actions"
                                 width="6em">

--- a/src/main/webapp/pharmacy/pharmacy_purhcase_order_approving.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_purhcase_order_approving.xhtml
@@ -57,6 +57,9 @@
                                                     <p:ajax process="@this" update="po" event="change"/>
                                                     <p:ajax process="@this" update="duration" event="itemSelect" />
                                                 </p:selectOneMenu>
+                                                <h:panelGroup rendered="#{configOptionApplicationController.getBooleanValueByKey('Enable Consignment in Pharmacy Purchasing', true)}">
+                                                    <p:selectBooleanCheckbox value="#{purchaseOrderController.aprovedBill.consignment}" itemLabel="Consignment"/>
+                                                </h:panelGroup>
                                             </div>
 
                                             <div class="col-4">

--- a/src/main/webapp/pharmacy/pharmacy_purhcase_order_list_to_approve.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_purhcase_order_list_to_approve.xhtml
@@ -93,6 +93,10 @@
                             <p:column headerText="Supplier" >
                                 <h:outputText value="#{b.paymentMethod}" ></h:outputText>
                             </p:column>
+                            <p:column headerText="Consignment" >
+                                <h:outputText value="#{b.consignment ? 'Yes' : 'No'}" />
+                            </p:column>
+
 
                             <p:column headerText="Requested Deprtment" >
                                 <h:commandLink action="pharmacy_reprint_order_request" >

--- a/src/main/webapp/pharmacy/pharmacy_purhcase_order_list_to_finalize.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_purhcase_order_list_to_finalize.xhtml
@@ -83,6 +83,10 @@
                             <p:column headerText="Payment Method" >
                                 <h:outputText value="#{b.paymentMethod.label}" ></h:outputText>
                             </p:column>
+                            <p:column headerText="Consignment" >
+                                <h:outputText value="#{b.consignment ? 'Yes' : 'No'}" />
+                            </p:column>
+
 
                             <p:column headerText="Requested Deprtment" >
                                 <h:outputLabel value="#{b.department.name}" >                                      

--- a/src/main/webapp/pharmacy/pharmacy_purhcase_order_request.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_purhcase_order_request.xhtml
@@ -214,6 +214,9 @@
                                     <p:ajax process="@this" update="po" event="change"/>
                                     <p:ajax process="@this" update="duration" event="itemSelect" />
                                 </p:selectOneMenu>
+                                <h:panelGroup rendered="#{configOptionApplicationController.getBooleanValueByKey('Enable Consignment in Pharmacy Purchasing', true)}">
+                                    <p:selectBooleanCheckbox value="#{purchaseOrderRequestController.currentBill.consignment}" itemLabel="Consignment"/>
+                                </h:panelGroup>
 
                                 <h:panelGroup rendered="#{purchaseOrderRequestController.currentBill.paymentMethod eq 'Credit'}" id="duration" >
                                     <div class="d-flex" >
@@ -439,6 +442,9 @@
                                         <h:outputLabel value="Payment Method" />
                                         <h:outputLabel value=":" style="width: 15px; text-align: center"/>
                                         <h:outputLabel value="#{purchaseOrderRequestController.currentBill.paymentMethod}" />
+                                        <h:outputLabel value="Consignment" />
+                                        <h:outputLabel value=":" style="width: 15px; text-align: center"/>
+                                        <h:outputLabel value="#{purchaseOrderRequestController.currentBill.consignment ? 'Yes' : 'No'}" />
                                     </h:panelGrid>
                                 </div>
 

--- a/src/main/webapp/resources/pharmacy/direct_purhcase_with_costing.xhtml
+++ b/src/main/webapp/resources/pharmacy/direct_purhcase_with_costing.xhtml
@@ -67,6 +67,8 @@
 
                     <h:outputLabel value="Supplier" class="billDetailsFiveFive"/>
                     <h:outputLabel value="#{cc.attrs.bill.fromInstitution.name}" class="billDetailsFiveFive"/>
+                    <h:outputLabel value="Consignment" class="billDetailsFiveFive"/>
+                    <h:outputLabel value="#{cc.attrs.bill.consignment ? 'Yes' : 'No'}" class="billDetailsFiveFive"/>
 
                 </h:panelGrid>
             </div>

--- a/src/main/webapp/resources/pharmacy/grn_with_costing.xhtml
+++ b/src/main/webapp/resources/pharmacy/grn_with_costing.xhtml
@@ -90,8 +90,12 @@
                 <div class="row">
                     <h:outputLabel value="Payment Method" class="col-3"/>
                     <h:outputLabel value="#{cc.attrs.bill.paymentMethod}" class="col-3"/>
-                    <h:outputLabel value="Crd. Duration" class="col-2" rendered="#{cc.attrs.bill.paymentMethod eq 'Credit'}"/>
-                    <h:outputLabel value="#{cc.attrs.bill.creditDuration}" class="col-2" style="text-align: left;" rendered="#{cc.attrs.bill.paymentMethod eq 'Credit'}"/>
+                    <h:outputLabel value="Consignment" class="col-2"/>
+                    <h:outputLabel value="#{cc.attrs.bill.consignment ? 'Yes' : 'No'}" class="col-4"/>
+                </div>
+                <div class="row">
+                    <h:outputLabel value="Crd. Duration" class="col-3" rendered="#{cc.attrs.bill.paymentMethod eq 'Credit'}"/>
+                    <h:outputLabel value="#{cc.attrs.bill.creditDuration}" class="col-3" rendered="#{cc.attrs.bill.paymentMethod eq 'Credit'}"/>
                 </div>
 
             </div>

--- a/src/main/webapp/resources/pharmacy/po.xhtml
+++ b/src/main/webapp/resources/pharmacy/po.xhtml
@@ -63,6 +63,9 @@
                         <h:outputText value="Payment Method" />
                         <h:outputText value=":" />
                         <h:outputText value="#{cc.attrs.bill.paymentMethod}" />
+                        <h:outputText value="Consignment" />
+                        <h:outputText value=":" />
+                        <h:outputText value="#{cc.attrs.bill.consignment ? 'Yes' : 'No'}" />
                     </h:panelGrid>
                 </div>
 


### PR DESCRIPTION
## Summary
- track consignment purchases via new `Bill.consignment` flag
- expose consignment option and display across pharmacy purchase flows
- add migration for `consignment` column and UI listing columns

## Testing
- `mvn -q test` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:3.3.1... Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68929f43e1b0832fa64194f07be69ab2