### PR TITLE
feat: add DTO-based daily return report

### DIFF
--- a/developer_docs/navigation/reports_navigation.md
+++ b/developer_docs/navigation/reports_navigation.md
@@ -41,6 +41,7 @@ This document lists all pages reachable from the **Reports** menu.
 | **Reports → Collection Center Reports → 12. Collction Centre Investigation List** | `/reports/collectionCenterReports/cc_investigation_list?faces-redirect=true` | `Reports` | |
 | **Reports → Collection Center Reports → 12. Collction Centre Bill Item List** | `/reports/collectionCenterReports/cc_bill_item_list?faces-redirect=true` | `Reports` | |
 | **Reports → Financial Reports → Daily return** | `/reports/financialReports/daily_return?faces-redirect=true` | `Reports` | |
+| **Reports → Financial Reports → Daily return (DTO – fast)** | `/reports/financialReports/daily_return_dto.xhtml?faces-redirect=true` | `Reports` | |
 | **Reports → Financial Reports → Income Breakdown by Category** | `/reports/financialReports/income_breakdown_by_category?faces-redirect=true` | `Reports` | |
 | **Reports → Financial Reports → Bills by Category** | `/reports/financialReports/bills_by_item_category?faces-redirect=true` | `Reports` | |
 | **Reports → Financial Reports → 4. Service Category Wise Bill Details** | `/reports/financialReports/service_category_wise_bill_detail?faces-redirect=true` | `Reports` | |

--- a/src/main/java/com/divudi/bean/common/DailyReturnDtoController.java
+++ b/src/main/java/com/divudi/bean/common/DailyReturnDtoController.java
@@ -1,0 +1,103 @@
+package com.divudi.bean.common;
+
+import com.divudi.core.data.dto.DailyReturnDTO;
+import com.divudi.core.data.dto.DailyReturnItemDTO;
+import com.divudi.core.entity.Department;
+import com.divudi.core.entity.Institution;
+import com.divudi.service.DailyReturnDtoService;
+import java.io.Serializable;
+import java.util.Date;
+import java.util.List;
+import javax.ejb.EJB;
+import javax.enterprise.context.SessionScoped;
+import javax.inject.Named;
+
+/**
+ * Controller for DTO-based Daily Return report.
+ */
+@Named
+@SessionScoped
+public class DailyReturnDtoController implements Serializable {
+
+    @EJB
+    private DailyReturnDtoService dailyReturnDtoService;
+
+    private Date fromDate;
+    private Date toDate;
+    private Institution institution;
+    private Institution site;
+    private Department department;
+    private boolean withProfessionalFee;
+
+    private List<DailyReturnDTO> dailyReturnDtos;
+    private List<DailyReturnItemDTO> dailyReturnItemDtos;
+
+    public void generateDailyReturnDto() {
+        dailyReturnDtos = dailyReturnDtoService.fetchDailyReturnByPaymentMethod(fromDate, toDate);
+        dailyReturnItemDtos = dailyReturnDtoService.fetchDailyReturnItems(fromDate, toDate);
+    }
+
+    public Date getFromDate() {
+        return fromDate;
+    }
+
+    public void setFromDate(Date fromDate) {
+        this.fromDate = fromDate;
+    }
+
+    public Date getToDate() {
+        return toDate;
+    }
+
+    public void setToDate(Date toDate) {
+        this.toDate = toDate;
+    }
+
+    public Institution getInstitution() {
+        return institution;
+    }
+
+    public void setInstitution(Institution institution) {
+        this.institution = institution;
+    }
+
+    public Institution getSite() {
+        return site;
+    }
+
+    public void setSite(Institution site) {
+        this.site = site;
+    }
+
+    public Department getDepartment() {
+        return department;
+    }
+
+    public void setDepartment(Department department) {
+        this.department = department;
+    }
+
+    public boolean isWithProfessionalFee() {
+        return withProfessionalFee;
+    }
+
+    public void setWithProfessionalFee(boolean withProfessionalFee) {
+        this.withProfessionalFee = withProfessionalFee;
+    }
+
+    public List<DailyReturnDTO> getDailyReturnDtos() {
+        return dailyReturnDtos;
+    }
+
+    public void setDailyReturnDtos(List<DailyReturnDTO> dailyReturnDtos) {
+        this.dailyReturnDtos = dailyReturnDtos;
+    }
+
+    public List<DailyReturnItemDTO> getDailyReturnItemDtos() {
+        return dailyReturnItemDtos;
+    }
+
+    public void setDailyReturnItemDtos(List<DailyReturnItemDTO> dailyReturnItemDtos) {
+        this.dailyReturnItemDtos = dailyReturnItemDtos;
+    }
+}

