### PR TITLE
feat: add pharmacy stock management bill types

### DIFF
--- a/src/main/java/com/divudi/core/data/BillTypeAtomic.java
+++ b/src/main/java/com/divudi/core/data/BillTypeAtomic.java
@@ -181,6 +181,9 @@ public enum BillTypeAtomic {
     MULTIPLE_PHARMACY_ORDER_CANCELLED_BILL("Multiple Pharmacy Purchase Order Cancelled", BillCategory.CANCELLATION, ServiceType.PHARMACY, BillFinanceType.NO_FINANCE_TRANSACTIONS, CountedServiceType.PHARMACY, PaymentCategory.CREDIT_SPEND, BillType.PharmacyOrder),
     PHARMACY_RETURN_ITEMS_AND_PAYMENTS_CANCELLATION("Pharmacy Return Items And Payments Cancellation", BillCategory.CANCELLATION, ServiceType.PHARMACY, BillFinanceType.CASH_IN, CountedServiceType.PHARMACY, PaymentCategory.NON_CREDIT_SPEND, BillType.PharmacySale),
     PHARMACY_STOCK_EXPIRY_DATE_AJUSTMENT("Pharmacy Medicine Expiry Date Ajustment", BillCategory.BILL, ServiceType.PHARMACY, BillFinanceType.NO_FINANCE_TRANSACTIONS, CountedServiceType.PHARMACY, PaymentCategory.NO_PAYMENT, BillType.PharmacyAdjustment),
+    PHARMACY_SNAPSHOT_GENERATION("Pharmacy Snapshot Generation", BillCategory.BILL, ServiceType.PHARMACY, BillFinanceType.NO_FINANCE_TRANSACTIONS, CountedServiceType.PHARMACY, PaymentCategory.NO_PAYMENT, BillType.PharmacySnapshotBill),
+    PHARMACY_PHYSICAL_COUNT_ENTRY("Pharmacy Physical Count Entry", BillCategory.BILL, ServiceType.PHARMACY, BillFinanceType.NO_FINANCE_TRANSACTIONS, CountedServiceType.PHARMACY, PaymentCategory.NO_PAYMENT, BillType.PharmacyPhysicalCountBill),
+    PHARMACY_STOCK_ADJUSTMENT_BILL("Pharmacy Stock Adjustment Bill", BillCategory.BILL, ServiceType.PHARMACY, BillFinanceType.NO_FINANCE_TRANSACTIONS, CountedServiceType.PHARMACY, PaymentCategory.CREDIT_SPEND, BillType.PharmacyStockAdjustmentBill),
     PHARMACY_RETURN_WITHOUT_TREASING("Pharmacy Return without a Receipt", BillCategory.REFUND, ServiceType.PHARMACY, BillFinanceType.NO_FINANCE_TRANSACTIONS, CountedServiceType.PHARMACY, PaymentCategory.NO_PAYMENT, BillType.PharmacySale),
     CHANNEL_BOOKING_WITH_PAYMENT("Channel Booking and Payment", BillCategory.BILL, ServiceType.CHANNELLING, BillFinanceType.CASH_IN, CountedServiceType.CHANNELLING, PaymentCategory.NON_CREDIT_SPEND, BillType.ChannelCash),
     CHANNEL_BOOKING_FOR_PAYMENT_ONLINE_PENDING_PAYMENT("Channel Booking For Online Payment - Pending Confirmation", BillCategory.BILL, ServiceType.CHANNELLING, BillFinanceType.NO_FINANCE_TRANSACTIONS, CountedServiceType.CHANNELLING, PaymentCategory.NO_PAYMENT, BillType.ChannelOnCall),
@@ -391,6 +394,12 @@ public enum BillTypeAtomic {
                         return BillTypeAtomic.PHARMACY_WHOLESALE_GRN_BILL;
                     case PharmacyPurchaseBill:
                         return BillTypeAtomic.PHARMACY_DIRECT_PURCHASE;
+                    case PharmacySnapshotBill:
+                        return BillTypeAtomic.PHARMACY_SNAPSHOT_GENERATION;
+                    case PharmacyPhysicalCountBill:
+                        return BillTypeAtomic.PHARMACY_PHYSICAL_COUNT_ENTRY;
+                    case PharmacyStockAdjustmentBill:
+                        return BillTypeAtomic.PHARMACY_STOCK_ADJUSTMENT_BILL;
                 }
                 break;
             case BilledBill:
@@ -401,6 +410,12 @@ public enum BillTypeAtomic {
                         return BillTypeAtomic.PHARMACY_WHOLESALE_GRN_BILL;
                     case PharmacyPurchaseBill:
                         return BillTypeAtomic.PHARMACY_DIRECT_PURCHASE;
+                    case PharmacySnapshotBill:
+                        return BillTypeAtomic.PHARMACY_SNAPSHOT_GENERATION;
+                    case PharmacyPhysicalCountBill:
+                        return BillTypeAtomic.PHARMACY_PHYSICAL_COUNT_ENTRY;
+                    case PharmacyStockAdjustmentBill:
+                        return BillTypeAtomic.PHARMACY_STOCK_ADJUSTMENT_BILL;
                 }
             case CancelledBill:
                 switch (billType) {


### PR DESCRIPTION
## Summary
- add atomic bill types for pharmacy snapshot, physical count, and stock adjustment
- wire new bill types into `getBillTypeAtomic` lookup

## Testing
- `mvn -q -e -DskipTests package` *(fails: Non-resolvable import POM: com.fasterxml.jackson:jackson-bom:pom:2.15.4)*

------
https://chatgpt.com/codex/tasks/task_e_68ab44021458832fbc8ef712f3d5c5c1