### PR TITLE
Use autocomplete for VMPP selection

### DIFF
--- a/src/main/webapp/pharmacy/admin/vmpp.xhtml
+++ b/src/main/webapp/pharmacy/admin/vmpp.xhtml
@@ -10,7 +10,7 @@
     <ui:define name="subcontent">
         <h:form>
             <p:growl id="msg"/>
-            <p:focus id="selectFocus" for="lstSelect" />
+            <p:focus id="selectFocus" for="acVmpp" />
             <p:focus id="detailFocus" for="gpDetail" />
             <p:panel header="Manage VMPPs"  >
                 <div class="row" >
@@ -33,7 +33,7 @@
                                     icon="fas fa-trash"
                                     ajax="false" 
                                     process="btnDelete"
-                                    update="gpDetail lstSelect"
+                                    update="gpDetail acVmpp"
                                     onclick="if (!confirm('Are you sure you want to delete this record?'))
                                                 return false;" 
                                     action="#{vmppController.delete()}"  
@@ -41,16 +41,18 @@
                                 </p:commandButton>
                             </h:panelGrid>
 
-                            <p:selectOneListbox
-                                class="w-100" 
-                                filter="true"
-                                filterMatchMode="contains"
-                                id="lstSelect" 
+                            <p:autoComplete
+                                id="acVmpp"
+                                class="w-100"
+                                inputStyleClass="w-100"
                                 value="#{vmppController.current}"
-                                >
-                                <f:selectItems value="#{vmppController.items}" var="vmpp" itemLabel="#{vmpp.name}" itemValue="#{vmpp}" ></f:selectItems>
-                                <p:ajax process="lstSelect" update="gpDetail" ></p:ajax>
-                            </p:selectOneListbox>
+                                forceSelection="true"
+                                completeMethod="#{vmppController.completeVmpp}"
+                                var="i"
+                                itemLabel="#{i.name}"
+                                itemValue="#{i}">
+                                <f:ajax event="itemSelect" execute="@this" render="gpDetail btnDelete"/>
+                            </p:autoComplete>
 
 
                         </p:panel>
@@ -128,7 +130,7 @@
                                 id="btnSave"
                                 value="Save"
                                 process="btnSave gridDetails" 
-                                update="lstSelect msg" 
+                                update="acVmpp msg"
                                 class="m-1 ui-button-warning w-25"
                                 icon="fas fa-save"
                                 action="#{vmppController.saveSelected()}"></p:commandButton>


### PR DESCRIPTION
## Summary
- Replace VMPP list box with autoComplete component bound to `vmppController.current`
- Refresh detail panel via itemSelect Ajax event
- Update focus and command button targets to use new `acVmpp` id

## Testing
- No tests were run; JSF-only change

------
https://chatgpt.com/codex/tasks/task_e_68a9a44f7030832f98fb158aa66094c0