### PR TITLE
Default department selection on navigation

### DIFF
--- a/src/main/java/com/divudi/bean/common/WebUserController.java
+++ b/src/main/java/com/divudi/bean/common/WebUserController.java
@@ -911,6 +911,9 @@ public class WebUserController implements Serializable {
         getUserPrivilageController().init();
         getUserPrivilageController().setDepartments(getUserPrivilageController().fillWebUserDepartments(selected));
         getUserPrivilageController().setPrivilegesLoaded(false);
+        if (getUserPrivilageController().getDepartment() == null) {
+            getUserPrivilageController().setDepartment(getSessionController().getDepartment());
+        }
         return "/admin/users/user_privileges?faces-redirect=true";
     }
 

--- a/src/main/java/com/divudi/bean/pharmacy/PharmacyController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacyController.java
@@ -283,6 +283,9 @@ public class PharmacyController implements Serializable {
     // </editor-fold>
     // <editor-fold defaultstate="collapsed" desc="Methods - Navigation">
     public String navigateToBinCard() {
+        if (department == null) {
+            department = getSessionController().getDepartment();
+        }
         return "/pharmacy/bin_card?faces-redirect=true";
     }
 


### PR DESCRIPTION
## Summary
- Default to logged-in user's department when navigating to user privileges if none selected
- Ensure bin card navigation defaults department to current session

## Testing
- `mvn -q -e test` *(fails: Could not resolve org.apache.maven.plugins:maven-resources-plugin:3.3.1)*

------
https://chatgpt.com/codex/tasks/task_e_68a0e15b1f60832fb23c8e5debfcd12b