### PR TITLE
feat: add item filtered purchase report

### DIFF
--- a/developer_docs/navigation/item_wise_purchase_bill_view.md
+++ b/developer_docs/navigation/item_wise_purchase_bill_view.md
@@ -1,0 +1,4 @@
+# Item-wise Purchase/Good Receive Report
+
+- **Navigation**: `Pharmacy → Analytics → Item Reports → Item - wise Purchase/Good Receive`
+- **Viewing bills**: After processing the report, each row lists a bill number. Click the bill number link to open the full bill for further actions such as printing or editing.

--- a/developer_docs/navigation/pharmacy_navigation.md
+++ b/developer_docs/navigation/pharmacy_navigation.md
@@ -39,6 +39,7 @@ This document lists key pages reachable from the **Pharmacy** menu. Each entry s
 | **Pharmacy → Reports → Sale by Date Summary** | `/faces/pharmacy/pharmacy_report_sale_by_date_summery.xhtml` | `ReportsSearchCashCardOwn` | |
 | **Pharmacy → Reports → Stock With Supplier** | `/faces/pharmacy/pharmacy_report_stock_report_with_supplier.xhtml` | `ReportsItemOwn` | |
 | **Pharmacy → Reports → BHT Issue Items With Margin** | `/faces/pharmacy/pharmacy_report_bht_issue_item_with_margin.xhtml` | `ReportsItemOwn` | |
+| **Pharmacy → Analytics → Item Reports → Item - wise Purchase/Good Receive** | `/faces/pharmacy/report_item_vice_purchase_and_good_receive.xhtml` | `PharmacyReports` | |
 | **Pharmacy → Settings → Administration** | `/faces/pharmacy/admin/index.xhtml` | `Pharmacy` | |
 | **Pharmacy → Settings → Importer Categories** | `/faces/pharmacy/pharmacy_importer_category.xhtml` | `Pharmacy` | |
 

--- a/src/main/java/com/divudi/core/data/dto/PharmacyItemPurchaseDTO.java
+++ b/src/main/java/com/divudi/core/data/dto/PharmacyItemPurchaseDTO.java
@@ -1,0 +1,52 @@
+package com.divudi.core.data.dto;
+
+import com.divudi.core.entity.Bill;
+import com.divudi.core.entity.Item;
+import java.io.Serializable;
+
+public class PharmacyItemPurchaseDTO implements Serializable {
+
+    private Bill bill;
+    private Item item;
+    private Double qty;
+    private Double freeQty;
+
+    public PharmacyItemPurchaseDTO(Bill bill, Item item, Double qty, Double freeQty) {
+        this.bill = bill;
+        this.item = item;
+        this.qty = qty;
+        this.freeQty = freeQty;
+    }
+
+    public Bill getBill() {
+        return bill;
+    }
+
+    public void setBill(Bill bill) {
+        this.bill = bill;
+    }
+
+    public Item getItem() {
+        return item;
+    }
+
+    public void setItem(Item item) {
+        this.item = item;
+    }
+
+    public Double getQty() {
+        return qty;
+    }
+
+    public void setQty(Double qty) {
+        this.qty = qty;
+    }
+
+    public Double getFreeQty() {
+        return freeQty;
+    }
+
+    public void setFreeQty(Double freeQty) {
+        this.freeQty = freeQty;
+    }
+}

--- a/src/main/webapp/pharmacy/report_item_vice_purchase_and_good_receive.xhtml
+++ b/src/main/webapp/pharmacy/report_item_vice_purchase_and_good_receive.xhtml
@@ -17,99 +17,138 @@
                     <p:panel header="Item - wise Purchase/Good Receive" >
                         
                         <div class="row">
-                            <div class="col-4">
+                            <div class="col-3">
                                 <h:outputLabel value="Department" />&nbsp;
-                            <p:autoComplete 
-                                completeMethod="#{departmentController.completeDept}" 
-                                var="dept" 
-                                itemLabel="#{dept.name}" 
-                                itemValue="#{dept}" 
-                                forceSelection="true" 
-                                value="#{pharmacyPurchaseController.department}" 
-                                 >
-                            </p:autoComplete>
+                                <p:autoComplete
+                                    completeMethod="#{departmentController.completeDept}"
+                                    var="dept"
+                                    itemLabel="#{dept.name}"
+                                    itemValue="#{dept}"
+                                    forceSelection="true"
+                                    value="#{pharmacyPurchaseController.department}"/>
                             </div>
