### PR TITLE
Restrict transfer rate visibility to privileged users

### DIFF
--- a/src/main/webapp/resources/pharmacy/pharmacy_transfer_issue_receipt.xhtml
+++ b/src/main/webapp/resources/pharmacy/pharmacy_transfer_issue_receipt.xhtml
@@ -109,12 +109,16 @@
                             <th class="item-name">Item</th>
                             <th class="item-name">Batch</th>
                             <th class="item-qty">DOE</th>
-                            <th class="item-rate">PR</th>
-                            <th class="item-rate">RR</th>
-                            <th class="item-rate">CR</th>
+                            <ui:fragment rendered="#{configOptionApplicationController.getBooleanValueByKey('Pharmacy Transfer Issue - Show Rate and Value', false) and webUserController.hasPrivilege('PharmacyTransferViewRates')}">
+                                <th class="item-rate">PR</th>
+                                <th class="item-rate">RR</th>
+                                <th class="item-rate">CR</th>
+                            </ui:fragment>
                             <th class="item-qty">Qty</th>
-                            <th class="item-rate">Rate</th>
-                            <th class="item-value">Value</th>
+                            <ui:fragment rendered="#{configOptionApplicationController.getBooleanValueByKey('Pharmacy Transfer Issue - Show Rate and Value', false) and webUserController.hasPrivilege('PharmacyTransferViewRates')}">
+                                <th class="item-rate">Rate</th>
+                                <th class="item-value">Value</th>
+                            </ui:fragment>
                         </tr>
                     </thead>
                     <tbody>
@@ -133,36 +137,40 @@
                                         <f:convertDateTime pattern="#{sessionController.applicationPreference.shortDateFormat}" />
                                     </h:outputLabel>
                                 </td>
-                                <td class="item-rate">
-                                    <h:outputLabel value="#{bip.pharmaceuticalBillItem.itemBatch.purcahseRate}">
-                                        <f:convertNumber pattern="#,##0.00" />
-                                    </h:outputLabel>
-                                </td>
-                                <td class="item-rate">
-                                    <h:outputLabel value="#{bip.pharmaceuticalBillItem.itemBatch.retailsaleRate}">
-                                        <f:convertNumber pattern="#,##0.00" />
-                                    </h:outputLabel>
-                                </td>
-                                <td class="item-rate">
-                                    <h:outputLabel value="#{bip.pharmaceuticalBillItem.itemBatch.costRate}">
-                                        <f:convertNumber pattern="#,##0.00" />
-                                    </h:outputLabel>
-                                </td>
+                                <ui:fragment rendered="#{configOptionApplicationController.getBooleanValueByKey('Pharmacy Transfer Issue - Show Rate and Value', false) and webUserController.hasPrivilege('PharmacyTransferViewRates')}">
+                                    <td class="item-rate">
+                                        <h:outputLabel value="#{bip.pharmaceuticalBillItem.itemBatch.purcahseRate}">
+                                            <f:convertNumber pattern="#,##0.00" />
+                                        </h:outputLabel>
+                                    </td>
+                                    <td class="item-rate">
+                                        <h:outputLabel value="#{bip.pharmaceuticalBillItem.itemBatch.retailsaleRate}">
+                                            <f:convertNumber pattern="#,##0.00" />
+                                        </h:outputLabel>
+                                    </td>
+                                    <td class="item-rate">
+                                        <h:outputLabel value="#{bip.pharmaceuticalBillItem.itemBatch.costRate}">
+                                            <f:convertNumber pattern="#,##0.00" />
+                                        </h:outputLabel>
+                                    </td>
+                                </ui:fragment>
                                 <td class="item-qty">
                                     <h:outputLabel value="#{bip.qty}">
                                         <f:convertNumber integerOnly="true" />
                                     </h:outputLabel>
                                 </td>
