### PR TITLE
Gate pharmacy transfer rate fields by privilege

### DIFF
--- a/src/main/webapp/pharmacy/pharmacy_transfer_issue.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_transfer_issue.xhtml
@@ -134,7 +134,7 @@
 
                                 <p:column 
                                     headerText="Rate" 
-                                    rendered="#{configOptionApplicationController.getBooleanValueByKey('Pharmacy Transfer Issue - Show Rate and Value', false)}"
+                                    rendered="#{configOptionApplicationController.getBooleanValueByKey('Pharmacy Transfer Issue - Show Rate and Value', false) and webUserController.hasPrivilege('PharmacyTransferViewRates')}"
                                     width="8em" 
                                     class="text-end">
                                     <p:inputText autocomplete="off" id="rate" value="#{bItm.billItemFinanceDetails.lineGrossRate}" class="w-100 text-end">
@@ -147,7 +147,7 @@
 
                                 <p:column 
                                     headerText="Value"
-                                    rendered="#{configOptionApplicationController.getBooleanValueByKey('Pharmacy Transfer Issue - Show Rate and Value', false)}"
+                                    rendered="#{configOptionApplicationController.getBooleanValueByKey('Pharmacy Transfer Issue - Show Rate and Value', false) and webUserController.hasPrivilege('PharmacyTransferViewRates')}"
                                     width="8em" 
                                     class="text-end">                   
                                     <p:inputText autocomplete="off" id="netValue" 
@@ -194,9 +194,9 @@
                                                 disabled="#{transferIssueController.issuedBill.toDepartment ne null}"
                                                 completeMethod="#{departmentController.completeDept}"/>
 
-                                <h:outputLabel value="Value &nbsp;" />
-                                <h:outputLabel value=": &nbsp;"/>
-                                <h:outputLabel id="billNetTotal" value="#{transferIssueController.issuedBill.netTotal}" />
+                                <h:outputLabel value="Value &nbsp;" rendered="#{configOptionApplicationController.getBooleanValueByKey('Pharmacy Transfer Issue - Show Rate and Value', false) and webUserController.hasPrivilege('PharmacyTransferViewRates')}" />
+                                <h:outputLabel value=": &nbsp;" rendered="#{configOptionApplicationController.getBooleanValueByKey('Pharmacy Transfer Issue - Show Rate and Value', false) and webUserController.hasPrivilege('PharmacyTransferViewRates')}"/>
+                                <h:outputLabel id="billNetTotal" value="#{transferIssueController.issuedBill.netTotal}" rendered="#{configOptionApplicationController.getBooleanValueByKey('Pharmacy Transfer Issue - Show Rate and Value', false) and webUserController.hasPrivilege('PharmacyTransferViewRates')}" />
 
 
 

--- a/src/main/webapp/pharmacy/pharmacy_transfer_issue_direct_department.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_transfer_issue_direct_department.xhtml
@@ -63,17 +63,17 @@
                                                     <f:convertNumber pattern="#,###" ></f:convertNumber>
                                                 </h:outputLabel>
                                             </p:column>
-                                            <p:column headerText="Cost Rate" styleClass="text-end #{transferIssueController.getStockColourClass(i)}">
+                                            <p:column headerText="Cost Rate" rendered="#{webUserController.hasPrivilege('PharmacyTransferViewRates')}" styleClass="text-end #{transferIssueController.getStockColourClass(i)}">
                                                 <h:outputLabel value="#{i.itemBatch.costRate}" >
                                                     <f:convertNumber pattern="#,##0.00" ></f:convertNumber>
                                                 </h:outputLabel>
                                             </p:column>
-                                            <p:column headerText="Purchase Rate" styleClass="text-end #{transferIssueController.getStockColourClass(i)}">
+                                            <p:column headerText="Purchase Rate" rendered="#{webUserController.hasPrivilege('PharmacyTransferViewRates')}" styleClass="text-end #{transferIssueController.getStockColourClass(i)}">
                                                 <h:outputLabel value="#{i.itemBatch.purcahseRate}" >
                                                     <f:convertNumber pattern="#,##0.00" ></f:convertNumber>
                                                 </h:outputLabel>
                                             </p:column>
-                                            <p:column headerText="Retail Rate" styleClass="text-end #{transferIssueController.getStockColourClass(i)}">
+                                            <p:column headerText="Retail Rate" rendered="#{webUserController.hasPrivilege('PharmacyTransferViewRates')}" styleClass="text-end #{transferIssueController.getStockColourClass(i)}">
                                                 <h:outputLabel value="#{i.itemBatch.retailsaleRate}" >
                                                     <f:convertNumber pattern="#,##0.00" ></f:convertNumber>
                                                 </h:outputLabel>
