### PR TITLE
fixed - need-new-lab-report-for-view-inpatient-details

### DIFF
--- a/src/main/java/com/divudi/core/data/IncomeBundle.java
+++ b/src/main/java/com/divudi/core/data/IncomeBundle.java
@@ -1160,6 +1160,12 @@ public class IncomeBundle implements Serializable {
         r.setDiscount(b.getDiscount());
         r.setServiceCharge(b.getMargin());
         r.setActualTotal(r.getNetTotal() - r.getServiceCharge());
+        
+        if(b.getPatientEncounter() != null){
+            r.setBhtNo(b.getPatientEncounter().getBhtNo());
+        }else{
+            r.setBhtNo("");
+        }
 
         PaymentMethod pm = b.getPaymentMethod();
 

--- a/src/main/webapp/reportLab/laboratary_income_report.xhtml
+++ b/src/main/webapp/reportLab/laboratary_income_report.xhtml
@@ -289,6 +289,7 @@
                             var="row"
                             paginator="true" 
                             rows="20"
+                            
                             rowsPerPageTemplate="20,50,100,500,1000,2000,5000,10000"
                             paginatorPosition="bottom">
 
@@ -305,6 +306,13 @@
                                                 <h:outputText value="#{laborataryReportController.department.name}"/>
                                             </div>
                                         </h:panelGroup>
+                                        <h:panelGroup  rendered="#{laborataryReportController.admissionType ne null}">
+                                            <div class="d-flex gap-2">
+                                                <h:outputText value="-" style="width: 1em!important;" class="text-center"/>
+                                                <h:outputText value="#{laborataryReportController.admissionType.name}"/>
+                                            </div>
+                                        </h:panelGroup>
+                                        
                                     </div>
                                     <div class="d-flex justify-content-center mt-2" style=" font-size: 14px;">
                                         <div class="d-flex gap-3">
@@ -351,6 +359,10 @@
 
                             <p:column headerText="Patient"  style="padding: 2px!important; margin: 0px!important;" >
                                 <h:outputText value="#{row.bill.patient.person.nameWithTitle}"  style="padding: 2px!important; margin: 0px!important;" />
+                            </p:column>
+                            
+                            <p:column headerText="BHT No" width="6em" style="padding: 2px!important; margin: 0px!important;">
+                                <h:outputText value="#{row.bhtNo}"  style="padding: 2px!important; margin: 0px!important;" ></h:outputText>
                             </p:column>
 
                             <p:column headerText="Date"   width="8em" style="padding: 2px!important; margin: 0px!important;">

--- a/src/main/webapp/reportLab/laboratary_income_report_print.xhtml
+++ b/src/main/webapp/reportLab/laboratary_income_report_print.xhtml
@@ -67,7 +67,7 @@
                                 
                                 tfoot{
                                     font-weight: 700!important;
-                                    font-size: 11px!important;
+                                    font-size: 10px!important;
                                 }
                             }
 
@@ -76,7 +76,7 @@
                                     @bottom-right {
                                         content: "Page " counter(page) " of " counter(pages);
                                         font-family: Arial, sans-serif;
-                                        font-size: 10pt;
+                                        font-size: 9pt;
                                     }
                                 }
 
@@ -94,13 +94,13 @@
                                 .header{
                                     line-height: 1.1;
                                     margin: 0mm!important;
-                                    font-size: 13px!important;
+                                    font-size: 10px!important;
                                 }
 
                                 table {
                                     border-collapse: collapse;
                                     width: 99.9%;
-                                    font-size: 12px!important;
+                                    font-size: 10px!important;
                                     margin-top: 1mm!important;
                                 }
                                 th, td {
@@ -115,7 +115,7 @@
                                 }
                                 tfoot{
                                     font-weight: 700!important;
-                                    font-size: 11px!important;
+                                    font-size: 10px!important;
                                 }
                             }
                         </style>
@@ -132,6 +132,12 @@
                                             <div class="d-flex gap-2">
                                                 <h:outputText value="-" style="width: 1em!important;" class="text-center"/>
                                                 <h:outputText value="#{laborataryReportController.department.name}"/>
