### PR TITLE
#15379 cogs grn

### DIFF
--- a/src/main/webapp/reports/inventoryReports/grn_cash.xhtml
+++ b/src/main/webapp/reports/inventoryReports/grn_cash.xhtml
@@ -236,7 +236,7 @@
                                 </h:outputText>
                             </p:column>
                             <p:column headerText="FREE QTY">
-                                <h:outputText value="#{bi.pharmaceuticalBillItem.freeQty}" >
+                                <h:outputText value="#{bi.billItemFinanceDetails.freeQuantity}" >
                                     <f:convertNumber pattern="#,##0" />
                                 </h:outputText>
                             </p:column>

--- a/src/main/webapp/reports/inventoryReports/grn_cash.xhtml
+++ b/src/main/webapp/reports/inventoryReports/grn_cash.xhtml
@@ -246,7 +246,7 @@
                                 </h:outputText>
                             </p:column>
                             <p:column headerText="COST VALUE" width="5em">
-                                <h:outputText value="#{bi.pharmaceuticalBillItem.itemBatch.costRate * bi.qty}" >
+                                <h:outputText value="#{bi.pharmaceuticalBillItem.itemBatch.costRate * bi.billItemFinanceDetails.quantityByUnits}" >
                                     <f:convertNumber pattern="#,##0.00" />
                                 </h:outputText>
                             </p:column>

--- a/src/main/webapp/reports/inventoryReports/grn_cash.xhtml
+++ b/src/main/webapp/reports/inventoryReports/grn_cash.xhtml
@@ -231,7 +231,7 @@
                                 <h:outputText value="#{bi.pharmaceuticalBillItem.itemBatch.batchNo}" />
                             </p:column>
                             <p:column headerText="QTY">
-                                <h:outputText value="#{bi.qty}" >
+                                <h:outputText value="#{bi.billItemFinanceDetails.quantityByUnits}" >
                                     <f:convertNumber pattern="#,##0" />
                                 </h:outputText>
                             </p:column>

--- a/src/main/webapp/reports/inventoryReports/grn_credit.xhtml
+++ b/src/main/webapp/reports/inventoryReports/grn_credit.xhtml
@@ -241,7 +241,7 @@
                                 <h:outputText value="#{bi.pharmaceuticalBillItem.itemBatch.batchNo}" />
                             </p:column>
                             <p:column headerText="QTY">
-                                <h:outputText value="#{bi.qty}" >
+                                <h:outputText value="#{bi.billItemFinanceDetails.quantityByUnits}" >
                                     <f:convertNumber pattern="#,##0" />
                                 </h:outputText>
                             </p:column>

--- a/src/main/webapp/reports/inventoryReports/grn_credit.xhtml
+++ b/src/main/webapp/reports/inventoryReports/grn_credit.xhtml
@@ -256,7 +256,7 @@
                                 </h:outputText>
                             </p:column>
                             <p:column headerText="COST VALUE" width="5em">
-                                <h:outputText value="#{bi.pharmaceuticalBillItem.itemBatch.costRate * bi.qty}" >
+                                <h:outputText value="#{bi.pharmaceuticalBillItem.itemBatch.costRate * bi.billItemFinanceDetails.quantityByUnits}" >
                                     <f:convertNumber pattern="#,##0.00" />
                                 </h:outputText>
                             </p:column>

--- a/src/main/webapp/reports/inventoryReports/grn_credit.xhtml
+++ b/src/main/webapp/reports/inventoryReports/grn_credit.xhtml
@@ -246,7 +246,7 @@
                                 </h:outputText>
                             </p:column>
                             <p:column headerText="FREE QTY">
-                                <h:outputText value="#{bi.pharmaceuticalBillItem.freeQty}" >
+                                <h:outputText value="#{bi.billItemFinanceDetails.freeQuantity}" >
                                     <f:convertNumber pattern="#,##0" />
                                 </h:outputText>
                             </p:column>

--- a/src/main/webapp/reports/inventoryReports/purchase_return.xhtml
+++ b/src/main/webapp/reports/inventoryReports/purchase_return.xhtml
@@ -259,7 +259,7 @@
                                 </p:commandLink>
                             </p:column>
                             <p:column headerText="QTY" width="5em">
-                                <h:outputText value="#{f.billItemFinanceDetails.quantity}" >
+                                <h:outputText value="#{f.billItemFinanceDetails.quantityByUnits}" >
                                     <f:convertNumber pattern="#,##0" />
                                 </h:outputText>
                             </p:column>
@@ -272,7 +272,7 @@
                                 </h:outputText>
                             </p:column>
                             <p:column headerText="Purchase Value" width="5em">
-                                <h:outputText value="#{f.pharmaceuticalBillItem.purchaseRate * f.billItemFinanceDetails.quantity}" >
+                                <h:outputText value="#{f.pharmaceuticalBillItem.purchaseRate * f.billItemFinanceDetails.quantityByUnits}" >
                                     <f:convertNumber pattern="#,##0.00" />
                                 </h:outputText>
                             </p:column>
@@ -282,7 +282,7 @@
                                 </h:outputText>
                             </p:column>
                             <p:column headerText="Cost Value">
-                                <h:outputText value="#{f.pharmaceuticalBillItem.itemBatch.costRate * f.billItemFinanceDetails.quantity}" >
+                                <h:outputText value="#{f.pharmaceuticalBillItem.itemBatch.costRate * f.billItemFinanceDetails.quantityByUnits}" >
                                     <f:convertNumber pattern="#,##0.00" />
                                 </h:outputText>
                             </p:column>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * GRN Cash & GRN Credit: QTY and FREE QTY now use unit-based quantities, and COST VALUE uses cost rate × unit-based quantity — fixes line totals, summaries, and printed/exported values.
  * Purchase Return: QTY, Purchase Value, and Cost Value now use unit-based quantities, ensuring consistent, accurate inventory and financial figures across reports.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->