### PR TITLE
feat(pharmacy): toggle print formats for direct purchase

### DIFF
--- a/src/main/java/com/divudi/bean/pharmacy/PharmacyDirectPurchaseController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacyDirectPurchaseController.java
@@ -77,6 +77,7 @@ public class PharmacyDirectPurchaseController implements Serializable {
     private List<BillItem> billItems;
     private BillItem currentBillItem;
     private boolean printPreview;
+    private boolean showAllBillFormats = false;
     private BillItem currentExpense;
     private List<BillItem> billExpenses;
     private String warningMessage;
@@ -1113,6 +1114,19 @@ public class PharmacyDirectPurchaseController implements Serializable {
 
     public void setPaymentMethod(PaymentMethod paymentMethod) {
         this.paymentMethod = paymentMethod;
+    }
+
+    public boolean isShowAllBillFormats() {
+        return showAllBillFormats;
+    }
+
+    public void setShowAllBillFormats(boolean showAllBillFormats) {
+        this.showAllBillFormats = showAllBillFormats;
+    }
+
+    public String toggleShowAllBillFormats() {
+        this.showAllBillFormats = !this.showAllBillFormats;
+        return "";
     }
 
 }

--- a/src/main/webapp/pharmacy/direct_purchase.xhtml
+++ b/src/main/webapp/pharmacy/direct_purchase.xhtml
@@ -772,6 +772,15 @@
                                     <p:printer target="gpBillPreview" ></p:printer>
                                 </p:commandButton>
                                 <p:commandButton
+                                    value="#{pharmacyDirectPurchaseController.showAllBillFormats ? 'Hide' : 'Show'} All Formats"
+                                    icon="fas fa-eye"
+                                    id="btnTogglePrintAll"
+                                    class="ui-button-secondary mx-1"
+                                    ajax="false"
+                                    action="#{pharmacyDirectPurchaseController.toggleShowAllBillFormats}"
+                                    rendered="#{webUserController.hasPrivilege('Developers')}"
+                                    title="Toggle visibility of all bill formats for development" />
+                                <p:commandButton
                                     ajax="false"
                                     class="ui-button-success"
                                     icon="fa fa-plus"
@@ -783,11 +792,23 @@
                     </f:facet>
 
                     <h:panelGroup id="gpBillPreview" >
-                        <pharmacy:direct_purhcase_with_costing
-                            bill="#{pharmacyDirectPurchaseController.bill}"
-                            ShowProfit="#{configOptionApplicationController.getBooleanValueByKey('Show Profit % in Direct Purchase Bill', true)}"
-                            ShowRetailValue="#{configOptionApplicationController.getBooleanValueByKey('Show Retail Value in Direct Purchase Bill', true)}">
-                        </pharmacy:direct_purhcase_with_costing>
+                        <!-- Main receipt format - always shown -->
+                        <h:panelGroup rendered="true">
+                            <pharmacy:direct_purhcase_with_costing
+                                bill="#{pharmacyDirectPurchaseController.bill}"
+                                ShowProfit="#{configOptionApplicationController.getBooleanValueByKey('Show Profit % in Direct Purchase Bill', true)}"
+                                ShowRetailValue="#{configOptionApplicationController.getBooleanValueByKey('Show Retail Value in Direct Purchase Bill', true)}">
+                            </pharmacy:direct_purhcase_with_costing>
+                        </h:panelGroup>
+
+                        <!-- Additional formats for development - shown only when toggle is enabled -->
+                        <h:panelGroup rendered="#{pharmacyDirectPurchaseController.showAllBillFormats}">
+                            <pharmacy:direct_purhcase
+                                bill="#{pharmacyDirectPurchaseController.bill}"
+                                ShowProfit="#{configOptionApplicationController.getBooleanValueByKey('Show Profit % in Direct Purchase Bill', true)}"
+                                ShowRetailValue="#{configOptionApplicationController.getBooleanValueByKey('Show Retail Value in Direct Purchase Bill', true)}">
+                            </pharmacy:direct_purhcase>
+                        </h:panelGroup>
                     </h:panelGroup>
 
                 </p:panel>


### PR DESCRIPTION
## Summary
- allow developers to toggle showing all direct purchase bill print formats
- enable multiple bill print previews in pharmacy direct purchase page

## Testing
- `mvn -q -e -DskipTests compile` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689fc6d65e80832f82628e129d918685