+                                            </div>
+                                        </h:panelGroup>
+                                        <h:panelGroup  rendered="#{laborataryReportController.admissionType ne null}">
+                                            <div class="d-flex gap-2">
+                                                <h:outputText value="-" style="width: 1em!important;" class="text-center"/>
+                                                <h:outputText value="#{laborataryReportController.admissionType.name}"/>
                                             </div>
                                         </h:panelGroup>
                                     </div>
@@ -182,43 +188,46 @@
                                                 <th style="width: 25mm;font-weight: 700;">
                                                     <h:outputText value="OrderNo" style="margin-left: 1mm;"/>
                                                 </th>
-                                                <th style="width: 67mm; font-weight: 700; text-align: left;">
+                                                <th style="width: 59mm; font-weight: 700; text-align: left;">
                                                     <h:outputText value="Patient Name" style="margin-left:  1mm;"/>
                                                 </th>
-                                                <th style="width: 17mm; font-weight: 700; text-align: left;">
+                                                <th style="width: 18mm; font-weight: 700; text-align: left;">
+                                                    <h:outputText value="BHT No" style="margin-left:  1mm;"/>
+                                                </th>
+                                                <th style="width: 16mm; font-weight: 700; text-align: left;">
                                                     <h:outputText value="Date" style="margin-left:  1mm;"/>
                                                 </th>
-                                                <th style="width: 17mm; font-weight: 700; text-align: right;">
+                                                <th style="width: 16mm; font-weight: 700; text-align: right;">
                                                     <h:outputText value="Net Total" style="margin-right: 1mm;"/>
                                                 </th>
-                                                <th style="width: 17mm; font-weight: 700; text-align: right;">
+                                                <th style="width: 16mm; font-weight: 700; text-align: right;">
                                                     <h:outputText value="Cash" style="margin-right: 1mm;"/>
                                                 </th>
-                                                <th style="width: 17mm; font-weight: 700; text-align: right;">
+                                                <th style="width: 16mm; font-weight: 700; text-align: right;">
                                                     <h:outputText value="Card" style="margin-right: 1mm;"/>
                                                 </th>
                                                 <th style="width: 10mm; font-weight: 700; text-align: center;">
                                                     <h:outputText value="#" style="margin-right: 1mm;"/>
                                                 </th>
-                                                <th style="width: 17mm; font-weight: 700; text-align: right;">
+                                                <th style="width: 16mm; font-weight: 700; text-align: right;">
                                                     <h:outputText value="IP Credit" style="margin-right: 1mm;"/>
                                                 </th>
-                                                <th style="width: 17mm; font-weight: 700; text-align: right;">
+                                                <th style="width: 16mm; font-weight: 700; text-align: right;">
                                                     <h:outputText value="OP Credit" style="margin-right: 1mm;"/>
                                                 </th>
-                                                <th style="width: 17mm; font-weight: 700; text-align: center;">
+                                                <th style="width: 16mm; font-weight: 700; text-align: center;">
                                                     <h:outputText value="Staff Credit" style="margin-right: 1mm;"/>
                                                 </th>
-                                                <th style="width: 17mm; font-weight: 700; text-align: center;">
+                                                <th style="width: 16mm; font-weight: 700; text-align: center;">
                                                     <h:outputText value="Agent Credit" style="margin-right: 1mm;"/>
                                                 </th>
-                                                <th style="width: 17mm; font-weight: 700; text-align: right;">
+                                                <th style="width: 16mm; font-weight: 700; text-align: right;">
                                                     <h:outputText value="Discount" style="margin-right: 1mm;"/>
                                                 </th>
-                                                <th style="width: 17mm; font-weight: 700; text-align: center;">
+                                                <th style="width: 16mm; font-weight: 700; text-align: center;">
                                                     <h:outputText value="Service Charge" style="margin-right: 1mm;"/>
                                                 </th>
-                                                <th style="width: 17mm; font-weight: 700; text-align: center;">
+                                                <th style="width: 16mm; font-weight: 700; text-align: center;">
                                                     <h:outputText value="Actual Total" style="margin-right: 1mm;"/>
                                                 </th>
                                             </tr>
@@ -232,25 +241,28 @@
                                                     <td style="width: 25mm; text-align: left;">
                                                         <h:outputText value="#{row.bill.deptId}" style="margin-left: 1mm;"/>
                                                     </td>
-                                                    <td style="width: 67mm; text-align: left;">
+                                                    <td style="width: 59mm; text-align: left;">
                                                         <h:outputText value="#{row.bill.patient.person.nameWithTitle}" style="margin-left: 1mm;"></h:outputText>
                                                     </td>
