### PR TITLE
15154 grn returned print unreturned items should not be displayed

### DIFF
--- a/developer_docs/config/README.md
+++ b/developer_docs/config/README.md
@@ -1,0 +1,3 @@
+# Configuration
+
+This section contains documents related to application configuration and options.

--- a/developer_docs/config/application-options.md
+++ b/developer_docs/config/application-options.md
@@ -1,0 +1,34 @@
+# Application Options
+
+This document lists the configuration options used in the application and their purpose.
+
+## Pharmacy Transfer Issue
+
+| Key                                                              | Type      | Default | Description                                                                                             |
+| ---------------------------------------------------------------- | --------- | ------- | ------------------------------------------------------------------------------------------------------- |
+| `Stock Transaction - Show Rate and Value`                          | Boolean   | `false` | Controls visibility of rate and value in stock transactions.                                            |
+| `Pharmacy Transfer Issue Bill is PosHeaderPaper`                 | Boolean   | `true`  | Controls visibility of the main print button.                                                           |
+| `Pharmacy Transfer Issue Bill is POS Paper without details`        | Boolean   | `false` | Renders the POS paper bill without details.                                                             |
+| `Pharmacy Transfer Issue Bill is POS Paper with details`         | Boolean   | `false` | Renders the POS paper bill with details.                                                                |
+| `Pharmacy Transfer Issue Bill is POS Paper with header`          | Boolean   | `false` | Renders the POS paper bill with a header.                                                               |
+| `Pharmacy Transfer Issue Bill is Template`                       | Boolean   | `false` | Renders the bill using a template.                                                                      |
+| `Pharmacy Transfer is by Purchase Rate`                          | Boolean   | `false` | Determines if the transfer rate is based on the purchase rate.                                            |
+| `Pharmacy Transfer is by Cost Rate`                              | Boolean   | `false` | Determines if the transfer rate is based on the cost rate.                                                |
+| `Pharmacy Transfer is by Retail Rate`                            | Boolean   | `true`  | Determines if the transfer rate is based on the retail rate.                                              |
+| `DepNumGenFromToDepartment`                                      | Boolean   | `false` | Determines how the department bill number is generated.                                                   |
+| `Display Colours for Stock Autocomplete Items`                   | Boolean   | `true`  | Controls whether to display colors for stock autocomplete items based on expiry dates.                    |
+| `Report Font Size of Item List in Pharmacy Disbursement Reports` | String    | `10pt`  | Sets the font size for the item list in the report.                                                       |
+| `Pharmacy Disbursement Reports - Display Serial Number`          | Boolean   | `true`  | Controls the visibility of the serial number column.                                                      |
+| `Pharmacy Disbursement Reports - Display Code`                   | Boolean   | `true`  | Controls the visibility of the item code column.                                                          |
+| `Pharmacy Disbursement Reports - Display Batch Number`           | Boolean   | `false` | Controls the visibility of the batch number column.                                                       |
+| `Pharmacy Disbursement Reports - Display Date of Expiary`        | Boolean   | `true`  | Controls the visibility of the expiry date column.                                                        |
+| `Pharmacy Disbursement Reports - Display Purchase Rate`          | Boolean   | `true`  | Controls the visibility of the purchase rate column.                                                      |
+| `Pharmacy Disbursement Reports - Display Purchase Value`         | Boolean   | `false` | Controls the visibility of the purchase value column.                                                     |
+| `Pharmacy Disbursement Reports - Display Retail Sale Rate`       | Boolean   | `false` | Controls the visibility of the retail sale rate column.                                                     |
+| `Pharmacy Disbursement Reports - Display Retail Sale Value`      | Boolean   | `false` | Controls the visibility of the retail sale value column.                                                    |
+| `Pharmacy Disbursement Reports - Display Transfer Rate`          | Boolean   | `false` | Controls the visibility of the transfer rate column.                                                      |
+| `Pharmacy Disbursement Reports - Display Transfer Value`         | Boolean   | `false` | Controls the visibility of the transfer value column.                                                     |
+| `Pharmacy Transfer Issue - Show Rate and Value`                  | Boolean   | `false` | Used in combination with `PharmacyTransferViewRates` to control visibility of rate and value columns. |
+| `Pharmacy Transfer Issue Bill Footer CSS`                        | String    | `''`    | CSS for the footer of the transfer issue bill.                                                            |
+| `Pharmacy Transfer Issue Bill Footer Text`                       | String    | `''`    | Text for the footer of the transfer issue bill.                                                             |
+

--- a/developer_docs/security/README.md
+++ b/developer_docs/security/README.md
@@ -1,0 +1,3 @@
+# Security
+
+This section contains documents related to application security, including privileges, roles, and other access control mechanisms.

--- a/developer_docs/security/privileges.md
+++ b/developer_docs/security/privileges.md
@@ -1,0 +1,11 @@
+# Privileges
+
+This document lists the privileges used in the application and their purpose.
+
+## Pharmacy Transfer Issue
+
+| Privilege                   | Description                                                                 |
+| --------------------------- | --------------------------------------------------------------------------- |
+| `StockTransactionViewRates`   | Allows viewing rates and values in stock transactions.                      |
+| `Developers`                | Allows showing/hiding all bill formats for printing for development purposes. |
+| `PharmacyTransferViewRates` | Allows viewing rates and values in pharmacy transfer issue reports.         |

