### PR TITLE
Protect pharmacy paper type controls

### DIFF
--- a/src/main/webapp/pharmacy/pharmacy_bill_return_retail.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_bill_return_retail.xhtml
@@ -213,12 +213,15 @@
 
                 </f:facet>
                 <div>
-                    <p:outputLabel value="Paper Type" class="m-2"></p:outputLabel>
-                    <p:selectOneMenu value="#{sessionController.departmentPreference.pharmacyBillPaperType}" class="m-1" id='ph' style="width: 13em;">
-                        <f:selectItem itemLabel="Please Select Paper Type" />
-                        <f:selectItems value="#{enumController.paperTypes}" />
-                    </p:selectOneMenu>
-                    <p:commandButton ajax="false" icon="fa fa-sync-alt" class="ui-button" title="Redraw Bill"></p:commandButton>
+                    <h:panelGroup rendered="#{webUserController.hasPrivilege('ChangeReceiptPrintingPaperTypes')}">
+                        <p:outputLabel value="Paper Type" class="m-2"></p:outputLabel>
+                        <p:selectOneMenu value="#{sessionController.departmentPreference.pharmacyBillPaperType}" class="m-1" id='ph' style="width: 13em;">
+                            <f:selectItem itemLabel="Please Select Paper Type" />
+                            <f:selectItems value="#{enumController.paperTypes}" />
+                        </p:selectOneMenu>
+                        <p:commandButton ajax="false" icon="fa fa-sync-alt" class="ui-button" title="Redraw Bill"></p:commandButton>
+                    </h:panelGroup>
+                    <h:inputHidden value="#{sessionController.departmentPreference.pharmacyBillPaperType}" rendered="#{!webUserController.hasPrivilege('ChangeReceiptPrintingPaperTypes')}"/>
                 </div>
 
                 <h:panelGroup   id="gpBillPreview"  > 

--- a/src/main/webapp/pharmacy/pharmacy_search_pre_bill_not_paid.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_search_pre_bill_not_paid.xhtml
@@ -136,20 +136,23 @@
                             </p:commandButton>
                             <div class="d-flex justify-content-end">
 
-                                <p:outputLabel value="Paper Type" class="m-2"></p:outputLabel>
-                                <p:selectOneMenu 
-                                    value="#{sessionController.departmentPreference.pharmacyBillPaperType}" 
-                                    class="m-1" 
-                                    style="width: 13em;">
-                                    <f:selectItem itemLabel="Please Select Paper Type" />
-                                    <f:selectItems value="#{enumController.paperTypes}" />
-                                </p:selectOneMenu>
-                                <p:commandButton 
-                                    ajax="false" 
-                                    icon="fa fa-sync-alt" 
-                                    class="ui-button m-1" 
-                                    title="Redraw Bill">
-                                </p:commandButton>
+                                <h:panelGroup rendered="#{webUserController.hasPrivilege('ChangeReceiptPrintingPaperTypes')}">
+                                    <p:outputLabel value="Paper Type" class="m-2"></p:outputLabel>
+                                    <p:selectOneMenu
+                                        value="#{sessionController.departmentPreference.pharmacyBillPaperType}"
+                                        class="m-1"
+                                        style="width: 13em;">
+                                        <f:selectItem itemLabel="Please Select Paper Type" />
+                                        <f:selectItems value="#{enumController.paperTypes}" />
+                                    </p:selectOneMenu>
+                                    <p:commandButton
+                                        ajax="false"
+                                        icon="fa fa-sync-alt"
+                                        class="ui-button"
+                                        title="Redraw Bill">
+                                    </p:commandButton>
+                                </h:panelGroup>
+                                <h:inputHidden value="#{sessionController.departmentPreference.pharmacyBillPaperType}" rendered="#{!webUserController.hasPrivilege('ChangeReceiptPrintingPaperTypes')}"/>
                                 <p:commandButton
                                     value="Print"
                                     ajax="false"

--- a/src/main/webapp/pharmacy/pharmacy_transfer_issue_direct_department.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_transfer_issue_direct_department.xhtml
@@ -297,12 +297,15 @@
                         value="Requested List"/>
 
                     <div class="d-flex m-1">
