### PR TITLE
15210 imrpveo stock taking

### DIFF
--- a/src/main/webapp/pharmacy/pharmacy_stock_take_list.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_stock_take_list.xhtml
@@ -34,13 +34,17 @@
                                         </p:selectOneMenu>
 
                                         <h:outputLabel for="fd" value="From Date"/>
-                                        <p:datePicker id="fd" value="#{pharmacyStockTakeController.fromDate}" pattern="#{sessionController.applicationPreference.shortDateFormat}" showIcon="true"/>
+                                        <p:datePicker id="fd" value="#{pharmacyStockTakeController.fromDate}" pattern="#{sessionController.applicationPreference.shortDateFormat}" />
 
                                         <h:outputLabel for="td" value="To Date"/>
-                                        <p:datePicker id="td" value="#{pharmacyStockTakeController.toDate}" pattern="#{sessionController.applicationPreference.shortDateFormat}" showIcon="true"/>
+                                        <p:datePicker id="td" value="#{pharmacyStockTakeController.toDate}" pattern="#{sessionController.applicationPreference.shortDateFormat}" />
 
                                         <p:spacer/>
-                                        <p:commandButton value="List" icon="fa fa-list" actionListener="#{pharmacyStockTakeController.listSnapshotBills()}" update=":frmTable"/>
+                                        <p:commandButton
+                                            value="List" 
+                                            icon="fa fa-list" 
+                                            action="#{pharmacyStockTakeController.listSnapshotBills()}" 
+                                            ajax="false"/>
                                     </p:panelGrid>
                                 </p:panel>
                             </h:form>
@@ -52,8 +56,7 @@
                                              rowsPerPageTemplate="10,25,50,100"
                                              styleClass="ui-datatable-striped ui-datatable-gridlines"
                                              emptyMessage="No bills found."
-                                             sortMode="multiple"
-                                             filterable="true">
+                                             sortMode="multiple">
 
                                     <p:column headerText="Bill No" sortBy="#{b.deptId}" filterBy="#{b.deptId}" style="width: 160px;">
                                         <h:outputText value="#{b.deptId}" style="font-family: monospace;"/>
@@ -83,12 +86,24 @@
                                         </h:outputText>
                                     </p:column>
 
-                                    <p:column headerText="Actions" style="width: 260px; text-align: center;">
-                                        <p:commandButton value="View" icon="fa fa-eye" ajax="false"
-                                                         action="#{pharmacyStockTakeController.viewSnapshot(b)}"/>
+                                    <p:column headerText="Actions" style="width: 420px; text-align: center;">
+                                        <p:commandButton 
+                                            value="View" 
+                                            icon="fa fa-eye" 
+                                            ajax="false"
+                                            action="#{pharmacyStockTakeController.viewSnapshot(b)}"/>
                                         <p:spacer width="8"/>
-                                        <p:commandButton value="Upload Adjustments" icon="fa fa-upload" ajax="false"
-                                                         action="#{pharmacyStockTakeController.gotoUploadAdjustments(b)}"/>
+                                        <p:commandButton 
+                                            value="Upload Adjustments" 
+                                            icon="fa fa-upload" 
+                                            ajax="false"
+                                            action="#{pharmacyStockTakeController.gotoUploadAdjustments(b)}"/>
+                                        <p:spacer width="8"/>
+                                        <p:commandButton 
+                                            value="View Variance" 
+                                            icon="fa fa-chart-bar" 
+                                            ajax="false"
+                                            action="#{pharmacyStockTakeController.gotoViewVariance(b)}"/>
                                     </p:column>
                                 </p:dataTable>
                             </h:form>
@@ -98,6 +113,5 @@
             </ui:define>
         </ui:composition>
     </h:body>
-    
-</html>
 
+</html>

--- a/src/main/webapp/pharmacy/pharmacy_stock_take_upload.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_stock_take_upload.xhtml
@@ -35,14 +35,16 @@
 
                                 <p:separator/>
 