-                                <td class="item-rate">
-                                    <h:outputLabel value="#{bip.rate}">
-                                        <f:convertNumber pattern="#,##0.00" />
-                                    </h:outputLabel>
-                                </td>
-                                <td class="item-value">
-                                    <h:outputLabel value="#{bip.netValue}">
-                                        <f:convertNumber pattern="#,##0.00" />
-                                    </h:outputLabel>
-                                </td>
+                                <ui:fragment rendered="#{configOptionApplicationController.getBooleanValueByKey('Pharmacy Transfer Issue - Show Rate and Value', false) and webUserController.hasPrivilege('PharmacyTransferViewRates')}">
+                                    <td class="item-rate">
+                                        <h:outputLabel value="#{bip.rate}">
+                                            <f:convertNumber pattern="#,##0.00" />
+                                        </h:outputLabel>
+                                    </td>
+                                    <td class="item-value">
+                                        <h:outputLabel value="#{bip.netValue}">
+                                            <f:convertNumber pattern="#,##0.00" />
+                                        </h:outputLabel>
+                                    </td>
+                                </ui:fragment>
                             </tr>
                         </ui:repeat>
                     </tbody>
@@ -171,26 +179,28 @@
 
             <div class="receipt-separator"><hr /></div>
 
-            <div class="receipt-summary">
-                <table class="receipt-summary-table">
-                    <tr>
-                        <td class="summary-label">Total</td>
-                        <td class="summary-value">
-                            <h:outputLabel value="#{cc.attrs.bill.netTotal}" styleClass="total-amount">
-                                <f:convertNumber pattern="#,##0.00" />
-                            </h:outputLabel>
-                        </td>
-                    </tr>
-                    <tr>
-                        <td class="summary-label">Number of Items</td>
-                        <td class="summary-value">
-                            <h:outputLabel value="#{cc.attrs.bill.billItems.size()}">
-                                <f:convertNumber pattern="#,##0" />
-                            </h:outputLabel>
-                        </td>
-                    </tr>
-                </table>
-            </div>
+            <h:panelGroup rendered="#{configOptionApplicationController.getBooleanValueByKey('Pharmacy Transfer Issue - Show Rate and Value', false) and webUserController.hasPrivilege('PharmacyTransferViewRates')}">
+                <div class="receipt-summary">
+                    <table class="receipt-summary-table">
+                        <tr>
+                            <td class="summary-label">Total</td>
+                            <td class="summary-value">
+                                <h:outputLabel value="#{cc.attrs.bill.netTotal}" styleClass="total-amount">
+                                    <f:convertNumber pattern="#,##0.00" />
+                                </h:outputLabel>
+                            </td>
+                        </tr>
+                        <tr>
+                            <td class="summary-label">Number of Items</td>
+                            <td class="summary-value">
+                                <h:outputLabel value="#{cc.attrs.bill.billItems.size()}">
+                                    <f:convertNumber pattern="#,##0" />
+                                </h:outputLabel>
+                            </td>
+                        </tr>
+                    </table>
+                </div>
+            </h:panelGroup>
 
             <div class="receipt-cashier">
                 <h:outputLabel value="Cashier : #{cc.attrs.bill.creater.name}" />

--- a/src/main/webapp/resources/pharmacy/pharmacy_transfer_receive_receipt.xhtml
+++ b/src/main/webapp/resources/pharmacy/pharmacy_transfer_receive_receipt.xhtml
@@ -139,12 +139,17 @@
                             <th class="item-name">Item</th>
                             <th class="item-name">Batch</th>
                             <th class="item-qty">DOE</th>
-                            <th class="item-rate">PR</th>
-                            <th class="item-rate">RR</th>
-                            <th class="item-rate">CR</th>
+                            <ui:fragment rendered="#{configOptionApplicationController.getBooleanValueByKey('Pharmacy Transfer Receive - Show Rate and Value', false) and webUserController.hasPrivilege('PharmacyTransferViewRates')}">
+                                <th class="item-rate">PR</th>
+                        
+                                <th class="item-rate">RR</th>
+                                <th class="item-rate">CR</th>
+                            </ui:fragment>
                             <th class="item-qty">Qty</th>