-                            <div class="col-4">
+                            <div class="col-3">
                                 <h:outputLabel value="From" />&nbsp;
-                            <p:calendar value="#{pharmacyPurchaseController.fromDate}" 
-                                        pattern="#{sessionController.applicationPreference.longDateTimeFormat}"  ></p:calendar>
+                                <p:calendar value="#{pharmacyPurchaseController.fromDate}"
+                                            pattern="#{sessionController.applicationPreference.longDateTimeFormat}" />
                             </div>
-                            <div class="col-4">
+                            <div class="col-3">
                                 <h:outputLabel value="To" />&nbsp;
-                            <p:calendar value="#{pharmacyPurchaseController.toDate}" 
-                                        pattern="#{sessionController.applicationPreference.longDateTimeFormat}"  ></p:calendar>
+                                <p:calendar value="#{pharmacyPurchaseController.toDate}"
+                                            pattern="#{sessionController.applicationPreference.longDateTimeFormat}" />
+                            </div>
+                            <div class="col-3">
+                                <h:outputLabel value="Item" />&nbsp;
+                                <p:autoComplete value="#{pharmacyPurchaseController.selectedItem}"
+                                                completeMethod="#{pharmacyPurchaseController.completeItems}"
+                                                var="it"
+                                                itemLabel="#{it.name}"
+                                                itemValue="#{it}"
+                                                forceSelection="true"
+                                                required="true"/>
                             </div>
                         </div>
 
-                        
+                        <div class="row my-2">
+                            <div class="col">
+                                <p:selectOneRadio value="#{pharmacyPurchaseController.reportType}" layout="responsive" columns="2">
+                                    <f:selectItem itemLabel="By Bill" itemValue="BILL"/>
+                                    <f:selectItem itemLabel="By Bill Item" itemValue="BILL_ITEM"/>
+                                </p:selectOneRadio>
+                            </div>
+                        </div>
 
-                        <h:panelGrid columns="3" class="my-2">
-                            <p:commandButton 
-                                ajax="false" 
-                                value="Process" 
-                                icon="fas fa-arrows-rotate"
+                        <h:panelGrid columns="4" class="my-2">
+                            <p:commandButton
+                                ajax="false"
+                                value="Process"
+                                icon="pi pi-refresh"
                                 class="ui-button-warning"
-                                action="#{pharmacyPurchaseController.fillItemVicePurchaseAndGoodReceive()}" >
-                            </p:commandButton>
-                            <p:commandButton 
-                                ajax="false" 
-                                value="Excel" 
-                                icon="fas fa-file-excel"
+                                action="#{pharmacyPurchaseController.fillItemVicePurchaseAndGoodReceive()}" />
+                            <p:commandButton
+                                ajax="false"
+                                value="Excel"
+                                icon="pi pi-file-excel"
                                 class="ui-button-success mx-2">
-                                <p:dataExporter type="xlsx" target="tbl" fileName="Unit_Issue_Report_by_department"  />
+                                <p:dataExporter type="xlsx" target="tbl" fileName="item_wise_purchase" />
                             </p:commandButton>
-                            <p:commandButton 
-                                value="Print" 
-                                ajax="false" 
-                                icon="fas fa-print"
+                            <p:commandButton
+                                ajax="false"
+                                value="PDF"
+                                icon="pi pi-file-pdf"
+                                class="ui-button-danger mx-2">
+                                <p:dataExporter type="pdf" target="tbl" fileName="item_wise_purchase" />
+                            </p:commandButton>
+                            <p:commandButton
+                                value="Print"
+                                ajax="false"
+                                icon="pi pi-print"
                                 class="ui-button-info"
                                 action="#" >
-                                <p:printer target="gpBillPreview" ></p:printer>
+                                <p:printer target="gpBillPreview" />
                             </p:commandButton>
