### PR TITLE
14275 oncall   cash booking is absent it is displayed twice in the patient absent report

### DIFF
--- a/src/main/java/com/divudi/bean/channel/BookingControllerViewScope.java
+++ b/src/main/java/com/divudi/bean/channel/BookingControllerViewScope.java
@@ -9386,27 +9386,7 @@ public class BookingControllerViewScope implements Serializable, ControllerWithP
     }
     
     public void saveSelected() {
-        if (patient == null) {
-            return;
-        }
-        if (patient.getPerson() == null) {
-            return;
-        }
-        if (patient.getPerson().getId() == null) {
-            patient.getPerson().setCreatedAt(new Date());
-            patient.getPerson().setCreater(sessionController.getLoggedUser());
-            personFacade.create(patient.getPerson());
-        } else {
-            personFacade.edit(patient.getPerson());
-        }
-        if (patient.getId() == null) {
-            patient.setCreatedAt(new Date());
-            patient.setCreatedInstitution(sessionController.getInstitution());
-            patient.setCreater(sessionController.getLoggedUser());
-            patientFacade.create(patient);
-        } else {
-            patientFacade.edit(patient);
-        }
+        saveSelected(this.patient);
         
     }
 

--- a/src/main/java/com/divudi/bean/channel/BookingControllerViewScope.java
+++ b/src/main/java/com/divudi/bean/channel/BookingControllerViewScope.java
@@ -9384,6 +9384,30 @@ public class BookingControllerViewScope implements Serializable, ControllerWithP
             patientFacade.edit(patient);
         }
     }
+    
+    public void saveSelected() {
+        if (patient == null) {
+            return;
+        }
+        if (patient.getPerson() == null) {
+            return;
+        }
+        if (patient.getPerson().getId() == null) {
+            patient.getPerson().setCreatedAt(new Date());
+            patient.getPerson().setCreater(sessionController.getLoggedUser());
+            personFacade.create(patient.getPerson());
+        } else {
+            personFacade.edit(patient.getPerson());
+        }
+        if (patient.getId() == null) {
+            patient.setCreatedAt(new Date());
+            patient.setCreatedInstitution(sessionController.getInstitution());
+            patient.setCreater(sessionController.getLoggedUser());
+            patientFacade.create(patient);
+        } else {
+            patientFacade.edit(patient);
+        }
+    }
 
     @Override
     public void saveSelectedPatient() {

--- a/src/main/java/com/divudi/bean/channel/BookingControllerViewScope.java
+++ b/src/main/java/com/divudi/bean/channel/BookingControllerViewScope.java
@@ -9407,6 +9407,7 @@ public class BookingControllerViewScope implements Serializable, ControllerWithP
         } else {
             patientFacade.edit(patient);
         }
+        
     }
 
     @Override

