### PR TITLE
15177 restrict regenerating a sample that has already been regenerated

### DIFF
--- a/src/main/java/com/divudi/bean/lab/PatientInvestigationController.java
+++ b/src/main/java/com/divudi/bean/lab/PatientInvestigationController.java
@@ -2193,7 +2193,9 @@ public class PatientInvestigationController implements Serializable {
                 }
             }
         }
-
+        
+        patientSamples.addAll(reGenarateSamples);
+        
         JsfUtil.addSuccessMessage("Selected Samples Recreated");
     }
 

--- a/src/main/java/com/divudi/bean/lab/PatientInvestigationController.java
+++ b/src/main/java/com/divudi/bean/lab/PatientInvestigationController.java
@@ -2067,7 +2067,12 @@ public class PatientInvestigationController implements Serializable {
             ps.setSampleRejectedAt(new Date());
             ps.setSampleRejectionComment(sampleRejectionComment);
             ps.setSampleRejectedBy(sessionController.getLoggedUser());
-            ps.setStatus(PatientInvestigationStatus.SAMPLE_REJECTED);
+            if(requestReCollected){
+                ps.setStatus(PatientInvestigationStatus.SAMPLE_RECOLLECTION_REQUESTED);
+            }else{
+                ps.setStatus(PatientInvestigationStatus.SAMPLE_REJECTED);
+            }
+            
             patientSampleFacade.edit(ps);
 
             // Retrieve and store PatientInvestigations by unique ID to avoid duplicates
@@ -2127,7 +2132,7 @@ public class PatientInvestigationController implements Serializable {
                 JsfUtil.addErrorMessage("This sample (" + ps.getId() + ") is not Rejected.");
                 return;
             }
-            if (ps.getStatus() != PatientInvestigationStatus.SAMPLE_RECOLLECTION_PENDING || ps.getStatus() != PatientInvestigationStatus.SAMPLE_RECOLLECTION_COMPLETE) {
+            if (ps.getStatus() == PatientInvestigationStatus.SAMPLE_RECOLLECTION_PENDING || ps.getStatus() == PatientInvestigationStatus.SAMPLE_RECOLLECTION_COMPLETE) {
                 JsfUtil.addErrorMessage("This sample (" + ps.getId() + ") has already been recreated for this sample.");
                 return;
             }
@@ -2135,7 +2140,7 @@ public class PatientInvestigationController implements Serializable {
                 JsfUtil.addErrorMessage("This sample (" + ps.getId() + ") is not not Requesr to Recollect.");
                 return;
             }
-            if (ps.getStatus() == PatientInvestigationStatus.SAMPLE_REJECTED && ps.getRequestReCollected()) {
+            if (ps.getStatus() == PatientInvestigationStatus.SAMPLE_RECOLLECTION_REQUESTED && ps.getRequestReCollected()) {
                 canReGenarateSamples.add(ps);
             }
         }
@@ -2194,7 +2199,7 @@ public class PatientInvestigationController implements Serializable {
             }
         }
         
-        patientSamples.addAll(reGenarateSamples);
+        patientSamples.addAll(0,reGenarateSamples);
         
         JsfUtil.addSuccessMessage("Selected Samples Recreated");
     }

--- a/src/main/java/com/divudi/bean/lab/PatientInvestigationController.java
+++ b/src/main/java/com/divudi/bean/lab/PatientInvestigationController.java
@@ -2123,8 +2123,12 @@ public class PatientInvestigationController implements Serializable {
                 JsfUtil.addErrorMessage("This Bill is Already Cancel");
                 return;
             }
-            if (ps.getStatus() != PatientInvestigationStatus.SAMPLE_REJECTED) {
+            if (ps.getStatus() != PatientInvestigationStatus.SAMPLE_REJECTED  && !ps.getRequestReCollected()) {
                 JsfUtil.addErrorMessage("This sample (" + ps.getId() + ") is not Rejected.");
+                return;
+            }
+            if (ps.getStatus() != PatientInvestigationStatus.SAMPLE_RECOLLECTION_PENDING || ps.getStatus() != PatientInvestigationStatus.SAMPLE_RECOLLECTION_COMPLETE) {
+                JsfUtil.addErrorMessage("This sample (" + ps.getId() + ") has already been recreated for this sample.");
                 return;
             }
             if (!ps.getRequestReCollected()) {

--- a/src/main/webapp/lab/generate_barcode_p.xhtml
+++ b/src/main/webapp/lab/generate_barcode_p.xhtml
@@ -1446,7 +1446,7 @@
                                         class="w-100" 
                                         maxResults="50"
                                         inputStyleClass="form-control"
-                                        itemLabel="#{mys.person.name}" 
+                                        itemLabel="#{mys.person.nameWithTitle}" 
                                         panelStyleClass="custom-dropdown-panel"
                                         itemValue="#{mys}">
                                         <p:column headerText="Code" style="padding: 6px; width: 20px;">#{mys.code}</p:column>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Newly recollected samples now appear at the top of the list for quicker access.
- Bug Fixes
  - Corrected sample rejection/recollection status handling and eligibility checks.
  - Prevented duplicate regeneration when recollection is already pending or complete.
  - Regeneration now proceeds only when recollection is explicitly requested.
- Style
  - Sample Transporter autocomplete now displays names with titles, matching the Name column.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->