-
-                            
-
                         </h:panelGrid>
 
 
                         <h:panelGroup id="gpBillPreview">
                             <p:dataTable id="tbl" styleClass="noBorder normalFont"
-                                         stickyHeader="false"
-                                         value="#{pharmacyPurchaseController.rows}" 
-                                         var="i"  
-                                         rowKey="#{i.name}"
+                                         value="#{pharmacyPurchaseController.rows}"
+                                         var="r"
+                                         rowKey="#{r.bill.id}"
                                          rows="10"
                                          paginator="true"
                                          paginatorPosition="bottom"
-                                         paginatorTemplate="{CurrentPageReport}  {FirstPageLink} {PreviousPageLink} {PageLinks} {NextPageLink} {LastPageLink} {RowsPerPageDropdown}"
-                                         rowsPerPageTemplate="20,50,100"
-                                         >
+                                         paginatorTemplate="{CurrentPageReport}  {FirstPageLink} {PreviousPageLink} {PageLinks}{NextPageLink} {LastPageLink} {RowsPerPageDropdown}"
+                                         rowsPerPageTemplate="20,50,100">
+
+                                <p:column headerText="Bill No"
+                                          sortBy="#{r.bill.deptId}"
+                                          filterBy="#{r.bill.deptId}"
+                                          filterMatchMode="contains">
+                                    <p:commandLink value="#{r.bill.deptId}"
+                                                   ajax="false"
+                                                   action="#{pharmacyPurchaseController.viewBill(r.bill)}"/>
+                                </p:column>
+
+                                <p:column headerText="Date"
+                                          sortBy="#{r.bill.createdAt}"
+                                          filterBy="#{r.bill.createdAt}"
+                                          filterMatchMode="contains">
+                                    <h:outputText value="#{r.bill.createdAt}">
+                                        <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateFormat}"/>
+                                    </h:outputText>
+                                </p:column>
 
                                 <p:column headerText="Item"
-                                          sortBy="#{i.name}" 
-                                          filterBy="#{i.name}"
+                                          rendered="#{pharmacyPurchaseController.reportType eq 'BILL_ITEM'}"
+                                          sortBy="#{r.item.name}"
+                                          filterBy="#{r.item.name}"
                                           filterMatchMode="contains">
-                                    <h:outputLabel value="#{i.name}"></h:outputLabel>                                    
+                                    <h:outputText value="#{r.item.name}"/>
                                 </p:column>
 
-                                <p:column headerText="Quantity" 
-                                          style="text-align: right;"
-                                          sortBy="#{i.qty}" 
-                                          filterBy="#{i.qty}" 
-                                          filterMatchMode="contains">
-                                    <h:outputLabel value="#{i.qty}" >
-                                    </h:outputLabel>
+                                <p:column headerText="Quantity"
+                                          sortBy="#{r.qty}"
+                                          filterBy="#{r.qty}"
+                                          filterMatchMode="contains"
+                                          styleClass="text-end">
+                                    <h:outputText value="#{r.qty}">
+                                        <f:convertNumber pattern="#,##0.00"/>
+                                    </h:outputText>
                                 </p:column>
 
-                                <p:column headerText="Free" sortBy="#{i.freeQty}" filterBy="#{i.freeQty}" style="text-align: right;">
-                                    <h:outputLabel value="#{i.freeQty}" >
-                                    </h:outputLabel>
+                                <p:column headerText="Free"
+                                          sortBy="#{r.freeQty}"
+                                          filterBy="#{r.freeQty}"
+                                          filterMatchMode="contains"
+                                          styleClass="text-end">
+                                    <h:outputText value="#{r.freeQty}">
+                                        <f:convertNumber pattern="#,##0.00"/>
+                                    </h:outputText>
                                 </p:column>
 
                             </p:dataTable>
-
-
-                        </h:panelGroup>
+</h:panelGroup>
                     </p:panel>
                 </h:form>
 


### PR DESCRIPTION
## Summary
- add item selector and report-type options for item-wise purchase report
- enable item-family filtering and bill navigation in controller
- document navigation and bill viewing for item-wise purchase report

## Testing
- `mvn -q -e -DskipTests package` *(fails: PluginResolutionException: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a6531c6dfc832fafcf1b7fb38609f3