-                            <th class="item-rate">Rate</th>
-                            <th class="item-value">Value</th>
+                            <ui:fragment rendered="#{configOptionApplicationController.getBooleanValueByKey('Pharmacy Transfer Receive - Show Rate and Value', false) and webUserController.hasPrivilege('PharmacyTransferViewRates')}">
+                                <th class="item-rate">Rate</th>
+                                <th class="item-value">Value</th>
+                            </ui:fragment>
                         </tr>
                     </thead>
                     <tbody>
@@ -163,36 +168,40 @@
                                         <f:convertDateTime pattern="#{sessionController.applicationPreference.shortDateFormat}" />
                                     </h:outputLabel>
                                 </td>
-                                <td class="item-rate">
-                                    <h:outputLabel value="#{bip.pharmaceuticalBillItem.itemBatch.purcahseRate}">
-                                        <f:convertNumber pattern="#,##0.00" />
-                                    </h:outputLabel>
-                                </td>
-                                <td class="item-rate">
-                                    <h:outputLabel value="#{bip.pharmaceuticalBillItem.itemBatch.retailsaleRate}">
-                                        <f:convertNumber pattern="#,##0.00" />
-                                    </h:outputLabel>
-                                </td>
-                                <td class="item-rate">
-                                    <h:outputLabel value="#{bip.pharmaceuticalBillItem.itemBatch.costRate}">
-                                        <f:convertNumber pattern="#,##0.00" />
-                                    </h:outputLabel>
-                                </td>
+                                <ui:fragment rendered="#{configOptionApplicationController.getBooleanValueByKey('Pharmacy Transfer Receive - Show Rate and Value', false) and webUserController.hasPrivilege('PharmacyTransferViewRates')}">
+                                    <td class="item-rate">
+                                        <h:outputLabel value="#{bip.pharmaceuticalBillItem.itemBatch.purcahseRate}">
+                                            <f:convertNumber pattern="#,##0.00" />
+                                        </h:outputLabel>
+                                    </td>
+                                    <td class="item-rate">
+                                        <h:outputLabel value="#{bip.pharmaceuticalBillItem.itemBatch.retailsaleRate}">
+                                            <f:convertNumber pattern="#,##0.00" />
+                                        </h:outputLabel>
+                                    </td>
+                                    <td class="item-rate">
+                                        <h:outputLabel value="#{bip.pharmaceuticalBillItem.itemBatch.costRate}">
+                                            <f:convertNumber pattern="#,##0.00" />
+                                        </h:outputLabel>
+                                    </td>
+                                </ui:fragment>
                                 <td class="item-qty">
                                     <h:outputLabel value="#{bip.qty}">
                                         <f:convertNumber integerOnly="true" />
                                     </h:outputLabel>
                                 </td>
-                                <td class="item-rate">
-                                    <h:outputLabel value="#{bip.rate}">
-                                        <f:convertNumber pattern="#,##0.00" />
-                                    </h:outputLabel>
-                                </td>
-                                <td class="item-value">
-                                    <h:outputLabel value="#{bip.netValue}">
-                                        <f:convertNumber pattern="#,##0.00" />
-                                    </h:outputLabel>
-                                </td>
+                                <ui:fragment rendered="#{configOptionApplicationController.getBooleanValueByKey('Pharmacy Transfer Receive - Show Rate and Value', false) and webUserController.hasPrivilege('PharmacyTransferViewRates')}">
+                                    <td class="item-rate">
+                                        <h:outputLabel value="#{bip.rate}">
+                                            <f:convertNumber pattern="#,##0.00" />
+                                        </h:outputLabel>
+                                    </td>
+                                    <td class="item-value">
+                                        <h:outputLabel value="#{bip.netValue}">
+                                            <f:convertNumber pattern="#,##0.00" />
+                                        </h:outputLabel>
+                                    </td>
+                                </ui:fragment>
                             </tr>
                         </ui:repeat>
                     </tbody>
