### PR TITLE
refactor: retire purchase order items

### DIFF
--- a/src/main/java/com/divudi/bean/pharmacy/PurchaseOrderRequestController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PurchaseOrderRequestController.java
@@ -194,27 +194,36 @@ public class PurchaseOrderRequestController implements Serializable {
 
     public void removeItem(BillItem bi) {
         Bill currentBill = getCurrentBill();
-        if (currentBill == null) {
+        if (currentBill == null || bi == null) {
             return;
         }
 
+        Date now = new Date();
+
+        bi.setRetired(true);
+        bi.setRetirer(sessionController.getLoggedUser());
+        bi.setRetiredAt(now);
+
+        PharmaceuticalBillItem tmpPbi = bi.getPharmaceuticalBillItem();
+        if (tmpPbi != null) {
+            tmpPbi.setRetired(true);
+            tmpPbi.setRetirer(sessionController.getLoggedUser());
+            tmpPbi.setRetiredAt(now);
+        }
+
+        if (bi.getId() != null) {
+            billItemFacade.edit(bi);
+        }
+
+        if (tmpPbi != null && tmpPbi.getId() != null) {
+            pharmaceuticalBillItemFacade.edit(tmpPbi);
+        }
+
         getBillItems().remove(bi);
-        getPharmaceuticalBillItemFacade().remove(bi.getPharmaceuticalBillItem());
 
         calTotal();
 
         currentBillItem = null;
-
-        if (currentBill.getBillTypeAtomic() != BillTypeAtomic.PHARMACY_ORDER_PRE) {
-            return;
-        }
-
-        try {
-            currentBill.getBillItems().remove(bi);
-            getBillFacade().edit(currentBill);
-        } catch (Exception e) {
-            JsfUtil.addErrorMessage(e, "Something went wrong");
-        }
     }
 
     @Inject

--- a/src/main/java/com/divudi/bean/store/StorePurchaseOrderRequestController.java
+++ b/src/main/java/com/divudi/bean/store/StorePurchaseOrderRequestController.java
@@ -128,21 +128,33 @@ public class StorePurchaseOrderRequestController implements Serializable {
     }
 
     public void removeItem(BillItem bi) {
-        //System.err.println("5 " + bi.getItem().getName());
-        //System.err.println("6 " + bi.getSearialNo());
-        ////// // System.out.println("bi = " + bi);
-        if (bi != null) {
-            getBillItems().remove(bi.getSearialNo());
-            if (bi.getId() != null) {
-                bi.setRetired(true);
-                bi.setCreater(getSessionController().getLoggedUser());
-                bi.setCreatedAt(new Date());
-                billItemFacade.edit(bi);
-            }
-            calTotal();
-            billFacade.edit(currentBill);
+        if (bi == null) {
+            return;
         }
 
+        getBillItems().remove(bi.getSearialNo());
+
+        Date now = new Date();
+
+        bi.setRetired(true);
+        bi.setRetirer(getSessionController().getLoggedUser());
+        bi.setRetiredAt(now);
+
+        PharmaceuticalBillItem tmpPbi = bi.getPharmaceuticalBillItem();
+        if (tmpPbi != null) {
+            tmpPbi.setRetired(true);
+            tmpPbi.setRetirer(getSessionController().getLoggedUser());
+            tmpPbi.setRetiredAt(now);
+        }
+
+        if (bi.getId() != null) {
+            billItemFacade.edit(bi);
+        }
+        if (tmpPbi != null && tmpPbi.getId() != null) {
+            pharmaceuticalBillItemFacade.edit(tmpPbi);
+        }
+
+        calTotal();
     }
 
     @Inject


### PR DESCRIPTION
## Summary
- mark purchase order request items and their pharmaceutical details as retired instead of deleting
- align store purchase order requests with retire-first removal

## Testing
- `mvn -q -e test` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:3.3.1 or one of its dependencies could not be resolved: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a2de032ab4832f8035e5bf55be4918