--- a/src/main/java/com/divudi/bean/pharmacy/TransferReceiveController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/TransferReceiveController.java
@@ -10,6 +10,7 @@ import com.divudi.core.util.JsfUtil;
 import com.divudi.core.data.BillClassType;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 import javax.persistence.TemporalType;
 import com.divudi.core.data.BillNumberSuffix;
 import com.divudi.core.data.BillType;
@@ -361,7 +362,7 @@ public class TransferReceiveController implements Serializable {
             for (BillItem receiveItem : receiveItems) {
                 // Only count items that reference the same issued item
                 if (receiveItem.getReferanceBillItem() != null && 
-                    receiveItem.getReferanceBillItem().getId().equals(issuedItem.getId()) &&
+                    Objects.equals(receiveItem.getReferanceBillItem().getId(), issuedItem.getId()) &&
                     receiveItem.getPharmaceuticalBillItem() != null) {
                     totalReceivedQty += Math.abs(receiveItem.getPharmaceuticalBillItem().getQty());
                 }

--- a/src/main/resources/META-INF/persistence.xml
+++ b/src/main/resources/META-INF/persistence.xml
@@ -2,7 +2,7 @@
 <persistence version="2.2" xmlns="http://java.sun.com/xml/ns/persistence" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/persistence http://xmlns.jcp.org/xml/ns/persistence/persistence_2_2.xsd">
     <persistence-unit name="hmisPU" transaction-type="JTA">
         <provider>org.eclipse.persistence.jpa.PersistenceProvider</provider>
-        <jta-data-source>jdbc/Ruhunu</jta-data-source>
+        <jta-data-source>jdbc/coop</jta-data-source>
         <exclude-unlisted-classes>false</exclude-unlisted-classes>
         <properties>
             <property name="eclipselink.logging.level.sql" value="SEVERE"/>

--- a/src/main/resources/META-INF/persistence.xml
+++ b/src/main/resources/META-INF/persistence.xml
@@ -2,7 +2,7 @@
 <persistence version="2.2" xmlns="http://java.sun.com/xml/ns/persistence" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/persistence http://xmlns.jcp.org/xml/ns/persistence/persistence_2_2.xsd">
     <persistence-unit name="hmisPU" transaction-type="JTA">
         <provider>org.eclipse.persistence.jpa.PersistenceProvider</provider>
-        <jta-data-source>jdbc/coop</jta-data-source>
+        <jta-data-source>${JDBC_DATASOURCE}</jta-data-source>
         <exclude-unlisted-classes>false</exclude-unlisted-classes>
         <properties>
             <property name="eclipselink.logging.level.sql" value="SEVERE"/>
@@ -10,7 +10,7 @@
         </properties>
     </persistence-unit>
     <persistence-unit name="hmisAuditPU" transaction-type="JTA">
-        <jta-data-source>jdbc/ruhunuAudit</jta-data-source>
+        <jta-data-source>${JDBC_AUDIT_DATASOURCE}</jta-data-source>
         <exclude-unlisted-classes>false</exclude-unlisted-classes>
         <properties>
             <property name="eclipselink.logging.level.sql" value="SEVERE"/>

--- a/src/main/webapp/resources/ezcomp/menu.xhtml
+++ b/src/main/webapp/resources/ezcomp/menu.xhtml
@@ -1780,9 +1780,10 @@
                         rendered="#{webUserController.hasPrivilege('ChangeMyTheme')}" 
                         action="#{themeController.navigateToChangeOwnTheme()}"
                         value="Change My Theme" icon="pi pi-palette" ></p:menuitem>
+                    <!--Can not correct the spelling mistake as the enum values are already in production databases-->
                     <p:menuitem 
                         ajax="false" 
-                        rendered="#{webUserController.hasPrivilege('ChangePreference')}"
+                        rendered="#{webUserController.hasPrivilege('ChangePreferece')}" 
                         action="#{sessionController.navigateToManageOwnWebUserPreferences()}"
                         value="Change My Preferences" icon="pi pi-sliders-h"  ></p:menuitem>
                     <p:menuitem  


### PR DESCRIPTION
Summary

  Problem: Items with zero return quantities were being saved and printed in GRN returns.

  Solution: Modified the GrnReturnWithCostingController.java to handle zero quantity items properly.

  Changes Made:

  1. Updated saveBillItems() method (GrnReturnWithCostingController.java:593-687):
    - Added logic to detect items with zero return quantities
    - Items with zero quantities are retired if already saved in the database
    - Items with zero quantities are removed from the current processing list
    - Added informative message showing which items were excluded
  2. Updated fillData() method (GrnReturnWithCostingController.java:747-754):
    - Added logic to skip items with zero quantities during total calculations
    - Ensures only items with actual return quantities contribute to bill totals

  Key Features:

  - Zero Quantity Detection: Checks both quantity and freeQuantity fields
  - Database Cleanup: Retires previously saved items with zero quantities
  - User Feedback: Informs users which items were excluded from the return
  - Automatic Filtering: Receipt automatically shows only items with non-zero quantities
  - Data Integrity: Maintains proper bill totals by excluding zero quantity items

  The receipt component (grn_return_receipt_with_costing.xhtml) automatically benefits from these changes since it
  displays #{cc.attrs.bill.billItems}, which now only contains items with non-zero return quantities.