@@ -201,26 +210,28 @@
 
             <div class="receipt-separator"><hr /></div>
 
-            <div class="receipt-summary">
-                <table class="receipt-summary-table">
-                    <tr>
-                        <td class="summary-label">Total</td>
-                        <td class="summary-value">
-                            <h:outputLabel value="#{cc.attrs.bill.netTotal}" styleClass="total-amount">
-                                <f:convertNumber pattern="#,##0.00" />
-                            </h:outputLabel>
-                        </td>
-                    </tr>
-                    <tr>
-                        <td class="summary-label">Number of Items</td>
-                        <td class="summary-value">
-                            <h:outputLabel value="#{cc.attrs.bill.billItems.size()}">
-                                <f:convertNumber pattern="#,##0" />
-                            </h:outputLabel>
-                        </td>
-                    </tr>
-                </table>
-            </div>
+            <h:panelGroup rendered="#{configOptionApplicationController.getBooleanValueByKey('Pharmacy Transfer Receive - Show Rate and Value', false) and webUserController.hasPrivilege('PharmacyTransferViewRates')}">
+                <div class="receipt-summary">
+                    <table class="receipt-summary-table">
+                        <tr>
+                            <td class="summary-label">Total</td>
+                            <td class="summary-value">
+                                <h:outputLabel value="#{cc.attrs.bill.netTotal}" styleClass="total-amount">
+                                    <f:convertNumber pattern="#,##0.00" />
+                                </h:outputLabel>
+                            </td>
+                        </tr>
+                        <tr>
+                            <td class="summary-label">Number of Items</td>
+                            <td class="summary-value">
+                                <h:outputLabel value="#{cc.attrs.bill.billItems.size()}">
+                                    <f:convertNumber pattern="#,##0" />
+                                </h:outputLabel>
+                            </td>
+                        </tr>
+                    </table>
+                </div>
+            </h:panelGroup>
 
             <div class="receipt-cashier">
                 <h:outputLabel value="Cashier : #{cc.attrs.bill.creater.name}" />

--- a/src/main/webapp/resources/pharmacy/transfeRecieve_detailed.xhtml
+++ b/src/main/webapp/resources/pharmacy/transfeRecieve_detailed.xhtml
@@ -123,7 +123,8 @@
                         </h:outputLabel>
                     </p:column>
                     
-                    <p:column style="text-align: right;">
+                    <p:column style="text-align: right;"
+                              rendered="#{configOptionApplicationController.getBooleanValueByKey('Pharmacy Transfer Receive - Show Rate and Value', false) and webUserController.hasPrivilege('PharmacyTransferViewRates')}">
                         <f:facet name="header">
                             <h:outputLabel value="Rate"/>
                         </f:facet>
@@ -139,7 +140,8 @@
                         <h:outputLabel value="#{0-bip.pharmaceuticalBillItem.qty}"/>
                     </p:column>                    
 
-                    <p:column style="text-align: right;">
+                    <p:column style="text-align: right;"
+                              rendered="#{configOptionApplicationController.getBooleanValueByKey('Pharmacy Transfer Receive - Show Rate and Value', false) and webUserController.hasPrivilege('PharmacyTransferViewRates')}">
                         <f:facet name="header">
                             <h:outputLabel value="Gross Price"/>
                         </f:facet>
@@ -148,7 +150,8 @@
                         </h:outputLabel>
                     </p:column>
 
-                    <p:columnGroup type="footer">
+                    <p:columnGroup type="footer"
+                                   rendered="#{configOptionApplicationController.getBooleanValueByKey('Pharmacy Transfer Receive - Show Rate and Value', false) and webUserController.hasPrivilege('PharmacyTransferViewRates')}">
                         <p:row>
                             <p:column colspan="6">
                                 <f:facet name="footer">

