### PR TITLE
fix: enable transporter lookup by staff code

### DIFF
--- a/src/main/java/com/divudi/bean/hr/StaffController.java
+++ b/src/main/java/com/divudi/bean/hr/StaffController.java
@@ -924,11 +924,13 @@ public class StaffController implements Serializable {
             suggestions = new ArrayList<>();
         } else {
             sql = "select p from Staff p where p.retired=false and "
-                    + "((p.person.name) like '%" + query.toUpperCase() + "%' or "
-                    + " (p.code) like '%" + query.toUpperCase() + "%' ) and type(p) != Doctor"
+                    + "((p.person.name) like :q or "
+                    + " (p.code) like :q or "
+                    + " (p.staffCode) like :q ) and type(p) != Doctor"
                     + " order by p.person.name";
-            //////System.out.println(sql);
-            suggestions = getFacade().findByJpql(sql, 20);
+            HashMap hm = new HashMap();
+            hm.put("q", "%" + query.toUpperCase() + "%");
+            suggestions = getFacade().findByJpql(sql, hm, 20);
         }
         return suggestions;
     }


### PR DESCRIPTION
## Summary
- allow searching staff by staff code when selecting transporter in transfer issue

## Testing
- `mvn -q -e -DskipTests package` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:3.3.1 or one of its dependencies could not be resolved: Network is unreachable)*

Closes #15004

------
https://chatgpt.com/codex/tasks/task_e_68a3ca3d15cc832fbf551bc4ff9e9aff