### PR TITLE
fix: resolve purchase order email body generation

### DIFF
--- a/src/main/java/com/divudi/bean/pharmacy/PurchaseOrderRequestController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PurchaseOrderRequestController.java
@@ -40,6 +40,8 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import javax.ejb.EJB;
 import javax.enterprise.context.SessionScoped;
 import javax.inject.Inject;
@@ -52,6 +54,8 @@ import javax.inject.Named;
 @Named
 @SessionScoped
 public class PurchaseOrderRequestController implements Serializable {
+
+    private static final Logger LOGGER = Logger.getLogger(PurchaseOrderRequestController.class.getName());
 
     @EJB
     private ItemFacade itemFacade;
@@ -544,8 +548,9 @@ public class PurchaseOrderRequestController implements Serializable {
     private String generatePurchaseOrderHtml() {
         try {
             javax.faces.context.FacesContext fc = javax.faces.context.FacesContext.getCurrentInstance();
-            javax.faces.component.UIComponent comp = fc.getViewRoot().findComponent("printPaper");
+            javax.faces.component.UIComponent comp = fc.getViewRoot().findComponent(":form:printPaper");
             if (comp == null) {
+                LOGGER.log(Level.SEVERE, "Component :form:printPaper not found when generating purchase order HTML");
                 return null;
             }
             java.io.StringWriter sw = new java.io.StringWriter();
@@ -556,6 +561,7 @@ public class PurchaseOrderRequestController implements Serializable {
             fc.setResponseWriter(original);
             return sw.toString();
         } catch (Exception e) {
+            LOGGER.log(Level.SEVERE, "Error generating purchase order HTML", e);
             return null;
         }
     }

--- a/src/main/webapp/pharmacy/pharmacy_purhcase_order_approving.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_purhcase_order_approving.xhtml
@@ -9,7 +9,7 @@
                 xmlns:pa="http://xmlns.jcp.org/jsf/composite/paymentMethod">
 
     <ui:define name="content">
-        <h:form>
+        <h:form id="form">
 
             <h:panelGroup rendered="#{!purchaseOrderController.printPreview}">
                 <p:panel >
@@ -212,7 +212,7 @@
                 <p:panel >
                     <p:commandButton ajax="false" value="Back To Po List" action="pharmacy_purhcase_order_list_to_approve" class="ui-button-warning" icon="fas fa-arrow-left"/>                    
                     <p:commandButton value="Print" ajax="false" action="#" class="ui-button-info m-1" icon="fas fa-print">
-                        <p:printer target="gpBillPreview" ></p:printer>
+                        <p:printer target=":form:gpBillPreview" ></p:printer>
                     </p:commandButton>
                     <p:commandButton
                         value="Send Email"

--- a/src/main/webapp/pharmacy/pharmacy_purhcase_order_request.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_purhcase_order_request.xhtml
@@ -377,7 +377,7 @@
                                     value="Print"
                                     icon="fas fa-print"
                                     class="ui-button-info">
-                                    <p:printer target="printPaper" />
+                                    <p:printer target=":form:printPaper" />
                                 </p:commandButton>
                                 <p:commandButton
                                     value="Send Email"


### PR DESCRIPTION
## Summary
- point purchase order email template lookup at `:form:printPaper` to include naming-container path
- log missing component or rendering errors when building purchase order HTML
- reference print components with full client IDs in request and approval pages

## Testing
- `mvn -q -e -DskipTests package` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:3.3.1 or one of its dependencies could not be resolved: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689698319390832fa8960fc36e5343f4