### PR TITLE
feat: add stock adjustment variance report

### DIFF
--- a/src/main/java/com/divudi/bean/pharmacy/PharmacyAdjustmentReportController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacyAdjustmentReportController.java
@@ -1,0 +1,221 @@
+package com.divudi.bean.pharmacy;
+
+import com.divudi.core.data.StockCorrectionRow;
+import com.divudi.core.data.BillType;
+import com.divudi.core.data.DepartmentType;
+import com.divudi.core.entity.Institution;
+import com.divudi.core.entity.Department;
+import com.divudi.core.entity.StockHistory;
+import com.divudi.core.facade.StockHistoryFacade;
+import com.divudi.core.util.JsfUtil;
+import java.io.OutputStream;
+import java.io.Serializable;
+import java.util.*;
+import javax.ejb.EJB;
+import javax.enterprise.context.SessionScoped;
+import javax.faces.context.FacesContext;
+import javax.inject.Named;
+import javax.persistence.TemporalType;
+import javax.servlet.http.HttpServletResponse;
+import com.itextpdf.text.*;
+import com.itextpdf.text.pdf.PdfPCell;
+import com.itextpdf.text.pdf.PdfPTable;
+import com.itextpdf.text.pdf.PdfWriter;
+import org.apache.poi.ss.usermodel.*;
+import org.apache.poi.xssf.usermodel.XSSFWorkbook;
+
+@Named
+@SessionScoped
+public class PharmacyAdjustmentReportController implements Serializable {
+
+    @EJB
+    private StockHistoryFacade stockHistoryFacade;
+
+    private Date fromDate;
+    private Date toDate;
+    private Institution institution;
+    private Institution site;
+    private Department department;
+    private List<StockCorrectionRow> stockCorrectionRows;
+
+    public void createAdjustmentReport() {
+        stockCorrectionRows = new ArrayList<>();
+        try {
+            List<BillType> billTypes = Arrays.asList(
+                    BillType.PharmacyAdjustmentSaleRate,
+                    BillType.PharmacyAdjustmentPurchaseRate,
+                    BillType.PharmacyAdjustmentWholeSaleRate,
+                    BillType.PharmacyAdjustmentCostRate
+            );
+
+            StringBuilder jpql = new StringBuilder("SELECT sh FROM StockHistory sh "
+                    + "WHERE sh.retired = false "
+                    + "AND sh.createdAt BETWEEN :fd AND :td "
+                    + "AND (sh.itemBatch.item.departmentType IS NULL OR sh.itemBatch.item.departmentType = :depty) "
+                    + "AND sh.pbItem.billItem.bill.billType IN :doctype");
+
+            Map<String, Object> params = new HashMap<>();
+            params.put("fd", fromDate);
+            params.put("td", toDate);
+            params.put("depty", DepartmentType.Pharmacy);
+            params.put("doctype", billTypes);
+
+            if (institution != null) {
+                jpql.append(" AND sh.institution = :ins");
+                params.put("ins", institution);
+            }
+            if (site != null) {
+                jpql.append(" AND sh.department.site = :sit");
+                params.put("sit", site);
+            }
+            if (department != null) {
+                jpql.append(" AND sh.department = :dep");
+                params.put("dep", department);
+            }
+
+            List<StockHistory> histories = stockHistoryFacade.findByJpql(jpql.toString(), params, TemporalType.TIMESTAMP);
+            if (histories != null) {
+                for (StockHistory sh : histories) {
+                    if (sh.getPbItem() == null || sh.getItemBatch() == null || sh.getItemBatch().getItem() == null) {
+                        continue;
+                    }
+                    StockCorrectionRow row = new StockCorrectionRow();
+                    row.setItemName(sh.getItemBatch().getItem().getName());
+                    row.setQty(sh.getPbItem().getStock().getStock());
+                    row.setOldRate(sh.getPbItem().getBeforeAdjustmentValue());
+                    row.setOldValue(sh.getPbItem().getStock().getStock() * sh.getPbItem().getBeforeAdjustmentValue());
+                    row.setNewRate(sh.getPbItem().getAfterAdjustmentValue());
+                    row.setNewValue(sh.getPbItem().getStock().getStock() * sh.getPbItem().getAfterAdjustmentValue());
+                    row.setVariance(row.getNewValue() - row.getOldValue());
+                    stockCorrectionRows.add(row);
+                }
+            }
+        } catch (Exception e) {
+            JsfUtil.addErrorMessage(e, "Error generating adjustment report");
+        }
+    }
+
+    public void exportToExcel() {
+        if (stockCorrectionRows == null) {
+            JsfUtil.addErrorMessage("No data to export");
+            return;
+        }
+        FacesContext context = FacesContext.getCurrentInstance();
+        HttpServletResponse response = (HttpServletResponse) context.getExternalContext().getResponse();
+        response.setContentType("application/vnd.openxmlformats-officedocument.spreadsheetml.sheet");
+        response.setHeader("Content-Disposition", "attachment; filename=stock_adjustment_variance.xlsx");
+        try (XSSFWorkbook workbook = new XSSFWorkbook(); OutputStream out = response.getOutputStream()) {
+            Sheet sheet = workbook.createSheet("Adjustments");
+            int rowIndex = 0;
+            Row header = sheet.createRow(rowIndex++);
+            String[] headers = {"Item", "Qty", "Old Rate", "Old Value", "New Rate", "New Value", "Variance"};
+            for (int i = 0; i < headers.length; i++) {
+                header.createCell(i).setCellValue(headers[i]);
+            }
+            for (StockCorrectionRow r : stockCorrectionRows) {
+                Row row = sheet.createRow(rowIndex++);
+                row.createCell(0).setCellValue(r.getItemName());
+                row.createCell(1).setCellValue(r.getQty());
+                row.createCell(2).setCellValue(r.getOldRate());
+                row.createCell(3).setCellValue(r.getOldValue());
+                row.createCell(4).setCellValue(r.getNewRate());
+                row.createCell(5).setCellValue(r.getNewValue());
+                row.createCell(6).setCellValue(r.getVariance());
+            }
+            workbook.write(out);
+            context.responseComplete();
+        } catch (Exception e) {
+            JsfUtil.addErrorMessage(e, "Error generating Excel report");
+        }
+    }
+
+    public void exportToPdf() {
+        if (stockCorrectionRows == null) {
+            JsfUtil.addErrorMessage("No data to export");
+            return;
+        }
+        FacesContext context = FacesContext.getCurrentInstance();
+        HttpServletResponse response = (HttpServletResponse) context.getExternalContext().getResponse();
+        response.setContentType("application/pdf");
+        response.setHeader("Content-Disposition", "attachment; filename=stock_adjustment_variance.pdf");
+        try (OutputStream out = response.getOutputStream()) {
+            Document document = new Document(PageSize.A4.rotate());
+            PdfWriter.getInstance(document, out);
+            document.open();
+            Font bold = FontFactory.getFont(FontFactory.HELVETICA_BOLD, 12);
+            document.add(new Paragraph("Stock Adjustment Variance", bold));
+            PdfPTable table = new PdfPTable(7);
+            table.setWidthPercentage(100);
+            String[] headers = {"Item", "Qty", "Old Rate", "Old Value", "New Rate", "New Value", "Variance"};
+            for (String h : headers) {
+                PdfPCell cell = new PdfPCell(new Phrase(h, bold));
+                table.addCell(cell);
+            }
+            Font normal = FontFactory.getFont(FontFactory.HELVETICA, 10);
+            for (StockCorrectionRow r : stockCorrectionRows) {
+                table.addCell(new Phrase(r.getItemName(), normal));
+                table.addCell(new Phrase(String.valueOf(r.getQty()), normal));
+                table.addCell(new Phrase(String.valueOf(r.getOldRate()), normal));
+                table.addCell(new Phrase(String.valueOf(r.getOldValue()), normal));
+                table.addCell(new Phrase(String.valueOf(r.getNewRate()), normal));
+                table.addCell(new Phrase(String.valueOf(r.getNewValue()), normal));
+                table.addCell(new Phrase(String.valueOf(r.getVariance()), normal));
+            }
+            document.add(table);
+            document.close();
+            context.responseComplete();
+        } catch (Exception e) {
+            JsfUtil.addErrorMessage(e, "Error generating PDF report");
+        }
+    }
+
+    // Getters and setters
+    public Date getFromDate() {
+        return fromDate;
+    }
+
+    public void setFromDate(Date fromDate) {
+        this.fromDate = fromDate;
+    }
+
+    public Date getToDate() {
+        return toDate;
+    }
+
+    public void setToDate(Date toDate) {
+        this.toDate = toDate;
+    }
+
+    public Institution getInstitution() {
+        return institution;
+    }
+
+    public void setInstitution(Institution institution) {
+        this.institution = institution;
+    }
+
+    public Institution getSite() {
+        return site;
+    }
+
+    public void setSite(Institution site) {
+        this.site = site;
+    }
+
+    public Department getDepartment() {
+        return department;
+    }
+
+    public void setDepartment(Department department) {
+        this.department = department;
+    }
+
+    public List<StockCorrectionRow> getStockCorrectionRows() {
+        return stockCorrectionRows;
+    }
+
+    public void setStockCorrectionRows(List<StockCorrectionRow> stockCorrectionRows) {
+        this.stockCorrectionRows = stockCorrectionRows;
+    }
+}
+

