### PR TITLE
14625 navigation button back to po list required in grn receive view

### DIFF
--- a/src/main/webapp/pharmacy/pharmacy_grn.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_grn.xhtml
@@ -15,14 +15,23 @@
                 rendered="#{!grnController.printPreview}">
                 <f:facet name="header">
                     <h:outputLabel value="GRN Receive" />
-                    <p:commandButton  
-                        value="Settle" 
+                    <p:commandButton
+                        ajax="false"
+                        action="/pharmacy/pharmacy_purchase_order_list_for_recieve?faces-redirect=true"
+                        actionListener="#{searchController.makeListNull()}"
+                        class="ui-button-warning"
+                        icon="fa fa-arrow-left"
+                        style="float: right; margin-right: 0.5em;"
+                        value="Back to PO List">
+                    </p:commandButton>
+                    <p:commandButton
+                        value="Settle"
                         action="#{grnController.settle}"
                         class="ui-button-success"
                         icon="fas fa-check"
-                        ajax="false"  
+                        ajax="false"
                         style="float: right;">
-                    </p:commandButton> 
+                    </p:commandButton>
                 </f:facet>
 
 
@@ -380,14 +389,14 @@
                     <div class="d-flex justify-content-between">
                         <h:outputLabel value="GRN Preview " class="mt-2"/>
                         <div class="d-flex gap-2">
-                            <p:commandButton 
-                                ajax="false" 
-                                action="pharmacy_purchase_order_list_for_recieve"
+                            <p:commandButton
+                                ajax="false"
+                                action="/pharmacy/pharmacy_purchase_order_list_for_recieve?faces-redirect=true"
+                                actionListener="#{searchController.makeListNull()}"
                                 class="ui-button-warning"
                                 icon="fa fa-arrow-left"
-                                actionListener="#{grnController.viewPoList()}" 
-                                value="Back to PO List"> 
-                            </p:commandButton>                   
+                                value="Back to PO List">
+                            </p:commandButton>
                             <p:commandButton 
                                 value="Print" 
                                 ajax="false" 

--- a/src/main/webapp/pharmacy/pharmacy_grn_costing.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_grn_costing.xhtml
@@ -18,14 +18,23 @@
                     class="w-100">
                     <f:facet name="header">
                         <h:outputLabel value="Goods Receive" />
-                        <p:commandButton  
-                            value="Settle" 
+                        <p:commandButton
+                            ajax="false"
+                            action="/pharmacy/pharmacy_purchase_order_list_for_recieve?faces-redirect=true"
+                            actionListener="#{searchController.makeListNull()}"
+                            class="ui-button-warning"
+                            icon="fa fa-arrow-left"
+                            style="float: right; margin-right: 0.5em;"
+                            value="Back to PO List">
+                        </p:commandButton>
+                        <p:commandButton
+                            value="Settle"
                             action="#{grnCostingController.settle}"
                             class="ui-button-success"
                             icon="fas fa-check"
-                            ajax="false"  
+                            ajax="false"
                             style="float: right;">
-                        </p:commandButton> 
+                        </p:commandButton>
                     </f:facet>
 
 
@@ -607,14 +616,14 @@
                         <div class="d-flex justify-content-between">
                             <h:outputLabel value="GRN Preview " class="mt-2"/>
                             <div class="d-flex gap-2">
-                                <p:commandButton 
-                                    ajax="false" 
-                                    action="pharmacy_purchase_order_list_for_recieve"
+                                <p:commandButton
+                                    ajax="false"
+                                    action="/pharmacy/pharmacy_purchase_order_list_for_recieve?faces-redirect=true"
+                                    actionListener="#{searchController.makeListNull()}"
                                     class="ui-button-warning"
                                     icon="fa fa-arrow-left"
-                                    actionListener="#{grnCostingController.viewPoList()}" 
-                                    value="Back to PO List"> 
-                                </p:commandButton>                   
+                                    value="Back to PO List">
+                                </p:commandButton>
                                 <p:commandButton 
                                     value="Print" 
                                     ajax="false" 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a “Back to PO List” button in GRN Receive and GRN Costing screens, including their Preview headers, enabling quick return to the Purchase Order list.
  * Ensures a clean, refreshed PO list on return by clearing prior selections/filters.
  * Uses clear visual styling with a left-arrow icon for easier discoverability and is positioned alongside existing action buttons.
  * Maintains existing Settle and Print actions without changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->