--- a/src/main/webapp/resources/pharmacy/transferIssue.xhtml
+++ b/src/main/webapp/resources/pharmacy/transferIssue.xhtml
@@ -173,9 +173,9 @@
                         <h:outputLabel value="#{0-bip.pharmaceuticalBillItem.qty}"/>
                     </p:column>
 
-                    <p:column  
-                          rendered="#{configOptionApplicationController.getBooleanValueByKey('Pharmacy Disbursement Reports - Display Purchase Rate', true)}"
-                        width="4em" 
+                    <p:column
+                          rendered="#{configOptionApplicationController.getBooleanValueByKey('Pharmacy Disbursement Reports - Display Purchase Rate', true) and configOptionApplicationController.getBooleanValueByKey('Pharmacy Transfer Issue - Show Rate and Value', false) and webUserController.hasPrivilege('PharmacyTransferViewRates')}"
+                        width="4em"
                         class="text-end">
                         <f:facet name="header">
                             <h:outputLabel value="Purchase Rate"/>
@@ -185,8 +185,8 @@
                         </h:outputLabel>
                     </p:column>
 
-                    <p:column  
-                          rendered="#{configOptionApplicationController.getBooleanValueByKey('Pharmacy Disbursement Reports - Display Purchase Value', false)}"
+                    <p:column
+                          rendered="#{configOptionApplicationController.getBooleanValueByKey('Pharmacy Disbursement Reports - Display Purchase Value', false) and configOptionApplicationController.getBooleanValueByKey('Pharmacy Transfer Issue - Show Rate and Value', false) and webUserController.hasPrivilege('PharmacyTransferViewRates')}"
                         width="4em" class="text-end">
                         <f:facet name="header">
                             <h:outputLabel value="Purchase Value"/>
@@ -195,14 +195,15 @@
                             <f:convertNumber pattern="#0.00" />
                         </h:outputLabel>
                         <f:facet name="footer">
-                            <h:outputLabel value="#{cc.attrs.bill.billFinanceDetails.totalPurchaseValue}">
+                            <h:outputLabel value="#{cc.attrs.bill.billFinanceDetails.totalPurchaseValue}"
+                                           rendered="#{configOptionApplicationController.getBooleanValueByKey('Pharmacy Transfer Issue - Show Rate and Value', false) and webUserController.hasPrivilege('PharmacyTransferViewRates')}">
                                 <f:convertNumber pattern="#0.00" />
                             </h:outputLabel>
                         </f:facet>
                     </p:column>
 
-                    <p:column  
-                          rendered="#{configOptionApplicationController.getBooleanValueByKey('Pharmacy Disbursement Reports - Display Retail Sale Rate', false)}"
+                    <p:column
+                          rendered="#{configOptionApplicationController.getBooleanValueByKey('Pharmacy Disbursement Reports - Display Retail Sale Rate', false) and configOptionApplicationController.getBooleanValueByKey('Pharmacy Transfer Issue - Show Rate and Value', false) and webUserController.hasPrivilege('PharmacyTransferViewRates')}"
                         width="4em" class="text-end">
                         <f:facet name="header">
                             <h:outputLabel value="Sale Rate"/>
@@ -212,8 +213,8 @@
                         </h:outputLabel>
                     </p:column>
 
-                    <p:column  
-                          rendered="#{configOptionApplicationController.getBooleanValueByKey('Pharmacy Disbursement Reports - Display Retail Sale Value', false)}"
+                    <p:column
+                          rendered="#{configOptionApplicationController.getBooleanValueByKey('Pharmacy Disbursement Reports - Display Retail Sale Value', false) and configOptionApplicationController.getBooleanValueByKey('Pharmacy Transfer Issue - Show Rate and Value', false) and webUserController.hasPrivilege('PharmacyTransferViewRates')}"
                         width="4em" class="text-end">
                         <f:facet name="header">
                             <h:outputLabel value="Sale Value"/>
