### PR TITLE
15155 disbursement allows issuing more items than requested

### DIFF
--- a/src/main/java/com/divudi/bean/pharmacy/TransferIssueController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/TransferIssueController.java
@@ -338,7 +338,9 @@ public class TransferIssueController implements Serializable {
 
         // OPTIMIZATION 1: Bulk fetch all calculations for all bill items (replaces 2N individual queries)
         java.util.Map<Long, com.divudi.core.data.dto.BillItemCalculationDTO> calculationsMap = 
-            getPharmacyCalculation().getBulkCalculationsForBillItems(billItemsOfRequest, BillType.PharmacyTransferIssue);
+            getPharmacyCalculation().getBulkCalculationsForBillItems(billItemsOfRequest, BillTypeAtomic.PHARMACY_ISSUE);
+        
+        System.out.println("DEBUG: Processing transfer issue for request ID " + getRequestedBill().getId() + " with " + billItemsOfRequest.size() + " items");
 
         // OPTIMIZATION 2: Extract unique items and bulk fetch stock availability (replaces N individual queries)
         java.util.List<Item> uniqueItems = billItemsOfRequest.stream()
@@ -361,21 +363,37 @@ public class TransferIssueController implements Serializable {
         for (BillItem billItemInRequest : billItemsOfRequest) {
             boolean flagStockFound = false;
 
+            System.out.println("\n--- Processing item: " + billItemInRequest.getItem().getName() + " (ID: " + billItemInRequest.getId() + ") ---");
+            System.out.println("Original requested qty: " + billItemInRequest.getQty());
+            System.out.println("Current issuedPhamaceuticalItemQty: " + billItemInRequest.getIssuedPhamaceuticalItemQty());
+            System.out.println("Current remainingQty field: " + billItemInRequest.getRemainingQty());
+
             // Get calculations from pre-fetched data instead of individual queries
             com.divudi.core.data.dto.BillItemCalculationDTO calculations = calculationsMap.get(billItemInRequest.getId());
             if (calculations == null) {
+                System.out.println("No bulk calculation found, creating fallback...");
                 // Create default calculation if not found - use remaining quantity from database if available
                 Double remainingFromDb = billItemInRequest.getRemainingQty();
                 Double issuedQtyFromDb = billItemInRequest.getIssuedPhamaceuticalItemQty();
                 double alreadyIssuedFromDb = (issuedQtyFromDb != null) ? issuedQtyFromDb : 0.0;
                 calculations = new com.divudi.core.data.dto.BillItemCalculationDTO(
                     billItemInRequest.getId(), billItemInRequest.getQty(), alreadyIssuedFromDb, 0.0);
+                System.out.println("Fallback calculation - already issued: " + alreadyIssuedFromDb);
+            } else {
+                System.out.println("Bulk calculation found:");
+                System.out.println("  - Original qty: " + calculations.getOriginalQty());
+                System.out.println("  - Billed issued: " + calculations.getBilledIssuedQty());
+                System.out.println("  - Cancelled issued: " + calculations.getCancelledIssuedQty());
+                System.out.println("  - Net issued: " + calculations.getNetIssuedQty());
+                System.out.println("  - Remaining qty: " + calculations.getRemainingQty());
             }
 
             billItemInRequest.setIssuedPhamaceuticalItemQty(calculations.getNetIssuedQty());
             // Update remaining quantity for consistency
             billItemInRequest.setRemainingQty(calculations.getRemainingQty());
             double quantityToIssue = getRemainingQuantityForItem(billItemInRequest);
+            
+            System.out.println("Final quantity to issue: " + quantityToIssue);
 
             if (quantityToIssue <= 0.001) { // Use small tolerance for floating point precision
                 continue; // Skip if nothing left to issue
@@ -737,11 +755,20 @@ public class TransferIssueController implements Serializable {
                 billItemsInIssue.getPharmaceuticalBillItem().setStaffStock(staffStock);
 
                 originalOrderItem = billItemFacade.findWithoutCache(originalOrderItem.getId());
+                
+                System.out.println("=== DEBUG: Updating Original Order Item ===");
+                System.out.println("Item: " + originalOrderItem.getItem().getName() + " (ID: " + originalOrderItem.getId() + ")");
+                System.out.println("Before update - IssuedQty: " + originalOrderItem.getIssuedPhamaceuticalItemQty() + ", RemainingQty: " + originalOrderItem.getRemainingQty());
+                System.out.println("Adding issued qty: " + billItemsInIssue.getQty());
+                
                 originalOrderItem.setIssuedPhamaceuticalItemQty(originalOrderItem.getIssuedPhamaceuticalItemQty() + billItemsInIssue.getQty());
                 // Update remaining quantity to track what's left to issue
                 Double remainingQty = originalOrderItem.getRemainingQty();
                 double currentRemaining = (remainingQty != null) ? remainingQty : originalOrderItem.getQty();
                 originalOrderItem.setRemainingQty(currentRemaining - billItemsInIssue.getQty());
+                
+                System.out.println("After update - IssuedQty: " + originalOrderItem.getIssuedPhamaceuticalItemQty() + ", RemainingQty: " + originalOrderItem.getRemainingQty());
+                
                 billItemFacade.editAndCommit(originalOrderItem);
 
                 getBillItemFacade().edit(billItemsInIssue);

--- a/src/main/java/com/divudi/ejb/PharmacyCalculation.java
+++ b/src/main/java/com/divudi/ejb/PharmacyCalculation.java
@@ -1194,11 +1194,14 @@ public class PharmacyCalculation implements Serializable {
             "  AND issued.bill.billType = :billType " +
             "  AND issued.creater IS NOT NULL " +
             "  AND TYPE(issued.bill) = " + com.divudi.core.entity.BilledBill.class.getSimpleName() + " " +
+            "  AND issued.retired = false " +
             "LEFT JOIN BillItem cancelled ON cancelled.referanceBillItem.referanceBillItem = bi " +
             "  AND cancelled.bill.billType = :billType " +
             "  AND cancelled.creater IS NOT NULL " +
             "  AND TYPE(cancelled.bill) = " + com.divudi.core.entity.CancelledBill.class.getSimpleName() + " " +
+            "  AND cancelled.retired = false " +
             "WHERE bi.id IN :billItemIds " +
+            "  AND bi.retired = false " +
             "GROUP BY bi.id, bi.qty";
         
         java.util.Map<String, Object> params = new java.util.HashMap<>();
@@ -1206,7 +1209,7 @@ public class PharmacyCalculation implements Serializable {
         params.put("billType", billType);
         
         try {
-            java.util.List<Object[]> results = getPharmaceuticalBillItemFacade().findObjectArrayByJpql(sql, params, TemporalType.TIMESTAMP);
+            java.util.List<Object[]> results = getPharmaceuticalBillItemFacade().findObjectArrayByJpql(sql, params, javax.persistence.TemporalType.TIMESTAMP);
             
             return results.stream()
                 .collect(java.util.stream.Collectors.toMap(

--- a/src/main/java/com/divudi/ejb/PharmacyCalculation.java
+++ b/src/main/java/com/divudi/ejb/PharmacyCalculation.java
@@ -1165,11 +1165,11 @@ public class PharmacyCalculation implements Serializable {
      * Retrieves issued and cancelled quantities for all bill items in a single query.
      * 
      * @param billItems List of bill items to calculate for
-     * @param billType The bill type to filter by (e.g., PharmacyTransferIssue)
+     * @param billTypeAtomic The atomic bill type to filter by (e.g., PHARMACY_ISSUE)
      * @return Map with bill item ID as key and calculation DTO as value
      */
     public java.util.Map<Long, com.divudi.core.data.dto.BillItemCalculationDTO> getBulkCalculationsForBillItems(
-            java.util.List<com.divudi.core.entity.BillItem> billItems, com.divudi.core.data.BillType billType) {
+            java.util.List<com.divudi.core.entity.BillItem> billItems, com.divudi.core.data.BillTypeAtomic billTypeAtomic) {
         
         if (billItems == null || billItems.isEmpty()) {
             return new java.util.HashMap<>();
@@ -1184,43 +1184,84 @@ public class PharmacyCalculation implements Serializable {
             return new java.util.HashMap<>();
         }
         
-        String sql = "SELECT " +
-            "  bi.id as billItemId, " +
-            "  bi.qty as originalQty, " +
-            "  COALESCE(SUM(CASE WHEN TYPE(issued.bill) = " + com.divudi.core.entity.BilledBill.class.getSimpleName() + " THEN ABS(issued.qty) ELSE 0 END), 0) as billedIssued, " +
-            "  COALESCE(SUM(CASE WHEN TYPE(cancelled.bill) = " + com.divudi.core.entity.CancelledBill.class.getSimpleName() + " THEN ABS(cancelled.qty) ELSE 0 END), 0) as cancelledIssued " +
-            "FROM BillItem bi " +
-            "LEFT JOIN BillItem issued ON issued.referanceBillItem = bi " +
-            "  AND issued.bill.billType = :billType " +
-            "  AND issued.creater IS NOT NULL " +
-            "  AND TYPE(issued.bill) = " + com.divudi.core.entity.BilledBill.class.getSimpleName() + " " +
-            "  AND issued.retired = false " +
-            "LEFT JOIN BillItem cancelled ON cancelled.referanceBillItem.referanceBillItem = bi " +
-            "  AND cancelled.bill.billType = :billType " +
-            "  AND cancelled.creater IS NOT NULL " +
-            "  AND TYPE(cancelled.bill) = " + com.divudi.core.entity.CancelledBill.class.getSimpleName() + " " +
-            "  AND cancelled.retired = false " +
-            "WHERE bi.id IN :billItemIds " +
-            "  AND bi.retired = false " +
-            "GROUP BY bi.id, bi.qty";
-        
-        java.util.Map<String, Object> params = new java.util.HashMap<>();
-        params.put("billItemIds", billItemIds);
-        params.put("billType", billType);
-        
         try {
-            java.util.List<Object[]> results = getPharmaceuticalBillItemFacade().findObjectArrayByJpql(sql, params, javax.persistence.TemporalType.TIMESTAMP);
+            System.out.println("DEBUG: Executing bulk calculation for " + billItemIds.size() + " bill items");
             
-            return results.stream()
-                .collect(java.util.stream.Collectors.toMap(
-                    row -> ((Number) row[0]).longValue(), // billItemId as key
-                    row -> new com.divudi.core.data.dto.BillItemCalculationDTO(
-                        ((Number) row[0]).longValue(),    // billItemId
-                        ((Number) row[1]).doubleValue(),  // originalQty
-                        ((Number) row[2]).doubleValue(),  // billedIssued
-                        ((Number) row[3]).doubleValue()   // cancelledIssued
-                    )
-                ));
+            // Step 1: Get issued quantities (BilledBill)
+            String issuedSql = "SELECT bi.referanceBillItem.id, SUM(ABS(bi.qty)) " +
+                             "FROM BillItem bi " +
+                             "WHERE bi.referanceBillItem.id IN :billItemIds " +
+                             "  AND bi.bill.billTypeAtomic = :billTypeAtomic " +
+                             "  AND bi.retired = false " +
+                             "  AND bi.creater IS NOT NULL " +
+                             "GROUP BY bi.referanceBillItem.id";
+            
+            java.util.Map<String, Object> issuedParams = new java.util.HashMap<>();
+            issuedParams.put("billItemIds", billItemIds);
+            issuedParams.put("billTypeAtomic", billTypeAtomic);
+            
+            java.util.List<Object[]> issuedResults = getPharmaceuticalBillItemFacade().findObjectArrayByJpql(issuedSql, issuedParams, javax.persistence.TemporalType.TIMESTAMP);
+            java.util.Map<Long, Double> issuedMap = new java.util.HashMap<>();
+            
+            for (Object[] row : issuedResults) {
+                Long billItemId = ((Number) row[0]).longValue();
+                Double issuedQty = ((Number) row[1]).doubleValue();
+                issuedMap.put(billItemId, issuedQty);
+            }
+            
+            // Step 2: Get cancelled quantities (CancelledBill) - cancellations of the issued bills
+            String cancelledSql = "SELECT bi.referanceBillItem.referanceBillItem.id, SUM(ABS(bi.qty)) " +
+                                "FROM BillItem bi " +
+                                "WHERE bi.referanceBillItem.referanceBillItem.id IN :billItemIds " +
+                                "  AND bi.bill.billTypeAtomic = :cancelledBillTypeAtomic " +
+                                "  AND bi.retired = false " +
+                                "  AND bi.creater IS NOT NULL " +
+                                "GROUP BY bi.referanceBillItem.referanceBillItem.id";
+            
+            java.util.Map<String, Object> cancelledParams = new java.util.HashMap<>();
+            cancelledParams.put("billItemIds", billItemIds);
+            cancelledParams.put("cancelledBillTypeAtomic", com.divudi.core.data.BillTypeAtomic.PHARMACY_ISSUE_CANCELLED);
+            
+            java.util.List<Object[]> cancelledResults = getPharmaceuticalBillItemFacade().findObjectArrayByJpql(cancelledSql, cancelledParams, javax.persistence.TemporalType.TIMESTAMP);
+            java.util.Map<Long, Double> cancelledMap = new java.util.HashMap<>();
+            
+            for (Object[] row : cancelledResults) {
+                Long billItemId = ((Number) row[0]).longValue();
+                Double cancelledQty = ((Number) row[1]).doubleValue();
+                cancelledMap.put(billItemId, cancelledQty);
+            }
+            
+            // Step 3: Get original quantities and combine results
+            String originalSql = "SELECT bi.id, bi.qty " +
+                               "FROM BillItem bi " +
+                               "WHERE bi.id IN :billItemIds " +
+                               "  AND bi.retired = false";
+            
+            java.util.Map<String, Object> originalParams = new java.util.HashMap<>();
+            originalParams.put("billItemIds", billItemIds);
+            
+            java.util.List<Object[]> originalResults = getPharmaceuticalBillItemFacade().findObjectArrayByJpql(originalSql, originalParams, javax.persistence.TemporalType.TIMESTAMP);
+            
+            System.out.println("DEBUG: Found " + issuedMap.size() + " issued, " + cancelledMap.size() + " cancelled, " + originalResults.size() + " original items");
+            
+            java.util.Map<Long, com.divudi.core.data.dto.BillItemCalculationDTO> resultMap = new java.util.HashMap<>();
+            
+            for (Object[] row : originalResults) {
+                Long billItemId = ((Number) row[0]).longValue();
+                Double originalQty = ((Number) row[1]).doubleValue();
+                Double issuedQty = issuedMap.getOrDefault(billItemId, 0.0);
+                Double cancelledQty = cancelledMap.getOrDefault(billItemId, 0.0);
+                
+                com.divudi.core.data.dto.BillItemCalculationDTO dto = new com.divudi.core.data.dto.BillItemCalculationDTO(
+                    billItemId, originalQty, issuedQty, cancelledQty);
+                    
+                resultMap.put(billItemId, dto);
+                
+                System.out.println("  Item ID: " + billItemId + " -> Original: " + originalQty + ", Issued: " + issuedQty + ", Cancelled: " + cancelledQty + ", Remaining: " + dto.getRemainingQty());
+            }
+            
+            return resultMap;
+            
         } catch (Exception e) {
             // Log error and return empty map as fallback
             System.err.println("Error in getBulkCalculationsForBillItems: " + e.getMessage());

--- a/src/main/resources/META-INF/persistence.xml
+++ b/src/main/resources/META-INF/persistence.xml
@@ -2,7 +2,7 @@
 <persistence version="2.2" xmlns="http://java.sun.com/xml/ns/persistence" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/persistence http://xmlns.jcp.org/xml/ns/persistence/persistence_2_2.xsd">
     <persistence-unit name="hmisPU" transaction-type="JTA">
         <provider>org.eclipse.persistence.jpa.PersistenceProvider</provider>
-        <jta-data-source>${JDBC_DATASOURCE}</jta-data-source>
+        <jta-data-source>jdbc/coop</jta-data-source>
         <exclude-unlisted-classes>false</exclude-unlisted-classes>
         <properties>
             <property name="eclipselink.logging.level.sql" value="SEVERE"/>
@@ -10,7 +10,7 @@
         </properties>
     </persistence-unit>
     <persistence-unit name="hmisAuditPU" transaction-type="JTA">
-        <jta-data-source>${JDBC_AUDIT_DATASOURCE}</jta-data-source>
+        <jta-data-source>jdbc/ruhunuAudit</jta-data-source>
         <exclude-unlisted-classes>false</exclude-unlisted-classes>
         <properties>
             <property name="eclipselink.logging.level.sql" value="SEVERE"/>

--- a/src/main/resources/META-INF/persistence.xml
+++ b/src/main/resources/META-INF/persistence.xml
@@ -2,7 +2,7 @@
 <persistence version="2.2" xmlns="http://java.sun.com/xml/ns/persistence" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/persistence http://xmlns.jcp.org/xml/ns/persistence/persistence_2_2.xsd">
     <persistence-unit name="hmisPU" transaction-type="JTA">
         <provider>org.eclipse.persistence.jpa.PersistenceProvider</provider>
-        <jta-data-source>jdbc/coop</jta-data-source>
+        <jta-data-source>${JDBC_DATASOURCE}</jta-data-source>
         <exclude-unlisted-classes>false</exclude-unlisted-classes>
         <properties>
             <property name="eclipselink.logging.level.sql" value="SEVERE"/>
@@ -10,7 +10,7 @@
         </properties>
     </persistence-unit>
     <persistence-unit name="hmisAuditPU" transaction-type="JTA">
-        <jta-data-source>jdbc/ruhunuAudit</jta-data-source>
+        <jta-data-source>${JDBC_AUDIT_DATASOURCE}</jta-data-source>
         <exclude-unlisted-classes>false</exclude-unlisted-classes>
         <properties>
             <property name="eclipselink.logging.level.sql" value="SEVERE"/>

--- a/src/main/webapp/pharmacy/pharmacy_transfer_request_list.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_transfer_request_list.xhtml
@@ -88,6 +88,7 @@
                                 </p:commandButton>
 
                                 <p:commandButton
+                                    id="btnToIssue"
                                     ajax="false"
                                     icon="fas fa-check"
                                     title="Issue"


### PR DESCRIPTION
  Summary of Changes Made

  Replaced Complex JPQL with Simple Separate Queries:

  1. Method Signature Updated - PharmacyCalculation.java:1171:
    - Before: getBulkCalculationsForBillItems(billItems, BillType billType)
    - After: getBulkCalculationsForBillItems(billItems, BillTypeAtomic billTypeAtomic)
  2. Three Simple Queries instead of one complex query:

  2. Query 1 - Issued Items:
  SELECT bi.referanceBillItem.id, SUM(ABS(bi.qty))
  FROM BillItem bi
  WHERE bi.referanceBillItem.id IN :billItemIds
    AND bi.bill.billTypeAtomic = :billTypeAtomic

  2. Query 2 - Cancelled Items:
  SELECT bi.referanceBillItem.referanceBillItem.id, SUM(ABS(bi.qty))
  FROM BillItem bi
  WHERE bi.referanceBillItem.referanceBillItem.id IN :billItemIds
    AND bi.bill.billTypeAtomic = PHARMACY_ISSUE_CANCELLED

  2. Query 3 - Original Quantities:
  SELECT bi.id, bi.qty
  FROM BillItem bi
  WHERE bi.id IN :billItemIds
  3. Updated Method Call - TransferIssueController.java:341:
    - Before: getBulkCalculationsForBillItems(billItemsOfRequest, BillType.PharmacyTransferIssue)
    - After: getBulkCalculationsForBillItems(billItemsOfRequest, BillTypeAtomic.PHARMACY_ISSUE)

  Benefits:

  - ✅ No complex joins - avoids SQL syntax errors
  - ✅ Uses BillTypeAtomic - more precise than BillType
  - ✅ Separate logic - easy to debug each step
  - ✅ Clear calculation: Issued - Cancelled = Net, Original - Net = Remaining

  The system will now properly calculate remaining quantities by:
  1. Finding all issued quantities (PHARMACY_ISSUE)
  2. Subtracting any cancelled quantities (PHARMACY_ISSUE_CANCELLED)
  3. Calculating remaining = original requested - net issued

  This should resolve the transfer issue quantity calculation problem.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Prevents issuing more than the remaining quantity with real-time validation during entry and settlement.
  - Improves accuracy of remaining/issued quantities and updates in transfer issues.
  - Provides clearer error messages showing remaining vs. requested quantities.

- Refactor
  - Optimizes transfer issue processing with bulk calculations, improving responsiveness and reliability.

- Chores
  - Adds a stable identifier to the Issue button for UI consistency (no behavior change).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->