### PR TITLE
feat: add pharmacy donation receipt

### DIFF
--- a/src/main/webapp/resources/pharmacy/pharmacy_donation_receipt.xhtml
+++ b/src/main/webapp/resources/pharmacy/pharmacy_donation_receipt.xhtml
@@ -1,0 +1,184 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:cc="http://xmlns.jcp.org/jsf/composite"
+      xmlns:f="http://xmlns.jcp.org/jsf/core"
+      xmlns:h="http://xmlns.jcp.org/jsf/html"
+      xmlns:ui="http://xmlns.jcp.org/jsf/facelets">
+
+    <!-- INTERFACE -->
+    <cc:interface>
+        <cc:attribute name="bill" type="com.divudi.core.entity.Bill"/>
+        <cc:attribute name="duplicate" />
+    </cc:interface>
+
+    <!-- IMPLEMENTATION -->
+    <cc:implementation>
+
+        <style>
+            <h:outputText escape="false"
+                          value="#{configOptionApplicationController.getLongTextValueByKey('Pharmacy Donation Receipt CSS')}"/>
+        </style>
+
+        <h:outputText escape="false"
+                      value="#{configOptionApplicationController.getLongTextValueByKey('Pharmacy Donation Receipt Header')}"/>
+
+        <div class="receipt-container">
+            <div class="receipt-header">
+                <div class="receipt-institution-name">
+                    <h:outputLabel value="#{cc.attrs.bill.department.printingName}" />
+                </div>
+                <div class="receipt-institution-contact">
+                    <h:outputLabel value="#{cc.attrs.bill.department.address}" /><br/>
+                    <h:outputLabel value="#{cc.attrs.bill.department.telephone1}" /><br/>
+                    <h:outputLabel value=" #{cc.attrs.bill.department.telephone2}" /><br/>
+                    <h:outputLabel value="#{cc.attrs.bill.department.fax}" />
+                </div>
+            </div>
+
+            <div class="receipt-title">
+                <h:outputLabel value="Pharmacy Donation Receipt" />
+                <h:outputLabel value="**Duplicate**" rendered="#{cc.attrs.duplicate eq true}"/>
+                <h:outputLabel value="**Cancelled**" rendered="#{cc.attrs.bill.cancelled eq true}"/>
+            </div>
+
+            <div class="receipt-separator"><hr /></div>
+
+            <div class="receipt-bill-details">
+                <table class="receipt-details-table">
+                    <tr>
+                        <td><h:outputLabel value="Date" styleClass="label" /></td>
+                        <td><h:outputLabel value=":" /></td>
+                        <td colspan="4">
+                            <h:outputLabel value="#{cc.attrs.bill.createdAt}">
+                                <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateFormat}" />
+                            </h:outputLabel>
+                            <h:outputLabel value="#{cc.attrs.bill.createdAt}">
+                                <f:convertDateTime timeZone="Asia/Colombo" pattern="#{sessionController.applicationPreference.shortTimeFormat}" />
+                            </h:outputLabel>
+                        </td>
+                    </tr>
+                    <tr>
+                        <td><h:outputLabel value="Receipt No" styleClass="label" /></td>
+                        <td><h:outputLabel value=":" /></td>
+                        <td colspan="4"><h:outputLabel value="#{cc.attrs.bill.deptId}" /></td>
+                    </tr>
+                    <tr>
+                        <td><h:outputLabel value="Donor" styleClass="label" /></td>
+                        <td><h:outputLabel value=":" /></td>
+                        <td colspan="4"><h:outputLabel value="#{cc.attrs.bill.fromInstitution.name}" /></td>
+                    </tr>
+                </table>
+            </div>
+
+            <div class="receipt-separator"><hr /></div>
+
+            <div class="receipt-items-section">
+                <table class="receipt-items-table">
+                    <thead>
+                        <tr>
+                            <th class="item-name">Item</th>
+                            <th class="item-name">Batch</th>
+                            <th class="item-qty">DOE</th>
+                            <th class="item-rate">Cost Rate</th>
+                            <th class="item-qty">Qty</th>
+                            <th class="item-value">Value</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <ui:repeat value="#{billBeanController.fetchBillItems(cc.attrs.bill)}" var="bip">
+                            <tr>
+                                <td class="item-name">
+                                    <h:outputLabel value="#{bip.item.name}" />
+                                </td>
+                                <td class="item-name">
+                                    <h:outputLabel value="#{bip.pharmaceuticalBillItem.itemBatch.batchNo}" />
+                                </td>
+                                <td class="item-qty">
+                                    <h:outputLabel value="#{bip.pharmaceuticalBillItem.itemBatch.dateOfExpire}">
+                                        <f:convertDateTime pattern="#{sessionController.applicationPreference.shortDateFormat}" />
+                                    </h:outputLabel>
+                                </td>
+                                <td class="item-rate">
+                                    <h:outputLabel value="#{bip.billItemFinanceDetails.lineCostRate}">
+                                        <f:convertNumber pattern="#,##0.00" />
+                                    </h:outputLabel>
+                                </td>
+                                <td class="item-qty">
+                                    <h:outputLabel value="#{bip.billItemFinanceDetails.quantity}">
+                                        <f:convertNumber integerOnly="true" />
+                                    </h:outputLabel>
+                                </td>
+                                <td class="item-value">
+                                    <h:outputLabel value="#{bip.billItemFinanceDetails.valueAtCostRate}">
+                                        <f:convertNumber pattern="#,##0.00" />
+                                    </h:outputLabel>
+                                </td>
+                            </tr>
+                        </ui:repeat>
+                    </tbody>
+                </table>
+            </div>
+
+            <div class="receipt-separator"><hr /></div>
+
+            <div class="receipt-summary">
+                <table class="receipt-summary-table">
+                    <tr>
+                        <td class="summary-label">Total Cost</td>
+                        <td class="summary-value">
+                            <h:outputLabel value="#{cc.attrs.bill.billFinanceDetails.totalCostValue}">
+                                <f:convertNumber pattern="#,##0.00" />
+                            </h:outputLabel>
+                        </td>
+                    </tr>
+                    <tr>
+                        <td class="summary-label">Expenses</td>
+                        <td class="summary-value">
+                            <h:outputLabel value="#{cc.attrs.bill.billFinanceDetails.totalExpense}">
+                                <f:convertNumber pattern="#,##0.00" />
+                            </h:outputLabel>
+                        </td>
+                    </tr>
+                    <tr>
+                        <td class="summary-label">Taxes</td>
+                        <td class="summary-value">
+                            <h:outputLabel value="#{cc.attrs.bill.billFinanceDetails.totalTaxValue}">
+                                <f:convertNumber pattern="#,##0.00" />
+                            </h:outputLabel>
+                        </td>
+                    </tr>
+                    <tr>
+                        <td class="summary-label">Net Value</td>
+                        <td class="summary-value">
+                            <h:outputLabel value="#{cc.attrs.bill.billFinanceDetails.netTotal}">
+                                <f:convertNumber pattern="#,##0.00" />
+                            </h:outputLabel>
+                        </td>
+                    </tr>
+                </table>
+            </div>
+
+            <div class="receipt-signatures">
+                <table class="receipt-staff-table">
+                    <tr>
+                        <td class="staff-label">Prepared By:</td>
+                        <td class="staff-value"><h:outputLabel value="#{cc.attrs.bill.creater.webUserPerson.name}" /></td>
+                    </tr>
+                    <tr>
+                        <td class="staff-label">Authorized By:</td>
+                        <td class="staff-value">_________________________</td>
+                    </tr>
+                    <tr>
+                        <td class="staff-label">Received By:</td>
+                        <td class="staff-value">_________________________</td>
+                    </tr>
+                </table>
+            </div>
+        </div>
+
+        <h:outputText escape="false"
+                      value="#{configOptionApplicationController.getLongTextValueByKey('Pharmacy Donation Receipt Footer')}"/>
+
+    </cc:implementation>
+</html>


### PR DESCRIPTION
## Summary
- add pharmacy donation receipt component based on existing receipts
- show donor information, item cost rates, totals, and sign-off area

## Testing
- `xmllint --noout src/main/webapp/resources/pharmacy/pharmacy_donation_receipt.xhtml` *(fails: command not found)*
- `apt-get install -y libxml2-utils` *(fails: package not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a2edfc0e04832fa9ad61044fba6cb8