@@ -222,15 +223,16 @@
                             <f:convertNumber pattern="#0.00" />
                         </h:outputLabel>
                         <f:facet name="footer">
-                            <h:outputLabel value="#{cc.attrs.bill.billFinanceDetails.totalRetailSaleValue}">
+                            <h:outputLabel value="#{cc.attrs.bill.billFinanceDetails.totalRetailSaleValue}"
+                                           rendered="#{configOptionApplicationController.getBooleanValueByKey('Pharmacy Transfer Issue - Show Rate and Value', false) and webUserController.hasPrivilege('PharmacyTransferViewRates')}">
                                 <f:convertNumber pattern="#0.00" />
                             </h:outputLabel>
                         </f:facet>
                     </p:column>
                     
-                     <p:column  
-                        rendered="#{configOptionApplicationController.getBooleanValueByKey('Pharmacy Disbursement Reports - Display Transfer Rate', false)}"
-                        width="4em" 
+                     <p:column
+                        rendered="#{configOptionApplicationController.getBooleanValueByKey('Pharmacy Disbursement Reports - Display Transfer Rate', false) and configOptionApplicationController.getBooleanValueByKey('Pharmacy Transfer Issue - Show Rate and Value', false) and webUserController.hasPrivilege('PharmacyTransferViewRates')}"
+                        width="4em"
                         class="text-end">
                         <f:facet name="header">
                             <h:outputLabel value="Transfer Rate"/>
@@ -240,9 +242,9 @@
                         </h:outputLabel>
                     </p:column>
 
-                    <p:column  
-                        rendered="#{configOptionApplicationController.getBooleanValueByKey('Pharmacy Disbursement Reports - Display Transfer Value', false)}"
-                        width="4em" 
+                    <p:column
+                        rendered="#{configOptionApplicationController.getBooleanValueByKey('Pharmacy Disbursement Reports - Display Transfer Value', false) and configOptionApplicationController.getBooleanValueByKey('Pharmacy Transfer Issue - Show Rate and Value', false) and webUserController.hasPrivilege('PharmacyTransferViewRates')}"
+                        width="4em"
                         class="text-end">
                         <f:facet name="header">
                             <h:outputLabel value="Transfer Value"/>
@@ -251,7 +253,8 @@
                             <f:convertNumber pattern="#0.00" />
                         </h:outputLabel>
                         <f:facet name="footer">
-                            <h:outputLabel value="#{cc.attrs.bill.billFinanceDetails.grossTotal}">
+                            <h:outputLabel value="#{cc.attrs.bill.billFinanceDetails.grossTotal}"
+                                           rendered="#{configOptionApplicationController.getBooleanValueByKey('Pharmacy Transfer Issue - Show Rate and Value', false) and webUserController.hasPrivilege('PharmacyTransferViewRates')}">
                                 <f:convertNumber pattern="#0.00" />
                             </h:outputLabel>
                         </f:facet>

--- a/src/main/webapp/resources/pharmacy/transferIssue_detailed.xhtml
+++ b/src/main/webapp/resources/pharmacy/transferIssue_detailed.xhtml
@@ -122,7 +122,8 @@
                         </h:outputLabel>
                     </p:column>
 
-                    <p:column style="text-align: right;">
+                    <p:column style="text-align: right;"
+                              rendered="#{configOptionApplicationController.getBooleanValueByKey('Pharmacy Transfer Issue - Show Rate and Value', false) and webUserController.hasPrivilege('PharmacyTransferViewRates')}">
                         <f:facet name="header">
                             <h:outputLabel value="Transfer Rate"/>
                         </f:facet>
@@ -138,7 +139,8 @@
                         <h:outputLabel value="#{0-bip.pharmaceuticalBillItem.qty}"/>
                     </p:column>                    
 