@@ -163,7 +163,7 @@
 
                                 <p:column 
                                     width="6em"
-                                    headerText="Transfer Rate"  
+                                    headerText="Transfer Rate" rendered="#{webUserController.hasPrivilege('PharmacyTransferViewRates')}"  
                                     class="text-end">
                                     <h:outputLabel value="#{bItm.billItemFinanceDetails.lineGrossRate}" styleClass="text-end">
                                         <f:convertNumber pattern="#,##0.00" />
@@ -172,7 +172,7 @@
 
                                 <p:column 
                                     width="6em"
-                                    headerText="Transfer Value"  
+                                    headerText="Transfer Value" rendered="#{webUserController.hasPrivilege('PharmacyTransferViewRates')}"  
                                     class="text-end">
                                     <h:outputLabel value="#{bItm.billItemFinanceDetails.lineGrossTotal}" styleClass="text-end">
                                         <f:convertNumber pattern="#,##0.00" />
@@ -253,19 +253,19 @@
                                     value="#{transferIssueController.issuedBill.toStaff}" >
                                 </p:autoComplete>
 
-                                <h:outputLabel value="Transfer Value" />
-                                <h:outputLabel value=": &nbsp;"/>
+                                <h:outputLabel value="Transfer Value" rendered="#{webUserController.hasPrivilege('PharmacyTransferViewRates')}" />
+                                <h:outputLabel value=": &nbsp;" rendered="#{webUserController.hasPrivilege('PharmacyTransferViewRates')}"/>
                                 <h:outputLabel 
                                     class="w-100 text-end"
-                                    value="#{transferIssueController.issuedBill.netTotal}" >
+                                    value="#{transferIssueController.issuedBill.netTotal}" rendered="#{webUserController.hasPrivilege('PharmacyTransferViewRates')}" >
                                     <f:convertNumber pattern="#,##0.00" ></f:convertNumber>
                                 </h:outputLabel>
 
-                                <h:outputLabel value="Transfer Cost Value" />
-                                <h:outputLabel value=": &nbsp;"/>
+                                <h:outputLabel value="Transfer Cost Value" rendered="#{webUserController.hasPrivilege('PharmacyTransferViewRates')}" />
+                                <h:outputLabel value=": &nbsp;" rendered="#{webUserController.hasPrivilege('PharmacyTransferViewRates')}"/>
                                 <h:outputLabel 
                                     class="w-100 text-end"
-                                    value="#{transferIssueController.issuedBill.billFinanceDetails.totalCostValue}" >
+                                    value="#{transferIssueController.issuedBill.billFinanceDetails.totalCostValue}" rendered="#{webUserController.hasPrivilege('PharmacyTransferViewRates')}" >
                                     <f:convertNumber pattern="#,##0.00" ></f:convertNumber>
                                 </h:outputLabel>
 

--- a/src/main/webapp/pharmacy/pharmacy_transfer_receive.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_transfer_receive.xhtml
@@ -71,13 +71,13 @@
                                         </h:outputText>
                                     </p:column>  
 
-                                    <p:column headerText="Rate"  style="width:25px!important; margin: 0px; padding: 1px 2px; line-height: 1.1;">
+                                    <p:column headerText="Rate" rendered="#{webUserController.hasPrivilege('PharmacyTransferViewRates')}"  style="width:25px!important; margin: 0px; padding: 1px 2px; line-height: 1.1;">
                                         <h:outputText id="rate" value="#{ph.rate}">
                                             <f:convertNumber pattern="#,##0.00"/>
                                         </h:outputText>
                                     </p:column>
 
-                                    <p:column headerText="Net Rate"  style="width:25px!important; margin: 0px; padding: 1px 2px; line-height: 1.1;">
+                                    <p:column headerText="Net Rate" rendered="#{webUserController.hasPrivilege('PharmacyTransferViewRates')}"  style="width:25px!important; margin: 0px; padding: 1px 2px; line-height: 1.1;">
                                         <h:outputText id="netRate" value="#{ph.netRate}">
                                             <f:convertNumber pattern="#,##0.00"/>
                                         </h:outputText>
@@ -101,7 +101,7 @@
                                         </p:inputText>
                                     </p:column>
 
-                                    <p:column headerText="Value"  style="width:25px!important; margin: 0px; padding: 1px 2px; line-height: 1.1;">
+                                    <p:column headerText="Value" rendered="#{webUserController.hasPrivilege('PharmacyTransferViewRates')}"  style="width:25px!important; margin: 0px; padding: 1px 2px; line-height: 1.1;">
                                         <h:outputText id="value" value="#{ph.absoluteNetValue}">
                                             <f:convertNumber pattern="#,##0.00"/>
                                         </h:outputText>
