### PR TITLE
feat: import pharmacy stock count sheets

### DIFF
--- a/src/main/webapp/pharmacy/pharmacy_stock_take.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_stock_take.xhtml
@@ -3,7 +3,8 @@
 <html xmlns="http://www.w3.org/1999/xhtml"
       xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
       xmlns:h="http://xmlns.jcp.org/jsf/html"
-      xmlns:p="http://primefaces.org/ui">
+      xmlns:p="http://primefaces.org/ui"
+      xmlns:f="http://xmlns.jcp.org/jsf/core">
     <h:head />
     <h:body>
         <ui:composition template="/forms/index.xhtml">
@@ -22,6 +23,30 @@
                                 <p:commandButton value="Download Blind Sheet" ajax="false" styleClass="ui-button-secondary" icon="fa fa-download" rendered="#{pharmacyStockTakeController.snapshotBill ne null}" onclick="PrimeFaces.monitorDownload(start, stop);">
                                     <p:fileDownload value="#{pharmacyStockTakeController.downloadBlindSheet}" />
                                 </p:commandButton>
+                                <p:separator/> 
+                                <p:fileUpload value="#{pharmacyStockTakeController.file}" mode="simple" rendered="#{pharmacyStockTakeController.snapshotBill ne null}"/>
+                                <p:commandButton value="Upload Sheet" action="#{pharmacyStockTakeController.parseUploadedSheet}" update="@form" icon="fa fa-upload" rendered="#{pharmacyStockTakeController.snapshotBill ne null}"/>
+                                <p:commandButton value="Save Physical Count" action="#{pharmacyStockTakeController.savePhysicalCount}" update="@form" icon="fa fa-save" rendered="#{pharmacyStockTakeController.physicalCountBill ne null}"/>
+                                <p:dataTable value="#{pharmacyStockTakeController.physicalCountBill.billItems}" var="bi" rendered="#{pharmacyStockTakeController.physicalCountBill ne null}">
+                                    <p:column headerText="Item">
+                                        <h:outputText value="#{bi.item.name}"/>
+                                    </p:column>
+                                    <p:column headerText="Snapshot Qty" style="text-align:right">
+                                        <h:outputText value="#{bi.referanceBillItem.qty}">
+                                            <f:convertNumber integerOnly="true"/>
+                                        </h:outputText>
+                                    </p:column>
+                                    <p:column headerText="Physical Qty" style="text-align:right">
+                                        <h:outputText value="#{bi.qty}">
+                                            <f:convertNumber integerOnly="true"/>
+                                        </h:outputText>
+                                    </p:column>
+                                    <p:column headerText="Variance" style="text-align:right">
+                                        <h:outputText value="#{bi.adjustedValue}">
+                                            <f:convertNumber integerOnly="true"/>
+                                        </h:outputText>
+                                    </p:column>
+                                </p:dataTable>
                             </h:form>
                         </div>
                     </div>


### PR DESCRIPTION
## Summary
- parse uploaded stock count Excel files and prepare physical count bill with per-item variances
- allow sheet uploads and variance review before saving counts

## Testing
- `mvn -q -e -DskipTests package` *(fails: Non-resolvable import POM: com.fasterxml.jackson:jackson-bom:pom:2.15.4)*

------
https://chatgpt.com/codex/tasks/task_e_68ab53aa46cc832f812c4af4e84dd80c