-                        <p:outputLabel value="Paper Type" class="mt-3"></p:outputLabel>
-                        <p:selectOneMenu value="#{sessionController.departmentPreference.pharmacyBillPaperType}" class="m-1" style="width: 13em;">
-                            <f:selectItem itemLabel="Please Select Paper Type" />
-                            <f:selectItems value="#{enumController.paperTypes}" />
-                        </p:selectOneMenu>
-                        <p:commandButton ajax="false" icon="fa fa-sync-alt" class="ui-button m-1" title="Redraw Bill"></p:commandButton>
+                        <h:panelGroup rendered="#{webUserController.hasPrivilege('ChangeReceiptPrintingPaperTypes')}">
+                            <p:outputLabel value="Paper Type" class="m-2"></p:outputLabel>
+                            <p:selectOneMenu value="#{sessionController.departmentPreference.pharmacyBillPaperType}" class="m-1" style="width: 13em;">
+                                <f:selectItem itemLabel="Please Select Paper Type" />
+                                <f:selectItems value="#{enumController.paperTypes}" />
+                            </p:selectOneMenu>
+                            <p:commandButton ajax="false" icon="fa fa-sync-alt" class="ui-button" title="Redraw Bill"></p:commandButton>
+                        </h:panelGroup>
+                        <h:inputHidden value="#{sessionController.departmentPreference.pharmacyBillPaperType}" rendered="#{!webUserController.hasPrivilege('ChangeReceiptPrintingPaperTypes')}"/>
                         <p:commandButton
                             value="Print"
                             icon="fas fa-print"

--- a/src/main/webapp/pharmacy/pharmacy_transfer_receive.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_transfer_receive.xhtml
@@ -202,17 +202,20 @@
                         value="Issued List"/>
 
                     <div class="d-flex">
-                        <p:outputLabel value="Paper Type" class="mt-3"></p:outputLabel>
-                        <p:selectOneMenu value="#{sessionController.departmentPreference.pharmacyBillPaperType}" class="m-1" style="width: 13em;">
-                            <f:selectItem itemLabel="Please Select Paper Type" />
-                            <f:selectItems value="#{enumController.paperTypes}" />
-                        </p:selectOneMenu>
-                        <p:commandButton ajax="false" icon="fa fa-sync-alt" class="ui-button m-1" title="Redraw Bill"></p:commandButton>
-                        <p:commandButton 
-                            value="Print" 
+                        <h:panelGroup rendered="#{webUserController.hasPrivilege('ChangeReceiptPrintingPaperTypes')}">
+                            <p:outputLabel value="Paper Type" class="m-2"></p:outputLabel>
+                            <p:selectOneMenu value="#{sessionController.departmentPreference.pharmacyBillPaperType}" class="m-1" style="width: 13em;">
+                                <f:selectItem itemLabel="Please Select Paper Type" />
+                                <f:selectItems value="#{enumController.paperTypes}" />
+                            </p:selectOneMenu>
+                            <p:commandButton ajax="false" icon="fa fa-sync-alt" class="ui-button" title="Redraw Bill"></p:commandButton>
+                        </h:panelGroup>
+                        <h:inputHidden value="#{sessionController.departmentPreference.pharmacyBillPaperType}" rendered="#{!webUserController.hasPrivilege('ChangeReceiptPrintingPaperTypes')}"/>
+                        <p:commandButton
+                            value="Print"
                             icon="fas fa-print"
                             class="ui-button-info m-1"
-                            ajax="false" 
+                            ajax="false"
                             action="#" >
                             <p:printer target="gpBillPreview" ></p:printer>
                         </p:commandButton>


### PR DESCRIPTION
## Summary
- hide paper type selector for pharmacy receipts unless user has ChangeReceiptPrintingPaperTypes privilege
- show hidden field to maintain default paper type when selector is hidden
- standardize paper type control styling across pages

## Testing
- No tests run (JSF-only changes)

------
https://chatgpt.com/codex/tasks/task_e_6895517b529c832f8f2c953d5944500f