@@ -123,13 +123,13 @@
                                     <h:outputLabel value="Staff" ></h:outputLabel>
                                     <h:outputLabel value="#{transferReceiveController.receivedBill.staff.person.nameWithTitle}" ></h:outputLabel>
 
-                                    <h:outputLabel value="Issued Value" ></h:outputLabel>
-                                    <h:outputLabel value="#{transferReceiveController.receivedBill.referenceBill.absoluteNetTotal}">
+                                    <h:outputLabel value="Issued Value" rendered="#{webUserController.hasPrivilege('PharmacyTransferViewRates')}" ></h:outputLabel>
+                                    <h:outputLabel value="#{transferReceiveController.receivedBill.referenceBill.absoluteNetTotal}" rendered="#{webUserController.hasPrivilege('PharmacyTransferViewRates')}">
                                         <f:convertNumber pattern="#,##0.00"/>
                                     </h:outputLabel>
 
-                                    <h:outputLabel value="Receiving Value" ></h:outputLabel>
-                                    <h:outputLabel id="txtReceivingNetTotal" value="#{transferReceiveController.displayReceivedNetTotal}">
+                                    <h:outputLabel value="Receiving Value" rendered="#{webUserController.hasPrivilege('PharmacyTransferViewRates')}" ></h:outputLabel>
+                                    <h:outputLabel id="txtReceivingNetTotal" value="#{transferReceiveController.displayReceivedNetTotal}" rendered="#{webUserController.hasPrivilege('PharmacyTransferViewRates')}">
                                         <f:convertNumber pattern="#,##0.00"/>
                                     </h:outputLabel>
 
@@ -172,18 +172,18 @@
                                 <f:convertDateTime pattern="#{sessionController.applicationPreference.shortDateFormat}"/>
                             </h:outputText>
 
-                            <h:outputLabel value="Purchase Price" styleClass="fw-bold"/>
-                            <h:outputText value="#{transferReceiveController.selectedBillItem.pharmaceuticalBillItem.itemBatch.purcahseRate}">
+                            <h:outputLabel value="Purchase Price" styleClass="fw-bold" rendered="#{webUserController.hasPrivilege('PharmacyTransferViewRates')}"/>
+                            <h:outputText value="#{transferReceiveController.selectedBillItem.pharmaceuticalBillItem.itemBatch.purcahseRate}" rendered="#{webUserController.hasPrivilege('PharmacyTransferViewRates')}">
                                 <f:convertNumber pattern="#,##0.00"/>
                             </h:outputText>
 
-                            <h:outputLabel value="Retail Rate" styleClass="fw-bold"/>
-                            <h:outputText value="#{transferReceiveController.selectedBillItem.pharmaceuticalBillItem.itemBatch.retailsaleRate}">
+                            <h:outputLabel value="Retail Rate" styleClass="fw-bold" rendered="#{webUserController.hasPrivilege('PharmacyTransferViewRates')}"/>
+                            <h:outputText value="#{transferReceiveController.selectedBillItem.pharmaceuticalBillItem.itemBatch.retailsaleRate}" rendered="#{webUserController.hasPrivilege('PharmacyTransferViewRates')}">
                                 <f:convertNumber pattern="#,##0.00"/>
                             </h:outputText>
 
-                            <h:outputLabel value="Cost" styleClass="fw-bold"/>
-                            <h:outputText value="#{transferReceiveController.selectedBillItem.pharmaceuticalBillItem.itemBatch.costRate}">
+                            <h:outputLabel value="Cost" styleClass="fw-bold" rendered="#{webUserController.hasPrivilege('PharmacyTransferViewRates')}"/>
+                            <h:outputText value="#{transferReceiveController.selectedBillItem.pharmaceuticalBillItem.itemBatch.costRate}" rendered="#{webUserController.hasPrivilege('PharmacyTransferViewRates')}">
                                 <f:convertNumber pattern="#,##0.00"/>
                             </h:outputText>
                         </p:panelGrid>

--- a/src/main/webapp/pharmacy/pharmacy_transfer_request.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_transfer_request.xhtml
@@ -161,7 +161,7 @@
                                             <p:ajax event="keyup" listener="#{transferRequestController.onCurrentQtyChange}" update="txtLineNetValue requestTotals" />
                                         </p:inputText>
                                     </div>
-                                    <h:panelGroup rendered="#{configOptionApplicationController.getBooleanValueByKey('Pharmacy Transfer Request - Show Rate and Value', false)}">
+                                    <h:panelGroup rendered="#{configOptionApplicationController.getBooleanValueByKey('Pharmacy Transfer Request - Show Rate and Value', false) and webUserController.hasPrivilege('PharmacyTransferViewRates')}">
                                         <div class="col-1" >
                                             <p:outputLabel value="Rate" for="txtLineGrossRate"/>
                                             <p:inputText id="txtLineGrossRate" class="w-100 text-end"
