### PR TITLE
feat: add privilege for pharmacy physical count approval

### DIFF
--- a/src/main/java/com/divudi/bean/common/UserPrivilageController.java
+++ b/src/main/java/com/divudi/bean/common/UserPrivilageController.java
@@ -684,6 +684,7 @@ public class UserPrivilageController implements Serializable {
         TreeNode PharmacyAdjustmentWholeSaleRate = new DefaultTreeNode(new PrivilegeHolder(Privileges.PharmacyAdjustmentWholeSaleRate, "Pharmacy Adjustment Wholesale Rate"), PharmacyAdjustment);
         TreeNode PharmacyAdjustmentExpiaryDate = new DefaultTreeNode(new PrivilegeHolder(Privileges.PharmacyAdjustmentExpiryDate, "Pharmacy Adjustment Expiary Date"), PharmacyAdjustment);
         TreeNode PharmacyAdjustmentReports = new DefaultTreeNode(new PrivilegeHolder(Privileges.PharmacyAdjustmentSearchAdjustmentBills, "Pharmacy Adjustment Search Adjustment Bills"), PharmacyAdjustment);
+        TreeNode PharmacyPhysicalCountApprove = new DefaultTreeNode(new PrivilegeHolder(Privileges.PharmacyPhysicalCountApprove, "Pharmacy Physical Count Approve"), PharmacyAdjustment);
 
         TreeNode PharmacyDisposal = new DefaultTreeNode("Pharmacy Disposal", pharmacyNode);
         TreeNode pharmacyDisposalMenu = new DefaultTreeNode(new PrivilegeHolder(Privileges.PharmacyDisposalMenue, "Pharmacy Disposal Menue"), PharmacyDisposal);

--- a/src/main/java/com/divudi/core/data/Privileges.java
+++ b/src/main/java/com/divudi/core/data/Privileges.java
@@ -521,6 +521,7 @@ public enum Privileges {
     PharmacyAdjustmentExpiryDate("Pharmacy Adjustment Expiry Date"),
     PharmacyAdjustmentSearchAdjustmentBills("Pharmacy Adjustment Search Adjustment Bills"),
     PharmacyAdjustmentTransferAllStock("Pharmacy Adjustment Transfer All Stock"),
+    PharmacyPhysicalCountApprove("Pharmacy Physical Count Approve"),
     // Pharmacy Dealer Payments
     PharmacyDealerPaymentMenue("Pharmacy Dealer Payment Menu"),
     PharmacyDealerDueSearch("Pharmacy Dealer Due Search"),
@@ -880,6 +881,7 @@ public enum Privileges {
             case PharmacyAdjustmentExpiryDate:
             case PharmacyAdjustmentSearchAdjustmentBills:
             case PharmacyAdjustmentTransferAllStock:
+            case PharmacyPhysicalCountApprove:
 
             // Pharmacy Dealer Payments
             case PharmacyDealerDueSearch:

--- a/src/main/webapp/pharmacy/pharmacy_variant_adjustment.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_variant_adjustment.xhtml
@@ -16,7 +16,7 @@
                         <h:panelGrid columns="4" style="min-width: 100%;">
                             <p:outputLabel value="Purchase order Request Order"/>
                             <p:commandButton action="#{variantAdjustment.onlyVariantItemBySystemStock()}" ajax="false" value="View Only Variant Item By System Stock"/>
-                            <p:commandButton ajax="false"  value="Approve" action="#{variantAdjustment.adjust}"/>
+                            <p:commandButton ajax="false" value="Approve" action="#{variantAdjustment.adjust}" rendered="#{webUserController.hasPrivilege('PharmacyPhysicalCountApprove')}"/>
                             <p:commandButton value="Print" ajax="false" >
                                 <p:printer target="gpBillPreview" ></p:printer>
                             </p:commandButton>

--- a/src/main/webapp/pharmacy/pharmacy_variant_ajustment_pre_list_.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_variant_ajustment_pre_list_.xhtml
@@ -72,8 +72,7 @@
                     </p:column>
 
                     <p:column headerText="Adjust">
-                        <p:commandButton ajax="false" value="Adjust" 
-                                        action="pharmacy_variant_adjustment">
+                        <p:commandButton ajax="false" value="Adjust" action="pharmacy_variant_adjustment" rendered="#{webUserController.hasPrivilege('PharmacyPhysicalCountApprove')}">
                             <f:setPropertyActionListener target="#{variantAdjustment.reportedBill}" value="#{b}"/>
                         </p:commandButton>
                     </p:column>


### PR DESCRIPTION
## Summary
- add `PharmacyPhysicalCountApprove` privilege and wire it into pharmacy adjustment permissions
- gate physical count approval UI actions behind the new privilege

## Testing
- `mvn -q -e test` *(fails: 'dependencies.dependency.version' for com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider:jar is missing)*

------
https://chatgpt.com/codex/tasks/task_e_68ab47d7c930832f9e9cba7eb6e2bc1d