-                                                    <td style="width: 17mm; text-align: left;">
+                                                    <td style="width: 18mm; text-align: left;">
+                                                        <h:outputText value="#{row.bhtNo}" style="margin-left: 1mm;"></h:outputText>
+                                                    </td>
+                                                    <td style="width: 16mm; text-align: left;">
                                                         <h:outputText value="#{row.bill.createdAt}" style="margin-left: 1mm;">
                                                             <f:convertDateTime pattern="dd/MM/YY" />
                                                         </h:outputText>
                                                     </td>
-                                                    <td style="width: 17mm; text-align: right;">
+                                                    <td style="width: 16mm; text-align: right;">
                                                         <h:outputText value="#{row.bill.netTotal}" style="margin-right: 1mm;">
                                                             <f:convertNumber pattern="#,##0.00" />
                                                         </h:outputText>
                                                     </td>
-                                                    <td style="width: 17mm; text-align: right;">
+                                                    <td style="width: 16mm; text-align: right;">
                                                         <h:outputText value="#{row.cashValue}" style="margin-right: 1mm;">
                                                             <f:convertNumber pattern="#,##0.00" />
                                                         </h:outputText>
                                                     </td>
-                                                    <td style="width: 17mm; text-align: right;">
+                                                    <td style="width: 16mm; text-align: right;">
                                                         <h:outputText value="#{row.cardValue}" style="margin-right: 1mm;">
                                                             <f:convertNumber pattern="#,##0.00" />
                                                         </h:outputText>
@@ -258,37 +270,37 @@
                                                     <td style="width: 10mm; text-align: center;">
                                                         <h:outputText value="-" style="margin-right: 1mm;"></h:outputText>
                                                     </td>
-                                                    <td style="width: 17mm; text-align: right;">
+                                                    <td style="width: 16mm; text-align: right;">
                                                         <h:outputText value="#{row.inpatientCreditValue}" style="margin-right: 1mm;">
                                                             <f:convertNumber pattern="#,##0.00" />
                                                         </h:outputText>
                                                     </td>
-                                                    <td style="width: 17mm; text-align: right;">
+                                                    <td style="width: 16mm; text-align: right;">
                                                         <h:outputText value="#{row.opdCreditValue}" style="margin-right: 1mm;">
                                                             <f:convertNumber pattern="#,##0.00" />
                                                         </h:outputText>
                                                     </td>
-                                                    <td style="width: 17mm; text-align: right;">
+                                                    <td style="width: 16mm; text-align: right;">
                                                         <h:outputText value="#{row.staffValue}" style="margin-right: 1mm;">
                                                             <f:convertNumber pattern="#,##0.00" />
                                                         </h:outputText>
                                                     </td>
-                                                    <td style="width: 17mm; text-align: right;">
+                                                    <td style="width: 16mm; text-align: right;">
                                                         <h:outputText value="#{row.agentValue}" style="margin-right: 1mm;">
                                                             <f:convertNumber pattern="#,##0.00" />
                                                         </h:outputText>
                                                     </td>
-                                                    <td style="width: 17mm; text-align: right;">
+                                                    <td style="width: 16mm; text-align: right;">
                                                         <h:outputText value="#{row.discount}" style="margin-right: 1mm;">
                                                             <f:convertNumber pattern="#,##0.00" />
                                                         </h:outputText>
                                                     </td>
-                                                    <td style="width: 17mm; text-align: right;">
+                                                    <td style="width: 16mm; text-align: right;">
                                                         <h:outputText value="#{row.serviceCharge}" style="margin-right: 1mm;">
                                                             <f:convertNumber pattern="#,##0.00" />
                                                         </h:outputText>
                                                     </td>
-                                                    <td style="width: 17mm; text-align: right;">
+                                                    <td style="width: 16mm; text-align: right;">
                                                         <h:outputText value="#{row.netTotal}" style="margin-right: 1mm;">
                                                             <f:convertNumber pattern="#,##0.00" />
                                                         </h:outputText>
@@ -300,19 +312,20 @@
                                             <tr>
                                                 <td style="width: 8mm;" ></td>
                                                 <td style="width: 25mm; text-align: left;"></td>