@@ -171,7 +171,7 @@
                                             </p:inputText>
                                         </div>
                                     </h:panelGroup>
-                                    <h:panelGroup rendered="#{configOptionApplicationController.getBooleanValueByKey('Pharmacy Transfer Request - Show Rate and Value', false)}" >
+                                    <h:panelGroup rendered="#{configOptionApplicationController.getBooleanValueByKey('Pharmacy Transfer Request - Show Rate and Value', false) and webUserController.hasPrivilege('PharmacyTransferViewRates')}" >
                                         <div class="col-1">
                                             <p:outputLabel value="Value" for="txtLineNetValue"/>
                                             <p:inputText id="txtLineNetValue" class="w-100 text-end"
@@ -243,14 +243,14 @@
                                         </p:inputText>
                                     </p:column>
 
-                                    <p:column headerText="Transfer Rate" class="text-end" width="8em" rendered="#{configOptionApplicationController.getBooleanValueByKey('Pharmacy Transfer Request - Show Rate and Value', false)}">
+                                    <p:column headerText="Transfer Rate" class="text-end" width="8em" rendered="#{configOptionApplicationController.getBooleanValueByKey('Pharmacy Transfer Request - Show Rate and Value', false) and webUserController.hasPrivilege('PharmacyTransferViewRates')}">
                                         <p:inputText value="#{bi.billItemFinanceDetails.lineGrossRate}" class="w-100 text-end">
                                             <f:convertNumber pattern="#,##0.00" />
                                             <p:ajax event="blur" listener="#{transferRequestController.onLineGrossRateChange(bi)}" update="itemList requestTotals"/>
                                         </p:inputText>
                                     </p:column>
 
-                                    <p:column headerText="Transfer Value" class="text-end" width="8em" rendered="#{configOptionApplicationController.getBooleanValueByKey('Pharmacy Transfer Request - Show Rate and Value', false)}">
+                                    <p:column headerText="Transfer Value" class="text-end" width="8em" rendered="#{configOptionApplicationController.getBooleanValueByKey('Pharmacy Transfer Request - Show Rate and Value', false) and webUserController.hasPrivilege('PharmacyTransferViewRates')}">
                                         <h:outputLabel value="#{bi.billItemFinanceDetails.lineGrossTotal}">
                                             <f:convertNumber pattern="#,##0.00" />
                                         </h:outputLabel>
@@ -284,9 +284,9 @@
                                     <h:outputLabel class="w-100 text-end" value="#{transferRequestController.toDepartment.name}">
                                     </h:outputLabel>
 
-                                    <h:outputLabel value="Approximate Request Value" rendered="#{configOptionApplicationController.getBooleanValueByKey('Pharmacy Transfer Request - Show Rate and Value', false)}" />
-                                    <h:outputLabel value=": &nbsp;" rendered="#{configOptionApplicationController.getBooleanValueByKey('Pharmacy Transfer Request - Show Rate and Value', false)}"/>
-                                    <h:outputLabel class="w-100 text-end" value="#{transferRequestController.transferRequestBillPre.netTotal}" rendered="#{configOptionApplicationController.getBooleanValueByKey('Pharmacy Transfer Request - Show Rate and Value', false)}">
+                                    <h:outputLabel value="Approximate Request Value" rendered="#{configOptionApplicationController.getBooleanValueByKey('Pharmacy Transfer Request - Show Rate and Value', false) and webUserController.hasPrivilege('PharmacyTransferViewRates')}" />
+                                    <h:outputLabel value=": &nbsp;" rendered="#{configOptionApplicationController.getBooleanValueByKey('Pharmacy Transfer Request - Show Rate and Value', false) and webUserController.hasPrivilege('PharmacyTransferViewRates')}"/>
+                                    <h:outputLabel class="w-100 text-end" value="#{transferRequestController.transferRequestBillPre.netTotal}" rendered="#{configOptionApplicationController.getBooleanValueByKey('Pharmacy Transfer Request - Show Rate and Value', false) and webUserController.hasPrivilege('PharmacyTransferViewRates')}">
                                         <f:convertNumber pattern="#,##0.00" />
                                     </h:outputLabel>
 


### PR DESCRIPTION
## Summary
- require `PharmacyTransferViewRates` privilege alongside existing config toggles to view rate/value fields on transfer request and issue pages
- hide rate/value columns and totals on direct issue and transfer receive pages unless user has `PharmacyTransferViewRates`

## Testing
- ⚠️ no tests run (JSF-only changes)


------
https://chatgpt.com/codex/tasks/task_e_689fd74d7744832f9de291d8f4e10776