### PR TITLE
Fixed - Remove Reject Sample ID from Patient Report

### DIFF
--- a/src/main/java/com/divudi/bean/lab/PatientReportController.java
+++ b/src/main/java/com/divudi/bean/lab/PatientReportController.java
@@ -2656,7 +2656,10 @@ public class PatientReportController implements Serializable {
         List<PatientSampleComponant> pscs = patientInvestigationController.getPatientSampleComponentsByInvestigation(pi);
         if (pscs != null) {
             for (PatientSampleComponant psc : pscs) {
-                sampleIDs += psc.getPatientSample().getIdStr() + " ";
+                if(! psc.getPatientSample().getSampleRejected()){
+                    sampleIDs += psc.getPatientSample().getIdStr() + " ";
+                }
+                
             }
         }
         return createNewPatientReport(pi, ix, sampleIDs);


### PR DESCRIPTION
closes #15275
Signed-off-by: DamithDeshan <hkddrajapaksha@gmail.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Patient reports now exclude rejected samples when compiling sample IDs, ensuring only valid samples are reflected in reports.
  * Prevents incorrect inclusion of rejected sample IDs, improving report accuracy and consistency without altering any user-facing workflows or settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->