### PR TITLE
feat: add pharmacy transfer rates privilege

### DIFF
--- a/src/main/java/com/divudi/core/data/Privileges.java
+++ b/src/main/java/com/divudi/core/data/Privileges.java
@@ -541,6 +541,7 @@ public enum Privileges {
     PharmacySearch("Pharmacy Search"),
     PharmacyReports("Pharmacy Reports"),
     PharmacyTransfer("Pharmacy Transfer"),
+    PharmacyTransferViewRates("Pharmacy Transfer View Rates"),
     PharmacySummery("Pharmacy Summary"),
     PharmacyAdministration("Pharmacy Administration"),
     PharmacySetReorderLevel("Pharmacy Set Reorder Level"),
@@ -762,6 +763,7 @@ public enum Privileges {
             case PharmacySummery:
             case PharmacyPurchase:
             case PharmacyTransfer:
+            case PharmacyTransferViewRates:
             case PharmacyPurchaseWh:
             case PharmacySaleCancel:
             case PharmacySaleReturn:


### PR DESCRIPTION
## Summary
- add `PharmacyTransferViewRates` privilege under Pharmacy to manage viewing rates on transfers
- categorize new privilege within Pharmacy group

## Testing
- `mvn -q -e test` *(fails: PluginResolutionException: Could not transfer artifact org.apache.maven.plugins:maven-resources-plugin:pom:3.3.1 from/to central (Network is unreachable))*

------
https://chatgpt.com/codex/tasks/task_e_689fd15931f0832fbe724e718894c5d5