--- a/src/main/java/com/divudi/core/data/dto/DailyReturnDTO.java
+++ b/src/main/java/com/divudi/core/data/dto/DailyReturnDTO.java
@@ -1,0 +1,36 @@
+package com.divudi.core.data.dto;
+
+import com.divudi.core.data.PaymentMethod;
+import java.io.Serializable;
+
+/**
+ * Lightweight projection for Daily Return summaries.
+ */
+public class DailyReturnDTO implements Serializable {
+    private PaymentMethod paymentMethod;
+    private Double total;
+
+    public DailyReturnDTO() {
+    }
+
+    public DailyReturnDTO(PaymentMethod paymentMethod, Double total) {
+        this.paymentMethod = paymentMethod;
+        this.total = total;
+    }
+
+    public PaymentMethod getPaymentMethod() {
+        return paymentMethod;
+    }
+
+    public void setPaymentMethod(PaymentMethod paymentMethod) {
+        this.paymentMethod = paymentMethod;
+    }
+
+    public Double getTotal() {
+        return total;
+    }
+
+    public void setTotal(Double total) {
+        this.total = total;
+    }
+}

--- a/src/main/java/com/divudi/core/data/dto/DailyReturnItemDTO.java
+++ b/src/main/java/com/divudi/core/data/dto/DailyReturnItemDTO.java
@@ -1,0 +1,35 @@
+package com.divudi.core.data.dto;
+
+import java.io.Serializable;
+
+/**
+ * Lightweight projection for detailed Daily Return items.
+ */
+public class DailyReturnItemDTO implements Serializable {
+    private String departmentName;
+    private Double total;
+
+    public DailyReturnItemDTO() {
+    }
+
+    public DailyReturnItemDTO(String departmentName, Double total) {
+        this.departmentName = departmentName;
+        this.total = total;
+    }
+
+    public String getDepartmentName() {
+        return departmentName;
+    }
+
+    public void setDepartmentName(String departmentName) {
+        this.departmentName = departmentName;
+    }
+
+    public Double getTotal() {
+        return total;
+    }
+
+    public void setTotal(Double total) {
+        this.total = total;
+    }
+}

--- a/src/main/java/com/divudi/service/DailyReturnDtoService.java
+++ b/src/main/java/com/divudi/service/DailyReturnDtoService.java
@@ -1,0 +1,43 @@
+package com.divudi.service;
+
+import com.divudi.core.data.dto.DailyReturnDTO;
+import com.divudi.core.data.dto.DailyReturnItemDTO;
+import com.divudi.core.facade.BillFacade;
+import java.util.*;
+import javax.ejb.EJB;
+import javax.ejb.Stateless;
+import javax.persistence.TemporalType;
+
+/**
+ * Service executing direct DTO queries for Daily Return reports.
+ */
+@Stateless
+public class DailyReturnDtoService {
+
+    @EJB
+    private BillFacade billFacade;
+
+    public List<DailyReturnDTO> fetchDailyReturnByPaymentMethod(Date fromDate, Date toDate) {
+        String jpql = "select new com.divudi.core.data.dto.DailyReturnDTO(b.paymentMethod, sum(b.netTotal)) "
+                + "from Bill b "
+                + "where b.retired=false "
+                + "and b.createdAt between :fd and :td "
+                + "group by b.paymentMethod";
+        Map<String, Object> params = new HashMap<>();
+        params.put("fd", fromDate);
+        params.put("td", toDate);
+        return (List<DailyReturnDTO>) billFacade.findLightsByJpql(jpql, params, TemporalType.TIMESTAMP);
+    }
+
+    public List<DailyReturnItemDTO> fetchDailyReturnItems(Date fromDate, Date toDate) {
+        String jpql = "select new com.divudi.core.data.dto.DailyReturnItemDTO(b.department.name, sum(b.netTotal)) "
+                + "from Bill b "
+                + "where b.retired=false "
+                + "and b.createdAt between :fd and :td "
+                + "group by b.department.name";
+        Map<String, Object> params = new HashMap<>();
+        params.put("fd", fromDate);
+        params.put("td", toDate);
+        return (List<DailyReturnItemDTO>) billFacade.findLightsByJpql(jpql, params, TemporalType.TIMESTAMP);
+    }
+}