-                                                <td style="width: 67mm; text-align: left;"></td>
-                                                <td style="width: 17mm; text-align: left;"></td>
-                                                <td style="width: 17mm; text-align: right;">
+                                                <td style="width: 59mm; text-align: left;"></td>
+                                                <td style="width: 18mm; text-align: left;"></td>
+                                                <td style="width: 16mm; text-align: left;"></td>
+                                                <td style="width: 16mm; text-align: right;">
                                                     <h:outputText value="#{laborataryReportController.bundle.summaryRow.netTotal}" style="margin-right: 1mm;">
                                                         <f:convertNumber pattern="#,##0.00" />
                                                     </h:outputText>
                                                 </td>
-                                                <td style="width: 17mm; text-align: right;">
+                                                <td style="width: 16mm; text-align: right;">
                                                     <h:outputText value="#{laborataryReportController.bundle.summaryRow.cashValue}" style="margin-right: 1mm;">
                                                         <f:convertNumber pattern="#,##0.00" />
                                                     </h:outputText>
                                                 </td>
-                                                <td style="width: 17mm; text-align: right;">
+                                                <td style="width: 16mm; text-align: right;">
                                                     <h:outputText value="#{laborataryReportController.bundle.summaryRow.cardValue}" style="margin-right: 1mm;">
                                                         <f:convertNumber pattern="#,##0.00" />
                                                     </h:outputText>
@@ -320,7 +333,7 @@
                                                 <td style="width: 10mm; text-align: center;">
                                                     <h:outputText value="-" style="margin-right: 1mm;"></h:outputText>
                                                 </td>
-                                                <td style="width: 17mm; text-align: right;">
+                                                <td style="width: 16mm; text-align: right;">
                                                     <h:outputText value="#{laborataryReportController.bundle.summaryRow.inpatientCreditValue}" style="margin-right: 1mm;">
                                                         <f:convertNumber pattern="#,##0.00" />
                                                     </h:outputText>
@@ -330,27 +343,27 @@
                                                         <f:convertNumber pattern="#,##0.00" />
                                                     </h:outputText>
                                                 </td>
-                                                <td style="width: 17mm; text-align: right;">
+                                                <td style="width: 16mm; text-align: right;">
                                                     <h:outputText value="#{laborataryReportController.bundle.summaryRow.staffValue}" style="margin-right: 1mm;">
                                                         <f:convertNumber pattern="#,##0.00" />
                                                     </h:outputText>
                                                 </td>
-                                                <td style="width: 17mm; text-align: right;">
+                                                <td style="width: 16mm; text-align: right;">
                                                     <h:outputText value="#{laborataryReportController.bundle.summaryRow.agentValue}" style="margin-right: 1mm;">
                                                         <f:convertNumber pattern="#,##0.00" />
                                                     </h:outputText>
                                                 </td>
-                                                <td style="width: 17mm; text-align: right;">
+                                                <td style="width: 16mm; text-align: right;">
                                                     <h:outputText value="#{laborataryReportController.bundle.summaryRow.discount}" style="margin-right: 1mm;">
                                                         <f:convertNumber pattern="#,##0.00" />
                                                     </h:outputText>
                                                 </td>
-                                                <td style="width: 17mm; text-align: right;">
+                                                <td style="width: 16mm; text-align: right;">
                                                     <h:outputText value="#{laborataryReportController.bundle.summaryRow.serviceCharge}" style="margin-right: 1mm;">
                                                         <f:convertNumber pattern="#,##0.00" />
                                                     </h:outputText>
                                                 </td>
-                                                <td style="width: 17mm; text-align: right;">
+                                                <td style="width: 16mm; text-align: right;">
                                                     <h:outputText value="#{laborataryReportController.bundle.summaryRow.netTotal}" style="margin-right: 1mm;">
                                                         <f:convertNumber pattern="#,##0.00" />
                                                     </h:outputText>


### PR DESCRIPTION
closes #14510
Signed-off-by: DamithDeshan <hkddrajapaksha@gmail.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added “BHT No” column to the Laboratory Income Report (screen and print).
  - Report header now shows Admission Type (when available) alongside Department.
  - BHT number is now populated in report rows when linked to an admission.

- Style
  - Adjusted font sizes for headers, tables, and footers in the print view for improved readability.
  - Refined column widths to accommodate the new “BHT No” column and standardize amount columns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->