### PR TITLE
15184 improving barcode regenerate process

### DIFF
--- a/src/main/java/com/divudi/bean/lab/PatientInvestigationController.java
+++ b/src/main/java/com/divudi/bean/lab/PatientInvestigationController.java
@@ -284,6 +284,8 @@ public class PatientInvestigationController implements Serializable {
 
     private String testDetails;
 
+    private List<PatientSample> regeneratedPatientSamples;
+
     public int getNumber() {
         return number;
     }
@@ -2028,25 +2030,25 @@ public class PatientInvestigationController implements Serializable {
                 JsfUtil.addErrorMessage("This Sample (" + ps.getId() + ") is Already Rejected");
                 return;
             }
-            
+
             String jpql = "SELECT r "
-                + " FROM PatientReport r "
-                + " WHERE r.retired = :ret "
-                + " AND r.patientInvestigation in ( select ps.patientInvestigation from PatientSampleComponant ps where ps.patientSample=:pts and ps.retired=false ) ";
-            
+                    + " FROM PatientReport r "
+                    + " WHERE r.retired = :ret "
+                    + " AND r.patientInvestigation in ( select ps.patientInvestigation from PatientSampleComponant ps where ps.patientSample=:pts and ps.retired=false ) ";
+
             Map<String, Object> params = new HashMap<>();
             params.put("pts", ps);
             params.put("ret", false);
-            
+
             PatientReport pr = patientReportFacade.findFirstByJpql(jpql, params, TemporalType.TIMESTAMP);
-            
+
             if (pr != null) {
                 JsfUtil.addErrorMessage("This Sample (" + ps.getId() + ") has Already Report Created");
                 return;
             }
-            
+
             canRejectSamples.add(ps);
-            
+
         }
 
         if (canRejectSamples.isEmpty()) {
@@ -2067,12 +2069,12 @@ public class PatientInvestigationController implements Serializable {
             ps.setSampleRejectedAt(new Date());
             ps.setSampleRejectionComment(sampleRejectionComment);
             ps.setSampleRejectedBy(sessionController.getLoggedUser());
-            if(requestReCollected){
+            if (requestReCollected) {
                 ps.setStatus(PatientInvestigationStatus.SAMPLE_RECOLLECTION_REQUESTED);
-            }else{
+            } else {
                 ps.setStatus(PatientInvestigationStatus.SAMPLE_REJECTED);
             }
-            
+
             patientSampleFacade.edit(ps);
 
             // Retrieve and store PatientInvestigations by unique ID to avoid duplicates
@@ -2112,7 +2114,7 @@ public class PatientInvestigationController implements Serializable {
         requestReCollected = true;
 
         JsfUtil.addSuccessMessage("Selected Samples Are Rejected");
-        
+
     }
 
     public void reGenerateSampleForRejectSamples() {
@@ -2128,7 +2130,7 @@ public class PatientInvestigationController implements Serializable {
                 JsfUtil.addErrorMessage("This Bill is Already Cancel");
                 return;
             }
-            if (ps.getStatus() != PatientInvestigationStatus.SAMPLE_REJECTED  && !ps.getRequestReCollected()) {
+            if (ps.getStatus() != PatientInvestigationStatus.SAMPLE_REJECTED && !ps.getRequestReCollected()) {
                 JsfUtil.addErrorMessage("This sample (" + ps.getId() + ") is not Rejected.");
                 return;
             }
@@ -2149,8 +2151,6 @@ public class PatientInvestigationController implements Serializable {
             JsfUtil.addErrorMessage("There are no suitable samples to Re-Genarate from the selected samples.");
             return;
         }
-
-        listingEntity = ListingEntity.PATIENT_SAMPLES;
 
         Map<Long, PatientInvestigation> collectedPtixs = new HashMap<>();
         Map<Long, Bill> collectedBills = new HashMap<>();
@@ -2198,10 +2198,28 @@ public class PatientInvestigationController implements Serializable {
                 }
             }
         }
-        
-        patientSamples.addAll(0,reGenarateSamples);
-        
+
+        if (configOptionApplicationController.getBooleanValueByKey("Show barcode on Regenerated Patient Samples", false)) {
+            regeneratedPatientSamples = new ArrayList<>();
+            regeneratedPatientSamples.addAll(reGenarateSamples);
+            listingEntity = ListingEntity.PATIENT_SAMPLES_INDIVIDUAL;
+        } else {
+            patientSamples.addAll(0, reGenarateSamples);
+            listingEntity = ListingEntity.PATIENT_SAMPLES;
+        }
+
         JsfUtil.addSuccessMessage("Selected Samples Recreated");
+    }
+
+    public void navigateToThePatientSample(PatientSample patientSample) {
+        listingEntity = ListingEntity.PATIENT_SAMPLES_INDIVIDUAL;
+        regeneratedPatientSamples = new ArrayList<>();
+        regeneratedPatientSamples.add(patientSample);
+    }
+    
+    public void navigateToThePatientSampleList() {
+        listingEntity = ListingEntity.PATIENT_SAMPLES;
+        searchPatientSamples();
     }
 
     public PatientSample createNewPatientSampleFromAnotherSample(PatientSample referringPatientSample) {
@@ -5691,6 +5709,14 @@ public class PatientInvestigationController implements Serializable {
 
     public void setRequestReCollected(boolean requestReCollected) {
         this.requestReCollected = requestReCollected;
+    }
+
+    public List<PatientSample> getRegeneratedPatientSamples() {
+        return regeneratedPatientSamples;
+    }
+
+    public void setRegeneratedPatientSamples(List<PatientSample> regeneratedPatientSamples) {
+        this.regeneratedPatientSamples = regeneratedPatientSamples;
     }
 
     /**

--- a/src/main/java/com/divudi/core/data/lab/ListingEntity.java
+++ b/src/main/java/com/divudi/core/data/lab/ListingEntity.java
@@ -10,6 +10,7 @@ public enum ListingEntity {
     BILL_ITEMS("Bill Items"),
     PATIENT_INVESTIGATIONS("Patient Investigations"),
     PATIENT_SAMPLES("Patient Samples"),
+    PATIENT_SAMPLES_INDIVIDUAL("IndividualPatient Samples"),
     PATIENT_REPORTS("Patient Reports"),
     VIEW_BARCODE("View Barcodes"),
     BILL_BARCODES("Bill Barcodes"),

--- a/src/main/webapp/lab/generate_barcode_p.xhtml
+++ b/src/main/webapp/lab/generate_barcode_p.xhtml
@@ -192,7 +192,7 @@
                             </div>
                             <div class="col-2">
                                 <h:panelGrid columns="1" class="w-100">
-                                    
+
                                     <p:commandButton 
                                         ajax="false" 
                                         action="#{patientInvestigationController.searchBills}"  
@@ -216,7 +216,7 @@
                                         <f:selectItem itemValue="INTERNAL_ONLY" itemLabel="Internal Samples Only"/>
                                         <f:selectItem itemValue="EXTERNAL_ONLY" itemLabel="Outsource Samples Only"/>
                                     </p:selectOneMenu>
-                                    
+
                                     <p:commandButton 
                                         ajax="false" 
                                         action="#{patientInvestigationController.searchPatientSamples}" 
@@ -818,7 +818,6 @@
                                                             </div>
                                                         </ui:repeat>
 
-
                                                     </ui:repeat>
                                                 </h:panelGroup>
                                             </h:panelGroup>
@@ -951,8 +950,15 @@
 
                                         <!-- Sample ID Column with Icon -->
                                         <p:column headerText="Sample" width="3em" style="vertical-align: top;">
-                                            <i class="fa-solid fa-vial-virus text-danger"></i> <!-- Sample Icon -->
-                                            <h:outputLabel value="#{ps.id}" class="mx-2" /><br/><br/>
+                                            <p:commandLink 
+                                                ajax="false" 
+                                                class="text-primary"
+                                                action="#{patientInvestigationController.navigateToThePatientSample(ps)}">
+                                                <i class="fa-solid fa-vial-virus text-danger"></i> <!-- Sample Icon -->
+                                                <h:outputLabel value="#{ps.id}" class="mx-2" />
+                                            </p:commandLink>
+
+                                            <br/><br/>
                                             <i class="fas fa-vial text-danger"></i> <!-- Sample Icon -->
                                             <h:outputLabel value="#{ps.tube.name}" class="mx-2" />
                                         </p:column>
@@ -1117,8 +1123,8 @@
                                                 </h:panelGrid>
                                             </div>
                                         </p:column>
-                                    </p:dataTable>
 
+                                    </p:dataTable>
 
                                 </h:panelGroup>
 
@@ -1369,6 +1375,215 @@
                                         </p:column>
 
                                     </p:dataTable>
+
+                                </h:panelGroup>
+
+                                <h:panelGroup rendered="#{patientInvestigationController.listingEntity eq 'PATIENT_SAMPLES_INDIVIDUAL'}" >
+                                    <p:panel>
+                                        <f:facet name="header">
+                                            <div class="d-flex justify-content-between">
+                                                <div class="d-flex gap-2">
+                                                    <i class="fa fa-barcode mt-3" aria-hidden="true"></i>
+                                                    <h:outputLabel value="Individual Barcode Sticker" class="mt-2"/>
+                                                </div>
+                                                <div class="d-flex gap-2">
+                                                    <div class="d-flex gap-3">
+                                                        <p:commandButton
+                                                            ajax="false" 
+                                                            class="ui-button-info"
+                                                            icon="fa fa-print"
+                                                            value="Print All">
+                                                            <p:printer target="batchBarcodeIndividual"></p:printer>
+                                                        </p:commandButton>
+
+                                                        <!--                                                        <h:outputLabel value="Print Individual Barcodes"/>
+                                                                                                                <p:selectBooleanButton id="cheindbarIndividual" onIcon="pi pi-check" offIcon="pi pi-times" value="#{patientInvestigationController.printIndividualBarcodes}">
+                                                                                                                    <p:ajax process="cheindbarIndividual" update="allBatchBarcodeIndividual individualBarcodeSingle batchBarcodeIndividual" event="change"></p:ajax>
+                                                                                                                </p:selectBooleanButton>-->
+
+                                                        <p:commandButton 
+                                                            icon="fa-solid fa-flask-vial"
+                                                            value="To Samples" 
+                                                            class="ui-button-warning"
+                                                            ajax="false"
+                                                            action="#{patientInvestigationController.navigateToThePatientSampleList()}" >
+                                                        </p:commandButton>
+                                                    </div>
+                                                </div>
+                                            </div>
+                                        </f:facet>
+
+                                        <h:panelGroup id="batchBarcodeIndividual">
+
+                                            <h:panelGroup id="allBatchBarcodeIndividual" rendered="#{patientInvestigationController.printIndividualBarcodes eq false}">
+                                                <ui:repeat value="#{patientInvestigationController.regeneratedPatientSamples}" var="ps">
+                                                    <div class="sticker">
+                                                        <div class="patient-info">
+                                                            <h:panelGroup rendered="#{configOptionApplicationController.getBooleanValueByKey('Print Sample ID PHN in Sample Stickers', true)}">
+                                                                <span class="sample-id">
+                                                                    #{ps.idStr}&nbsp;&nbsp;
+                                                                </span>
+                                                            </h:panelGroup>
+                                                            <h:panelGroup rendered="#{configOptionApplicationController.getBooleanValueByKey('Print Patient Age in Sample Stickers')}">
+                                                                <span class="patient-age">
+                                                                    #{ps.patient.person.ageAsShortString}&nbsp;&nbsp;
+                                                                </span>
+                                                            </h:panelGroup>
+                                                            <h:panelGroup rendered="#{configOptionApplicationController.getBooleanValueByKey('Print Patient Sex in Sample Stickers')}">
+                                                                <span class="patient-sex">
+                                                                    #{ps.patient.person.sex.shortLabel}&nbsp;&nbsp;
+                                                                </span>
+                                                            </h:panelGroup>
+                                                            <h:panelGroup rendered="#{configOptionApplicationController.getBooleanValueByKey('Print Patient ID in Sample Stickers')}">
+                                                                <span class="patient-id">
+                                                                    #{ps.patient.person.id}&nbsp;&nbsp;
+                                                                </span>
+                                                            </h:panelGroup>
+                                                            <h:panelGroup rendered="#{configOptionApplicationController.getBooleanValueByKey('Print Bill Type (IP/OP/CC) in Sample Stickers')}">
+                                                                <span class="patient-id">
+                                                                    #{psc.patientSample.bill.ipOpOrCc}&nbsp;&nbsp;
+                                                                </span>
+                                                            </h:panelGroup>
+                                                            <h:panelGroup rendered="#{configOptionApplicationController.getBooleanValueByKey('Print Barcode Generated Time in Sample Stickers')}">
+                                                                <span class="patient-id">
+                                                                    <h:outputLabel value="#{ps.barcodeGeneratedAt}">
+                                                                        <f:convertDateTime pattern="#{configOptionApplicationController.getShortTextValueByKey('Date Time Format for Barcode Generated Time in Sample Stickers','d/M/yy-hh:mm')}"></f:convertDateTime>
+                                                                    </h:outputLabel>
+                                                                    &nbsp;&nbsp;
+                                                                </span>
+                                                            </h:panelGroup>
+                                                            <h:panelGroup rendered="#{configOptionApplicationController.getBooleanValueByKey('Print Patient PHN in Sample Stickers')}">
+                                                                <span class="patient-phn">
+                                                                    #{ps.patient.phn}
+                                                                </span>
+                                                            </h:panelGroup>
+                                                            <span class="patient-name">
+                                                                #{ps.patient.person.name}&nbsp;&nbsp;
+                                                            </span>
+                                                        </div>
+                                                        <div class="patient-sample-info">
+                                                            <ui:repeat value="#{patientInvestigationController.getPatientSampleComponentsByPatientSample(ps)}" var="psw">
+                                                                <span class="sample-component" style="font-weight: 800">
+                                                                    #{psw.nameTranscient}&nbsp;&nbsp;
+                                                                </span>
+                                                            </ui:repeat>
+                                                        </div>
+                                                        <div class="barcode-info">
+                                                            <h:panelGroup rendered="#{configOptionApplicationController.getBooleanValueByKey('Print Barcode in Sample Stickers')}">
+                                                                <p:barcode 
+                                                                    value="#{ps.idStr}" 
+                                                                    cache="false"
+                                                                    hrp="none"
+                                                                    type="#{configOptionApplicationController.getShortTextValueByKey('Sample Sticker - Barcode Type','code128')}" 
+                                                                    height="#{configOptionApplicationController.getShortTextValueByKey('Sample Sticker - Barcode Height in Pixles','80')}"
+                                                                    width="#{configOptionApplicationController.getShortTextValueByKey('Sample Sticker - Barcode Width in Pixles','280')}"
+                                                                    orientation="0"></p:barcode>
+                                                            </h:panelGroup>
+                                                        </div>
+                                                        <div class="patient-info">
+                                                            <h:panelGroup rendered="#{configOptionApplicationController.getBooleanValueByKey('Print Bill No in Sample Stickers', true)}">
+                                                                <span class="sample-id">
+                                                                    #{ps.bill.deptId}&nbsp;&nbsp;
+                                                                </span>
+                                                            </h:panelGroup>
+                                                        </div>
+                                                    </div>
+                                                </ui:repeat>
+                                            </h:panelGroup>
+
+                                            <!--
+                                                                                        <h:panelGroup id="individualBarcodeSingle" rendered="#{patientInvestigationController.printIndividualBarcodes eq true}">
+                                            
+                                                                                            <ui:repeat value="#{patientInvestigationController.regeneratedPatientSamples}" var="ps">
+                                                                                                <div>
+                                                                                                    <div class="row">
+                                                                                                        <div class="col-4">
+                                                                                                            <h:panelGroup id="tt">
+                                                                                                                <div class="sticker" >
+                                                                                                                    <div class="patient-info">
+                                                                                                                        <h:panelGroup rendered="#{configOptionApplicationController.getBooleanValueByKey('Print Sample ID PHN in Sample Stickers', true)}">
+                                                                                                                            <span class="sample-id">
+                                            #{ps.idStr}&nbsp;&nbsp;
+                                        </span>
+                                    </h:panelGroup>
+                                    <h:panelGroup rendered="#{configOptionApplicationController.getBooleanValueByKey('Print Patient Age in Sample Stickers')}">
+                                        <span class="patient-age">
+                                            #{ps.patient.person.ageAsShortString}&nbsp;&nbsp;
+                                        </span>
+                                    </h:panelGroup>
+                                    <h:panelGroup rendered="#{configOptionApplicationController.getBooleanValueByKey('Print Patient Sex in Sample Stickers')}">
+                                        <span class="patient-sex">
+                                            #{ps.patient.person.sex.shortLabel}&nbsp;&nbsp;
+                                        </span>
+                                    </h:panelGroup>
+                                    <h:panelGroup rendered="#{configOptionApplicationController.getBooleanValueByKey('Print Patient ID in Sample Stickers')}">
+                                        <span class="patient-id">
+                                            #{ps.patient.person.id}&nbsp;&nbsp;
+                                        </span>
+                                    </h:panelGroup>
+                                    <h:panelGroup rendered="#{configOptionApplicationController.getBooleanValueByKey('Print Bill Type (IP/OP/CC) in Sample Stickers')}">
+                                        <span class="patient-id">
+                                            #{ps.bill.ipOpOrCc}&nbsp;&nbsp;
+                                        </span>
+                                    </h:panelGroup>
+                                    <h:panelGroup rendered="#{configOptionApplicationController.getBooleanValueByKey('Print Barcode Generated Time in Sample Stickers')}">
+                                        <span class="patient-id">
+                                            <h:outputLabel value="#{ps.barcodeGeneratedAt}">
+                                                <f:convertDateTime pattern="#{configOptionApplicationController.getShortTextValueByKey('Date Time Format for Barcode Generated Time in Sample Stickers','d/M/yy-hh:mm')}"></f:convertDateTime>
+                                            </h:outputLabel>
+                                            &nbsp;&nbsp;
+                                        </span>
+                                    </h:panelGroup>
+                                    <h:panelGroup rendered="#{configOptionApplicationController.getBooleanValueByKey('Print Patient PHN in Sample Stickers')}">
+                                        <span class="patient-phn">
+                                            #{ps.patient.phn}&nbsp;&nbsp;
+                                        </span>
+                                    </h:panelGroup>
+                                    <span class="patient-name">
+                                            #{ps.patient.person.name}&nbsp;&nbsp;
+                                        </span>
+                                    </div>
+                                    <div class="patient-sample-info">
+                                        <ui:repeat value="#{patientInvestigationController.getPatientSampleComponentsByPatientSample(ps)}" var="psw">
+                                            <span class="sample-component" style="font-weight: 800">
+                                            #{psw.nameTranscient}&nbsp;&nbsp;
+                                        </span>
+                                    </ui:repeat>
+                                </div>
+                                <div class="barcode-info">
+                                    <h:panelGroup rendered="#{configOptionApplicationController.getBooleanValueByKey('Print Barcode in Sample Stickers')}">
+                                        <p:barcode 
+                                            value="#{ps.idStr}" 
+                                            cache="false"
+                                            hrp="none"
+                                            type="#{configOptionApplicationController.getShortTextValueByKey('Sample Sticker - Barcode Type','code128')}" 
+                                            height="#{configOptionApplicationController.getShortTextValueByKey('Sample Sticker - Barcode Height in Pixles','80')}"
+                                            width="#{configOptionApplicationController.getShortTextValueByKey('Sample Sticker - Barcode Width in Pixles','280')}"
+                                            orientation="0"></p:barcode>
+                                    </h:panelGroup>
+                                </div> 
+                            </div>
+                            <div class="patient-info">
+                                <h:panelGroup rendered="#{configOptionApplicationController.getBooleanValueByKey('Print Bill No in Sample Stickers', true)}">
+                                    <span class="sample-id">
+                                            #{ps.bill.deptId}&nbsp;&nbsp;
+                                        </span>
+                                    </h:panelGroup>
+                                </div>
+                            </h:panelGroup>
+                        </div> 
+
+                    </div> 
+                </div>
+
+            </ui:repeat>
+
+
+        </h:panelGroup>-->
+
+                                        </h:panelGroup>
+
+                                    </p:panel>
 
                                 </h:panelGroup>
 

--- a/src/main/webapp/lab/generate_barcode_p.xhtml
+++ b/src/main/webapp/lab/generate_barcode_p.xhtml
@@ -1707,6 +1707,7 @@
 
                                     <p:inputText 
                                         class="w-100"
+                                        disabled="#{patientInvestigationController.listingEntity ne 'PATIENT_SAMPLES'}"
                                         placeholder="Sample Reject Reason"
                                         value="#{patientInvestigationController.sampleRejectionComment}" >
                                     </p:inputText>

--- a/src/main/webapp/lab/generate_barcode_p.xhtml
+++ b/src/main/webapp/lab/generate_barcode_p.xhtml
@@ -1395,8 +1395,8 @@
                                                             value="Print All">
                                                             <p:printer target="batchBarcodeIndividual"></p:printer>
                                                         </p:commandButton>
-
-                                                        <!--                                                        <h:outputLabel value="Print Individual Barcodes"/>
+<!--
+                                                                                                              <h:outputLabel value="Print Individual Barcodes"/>
                                                                                                                 <p:selectBooleanButton id="cheindbarIndividual" onIcon="pi pi-check" offIcon="pi pi-times" value="#{patientInvestigationController.printIndividualBarcodes}">
                                                                                                                     <p:ajax process="cheindbarIndividual" update="allBatchBarcodeIndividual individualBarcodeSingle batchBarcodeIndividual" event="change"></p:ajax>
                                                                                                                 </p:selectBooleanButton>-->
@@ -1415,7 +1415,7 @@
 
                                         <h:panelGroup id="batchBarcodeIndividual">
 
-                                            <h:panelGroup id="allBatchBarcodeIndividual" rendered="#{patientInvestigationController.printIndividualBarcodes eq false}">
+                                            <h:panelGroup id="allBatchBarcodeIndividual">
                                                 <ui:repeat value="#{patientInvestigationController.regeneratedPatientSamples}" var="ps">
                                                     <div class="sticker">
                                                         <div class="patient-info">
@@ -1441,7 +1441,7 @@
                                                             </h:panelGroup>
                                                             <h:panelGroup rendered="#{configOptionApplicationController.getBooleanValueByKey('Print Bill Type (IP/OP/CC) in Sample Stickers')}">
                                                                 <span class="patient-id">
-                                                                    #{psc.patientSample.bill.ipOpOrCc}&nbsp;&nbsp;
+                                                                    #{ps.bill.ipOpOrCc}&nbsp;&nbsp;
                                                                 </span>
                                                             </h:panelGroup>
                                                             <h:panelGroup rendered="#{configOptionApplicationController.getBooleanValueByKey('Print Barcode Generated Time in Sample Stickers')}">


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Individual barcode printing workflow for regenerated patient samples with per-sample stickers and a “Print All” option.
  * Configurable option to display regenerated samples as individual items with their own barcodes.
  * Navigate from a sample ID to an individual-sample view and back to the full samples list.

* **UI Enhancements**
  * Added “Bills” and “Samples” quick-action buttons beside Investigations.
  * Clickable sample IDs for faster access; improved sticker content (PHN, age, sex, ID, bill type, time).
  * Reject-reason editing disabled outside the main samples listing; minor styling and layout refinements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->