-                    <p:column style="text-align: right;">
+                    <p:column style="text-align: right;"
+                              rendered="#{configOptionApplicationController.getBooleanValueByKey('Pharmacy Transfer Issue - Show Rate and Value', false) and webUserController.hasPrivilege('PharmacyTransferViewRates')}">
                         <f:facet name="header">
                             <h:outputLabel value="Transfer Value"/>
                         </f:facet>
@@ -148,7 +150,8 @@
                     </p:column>
 
 
-                    <p:columnGroup type="footer">
+                    <p:columnGroup type="footer"
+                                   rendered="#{configOptionApplicationController.getBooleanValueByKey('Pharmacy Transfer Issue - Show Rate and Value', false) and webUserController.hasPrivilege('PharmacyTransferViewRates')}">
                         <p:row>
                             <p:column colspan="6">
                                 <f:facet name="footer">

--- a/src/main/webapp/resources/pharmacy/transferReceive.xhtml
+++ b/src/main/webapp/resources/pharmacy/transferReceive.xhtml
@@ -171,7 +171,7 @@
 
                     
                     <p:column
-                        rendered="#{configOptionApplicationController.getBooleanValueByKey('Pharmacy Disbursement Reports - Display Purchase Rate', false)}"
+                        rendered="#{configOptionApplicationController.getBooleanValueByKey('Pharmacy Disbursement Reports - Display Purchase Rate', false) and configOptionApplicationController.getBooleanValueByKey('Pharmacy Transfer Receive - Show Rate and Value', false) and webUserController.hasPrivilege('PharmacyTransferViewRates')}"
                         width="4em" class="text-end" style="margin: 0px; padding: 1px 2px; line-height: 1.1;">
                         <f:facet name="header">
                             <h:outputLabel value="Purchase Rate"/>
@@ -182,7 +182,7 @@
                     </p:column>
                     
                     <p:column
-                        rendered="#{configOptionApplicationController.getBooleanValueByKey('Pharmacy Disbursement Reports - Display Purchase Value', false)}"
+                        rendered="#{configOptionApplicationController.getBooleanValueByKey('Pharmacy Disbursement Reports - Display Purchase Value', false) and configOptionApplicationController.getBooleanValueByKey('Pharmacy Transfer Receive - Show Rate and Value', false) and webUserController.hasPrivilege('PharmacyTransferViewRates')}"
                         width="4em" class="text-end" style="margin: 0px; padding: 1px 2px; line-height: 1.1;">
                         <f:facet name="header">
                             <h:outputLabel value="Purchase Value"/>
@@ -192,14 +192,15 @@
                             <f:convertNumber pattern="#,##0.00"/>
                         </h:outputLabel>
                         <f:facet name="footer">
-                            <h:outputLabel value="#{cc.attrs.bill.billFinanceDetails.totalPurchaseValue}">
+                            <h:outputLabel value="#{cc.attrs.bill.billFinanceDetails.totalPurchaseValue}"
+                                           rendered="#{configOptionApplicationController.getBooleanValueByKey('Pharmacy Transfer Receive - Show Rate and Value', false) and webUserController.hasPrivilege('PharmacyTransferViewRates')}">
                                 <f:convertNumber pattern="#0.00"/>
                             </h:outputLabel>
                         </f:facet>
                     </p:column>
 
                     <p:column
-                        rendered="#{configOptionApplicationController.getBooleanValueByKey('Pharmacy Disbursement Reports - Display Retail Sale Rate', false)}"
+                        rendered="#{configOptionApplicationController.getBooleanValueByKey('Pharmacy Disbursement Reports - Display Retail Sale Rate', false) and configOptionApplicationController.getBooleanValueByKey('Pharmacy Transfer Receive - Show Rate and Value', false) and webUserController.hasPrivilege('PharmacyTransferViewRates')}"
                         width="4em" class="text-end" style="margin: 0px; padding: 1px 2px; line-height: 1.1;">
                         <f:facet name="header">
                             <h:outputLabel value="Retail Rate"/>
