### PR TITLE
Update stale printer target IDs from gpBillPreviewTokenAndBill to bil…

### DIFF
--- a/src/main/webapp/pharmacy/pharmacy_bill_retail_sale_for_cashier_1.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_bill_retail_sale_for_cashier_1.xhtml
@@ -762,7 +762,7 @@
                                     icon="fa fa-print"
                                     class="ui-button-info mx-1"
                                     action="#" >
-                                    <p:printer target="gpBillPreviewTokenAndBill" ></p:printer>
+                                    <p:printer target="billAndTokenPrint" ></p:printer>
                                 </p:commandButton>
 
                                 <h:panelGroup rendered="#{webUserController.hasPrivilege('ChangeReceiptPrintingPaperTypes')}">
@@ -793,7 +793,7 @@
                             <p:commandButton icon="fas fa-file-invoice" value="Sale 4" action="/pharmacy/pharmacy_bill_retail_sale_for_cashier_3" rendered="#{webUserController.hasPrivilege('PharmacySale')}" actionListener="#{pharmacySaleController3.pharmacyRetailSale()}" />
                         </div>
 
-                        <h:panelGroup id="gpBillPreviewTokenAndBill">
+                        <h:panelGroup id="billAndTokenPrint">
                             <h:panelGroup  rendered="#{pharmacySaleController1.printBill ne null}"  id="TokenPreview" class="m-2">
                                 <h:panelGroup id="gpBillPreviewPosToken" rendered="#{sessionController.departmentPreference.pharmacyBillPaperType eq 'PosPaper'}">
                                     <div >

--- a/src/main/webapp/pharmacy/pharmacy_bill_retail_sale_for_cashier_2.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_bill_retail_sale_for_cashier_2.xhtml
@@ -752,7 +752,7 @@
                                     icon="fa fa-print"
                                     class="ui-button-info mx-1"
                                     action="#" >
-                                    <p:printer target="gpBillPreviewTokenAndBill" ></p:printer>
+                                    <p:printer target="billAndTokenPrint" ></p:printer>
                                 </p:commandButton>
 
                                 <h:panelGroup rendered="#{webUserController.hasPrivilege('ChangeReceiptPrintingPaperTypes')}">
@@ -783,7 +783,7 @@
                             <p:commandButton icon="fas fa-file-invoice" value="Sale 4" action="/pharmacy/pharmacy_bill_retail_sale_for_cashier_3" rendered="#{webUserController.hasPrivilege('PharmacySale')}" actionListener="#{pharmacySaleController3.pharmacyRetailSale()}" />
                         </div>
 
-                        <h:panelGroup id="gpBillPreviewTokenAndBill">
+                        <h:panelGroup id="billAndTokenPrint">
                             <h:panelGroup  rendered="#{pharmacySaleController2.printBill ne null}"  id="TokenPreview" class="m-2">
                                 <h:panelGroup id="gpBillPreviewPosToken" rendered="#{sessionController.departmentPreference.pharmacyBillPaperType eq 'PosPaper'}">
                                     <div >

--- a/src/main/webapp/pharmacy/pharmacy_bill_retail_sale_for_cashier_3.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_bill_retail_sale_for_cashier_3.xhtml
@@ -767,7 +767,7 @@
                                     icon="fa fa-print"
                                     class="ui-button-info mx-1"
                                     action="#" >
-                                    <p:printer target="gpBillPreviewTokenAndBill" ></p:printer>
+                                    <p:printer target="billAndTokenPrint" ></p:printer>
                                 </p:commandButton>
 
                                 <h:panelGroup rendered="#{webUserController.hasPrivilege('ChangeReceiptPrintingPaperTypes')}">
@@ -798,7 +798,7 @@
                             <p:commandButton icon="fas fa-file-invoice" disabled="true" value="Sale 4" action="/pharmacy/pharmacy_bill_retail_sale_for_cashier_3" rendered="#{webUserController.hasPrivilege('PharmacySale')}" actionListener="#{pharmacySaleController3.pharmacyRetailSale()}" />
                         </div>
 
-                        <h:panelGroup id="gpBillPreviewTokenAndBill">
+                        <h:panelGroup id="billAndTokenPrint">
                             <h:panelGroup  rendered="#{pharmacySaleController3.printBill ne null}"  id="TokenPreview" class="m-2">
                                 <h:panelGroup id="gpBillPreviewPosToken" rendered="#{sessionController.departmentPreference.pharmacyBillPaperType eq 'PosPaper'}">
                                     <div >

--- a/src/main/webapp/pharmacy/pharmacy_fast_retail_sale_for_cashier.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_fast_retail_sale_for_cashier.xhtml
@@ -935,7 +935,7 @@
                                         icon="fa fa-print"
                                         class="ui-button-info m-1"
                                         action="#" >
-                                        <p:printer target="gpBillPreviewTokenAndBill" ></p:printer>
+                                        <p:printer target="billAndTokenPrint" ></p:printer>
                                     </p:commandButton>
                                     <p:commandButton
 
@@ -1003,7 +1003,7 @@
                                 </div>
                             </div>
 
-                            <h:panelGroup id="gpBillPreviewTokenAndBill">
+                            <h:panelGroup id="billAndTokenPrint">
                                 <h:panelGroup  rendered="#{pharmacyFastRetailSaleForCashierController.printBill ne null and (configOptionApplicationController.getBooleanValueByKey('Create Token At Pharmacy Sale For Cashier') or configOptionApplicationController.getBooleanValueByKey('Enable token system in sale for cashier', false))}"  id="TokenPreview" class="m-2">
                                     <h:panelGroup id="gpBillPreviewFiveFiveToken" rendered="#{sessionController.departmentPreference.pharmacyBillPaperType eq 'FiveFivePaper'}">
                                         <div >


### PR DESCRIPTION
…lAndTokenPrint

This commit fixes stale printer target ID references in pharmacy sale pages that were preventing print functionality from working correctly. The old target ID 'gpBillPreviewTokenAndBill' has been updated to 'billAndTokenPrint' to align with the changes made in PR #14943.

Changes made:
- Updated 4 pharmacy sale pages with consistent printer target IDs
- Fixed both <p:printer target> and <h:panelGroup id> references
- Ensures print functionality works correctly for pharmacy cashiers

Files modified:
- src/main/webapp/pharmacy/pharmacy_fast_retail_sale_for_cashier.xhtml
- src/main/webapp/pharmacy/pharmacy_bill_retail_sale_for_cashier_1.xhtml
- src/main/webapp/pharmacy/pharmacy_bill_retail_sale_for_cashier_2.xhtml
- src/main/webapp/pharmacy/pharmacy_bill_retail_sale_for_cashier_3.xhtml

Testing performed:
- Verified no stale 'gpBillPreviewTokenAndBill' references remain
- Confirmed all 'billAndTokenPrint' references are properly updated
- Validated consistent naming across all pharmacy sale pages

Impact:
- Fixes broken print functionality for pharmacy cashiers
- Improves user experience for daily pharmacy operations
- Maintains consistency with existing print target naming

This is a low-risk UI-only change that improves functionality for pharmacy staff across all HMIS healthcare deployments.

Closes #14944

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Standardized the “Print Bill & Token” action across cashier screens to ensure the correct combined content is printed every time.
  - Resolved inconsistencies that could cause incorrect or partial printouts when printing the token and bill together.
  - Improves reliability and user experience for printing during retail and fast retail sales flows, with consistent behavior across related cashier views.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->