### PR TITLE
Remove duplicate PharmacyDonation privilege

### DIFF
--- a/src/main/java/com/divudi/core/data/Privileges.java
+++ b/src/main/java/com/divudi/core/data/Privileges.java
@@ -490,7 +490,6 @@ public enum Privileges {
     PharmacyReturnItemsAndPayments("Pharmacy Return Items and Payments"),
     PharmacySearchReturnBill("Pharmacy Search Return Bill"),
     PharmacyAddToStock("Pharmacy Add to Stock"),
-    PharmacyDonation("Pharmacy Donation"),
     // Pharmacy Wholesale Transaction
     PharmacyWholeSaleTransactionMenue("Pharmacy Wholesale Transaction Menu"),
     PharmacyWholeSaleTransaction("Pharmacy Wholesale Transaction"),


### PR DESCRIPTION
## Summary
- remove duplicate `PharmacyDonation` enum constant from `Privileges`

## Testing
- `mvn -q -e test` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:3.3.1 could not be resolved: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a3166dd358832f97a6086c7ad962c5