### PR TITLE
fix spellings change

### DIFF
--- a/src/main/webapp/admin/items/inward_service.xhtml
+++ b/src/main/webapp/admin/items/inward_service.xhtml
@@ -105,7 +105,7 @@
                                             <p:column>#{pta.parentCategory}</p:column>                                        
                                         </p:autoComplete>
 
-                                        <p:selectBooleanCheckbox   id="chkBilledAs" value="#{inwardServiceController.billedAs}" itemLabel="Billed as a seperate investigation"  >
+                                        <p:selectBooleanCheckbox   id="chkBilledAs" value="#{inwardServiceController.billedAs}" itemLabel="Billed as a separate investigation"  >
                                             <p:ajax event="change" process="@this" update="billedAsIx" />
                                         </p:selectBooleanCheckbox>
                                         <p:autoComplete   disabled="#{!inwardServiceController.billedAs}" 
@@ -113,7 +113,7 @@
                                                           value="#{inwardServiceController.current.billedAs}" completeMethod="#{inwardServiceController.completeItem}" var="ix1" itemLabel="#{ix1.name}" itemValue="#{ix1}" size="30">
                                         </p:autoComplete>
 
-                                        <p:selectBooleanCheckbox  id="chkReportedAs" value="#{inwardServiceController.reportedAs}" itemLabel="Reported as a seperate investigation" >
+                                        <p:selectBooleanCheckbox  id="chkReportedAs" value="#{inwardServiceController.reportedAs}" itemLabel="Reported as a separate investigation" >
                                             <p:ajax event="change" process="@this" update="reportedAsIx" />
                                         </p:selectBooleanCheckbox>
                                         <p:autoComplete  


### PR DESCRIPTION
/admin/items/inward_service.xhtml



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected a spelling error in two checkbox labels on the Admin > Items > Inward Service page, changing “seperate investigation” to “separate investigation” for the “Billed As” and “Reported As” options.
  * UI-only change: improves clarity and professionalism of labels without altering behavior, data, or bindings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->