### PR TITLE
fix spellings change

### DIFF
--- a/src/main/webapp/admin/items/opd_service.xhtml
+++ b/src/main/webapp/admin/items/opd_service.xhtml
@@ -195,7 +195,7 @@
                                             <h:outputText value="VATable" ></h:outputText>
                                             <p:selectBooleanCheckbox  value="#{serviceController.current.vatable}" >
                                             </p:selectBooleanCheckbox>
-                                            <p:selectBooleanCheckbox   id="chkBilledAs" value="#{serviceController.billedAs}" itemLabel="Billed as a seperate investigation"  >
+                                            <p:selectBooleanCheckbox   id="chkBilledAs" value="#{serviceController.billedAs}" itemLabel="Billed as a separate investigation"  >
                                                 <p:ajax event="change" process="@this" update="billedAsIx" />
                                             </p:selectBooleanCheckbox>
                                             <p:autoComplete   disabled="#{!serviceController.billedAs}" 
@@ -203,7 +203,7 @@
                                                               value="#{serviceController.current.billedAs}" completeMethod="#{serviceController.completeItem}" var="ix1" itemLabel="#{ix1.name}" itemValue="#{ix1}" size="30"  >
                                             </p:autoComplete>
 
-                                            <p:selectBooleanCheckbox  id="chkReportedAs" value="#{serviceController.reportedAs}" itemLabel="Reported as a seperate investigation" >
+                                            <p:selectBooleanCheckbox  id="chkReportedAs" value="#{serviceController.reportedAs}" itemLabel="Reported as a separate investigation" >
                                                 <p:ajax event="change" process="@this" update="reportedAsIx" />
                                             </p:selectBooleanCheckbox>
                                             <p:autoComplete  disabled="#{!serviceController.reportedAs}" widgetVar="aIx2" id="reportedAsIx" forceSelection="true" value="#{serviceController.current.reportedAs}" completeMethod="#{serviceController.completeItem}" var="ix2" itemLabel="#{ix2.name}" itemValue="#{ix2}" size="30"  >


### PR DESCRIPTION
fix seperate in to separate 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected spelling in Admin > Items > OPD Service (Deprecated tab) checkbox labels to improve clarity and professionalism:
    - “Billed as a separate investigation”
    - “Reported as a separate investigation”
  * No changes to behavior, IDs, bindings, or interactions; only text labels were updated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->