### PR TITLE
Not showing cancelled and refunded bills in Bill Item list report

### DIFF
--- a/src/main/java/com/divudi/bean/lab/LaborataryReportController.java
+++ b/src/main/java/com/divudi/bean/lab/LaborataryReportController.java
@@ -869,6 +869,8 @@ public class LaborataryReportController implements Serializable {
                     + " pi.billItem.bill.patient.person.sex) "
                     + " from PatientInvestigation pi "
                     + " where pi.billItem.retired = :ret "
+                    + " and pi.billItem.bill.cancelled =:can "
+                    + " and pi.billItem.refunded =:ref "
                     + " and pi.billItem.bill.createdAt between :fd and :td "
                     + " and pi.billItem.bill.billTypeAtomic IN :bType "
                     + " and type(pi.billItem.item) = :invType ";
@@ -897,6 +899,8 @@ public class LaborataryReportController implements Serializable {
             params.put("fd", fromDate);
             params.put("td", toDate);
             params.put("invType", Investigation.class);
+            params.put("can", false);
+            params.put("ref", false);
 
             List<BillTypeAtomic> bTypes = Arrays.asList(
                     BillTypeAtomic.OPD_BILL_WITH_PAYMENT,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Laboratory reports now exclude cancelled bills and refunded items, eliminating erroneous entries.
  * Improves accuracy of patient investigation counts, totals, and summaries across generated reports.
  * Ensures consistent filtering so dashboards and exports reflect correct data.
  * No changes to workflows or settings; behavior is automatic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->