### PR TITLE
Add PharmacyDonation privilege and secure donation menus

### DIFF
--- a/src/main/java/com/divudi/core/data/Privileges.java
+++ b/src/main/java/com/divudi/core/data/Privileges.java
@@ -489,6 +489,7 @@ public enum Privileges {
     PharmacyReturnItemsAndPayments("Pharmacy Return Items and Payments"),
     PharmacySearchReturnBill("Pharmacy Search Return Bill"),
     PharmacyAddToStock("Pharmacy Add to Stock"),
+    PharmacyDonation("Pharmacy Donation"),
     // Pharmacy Wholesale Transaction
     PharmacyWholeSaleTransactionMenue("Pharmacy Wholesale Transaction Menu"),
     PharmacyWholeSaleTransaction("Pharmacy Wholesale Transaction"),
@@ -848,6 +849,7 @@ public enum Privileges {
             case PharmacyReturnItemsAndPayments:
             case PharmacySearchReturnBill:
             case PharmacyAddToStock:
+            case PharmacyDonation:
 
             // Wholesale Transaction
             case PharmacyWholeSaleTransaction:

--- a/src/main/webapp/pharmacy/pharmacy_analytics.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_analytics.xhtml
@@ -346,7 +346,7 @@
                                                              value="Procurement Bill Item List"
                                                              action="#{pharmacyProcurementReportController.navigateToPurchaseItemList()}" />
 
-                                            <p:commandButton rendered="#{configOptionApplicationController.getBooleanValueByKey('Pharmacy Analytics - Show Donation Bills', true)}" class="w-100 ui-button-warning" ajax="false"
+                                            <p:commandButton rendered="#{configOptionApplicationController.getBooleanValueByKey('Pharmacy Analytics - Show Donation Bills', true) and webUserController.hasPrivilege('PharmacyDonation')}" class="w-100 ui-button-warning" ajax="false"
                                                              value="Donation Bills"
                                                              action="#{pharmacyProcurementReportController.navigateToDonationBillList()}" />
 

--- a/src/main/webapp/pharmacy/reports/procurement_reports/donation_bill_list.xhtml
+++ b/src/main/webapp/pharmacy/reports/procurement_reports/donation_bill_list.xhtml
@@ -10,7 +10,7 @@
         <ui:composition template="/pharmacy/pharmacy_analytics.xhtml">
             <ui:define name="subcontent">
                 <h:form>
-                    <p:panel header="Donation Bills">
+                    <p:panel header="Donation Bills" rendered="#{webUserController.hasPrivilege('PharmacyDonation')}">
                         <p:dataTable value="#{pharmacyProcurementReportController.donationBills}" var="b" paginator="true"
                                      rows="20" rowIndexVar="i" styleClass="w-100" rowsPerPageTemplate="10,20,50">
                             <p:column headerText="No">

--- a/src/main/webapp/pharmacy/reports/procurement_reports/donation_bill_list_print.xhtml
+++ b/src/main/webapp/pharmacy/reports/procurement_reports/donation_bill_list_print.xhtml
@@ -8,7 +8,7 @@
     <h:body>
         <ui:composition template="/reports/index.xhtml">
             <ui:define name="subcontent">
-                <h:form>
+                <h:form rendered="#{webUserController.hasPrivilege('PharmacyDonation')}">
                     <div class="mb-2">
                         <p:commandButton value="Back" ajax="false" icon="pi pi-arrow-left"
                                          action="#{pharmacyProcurementReportController.navigateToDonationBillList()}" />


### PR DESCRIPTION
## Summary
- add PharmacyDonation privilege to central Privileges enum
- gate donation analytics and reports behind PharmacyDonation privilege checks

## Testing
- `mvn -q -e -DskipTests package` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:pom:3.3.1 could not be resolved: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a2f4560274832fa69446f19b45aed8