### PR TITLE
Fix pharmacy issue search to use billed bills

### DIFF
--- a/src/main/java/com/divudi/bean/common/SearchController.java
+++ b/src/main/java/com/divudi/bean/common/SearchController.java
@@ -3378,7 +3378,7 @@ public class SearchController implements Serializable {
     public void listPharmacyIssue() {
         Date startTime = new Date();
 
-        listPharmacyPreBills(BillType.PharmacyIssue);
+        listPharmacyBilledBills(BillType.PharmacyIssue);
 
     }
 
@@ -4664,7 +4664,7 @@ public class SearchController implements Serializable {
         m.put("fromDate", fromDate);
         m.put("bType", BillType.PharmacyIssue);
         m.put("ins", getSessionController().getInstitution());
-        m.put("class", PreBill.class);
+        m.put("class", BilledBill.class);
 
         sql = "select bi from BillItem bi"
                 + " where  type(bi.bill)=:class "


### PR DESCRIPTION
## Summary
- Ensure pharmacy issue searches load billed bills instead of pre bills
- Query issue bill items from billed bill class to retrieve billed issues

## Testing
- `mvn -q test` *(fails: PluginResolutionException - maven-resources-plugin: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a4412e631c832f8760670cfd297648