### PR TITLE
feat: show pharmacy item history

### DIFF
--- a/src/main/java/com/divudi/bean/pharmacy/PharmacyDirectPurchaseController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacyDirectPurchaseController.java
@@ -43,6 +43,7 @@ import com.divudi.core.util.CommonFunctions;
 import com.divudi.service.PaymentService;
 import com.divudi.service.pharmacy.PharmacyCostingService;
 import com.divudi.core.util.BigDecimalUtil;
+import com.divudi.bean.pharmacy.PharmacyController;
 import java.io.Serializable;
 import java.math.BigDecimal;
 import java.math.MathContext;
@@ -304,6 +305,8 @@ public class PharmacyDirectPurchaseController implements Serializable {
     PharmacyCalculation pharmacyBillBean;
     @Inject
     ConfigOptionApplicationController configOptionApplicationController;
+    @Inject
+    private PharmacyController pharmacyController;
     /**
      * Properties
      */
@@ -498,6 +501,10 @@ public class PharmacyDirectPurchaseController implements Serializable {
         }
         double margin = calculateProfitMargin(ph);
         return ph.getItem().getCategory().getProfitMargin() > margin;
+    }
+
+    public void displayItemDetails(BillItem bi) {
+        pharmacyController.fillItemDetails(bi.getItem());
     }
 
     public List<PharmacyStockRow> getRows() {

--- a/src/main/webapp/pharmacy/direct_purchase.xhtml
+++ b/src/main/webapp/pharmacy/direct_purchase.xhtml
@@ -387,24 +387,14 @@
                                 </p:column>
 
                                 <p:column headerText="Item" width="10em">
-                                    <p:commandLink
-                                        class="w-100"
-                                        title="#{ph.item.name} - Click to view details"
-                                        value="#{ph.item.name}"
-                                        oncomplete="PF('dialog#{i}').show()"
-                                        update="itemList"
-                                        process="itemList">
-                                    </p:commandLink>
-                                    <p:dialog id="dialog"
-                                              widgetVar="dialog#{i}"
-                                              header="Details"
-                                              modal="true"
-                                              closable="true"
-                                              resizable="false"
-                                              class="w-75"
-                                              dynamic="true">
-                                        <ph:bill_item_finance_details pbi="#{ph}"/>
-                                    </p:dialog>
+                                    <h:outputText value="#{ph.item.name}" />
+                                    <p:commandButton id="btnViewSelectedItemDetails"
+                                                     icon="pi pi-search"
+                                                     title="View Item Details"
+                                                     action="#{pharmacyDirectPurchaseController.displayItemDetails(ph)}"
+                                                     update=":#{p:resolveFirstComponentWithId('tab', view).clientId}"
+                                                     process="@this"
+                                                     styleClass="ui-button-icon-only mx-3"/>
                                 </p:column>
 
                                 <p:column headerText="Qty"  styleClass="text-end">
@@ -470,6 +460,8 @@
                                     <p:commandButton class="mr-4 ui-button-danger" icon="fas fa-trash" ajax="false" action="#{pharmacyDirectPurchaseController.removeItem(ph)}" />
                                 </p:column>
                             </p:dataTable>
+
+                            <pharmacy:history/>
 
                             <p:separator ></p:separator>
 


### PR DESCRIPTION
## Summary
- add search button per row in direct purchase items table to load item history
- show pharmacy history panel below item list
- wire through PharmacyController to display item details

## Testing
- `mvn -q -e -DskipTests package` *(failed: Plugin org.apache.maven.plugins:maven-resources-plugin:3.3.1 ... Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689eb6231a48832fa34e2bb3033cb238