### PR TITLE
Handle null and whitespace frequency names in dose calculation

### DIFF
--- a/src/main/java/com/divudi/ejb/PrescriptionToItemService.java
+++ b/src/main/java/com/divudi/ejb/PrescriptionToItemService.java
@@ -14,6 +14,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import javax.ejb.EJB;
 import javax.ejb.Stateless;
 
@@ -237,8 +238,15 @@ public class PrescriptionToItemService {
         if (frequencyUnit == null) {
             return 1.0; // Default to once per day
         }
+        String frequencyName = Optional.ofNullable(frequencyUnit.getName())
+                .orElse("")
+                .trim()
+                .toLowerCase()
+                .replaceAll("\\s+", " ");
 
-        String frequencyName = frequencyUnit.getName().toLowerCase();
+        if (frequencyName.isEmpty()) {
+            return 1.0;
+        }
         
         // Common frequency mappings
         Map<String, Double> frequencyMap = new HashMap<>();

--- a/src/test/java/com/divudi/ejb/PrescriptionToItemServiceTest.java
+++ b/src/test/java/com/divudi/ejb/PrescriptionToItemServiceTest.java
@@ -1,0 +1,39 @@
+package com.divudi.ejb;
+
+import com.divudi.core.entity.pharmacy.MeasurementUnit;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Method;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class PrescriptionToItemServiceTest {
+
+    private Double invokeCalculateDosesPerDay(MeasurementUnit unit) throws Exception {
+        PrescriptionToItemService service = new PrescriptionToItemService();
+        Method method = PrescriptionToItemService.class.getDeclaredMethod("calculateDosesPerDay", MeasurementUnit.class);
+        method.setAccessible(true);
+        return (Double) method.invoke(service, unit);
+    }
+
+    @Test
+    public void calculateDosesPerDay_nullName_returnsDefault() throws Exception {
+        MeasurementUnit unit = new MeasurementUnit();
+        unit.setName(null);
+        assertEquals(1.0, invokeCalculateDosesPerDay(unit));
+    }
+
+    @Test
+    public void calculateDosesPerDay_trimsAndLowercases() throws Exception {
+        MeasurementUnit unit = new MeasurementUnit();
+        unit.setName("  Twice daily  ");
+        assertEquals(2.0, invokeCalculateDosesPerDay(unit));
+    }
+
+    @Test
+    public void calculateDosesPerDay_normalizesInternalSpaces() throws Exception {
+        MeasurementUnit unit = new MeasurementUnit();
+        unit.setName("once    daily");
+        assertEquals(1.0, invokeCalculateDosesPerDay(unit));
+    }
+}


### PR DESCRIPTION
## Summary
- handle null, whitespace, and case-insensitive frequency unit names in dose calculations
- add unit tests verifying normalization of frequency unit names

## Testing
- `mvn test -q` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:3.3.1 could not be resolved)*

------
https://chatgpt.com/codex/tasks/task_e_68a028e46dac832f8ad693aa10058f84