### PR TITLE
feat: enable substitution selection in transfer issue

### DIFF
--- a/src/main/webapp/pharmacy/pharmacy_transfer_issue.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_transfer_issue.xhtml
@@ -55,6 +55,15 @@
                                         oncomplete="PF('batchDetailsDialog').show();"
                                         process="@this"
                                         class="ui-button-info ui-button-icon-only mx-1"/>
+                                    <p:commandButton
+                                        icon="pi pi-exchange"
+                                        id="btnSelectSubstitute"
+                                        title="Select a Substitute"
+                                        action="#{transferIssueController.prepareSubstitute(bItm)}"
+                                        update="substituteDlg"
+                                        oncomplete="PF('substituteDialog').show();"
+                                        process="@this"
+                                        class="ui-button-secondary ui-button-icon-only mx-1"/>
                                 </p:column>
 
                                 <p:column
@@ -193,13 +202,40 @@
 
                 <ph:history/>
 
-                <p:dialog 
-                    widgetVar="batchDetailsDialog" 
-                    modal="true" 
+                <p:dialog
+                    id="substituteDlg"
+                    widgetVar="substituteDialog"
+                    modal="true"
+                    appendTo="@(body)"
+                    header="Select a Substitute"
+                    width="50%">
+                    <p:dataTable
+                        id="substituteTable"
+                        value="#{transferIssueController.substituteAmps}"
+                        var="sAmp"
+                        selectionMode="single"
+                        selection="#{transferIssueController.selectedSubstituteAmp}">
+                        <p:column headerText="Name">
+                            <h:outputText value="#{sAmp.name}"/>
+                        </p:column>
+                    </p:dataTable>
+                    <f:facet name="footer">
+                        <p:commandButton
+                            value="Replace"
+                            action="#{transferIssueController.replaceSelectedSubstitute}"
+                            update="itemList"
+                            oncomplete="PF('substituteDialog').hide();"
+                            process="@this substituteTable"/>
+                    </f:facet>
+                </p:dialog>
+
+                <p:dialog
+                    widgetVar="batchDetailsDialog"
+                    modal="true"
                     position="top"
                     fitViewport="true"
                     appendTo="@(body)"
-                    header="Batch Details" 
+                    header="Batch Details"
                     width="40%">
                     <p:panelGrid 
                         id="batchDetailsForm" 


### PR DESCRIPTION
## Summary
- add 'Select a Substitute' button to transfer issue item list
- introduce substitute selection dialog for alternate AMPs
- support AMP substitution in `TransferIssueController`

## Testing
- `mvn -q -e test` *(fails: PluginResolutionException - Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689398305d74832fb9e367d2e00cec86