-                                <div class="mb-3">
-                                    <p:commandButton value="Download Guided Sheet" ajax="false" styleClass="ui-button-success mr-2" icon="fa fa-download">
-                                        <p:fileDownload value="#{pharmacyStockTakeController.downloadGuidedSheet}" />
-                                    </p:commandButton>
-                                    <p:commandButton value="Download Blind Sheet" ajax="false" styleClass="ui-button-warning" icon="fa fa-download">
-                                        <p:fileDownload value="#{pharmacyStockTakeController.downloadBlindSheet}" />
-                                    </p:commandButton>
-                                </div>
+                                <h:form id="frmDownloads">
+                                    <div class="mb-3">
+                                        <p:commandButton value="Download Guided Sheet" ajax="false" styleClass="ui-button-success mr-2" icon="fa fa-download" onclick="PrimeFaces.monitorDownload(start, stop);">
+                                            <p:fileDownload value="#{pharmacyStockTakeController.downloadGuidedSheet}" />
+                                        </p:commandButton>
+                                        <p:commandButton value="Download Blind Sheet" ajax="false" styleClass="ui-button-warning" icon="fa fa-download" onclick="PrimeFaces.monitorDownload(start, stop);">
+                                            <p:fileDownload value="#{pharmacyStockTakeController.downloadBlindSheet}" />
+                                        </p:commandButton>
+                                    </div>
+                                </h:form>
 
                                 <h:form id="frmUpload" enctype="multipart/form-data">
                                     <p:panel header="Upload Completed Sheet">
@@ -101,4 +103,3 @@
         </ui:composition>
     </h:body>
 </html>
-

--- a/src/main/webapp/pharmacy/pharmacy_stock_take_variance.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_stock_take_variance.xhtml
@@ -1,0 +1,93 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
+      xmlns:h="http://xmlns.jcp.org/jsf/html"
+      xmlns:p="http://primefaces.org/ui"
+      xmlns:f="http://xmlns.jcp.org/jsf/core">
+    <h:head />
+    <h:body>
+        <ui:composition template="/pharmacy/adjustments/pharmacy_adjustment_index.xhtml">
+            <ui:define name="subcontent">
+                <div class="container-fluid">
+                    <div class="card">
+                        <div class="card-header d-flex justify-content-between align-items-center">
+                            <h2 class="mb-0">Stock Take Variance Report</h2>
+                            <h:form>
+                                <p:commandButton value="Print" icon="fa fa-print" ajax="false" styleClass="mr-2">
+                                    <p:printer target="variancePanel" />
+                                </p:commandButton>
+                                <p:commandButton value="Download" icon="fa fa-download" ajax="false">
+                                    <p:dataExporter type="xlsx" target="tblVariance" fileName="pharmacy_stock_take_variance" />
+                                </p:commandButton>
+                            </h:form>
+                        </div>
+                        <div class="card-body">
+                            <h:panelGroup id="variancePanel">
+                                <h:panelGroup rendered="#{empty pharmacyStockTakeController.snapshotBill}">
+                                    <div class="alert alert-warning">No snapshot bill selected. Please go back to the list and choose a bill.</div>
+                                </h:panelGroup>
+
+                                <h:panelGroup rendered="#{not empty pharmacyStockTakeController.snapshotBill}">
+                                    <p:panelGrid columns="2" styleClass="ui-panelgrid-blank" columnClasses="text-right pr-3 font-weight-bold,text-left">
+                                        <h:outputText value="Institution:"/>
+                                        <h:outputText value="#{pharmacyStockTakeController.snapshotBill.institution.name}"/>
+                                        <h:outputText value="Department:"/>
+                                        <h:outputText value="#{pharmacyStockTakeController.snapshotBill.department.name}"/>
+                                        <h:outputText value="Snapshot Bill No:"/>
+                                        <h:outputText value="#{pharmacyStockTakeController.snapshotBill.deptId}" style="font-family: monospace;"/>
+                                        <h:outputText value="Snapshot Date:"/>
+                                        <h:outputText value="#{pharmacyStockTakeController.snapshotBill.createdAt}">
+                                            <f:convertDateTime pattern="#{sessionController.applicationPreference.shortDateFormat}"/>
+                                        </h:outputText>
+                                    </p:panelGrid>
+
+                                    <p:separator/>
+
+                                    <h:form id="frmVariance">
+                                        <p:dataTable id="tblVariance" value="#{pharmacyStockTakeController.varianceRows}" var="r"
+                                                     rows="25" paginator="true"
+                                                     paginatorPosition="both"
+                                                     paginatorTemplate="{CurrentPageReport} {FirstPageLink} {PreviousPageLink} {PageLinks} {NextPageLink} {LastPageLink} {RowsPerPageDropdown}"
+                                                     rowsPerPageTemplate="10,25,50,100"
+                                                     styleClass="ui-datatable-striped ui-datatable-gridlines">
+                                            <p:column headerText="BillItem ID" style="width: 120px; text-align:right;">
+                                                <h:outputText value="#{r.billItemId}"/>
+                                            </p:column>
+                                            <p:column headerText="Code" style="min-width: 100px;">
+                                                <h:outputText value="#{r.code}"/>
+                                            </p:column>
+                                            <p:column headerText="Item" style="min-width: 220px;">
+                                                <h:outputText value="#{r.itemName}"/>
+                                            </p:column>
+                                            <p:column headerText="Batch" style="width: 120px; text-align:center;">
+                                                <h:outputText value="#{r.batch}"/>
+                                            </p:column>
+                                            <p:column headerText="Initial Stock" style="width: 120px; text-align:right;">
+            
+                                                <h:outputText value="#{r.initialQty}">
+                                                    <f:convertNumber integerOnly="true"/>
+                                                </h:outputText>
+                                            </p:column>
+                                            <p:column headerText="Sum of Variances" style="width: 150px; text-align:right;">
+                                                <h:outputText value="#{r.sumVariance}">
+                                                    <f:convertNumber integerOnly="true"/>
+                                                </h:outputText>
+                                            </p:column>
+                                            <p:column headerText="Last Physical Count" style="width: 160px; text-align:right;">
+                                                <h:outputText value="#{r.lastPhysicalQty}">
+                                                    <f:convertNumber integerOnly="true"/>
+                                                </h:outputText>
+                                            </p:column>
+                                        </p:dataTable>
+                                    </h:form>
+                                </h:panelGroup>
+                            </h:panelGroup>
+                        </div>
+                    </div>
+                </div>
+            </ui:define>
+        </ui:composition>
+    </h:body>
+</html>
+


