### PR TITLE
Fixed - cc-book-adding-view-book-no-duplicate-error-message-duplicate…

### DIFF
--- a/src/main/java/com/divudi/bean/channel/AgentReferenceBookController.java
+++ b/src/main/java/com/divudi/bean/channel/AgentReferenceBookController.java
@@ -276,7 +276,7 @@ public class AgentReferenceBookController implements Serializable {
         AgentReferenceBook arb = getAgentReferenceBookFacade().findFirstByJpql(sql, hm);
         
         if (arb != null) {
-            JsfUtil.addErrorMessage("Book Number Is Already use in " + arb.getInstitution().getName());
+            JsfUtil.addErrorMessage("Book Number Is Already use in "+ arb.getInstitution().getCode()+ " - " + arb.getInstitution().getName());
             return;
         }
 


### PR DESCRIPTION
…-bill-book-priviously-added-cc-code-need-to-show-in-error-message

closes #14714
Signed-off-by: DamithDeshan <hkddrajapaksha@gmail.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the duplicate book number error message shown when saving an agent reference book. The message now includes both the institution code and name, making it easier to identify the affected institution and resolve conflicts. This enhances clarity for users working across multiple institutions and reduces confusion when duplicate numbers are detected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->