### PR TITLE
feat: add GRN return approval workflow

### DIFF
--- a/src/main/java/com/divudi/bean/common/BillSearch.java
+++ b/src/main/java/com/divudi/bean/common/BillSearch.java
@@ -11,6 +11,7 @@ import com.divudi.bean.channel.ChannelSearchController;
 import com.divudi.bean.collectingCentre.CollectingCentreBillController;
 import com.divudi.bean.lab.PatientInvestigationController;
 import com.divudi.bean.pharmacy.PharmacyPreSettleController;
+import com.divudi.bean.pharmacy.GrnReturnApprovalController;
 import com.divudi.core.data.BillClassType;
 import com.divudi.core.data.BillNumberSuffix;
 import com.divudi.core.data.BillSummery;
@@ -237,6 +238,8 @@ public class BillSearch implements Serializable {
     IssueReturnController issueReturnController;
     @Inject
     PharmacyIssueController pharmacyIssueController;
+    @Inject
+    GrnReturnApprovalController grnReturnApprovalController;
     @Inject
     TransferIssueController transferIssueController;
     @Inject
@@ -4327,6 +4330,12 @@ public class BillSearch implements Serializable {
             return null;
         }
         loadBillDetails(bill);
+        boolean approvalOnly = configOptionApplicationController.getBooleanValueByKey("GRN Returns is only after Approval", false);
+        if (approvalOnly) {
+            grnReturnApprovalController.setGrnBill(bill);
+            grnReturnApprovalController.prepareReturnRequest();
+            return "/pharmacy/pharmacy_grn_return_request?faces-redirect=true";
+        }
         grnReturnWithCostingController.resetValuesForReturn();
         boolean manageCosting = configOptionApplicationController.getBooleanValueByKey("Manage Costing", true);
         if (manageCosting) {

--- a/src/main/java/com/divudi/bean/common/ConfigOptionApplicationController.java
+++ b/src/main/java/com/divudi/bean/common/ConfigOptionApplicationController.java
@@ -144,7 +144,9 @@ public class ConfigOptionApplicationController implements Serializable {
         getBooleanValueByKey("Display Colours for Stock Autocomplete Items", true);
         getBooleanValueByKey("Enable Consignment in Pharmacy Purchasing", true);
         getBooleanValueByKey("Consignment Option is checked in new Pharmacy Purchasing Bills", false);
-        
+        getBooleanValueByKey("GRN Returns is only after Approval", true);
+        getBooleanValueByKey("GRN Return can be done without Approval", true);
+
     }
 
     private void loadPharmacyIssueReceiptConfigurationDefaults() {

--- a/src/main/java/com/divudi/bean/pharmacy/GrnReturnApprovalController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/GrnReturnApprovalController.java
@@ -1,0 +1,146 @@
+package com.divudi.bean.pharmacy;
+
+import com.divudi.core.data.BillType;
+import com.divudi.core.entity.Bill;
+import com.divudi.core.entity.BillItem;
+import com.divudi.core.entity.BilledBill;
+import com.divudi.core.entity.pharmacy.PharmaceuticalBillItem;
+import com.divudi.core.facade.BillFacade;
+import com.divudi.core.facade.BillItemFacade;
+import com.divudi.core.facade.PharmaceuticalBillItemFacade;
+import com.divudi.ejb.PharmacyBean;
+import com.divudi.bean.common.SessionController;
+import com.divudi.core.util.JsfUtil;
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Calendar;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import javax.ejb.EJB;
+import javax.enterprise.context.SessionScoped;
+import javax.inject.Inject;
+import javax.inject.Named;
+
+/**
+ * Handles GRN return workflow with approval.
+ */
+@Named
+@SessionScoped
+public class GrnReturnApprovalController implements Serializable {
+
+    @EJB
+    private BillFacade billFacade;
+    @EJB
+    private BillItemFacade billItemFacade;
+    @EJB
+    private PharmaceuticalBillItemFacade pharmaceuticalBillItemFacade;
+    @EJB
+    private PharmacyBean pharmacyBean;
+
+    @Inject
+    private SessionController sessionController;
+
+    private Bill grnBill;
+    private Bill pendingReturn;
+
+    public void prepareReturnRequest() {
+        if (grnBill == null) {
+            JsfUtil.addErrorMessage("No GRN selected");
+            return;
+        }
+        pendingReturn = new BilledBill();
+        pendingReturn.setBillType(BillType.PharmacyGrnReturn);
+        pendingReturn.setReferenceBill(grnBill);
+        pendingReturn.setDepartment(sessionController.getDepartment());
+        pendingReturn.setInstitution(sessionController.getInstitution());
+        pendingReturn.setFromInstitution(grnBill.getToInstitution());
+        pendingReturn.setToDepartment(grnBill.getDepartment());
+        pendingReturn.setCreatedAt(new Date());
+        pendingReturn.setCreater(sessionController.getLoggedUser());
+        pendingReturn.setBillItems(new ArrayList<>());
+        pendingReturn.setPaid(false);
+        pendingReturn.setBalance(pendingReturn.getNetTotal());
+    }
+
+    public String saveReturnRequest() {
+        if (pendingReturn == null) {
+            JsfUtil.addErrorMessage("Nothing to save");
+            return null;
+        }
+        if (pendingReturn.getId() == null) {
+            billFacade.create(pendingReturn);
+        } else {
+            billFacade.edit(pendingReturn);
+        }
+        for (BillItem bi : pendingReturn.getBillItems()) {
+            bi.setBill(pendingReturn);
+            if (bi.getPharmaceuticalBillItem() != null) {
+                PharmaceuticalBillItem pi = bi.getPharmaceuticalBillItem();
+                pi.setBillItem(bi);
+                if (pi.getId() == null) {
+                    pharmaceuticalBillItemFacade.create(pi);
+                } else {
+                    pharmaceuticalBillItemFacade.edit(pi);
+                }
+            }
+            if (bi.getId() == null) {
+                billItemFacade.create(bi);
+            } else {
+                billItemFacade.edit(bi);
+            }
+        }
+        JsfUtil.addSuccessMessage("Return request saved");
+        return "/pharmacy/pharmacy_grn_list_for_return?faces-redirect=true";
+    }
+
+    public List<Bill> getPendingReturns() {
+        String jpql = "select b from Bill b where b.retired=false and b.billType=:bt and b.approveUser is null";
+        Map<String, Object> params = new HashMap<>();
+        params.put("bt", BillType.PharmacyGrnReturn);
+        return billFacade.findByJpql(jpql, params);
+    }
+
+    public void approveReturn(Bill b) {
+        if (b == null) {
+            return;
+        }
+        b.setApproveUser(sessionController.getLoggedUser());
+        b.setApproveAt(Calendar.getInstance().getTime());
+        b.setPaid(true);
+        b.setPaidAmount(b.getNetTotal());
+        b.setBalance(0d);
+        for (BillItem bi : b.getBillItems()) {
+            PharmaceuticalBillItem pbi = bi.getPharmaceuticalBillItem();
+            if (pbi != null) {
+                pharmacyBean.deductFromStock(pbi.getStock(), Math.abs(pbi.getQtyInUnit() + pbi.getFreeQtyInUnit()), pbi, sessionController.getDepartment());
+                double qty = pbi.getQty();
+                double free = pbi.getFreeQty();
+                pbi.setQty(0 - Math.abs(qty));
+                pbi.setFreeQty(0 - Math.abs(free));
+                pharmaceuticalBillItemFacade.edit(pbi);
+            }
+            billItemFacade.edit(bi);
+        }
+        billFacade.edit(b);
+        JsfUtil.addSuccessMessage("Return approved");
+    }
+
+    public Bill getGrnBill() {
+        return grnBill;
+    }
+
+    public void setGrnBill(Bill grnBill) {
+        this.grnBill = grnBill;
+    }
+
+    public Bill getPendingReturn() {
+        return pendingReturn;
+    }
+
+    public void setPendingReturn(Bill pendingReturn) {
+        this.pendingReturn = pendingReturn;
+    }
+}
+

--- a/src/main/webapp/pharmacy/pharmacy_grn_list_for_return.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_grn_list_for_return.xhtml
@@ -192,13 +192,24 @@
                                     <f:setPropertyActionListener target="#{goodsReturnController.bill}" value="#{p}" />
                                 </p:commandButton>
 
-                                <p:commandButton 
+                                <p:commandButton
                                     ajax="false"
                                     icon="pi pi-undo"
                                     title="Return"
                                     action="#{billSearch.navigateToPharmacyGrnReturnBillView()}"
                                     disabled="#{p.cancelled}"
+                                    rendered="#{configOptionApplicationController.getBooleanValueByKey('GRN Return can be done without Approval')}"
                                     styleClass="ui-button-sm ui-button-warning mx-1">
+                                    <f:setPropertyActionListener target="#{billSearch.bill}" value="#{p}" />
+                                </p:commandButton>
+                                <p:commandButton
+                                    ajax="false"
+                                    icon="pi pi-clock"
+                                    title="Return Request"
+                                    action="#{billSearch.navigateToPharmacyGrnReturnBillView()}"
+                                    disabled="#{p.cancelled}"
+                                    rendered="#{configOptionApplicationController.getBooleanValueByKey('GRN Returns is only after Approval')}"
+                                    styleClass="ui-button-sm ui-button-secondary mx-1">
                                     <f:setPropertyActionListener target="#{billSearch.bill}" value="#{p}" />
                                 </p:commandButton>
                             </p:column>

--- a/src/main/webapp/pharmacy/pharmacy_grn_return_approval.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_grn_return_approval.xhtml
@@ -1,0 +1,25 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<!DOCTYPE composition PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<ui:composition xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
+                template="/resources/template/template.xhtml"
+                xmlns:h="http://xmlns.jcp.org/jsf/html"
+                xmlns:p="http://primefaces.org/ui"
+                xmlns:f="http://xmlns.jcp.org/jsf/core">
+    <ui:define name="content">
+        <h:panelGroup rendered="#{configOptionApplicationController.getBooleanValueByKey('GRN Returns is only after Approval')}">
+            <h:form>
+                <p:panel header="Pending GRN Return Approvals">
+                    <p:dataTable value="#{grnReturnApprovalController.pendingReturns}" var="r">
+                        <p:column headerText="Return No">
+                            <h:outputText value="#{r.deptId}" />
+                        </p:column>
+                        <p:column headerText="Approve">
+                            <p:commandButton value="Approve" action="#{grnReturnApprovalController.approveReturn(r)}" update="@form"/>
+                        </p:column>
+                    </p:dataTable>
+                </p:panel>
+            </h:form>
+        </h:panelGroup>
+    </ui:define>
+</ui:composition>
+

--- a/src/main/webapp/pharmacy/pharmacy_grn_return_request.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_grn_return_request.xhtml
@@ -1,0 +1,21 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<!DOCTYPE composition PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<ui:composition xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
+                template="/resources/template/template.xhtml"
+                xmlns:h="http://xmlns.jcp.org/jsf/html"
+                xmlns:p="http://primefaces.org/ui"
+                xmlns:f="http://xmlns.jcp.org/jsf/core">
+    <ui:define name="content">
+        <h:panelGroup rendered="#{configOptionApplicationController.getBooleanValueByKey('GRN Returns is only after Approval')}">
+            <h:form>
+                <p:panel header="GRN Return Request">
+                    <h:outputLabel value="Creating return request for"/>
+                    <h:outputText value=" #{grnReturnApprovalController.grnBill.deptId}"/>
+                    <br/>
+                    <p:commandButton value="Save Request" action="#{grnReturnApprovalController.saveReturnRequest()}" update="@form"/>
+                </p:panel>
+            </h:form>
+        </h:panelGroup>
+    </ui:define>
+</ui:composition>
+


### PR DESCRIPTION
## Summary
- add config flags to control GRN return approval flow
- gate existing Return button and add Return Request button
- introduce GrnReturnApprovalController with pages for request and approval

## Testing
- `mvn -q test` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:3.3.1... Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a232623b30832f8b8bb444df7c4cef