### PR TITLE
feat: guard stock rates with section privileges

### DIFF
--- a/src/main/java/com/divudi/bean/common/UserPrivilageController.java
+++ b/src/main/java/com/divudi/bean/common/UserPrivilageController.java
@@ -635,6 +635,10 @@ public class UserPrivilageController implements Serializable {
         TreeNode TransferReciveApproval = new DefaultTreeNode(new PrivilegeHolder(Privileges.TransferReciveApproval, "Recieve Approval"), disbursementNode);
         TreeNode PharmacyDisbursementReports = new DefaultTreeNode(new PrivilegeHolder(Privileges.PharmacyDisbursementReports, "Pharmacy Disbursement Reports"), disbursementNode);
         TreeNode PharmacyTransferViewRates = new DefaultTreeNode(new PrivilegeHolder(Privileges.PharmacyTransferViewRates, "Pharmacy Transfer View Rates"), disbursementNode);
+        TreeNode StockRequestViewRates = new DefaultTreeNode(new PrivilegeHolder(Privileges.StockRequestViewRates, "Stock Request View Rates"), disbursementNode);
+        TreeNode ConsumptionViewRates = new DefaultTreeNode(new PrivilegeHolder(Privileges.ConsumptionViewRates, "Consumption View Rates"), disbursementNode);
+        TreeNode StockTransactionViewRates = new DefaultTreeNode(new PrivilegeHolder(Privileges.StockTransactionViewRates, "Stock Transaction View Rates"), disbursementNode);
+        TreeNode DiscardViewRates = new DefaultTreeNode(new PrivilegeHolder(Privileges.DiscardViewRates, "Discard View Rates"), disbursementNode);
 
         TreeNode InpatientMedicationManagementNode = new DefaultTreeNode("Inpatient medication Management", pharmacyNode);
         TreeNode InpatientMedicationManagementMenue = new DefaultTreeNode(new PrivilegeHolder(Privileges.InpatientMedicationManagementMenue, "Procurement Menu"), InpatientMedicationManagementNode);
@@ -645,6 +649,8 @@ public class UserPrivilageController implements Serializable {
         TreeNode PharmacySearchInpatientDirectIssuesbyItem = new DefaultTreeNode(new PrivilegeHolder(Privileges.PharmacySearchInpatientDirectIssuesbyItem, "Pharmacy Search Inpatient Direct Issues by Item"), InpatientMedicationManagementNode);
         TreeNode PharmacySearchInpatientDirectIssueReturnsbyBill = new DefaultTreeNode(new PrivilegeHolder(Privileges.PharmacySearchInpatientDirectIssueReturnsbyBill, "Pharmacy Search Inpatient Direct Issue Returns by Bill"), InpatientMedicationManagementNode);
         TreeNode PharmacysSearchInpatientDirectIssueReturnsbyItem = new DefaultTreeNode(new PrivilegeHolder(Privileges.PharmacysSearchInpatientDirectIssueReturnsbyItem, "Pharmacy Search Inpatient Direct Issue Returns by Item"), InpatientMedicationManagementNode);
+        TreeNode NursingIPBillingViewRates = new DefaultTreeNode(new PrivilegeHolder(Privileges.NursingIPBillingViewRates, "Nursing IP Billing View Rates"), InpatientMedicationManagementNode);
+        TreeNode IPRequestViewRates = new DefaultTreeNode(new PrivilegeHolder(Privileges.IPRequestViewRates, "IP Request View Rates"), InpatientMedicationManagementNode);
 
         TreeNode ProcumentNode = new DefaultTreeNode("Pharmacy Procument", pharmacyNode);
         TreeNode pharmacyProcurementMenu = new DefaultTreeNode(new PrivilegeHolder(Privileges.PharmacyProcurementMenu, "Procurement Menu"), ProcumentNode);

--- a/src/main/java/com/divudi/core/data/Privileges.java
+++ b/src/main/java/com/divudi/core/data/Privileges.java
@@ -542,6 +542,12 @@ public enum Privileges {
     PharmacyReports("Pharmacy Reports"),
     PharmacyTransfer("Pharmacy Transfer"),
     PharmacyTransferViewRates("Pharmacy Transfer View Rates"),
+    NursingIPBillingViewRates("Nursing IP Billing View Rates"),
+    IPRequestViewRates("IP Request View Rates"),
+    StockRequestViewRates("Stock Request View Rates"),
+    ConsumptionViewRates("Consumption View Rates"),
+    StockTransactionViewRates("Stock Transaction View Rates"),
+    DiscardViewRates("Discard View Rates"),
     PharmacySummery("Pharmacy Summary"),
     PharmacyAdministration("Pharmacy Administration"),
     PharmacySetReorderLevel("Pharmacy Set Reorder Level"),
@@ -764,6 +770,12 @@ public enum Privileges {
             case PharmacyPurchase:
             case PharmacyTransfer:
             case PharmacyTransferViewRates:
+            case NursingIPBillingViewRates:
+            case IPRequestViewRates:
+            case StockRequestViewRates:
+            case ConsumptionViewRates:
+            case StockTransactionViewRates:
+            case DiscardViewRates:
             case PharmacyPurchaseWh:
             case PharmacySaleCancel:
             case PharmacySaleReturn:

--- a/src/main/webapp/pharmacy/pharmacy_issue.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_issue.xhtml
@@ -78,7 +78,7 @@
                                                 </p:column>
                                                 <p:column
                                                     headerText="Purchase Rate"
-                                                    rendered="#{configOptionApplicationController.getBooleanValueByKey('Pharmacy Dispotals - Display Purchase Rate',true)}"
+                                                    rendered="#{configOptionApplicationController.getBooleanValueByKey('Consumption - Show Rate and Value', false) and webUserController.hasPrivilege('ConsumptionViewRates')}"
                                                     styleClass="text-end #{commonFunctionsProxy.currentDateTime > i.itemBatch.dateOfExpire ?'ui-messages-fatal': commonFunctionsProxy.dateAfterThreeMonthsCurrentDateTime > i.itemBatch.dateOfExpire ?'ui-messages-warn':''}">
                                                     <h:outputLabel value="#{i.itemBatch.purcahseRate}" >
                                                         <f:convertNumber pattern="#,##0.00" ></f:convertNumber>
@@ -86,7 +86,7 @@
                                                 </p:column>
                                                 <p:column
                                                     headerText="Retail Rate"
-                                                    rendered="#{configOptionApplicationController.getBooleanValueByKey('Pharmacy Dispotals - Display Cost Rate',true)}"
+                                                    rendered="#{configOptionApplicationController.getBooleanValueByKey('Consumption - Show Rate and Value', false) and webUserController.hasPrivilege('ConsumptionViewRates')}"
                                                     styleClass="text-end #{commonFunctionsProxy.currentDateTime > i.itemBatch.dateOfExpire ?'ui-messages-fatal': commonFunctionsProxy.dateAfterThreeMonthsCurrentDateTime > i.itemBatch.dateOfExpire ?'ui-messages-warn':''}">
                                                     <h:outputLabel value="#{i.itemBatch.retailsaleRate}" >
                                                         <f:convertNumber pattern="#,##0.00" ></f:convertNumber>
@@ -94,7 +94,7 @@
                                                 </p:column>
                                                 <p:column
                                                     headerText="Cost Rate"
-                                                    rendered="#{configOptionApplicationController.getBooleanValueByKey('Pharmacy Dispotals - Display Cost Rate',true)}"
+                                                    rendered="#{configOptionApplicationController.getBooleanValueByKey('Consumption - Show Rate and Value', false) and webUserController.hasPrivilege('ConsumptionViewRates')}"
                                                     styleClass="text-end #{commonFunctionsProxy.currentDateTime > i.itemBatch.dateOfExpire ?'ui-messages-fatal': commonFunctionsProxy.dateAfterThreeMonthsCurrentDateTime > i.itemBatch.dateOfExpire ?'ui-messages-warn':''}">
                                                     <h:outputLabel value="#{i.itemBatch.costRate}" >
                                                         <f:convertNumber pattern="#,##0.00" ></f:convertNumber>
@@ -161,7 +161,7 @@
                                                 <f:convertNumber pattern="#,##0.00" />
                                             </p:inputText>
                                         </div>
-                                        <div class="col-1 d-grid" rendered="#{configOptionApplicationController.getBooleanValueByKey('Pharmacy Dispotals - Display Cost Rate',true)}">
+                                        <div class="col-1 d-grid" rendered="#{configOptionApplicationController.getBooleanValueByKey('Consumption - Show Rate and Value', false) and webUserController.hasPrivilege('ConsumptionViewRates')}">
                                             <p:outputLabel value="Retail Rate" for="txtRate" />
                                             <p:inputText
                                                 id="txtRate"
@@ -171,7 +171,7 @@
                                                 <f:convertNumber pattern="#,##0.00" />
                                             </p:inputText>
                                         </div>
-                                        <div class="col-1 d-grid" rendered="#{configOptionApplicationController.getBooleanValueByKey('Pharmacy Dispotals - Display Purchase Rate',true)}">
+                                        <div class="col-1 d-grid" rendered="#{configOptionApplicationController.getBooleanValueByKey('Consumption - Show Rate and Value', false) and webUserController.hasPrivilege('ConsumptionViewRates')}">
                                             <p:outputLabel value="Purchase Rate" for="txtPurchaseRate" />
                                             <p:inputText
                                                 id="txtPurchaseRate"
@@ -181,7 +181,7 @@
                                                 <f:convertNumber pattern="#,##0.00" />
                                             </p:inputText>
                                         </div>
-                                        <div class="col-1 d-grid" rendered="#{configOptionApplicationController.getBooleanValueByKey('Pharmacy Dispotals - Display Cost Rate',true)}">
+                                        <div class="col-1 d-grid" rendered="#{configOptionApplicationController.getBooleanValueByKey('Consumption - Show Rate and Value', false) and webUserController.hasPrivilege('ConsumptionViewRates')}">
                                             <p:outputLabel value="Cost Rate" for="txtCostRate" />
                                             <p:inputText
                                                 id="txtCostRate"
@@ -192,7 +192,7 @@
                                             </p:inputText>
                                         </div>
 
-                                        <div class="col-2 d-grid" rendered="#{configOptionApplicationController.getBooleanValueByKey('Pharmacy Dispotals - Display Purchase Value',true)}">
+                                        <div class="col-2 d-grid" rendered="#{configOptionApplicationController.getBooleanValueByKey('Consumption - Show Rate and Value', false) and webUserController.hasPrivilege('ConsumptionViewRates')}">
                                             <p:outputLabel value="Purchase Value" for="txtPVal" />
                                             <p:inputText
                                                 id="txtPVal"
@@ -202,7 +202,7 @@
                                                 <f:convertNumber pattern="#,##0.00" />
                                             </p:inputText>
                                         </div>
-                                        <div class="col-2 d-grid" rendered="#{configOptionApplicationController.getBooleanValueByKey('Pharmacy Dispotals - Display Retail Value',true)}">
+                                        <div class="col-2 d-grid" rendered="#{configOptionApplicationController.getBooleanValueByKey('Consumption - Show Rate and Value', false) and webUserController.hasPrivilege('ConsumptionViewRates')}">
                                             <p:outputLabel value="Retail Value" for="txtRVal" />
                                             <p:inputText
                                                 id="txtRVal"
@@ -212,7 +212,7 @@
                                                 <f:convertNumber pattern="#,##0.00" />
                                             </p:inputText>
                                         </div>
-                                        <div class="col-2 d-grid" rendered="#{configOptionApplicationController.getBooleanValueByKey('Pharmacy Dispotals - Display Cost Value',true)}">
+                                        <div class="col-2 d-grid" rendered="#{configOptionApplicationController.getBooleanValueByKey('Consumption - Show Rate and Value', false) and webUserController.hasPrivilege('ConsumptionViewRates')}">
                                             <p:outputLabel value="Cost Value" for="txtCostVal" />
                                             <p:inputText
                                                 id="txtCostVal"
@@ -223,7 +223,7 @@
                                             </p:inputText>
                                         </div>     
 
-                                        <div class="col-2 d-grid" rendered="#{configOptionApplicationController.getBooleanValueByKey('Pharmacy Dispotals - Display Issue Value',true)}">
+                                        <div class="col-2 d-grid" rendered="#{configOptionApplicationController.getBooleanValueByKey('Consumption - Show Rate and Value', false) and webUserController.hasPrivilege('ConsumptionViewRates')}">
                                             <p:outputLabel value="Issue Value" for="txtIssueVal" />
                                             <p:inputText
                                                 id="txtIssueVal"
@@ -271,7 +271,7 @@
                                         <p:column headerText="Qty" style="padding: 6px;">
                                             <h:outputLabel value="#{bi.pharmaceuticalBillItem.qty}" ></h:outputLabel>
                                         </p:column>
-                                        <p:column headerText="Issue Rate" style="padding: 6px;" styleClass="text-end">
+                                        <p:column headerText="Issue Rate" style="padding: 6px;" styleClass="text-end" rendered="#{configOptionApplicationController.getBooleanValueByKey('Consumption - Show Rate and Value', false) and webUserController.hasPrivilege('ConsumptionViewRates')}">
                                             <h:outputLabel value="#{bi.billItemFinanceDetails.lineGrossRate}">
                                                 <f:convertNumber pattern="#,##0.00" />
                                             </h:outputLabel>
@@ -280,7 +280,7 @@
                                             headerText="Retail Rate" 
                                             style="padding: 6px;" 
                                             styleClass="text-end"
-                                            rendered="#{configOptionApplicationController.getBooleanValueByKey('Pharmacy Dispotals - Display Cost Rate',true)}">
+                                            rendered="#{configOptionApplicationController.getBooleanValueByKey('Consumption - Show Rate and Value', false) and webUserController.hasPrivilege('ConsumptionViewRates')}">
                                             <h:outputLabel value="#{bi.pharmaceuticalBillItem.itemBatch.retailsaleRate}">
                                                 <f:convertNumber pattern="#,##0.00" />
                                             </h:outputLabel>
@@ -289,7 +289,7 @@
                                             headerText="Purchase Rate" 
                                             style="padding: 6px;" 
                                             styleClass="text-end"
-                                            rendered="#{configOptionApplicationController.getBooleanValueByKey('Pharmacy Dispotals - Display Purchase Rate',true)}">
+                                            rendered="#{configOptionApplicationController.getBooleanValueByKey('Consumption - Show Rate and Value', false) and webUserController.hasPrivilege('ConsumptionViewRates')}">
                                             <h:outputLabel value="#{bi.pharmaceuticalBillItem.itemBatch.purcahseRate}">
                                                 <f:convertNumber pattern="#,##0.00" />
                                             </h:outputLabel>
@@ -298,7 +298,7 @@
                                             headerText="Cost Rate" 
                                             style="padding: 6px;" 
                                             styleClass="text-end"
-                                            rendered="#{configOptionApplicationController.getBooleanValueByKey('Pharmacy Dispotals - Display Cost Rate',true)}">
+                                            rendered="#{configOptionApplicationController.getBooleanValueByKey('Consumption - Show Rate and Value', false) and webUserController.hasPrivilege('ConsumptionViewRates')}">
                                             <h:outputLabel value="#{bi.pharmaceuticalBillItem.itemBatch.costRate}">
                                                 <f:convertNumber pattern="#,##0.00" />
                                             </h:outputLabel>
@@ -308,7 +308,7 @@
                                             headerText="Purchase Value" 
                                             style="padding: 6px;" 
                                             styleClass="text-end"
-                                            rendered="#{configOptionApplicationController.getBooleanValueByKey('Pharmacy Dispotals - Display Purchase Value',true)}">
+                                            rendered="#{configOptionApplicationController.getBooleanValueByKey('Consumption - Show Rate and Value', false) and webUserController.hasPrivilege('ConsumptionViewRates')}">
                                             <h:outputLabel value="#{bi.billItemFinanceDetails.valueAtPurchaseRate}">
                                                 <f:convertNumber pattern="#,##0.00" />
                                             </h:outputLabel>
@@ -317,7 +317,7 @@
                                             headerText="Retail Value" 
                                             style="padding: 6px;" 
                                             styleClass="text-end"
-                                            rendered="#{configOptionApplicationController.getBooleanValueByKey('Pharmacy Dispotals - Display Retail Value',true)}">
+                                            rendered="#{configOptionApplicationController.getBooleanValueByKey('Consumption - Show Rate and Value', false) and webUserController.hasPrivilege('ConsumptionViewRates')}">
                                             <h:outputLabel value="#{bi.billItemFinanceDetails.valueAtRetailRate}">
                                                 <f:convertNumber pattern="#,##0.00" />
                                             </h:outputLabel>
@@ -326,7 +326,7 @@
                                             headerText="Cost Value" 
                                             style="padding: 6px;" 
                                             styleClass="text-end"
-                                            rendered="#{configOptionApplicationController.getBooleanValueByKey('Pharmacy Dispotals - Display Cost Value',true)}">
+                                            rendered="#{configOptionApplicationController.getBooleanValueByKey('Consumption - Show Rate and Value', false) and webUserController.hasPrivilege('ConsumptionViewRates')}">
                                             <h:outputLabel value="#{bi.billItemFinanceDetails.valueAtCostRate}">
                                                 <f:convertNumber pattern="#,##0.00" />
                                             </h:outputLabel>
@@ -335,7 +335,7 @@
                                             headerText="Issue Value" 
                                             style="padding: 6px;" 
                                             styleClass="text-end"
-                                            rendered="#{configOptionApplicationController.getBooleanValueByKey('Pharmacy Dispotals - Display Issue Value',true)}">
+                                            rendered="#{configOptionApplicationController.getBooleanValueByKey('Consumption - Show Rate and Value', false) and webUserController.hasPrivilege('ConsumptionViewRates')}">
                                             <h:outputLabel value="#{bi.billItemFinanceDetails.lineNetTotal}">
                                                 <f:convertNumber pattern="#,##0.00" />
                                             </h:outputLabel>
@@ -403,7 +403,7 @@
                                         <h:outputText class="mx-4" value="Bill Details" />
                                     </f:facet>
                                     <div class="row g-2">
-                                        <div class="col-12" rendered="#{configOptionApplicationController.getBooleanValueByKey('Pharmacy Dispotals - Display Issue Value',true)}">
+                                        <div class="col-12" rendered="#{configOptionApplicationController.getBooleanValueByKey('Consumption - Show Rate and Value', false) and webUserController.hasPrivilege('ConsumptionViewRates')}">
                                             <div class="d-flex justify-content-between align-items-center">
                                                 <h:outputLabel class="fw-bold text-muted" value="Total Issue Value:" />
                                                 <p:inputText 
@@ -416,7 +416,7 @@
                                             </div>
                                         </div>
 
-                                        <div class="col-12" rendered="#{configOptionApplicationController.getBooleanValueByKey('Pharmacy Dispotals - Display Purchase Value',true)}">
+                                        <div class="col-12" rendered="#{configOptionApplicationController.getBooleanValueByKey('Consumption - Show Rate and Value', false) and webUserController.hasPrivilege('ConsumptionViewRates')}">
                                             <div class="d-flex justify-content-between align-items-center">
                                                 <h:outputLabel class="fw-bold text-muted" value="Total Purchase Value:" />
                                                 <p:inputText 
@@ -429,7 +429,7 @@
                                             </div>
                                         </div>
 
-                                        <div class="col-12" rendered="#{configOptionApplicationController.getBooleanValueByKey('Pharmacy Dispotals - Display Retail Value',true)}">
+                                        <div class="col-12" rendered="#{configOptionApplicationController.getBooleanValueByKey('Consumption - Show Rate and Value', false) and webUserController.hasPrivilege('ConsumptionViewRates')}">
                                             <div class="d-flex justify-content-between align-items-center">
                                                 <h:outputLabel class="fw-bold text-muted" value="Total Retail Value:" />
                                                 <p:inputText 
@@ -442,7 +442,7 @@
                                             </div>
                                         </div>
 
-                                        <div class="col-12" rendered="#{configOptionApplicationController.getBooleanValueByKey('Pharmacy Dispotals - Display Cost Value',true)}">
+                                        <div class="col-12" rendered="#{configOptionApplicationController.getBooleanValueByKey('Consumption - Show Rate and Value', false) and webUserController.hasPrivilege('ConsumptionViewRates')}">
                                             <div class="d-flex justify-content-between align-items-center">
                                                 <h:outputLabel class="fw-bold text-muted" value="Total Cost Value:" />
                                                 <p:inputText 

--- a/src/main/webapp/pharmacy/pharmacy_transfer_issue.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_transfer_issue.xhtml
@@ -132,10 +132,10 @@
                                     </p:inputText>
                                 </p:column>
 
-                                <p:column 
-                                    headerText="Rate" 
-                                    rendered="#{configOptionApplicationController.getBooleanValueByKey('Pharmacy Transfer Issue - Show Rate and Value', false) and webUserController.hasPrivilege('PharmacyTransferViewRates')}"
-                                    width="8em" 
+                                <p:column
+                                    headerText="Rate"
+                                    rendered="#{configOptionApplicationController.getBooleanValueByKey('Stock Transaction - Show Rate and Value', false) and webUserController.hasPrivilege('StockTransactionViewRates')}"
+                                    width="8em"
                                     class="text-end">
                                     <p:inputText autocomplete="off" id="rate" value="#{bItm.billItemFinanceDetails.lineGrossRate}" class="w-100 text-end">
                                         <f:convertNumber pattern="#,##0.00" />
@@ -145,11 +145,11 @@
                                     </p:inputText>
                                 </p:column>
 
-                                <p:column 
+                                <p:column
                                     headerText="Value"
-                                    rendered="#{configOptionApplicationController.getBooleanValueByKey('Pharmacy Transfer Issue - Show Rate and Value', false) and webUserController.hasPrivilege('PharmacyTransferViewRates')}"
-                                    width="8em" 
-                                    class="text-end">                   
+                                    rendered="#{configOptionApplicationController.getBooleanValueByKey('Stock Transaction - Show Rate and Value', false) and webUserController.hasPrivilege('StockTransactionViewRates')}"
+                                    width="8em"
+                                    class="text-end">
                                     <p:inputText autocomplete="off" id="netValue" 
                                                  value="#{bItm.billItemFinanceDetails.netTotal}" class="w-100 text-end">
                                         <f:convertNumber pattern="#,##0.00" />
@@ -196,9 +196,9 @@
                                                 disabled="#{transferIssueController.issuedBill.toDepartment ne null}"
                                                 completeMethod="#{departmentController.completeDept}"/>
 
-                                <h:outputLabel value="Value &nbsp;" rendered="#{configOptionApplicationController.getBooleanValueByKey('Pharmacy Transfer Issue - Show Rate and Value', false) and webUserController.hasPrivilege('PharmacyTransferViewRates')}" />
-                                <h:outputLabel value=": &nbsp;" rendered="#{configOptionApplicationController.getBooleanValueByKey('Pharmacy Transfer Issue - Show Rate and Value', false) and webUserController.hasPrivilege('PharmacyTransferViewRates')}"/>
-                                <h:outputLabel id="billNetTotal" value="#{transferIssueController.issuedBill.netTotal}" rendered="#{configOptionApplicationController.getBooleanValueByKey('Pharmacy Transfer Issue - Show Rate and Value', false) and webUserController.hasPrivilege('PharmacyTransferViewRates')}" />
+                                <h:outputLabel value="Value &nbsp;" rendered="#{configOptionApplicationController.getBooleanValueByKey('Stock Transaction - Show Rate and Value', false) and webUserController.hasPrivilege('StockTransactionViewRates')}" />
+                                <h:outputLabel value=": &nbsp;" rendered="#{configOptionApplicationController.getBooleanValueByKey('Stock Transaction - Show Rate and Value', false) and webUserController.hasPrivilege('StockTransactionViewRates')}"/>
+                                <h:outputLabel id="billNetTotal" value="#{transferIssueController.issuedBill.netTotal}" rendered="#{configOptionApplicationController.getBooleanValueByKey('Stock Transaction - Show Rate and Value', false) and webUserController.hasPrivilege('StockTransactionViewRates')}" />
 
 
 

--- a/src/main/webapp/pharmacy/pharmacy_transfer_request.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_transfer_request.xhtml
@@ -161,7 +161,7 @@
                                             <p:ajax event="keyup" listener="#{transferRequestController.onCurrentQtyChange}" update="txtLineNetValue requestTotals" />
                                         </p:inputText>
                                     </div>
-                                    <h:panelGroup rendered="#{configOptionApplicationController.getBooleanValueByKey('Pharmacy Transfer Request - Show Rate and Value', false) and webUserController.hasPrivilege('PharmacyTransferViewRates')}">
+                                    <h:panelGroup rendered="#{configOptionApplicationController.getBooleanValueByKey('Stock Request - Show Rate and Value', false) and webUserController.hasPrivilege('StockRequestViewRates')}">
                                         <div class="col-1" >
                                             <p:outputLabel value="Rate" for="txtLineGrossRate"/>
                                             <p:inputText id="txtLineGrossRate" class="w-100 text-end"
@@ -171,7 +171,7 @@
                                             </p:inputText>
                                         </div>
                                     </h:panelGroup>
-                                    <h:panelGroup rendered="#{configOptionApplicationController.getBooleanValueByKey('Pharmacy Transfer Request - Show Rate and Value', false) and webUserController.hasPrivilege('PharmacyTransferViewRates')}" >
+                                    <h:panelGroup rendered="#{configOptionApplicationController.getBooleanValueByKey('Stock Request - Show Rate and Value', false) and webUserController.hasPrivilege('StockRequestViewRates')}" >
                                         <div class="col-1">
                                             <p:outputLabel value="Value" for="txtLineNetValue"/>
                                             <p:inputText id="txtLineNetValue" class="w-100 text-end"
@@ -243,14 +243,14 @@
                                         </p:inputText>
                                     </p:column>
 
-                                    <p:column headerText="Transfer Rate" class="text-end" width="8em" rendered="#{configOptionApplicationController.getBooleanValueByKey('Pharmacy Transfer Request - Show Rate and Value', false) and webUserController.hasPrivilege('PharmacyTransferViewRates')}">
+                                    <p:column headerText="Transfer Rate" class="text-end" width="8em" rendered="#{configOptionApplicationController.getBooleanValueByKey('Stock Request - Show Rate and Value', false) and webUserController.hasPrivilege('StockRequestViewRates')}">
                                         <p:inputText value="#{bi.billItemFinanceDetails.lineGrossRate}" class="w-100 text-end">
                                             <f:convertNumber pattern="#,##0.00" />
                                             <p:ajax event="blur" listener="#{transferRequestController.onLineGrossRateChange(bi)}" update="itemList requestTotals"/>
                                         </p:inputText>
                                     </p:column>
 
-                                    <p:column headerText="Transfer Value" class="text-end" width="8em" rendered="#{configOptionApplicationController.getBooleanValueByKey('Pharmacy Transfer Request - Show Rate and Value', false) and webUserController.hasPrivilege('PharmacyTransferViewRates')}">
+                                    <p:column headerText="Transfer Value" class="text-end" width="8em" rendered="#{configOptionApplicationController.getBooleanValueByKey('Stock Request - Show Rate and Value', false) and webUserController.hasPrivilege('StockRequestViewRates')}">
                                         <h:outputLabel value="#{bi.billItemFinanceDetails.lineGrossTotal}">
                                             <f:convertNumber pattern="#,##0.00" />
                                         </h:outputLabel>
@@ -284,9 +284,9 @@
                                     <h:outputLabel class="w-100 text-end" value="#{transferRequestController.toDepartment.name}">
                                     </h:outputLabel>
 
-                                    <h:outputLabel value="Approximate Request Value" rendered="#{configOptionApplicationController.getBooleanValueByKey('Pharmacy Transfer Request - Show Rate and Value', false) and webUserController.hasPrivilege('PharmacyTransferViewRates')}" />
-                                    <h:outputLabel value=": &nbsp;" rendered="#{configOptionApplicationController.getBooleanValueByKey('Pharmacy Transfer Request - Show Rate and Value', false) and webUserController.hasPrivilege('PharmacyTransferViewRates')}"/>
-                                    <h:outputLabel class="w-100 text-end" value="#{transferRequestController.transferRequestBillPre.netTotal}" rendered="#{configOptionApplicationController.getBooleanValueByKey('Pharmacy Transfer Request - Show Rate and Value', false) and webUserController.hasPrivilege('PharmacyTransferViewRates')}">
+                                    <h:outputLabel value="Approximate Request Value" rendered="#{configOptionApplicationController.getBooleanValueByKey('Stock Request - Show Rate and Value', false) and webUserController.hasPrivilege('StockRequestViewRates')}" />
+                                    <h:outputLabel value=": &nbsp;" rendered="#{configOptionApplicationController.getBooleanValueByKey('Stock Request - Show Rate and Value', false) and webUserController.hasPrivilege('StockRequestViewRates')}"/>
+                                    <h:outputLabel class="w-100 text-end" value="#{transferRequestController.transferRequestBillPre.netTotal}" rendered="#{configOptionApplicationController.getBooleanValueByKey('Stock Request - Show Rate and Value', false) and webUserController.hasPrivilege('StockRequestViewRates')}">
                                         <f:convertNumber pattern="#,##0.00" />
                                     </h:outputLabel>
 

--- a/src/main/webapp/ward/ward_pharmacy_bht_issue.xhtml
+++ b/src/main/webapp/ward/ward_pharmacy_bht_issue.xhtml
@@ -62,7 +62,8 @@
                                             <h:outputLabel value="#{i.itemBatch.item.vmp.name}" style="width: 150px!important;"></h:outputLabel>
                                         </p:column>
                                         <p:column headerText="Rate" style="padding: 4px" styleClass="#{commonFunctionsProxy.currentDateTime > i.itemBatch.dateOfExpire ?'ui-messages-fatal':
-                                                                                                       commonFunctionsProxy.dateAfterThreeMonthsCurrentDateTime > i.itemBatch.dateOfExpire ?'ui-messages-warn':''}">
+                                                                                                       commonFunctionsProxy.dateAfterThreeMonthsCurrentDateTime > i.itemBatch.dateOfExpire ?'ui-messages-warn':''}"
+                                                  rendered="#{configOptionApplicationController.getBooleanValueByKey('Nursing IP Billing - Show Rate and Value', false) and webUserController.hasPrivilege('NursingIPBillingViewRates')}">
                                             <h:outputLabel value="#{i.itemBatch.retailsaleRate}" >
                                                 <f:convertNumber pattern="#,##0.00" ></f:convertNumber>
                                             </h:outputLabel>
@@ -308,13 +309,13 @@
                             </h:outputText>
                         </p:column>
 
-                        <p:column headerText="Purchase Rate">
+                        <p:column headerText="Purchase Rate" rendered="#{configOptionApplicationController.getBooleanValueByKey('Nursing IP Billing - Show Rate and Value', false) and webUserController.hasPrivilege('NursingIPBillingViewRates')}">
                             <h:outputText value="#{sStock.itemBatch.purcahseRate}">
                                 <f:convertNumber pattern="#,##0.00"/>
                             </h:outputText>
                         </p:column>
 
-                        <p:column headerText="Retail Rate">
+                        <p:column headerText="Retail Rate" rendered="#{configOptionApplicationController.getBooleanValueByKey('Nursing IP Billing - Show Rate and Value', false) and webUserController.hasPrivilege('NursingIPBillingViewRates')}">
                             <h:outputText value="#{sStock.itemBatch.retailsaleRate}">
                                 <f:convertNumber pattern="#,##0.00"/>
                             </h:outputText>

--- a/src/main/webapp/ward/ward_pharmacy_bht_issue_request_edit.xhtml
+++ b/src/main/webapp/ward/ward_pharmacy_bht_issue_request_edit.xhtml
@@ -266,7 +266,7 @@
                                             <p:column headerText="Code">
                                                 #{ri.itemBatch.item.code}
                                             </p:column>
-                                            <p:column headerText="Rate"  style="text-align: right;">
+                                            <p:column headerText="Rate"  style="text-align: right;" rendered="#{configOptionApplicationController.getBooleanValueByKey('IP Request - Show Rate and Value', false) and webUserController.hasPrivilege('IPRequestViewRates')}">
                                                 <p:outputLabel value="#{ri.itemBatch.retailsaleRate}">
                                                     <f:convertNumber pattern="#,##0.00" ></f:convertNumber>
                                                 </p:outputLabel>


### PR DESCRIPTION
## Summary
- add granular privileges to control rate/value visibility
- show stock values only when relevant privilege granted

## Testing
- `mvn -q -e -DskipTests package` *(fails: Could not transfer artifact org.apache.maven.plugins:maven-resources-plugin: network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a160f88a00832fa9b30a768ba7f020