### PR TITLE
Use SVG icon for disposal issue menu item

### DIFF
--- a/src/main/webapp/resources/ezcomp/menu.xhtml
+++ b/src/main/webapp/resources/ezcomp/menu.xhtml
@@ -982,9 +982,13 @@
                         <p:menuitem
                             ajax="false"
                             action="/pharmacy/pharmacy_issue?faces-redirect=true"
-                            value="Issue" icon="fas fa-trash"
+                            value="Issue"
                             actionListener="#{pharmacyIssueController.resetAll()}"
-                            rendered="#{webUserController.hasPrivilege('PharmacyDisposalIssue')}" ></p:menuitem>
+                            rendered="#{webUserController.hasPrivilege('PharmacyDisposalIssue')}">
+                            <f:facet name="icon">
+                                <p:graphicImage library="images" name="icons/trash.svg" />
+                            </f:facet>
+                        </p:menuitem>
                         <p:menuitem
                             ajax="false"
                             action="/pharmacy/pharmacy_search_issue_bill?faces-redirect=true"


### PR DESCRIPTION
## Summary
- replace disposal menu item's Font Awesome icon with SVG image

## Testing
- no tests run

------
https://chatgpt.com/codex/tasks/task_e_6894ddd57480832f9fd074fef9e1067d