--- a/src/main/java/com/divudi/bean/pharmacy/PharmacyController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacyController.java
@@ -547,6 +547,10 @@ public class PharmacyController implements Serializable {
         return "/pharmacy/pharmacy_report_department_stock_by_batch_minus?faces-redirect=true";
     }
 
+    public String navigateToStockAdjustmentVariance() {
+        return "/pharmacy/reports/stock_adjustment_variance?faces-redirect=true";
+    }
+
     // </editor-fold>
     // <editor-fold defaultstate="collapsed" desc="Methods - Data Maniulation">
     public void deleteSingleVtm() {

--- a/src/main/webapp/pharmacy/pharmacy_analytics.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_analytics.xhtml
@@ -153,10 +153,12 @@
                                             <p:commandButton rendered="#{configOptionApplicationController.getBooleanValueByKey('Pharmacy Analytics - Show Stock Taking Report(New)')}" class="w-100 ui-button-warning" value="Stock Taking Report(New)" action="pharmacy_report_adjustment_bill_for_stock_taking?faces-redirect=true" ajax="false" />
                                             <p:commandButton rendered="#{configOptionApplicationController.getBooleanValueByKey('Pharmacy Analytics - Show Stock With Movement')}" class="w-100 ui-button-warning" value="Stock With Movement" action="pharmacy_report_item_stock_sale?faces-redirect=true" ajax="false" />
 
-                                            <p:commandButton rendered="#{configOptionApplicationController.getBooleanValueByKey('Pharmacy Analytics - Show Stock Summary (with Suppliers)')}" 
+                                            <p:commandButton rendered="#{configOptionApplicationController.getBooleanValueByKey('Pharmacy Analytics - Show Stock Adjustment Variance Report',true)}" class="w-100 ui-button-warning" value="Stock Adjustment Variance" action="#{pharmacyController.navigateToStockAdjustmentVariance}" ajax="false" />
+
+                                            <p:commandButton rendered="#{configOptionApplicationController.getBooleanValueByKey('Pharmacy Analytics - Show Stock Summary (with Suppliers)')}"
                                                              class="w-100"
-                                                             value="Stock Summary (with Suppliers)" 
-                                                             action="pharmacy_stock_summary_with_supplier?faces-redirect=true" 
+                                                             value="Stock Summary (with Suppliers)"
+                                                             action="pharmacy_stock_summary_with_supplier?faces-redirect=true"
                                                              ajax="false" >
                                             </p:commandButton>   
 

--- a/src/main/webapp/pharmacy/reports/stock_adjustment_variance.xhtml
+++ b/src/main/webapp/pharmacy/reports/stock_adjustment_variance.xhtml
@@ -1,0 +1,133 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
+      xmlns:h="http://xmlns.jcp.org/jsf/html"
+      xmlns:p="http://primefaces.org/ui"
+      xmlns:f="http://xmlns.jcp.org/jsf/core">
+    <h:body>
+        <ui:composition template="/pharmacy/pharmacy_analytics.xhtml">
+            <ui:define name="subcontent">
+                <h:form>
+                    <p:panel header="Stock Adjustment Variance">
+                        <h:panelGrid columns="8" class="w-100">
+                            <h:panelGroup layout="block" styleClass="form-group">
+                                <h:outputText value="&#xf073;" styleClass="fa mr-2" />
+                                <p:outputLabel value="From Date" for="fromDate" class="m-3" />
+                            </h:panelGroup>
+                            <p:calendar id="fromDate" styleClass="w-100" inputStyleClass="w-100 form-control"
+                                        value="#{pharmacyAdjustmentReportController.fromDate}"
+                                        pattern="#{sessionController.applicationPreference.longDateTimeFormat}" />
+
+                            <p:spacer width="20" />
+
+                            <h:panelGroup layout="block" styleClass="form-group">
+                                <h:outputText value="&#xf073;" styleClass="fa mr-2" />
+                                <p:outputLabel value="To Date" for="toDate" class="m-3" />
+                            </h:panelGroup>
+                            <p:calendar id="toDate" styleClass="w-100" inputStyleClass="w-100 form-control"
+                                        value="#{pharmacyAdjustmentReportController.toDate}"
+                                        pattern="#{sessionController.applicationPreference.longDateTimeFormat}" />
+
+                            <p:spacer width="20" />
+                            <p:spacer width="20" />
+                            <p:spacer width="20" />
+
+                            <h:panelGroup layout="block" styleClass="form-group">
+                                <h:outputText styleClass="fa fa-university mr-2" />
+                                <p:outputLabel value="Institution" for="phmIns" class="m-3" />
+                            </h:panelGroup>
+                            <p:selectOneMenu id="phmIns" class="w-100" value="#{pharmacyAdjustmentReportController.institution}" filter="true">
+                                <f:selectItem itemLabel="All Institutions" />
+                                <f:selectItems value="#{institutionController.companies}" var="ins" itemLabel="#{ins.name}" itemValue="#{ins}" />
+                                <p:ajax process="phmIns" update="phmDept" />
+                            </p:selectOneMenu>
+
+                            <p:spacer width="20" />
+
+                            <h:panelGroup layout="block" styleClass="form-group">
+                                <h:outputText styleClass="fa fa-map-marker-alt mr-2" />
+                                <p:outputLabel value="Site" for="phmSite" class="m-3" />
+                            </h:panelGroup>
+                            <p:selectOneMenu id="phmSite" class="w-100" value="#{pharmacyAdjustmentReportController.site}" filter="true">
+                                <f:selectItem itemLabel="All Sites" />
+                                <f:selectItems value="#{institutionController.sites}" var="site" itemLabel="#{site.name}" itemValue="#{site}" />
+                                <p:ajax process="phmSite" update="phmDept" />
+                            </p:selectOneMenu>
+
+                            <p:spacer width="20" />
+
+                            <h:panelGroup layout="block" styleClass="form-group">
+                                <h:outputText styleClass="fa fa-building mr-2" />
+                                <p:outputLabel value="Department" for="phmDept" class="m-3" />
+                            </h:panelGroup>
+                            <h:panelGroup id="phmDept">
+                                <p:selectOneMenu rendered="#{pharmacyAdjustmentReportController.institution eq null and pharmacyAdjustmentReportController.site eq null}" styleClass="w-100 form-control" value="#{pharmacyAdjustmentReportController.department}" filterMatchMode="contains" filter="true">
+                                    <f:selectItem itemLabel="All Departments" />
+                                    <f:selectItems value="#{departmentController.getDepartmentsOfInstitutionAndSite()}" var="dept" itemLabel="#{dept.name}" itemValue="#{dept}" />
+                                </p:selectOneMenu>
+                                <p:selectOneMenu rendered="#{pharmacyAdjustmentReportController.institution eq null and pharmacyAdjustmentReportController.site ne null}" styleClass="w-100 form-control" value="#{pharmacyAdjustmentReportController.department}" filterMatchMode="contains" filter="true">
+                                    <f:selectItem itemLabel="All Departments" />
+                                    <f:selectItems value="#{departmentController.getDepartmentsOfInstitutionAndSite(pharmacyAdjustmentReportController.site)}" var="dept" itemLabel="#{dept.name}" itemValue="#{dept}" />
+                                </p:selectOneMenu>
+                                <p:selectOneMenu rendered="#{pharmacyAdjustmentReportController.institution ne null and pharmacyAdjustmentReportController.site eq null}" styleClass="w-100 form-control" value="#{pharmacyAdjustmentReportController.department}" filterMatchMode="contains" filter="true">
+                                    <f:selectItem itemLabel="All Departments" />
+                                    <f:selectItems value="#{departmentController.getDepartmentsOfInstitutionAndSite(pharmacyAdjustmentReportController.institution)}" var="dept" itemLabel="#{dept.name}" itemValue="#{dept}" />
+                                </p:selectOneMenu>
+                                <p:selectOneMenu rendered="#{pharmacyAdjustmentReportController.institution ne null and pharmacyAdjustmentReportController.site ne null}" styleClass="w-100 form-control" value="#{pharmacyAdjustmentReportController.department}" filterMatchMode="contains" filter="true">
+                                    <f:selectItem itemLabel="All Departments" />
+                                    <f:selectItems value="#{departmentController.getDepartmentsOfInstitutionAndSite(pharmacyAdjustmentReportController.institution, pharmacyAdjustmentReportController.site)}" var="dept" itemLabel="#{dept.name}" itemValue="#{dept}" />
+                                </p:selectOneMenu>
+                            </h:panelGroup>
+                        </h:panelGrid>
+                        <br/>
+                        <div class="d-flex align-items-center">
+                            <p:commandButton class="ui-button-warning mx-1" icon="fas fa-cogs" ajax="false" value="Process" action="#{pharmacyAdjustmentReportController.createAdjustmentReport}" />
+                            <p:commandButton class="ui-button mx-1" icon="fas fa-print" ajax="false" value="Print All" onclick="hidePaginatorBeforePrint()">
+                                <p:printer target="tbl1" />
+                            </p:commandButton>
+                            <p:commandButton class="ui-button-success mx-1" icon="fas fa-file-excel" ajax="false" value="Excel" action="#{pharmacyAdjustmentReportController.exportToExcel}" />
+                            <p:commandButton class="ui-button-danger mx-1" icon="fas fa-file-pdf" ajax="false" value="PDF" action="#{pharmacyAdjustmentReportController.exportToPdf}" />
+                        </div>
+                        <p:dataTable id="tbl1" value="#{pharmacyAdjustmentReportController.stockCorrectionRows}" var="item" paginator="true" rows="20">
+                            <p:column headerText="Item">
+                                <h:outputText value="#{item.itemName}" />
+                            </p:column>
+                            <p:column headerText="Qty">
+                                <h:outputText value="#{item.qty}" />
+                            </p:column>
+                            <p:column headerText="Old Rate">
+                                <h:outputText value="#{item.oldRate}" />
+                            </p:column>
+                            <p:column headerText="Old Value">
+                                <h:outputText value="#{item.oldValue}" />
+                            </p:column>
+                            <p:column headerText="New Rate">
+                                <h:outputText value="#{item.newRate}" />
+                            </p:column>
+                            <p:column headerText="New Value">
+                                <h:outputText value="#{item.newValue}" />
+                            </p:column>
+                            <p:column headerText="Variance">
+                                <h:outputText value="#{item.variance}" />
+                            </p:column>
+                        </p:dataTable>
+                    </p:panel>
+                    <h:outputScript>
+                        function hidePaginatorBeforePrint() {
+                            let paginators = document.querySelectorAll('.ui-paginator');
+                            paginators.forEach(el => el.style.display = 'none');
+                        }
+                        function restorePaginatorAfterPrint() {
+                            let paginators = document.querySelectorAll('.ui-paginator');
+                            paginators.forEach(el => el.style.display = '');
+                        }
+                        window.onafterprint = function () {
+                            restorePaginatorAfterPrint();
+                        }
+                    </h:outputScript>
+                </h:form>
+            </ui:define>
+        </ui:composition>
+    </h:body>
+</html>


### PR DESCRIPTION
## Summary
- add PharmacyAdjustmentReportController with methods to build and export variance and final adjustment data
- expose new stock adjustment variance page with printable and Excel/PDF options
- link report from pharmacy analytics menu

## Testing
- `mvn -q -e -DskipTests package` *(fails: Non-resolvable import POM: jackson-bom 2.15.4)*

------
https://chatgpt.com/codex/tasks/task_e_68ab689fc5e0832fb0cf0a2b6246d265