### PR TITLE
Align totals in pharmacy department stock report footer

### DIFF
--- a/src/main/webapp/pharmacy/pharmacy_report_department_stock_by_batch_dto.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_report_department_stock_by_batch_dto.xhtml
@@ -191,7 +191,7 @@
 
                 <p:columnGroup type="footer">
                     <p:row>
-                        <p:column colspan="6">
+                        <p:column colspan="9">
                             <f:facet name="footer">
                                 <h:outputLabel value="Total" />
                             </f:facet>
@@ -204,6 +204,7 @@
                             </f:facet>
                         </p:column>
                         <p:column />
+                        <p:column />
                         <p:column style="text-align: right;">
                             <f:facet name="footer">
                                 <h:outputLabel value="#{reportsStock.stockCostValue}">
@@ -211,7 +212,6 @@
                                 </h:outputLabel>
                             </f:facet>
                         </p:column>
-                        <p:column />
                         <p:column style="text-align: right;">
                             <f:facet name="footer">
                                 <h:outputLabel value="#{reportsStock.stockSaleValue}">
@@ -221,7 +221,7 @@
                         </p:column>
                     </p:row>
                     <p:row>
-                        <p:column colspan="11">
+                        <p:column colspan="14">
                             <f:facet name="footer">
                                 <h:outputLabel value="Printed At " />
                                 <h:outputLabel value="#{sessionController.currentDate}">


### PR DESCRIPTION
## Summary
- Extend footer Total label to span Purchase Rate column
- Skip Cost Rate and Retail Rate columns so cost and sale totals align
- Stretch Printed At footer across all table columns

## Testing
- `mvn -q -version`


------
https://chatgpt.com/codex/tasks/task_e_68a211773508832fa48c9c0998414066