### PR TITLE
Align cost value totals in department stock report

### DIFF
--- a/src/main/webapp/pharmacy/pharmacy_report_department_stock_by_batch_dto.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_report_department_stock_by_batch_dto.xhtml
@@ -203,7 +203,7 @@
                                 </h:outputLabel>
                             </f:facet>
                         </p:column>
-                        <p:column />
+        <!-- Blank column for Cost Rate -->
                         <p:column />
                         <p:column style="text-align: right;">
                             <f:facet name="footer">
@@ -212,6 +212,8 @@
                                 </h:outputLabel>
                             </f:facet>
                         </p:column>
+        <!-- Blank column for Retail Rate -->
+                        <p:column />
                         <p:column style="text-align: right;">
                             <f:facet name="footer">
                                 <h:outputLabel value="#{reportsStock.stockSaleValue}">


### PR DESCRIPTION
## Summary
- show cost value totals in department stock report footer
- keep footer totals aligned with Cost Rate and Retail Rate columns

## Testing
- `xmllint --noout src/main/webapp/pharmacy/pharmacy_report_department_stock_by_batch_dto.xhtml`


------
https://chatgpt.com/codex/tasks/task_e_68a2165df510832f98e32ead45ddbb37