### PR TITLE
feat: add inventory snapshot and adjustment bill types

### DIFF
--- a/src/main/java/com/divudi/core/data/BillType.java
+++ b/src/main/java/com/divudi/core/data/BillType.java
@@ -111,6 +111,9 @@ public enum BillType {
     PharmacyAddtoStock,
     DrawerAdjustment,
     PharmacyMajorAdjustment,
+    PharmacySnapshotBill,
+    PharmacyPhysicalCountBill,
+    PharmacyStockAdjustmentBill,
     ChannelCash(ChannelCashFlow),
     ChannelPaid(ChannelCashFlow),
     ChannelAgent(ChannelCashFlow),
@@ -232,6 +235,12 @@ public enum BillType {
                 return "Pharmacy Sale Bill for Cashier";
             case PharmacyAdjustment:
                 return "Pharmacy Adjustment";
+            case PharmacySnapshotBill:
+                return "Snapshot Bill";
+            case PharmacyPhysicalCountBill:
+                return "Physical Count Bill";
+            case PharmacyStockAdjustmentBill:
+                return "Stock Adjustment Bill";
             case GrnPayment:
                 return "Grn Payment";
             case GrnPaymentPre:


### PR DESCRIPTION
## Summary
- extend BillType enum with Snapshot, Physical Count, and Stock Adjustment bills
- provide human-friendly labels for new bill types

## Testing
- `mvn -q -e -DskipTests package` *(fails: 'dependencies.dependency.version' for jackson modules is missing)*

------
https://chatgpt.com/codex/tasks/task_e_68ab420eaa4c832f805b1fefe21b785b