--- a/src/main/java/com/divudi/bean/channel/ChannelReportController.java
+++ b/src/main/java/com/divudi/bean/channel/ChannelReportController.java
@@ -2752,10 +2752,24 @@ public class ChannelReportController implements Serializable {
         hm.put("td", toDate);
 
         List<Bill> b = getBillFacade().findByJpql(sql, hm, TemporalType.TIMESTAMP);
+        List<Bill> billList = new ArrayList<>();
+        
+        for(Bill bill : b){
+            if(bill.getPaymentMethod() == PaymentMethod.OnCall){
+                if(bill.getReferenceBill() != null){
+                    billList.add(bill.getReferenceBill());
+                    continue;
+                }else{
+                    billList.add(bill);
+                }
+            }else{
+                billList.add(bill);
+            }
+        }
 
-        doctorFeeTotal = getStaffFeeTotal(b);
+        doctorFeeTotal = getStaffFeeTotal(billList);
 
-        return b;
+        return billList;
     }
 
     public double getChannelPaymentBillCountbyClassTypes(Bill b, List<BillType> bts, BillType bt, Date d, Staff stf, PaymentMethod pm) {

--- a/src/main/java/com/divudi/bean/channel/ChannelReportController.java
+++ b/src/main/java/com/divudi/bean/channel/ChannelReportController.java
@@ -7,8 +7,10 @@ package com.divudi.bean.channel;
 import com.divudi.bean.common.InstitutionController;
 import com.divudi.bean.common.ReportTimerController;
 import com.divudi.bean.common.SessionController;
+import com.divudi.core.data.BillClassType;
 
 import com.divudi.core.data.BillType;
+import com.divudi.core.data.BillTypeAtomic;
 import com.divudi.core.data.FeeType;
 import com.divudi.core.data.HistoryType;
 import com.divudi.core.data.InstitutionType;
@@ -2731,6 +2733,7 @@ public class ChannelReportController implements Serializable {
 
     public List<Bill> getChannelBillsAbsentPatient(Staff stf, List<PaymentMethod> pms) {
         HashMap hm = new HashMap();
+
         String sql = " select b from Bill b "
                 + " where b.retired=false "
                 + " and b.singleBillSession.absent=true "
@@ -2746,24 +2749,29 @@ public class ChannelReportController implements Serializable {
             hm.put("pm", pms);
         }
 
-        sql += " order by b.insId ";
+        sql += " order by b.createdAt desc ";
 
         hm.put("fd", fromDate);
         hm.put("td", toDate);
 
         List<Bill> b = getBillFacade().findByJpql(sql, hm, TemporalType.TIMESTAMP);
         List<Bill> billList = new ArrayList<>();
-        
-        for(Bill bill : b){
-            if(bill.getPaymentMethod() == PaymentMethod.OnCall){
-                if(bill.getReferenceBill() != null){
-                    billList.add(bill.getReferenceBill());
+
+        for (Bill bill : b) {
+            if (bill.getPaymentMethod() == PaymentMethod.OnCall) {
+                if (bill.getPaidBill() != null) {
+                    billList.add(bill.getPaidBill());
                     continue;
-                }else{
+                } else {
                     billList.add(bill);
                 }
-            }else{
-                billList.add(bill);
+            } else {
+                if (bill.getReferenceBill() != null && bill.getBillTypeAtomic() != BillTypeAtomic.CHANNEL_BOOKING_FOR_PAYMENT_ONLINE_COMPLETED_PAYMENT) {
+                    continue;
+                } else {
+                    billList.add(bill);
+                }
+
             }
         }
 

--- a/src/main/resources/META-INF/persistence.xml
+++ b/src/main/resources/META-INF/persistence.xml
@@ -2,24 +2,19 @@
 <persistence version="2.2" xmlns="http://java.sun.com/xml/ns/persistence" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/persistence http://xmlns.jcp.org/xml/ns/persistence/persistence_2_2.xsd">
     <persistence-unit name="hmisPU" transaction-type="JTA">
         <provider>org.eclipse.persistence.jpa.PersistenceProvider</provider>
-        <jta-data-source>jdbc/hmis</jta-data-source>
+        <jta-data-source>${JDBC_DATASOURCE}</jta-data-source>
         <exclude-unlisted-classes>false</exclude-unlisted-classes>
         <properties>
+            <property name="eclipselink.logging.level.sql" value="SEVERE"/>
             <property name="eclipselink.logging.level" value="SEVERE"/>
-            <property name="eclipselink.ddl-generation" value="create-or-extend-tables"/>
-            <property name="eclipselink.ddl-generation.output-mode" value="both"/>
-            <property name="eclipselink.application-location" value="C:\Users\CHINTHAKA\Documents\New folder"/>
-           
         </properties>
     </persistence-unit>
     <persistence-unit name="hmisAuditPU" transaction-type="JTA">
-        <jta-data-source>jdbc/hmisaudit</jta-data-source>
+        <jta-data-source>${JDBC_AUDIT_DATASOURCE}</jta-data-source>
         <exclude-unlisted-classes>false</exclude-unlisted-classes>
         <properties>
+            <property name="eclipselink.logging.level.sql" value="SEVERE"/>
             <property name="eclipselink.logging.level" value="SEVERE"/>
-            <property name="eclipselink.ddl-generation" value="create-or-extend-tables"/>
-            <property name="eclipselink.ddl-generation.output-mode" value="database"/>
-           
         </properties>
     </persistence-unit>
 </persistence>

--- a/src/main/resources/META-INF/persistence.xml
+++ b/src/main/resources/META-INF/persistence.xml
@@ -2,19 +2,24 @@
 <persistence version="2.2" xmlns="http://java.sun.com/xml/ns/persistence" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/persistence http://xmlns.jcp.org/xml/ns/persistence/persistence_2_2.xsd">
     <persistence-unit name="hmisPU" transaction-type="JTA">
         <provider>org.eclipse.persistence.jpa.PersistenceProvider</provider>
-        <jta-data-source>${JDBC_DATASOURCE}</jta-data-source>
+        <jta-data-source>jdbc/hmis</jta-data-source>
         <exclude-unlisted-classes>false</exclude-unlisted-classes>
         <properties>
-            <property name="eclipselink.logging.level.sql" value="SEVERE"/>
             <property name="eclipselink.logging.level" value="SEVERE"/>
+            <property name="eclipselink.ddl-generation" value="create-or-extend-tables"/>
+            <property name="eclipselink.ddl-generation.output-mode" value="both"/>
+            <property name="eclipselink.application-location" value="C:\Users\CHINTHAKA\Documents\New folder"/>
+           
         </properties>
     </persistence-unit>
     <persistence-unit name="hmisAuditPU" transaction-type="JTA">
-        <jta-data-source>${JDBC_AUDIT_DATASOURCE}</jta-data-source>
+        <jta-data-source>jdbc/hmisaudit</jta-data-source>
         <exclude-unlisted-classes>false</exclude-unlisted-classes>
         <properties>
-            <property name="eclipselink.logging.level.sql" value="SEVERE"/>
             <property name="eclipselink.logging.level" value="SEVERE"/>
+            <property name="eclipselink.ddl-generation" value="create-or-extend-tables"/>
+            <property name="eclipselink.ddl-generation.output-mode" value="database"/>
+           
         </properties>
     </persistence-unit>
 </persistence>

--- a/src/main/webapp/channel/session_instance.xhtml
+++ b/src/main/webapp/channel/session_instance.xhtml
@@ -290,7 +290,7 @@
                                                 </div>
                                             </p:column>
 
-                                            <p:column>
+                                            <p:column width="6em">
                                                 <p:commandButton 
                                                     rendered="#{bs.absent and bs.bill.billTypeAtomic ne 'CHANNEL_BOOKING_FOR_PAYMENT_ONLINE_COMPLETED_PAYMENT'}"
                                                     disabled="#{!(bs.bill.paidAmount eq 0 or (!(bs.bill.paymentMethod eq 'OnCall') or bs.bill.paidBill.paymentMethod ne 'OnCall'))}"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Bug Fixes
  - Corrected absent‑patient channel bills:
    - Map On‑Call entries to their paid bills when available.
    - Exclude irrelevant referenced bills.
    - Sort by most recent.
    - Doctor’s fee total now matches the displayed list.

- Style
  - Fixed Actions column width in bookings and temporary bookings tables for consistent alignment of the Change Patient button.

- Chores
  - Internal convenience added to streamline saving the currently viewed patient.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->