@@ -210,7 +211,7 @@
                     </p:column>
 
                     <p:column
-                        rendered="#{configOptionApplicationController.getBooleanValueByKey('Pharmacy Disbursement Reports - Display Retail Sale Value', false)}"
+                        rendered="#{configOptionApplicationController.getBooleanValueByKey('Pharmacy Disbursement Reports - Display Retail Sale Value', false) and configOptionApplicationController.getBooleanValueByKey('Pharmacy Transfer Receive - Show Rate and Value', false) and webUserController.hasPrivilege('PharmacyTransferViewRates')}"
                         width="4em" class="text-end" style="margin: 0px; padding: 1px 2px; line-height: 1.1;">
                         <f:facet name="header">
                             <h:outputLabel value="Retail Value"/>
@@ -221,14 +222,15 @@
                         </h:outputLabel>
 
                         <f:facet name="footer">
-                            <h:outputLabel styleClass="totalRetailValue" value="#{cc.attrs.bill.billFinanceDetails.totalRetailSaleValue}">
+                            <h:outputLabel styleClass="totalRetailValue" value="#{cc.attrs.bill.billFinanceDetails.totalRetailSaleValue}"
+                                           rendered="#{configOptionApplicationController.getBooleanValueByKey('Pharmacy Transfer Receive - Show Rate and Value', false) and webUserController.hasPrivilege('PharmacyTransferViewRates')}">
                                 <f:convertNumber pattern="#,##0.00"/>
                             </h:outputLabel>
                         </f:facet>
                     </p:column>
 
                     <p:column
-                        rendered="#{configOptionApplicationController.getBooleanValueByKey('Pharmacy Disbursement Reports - Display Transfer Rate', false)}"
+                        rendered="#{configOptionApplicationController.getBooleanValueByKey('Pharmacy Disbursement Reports - Display Transfer Rate', false) and configOptionApplicationController.getBooleanValueByKey('Pharmacy Transfer Receive - Show Rate and Value', false) and webUserController.hasPrivilege('PharmacyTransferViewRates')}"
                         width="4em" class="text-end" style="margin: 0px; padding: 1px 2px; line-height: 1.1;">
                         <f:facet name="header">
                             <h:outputLabel value="Transfer Rate"/>
@@ -239,7 +241,7 @@
                     </p:column>
 
                     <p:column
-                        rendered="#{configOptionApplicationController.getBooleanValueByKey('Pharmacy Disbursement Reports - Display Transfer Value', false)}"
+                        rendered="#{configOptionApplicationController.getBooleanValueByKey('Pharmacy Disbursement Reports - Display Transfer Value', false) and configOptionApplicationController.getBooleanValueByKey('Pharmacy Transfer Receive - Show Rate and Value', false) and webUserController.hasPrivilege('PharmacyTransferViewRates')}"
                         width="4em" class="text-end">
                         <f:facet name="header">
                             <h:outputLabel value="Transfer Value"/>
@@ -249,7 +251,8 @@
                         </h:outputLabel>
 
                         <f:facet name="footer">
-                            <h:outputLabel value="#{cc.attrs.bill.netTotal}">
+                            <h:outputLabel value="#{cc.attrs.bill.netTotal}"
+                                           rendered="#{configOptionApplicationController.getBooleanValueByKey('Pharmacy Transfer Receive - Show Rate and Value', false) and webUserController.hasPrivilege('PharmacyTransferViewRates')}">
                                 <f:convertNumber pattern="#,##0.00"/>
                             </h:outputLabel>
                         </f:facet>


### PR DESCRIPTION
## Summary
- hide pharmacy transfer rate and value columns unless `PharmacyTransferViewRates` privilege and relevant config option are enabled
- guard printed totals on transfer receipts and reports behind the same checks

## Testing
- no tests run

------
https://chatgpt.com/codex/tasks/task_e_689fd91a975c832f8e25f5568df413a8