### PR DESCRIPTION
# Pharmacy Stock Take Workflow (End-User Guide)

This guide explains how to perform a pharmacy stock take using snapshot bills, Excel export/import, multiple uploads, and how to view the aggregated variance report. It is written for end users (pharmacy staff, supervisors) and assumes you can access the pharmacy module in the application.

---

## Overview

- Take a point-in-time snapshot of current stock (by department).
- Export a guided or blind Excel sheet to conduct the physical count.
- Enter real stock quantities in Excel and upload them to prepare a physical count bill.
- You can upload multiple times for the same snapshot; nothing is saved until you click Save.
- Approve the physical count when ready to post adjustments to stock.
- Use the View Variance report to see the initial stock, aggregated variances across all uploads, and the last physical count per item.

---

## Prerequisites

- You have permissions to access Pharmacy Stock Take pages.
- You know the Institution and Department for which you are counting stock.

---

## Navigation

- Stock Take Home: `Pharmacy → Adjustments → Stock Take`
  - URL: `/pharmacy/adjustments/pharmacy_adjustment_index.xhtml`
- Create Snapshot: `Stock Take` button → `Pharmacy Stock Take` page
  - URL: `/pharmacy/pharmacy_stock_take.xhtml`
- List Snapshots and Actions (View, Upload, View Variance): `Stock Take Bills` button
  - URL: `/pharmacy/pharmacy_stock_take_list.xhtml`
- Upload Adjustments for a Snapshot:
  - URL: `/pharmacy/pharmacy_stock_take_upload.xhtml`
- Variance Report for a Snapshot:
  - URL: `/pharmacy/pharmacy_stock_take_variance.xhtml`

---

## Step 1 — Create a Snapshot

1. Open `Pharmacy Stock Take`.
2. Select the `Institution` and `Department`.
3. Generate snapshot preview and review listed items and quantities.
4. Click `Settle` to save the snapshot bill.
5. Use `Print` if you need a hard copy reference.

The snapshot bill represents the system’s stock at that point in time. Each item in the snapshot has a unique BillItem ID.

---

