### PR TITLE
Add privilege for receipt paper type change

### DIFF
--- a/src/main/java/com/divudi/bean/common/UserPrivilageController.java
+++ b/src/main/java/com/divudi/bean/common/UserPrivilageController.java
@@ -571,6 +571,7 @@ public class UserPrivilageController implements Serializable {
         new DefaultTreeNode(new PrivilegeHolder(Privileges.ChangeMyTheme, "Change User Theme"), userNode);
         new DefaultTreeNode(new PrivilegeHolder(Privileges.ChangePreferece, "Change User Preferances"), userNode);
         new DefaultTreeNode(new PrivilegeHolder(Privileges.ChangeMyApiKeys, "Change API Keys"), userNode);
+        new DefaultTreeNode(new PrivilegeHolder(Privileges.ChangeReceiptPrintingPaperTypes, "Change Receipt Printing Paper Types"), userNode);
         new DefaultTreeNode(new PrivilegeHolder(Privileges.MyFinanacialTransactionManager, "User Financial Transaction Manager"), userNode);
 
         // Search Privileges

--- a/src/main/java/com/divudi/core/data/Privileges.java
+++ b/src/main/java/com/divudi/core/data/Privileges.java
@@ -620,6 +620,7 @@ public enum Privileges {
     ChangeMyTheme("Change My Theme"),
     ChangePreferece("Change My Preference"),
     ChangeMyApiKeys("Change My Api Keys"),
+    ChangeReceiptPrintingPaperTypes("Change Receipt Printing Paper Types"),
     MyFinanacialTransactionManager("My Finanacial Transaction Manager"),
     //</editor-fold>
 


### PR DESCRIPTION
## Summary
- add ChangeReceiptPrintingPaperTypes to privilege enum
- expose new privilege in user privilege tree for assignment

## Testing
- `mvn -q test` *(fails: Could not transfer artifact org.apache.maven.plugins:maven-resources-plugin:pom:3.3.1 due to Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689461670b88832f930dd8c943edd058