### PR TITLE
Use pharmacy_donation_receipt for donation previews and reprints

### DIFF
--- a/src/main/webapp/pharmacy/donation.xhtml
+++ b/src/main/webapp/pharmacy/donation.xhtml
@@ -4,7 +4,8 @@
                 template="/resources/template/template.xhtml"
                 xmlns:h="http://xmlns.jcp.org/jsf/html"
                 xmlns:p="http://primefaces.org/ui"
-                xmlns:f="http://xmlns.jcp.org/jsf/core">
+                xmlns:f="http://xmlns.jcp.org/jsf/core"
+                xmlns:pharmacy="http://xmlns.jcp.org/jsf/composite/pharmacy">
     <ui:define name="content">
         <h:panelGroup rendered="#{!webUserController.hasPrivilege('PharmacyDonation')}">
             <h:outputText value="You are not authorized" styleClass="text-danger"/>
@@ -165,34 +166,7 @@
                             </div>
                         </f:facet>
                         <h:panelGroup id="gpBillPreview">
-                            <p:dataTable value="#{pharmacyDonationController.bill.billItems}" var="bi">
-                                <p:column headerText="Item">
-                                    <h:outputText value="#{bi.item.name}" />
-                                </p:column>
-                                <p:column headerText="Qty">
-                                    <h:outputText value="#{bi.billItemFinanceDetails.quantity}" />
-                                </p:column>
-                                <p:column headerText="Cost Rate">
-                                    <h:outputText value="#{bi.billItemFinanceDetails.lineCostRate}">
-                                        <f:convertNumber pattern="#,##0.00" />
-                                    </h:outputText>
-                                </p:column>
-                                <p:column headerText="Purchase Rate">
-                                    <h:outputText value="#{bi.billItemFinanceDetails.lineGrossRate}">
-                                        <f:convertNumber pattern="#,##0.00" />
-                                    </h:outputText>
-                                </p:column>
-                                <p:column headerText="Retail Rate">
-                                    <h:outputText value="#{bi.billItemFinanceDetails.retailSaleRate}">
-                                        <f:convertNumber pattern="#,##0.00" />
-                                    </h:outputText>
-                                </p:column>
-                                <p:column headerText="DOE">
-                                    <h:outputText value="#{bi.pharmaceuticalBillItem.doe}">
-                                        <f:convertDateTime pattern="#{sessionController.applicationPreference.shortDateFormat}" />
-                                    </h:outputText>
-                                </p:column>
-                            </p:dataTable>
+                            <pharmacy:pharmacy_donation_receipt bill="#{pharmacyDonationController.bill}"/>
                         </h:panelGroup>
                     </p:panel>
                 </h:panelGroup>

--- a/src/main/webapp/pharmacy/pharmacy_reprint_purchase.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_reprint_purchase.xhtml
@@ -61,11 +61,16 @@
 
 
                         <h:panelGroup id="gpBillPreview" >
-                            <pharmacy:purhcase
-                                bill="#{pharmacyBillSearch.bill}"
-                                ShowProfit="#{configOptionApplicationController.getBooleanValueByKey('Show Profit % in Direct Purchase Bill', true)}"
-                                ShowRetailValue="#{configOptionApplicationController.getBooleanValueByKey('Show Retail Value in Direct Purchase Bill', true)}">
-                            </pharmacy:purhcase>
+                            <h:panelGroup rendered="#{pharmacyBillSearch.bill.billType eq 'PharmacyDonationBill'}">
+                                <pharmacy:pharmacy_donation_receipt bill="#{pharmacyBillSearch.bill}" />
+                            </h:panelGroup>
+                            <h:panelGroup rendered="#{pharmacyBillSearch.bill.billType ne 'PharmacyDonationBill'}">
+                                <pharmacy:purhcase
+                                    bill="#{pharmacyBillSearch.bill}"
+                                    ShowProfit="#{configOptionApplicationController.getBooleanValueByKey('Show Profit % in Direct Purchase Bill', true)}"
+                                    ShowRetailValue="#{configOptionApplicationController.getBooleanValueByKey('Show Retail Value in Direct Purchase Bill', true)}">
+                                </pharmacy:purhcase>
+                            </h:panelGroup>
                         </h:panelGroup>
 
                     </p:panel>


### PR DESCRIPTION
## Summary
- Replace inline donation preview table with `pharmacy_donation_receipt` composite component
- Show donation receipt when reprinting donation bills instead of purchase layout

## Testing
- `mvn -q -N test` *(fails: PluginResolutionException: Could not transfer artifact due to Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a31661a210832f9991e0e29f21fc01