### PR TITLE
15294 profit margin for ampp error in grn with costing

### DIFF
--- a/src/main/java/com/divudi/bean/pharmacy/GrnCostingController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/GrnCostingController.java
@@ -1151,7 +1151,16 @@ public class GrnCostingController implements Serializable {
                     double unitsPerPack = pbiInApprovedOrder.getBillItem().getItem().getDblValue();
                     unitsPerPack = unitsPerPack > 0 ? unitsPerPack : 1.0;
                     lineGrossRateForBillItem = pr * unitsPerPack; // Convert unit rate to pack rate
-                    retailRateForBillItem = rr * unitsPerPack;
+                    
+                    // For retail rate, check if we have a pack rate, otherwise calculate from unit rate
+                    double retailRatePack = pbiInApprovedOrder.getRetailRatePack();
+                    if (retailRatePack > 0) {
+                        // Use the pack rate directly
+                        retailRateForBillItem = retailRatePack;
+                    } else {
+                        // Calculate pack rate from unit rate (rr is already unit rate from PO)
+                        retailRateForBillItem = rr * unitsPerPack;
+                    }
                 }
 
                 newlyCreatedBillItemForGrn.setPharmaceuticalBillItem(newlyCreatedPbiForGrn);

--- a/src/main/java/com/divudi/bean/pharmacy/GrnCostingController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/GrnCostingController.java
@@ -1152,15 +1152,19 @@ public class GrnCostingController implements Serializable {
                     unitsPerPack = unitsPerPack > 0 ? unitsPerPack : 1.0;
                     lineGrossRateForBillItem = pr * unitsPerPack; // Convert unit rate to pack rate
                     
-                    // For retail rate, check if we have a pack rate, otherwise calculate from unit rate
+                    // For retail rate, check if we have a pack rate from PO
                     double retailRatePack = pbiInApprovedOrder.getRetailRatePack();
                     if (retailRatePack > 0) {
-                        // Use the pack rate directly
+                        // Use the pack rate directly from PO
                         retailRateForBillItem = retailRatePack;
+                    } else if (pbiInApprovedOrder.getRetailRate() > 0) {
+                        // PO has unit rate, convert to pack rate
+                        retailRateForBillItem = pbiInApprovedOrder.getRetailRate() * unitsPerPack;
                     } else {
-                        // Calculate pack rate from unit rate (rr is already unit rate from PO)
-                        retailRateForBillItem = rr * unitsPerPack;
+                        // Use fallback rate directly (getLastRetailRateByBillItemFinanceDetails likely returns pack rate for AMPP)
+                        retailRateForBillItem = rr;
                     }
+                } else {
                 }
 
                 newlyCreatedBillItemForGrn.setPharmaceuticalBillItem(newlyCreatedPbiForGrn);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Corrected retail price calculation for pack-based (Ampp) items during GRN costing by prioritizing purchase order pack rates when available, with sensible fallbacks when only unit rates or no PO rates exist.
  - Improves pricing accuracy and consistency between purchase orders and billed items, reducing manual adjustments and discrepancies.
  - Enhances reliability of downstream margins and reports without altering user workflows or interfaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->