### PR TITLE
feat: add donation bill list report

### DIFF
--- a/src/main/java/com/divudi/bean/pharmacy/PharmacyProcurementReportController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacyProcurementReportController.java
@@ -37,10 +37,14 @@ import com.divudi.core.facade.DrawerFacade;
 import com.divudi.core.facade.PaymentFacade;
 import com.divudi.core.util.CommonFunctions;
 import com.divudi.service.BillService;
+import com.divudi.core.light.common.BillLight;
+import com.divudi.core.util.JsfUtil;
 import java.io.Serializable;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.Date;
 import java.util.List;
+import java.util.Map;
 import javax.ejb.EJB;
 import javax.enterprise.context.SessionScoped;
 import javax.inject.Inject;
@@ -48,6 +52,8 @@ import javax.inject.Named;
 import org.primefaces.model.file.UploadedFile;
 
 import org.primefaces.model.StreamedContent;
+import javax.persistence.TemporalType;
+import com.divudi.core.entity.Bill;
 // </editor-fold>
 
 /**
@@ -179,10 +185,33 @@ public class PharmacyProcurementReportController implements Serializable {
     // Numeric variables
     private int maxResult = 50;
 
+    private List<BillLight> donationBills;
+    private BillLight billLight;
+
 // </editor-fold>
 // <editor-fold defaultstate="collapsed" desc="Navigators">
     public String navigateToPurchaseItemList() {
         return "/pharmacy/reports/procurement_reports/purchase_item_list?faces-redirect=true";
+    }
+
+    public String navigateToDonationBillList() {
+        generateDonationBillList();
+        return "/pharmacy/reports/procurement_reports/donation_bill_list?faces-redirect=true";
+    }
+
+    public String navigateToDonationBillListPrint() {
+        generateDonationBillList();
+        return "/pharmacy/reports/procurement_reports/donation_bill_list_print?faces-redirect=true";
+    }
+
+    public String navigateToViewDonationBill() {
+        if (billLight == null) {
+            JsfUtil.addErrorMessage("No Bill Selected");
+            return null;
+        }
+        Bill b = billFacade.find(billLight.getId());
+        pharmacyBillSearch.setBill(b);
+        return "/pharmacy/pharmacy_reprint_purchase?faces-redirect=true";
     }
 
 
@@ -244,6 +273,26 @@ public class PharmacyProcurementReportController implements Serializable {
 
         }
         bundle.generateProcurementDetailsForBillItems();
+    }
+
+    private void generateDonationBillList() {
+        Map<String, Object> m = new HashMap<>();
+        String jpql = "select new com.divudi.core.light.common.BillLight(b.id, b.deptId, b.createdAt, b.institution.name, b.toDepartment.name, b.creater.name, b.fromInstitution.name, b.fromInstitution.phone, b.total, b.discount, b.netTotal, b.fromInstitution.id) "
+                + " from Bill b where b.retired=:ret and b.billType=:bt and b.createdAt between :fromDate and :toDate";
+        if (institution != null) {
+            jpql += " and b.institution=:ins";
+            m.put("ins", institution);
+        }
+        if (department != null) {
+            jpql += " and b.department=:dep";
+            m.put("dep", department);
+        }
+        jpql += " order by b.createdAt desc";
+        m.put("ret", false);
+        m.put("bt", BillType.PharmacyDonationBill);
+        m.put("fromDate", fromDate);
+        m.put("toDate", toDate);
+        donationBills = billFacade.findLightsByJpql(jpql, m, TemporalType.TIMESTAMP);
     }
 
 // </editor-fold>
@@ -1126,6 +1175,25 @@ public class PharmacyProcurementReportController implements Serializable {
      */
     public void setFile(UploadedFile file) {
         this.file = file;
+    }
+
+    public List<BillLight> getDonationBills() {
+        if (donationBills == null) {
+            donationBills = new ArrayList<>();
+        }
+        return donationBills;
+    }
+
+    public void setDonationBills(List<BillLight> donationBills) {
+        this.donationBills = donationBills;
+    }
+
+    public BillLight getBillLight() {
+        return billLight;
+    }
+
+    public void setBillLight(BillLight billLight) {
+        this.billLight = billLight;
     }
 
     /**

--- a/src/main/webapp/pharmacy/pharmacy_analytics.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_analytics.xhtml
@@ -346,6 +346,10 @@
                                                              value="Procurement Bill Item List"
                                                              action="#{pharmacyProcurementReportController.navigateToPurchaseItemList()}" />
 
+                                            <p:commandButton rendered="#{configOptionApplicationController.getBooleanValueByKey('Pharmacy Analytics - Show Donation Bills', true)}" class="w-100 ui-button-warning" ajax="false"
+                                                             value="Donation Bills"
+                                                             action="#{pharmacyProcurementReportController.navigateToDonationBillList()}" />
+
                                         </div>
                                     </p:tab>
 

--- a/src/main/webapp/pharmacy/reports/procurement_reports/donation_bill_list.xhtml
+++ b/src/main/webapp/pharmacy/reports/procurement_reports/donation_bill_list.xhtml
@@ -1,0 +1,57 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
+      xmlns:h="http://xmlns.jcp.org/jsf/html"
+      xmlns:p="http://primefaces.org/ui"
+      xmlns:f="http://xmlns.jcp.org/jsf/core">
+
+    <h:body>
+        <ui:composition template="/pharmacy/pharmacy_analytics.xhtml">
+            <ui:define name="subcontent">
+                <h:form>
+                    <p:panel header="Donation Bills">
+                        <p:dataTable value="#{pharmacyProcurementReportController.donationBills}" var="b" paginator="true"
+                                     rows="20" rowIndexVar="i" styleClass="w-100" rowsPerPageTemplate="10,20,50">
+                            <p:column headerText="No">
+                                <h:outputText value="#{i+1}" />
+                            </p:column>
+                            <p:column headerText="Bill No">
+                                <p:commandLink value="#{b.billNo}" ajax="false"
+                                               action="#{pharmacyProcurementReportController.navigateToViewDonationBill()}">
+                                    <f:setPropertyActionListener value="#{b}" target="#{pharmacyProcurementReportController.billLight}" />
+                                </p:commandLink>
+                            </p:column>
+                            <p:column headerText="Date">
+                                <h:outputText value="#{b.billDate}">
+                                    <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateTimeFormat}" />
+                                </h:outputText>
+                            </p:column>
+                            <p:column headerText="Institution">
+                                <h:outputText value="#{b.institutionName}" />
+                            </p:column>
+                            <p:column headerText="Department">
+                                <h:outputText value="#{b.departmentName}" />
+                            </p:column>
+                            <p:column headerText="User">
+                                <h:outputText value="#{b.userName}" />
+                            </p:column>
+                            <p:column headerText="Donator">
+                                <h:outputText value="#{b.patientName}" />
+                            </p:column>
+                            <p:column headerText="Net Total" styleClass="text-end">
+                                <h:outputText value="#{b.netValue}">
+                                    <f:convertNumber pattern="#,##0.00" />
+                                </h:outputText>
+                            </p:column>
+                        </p:dataTable>
+                        <div class="mt-2 d-flex justify-content-end">
+                            <p:commandButton value="Print" icon="pi pi-print" ajax="false"
+                                             action="#{pharmacyProcurementReportController.navigateToDonationBillListPrint()}" />
+                        </div>
+                    </p:panel>
+                </h:form>
+            </ui:define>
+        </ui:composition>
+    </h:body>
+</html>

--- a/src/main/webapp/pharmacy/reports/procurement_reports/donation_bill_list_print.xhtml
+++ b/src/main/webapp/pharmacy/reports/procurement_reports/donation_bill_list_print.xhtml
@@ -1,0 +1,47 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
+      xmlns:h="http://xmlns.jcp.org/jsf/html"
+      xmlns:p="http://primefaces.org/ui"
+      xmlns:f="http://xmlns.jcp.org/jsf/core">
+    <h:body>
+        <ui:composition template="/reports/index.xhtml">
+            <ui:define name="subcontent">
+                <h:form>
+                    <div class="mb-2">
+                        <p:commandButton value="Back" ajax="false" icon="pi pi-arrow-left"
+                                         action="#{pharmacyProcurementReportController.navigateToDonationBillList()}" />
+                        <p:commandButton value="Print" ajax="false" icon="pi pi-print" styleClass="ui-button-info">
+                            <p:printer target="tbl" />
+                        </p:commandButton>
+                    </div>
+                    <p:dataTable id="tbl" value="#{pharmacyProcurementReportController.donationBills}" var="b" styleClass="w-100">
+                        <p:column headerText="Bill No">
+                            <h:outputText value="#{b.billNo}" />
+                        </p:column>
+                        <p:column headerText="Date">
+                            <h:outputText value="#{b.billDate}">
+                                <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateTimeFormat}" />
+                            </h:outputText>
+                        </p:column>
+                        <p:column headerText="Institution">
+                            <h:outputText value="#{b.institutionName}" />
+                        </p:column>
+                        <p:column headerText="Department">
+                            <h:outputText value="#{b.departmentName}" />
+                        </p:column>
+                        <p:column headerText="Donator">
+                            <h:outputText value="#{b.patientName}" />
+                        </p:column>
+                        <p:column headerText="Net Total" styleClass="text-end">
+                            <h:outputText value="#{b.netValue}">
+                                <f:convertNumber pattern="#,##0.00" />
+                            </h:outputText>
+                        </p:column>
+                    </p:dataTable>
+                </h:form>
+            </ui:define>
+        </ui:composition>
+    </h:body>
+</html>


### PR DESCRIPTION
## Summary
- add "Donation Bills" navigation under procurement reports
- enable listing, printing, and viewing of pharmacy donation bills
- introduce pages to display and print donation bill DTOs

## Testing
- `mvn -q -e -DskipTests package` *(fails: Network is unreachable)*
- `mvn -q -e test -DfailIfNoTests=false` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a2ef016494832f91c51e21d8803f4d