### PR TITLE
enhance: Add stockQty and batchNo fields to PharmacyBinCardDTO for hotfix compatibility

### DIFF
--- a/src/main/java/com/divudi/bean/pharmacy/StockHistoryController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/StockHistoryController.java
@@ -172,7 +172,8 @@ public class StockHistoryController implements Serializable {
                 .append("s.pbItem.billItem.item.name, ")
                 .append("s.pbItem.qty, s.pbItem.freeQty, ")
                 .append("s.pbItem.qtyPacks, s.pbItem.freeQtyPacks, ")
-                .append("s.pbItem.billItem.item.dblValue, s.itemStock")
+                .append("s.pbItem.billItem.item.dblValue, s.itemStock, ")
+                .append("s.stockQty, s.pbItem.stock.itemBatch.batchNo")
                 .append(") from StockHistory s ")
                 .append("where s.createdAt between :fd and :td ");
 

--- a/src/main/java/com/divudi/core/data/dto/PharmacyBinCardDTO.java
+++ b/src/main/java/com/divudi/core/data/dto/PharmacyBinCardDTO.java
@@ -54,6 +54,30 @@ public class PharmacyBinCardDTO implements Serializable {
         this.batchNo = batchNo;
     }
 
+    public PharmacyBinCardDTO(Long id,
+            Date createdAt,
+            BillType billType,
+            BillTypeAtomic billTypeAtomic,
+            String itemName,
+            Double qty,
+            Double freeQty,
+            Double qtyPacks,
+            Double freeQtyPacks,
+            Double itemDblValue,
+            Double itemStock) {
+        this.id = id;
+        this.createdAt = createdAt;
+        this.billType = billType;
+        this.billTypeAtomic = billTypeAtomic;
+        this.itemName = itemName;
+        this.qty = qty;
+        this.freeQty = freeQty;
+        this.qtyPacks = qtyPacks;
+        this.freeQtyPacks = freeQtyPacks;
+        this.itemDblValue = itemDblValue;
+        this.itemStock = itemStock;
+    }
+
     public PharmacyBinCardDTO() {
     }
 

--- a/src/main/java/com/divudi/core/data/dto/PharmacyBinCardDTO.java
+++ b/src/main/java/com/divudi/core/data/dto/PharmacyBinCardDTO.java
@@ -23,6 +23,8 @@ public class PharmacyBinCardDTO implements Serializable {
     private Double freeQtyPacks;
     private Double itemDblValue;
     private Double itemStock;
+    private Double stockQty;
+    private String batchNo;
 
     public PharmacyBinCardDTO(Long id,
             Date createdAt,
@@ -34,7 +36,9 @@ public class PharmacyBinCardDTO implements Serializable {
             Double qtyPacks,
             Double freeQtyPacks,
             Double itemDblValue,
-            Double itemStock) {
+            Double itemStock,
+            Double stockQty,
+            String batchNo) {
         this.id = id;
         this.createdAt = createdAt;
         this.billType = billType;
@@ -46,6 +50,8 @@ public class PharmacyBinCardDTO implements Serializable {
         this.freeQtyPacks = freeQtyPacks;
         this.itemDblValue = itemDblValue;
         this.itemStock = itemStock;
+        this.stockQty = stockQty;
+        this.batchNo = batchNo;
     }
 
     public PharmacyBinCardDTO() {
@@ -145,6 +151,22 @@ public class PharmacyBinCardDTO implements Serializable {
 
     public void setItemStock(Double itemStock) {
         this.itemStock = itemStock;
+    }
+
+    public Double getStockQty() {
+        return stockQty;
+    }
+
+    public void setStockQty(Double stockQty) {
+        this.stockQty = stockQty;
+    }
+
+    public String getBatchNo() {
+        return batchNo;
+    }
+
+    public void setBatchNo(String batchNo) {
+        this.batchNo = batchNo;
     }
 
     // Derived helper properties

--- a/src/main/webapp/pharmacy/bin_card.xhtml
+++ b/src/main/webapp/pharmacy/bin_card.xhtml
@@ -148,6 +148,16 @@
 
 
 
+                    <p:column headerText="Batch Number" class="text-end">
+                        <h:outputText value="#{sh.batchNo}" />
+                    </p:column>
+
+                    <p:column headerText="Balance Qty (Batch)" class="text-end">
+                        <h:outputText value="#{sh.stockQty}">
+                            <f:convertNumber pattern="#.#"/>
+                        </h:outputText>
+                    </p:column>
+
                     <p:column headerText="Closing Stock" class="text-end">
                         <h:outputText value="#{sh.itemStock}">
                             <f:convertNumber pattern="#,##0.#"/>


### PR DESCRIPTION
## Summary
• Added `stockQty` and `batchNo` fields to PharmacyBinCardDTO with constructor updates and getters/setters
• Enhanced StockHistoryController JPQL query to include `s.stockQty` and `s.pbItem.stock.itemBatch.batchNo`
• Added "Batch Number" and "Balance Qty (Batch)" columns to bin_card.xhtml template
• Maintains backward compatibility with existing binCardEntries usage

## Context
This enhancement addresses the need to include hotfix bincard improvements in the development branch's DTO-based implementation. The hotfix branch added new fields (stockQty for batch balance and batchNo for batch number) to the bincard display, but the development branch had already converted to use PharmacyBinCardDTO. This PR ensures future hotfix merges into development will be conflict-free.

## Test plan
- [x] Compilation test passed (mvn compile)
- [ ] Verify bin card page displays new Batch Number and Balance Qty (Batch) columns  
- [ ] Test with various pharmacy departments and date ranges
- [ ] Confirm existing functionality remains intact

Closes #14938

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Pharmacy Bin Card displays two new columns: Batch Number and Balance Qty (Batch) to show per-batch stock details.
  * Values in the new columns are right-aligned and formatted for improved readability.
  * No changes to existing columns or workflows; prior functionality remains unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->