### PR TITLE
Use autocomplete for VMP selection

### DIFF
--- a/src/main/webapp/pharmacy/admin/vmp.xhtml
+++ b/src/main/webapp/pharmacy/admin/vmp.xhtml
@@ -10,7 +10,7 @@
     <ui:define name="subcontent">
         <h:form id="vmpForm">
             <p:growl id="messages"  life="3000"/>
-            <p:focus id="selectFocus" for="lstSelect" />
+            <p:focus id="selectFocus" for="acVmp" />
 
             <p:panel header="Virtual Medicinal Product (VMP) Management" styleClass="w-100 mb-3">
 
@@ -21,24 +21,24 @@
                         <div class="mb-3">
                             <h5 class="mb-2">Actions</h5>
                             <div  id="actionButtons">
-                                <p:commandButton 
-                                    id="btnAdd" 
-                                    value="Add New" 
+                            <p:commandButton
+                                    id="btnAdd"
+                                    value="Add New"
                                     action="#{vmpController.prepareAdd()}"
                                     styleClass="ui-button-success m-1"
-                                    update="detailPanel btnAdd btnEdit btnDelete btnSave btnCancel" 
+                                    update="acVmp detailPanel btnAdd btnEdit btnDelete btnSave btnCancel"
                                     icon="fas fa-plus"
                                     process="@this"
                                     disabled="#{vmpController.editable}"
                                     title="Add a new VMP record">
                                 </p:commandButton>
 
-                                <p:commandButton 
-                                    id="btnEdit" 
+                                <p:commandButton
+                                    id="btnEdit"
                                     value="Edit Selected"
                                     action="#{vmpController.edit()}"
                                     icon="fas fa-edit"
-                                    update="detailPanel btnAdd btnEdit btnDelete btnSave btnCancel lstSelect" 
+                                    update="detailPanel btnAdd btnEdit btnDelete btnSave btnCancel acVmp"
                                     process="@this"
                                     styleClass="ui-button-warning m-1"
                                     disabled="#{vmpController.editable or vmpController.current.id eq null}"
@@ -66,24 +66,24 @@
                         <!-- Selection List -->
                         <div>
                             <h5 class="mb-2">Select VMP</h5>
-                            <p:selectOneListbox 
-                                id="lstSelect"
+                            <p:autoComplete
+                                id="acVmp"
+                                class="w-100"
+                                inputStyleClass="w-100"
                                 value="#{vmpController.current}"
-                                filter="true"
-                                filterMatchMode="contains"
-                                styleClass="w-100" 
-                                style="height: 400px;"
+                                completeMethod="#{vmpController.completeVmp}"
+                                var="vmp"
+                                itemLabel="#{vmp.name}"
+                                itemValue="#{vmp}"
+                                maxResults="10"
+                                minQueryLength="3"
+                                forceSelection="true"
                                 disabled="#{vmpController.editable}">
-                                <f:selectItems 
-                                    value="#{vmpController.selectedItems}" 
-                                    itemLabel="#{v.name}" 
-                                    var="v" 
-                                    itemValue="#{v}"/>
-                                <p:ajax 
-                                    update="detailPanel btnAdd btnEdit btnDelete" 
-                                    process="lstSelect">
-                                </p:ajax>
-                            </p:selectOneListbox>
+                                <p:ajax update="detailPanel btnAdd btnEdit btnDelete" process="acVmp"/>
+                                <p:column headerText="Name" style="padding: 3px;">
+                                    <h:outputText value="#{vmp.name}"/>
+                                </p:column>
+                            </p:autoComplete>
                         </div>
                     </div>
 


### PR DESCRIPTION
## Summary
- Replace VMP select list with PrimeFaces autocomplete driven by `vmpController.completeVmp`
- Update related action buttons and focus to reference the new component

## Testing
- `mvn -q -e -DskipTests package` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:3.3.1 or one of its dependencies could not be resolved)*

------
https://chatgpt.com/codex/tasks/task_e_68a0dfbbe4f4832f831967c8713129c4