--- a/src/main/webapp/reports/financialReports/daily_return_dto.xhtml
+++ b/src/main/webapp/reports/financialReports/daily_return_dto.xhtml
@@ -1,0 +1,182 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
+      xmlns:h="http://xmlns.jcp.org/jsf/html"
+      xmlns:p="http://primefaces.org/ui"
+      xmlns:f="http://xmlns.jcp.org/jsf/core"
+      xmlns:ez="http://xmlns.jcp.org/jsf/composite/ezcomp/bundles">
+
+    <h:body class="w-100 border">
+
+        <ui:composition template="/reports/index.xhtml" class="w-100 border">
+            <ui:define name="subcontent">
+                <h:form >
+                    <p:panel   header="Daily Return" class="m-1">
+
+                        <h:panelGrid columns="8" styleClass="w-100 form-grid" columnClasses="label-icon-column, input-column">
+                            <h:panelGroup layout="block" styleClass="form-group">
+                                <h:outputText value="&#xf073;" styleClass="fa ml-5" /> <!-- FontAwesome calendar icon -->
+                                <h:outputLabel value="From" for="fromDate" class="mx-3"/>
+                            </h:panelGroup>
+                            <p:calendar 
+                                styleClass="w-100" 
+                                inputStyleClass="w-100 form-control" 
+                                id="fromDate" 
+                                value="#{dailyReturnDtoController.fromDate}" 
+                                pattern="#{sessionController.applicationPreference.longDateTimeFormat}" 
+                                />
+
+                            <p:spacer width="50" ></p:spacer>
+
+                            <h:panelGroup layout="block" styleClass="form-group">
+                                <h:outputText value="&#xf073;" styleClass="fa mr-2" /> <!-- FontAwesome calendar icon -->
+                                <h:outputLabel value="To" for="toDate" class="mx-3"/>
+                            </h:panelGroup>
+                            <p:calendar 
+                                styleClass="w-100" 
+                                inputStyleClass="w-100 form-control" 
+                                id="toDate" 
+                                value="#{dailyReturnDtoController.toDate}" 
+                                navigator="false" 
+                                pattern="#{sessionController.applicationPreference.longDateTimeFormat}" 
+                                />
+
+                            <p:spacer width="50" ></p:spacer>
+                            <p:spacer width="50" ></p:spacer>
+                            <p:selectBooleanButton
+                                onLabel="With Professional Fee" 
+                                offLabel="without Professional Fee" 
+                                value="#{dailyReturnDtoController.withProfessionalFee}"
+                                onIcon="pi pi-check" 
+                                class="w-100"
+                                offIcon="pi pi-times" 
+                                >
+                            </p:selectBooleanButton>
+
+                            <h:panelGroup layout="block" styleClass="form-group">
+                                <h:outputText value="&#xf19c;" styleClass="fa mr-2" /> <!-- FontAwesome building icon -->
+                                <h:outputLabel value="Institution" for="cmbIns" class="mx-3"/>
+                            </h:panelGroup>
+                            <p:selectOneMenu
+                                id="cmbIns"
+                                styleClass="w-100 form-control" 
+                                value="#{dailyReturnDtoController.institution}" 
+                                filter="true">
+                                <f:selectItem itemLabel="All Institutions" />
+                                <f:selectItems value="#{institutionController.companies}" var="ins" itemLabel="#{ins.name}" itemValue="#{ins}" />
+                                <p:ajax process="cmbIns" update="cmbDept" />
+                            </p:selectOneMenu>
+
+                            <p:spacer ></p:spacer>
+
+                            <h:panelGroup layout="block" styleClass="form-group">
+                                <h:outputText value="&#xf3c5;" styleClass="fa mr-2" /> <!-- FontAwesome map marker icon -->
+                                <h:outputLabel value="Site" for="siteMenu" class="mx-3"/>
+                            </h:panelGroup>
+                            <p:selectOneMenu
+                                id="siteMenu"
+                                styleClass="w-100 form-control"  
+                                value="#{dailyReturnDtoController.site}" 
+                                filter="true">
+                                <f:selectItem itemLabel="All Sites" />
+                                <f:selectItems value="#{institutionController.sites}" var="site" itemLabel="#{site.name}" itemValue="#{site}" />
+                                <p:ajax process="siteMenu" update="cmbDept" />
+                            </p:selectOneMenu>
+
+                            <p:spacer ></p:spacer>
+
+                            <h:panelGroup layout="block" styleClass="form-group">
+                                <h:outputText value="&#xf0e8;" styleClass="fa mr-2" /> <!-- FontAwesome sitemap icon -->
+                                <h:outputLabel value="Department" for="cmbDept" class="mx-3"/>
+                            </h:panelGroup>
+                            <h:panelGroup id="cmbDept">
+
+                                <!-- Component 1: Without Institution and Site -->
+                                <p:selectOneMenu
+                                    rendered="#{dailyReturnDtoController.institution eq null and dailyReturnDtoController.site eq null}"
+                                    styleClass="w-100 form-control"
+                                    value="#{dailyReturnDtoController.department}"
+                                    filterMatchMode="contains"
+                                    filter="true">
+                                    <f:selectItem itemLabel="All Departments" />
+                                    <f:selectItems 
+                                        value="#{departmentController.getDepartmentsOfInstitutionAndSite()}"
+                                        var="d"
+                                        itemLabel="#{d.name}"
+                                        itemValue="#{d}" />
+                                </p:selectOneMenu>
+
+                                <!-- Component 2: With Site Only -->
+                                <p:selectOneMenu
+                                    rendered="#{dailyReturnDtoController.institution eq null and dailyReturnDtoController.site ne null}"
+                                    styleClass="w-100 form-control"
+                                    value="#{dailyReturnDtoController.department}"
+                                    filterMatchMode="contains"
+                                    filter="true">
+                                    <f:selectItem itemLabel="All Departments" />
+                                    <f:selectItems 
+                                        value="#{departmentController.getDepartmentsOfInstitutionAndSite(dailyReturnDtoController.site)}"
+                                        var="d"
+                                        itemLabel="#{d.name}"
+                                        itemValue="#{d}" />
+                                </p:selectOneMenu>
+
+                                <!-- Component 3: With Institution Only -->
+                                <p:selectOneMenu
+                                    rendered="#{dailyReturnDtoController.institution ne null and dailyReturnDtoController.site eq null}"
+                                    styleClass="w-100 form-control"
+                                    value="#{dailyReturnDtoController.department}"
+                                    filterMatchMode="contains"
+                                    filter="true">
+                                    <f:selectItem itemLabel="All Departments" />
+                                    <f:selectItems 
+                                        value="#{departmentController.getDepartmentsOfInstitutionAndSiteForInstitution(dailyReturnDtoController.institution)}"
+                                        var="d"
+                                        itemLabel="#{d.name}"
+                                        itemValue="#{d}" />
+                                </p:selectOneMenu>
+
+                                <!-- Component 4: With Both Institution and Site -->
+                                <p:selectOneMenu
+                                    rendered="#{dailyReturnDtoController.institution ne null and dailyReturnDtoController.site ne null}"
+                                    styleClass="w-100 form-control"
+                                    value="#{dailyReturnDtoController.department}"
+                                    filterMatchMode="contains"
+                                    filter="true">
+                                    <f:selectItem itemLabel="All Departments" />
+                                    <f:selectItems 
+                                        value="#{departmentController.getDepartmentsOfInstitutionAndSite(dailyReturnDtoController.institution, dailyReturnDtoController.site)}"
+                                        var="d"
+                                        itemLabel="#{d.name}"
+                                        itemValue="#{d}" />
+                                </p:selectOneMenu>
+                                
+                            </h:panelGroup>
+                        </h:panelGrid>
+
+                        <p:commandButton
+                            value="Process"
+                            ajax="false"
+                            action="#{dailyReturnDtoController.generateDailyReturnDto()}"
+                            class="ui-button-success m-1"
+                            icon="fas fa-cogs"
+                            style="background-color: #28a745; border-color: #28a745;">
+                        </p:commandButton>
+
+                        <p:dataTable value="#{dailyReturnDtoController.dailyReturnDtos}" var="d"
+                                     rendered="#{not empty dailyReturnDtoController.dailyReturnDtos}">
+                            <p:column headerText="Payment Method">
+                                <h:outputText value="#{d.paymentMethod}" />
+                            </p:column>
+                            <p:column headerText="Total">
+                                <h:outputText value="#{d.total}" />
+                            </p:column>
+                        </p:dataTable>
+
+                    </p:panel>
+                </h:form>
+            </ui:define>
+        </ui:composition>
+    </h:body>
+</html>