## Step 2 — Download Excel

From either the Snapshot print page or the Upload page:

- Download Guided Sheet: includes system quantities to help counting.
- Download Blind Sheet: hides system quantities for unbiased counting.

Excel columns include identifying fields such as Item Code, Batch, and the unique `BillItem ID`. Use that `BillItem ID` whenever possible.

---

## Step 3 — Perform the Physical Count

1. Conduct your physical count in the store/ward.
2. Open the downloaded Excel sheet.
3. Enter the counted amount in the `Real Stock Qty` column.
4. Leave the `Real Stock Qty` cell blank for items you did not count. Blank means “skip”.
5. Save your Excel file.

Important behavior:
- Blank `Real Stock Qty` is treated as SKIP (not zero). The item is ignored during upload.
- You can submit partial counts and come back later with more uploads.

---

## Step 4 — Upload the Excel (Prepare Physical Count)

1. Open `Stock Take Bills` and locate your snapshot.
2. Click `Upload Adjustments` for that snapshot.
3. Use the page’s buttons to re-download the Guided or Blind sheet if needed.
4. Select your completed Excel file and click `Parse Uploaded Sheet`.
5. Review the preview of parsed items:
   - System Qty (from snapshot)
   - Real Qty (from Excel)
   - Variance (Real − System)

Notes:
- The system identifies items by `BillItem ID` first. If missing, it falls back to Item Code + Batch.
- Uploading multiple times is allowed. Uploads do not save anything automatically.

---

## Step 5 — Save the Physical Count (When Ready)

- On the preview, click `Save Physical Count`.
- This saves a Physical Count bill that references the Snapshot bill.
- You may repeat upload and save again (multiple physical counts can reference the same snapshot) if you refine counts over time.

Nothing affects stock quantities yet. This step only persists the physical count record(s) linked to the snapshot.

---

## Step 6 — View the Variance Report (Read-only)

1. Go to `Stock Take Bills`.
2. Click `View Variance` for your snapshot.
3. The report shows one row per snapshot item:
   - BillItem ID
   - Code, Item, Batch
   - Initial Stock (from snapshot)
   - Sum of Variances (across all saved physical counts for the snapshot)
   - Last Physical Count (from the most recent physical count)
4. Use the `Print` button to print, or `Download` to export to Excel.

This page is a read-only report. No editing occurs here.

---

## Step 7 — Approve to Post Stock Adjustments

- When satisfied with the counts and variances, approve the physical count (from the physical count context).
- Approval creates a Stock Adjustment bill and posts non-zero variances to stock.
- Approval requires appropriate privileges.

---

## Tips and Best Practices

- Prefer using the `BillItem ID` column in Excel to ensure exact matching between the snapshot and your counts.
- Keep `Real Stock Qty` blank for items you didn’t count yet; later uploads can complete the picture.
- Save Physical Count only when you want to preserve your current progress. Approval can be done after final review.
- Use the `View Variance` report to spot check:
  - Large positive/negative variances
  - Whether all critical items have a recent physical count

---

## Troubleshooting

- “No snapshot selected” warnings:
  - Navigate from `Stock Take Bills` and use the action buttons on the correct row.
- Upload shows fewer rows than expected:
  - Ensure `Real Stock Qty` is filled for items you want processed.
  - Ensure the Excel headers remain intact; do not delete or rename `BillItem ID`, `Code`, `Batch`, or `Real Stock Qty` columns.
- Items not matching:
  - Verify `BillItem ID` in Excel matches the Snapshot’s item IDs for the selected snapshot.
  - If relying on Code + Batch, confirm those values exactly match the snapshot.
- Variance seems duplicated:
  - Remember the Variance Report aggregates all saved physical counts referencing the snapshot.

---

## Data Flow Notes (For Awareness)

- Snapshot Bill: captures items and quantities at a point in time.
- Physical Count Bill(s): created only when you click `Save Physical Count`; link back to snapshot via `referenceBill`.
- Multiple Physical Counts: allowed per snapshot (there is no forward link from snapshot to a single physical count).
- Approval: creates a Stock Adjustment bill and updates stock based on non-zero variances.

If you have further questions or need assistance, contact your system administrator or pharmacy IT support.

*** End of Document ***
