### PR TITLE
feat: add pharmacy disposal direct issue tile

### DIFF
--- a/src/main/java/com/divudi/core/data/Icon.java
+++ b/src/main/java/com/divudi/core/data/Icon.java
@@ -135,7 +135,8 @@ public enum Icon {
     Report_Execution_Logs("Report Execution Logs"),
     Purchase_Orders_Finalize("Finalize Purchase Orders"),
     pharmacy_bill_search("Pharmacy Bill Search"),
-    pharmacy_bill_search_new("Pharmacy Bill Search (New)");
+    pharmacy_bill_search_new("Pharmacy Bill Search (New)"),
+    pharmacy_disposal_issue("Pharmacy Disposal - Direct Issue");
 
     private final String label;
 

--- a/src/main/webapp/home.xhtml
+++ b/src/main/webapp/home.xhtml
@@ -1157,7 +1157,7 @@
                 <h:panelGroup layout="block" class="col-1 p-1"  rendered="#{ui.icon eq 'pharmacy_issue'}">
                     <h:form>
                         <p:tooltip for="pharmacy_issue" value="Pharmacy Issue"  showDelay="0" hideDelay="0"></p:tooltip>
-                        <p:commandLink 
+                        <p:commandLink
                             id="pharmacy_issue"
                             ajax="false" 
                             action="/pharmacy/pharmacy_issue?faces-redirect=true"  
@@ -1165,6 +1165,22 @@
                             styleClass="svg-link" >
                             <p:graphicImage class="img-thumbnail"  library="images" name="home/pharmacy-default.svg" style="cursor: pointer;" width="80" height="80"/>
                             <h:outputText style="display: none;" value="Issue" />
+                        </p:commandLink>
+                    </h:form>
+                </h:panelGroup>
+
+                <!-- Pharmacy Disposal Direct Issue -->
+                <h:panelGroup layout="block" class="col-1 p-1"  rendered="#{ui.icon eq 'pharmacy_disposal_issue' and webUserController.hasPrivilege('PharmacyDisposalIssue')}">
+                    <h:form>
+                        <p:tooltip for="pharmacy_disposal_issue" value="Pharmacy Disposal Direct Issue"  showDelay="0" hideDelay="0"></p:tooltip>
+                        <p:commandLink
+                            id="pharmacy_disposal_issue"
+                            ajax="false"
+                            action="/pharmacy/pharmacy_issue?faces-redirect=true"
+                            actionListener="#{pharmacyIssueController.resetAll()}"
+                            styleClass="svg-link" >
+                            <p:graphicImage class="img-thumbnail"  library="images" name="home/pharmacy-disposal-issue.svg" style="cursor: pointer;" width="80" height="80"/>
+                            <h:outputText style="display: none;" value="Pharmacy Disposal - Direct Issue" />
                         </p:commandLink>
                     </h:form>
                 </h:panelGroup>

--- a/src/main/webapp/resources/images/home/pharmacy-disposal-issue.svg
+++ b/src/main/webapp/resources/images/home/pharmacy-disposal-issue.svg
@@ -1,0 +1,7 @@
+<svg width="80" height="80" viewBox="0 0 80 80" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect x="20" y="30" width="40" height="40" rx="4" stroke="currentColor" stroke-width="4" fill="none"/>
+  <path d="M30 30V20H50V30" stroke="currentColor" stroke-width="4"/>
+  <line x1="20" y1="30" x2="60" y2="30" stroke="currentColor" stroke-width="4"/>
+  <line x1="35" y1="40" x2="35" y2="60" stroke="currentColor" stroke-width="4"/>
+  <line x1="45" y1="40" x2="45" y2="60" stroke="currentColor" stroke-width="4"/>
+</svg>


### PR DESCRIPTION
## Summary
- add `pharmacy_disposal_issue` icon enum and svg
- expose pharmacy disposal direct issue tile on home page

## Testing
- `mvn -q test` *(fails: Could not transfer artifact maven-resources-plugin: Network is unreachable)*
- `jshell --class-path target/classes` `pharmacy_disposal_issue -> Pharmacy Disposal - Direct Issue`
- `jshell --class-path target/classes` assignment to DummyUserIcon prints `Pharmacy Disposal - Direct Issue`


------
https://chatgpt.com/codex/tasks/task_e_6894ddba6f68832f982d5e4784386547