--- a/src/main/webapp/reports/index.xhtml
+++ b/src/main/webapp/reports/index.xhtml
@@ -225,6 +225,7 @@
                             <p:tab title="Financial Reports">
                                 <div class="d-grid gap-2">
                                     <p:commandButton   class="w-100"  ajax="false" value="Daily return" action="/reports/financialReports/daily_return?faces-redirect=true"/>
+                                    <p:commandButton   class="w-100"  ajax="false" value="Daily return (DTO – fast)" action="/reports/financialReports/daily_return_dto.xhtml?faces-redirect=true"/>
                                     <p:commandButton   class="w-100"  ajax="false" value="Income Breakdown by Category"  action="/reports/financialReports/income_breakdown_by_category?faces-redirect=true"/>
                                     <p:commandButton   class="w-100"  ajax="false" value="Bills by Category" action="/reports/financialReports/bills_by_item_category?faces-redirect=true"/>
 


### PR DESCRIPTION
## Summary
- add DailyReturnDTO and DailyReturnItemDTO for lightweight daily return projections
- create DailyReturnDtoService and controller to query and expose DTO data
- introduce new JSF page and navigation entry for fast DTO-based daily return report
- document navigation update

## Testing
- `mvn -q -e -ntp test` *(failed: Plugin org.apache.maven.plugins:maven-resources-plugin:3.3.1 could not be resolved: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a40d416f00832f9260b6e04e41a4ed