### PR TITLE
14845 need history tabs for direct purchase

### DIFF
--- a/agents/prompts/PharmacyHistoryTab.txt
+++ b/agents/prompts/PharmacyHistoryTab.txt
@@ -1,0 +1,22 @@
+Need to convert an Entity Based method to a DTO based method
+First Refer to the documents in the folder \developer_docs\dto
+
+UI is from the page \src\main\webapp\resources\pharmacy\history.xhtml - component id="tblDirectPurchase" 
+Identify the details needed to be listed in that table
+
+Relevant Controller - PharmacyController
+Relevant Method - createPoTable()
+	This is based in Entity
+	Need to convert to a DTO Based one
+	Keep this old method and deprecate it with a comment to the correct method
+
+Proposed New Method Name createPoTableDto()
+
+In public void fillDetails() { method, insert new DTO Method, and comment out old method
+
+This conversion is already completed for id="tblDirectPurchase" in history.xhtml
+The old method createDirectPurchaseTable
+The new method createDirectPurchaseTableDto
+
+
+

--- a/src/main/java/com/divudi/bean/common/EnumController.java
+++ b/src/main/java/com/divudi/bean/common/EnumController.java
@@ -48,7 +48,8 @@ public class EnumController implements Serializable {
     @Inject
     ConfigOptionApplicationController configOptionApplicationController;
 
-    private PaymentScheme paymentScheme;
+    // PaymentScheme removed from instance field to avoid cross-user state in ApplicationScoped bean
+    // Use local variables or session-scoped beans for user-specific state
     private List<Class<? extends Enum<?>>> enumList;
     List<PaymentMethod> paymentMethodsForOpdBilling;
     private List<PaymentMethod> paymentMethodsForGrn;
@@ -1011,19 +1012,19 @@ public class EnumController implements Serializable {
 //
 //    }
     public boolean checkPaymentMethod(PaymentMethod paymentMethod, String paymentMathodStr) {
-        if (paymentMethod != null) {
-            //System.err.println("Payment method : " + paymentMethod);
-            //System.err.println("Payment Method String : " + PaymentMethod.valueOf(paymentMathodStr));
-            if (paymentMethod.equals(PaymentMethod.valueOf(paymentMathodStr))) {
-                //System.err.println("Returning True");
-                return true;
-            } else {
+        if (paymentMethod != null && paymentMathodStr != null && !paymentMathodStr.trim().isEmpty()) {
+            try {
+                PaymentMethod parsedMethod = PaymentMethod.valueOf(paymentMathodStr);
+                return paymentMethod.equals(parsedMethod);
+            } catch (IllegalArgumentException e) {
+                // Log the error and return false for invalid enum values
+                java.util.logging.Logger.getLogger(getClass().getName()).log(
+                    java.util.logging.Level.WARNING,
+                    "Invalid PaymentMethod string: " + paymentMathodStr, e);
                 return false;
             }
         }
-
         return false;
-
     }
 
     public AdmissionTypeEnum[] getAdmissionTypeEnum() {
@@ -1040,13 +1041,7 @@ public class EnumController implements Serializable {
     public EnumController() {
     }
 
-    public PaymentScheme getPaymentScheme() {
-        return paymentScheme;
-    }
-
-    public void setPaymentScheme(PaymentScheme paymentScheme) {
-        this.paymentScheme = paymentScheme;
-    }
+    // PaymentScheme getters/setters removed - use local variables or session-scoped beans for user-specific state
 
     public List<PaymentMethod> getPaymentMethodsForPatientDeposit() {
         paymentMethodsForPatientDeposit = new ArrayList<>();

--- a/src/main/java/com/divudi/bean/common/EnumController.java
+++ b/src/main/java/com/divudi/bean/common/EnumController.java
@@ -51,7 +51,8 @@ public class EnumController implements Serializable {
     private PaymentScheme paymentScheme;
     private List<Class<? extends Enum<?>>> enumList;
     List<PaymentMethod> paymentMethodsForOpdBilling;
-    private List<PaymentMethod> paymentMethodsForPharmacyPurchase;
+    private List<PaymentMethod> paymentMethodsForGrn;
+    private List<PaymentMethod> paymentMethodsForDirectPurchase;
     List<PaymentMethod> paymentMethodsForChanneling;
     List<PaymentMethod> paymentMethodsForChannelSettling;
     List<PaymentMethod> paymentMethodsForPharmacyBilling;
@@ -78,7 +79,6 @@ public class EnumController implements Serializable {
         enumList.add(ItemType.class);
         enumList.add(DiscountType.class);
     }
-    
 
     public Sex[] getSex() {
         return Sex.values();
@@ -135,12 +135,34 @@ public class EnumController implements Serializable {
         }
     }
 
-    public void fillPaymentMethodsFoPharmacyPurchase() {
-        paymentMethodsForPharmacyPurchase = new ArrayList<>();
+    public void fillPaymentMethodsForGrn() {
+        paymentMethodsForGrn = new ArrayList<>();
         for (PaymentMethod pm : PaymentMethod.values()) {
-            boolean include = configOptionApplicationController.getBooleanValueByKey(pm.getLabel() + " is available for Pharmacy Purchase", true);
+            boolean include;
+            if (pm == PaymentMethod.Cash || pm == PaymentMethod.Credit) {
+                include = configOptionApplicationController.getBooleanValueByKey(pm.getLabel() + " is available for GRN", true);
+            } else {
+                include = configOptionApplicationController.getBooleanValueByKey(pm.getLabel() + " is available for GRN", false);
+            }
             if (include) {
-                paymentMethodsForPharmacyPurchase.add(pm);
+                paymentMethodsForGrn.add(pm);
+            }
+        }
+    }
+
+    public void fillPaymentMethodsForDirectPurchase() {
+        paymentMethodsForDirectPurchase = new ArrayList<>();
+        // Include other methods based on configuration (default false)
+        for (PaymentMethod pm : PaymentMethod.values()) {
+            boolean include;
+            if (pm == PaymentMethod.Cash || pm == PaymentMethod.Credit) {
+                include = configOptionApplicationController.getBooleanValueByKey(pm.getLabel() + " is available for Direct Purchase", true);
+            } else {
+                include = configOptionApplicationController.getBooleanValueByKey(pm.getLabel() + " is available for Direct Purchase", false);
+            }
+
+            if (include) {
+                paymentMethodsForDirectPurchase.add(pm);
             }
         }
     }
@@ -290,8 +312,8 @@ public class EnumController implements Serializable {
     public List<ScheduledProcess> getScheduledProcesses() {
         return Arrays.asList(ScheduledProcess.values());
     }
-    
-     public List<EmployeeStatus> getEmploymentStatuses() {
+
+    public List<EmployeeStatus> getEmploymentStatuses() {
         return Arrays.asList(EmployeeStatus.values());
     }
 
@@ -327,10 +349,10 @@ public class EnumController implements Serializable {
                 ReportViewType.BY_BILL_TYPE,
                 ReportViewType.BY_DISCOUNT_TYPE_AND_ADMISSION_TYPE,
                 ReportViewType.BY_BILL_TYPE_AND_DISCOUNT_TYPE_AND_ADMISSION_TYPE
-//                ReportViewType.BY_ITEM
+        //                ReportViewType.BY_ITEM
         );
     }
-    
+
     public List<ReportViewType> getPharmacyProcurementByBillItemViewTypes() {
         return Arrays.asList(
                 ReportViewType.BY_BILL,
@@ -735,13 +757,13 @@ public class EnumController implements Serializable {
 
     public BillType[] getPharmacyBillTypes4() {
         BillType[] b = {
-                BillType.PharmacyPre,
-                BillType.PharmacyWholesalePre,
-                BillType.PharmacyAdjustment,
-                BillType.PharmacyTransferIssue,
-                BillType.PharmacyIssue,
-                BillType.PharmacyBhtPre,
-                BillType.PharmacyDisposalIssue};
+            BillType.PharmacyPre,
+            BillType.PharmacyWholesalePre,
+            BillType.PharmacyAdjustment,
+            BillType.PharmacyTransferIssue,
+            BillType.PharmacyIssue,
+            BillType.PharmacyBhtPre,
+            BillType.PharmacyDisposalIssue};
 
         return b;
     }
@@ -1134,11 +1156,11 @@ public class EnumController implements Serializable {
         this.availableStatusforCancel = availableStatusforCancel;
     }
 
-    public List<PaymentMethod> getPaymentMethodsForPharmacyPurchase() {
-        if (paymentMethodsForPharmacyPurchase == null) {
-            fillPaymentMethodsFoPharmacyPurchase();
+    public List<PaymentMethod> getPaymentMethodsForGrn() {
+        if (paymentMethodsForGrn == null) {
+            fillPaymentMethodsForGrn();
         }
-        return paymentMethodsForPharmacyPurchase;
+        return paymentMethodsForGrn;
     }
 
     public InvestigationItemType getInvestigationItemType(String name) {
@@ -1237,11 +1259,11 @@ public class EnumController implements Serializable {
     public void setAllUtilizedBillTypeAtomicsForPharmacy(List<BillTypeAtomic> allUtilizedBillTypeAtomicsForPharmacy) {
         this.allUtilizedBillTypeAtomicsForPharmacy = allUtilizedBillTypeAtomicsForPharmacy;
     }
-    
+
     public TestHistoryType[] getLabTestHistoryList() {
         return TestHistoryType.values();
     }
-    
+
     public TestHistoryType getLabTestHistory(String name) {
         for (TestHistoryType type : TestHistoryType.values()) {
             if (type.toString().equalsIgnoreCase(name)) {
@@ -1250,5 +1272,11 @@ public class EnumController implements Serializable {
         }
         return null;
     }
+
+    public List<PaymentMethod> getPaymentMethodsForDirectPurchase() {
+        return paymentMethodsForDirectPurchase;
+    }
+    
+    
 
 }

--- a/src/main/java/com/divudi/bean/common/EnumController.java
+++ b/src/main/java/com/divudi/bean/common/EnumController.java
@@ -1011,16 +1011,16 @@ public class EnumController implements Serializable {
 //        return false;
 //
 //    }
-    public boolean checkPaymentMethod(PaymentMethod paymentMethod, String paymentMathodStr) {
-        if (paymentMethod != null && paymentMathodStr != null && !paymentMathodStr.trim().isEmpty()) {
+    public boolean checkPaymentMethod(PaymentMethod paymentMethod, String paymentMethodStr) {
+        if (paymentMethod != null && paymentMethodStr != null && !paymentMethodStr.trim().isEmpty()) {
             try {
-                PaymentMethod parsedMethod = PaymentMethod.valueOf(paymentMathodStr);
+                PaymentMethod parsedMethod = PaymentMethod.valueOf(paymentMethodStr);
                 return paymentMethod.equals(parsedMethod);
             } catch (IllegalArgumentException e) {
                 // Log the error and return false for invalid enum values
                 java.util.logging.Logger.getLogger(getClass().getName()).log(
                     java.util.logging.Level.WARNING,
-                    "Invalid PaymentMethod string: " + paymentMathodStr, e);
+                    "Invalid PaymentMethod string: " + paymentMethodStr, e);
                 return false;
             }
         }
@@ -1269,6 +1269,9 @@ public class EnumController implements Serializable {
     }
 
     public List<PaymentMethod> getPaymentMethodsForDirectPurchase() {
+        if (paymentMethodsForDirectPurchase == null) {
+            fillPaymentMethodsForDirectPurchase();
+        }
         return paymentMethodsForDirectPurchase;
     }
     

--- a/src/main/java/com/divudi/bean/pharmacy/GrnCostingController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/GrnCostingController.java
@@ -2921,7 +2921,10 @@ public class GrnCostingController implements Serializable {
                         if (poPbi != null) {
                             //getRemainingQty() is double, can NOT be null
                             //At this point grnBillItem.getPharmaceuticalBillItem() is NOT null as it is used above. its getQty is double, so can not be null
-                            poPbi.setRemainingQty(Math.abs(poPbi.getRemainingQty()) + Math.abs(grnBillItem.getPharmaceuticalBillItem().getQty()));
+                            poPbi.setRemainingQty(Math.abs(poPbi.getRemainingQty()) - Math.abs(grnBillItem.getPharmaceuticalBillItem().getQty()));
+                            poPbi.setRemainingFreeQty(Math.abs(poPbi.getRemainingFreeQty()) - Math.abs(grnBillItem.getPharmaceuticalBillItem().getFreeQty()));
+                            poPbi.setCompletedQty(Math.abs(poPbi.getCompletedQty()) + Math.abs(grnBillItem.getPharmaceuticalBillItem().getQty()));
+                            poPbi.setCompletedFreeQty(Math.abs(poPbi.getCompletedFreeQty()) + Math.abs(grnBillItem.getPharmaceuticalBillItem().getFreeQty()));
                             billItemFacade.editAndCommit(poBillItem);
                         }
                     }

--- a/src/main/java/com/divudi/bean/pharmacy/GrnCostingController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/GrnCostingController.java
@@ -1805,13 +1805,14 @@ public class GrnCostingController implements Serializable {
     }
 
     /**
-     * Recalculates profit margins for all bill items after discount distribution
+     * Recalculates profit margins for all bill items after discount
+     * distribution
      */
     private void recalculateProfitMarginsForAllItems() {
         if (getBillItems() == null || getBillItems().isEmpty()) {
             return;
         }
-        
+
         for (BillItem item : getBillItems()) {
             if (item != null && item.getBillItemFinanceDetails() != null) {
                 // Recalculate profit margin using the updated total cost (which includes distributed discount)
@@ -2874,37 +2875,59 @@ public class GrnCostingController implements Serializable {
         }
 
         // Process bill items for finalization with full stock management
-        for (BillItem i : getBillItems()) {
-            BillItemFinanceDetails f = i.getBillItemFinanceDetails();
+        for (BillItem grnBillItem : getBillItems()) {
+            BillItemFinanceDetails f = grnBillItem.getBillItemFinanceDetails();
             if (f == null || ((f.getQuantity() == null || f.getQuantity().compareTo(BigDecimal.ZERO) == 0)
                     && (f.getFreeQuantity() == null || f.getFreeQuantity().compareTo(BigDecimal.ZERO) == 0))) {
                 continue;
             }
 
             // Apply standardized finance details conversion
-            applyFinanceDetailsToPharmaceutical(i);
+            applyFinanceDetailsToPharmaceutical(grnBillItem);
 
             // Create/update item batch for stock management with costing respect
             ItemBatch itemBatch;
             if (configOptionApplicationController.getBooleanValueByKey("Manage Costing", true)) {
-                itemBatch = saveItemBatchWithCosting(i);
+                itemBatch = saveItemBatchWithCosting(grnBillItem);
             } else {
-                itemBatch = saveItemBatch(i);
+                itemBatch = saveItemBatch(grnBillItem);
             }
-            i.getPharmaceuticalBillItem().setItemBatch(itemBatch);
+            grnBillItem.getPharmaceuticalBillItem().setItemBatch(itemBatch);
 
             // Create stock record
-            double addingQty = i.getPharmaceuticalBillItem().getQtyInUnit() + i.getPharmaceuticalBillItem().getFreeQtyInUnit();
+            double addingQty = grnBillItem.getPharmaceuticalBillItem().getQty() + grnBillItem.getPharmaceuticalBillItem().getFreeQty();
             Stock stock = getPharmacyBean().addToStock(
-                    i.getPharmaceuticalBillItem(),
+                    grnBillItem.getPharmaceuticalBillItem(),
                     Math.abs(addingQty),
                     getSessionController().getDepartment());
 
-            i.getPharmaceuticalBillItem().setStock(stock);
+            grnBillItem.getPharmaceuticalBillItem().setStock(stock);
 
             // Update pharmaceutical bill item with stock calculations
-            getPharmaceuticalBillItemFacade().edit(i.getPharmaceuticalBillItem());
-            editBillItem(i.getPharmaceuticalBillItem(), getSessionController().getLoggedUser());
+            getPharmaceuticalBillItemFacade().edit(grnBillItem.getPharmaceuticalBillItem());
+            editBillItem(grnBillItem.getPharmaceuticalBillItem(), getSessionController().getLoggedUser());
+
+            BillItem poBillItem = grnBillItem.getReferanceBillItem();
+            System.out.println("grnBillItem = " + grnBillItem);
+            System.out.println("poBillItem = " + poBillItem);
+            if (poBillItem != null) {
+                System.out.println("poBillItem = " + poBillItem);
+                if (poBillItem.getId() != null) {
+                    System.out.println("poBillItem.getId() = " + poBillItem.getId());
+                    poBillItem = billItemFacade.findWithoutCache(poBillItem.getId());
+                    if (poBillItem != null) {
+                        System.out.println("poBillItem = " + poBillItem);
+                        PharmaceuticalBillItem poPbi = poBillItem.getPharmaceuticalBillItem();
+                        if (poPbi != null) {
+                            //getRemainingQty() is double, can NOT be null
+                            //At this point grnBillItem.getPharmaceuticalBillItem() is NOT null as it is used above. its getQty is double, so can not be null
+                            poPbi.setRemainingQty(Math.abs(poPbi.getRemainingQty()) + Math.abs(grnBillItem.getPharmaceuticalBillItem().getQty()));
+                            billItemFacade.editAndCommit(poBillItem);
+                        }
+                    }
+                }
+            }
+
         }
 
         String billId;
@@ -3252,7 +3275,7 @@ public class GrnCostingController implements Serializable {
         BigDecimal effectiveCost = BigDecimalUtil.valueOrZero(f.getTotalCost());
         if (effectiveCost.compareTo(BigDecimal.ZERO) == 0) {
             effectiveCost = BigDecimalUtil.valueOrZero(
-                f.getNetTotal() != null ? f.getNetTotal() : f.getLineNetTotal()
+                    f.getNetTotal() != null ? f.getNetTotal() : f.getLineNetTotal()
             );
         }
         if (effectiveCost.compareTo(BigDecimal.ZERO) <= 0) {
@@ -3550,9 +3573,7 @@ public class GrnCostingController implements Serializable {
      */
     public double calculateRemainigQtyFromOrder(PharmaceuticalBillItem po) {
         double billed = getTotalQty(po.getBillItem(), BillTypeAtomic.PHARMACY_GRN);
-        System.out.println("billed = " + billed);
         double cancelled = getTotalQty(po.getBillItem(), BillTypeAtomic.PHARMACY_GRN_CANCELLED);
-        System.out.println("cancelled = " + cancelled);
         double recieveNet = Math.abs(billed) - Math.abs(cancelled);
         return Math.abs(recieveNet);
     }

--- a/src/main/java/com/divudi/bean/pharmacy/PharmacyController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacyController.java
@@ -3972,7 +3972,7 @@ public class PharmacyController implements Serializable {
             sql += " and i.bill.department=:dep";
         }
         if (item != null) {
-            m.put("item", department);
+            m.put("item", item);
             sql += " and i.item=:item ";
         }
 
@@ -5481,8 +5481,8 @@ public class PharmacyController implements Serializable {
                 + "b.pharmaceuticalBillItem.completedFreeQty "
                 + ") "
                 + "FROM BillItem b "
-                + "WHERE (b.bill.cancelled IS NULL OR b.retired = FALSE) "
-                + "AND (b.bill.retired IS NULL OR b.retired = FALSE) "
+                + "WHERE (b.bill.cancelled IS NULL OR b.bill.cancelled = FALSE) "
+                + "AND (b.bill.retired IS NULL OR b.bill.retired = FALSE) "
                 + "AND (b.retired IS NULL OR b.retired = FALSE) "
                 + "AND b.item IN :relatedItems "
                 + "AND b.bill.billTypeAtomic in :bta "
@@ -5524,8 +5524,8 @@ public class PharmacyController implements Serializable {
                 + "b.pharmaceuticalBillItem.completedFreeQty "
                 + ") "
                 + "FROM BillItem b "
-                + "WHERE (b.bill.cancelled IS NULL OR b.retired = FALSE) "
-                + "AND (b.bill.retired IS NULL OR b.retired = FALSE) "
+                + "WHERE (b.bill.cancelled IS NULL OR b.bill.cancelled = FALSE) "
+                + "AND (b.bill.retired IS NULL OR b.bill.retired = FALSE) "
                 + "AND (b.retired IS NULL OR b.retired = FALSE) "
                 + "AND b.item IN :relatedItems "
                 + "AND b.bill.billTypeAtomic in :bta "

--- a/src/main/java/com/divudi/bean/pharmacy/PharmacyController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacyController.java
@@ -30,6 +30,7 @@ import com.divudi.core.data.dataStructure.CategoryWithItem;
 import com.divudi.core.data.dataStructure.PharmacySummery;
 import com.divudi.core.data.dto.PharmacyGrnItemDTO;
 import com.divudi.core.data.dto.PharmacyGrnReturnItemDTO;
+import com.divudi.core.data.dto.PharmacyItemPurchaseDTO;
 import com.divudi.core.data.table.String1Value1;
 import com.divudi.core.util.CommonFunctions;
 import com.divudi.core.light.pharmacy.PharmaceuticalItemLight;
@@ -164,6 +165,7 @@ public class PharmacyController implements Serializable {
     private List<com.divudi.core.data.dto.PharmacyGrnReturnItemDTO> grnReturnDtos;
     private List<BillItem> pos;
     private List<BillItem> directPurchase;
+    private List<PharmacyItemPurchaseDTO> directPurchaseDtos;
     private List<Bill> bills;
     List<ItemTransactionSummeryRow> itemTransactionSummeryRows;
     private int managePharamcyReportIndex = -1;
@@ -562,8 +564,6 @@ public class PharmacyController implements Serializable {
     public String navigateToDepartmentStockByBatchMinus() {
         return "/pharmacy/pharmacy_report_department_stock_by_batch_minus?faces-redirect=true";
     }
-
-    
 
     // </editor-fold>
     // <editor-fold defaultstate="collapsed" desc="Methods - Data Maniulation">
@@ -1044,11 +1044,11 @@ public class PharmacyController implements Serializable {
             }
 
             String[] headers = {"GRN No", "Invoice No", "Created Date", "Approved Date", "Supplier Name", "Institution",
-                    "Site", "Department", "Po No", "Purchase Cash", "Purchase Credit", "Sale Cash", "Sale Credit", "Remark", "Purchase Details"};
+                "Site", "Department", "Po No", "Purchase Cash", "Purchase Credit", "Sale Cash", "Sale Credit", "Remark", "Purchase Details"};
 
             if (hasCosting) {
                 headers = new String[]{"GRN No", "Invoice No", "Created Date", "Approved Date", "Supplier Name", "Institution",
-                        "Site", "Department", "Po No", "Purchase Cash", "Purchase Credit", "Cost Cash", "Cost Credit", "Sale Cash", "Sale Credit", "Remark", "Purchase Details"};
+                    "Site", "Department", "Po No", "Purchase Cash", "Purchase Credit", "Cost Cash", "Cost Credit", "Sale Cash", "Sale Credit", "Remark", "Purchase Details"};
             }
 
             for (String header : headers) {
@@ -1065,8 +1065,8 @@ public class PharmacyController implements Serializable {
                 mainTable.addCell(new Phrase(sdf.format(b.getCreatedAt()), normalFont));
                 mainTable.addCell(new Phrase(sdf.format(b.getReferenceBill() != null ? b.getReferenceBill().getCreatedAt() : b.getCreatedAt()), normalFont));
                 mainTable.addCell(new Phrase(
-                        b.getFromInstitution() != null ? b.getFromInstitution().getName() :
-                                (b.getToInstitution() != null ? b.getToInstitution().getName() : ""), normalFont));
+                        b.getFromInstitution() != null ? b.getFromInstitution().getName()
+                        : (b.getToInstitution() != null ? b.getToInstitution().getName() : ""), normalFont));
                 mainTable.addCell(new Phrase(b.getInstitution() != null ? b.getInstitution().getName() : "", normalFont));
                 mainTable.addCell(new Phrase(b.getDepartment() != null && b.getDepartment().getSite() != null ? b.getDepartment().getSite().getName() : "", normalFont));
                 mainTable.addCell(new Phrase(b.getDepartment() != null ? b.getDepartment().getName() : "", normalFont));
@@ -1082,7 +1082,7 @@ public class PharmacyController implements Serializable {
                 if (b.getBillTypeAtomic().toString().contains("RETURN") || b.getBillTypeAtomic().toString().contains("CANCELLED") || b.getBillTypeAtomic().toString().contains("REFUND")) {
                     if (b.getReferenceBill() != null) {
                         if (b.getReferenceBill().getPaymentMethod() == PaymentMethod.Cash) {
-                            purchaseCash = -Math.abs(b.getBillFinanceDetails().getLineNetTotal() != null ? b.getBillFinanceDetails().getLineNetTotal().doubleValue(): 0.0);
+                            purchaseCash = -Math.abs(b.getBillFinanceDetails().getLineNetTotal() != null ? b.getBillFinanceDetails().getLineNetTotal().doubleValue() : 0.0);
                             saleCash = -Math.abs(b.getBillFinanceDetails().getTotalRetailSaleValue() != null ? b.getBillFinanceDetails().getTotalRetailSaleValue().doubleValue() : 0.0);
                             if (hasCosting) {
                                 costCash = -Math.abs(b.getBillFinanceDetails().getTotalCostValue() != null ? b.getBillFinanceDetails().getTotalCostValue().doubleValue() : 0.0);
@@ -1093,7 +1093,7 @@ public class PharmacyController implements Serializable {
                             costCash = 0;
                         }
                         if (b.getReferenceBill().getPaymentMethod() == PaymentMethod.Credit) {
-                            purchaseCredit = -Math.abs(b.getBillFinanceDetails().getLineNetTotal() != null ? b.getBillFinanceDetails().getLineNetTotal().doubleValue(): 0.0);
+                            purchaseCredit = -Math.abs(b.getBillFinanceDetails().getLineNetTotal() != null ? b.getBillFinanceDetails().getLineNetTotal().doubleValue() : 0.0);
                             saleCredit = -Math.abs(b.getBillFinanceDetails().getTotalRetailSaleValue() != null ? b.getBillFinanceDetails().getTotalRetailSaleValue().doubleValue() : 0.0);
                             if (hasCosting) {
                                 costCredit = -Math.abs(b.getBillFinanceDetails().getTotalCostValue() != null ? b.getBillFinanceDetails().getTotalCostValue().doubleValue() : 0.0);
@@ -1202,15 +1202,15 @@ public class PharmacyController implements Serializable {
             Cell titleCell = titleRow.createCell(0);
             titleCell.setCellValue("GRN Report");
             titleCell.setCellStyle(boldStyle);
-            sheet.addMergedRegion(new CellRangeAddress(0, 0, 0, hasCosting?16:14));
+            sheet.addMergedRegion(new CellRangeAddress(0, 0, 0, hasCosting ? 16 : 14));
 
             String[] headers = {"GRN No", "Invoice No", "Created Date", "Approved Date", "Supplier Name", "Institution",
-                    "Site", "Department", "Po No", "Purchase Cash", "Purchase Credit", "Sale Cash", "Sale Credit", "Remark", "Purchase Details"};
+                "Site", "Department", "Po No", "Purchase Cash", "Purchase Credit", "Sale Cash", "Sale Credit", "Remark", "Purchase Details"};
 
             if (hasCosting) {
                 headers = new String[]{"GRN No", "Invoice No", "Created Date", "Approved Date", "Supplier Name", "Institution",
-                        "Site", "Department", "Po No", "Purchase Cash", "Purchase Credit", "Cost Cash", "Cost Credit",
-                        "Sale Cash", "Sale Credit", "Remark", "Purchase Details"};
+                    "Site", "Department", "Po No", "Purchase Cash", "Purchase Credit", "Cost Cash", "Cost Credit",
+                    "Sale Cash", "Sale Credit", "Remark", "Purchase Details"};
             }
 
             Row headerRow = sheet.createRow(rowIndex++);
@@ -1251,7 +1251,7 @@ public class PharmacyController implements Serializable {
                 if (b.getBillTypeAtomic().toString().contains("RETURN") || b.getBillTypeAtomic().toString().contains("CANCELLED") || b.getBillTypeAtomic().toString().contains("REFUND")) {
                     if (b.getReferenceBill() != null) {
                         if (b.getReferenceBill().getPaymentMethod() == PaymentMethod.Cash) {
-                            purchaseCash = -Math.abs(b.getBillFinanceDetails().getLineNetTotal() != null ? b.getBillFinanceDetails().getLineNetTotal().doubleValue(): 0.0);
+                            purchaseCash = -Math.abs(b.getBillFinanceDetails().getLineNetTotal() != null ? b.getBillFinanceDetails().getLineNetTotal().doubleValue() : 0.0);
                             saleCash = -Math.abs(b.getBillFinanceDetails().getTotalRetailSaleValue() != null ? b.getBillFinanceDetails().getTotalRetailSaleValue().doubleValue() : 0.0);
                             if (hasCosting) {
                                 costCash = -Math.abs(b.getBillFinanceDetails().getTotalCostValue() != null ? b.getBillFinanceDetails().getTotalCostValue().doubleValue() : 0.0);
@@ -1264,7 +1264,7 @@ public class PharmacyController implements Serializable {
                             }
                         }
                         if (b.getReferenceBill().getPaymentMethod() == PaymentMethod.Credit) {
-                            purchaseCredit = -Math.abs(b.getBillFinanceDetails().getLineNetTotal() != null ? b.getBillFinanceDetails().getLineNetTotal().doubleValue(): 0.0);
+                            purchaseCredit = -Math.abs(b.getBillFinanceDetails().getLineNetTotal() != null ? b.getBillFinanceDetails().getLineNetTotal().doubleValue() : 0.0);
                             saleCredit = -Math.abs(b.getBillFinanceDetails().getTotalRetailSaleValue() != null ? b.getBillFinanceDetails().getTotalRetailSaleValue().doubleValue() : 0.0);
                             if (hasCosting) {
                                 costCredit = -Math.abs(b.getBillFinanceDetails().getTotalCostValue() != null ? b.getBillFinanceDetails().getTotalCostValue().doubleValue() : 0.0);
@@ -1304,17 +1304,17 @@ public class PharmacyController implements Serializable {
                     nestedHeaders = new String[]{"Item Name", "Qty", "Free Qty", "Purchase Rate", "Cost Rate", "Discount Rate", "MRP", "Batch", "UOM"};
                 }
                 for (int i = 0; i < nestedHeaders.length; i++) {
-                    Cell cell = hasCosting? nestedHeader.createCell(i + 16) : nestedHeader.createCell(i + 14);
+                    Cell cell = hasCosting ? nestedHeader.createCell(i + 16) : nestedHeader.createCell(i + 14);
                     cell.setCellValue(nestedHeaders[i]);
                     cell.setCellStyle(boldStyle);
                 }
 
                 for (BillItem bi : b.getBillItems()) {
                     Row itemRow = sheet.createRow(rowIndex++);
-                    itemRow.createCell(hasCosting? 16 : 14).setCellValue(bi.getItem().getName());
-                    itemRow.createCell(hasCosting? 17 :15).setCellValue(bi.getPharmaceuticalBillItem().getQty());
-                    itemRow.createCell(hasCosting? 18 :16).setCellValue(bi.getPharmaceuticalBillItem().getFreeQty());
-                    itemRow.createCell(hasCosting? 19 :17).setCellValue(bi.getPharmaceuticalBillItem().getPurchaseRate());
+                    itemRow.createCell(hasCosting ? 16 : 14).setCellValue(bi.getItem().getName());
+                    itemRow.createCell(hasCosting ? 17 : 15).setCellValue(bi.getPharmaceuticalBillItem().getQty());
+                    itemRow.createCell(hasCosting ? 18 : 16).setCellValue(bi.getPharmaceuticalBillItem().getFreeQty());
+                    itemRow.createCell(hasCosting ? 19 : 17).setCellValue(bi.getPharmaceuticalBillItem().getPurchaseRate());
                     if (hasCosting) {
                         itemRow.createCell(20).setCellValue(bi.getBillItemFinanceDetails().getLineCostRate().doubleValue());
                     }
@@ -1328,10 +1328,10 @@ public class PharmacyController implements Serializable {
                         }
                     }
 
-                    itemRow.createCell(hasCosting? 21 :18).setCellValue(discountRate);
-                    itemRow.createCell(hasCosting? 22 :19).setCellValue(bi.getPharmaceuticalBillItem().getRetailRate());
-                    itemRow.createCell(hasCosting? 23 :20).setCellValue(bi.getPharmaceuticalBillItem().getItemBatch().getBatchNo());
-                    itemRow.createCell(hasCosting? 24 :21).setCellValue(bi.getItem().getMeasurementUnit() != null ? bi.getItem().getMeasurementUnit().getName() : "");
+                    itemRow.createCell(hasCosting ? 21 : 18).setCellValue(discountRate);
+                    itemRow.createCell(hasCosting ? 22 : 19).setCellValue(bi.getPharmaceuticalBillItem().getRetailRate());
+                    itemRow.createCell(hasCosting ? 23 : 20).setCellValue(bi.getPharmaceuticalBillItem().getItemBatch().getBatchNo());
+                    itemRow.createCell(hasCosting ? 24 : 21).setCellValue(bi.getItem().getMeasurementUnit() != null ? bi.getItem().getMeasurementUnit().getName() : "");
                 }
             }
 
@@ -1347,8 +1347,8 @@ public class PharmacyController implements Serializable {
                 footer.createCell(11).setCellValue(totalCashCost);
                 footer.createCell(12).setCellValue(totalCreditCost);
             }
-            footer.createCell(hasCosting?13:11).setCellValue(totalCashSale);
-            footer.createCell(hasCosting?14:12).setCellValue(totalCreditSale);
+            footer.createCell(hasCosting ? 13 : 11).setCellValue(totalCashSale);
+            footer.createCell(hasCosting ? 14 : 12).setCellValue(totalCreditSale);
 
             workbook.write(out);
             context.responseComplete();
@@ -1414,7 +1414,7 @@ public class PharmacyController implements Serializable {
                 mainTable.addCell(new Phrase(r.getReferenceBill() != null && r.getReferenceBill().getCreatedAt() != null ? sdf.format(r.getReferenceBill().getCreatedAt()) : "", normalFont));
                 mainTable.addCell(new Phrase(r.getToInstitution() != null ? r.getToInstitution().getName() : "", normalFont));
 
-                double purchase = r.getBillFinanceDetails().getLineNetTotal() != null ? r.getBillFinanceDetails().getLineNetTotal().doubleValue(): 0.0;
+                double purchase = r.getBillFinanceDetails().getLineNetTotal() != null ? r.getBillFinanceDetails().getLineNetTotal().doubleValue() : 0.0;
                 double sale = r.getBillFinanceDetails().getTotalRetailSaleValue() != null ? r.getBillFinanceDetails().getTotalRetailSaleValue().doubleValue() : 0.0;
                 double cost = hasCosting ? (r.getBillFinanceDetails().getTotalCostValue() != null ? r.getBillFinanceDetails().getTotalCostValue().doubleValue() : 0.0) : 0.0;
 
@@ -1515,7 +1515,7 @@ public class PharmacyController implements Serializable {
             Cell titleCell = mainHeader.createCell(0);
             titleCell.setCellValue("GRN Return Report");
             titleCell.setCellStyle(boldStyle);
-            sheet.addMergedRegion(new CellRangeAddress(0, 0, 0, hasCosting?11:10));
+            sheet.addMergedRegion(new CellRangeAddress(0, 0, 0, hasCosting ? 11 : 10));
 
             String[] headers = {"Return No", "GRN No", "GRN Invoice No", "GRN Date", "Reference Institution", "Created At", "Approved At", "Supplier", "Purchase Value", "Sale Value", "Purchase Details"};
 
@@ -1547,7 +1547,7 @@ public class PharmacyController implements Serializable {
                 row.createCell(col++).setCellValue(r.getReferenceBill() != null && r.getReferenceBill().getCreatedAt() != null ? sdf.format(r.getReferenceBill().getCreatedAt()) : "");
                 row.createCell(col++).setCellValue(r.getToInstitution() != null ? r.getToInstitution().getName() : "");
 
-                double purchase = r.getBillFinanceDetails().getLineNetTotal() != null ? r.getBillFinanceDetails().getLineNetTotal().doubleValue(): 0.0;
+                double purchase = r.getBillFinanceDetails().getLineNetTotal() != null ? r.getBillFinanceDetails().getLineNetTotal().doubleValue() : 0.0;
                 double sale = r.getBillFinanceDetails().getTotalRetailSaleValue() != null ? r.getBillFinanceDetails().getTotalRetailSaleValue().doubleValue() : 0.0;
                 double cost = hasCosting ? (r.getBillFinanceDetails().getTotalCostValue() != null ? r.getBillFinanceDetails().getTotalCostValue().doubleValue() : 0.0) : 0.0;
 
@@ -1581,10 +1581,10 @@ public class PharmacyController implements Serializable {
 
                 for (BillItem bi : r.getBillItems()) {
                     Row itemRow = sheet.createRow(rowIndex++);
-                    itemRow.createCell(hasCosting ? 11 :10).setCellValue(bi.getItem().getName());
-                    itemRow.createCell(hasCosting ? 12 :11).setCellValue(bi.getPharmaceuticalBillItem().getQty());
-                    itemRow.createCell(hasCosting ? 13 :12).setCellValue(bi.getPharmaceuticalBillItem().getFreeQty());
-                    itemRow.createCell(hasCosting ? 14 :13).setCellValue(bi.getPharmaceuticalBillItem().getPurchaseRate());
+                    itemRow.createCell(hasCosting ? 11 : 10).setCellValue(bi.getItem().getName());
+                    itemRow.createCell(hasCosting ? 12 : 11).setCellValue(bi.getPharmaceuticalBillItem().getQty());
+                    itemRow.createCell(hasCosting ? 13 : 12).setCellValue(bi.getPharmaceuticalBillItem().getFreeQty());
+                    itemRow.createCell(hasCosting ? 14 : 13).setCellValue(bi.getPharmaceuticalBillItem().getPurchaseRate());
                     if (hasCosting) {
                         itemRow.createCell(15).setCellValue(bi.getBillItemFinanceDetails().getLineCostRate().doubleValue());
                     }
@@ -1598,8 +1598,8 @@ public class PharmacyController implements Serializable {
                         }
                     }
 
-                    itemRow.createCell(hasCosting ? 16 :14).setCellValue(discountRate);
-                    itemRow.createCell(hasCosting ? 17 :15).setCellValue(bi.getPharmaceuticalBillItem().getRetailRate());
+                    itemRow.createCell(hasCosting ? 16 : 14).setCellValue(discountRate);
+                    itemRow.createCell(hasCosting ? 17 : 15).setCellValue(bi.getPharmaceuticalBillItem().getRetailRate());
                     itemRow.createCell(hasCosting ? 18 : 16).setCellValue(bi.getPharmaceuticalBillItem().getItemBatch().getBatchNo());
                     itemRow.createCell(hasCosting ? 19 : 17).setCellValue(bi.getItem().getMeasurementUnit() != null ? bi.getItem().getMeasurementUnit().getName() : "");
                 }
@@ -1653,7 +1653,7 @@ public class PharmacyController implements Serializable {
             title.setAlignment(Element.ALIGN_CENTER);
             document.add(title);
 
-            PdfPTable mainTable = new PdfPTable(hasCosting? 12 : 11);
+            PdfPTable mainTable = new PdfPTable(hasCosting ? 12 : 11);
             mainTable.setWidthPercentage(100);
             if (hasCosting) {
                 mainTable.setWidths(new float[]{2f, 2f, 2f, 2f, 2.5f, 2f, 2f, 2f, 2f, 2f, 2f, 6f});
@@ -1711,7 +1711,7 @@ public class PharmacyController implements Serializable {
                 }
                 mainTable.addCell(new Phrase(String.format("%,.2f", adjustedSale), normalFont));
 
-                PdfPTable nested = new PdfPTable(hasCosting? 9:8);
+                PdfPTable nested = new PdfPTable(hasCosting ? 9 : 8);
                 nested.setWidthPercentage(100);
                 String[] nestedHeaders = {"Item Name", "Qty", "Free Qty", "Purchase Rate", "Discount Rate", "MRP", "Batch", "UOM"};
                 if (hasCosting) {
@@ -1796,7 +1796,7 @@ public class PharmacyController implements Serializable {
             Cell titleCell = titleRow.createCell(0);
             titleCell.setCellValue("GRN Cancellation Report");
             titleCell.setCellStyle(boldStyle);
-            sheet.addMergedRegion(new CellRangeAddress(0, 0, 0, hasCosting?11:10));
+            sheet.addMergedRegion(new CellRangeAddress(0, 0, 0, hasCosting ? 11 : 10));
 
             Row headerRow = sheet.createRow(rowIndex++);
             String[] headers = {"Cancelled No", "GRN No", "GRN Invoice No", "GRN Date", "Reference Institution", "Created At", "Approved At", "Supplier", "Purchase Value", "Sale Value", "Purchase Details"};
@@ -1847,7 +1847,7 @@ public class PharmacyController implements Serializable {
                 if (hasCosting) {
                     row.createCell(9).setCellValue(adjustedCost);
                 }
-                row.createCell(hasCosting?10:9).setCellValue(adjustedSale);
+                row.createCell(hasCosting ? 10 : 9).setCellValue(adjustedSale);
 
                 Row nestedHeader = sheet.createRow(rowIndex++);
                 String[] nestedHeaders = {"Item Name", "Qty", "Free Qty", "Purchase Rate", "Discount Rate", "MRP", "Batch", "UOM"};
@@ -1880,7 +1880,7 @@ public class PharmacyController implements Serializable {
                             }
                         }
 
-                        itemRow.createCell(hasCosting ? 16 :14).setCellValue(discountRate);
+                        itemRow.createCell(hasCosting ? 16 : 14).setCellValue(discountRate);
                         itemRow.createCell(hasCosting ? 17 : 15).setCellValue(bi.getPharmaceuticalBillItem() != null ? bi.getPharmaceuticalBillItem().getRetailRate() : 0);
                         itemRow.createCell(hasCosting ? 18 : 16).setCellValue(bi.getPharmaceuticalBillItem() != null && bi.getPharmaceuticalBillItem().getItemBatch() != null && bi.getPharmaceuticalBillItem().getItemBatch().getBatchNo() != null ? bi.getPharmaceuticalBillItem().getItemBatch().getBatchNo() : "");
                         itemRow.createCell(hasCosting ? 19 : 17).setCellValue(bi.getItem() != null && bi.getItem().getMeasurementUnit() != null && bi.getItem().getMeasurementUnit().getName() != null ? bi.getItem().getMeasurementUnit().getName() : "");
@@ -2436,8 +2436,8 @@ public class PharmacyController implements Serializable {
                     .merge(categoryName,
                             new Double[]{item.getNetTotal(), (item.getCostRate() != null ? item.getCostRate() * item.getQty() : 0.0)},
                             (existing, newValues) -> new Double[]{
-                                    existing[0] + newValues[0],  // Sum net totals
-                                    existing[1] + newValues[1]   // Sum cost rates
+                                existing[0] + newValues[0], // Sum net totals
+                                existing[1] + newValues[1] // Sum cost rates
                             });
 
             totalSaleValue += item.getNetTotal();
@@ -2515,8 +2515,8 @@ public class PharmacyController implements Serializable {
             pharmacyTotals.merge(mainDepartmentName,
                     new Double[]{paidAmount, costAmount},
                     (existing, newValues) -> new Double[]{
-                            existing[0] + newValues[0],  // Sum net totals
-                            existing[1] + newValues[1]   // Sum cost rates
+                        existing[0] + newValues[0], // Sum net totals
+                        existing[1] + newValues[1] // Sum cost rates
                     });
 
             // Store net total at [0] and cost rate at [1] for department totals
@@ -2525,8 +2525,8 @@ public class PharmacyController implements Serializable {
                     .merge(consumptionDepartmentName,
                             new Double[]{paidAmount, costAmount},
                             (existing, newValues) -> new Double[]{
-                                    existing[0] + newValues[0],  // Sum net totals
-                                    existing[1] + newValues[1]   // Sum cost rates
+                                existing[0] + newValues[0], // Sum net totals
+                                existing[1] + newValues[1] // Sum cost rates
                             });
 
             totalSaleValue += paidAmount;
@@ -2935,8 +2935,8 @@ public class PharmacyController implements Serializable {
             } else {
                 netTotal = bill.getNetTotal();
                 saleValue = bill.getSaleValue();
-                costValue = bill.getBillFinanceDetails() != null ? (bill.getBillFinanceDetails().getTotalCostValue() != null ?
-                        bill.getBillFinanceDetails().getTotalCostValue().doubleValue():0.0) : 0.0;
+                costValue = bill.getBillFinanceDetails() != null ? (bill.getBillFinanceDetails().getTotalCostValue() != null
+                        ? bill.getBillFinanceDetails().getTotalCostValue().doubleValue() : 0.0) : 0.0;
             }
 
             if (bill.getPaymentMethod() == null || (bill.getReferenceBill() != null && bill.getReferenceBill().getPaymentMethod() == null)) {
@@ -3293,7 +3293,7 @@ public class PharmacyController implements Serializable {
 
                     if (costingEnabled) {
                         table.addCell(new PdfPCell(new Phrase(i.getItemBatch() != null && i.getItemBatch().getCostRate() != null ? String.format("%.2f", i.getItemBatch().getCostRate()) : "0.00", FontFactory.getFont(FontFactory.HELVETICA, 8))));
-                        table.addCell(new PdfPCell(new Phrase( i.getItemBatch() != null && i.getItemBatch().getCostRate() != null ? String.format("%.2f", (i.getBillItem().getPharmaceuticalBillItem().getQty() * i.getItemBatch().getCostRate())) : "0.00", FontFactory.getFont(FontFactory.HELVETICA, 8))));
+                        table.addCell(new PdfPCell(new Phrase(i.getItemBatch() != null && i.getItemBatch().getCostRate() != null ? String.format("%.2f", (i.getBillItem().getPharmaceuticalBillItem().getQty() * i.getItemBatch().getCostRate())) : "0.00", FontFactory.getFont(FontFactory.HELVETICA, 8))));
                     }
 
                     table.addCell(new PdfPCell(new Phrase(i.getBillItem().getBill().getCreater() != null && i.getBillItem().getBill().getCreater().getWebUserPerson() != null ? i.getBillItem().getBill().getCreater().getWebUserPerson().getName() : "-", FontFactory.getFont(FontFactory.HELVETICA, 8))));
@@ -3324,17 +3324,17 @@ public class PharmacyController implements Serializable {
         Map<String, Object> parameters = new HashMap<>();
         StringBuilder sql = new StringBuilder(
                 "SELECT b.toDepartment, "
-                        + "b.department, "
-                        + "b.deptId, "
-                        + "b.createdAt, "
-                        + "b.backwardReferenceBill, "
-                        + "b.backwardReferenceBill.deptId, "
-                        + "SUM(b.netTotal), "
-                        + "b "
-                        + "FROM Bill b "
-                        + "WHERE b.retired = false "
-                        + "AND b.createdAt BETWEEN :fromDate AND :toDate "
-                        + "AND b.billType = :billType "
+                + "b.department, "
+                + "b.deptId, "
+                + "b.createdAt, "
+                + "b.backwardReferenceBill, "
+                + "b.backwardReferenceBill.deptId, "
+                + "SUM(b.netTotal), "
+                + "b "
+                + "FROM Bill b "
+                + "WHERE b.retired = false "
+                + "AND b.createdAt BETWEEN :fromDate AND :toDate "
+                + "AND b.billType = :billType "
         );
 
         parameters.put("billType", billType);
@@ -3375,9 +3375,9 @@ public class PharmacyController implements Serializable {
                 departmentWiseBillList.add(departmentWiseBill);
                 totalPurchase += departmentWiseBill.getBill().getNetTotal();
 
-                double costValue = Math.abs(departmentWiseBill.getBill().getBillFinanceDetails() != null &&
-                        departmentWiseBill.getBill().getBillFinanceDetails().getTotalCostValue() != null ?
-                        departmentWiseBill.getBill().getBillFinanceDetails().getTotalCostValue().doubleValue() : 0.0);
+                double costValue = Math.abs(departmentWiseBill.getBill().getBillFinanceDetails() != null
+                        && departmentWiseBill.getBill().getBillFinanceDetails().getTotalCostValue() != null
+                        ? departmentWiseBill.getBill().getBillFinanceDetails().getTotalCostValue().doubleValue() : 0.0);
 
                 totalCostValue += departmentWiseBill.getBill().getNetTotal() < 0 ? -costValue : costValue;
             }
@@ -3467,16 +3467,16 @@ public class PharmacyController implements Serializable {
                         : "Other";
 
                 double purchaseValue = row.getBillItem().getPharmaceuticalBillItem().getQty() * row.getBillItem().getPharmaceuticalBillItem().getPurchaseRate();
-                double costValue = costingEnabled ?
-                        row.getBillItem().getPharmaceuticalBillItem().getQty() * (row.getItemBatch() != null && row.getItemBatch().getCostRate() != null ?
-                                row.getItemBatch().getCostRate() : 0.0) : 0.0;
+                double costValue = costingEnabled
+                        ? row.getBillItem().getPharmaceuticalBillItem().getQty() * (row.getItemBatch() != null && row.getItemBatch().getCostRate() != null
+                        ? row.getItemBatch().getCostRate() : 0.0) : 0.0;
 
                 totalPurchase += row.getBillItem().getPharmaceuticalBillItem().getQty() * row.getBillItem().getPharmaceuticalBillItem().getPurchaseRate();
 
                 departmentWiseRows.computeIfAbsent(departmentName, k -> new ArrayList<>()).add(row);
                 departmentTotalsMap.compute(departmentName, (k, v) -> {
                     if (v == null) {
-                        return new Double[] { purchaseValue, costValue };
+                        return new Double[]{purchaseValue, costValue};
                     } else {
                         v[0] += purchaseValue;
                         v[1] += costValue;
@@ -3944,12 +3944,12 @@ public class PharmacyController implements Serializable {
     }
 
     public List<ItemQuantityAndValues> findPharmacyTrnasactionQuantityAndValues(Date fromDate,
-                                                                                Date toDate,
-                                                                                Institution ins,
-                                                                                Department department,
-                                                                                Item item,
-                                                                                BillType[] billTypes,
-                                                                                BillType[] referenceBillTypes) {
+            Date toDate,
+            Institution ins,
+            Department department,
+            Item item,
+            BillType[] billTypes,
+            BillType[] referenceBillTypes) {
 
 //        if (false) {
 //            BillItem bi = new BillItem();
@@ -5180,7 +5180,8 @@ public class PharmacyController implements Serializable {
         createGrnTable();
         createGrnReturnTable();
         createPoTable();
-        createDirectPurchaseTable();
+        createDirectPurchaseTableDto();
+        //createDirectPurchaseTable();  // Deprecated - use createDirectPurchaseTableDto() instead
         createInstitutionIssue();
     }
 
@@ -5316,7 +5317,6 @@ public class PharmacyController implements Serializable {
         params.put("class", BilledBill.class);
         params.put("btas", btas);
 
-
         List<BillItem> billItems = (List<BillItem>) getBillItemFacade().findLightsByJpql(jpql, params, TemporalType.TIMESTAMP);
         grnReturnDtos = new ArrayList<>();
 
@@ -5345,6 +5345,11 @@ public class PharmacyController implements Serializable {
 
     }
 
+    /**
+     * @deprecated Use createDirectPurchaseTableDto() for better performance
+     * with DTO-based queries
+     */
+    @Deprecated
     public void createDirectPurchaseTable() {
         List<Item> relatedItems = pharmacyService.findRelatedItems(pharmacyItem);
         if (relatedItems == null || relatedItems.isEmpty()) {
@@ -5366,6 +5371,44 @@ public class PharmacyController implements Serializable {
                 );
         directPurchase = getBillItemFacade().findByJpql(sql, hm, TemporalType.TIMESTAMP);
 
+    }
+
+    public void createDirectPurchaseTableDto() {
+        List<Item> relatedItems = pharmacyService.findRelatedItems(pharmacyItem);
+        if (relatedItems == null || relatedItems.isEmpty()) {
+            directPurchaseDtos = new ArrayList<>();
+            return;
+        }
+
+        String sql = "SELECT new com.divudi.core.data.dto.PharmacyItemPurchaseDTO("
+                + "b.bill.id, "
+                + "b.bill.deptId, "
+                + "b.bill.fromInstitution.name, "
+                + "b.bill.creater.webUserPerson.name, "
+                + "b.bill.createdAt, "
+                + "b.pharmaceuticalBillItem.purchaseRate, "
+                + "b.pharmaceuticalBillItem.retailRate, "
+                + "b.pharmaceuticalBillItem.qty, "
+                + "b.pharmaceuticalBillItem.freeQty, "
+                + "b.netValue) "
+                + "FROM BillItem b "
+                + "WHERE type(b.bill) = :class "
+                + "AND b.bill.creater IS NOT NULL "
+                + "AND b.bill.cancelled = false "
+                + "AND b.retired = false "
+                + "AND b.item IN :relatedItems "
+                + "AND b.bill.billType = :btp "
+                + "AND b.createdAt BETWEEN :frm AND :to "
+                + "ORDER BY b.id DESC";
+
+        HashMap<String, Object> hm = new HashMap<>();
+        hm.put("relatedItems", relatedItems);
+        hm.put("frm", getFromDate());
+        hm.put("to", getToDate());
+        hm.put("btp", BillType.PharmacyPurchaseBill);
+        hm.put("class", BilledBill.class);
+
+        directPurchaseDtos = (List<PharmacyItemPurchaseDTO>) getBillItemFacade().findLightsByJpql(sql, hm, TemporalType.TIMESTAMP);
     }
 
     public List<BillItem> getPos() {
@@ -5581,8 +5624,8 @@ public class PharmacyController implements Serializable {
                 emptyRow.createCell(2).setCellValue(bill.getReferenceBill().getDeptId());
                 emptyRow.createCell(3).setCellValue(
                         bill.getInvoiceNumber() != null ? bill.getInvoiceNumber()
-                                : (bill.getReferenceBill() != null && bill.getReferenceBill().getInvoiceNumber() != null
-                                ? bill.getReferenceBill().getInvoiceNumber() : "-"));
+                        : (bill.getReferenceBill() != null && bill.getReferenceBill().getInvoiceNumber() != null
+                        ? bill.getReferenceBill().getInvoiceNumber() : "-"));
                 emptyRow.createCell(4).setCellValue("-");
                 emptyRow.createCell(5).setCellValue("-");
                 emptyRow.createCell(6).setCellValue("-");
@@ -5595,10 +5638,10 @@ public class PharmacyController implements Serializable {
                 emptyRow.createCell(13).setCellValue("-");
                 emptyRow.createCell(14).setCellValue(
                         bill.getBillTypeAtomic() != null && bill.getBillTypeAtomic().equals(BillTypeAtomic.PHARMACY_GRN_RETURN)
-                                ? (bill.getToInstitution() != null && bill.getToInstitution().getName() != null
-                                ? bill.getToInstitution().getName() : "-")
-                                : (bill.getFromInstitution() != null && bill.getFromInstitution().getName() != null
-                                ? bill.getFromInstitution().getName() : "-"));
+                        ? (bill.getToInstitution() != null && bill.getToInstitution().getName() != null
+                        ? bill.getToInstitution().getName() : "-")
+                        : (bill.getFromInstitution() != null && bill.getFromInstitution().getName() != null
+                        ? bill.getFromInstitution().getName() : "-"));
                 emptyRow.createCell(15).setCellValue("-");
                 emptyRow.createCell(16).setCellValue("-");
                 emptyRow.createCell(17).setCellValue("-");
@@ -5617,12 +5660,12 @@ public class PharmacyController implements Serializable {
                     emptyInnerRow.createCell(3).setCellValue("-");
                     emptyInnerRow.createCell(4).setCellValue(
                             (billItem.getBill() != null && billItem.getBill().getToDepartment() != null && billItem.getBill().getToDepartment().getName() != null)
-                                    ? billItem.getBill().getToDepartment().getName()
-                                    : (billItem.getBill() != null && billItem.getBill().getReferenceBill() != null
-                                    && billItem.getBill().getReferenceBill().getToDepartment() != null
-                                    && billItem.getBill().getReferenceBill().getToDepartment().getName() != null)
-                                    ? billItem.getBill().getReferenceBill().getToDepartment().getName()
-                                    : "-");
+                            ? billItem.getBill().getToDepartment().getName()
+                            : (billItem.getBill() != null && billItem.getBill().getReferenceBill() != null
+                            && billItem.getBill().getReferenceBill().getToDepartment() != null
+                            && billItem.getBill().getReferenceBill().getToDepartment().getName() != null)
+                            ? billItem.getBill().getReferenceBill().getToDepartment().getName()
+                            : "-");
                     emptyInnerRow.createCell(5).setCellValue(billItem.getItem().getCategory().getName());
                     emptyInnerRow.createCell(6).setCellValue(billItem.getItem().getCode());
                     emptyInnerRow.createCell(7).setCellValue(billItem.getItem().getName());
@@ -5630,8 +5673,8 @@ public class PharmacyController implements Serializable {
                     emptyInnerRow.createCell(9).setCellValue(billItem.getQty());
                     emptyInnerRow.createCell(10).setCellValue(
                             (billItem.getItem() != null && billItem.getItem().getMeasurementUnit() != null
-                                    && billItem.getItem().getMeasurementUnit().getName() != null)
-                                    ? billItem.getItem().getMeasurementUnit().getName() : "-");
+                            && billItem.getItem().getMeasurementUnit().getName() != null)
+                            ? billItem.getItem().getMeasurementUnit().getName() : "-");
                     emptyInnerRow.createCell(11).setCellValue(billItem.getPharmaceuticalBillItem().getPurchaseRate());
                     emptyInnerRow.createCell(12).setCellValue(billItem.getPharmaceuticalBillItem().getItemBatch().getBatchNo());
                     emptyInnerRow.createCell(13).setCellValue(sdf.format(billItem.getPharmaceuticalBillItem().getItemBatch().getDateOfExpire()));
@@ -5946,6 +5989,14 @@ public class PharmacyController implements Serializable {
 
     public void setDirectPurchase(List<BillItem> directPurchase) {
         this.directPurchase = directPurchase;
+    }
+
+    public List<PharmacyItemPurchaseDTO> getDirectPurchaseDtos() {
+        return directPurchaseDtos;
+    }
+
+    public void setDirectPurchaseDtos(List<PharmacyItemPurchaseDTO> directPurchaseDtos) {
+        this.directPurchaseDtos = directPurchaseDtos;
     }
 
     public List<InstitutionStock> getInstitutionStocks() {
@@ -6672,7 +6723,9 @@ public class PharmacyController implements Serializable {
     }
 
     /**
-     * Returns the appropriate PrimeFaces UI message CSS class based on item expiry date
+     * Returns the appropriate PrimeFaces UI message CSS class based on item
+     * expiry date
+     *
      * @param dateOfExpire the expiry date of the item
      * @return PrimeFaces CSS class for styling
      */
@@ -6680,12 +6733,12 @@ public class PharmacyController implements Serializable {
         if (dateOfExpire == null) {
             return "ui-messages-success";
         }
-        
+
         // Normalize dates to end-of-day for consistent comparison
         Date currentDateEndOfDay = CommonFunctions.getEndOfDay(new Date());
         Date dateOfExpireEndOfDay = CommonFunctions.getEndOfDay(dateOfExpire);
         Date threeMonthsFromNow = CommonFunctions.getDateAfterThreeMonthsCurrentDateTime();
-        
+
         if (currentDateEndOfDay.after(dateOfExpireEndOfDay)) {
             return "ui-messages-fatal";
         } else if (threeMonthsFromNow.after(dateOfExpireEndOfDay)) {
@@ -6696,6 +6749,7 @@ public class PharmacyController implements Serializable {
 
     /**
      * Returns the appropriate background style based on item expiry date
+     *
      * @param dateOfExpire the expiry date of the item
      * @return CSS background style
      */
@@ -6703,12 +6757,12 @@ public class PharmacyController implements Serializable {
         if (dateOfExpire == null) {
             return "background-color: #dff0d8";
         }
-        
+
         // Normalize dates to end-of-day for consistent comparison
         Date currentDateEndOfDay = CommonFunctions.getEndOfDay(new Date());
         Date dateOfExpireEndOfDay = CommonFunctions.getEndOfDay(dateOfExpire);
         Date threeMonthsFromNow = CommonFunctions.getDateAfterThreeMonthsCurrentDateTime();
-        
+
         if (currentDateEndOfDay.after(dateOfExpireEndOfDay)) {
             return "background-color: #f2dede";  // Light red for expired
         } else if (threeMonthsFromNow.after(dateOfExpireEndOfDay)) {
@@ -6716,9 +6770,10 @@ public class PharmacyController implements Serializable {
         }
         return "background-color: #dff0d8";  // Light green for good expiry
     }
-    
+
     /**
      * Creates stock variance report from stock taking adjustments
+     *
      * @param fromDate start date for the report
      * @param toDate end date for the report
      * @param department specific department (optional)
@@ -6726,25 +6781,25 @@ public class PharmacyController implements Serializable {
      */
     public List<Map<String, Object>> createStockVarianceReport(Date fromDate, Date toDate, Department department) {
         List<Map<String, Object>> varianceData = new ArrayList<>();
-        
+
         try {
             String jpql = "SELECT bi FROM BillItem bi "
                     + "WHERE bi.bill.billType = :billType "
                     + "AND bi.bill.createdAt BETWEEN :fromDate AND :toDate "
                     + "AND bi.bill.retired = false ";
-            
+
             Map<String, Object> params = new HashMap<>();
             params.put("billType", BillType.PharmacyStockAdjustmentBill);
             params.put("fromDate", fromDate);
             params.put("toDate", toDate);
-            
+
             if (department != null) {
                 jpql += " AND bi.bill.department = :dept";
                 params.put("dept", department);
             }
-            
+
             List<BillItem> adjustmentItems = billItemFacade.findByJpql(jpql, params);
-            
+
             for (BillItem bi : adjustmentItems) {
                 if (bi.getPharmaceuticalBillItem() != null && bi.getPharmaceuticalBillItem().getItemBatch() != null) {
                     Map<String, Object> variance = new HashMap<>();
@@ -6758,17 +6813,18 @@ public class PharmacyController implements Serializable {
                     varianceData.add(variance);
                 }
             }
-            
+
         } catch (Exception e) {
             // Handle exception appropriately
             System.err.println("Error creating stock variance report: " + e.getMessage());
         }
-        
+
         return varianceData;
     }
-    
+
     /**
      * Gets stock variance report data
+     *
      * @param fromDate start date
      * @param toDate end date
      * @param department department filter

--- a/src/main/java/com/divudi/bean/pharmacy/PharmacyController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacyController.java
@@ -5399,7 +5399,7 @@ public class PharmacyController implements Serializable {
                 + "b.pharmaceuticalBillItem.retailRate, "
                 + "b.pharmaceuticalBillItem.qty, "
                 + "b.pharmaceuticalBillItem.freeQty, "
-                + "b.netValue) "
+                + "b.bill.netTotal) "
                 + "FROM BillItem b "
                 + "WHERE (b.retired IS NULL OR b.retired = FALSE) "
                 + "AND b.item IN :relatedItems "

--- a/src/main/java/com/divudi/bean/pharmacy/PharmacyDirectPurchaseController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacyDirectPurchaseController.java
@@ -257,10 +257,10 @@ public class PharmacyDirectPurchaseController implements Serializable {
         currentBillItem = null;
         // Calculate bill totals using internal methods
         calculateBillTotalsFromItems();
-        
+
         // Distribute bill-level adjustments proportionally to line items
         distributeProportionalBillValuesToItems();
-        
+
         // Recalculate profit margins after distributions have been applied
         recalculateProfitMarginsForAllItems();
 
@@ -867,8 +867,6 @@ public class PharmacyDirectPurchaseController implements Serializable {
         //   saveBillComponent();
 
 //        Payment p = createPayment(getBill());
-        List<Payment> ps = paymentService.createPayment(getBill(), getPaymentMethodData());
-
         billItemsTotalQty = 0;
 
         for (BillItem i : getBillItems()) {
@@ -943,6 +941,7 @@ public class PharmacyDirectPurchaseController implements Serializable {
 
 //        getPharmacyBillBean().calculateRetailSaleValueAndFreeValueAtPurchaseRate(getBill());
         getBillFacade().edit(getBill());
+        List<Payment> ps = paymentService.createPayment(getBill(), getPaymentMethodData());
 
         JsfUtil.addSuccessMessage("Direct Purchase Successfully Completed.");
         printPreview = true;

--- a/src/main/java/com/divudi/bean/pharmacy/PurchaseOrderConfigController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PurchaseOrderConfigController.java
@@ -1,0 +1,79 @@
+package com.divudi.bean.pharmacy;
+
+import com.divudi.bean.common.ConfigOptionApplicationController;
+import com.divudi.core.util.JsfUtil;
+import javax.inject.Named;
+import javax.faces.view.ViewScoped;
+import javax.inject.Inject;
+import java.io.Serializable;
+
+/**
+ * Controller for managing Pharmacy Purchase Order Request configuration options
+ *
+ * @author Claude Code Assistant
+ */
+@Named
+@ViewScoped
+public class PurchaseOrderConfigController implements Serializable {
+
+    @Inject
+    private ConfigOptionApplicationController configOptionApplicationController;
+
+    @Inject
+    private com.divudi.bean.common.ConfigOptionController configOptionController;
+
+    @Inject
+    private com.divudi.bean.common.SessionController sessionController;
+
+    // Paper Type Settings for Purchase Order Request
+    private boolean custom1Paper;
+    private boolean custom2Paper;
+
+    public PurchaseOrderConfigController() {
+    }
+
+    /**
+     * Load current configuration values from the department-specific options
+     */
+    public void loadCurrentConfig() {
+        // Purchase Order Request Paper Settings
+        custom1Paper = configOptionController.getBooleanValueByKey("Pharmacy Purchase Order Request Print - A4 Paper Custom 1", true);
+        custom2Paper = configOptionController.getBooleanValueByKey("Pharmacy Purchase Order Request Print - A4 Paper Custom 2", false);
+    }
+
+    /**
+     * Save all configuration changes
+     */
+    public void saveConfig() {
+        try {
+            // Purchase Order Request Paper Settings
+            configOptionController.setBooleanValueByKey("Pharmacy Purchase Order Request Print - A4 Paper Custom 1", custom1Paper);
+            configOptionController.setBooleanValueByKey("Pharmacy Purchase Order Request Print - A4 Paper Custom 2", custom2Paper);
+
+            JsfUtil.addSuccessMessage("Purchase Order configuration saved successfully");
+
+            // Reload current values to ensure consistency
+            loadCurrentConfig();
+
+        } catch (Exception e) {
+            JsfUtil.addErrorMessage("Error saving configuration: " + e.getMessage());
+        }
+    }
+
+    // Getters and Setters
+    public boolean isCustom1Paper() {
+        return custom1Paper;
+    }
+
+    public void setCustom1Paper(boolean custom1Paper) {
+        this.custom1Paper = custom1Paper;
+    }
+
+    public boolean isCustom2Paper() {
+        return custom2Paper;
+    }
+
+    public void setCustom2Paper(boolean custom2Paper) {
+        this.custom2Paper = custom2Paper;
+    }
+}

--- a/src/main/java/com/divudi/bean/pharmacy/PurchaseOrderController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PurchaseOrderController.java
@@ -454,17 +454,14 @@ public class PurchaseOrderController implements Serializable {
 
             double qty;
             qty = i.getPharmaceuticalBillItem().getQty() + i.getPharmaceuticalBillItem().getFreeQty();
-            System.out.println("qty = " + qty);
-            
-            
+
             i.getPharmaceuticalBillItem().setRemainingQty(i.getPharmaceuticalBillItem().getQty());
             i.getPharmaceuticalBillItem().setRemainingFreeQty(i.getPharmaceuticalBillItem().getFreeQty());
-            
+
             if (qty <= 0.0) {
                 i.setRetired(true);
                 i.setRetirer(sessionController.getLoggedUser());
                 i.setRetiredAt(new Date());
-                i.setBill(null);
                 i.setRetireComments("Retired at Approving PO");
             }
             if (i.getId() == null) {

--- a/src/main/java/com/divudi/bean/pharmacy/PurchaseOrderController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PurchaseOrderController.java
@@ -170,7 +170,7 @@ public class PurchaseOrderController implements Serializable {
             JsfUtil.addErrorMessage("This purchase order is already approved");
             return "";
         }
-        
+
         if (getAprovedBill().getPaymentMethod() == null) {
             JsfUtil.addErrorMessage("Select Paymentmethod");
             return "";
@@ -453,43 +453,26 @@ public class PurchaseOrderController implements Serializable {
             i.setNetValue(i.getPharmaceuticalBillItem().getQty() * i.getPharmaceuticalBillItem().getPurchaseRate());
 
             double qty;
-            qty = i.getQty() + i.getPharmaceuticalBillItem().getFreeQty();
+            qty = i.getPharmaceuticalBillItem().getQty() + i.getPharmaceuticalBillItem().getFreeQty();
+            System.out.println("qty = " + qty);
+            
+            
+            i.getPharmaceuticalBillItem().setRemainingQty(i.getPharmaceuticalBillItem().getQty());
+            i.getPharmaceuticalBillItem().setRemainingFreeQty(i.getPharmaceuticalBillItem().getFreeQty());
+            
             if (qty <= 0.0) {
                 i.setRetired(true);
                 i.setRetirer(sessionController.getLoggedUser());
                 i.setRetiredAt(new Date());
+                i.setBill(null);
                 i.setRetireComments("Retired at Approving PO");
-
             }
-//            totalBillItemsCount = totalBillItemsCount + qty;
-            PharmaceuticalBillItem phItem = i.getPharmaceuticalBillItem();
-            i.setPharmaceuticalBillItem(null);
-            try {
-                if (i.getId() == null) {
-                    getBillItemFacade().create(i);
-                } else {
-                    getBillItemFacade().edit(i);
-                }
-            } catch (Exception e) {
-            }
-
-            phItem.setBillItem(i);
-
-            try {
-                if (phItem.getId() == null) {
-                    getPharmaceuticalBillItemFacade().create(phItem);
-                } else {
-                    getPharmaceuticalBillItemFacade().edit(phItem);
-                }
-            } catch (Exception e) {
-            }
-
-            i.setPharmaceuticalBillItem(phItem);
-            try {
+            if (i.getId() == null) {
+                getBillItemFacade().create(i);
+            } else {
                 getBillItemFacade().edit(i);
-            } catch (Exception e) {
-
             }
+
             getAprovedBill().getBillItems().add(i);
         }
 

--- a/src/main/java/com/divudi/bean/pharmacy/PurchaseOrderRequestController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PurchaseOrderRequestController.java
@@ -491,6 +491,8 @@ public class PurchaseOrderRequestController implements Serializable {
                 b.setRetireComments("Retired at Finalising PO");
             }
             totalBillItemsCount += totalUnits.doubleValue();
+            b.getPharmaceuticalBillItem().setRemainingQty(b.getPharmaceuticalBillItem().getQty());
+            b.getPharmaceuticalBillItem().setRemainingFreeQty(b.getPharmaceuticalBillItem().getFreeQty());
             if (b.getId() == null) {
                 getBillItemFacade().create(b);
             } else {

--- a/src/main/java/com/divudi/core/data/dto/PharmacyItemPoDTO.java
+++ b/src/main/java/com/divudi/core/data/dto/PharmacyItemPoDTO.java
@@ -20,9 +20,15 @@ public class PharmacyItemPoDTO implements Serializable {
     private String supplierName; // toInstitution.name
     private String creatorName;  // creater.webUserPerson.name
 
+    // Item details
+    private String itemName;     // item.name
+
     // Item quantities
     private Double qty;         // Ordered quantity (PO)
     private Double freeQty;      // Ordered Free Qty
+
+    private Double completedFreeQty;
+    private Double completedQty;
 
     public PharmacyItemPoDTO() {
     }
@@ -32,15 +38,21 @@ public class PharmacyItemPoDTO implements Serializable {
             Date billCreatedAt,
             String supplierName,
             String creatorName,
+            String itemName,
             Double qty,
-            Double grnQty) {
+            Double freeQty,
+            Double completedQty,
+            Double completedFreeQty) {
         this.billId = billId;
         this.billDeptId = billDeptId;
         this.billCreatedAt = billCreatedAt;
         this.supplierName = supplierName;
         this.creatorName = creatorName;
+        this.itemName = itemName;
         this.qty = qty;
-        this.freeQty = grnQty;
+        this.freeQty = freeQty;
+        this.completedQty = completedQty;
+        this.completedFreeQty = completedFreeQty;
     }
 
     public Long getBillId() {
@@ -83,6 +95,14 @@ public class PharmacyItemPoDTO implements Serializable {
         this.creatorName = creatorName;
     }
 
+    public String getItemName() {
+        return itemName;
+    }
+
+    public void setItemName(String itemName) {
+        this.itemName = itemName;
+    }
+
     public Double getQty() {
         return qty;
     }
@@ -98,4 +118,22 @@ public class PharmacyItemPoDTO implements Serializable {
     public void setFreeQty(Double freeQty) {
         this.freeQty = freeQty;
     }
+
+    public Double getCompletedFreeQty() {
+        return completedFreeQty;
+    }
+
+    public void setCompletedFreeQty(Double completedFreeQty) {
+        this.completedFreeQty = completedFreeQty;
+    }
+
+    public Double getCompletedQty() {
+        return completedQty;
+    }
+
+    public void setCompletedQty(Double completedQty) {
+        this.completedQty = completedQty;
+    }
+    
+    
 }

--- a/src/main/java/com/divudi/core/data/dto/PharmacyItemPoDTO.java
+++ b/src/main/java/com/divudi/core/data/dto/PharmacyItemPoDTO.java
@@ -1,0 +1,101 @@
+package com.divudi.core.data.dto;
+
+import java.io.Serializable;
+import java.util.Date;
+
+/**
+ * DTO for Pharmacy Item-based Purchase Orders (PO) in item history. Keeps only
+ * fields required by UI tables to improve performance.
+ */
+public class PharmacyItemPoDTO implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    // Bill header
+    private Long billId;
+    private String billDeptId;
+    private Date billCreatedAt;
+
+    // Party & user
+    private String supplierName; // toInstitution.name
+    private String creatorName;  // creater.webUserPerson.name
+
+    // Item quantities
+    private Double qty;         // Ordered quantity (PO)
+    private Double freeQty;      // Ordered Free Qty
+
+    public PharmacyItemPoDTO() {
+    }
+
+    public PharmacyItemPoDTO(Long billId,
+            String billDeptId,
+            Date billCreatedAt,
+            String supplierName,
+            String creatorName,
+            Double qty,
+            Double grnQty) {
+        this.billId = billId;
+        this.billDeptId = billDeptId;
+        this.billCreatedAt = billCreatedAt;
+        this.supplierName = supplierName;
+        this.creatorName = creatorName;
+        this.qty = qty;
+        this.freeQty = grnQty;
+    }
+
+    public Long getBillId() {
+        return billId;
+    }
+
+    public void setBillId(Long billId) {
+        this.billId = billId;
+    }
+
+    public String getBillDeptId() {
+        return billDeptId;
+    }
+
+    public void setBillDeptId(String billDeptId) {
+        this.billDeptId = billDeptId;
+    }
+
+    public Date getBillCreatedAt() {
+        return billCreatedAt;
+    }
+
+    public void setBillCreatedAt(Date billCreatedAt) {
+        this.billCreatedAt = billCreatedAt;
+    }
+
+    public String getSupplierName() {
+        return supplierName;
+    }
+
+    public void setSupplierName(String supplierName) {
+        this.supplierName = supplierName;
+    }
+
+    public String getCreatorName() {
+        return creatorName;
+    }
+
+    public void setCreatorName(String creatorName) {
+        this.creatorName = creatorName;
+    }
+
+    public Double getQty() {
+        return qty;
+    }
+
+    public void setQty(Double qty) {
+        this.qty = qty;
+    }
+
+    public Double getFreeQty() {
+        return freeQty;
+    }
+
+    public void setFreeQty(Double freeQty) {
+        this.freeQty = freeQty;
+    }
+}

--- a/src/main/java/com/divudi/core/data/dto/PharmacyItemPurchaseDTO.java
+++ b/src/main/java/com/divudi/core/data/dto/PharmacyItemPurchaseDTO.java
@@ -21,6 +21,7 @@ public class PharmacyItemPurchaseDTO implements Serializable {
     private String billInstitutionName;
     private String billDepartmentName;
     private String billFromInstitutionName;
+    private String billCreaterName;
     private BillType billType;
     private Double billTotal;
     private Double billNetTotal;
@@ -158,6 +159,22 @@ public class PharmacyItemPurchaseDTO implements Serializable {
         this.billTotal = billTotal;
     }
 
+    // Constructor for Direct Purchase table (11 parameters)
+    public PharmacyItemPurchaseDTO(Long billId, String billDeptId, String billFromInstitutionName, 
+                                   String billCreaterName, Date billCreatedAt, Double purchaseRate, 
+                                   Double retailRate, Double qty, Double freeQty, Double billNetTotal) {
+        this.billId = billId;
+        this.billDeptId = billDeptId;
+        this.billFromInstitutionName = billFromInstitutionName;
+        this.billCreaterName = billCreaterName;
+        this.billCreatedAt = billCreatedAt;
+        this.purchaseRate = purchaseRate;
+        this.retailRate = retailRate;
+        this.qty = qty;
+        this.freeQty = freeQty;
+        this.billNetTotal = billNetTotal;
+    }
+
     public Bill getBill() {
         return bill;
     }
@@ -208,6 +225,9 @@ public class PharmacyItemPurchaseDTO implements Serializable {
 
     public String getBillFromInstitutionName() { return billFromInstitutionName; }
     public void setBillFromInstitutionName(String billFromInstitutionName) { this.billFromInstitutionName = billFromInstitutionName; }
+
+    public String getBillCreaterName() { return billCreaterName; }
+    public void setBillCreaterName(String billCreaterName) { this.billCreaterName = billCreaterName; }
 
     public BillType getBillType() { return billType; }
     public void setBillType(BillType billType) { this.billType = billType; }

--- a/src/main/java/com/divudi/core/entity/pharmacy/PharmaceuticalBillItem.java
+++ b/src/main/java/com/divudi/core/entity/pharmacy/PharmaceuticalBillItem.java
@@ -294,6 +294,8 @@ public class PharmaceuticalBillItem implements Serializable {
         remainingFreeQtyPack = ph.remainingFreeQtyPack;
         remainingQty = ph.remainingQty;
         remainingQtyPack = ph.remainingQtyPack;
+        completedQty = ph.completedQty;
+        completedFreeQty = ph.completedFreeQty;
 
         wholesaleRate = ph.wholesaleRate;
         wholesaleRatePack = ph.wholesaleRatePack;
@@ -332,6 +334,8 @@ public class PharmaceuticalBillItem implements Serializable {
         qtyPacks = 0 - ph.qtyPacks;
         freeQty = 0 - ph.freeQty;
         freeQtyPacks = 0 - ph.freeQtyPacks;
+        completedQty = 0 - ph.completedQty;
+        completedFreeQty = 0 - ph.completedFreeQty;
     }
 
     public void invertValue() {
@@ -339,6 +343,8 @@ public class PharmaceuticalBillItem implements Serializable {
         qtyPacks = 0 - qtyPacks;
         freeQty = 0 - freeQty;
         freeQtyPacks = 0 - freeQtyPacks;
+        completedQty = 0 - completedQty;
+        completedFreeQty = 0 - completedFreeQty;
     }
 
     public Stock getStock() {

--- a/src/main/java/com/divudi/core/entity/pharmacy/PharmaceuticalBillItem.java
+++ b/src/main/java/com/divudi/core/entity/pharmacy/PharmaceuticalBillItem.java
@@ -61,6 +61,9 @@ public class PharmaceuticalBillItem implements Serializable {
 
     private double retailRate;
     private double retailRatePack;
+    
+    private double completedQty;
+    private double completedFreeQty;
 
     private double wholesaleRate;
     private double wholesaleRatePack;
@@ -835,6 +838,22 @@ public class PharmaceuticalBillItem implements Serializable {
 
     public void setCostValue(double costValue) {
         this.costValue = costValue;
+    }
+
+    public double getCompletedQty() {
+        return completedQty;
+    }
+
+    public void setCompletedQty(double completedQty) {
+        this.completedQty = completedQty;
+    }
+
+    public double getCompletedFreeQty() {
+        return completedFreeQty;
+    }
+
+    public void setCompletedFreeQty(double completedFreeQty) {
+        this.completedFreeQty = completedFreeQty;
     }
 
     

--- a/src/main/resources/META-INF/persistence.xml
+++ b/src/main/resources/META-INF/persistence.xml
@@ -2,7 +2,7 @@
 <persistence version="2.2" xmlns="http://java.sun.com/xml/ns/persistence" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/persistence http://xmlns.jcp.org/xml/ns/persistence/persistence_2_2.xsd">
     <persistence-unit name="hmisPU" transaction-type="JTA">
         <provider>org.eclipse.persistence.jpa.PersistenceProvider</provider>
-        <jta-data-source>jdbc/ruhunu</jta-data-source>
+        <jta-data-source>${JDBC_DATASOURCE}</jta-data-source>
         <exclude-unlisted-classes>false</exclude-unlisted-classes>
         <properties>
             <property name="eclipselink.logging.level.sql" value="SEVERE"/>
@@ -10,7 +10,7 @@
         </properties>
     </persistence-unit>
     <persistence-unit name="hmisAuditPU" transaction-type="JTA">
-        <jta-data-source>jdbc/ruhunuaudit</jta-data-source>
+        <jta-data-source>${JDBC_AUDIT_DATASOURCE}</jta-data-source>
         <exclude-unlisted-classes>false</exclude-unlisted-classes>
         <properties>
             <property name="eclipselink.logging.level.sql" value="SEVERE"/>

--- a/src/main/resources/META-INF/persistence.xml
+++ b/src/main/resources/META-INF/persistence.xml
@@ -2,7 +2,7 @@
 <persistence version="2.2" xmlns="http://java.sun.com/xml/ns/persistence" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/persistence http://xmlns.jcp.org/xml/ns/persistence/persistence_2_2.xsd">
     <persistence-unit name="hmisPU" transaction-type="JTA">
         <provider>org.eclipse.persistence.jpa.PersistenceProvider</provider>
-        <jta-data-source>${JDBC_DATASOURCE}</jta-data-source>
+        <jta-data-source>jdbc/ruhunu</jta-data-source>
         <exclude-unlisted-classes>false</exclude-unlisted-classes>
         <properties>
             <property name="eclipselink.logging.level.sql" value="SEVERE"/>
@@ -10,7 +10,7 @@
         </properties>
     </persistence-unit>
     <persistence-unit name="hmisAuditPU" transaction-type="JTA">
-        <jta-data-source>${JDBC_AUDIT_DATASOURCE}</jta-data-source>
+        <jta-data-source>jdbc/ruhunuaudit</jta-data-source>
         <exclude-unlisted-classes>false</exclude-unlisted-classes>
         <properties>
             <property name="eclipselink.logging.level.sql" value="SEVERE"/>

--- a/src/main/webapp/pharmacy/direct_purchase.xhtml
+++ b/src/main/webapp/pharmacy/direct_purchase.xhtml
@@ -647,7 +647,7 @@
                                     <h:outputLabel value="Payment Method" class="mb-2"/>
                                     <p:selectOneMenu style="width: 300px;" id="cmbPs" value="#{pharmacyDirectPurchaseController.bill.paymentMethod}">
                                         <f:selectItem itemLabel="Select Payment Method" />
-                                        <f:selectItems value="#{enumController.paymentMethodsForPharmacyPurchase}" />
+                                        <f:selectItems value="#{enumController.paymentMethodsForGrn}" />
                                         <p:ajax event="change" process="cmbPs" ></p:ajax>
                                     </p:selectOneMenu>
 

--- a/src/main/webapp/pharmacy/pharmacy_grn_costing_with_save_approve.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_grn_costing_with_save_approve.xhtml
@@ -101,6 +101,13 @@
                                         update="@none">
                                         <i class="fas fa-info-circle" />
                                     </p:commandLink>
+                                    <p:commandButton
+                                        icon="fas fa-history"
+                                        class="ui-button-info mx-1"
+                                        title="View Item History"
+                                        action="#{pharmacyController.selectItemForHistory(bi.item)}"
+                                        update=":#{p:resolveFirstComponentWithId('tab',view).clientId}"
+                                        process="@this"/>
                                     <p:dialog id="dialog"
                                               widgetVar="dialog#{i}"
                                               header="Details"
@@ -296,11 +303,12 @@
                                         icon="fas fa-plus"
                                         class="ui-button-warning mx-1"
                                         action="#{grnCostingController.duplicateItem(bi)}"/>
-                                    <p:commandButton 
+                                    <p:commandButton
                                         ajax="false"
                                         icon="fas fa-trash"
                                         class="ui-button-danger"
                                         action="#{grnCostingController.removeItem(bi)}"/>
+
 
                                 </p:column>
 

--- a/src/main/webapp/pharmacy/pharmacy_purchase.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_purchase.xhtml
@@ -97,7 +97,7 @@
                                         <h:outputLabel value="Payment Method" class="mb-2"/>
                                         <p:selectOneMenu style="width: 300px;" id="cmbPs" value="#{pharmacyPurchaseController.bill.paymentMethod}">
                                             <f:selectItem itemLabel="Select Payment Method" />
-                                            <f:selectItems value="#{enumController.paymentMethodsForPharmacyPurchase}" />
+                                            <f:selectItems value="#{enumController.paymentMethodsForGrn}" />
                                             <p:ajax event="change" process="cmbPs" update="paymentMethodDetails" ></p:ajax>
                                         </p:selectOneMenu>
 

--- a/src/main/webapp/pharmacy/pharmacy_purhcase_order_request.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_purhcase_order_request.xhtml
@@ -216,7 +216,7 @@
                                                    for="cmbPs"></p:outputLabel>
                                     <p:selectOneMenu class="w-100"  id="cmbPs" value="#{purchaseOrderRequestController.currentBill.paymentMethod}">    
                                         <f:selectItem itemLabel="Select Payment method"/>
-                                        <f:selectItems value="#{enumController.paymentMethodsForPurchases}">
+                                        <f:selectItems value="#{enumController.paymentMethodsForGrn}" var="pm" itemLabel="#{pm.label}" itemValue="#{pm}">
                                         </f:selectItems>
                                         <p:ajax process="@this" update="po" event="change"/>
                                         <p:ajax process="@this" update="duration" event="itemSelect" />
@@ -435,11 +435,9 @@
 
                     <div class="d-flex justify-content-center">
                         <p:panel style="width: 212mm;" >
-                            <h:outputStylesheet library="css" name="printing/purchase_order_a4_bill.css" ></h:outputStylesheet>
                             <h:panelGroup id="printPaper" layout="block">
 
-                                <h:panelGroup rendered="#{configOptionApplicationController.getBooleanValueByKey('Pharmacy Purchase Order Request Print - A4 Paper Custom 1')}">
-
+                                <h:panelGroup rendered="#{configOptionApplicationController.getBooleanValueByKey('Pharmacy Purchase Order Request Print - A4 Paper Custom 1', true)}">
                                     <div class="institutionName">
                                         <h:outputLabel value="#{purchaseOrderRequestController.currentBill.creater.institution.name}"/>
                                     </div>
@@ -459,11 +457,9 @@
                                             <h:outputLabel value="#{purchaseOrderRequestController.currentBill.creater.department.email}" rendered="#{!empty purchaseOrderRequestController.currentBill.creater.department.email}"/>                                                 
                                         </div>
                                     </div>
-
                                     <div class="headingBill">
                                         <h:outputLabel value="Purchase Order Request" style="text-decoration: underline;"/>
                                     </div>
-
                                     <div class="purchase-order">
                                         <h:panelGrid columns="6" class="my-2 w-100">
                                             <h:outputLabel value="Order No" />
@@ -493,7 +489,6 @@
                                             <h:outputLabel value="#{purchaseOrderRequestController.currentBill.consignment ? 'Yes' : 'No'}" />
                                         </h:panelGrid>
                                     </div>
-
                                     <table style="border-collapse: collapse; width: 100%; border: 1px solid black;">
                                         <thead>
                                             <tr style="border: 1px solid black;">
@@ -550,9 +545,7 @@
                                             </tr>
                                         </tfoot>
                                     </table>
-
                                     <br/>
-
                                     <div class="purchase-order">
                                         <div>
                                             <h:outputLabel value="Order Initiated By"/>

--- a/src/main/webapp/pharmacy/pharmacy_purhcase_order_request.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_purhcase_order_request.xhtml
@@ -448,13 +448,13 @@
                             <h:panelGroup id="printPaper" layout="block">
 
                                 <po:purchase_order_request_custom_1
-                                    rendered="#{configOptionController.getBooleanValueByKey('Pharmacy Purchase Order Request Print - A4 Paper Custom 1', true)}"
+                                    rendered="#{configOptionApplicationController.getBooleanValueByKey('Pharmacy Purchase Order Request Print - A4 Paper Custom 1', true)}"
                                     bill="#{purchaseOrderRequestController.currentBill}"
                                     billItems="#{purchaseOrderRequestController.billItems}">
                                 </po:purchase_order_request_custom_1>
 
                                 <po:purchase_order_request_custom_2
-                                    rendered="#{configOptionController.getBooleanValueByKey('Pharmacy Purchase Order Request Print - A4 Paper Custom 2', false)}"
+                                    rendered="#{configOptionApplicationController.getBooleanValueByKey('Pharmacy Purchase Order Request Print - A4 Paper Custom 2', false)}"
                                     bill="#{purchaseOrderRequestController.currentBill}"
                                     billItems="#{purchaseOrderRequestController.billItems}">
                                 </po:purchase_order_request_custom_2>

--- a/src/main/webapp/pharmacy/pharmacy_purhcase_order_request.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_purhcase_order_request.xhtml
@@ -6,7 +6,8 @@
                 xmlns:p="http://primefaces.org/ui"
                 xmlns:f="http://xmlns.jcp.org/jsf/core"
                 xmlns:ph="http://xmlns.jcp.org/jsf/composite/pharmacy"
-                xmlns:pa="http://xmlns.jcp.org/jsf/composite/paymentMethod">
+                xmlns:pa="http://xmlns.jcp.org/jsf/composite/paymentMethod"
+                xmlns:po="http://xmlns.jcp.org/jsf/composite/pharmacy">
     <ui:define name="content">
         <h:form id="form">
             <h:panelGroup rendered="#{!webUserController.hasPrivilege('CreatePurchaseOrder')}" >
@@ -410,6 +411,14 @@
                             </div>
                             <div class="d-flex gap-2">
                                 <p:commandButton
+                                    rendered="#{webUserController.hasPrivilege('ChangeReceiptPrintingPaperTypes')}"
+                                    value="Settings"
+                                    icon="fas fa-cog"
+                                    class="ui-button-secondary"
+                                    type="button"
+                                    onclick="PF('purchaseOrderConfigDialog').show();" >
+                                </p:commandButton>
+                                <p:commandButton
                                     ajax="false"
                                     value="Print"
                                     icon="fas fa-print"
@@ -434,304 +443,21 @@
                     </f:facet>
 
                     <div class="d-flex justify-content-center">
+                        
                         <p:panel style="width: 212mm;" >
                             <h:panelGroup id="printPaper" layout="block">
 
-                                <h:panelGroup rendered="#{configOptionApplicationController.getBooleanValueByKey('Pharmacy Purchase Order Request Print - A4 Paper Custom 1', true)}">
-                                    <div class="institutionName">
-                                        <h:outputLabel value="#{purchaseOrderRequestController.currentBill.creater.institution.name}"/>
-                                    </div>
-                                    <div class="institutionContact" >
-                                        <div class="d-flex gap-2 justify-content-center">
-                                            <h:outputLabel value="#{purchaseOrderRequestController.currentBill.creater.institution.address}" rendered="#{!empty purchaseOrderRequestController.currentBill.creater.institution.address}"/>
-                                            <h:outputLabel value="Telephone : " rendered="#{!empty purchaseOrderRequestController.currentBill.creater.institution.phone or !empty purchaseOrderRequestController.currentBill.creater.department.telephone1}" />
-                                            <h:outputLabel value="#{purchaseOrderRequestController.currentBill.creater.institution.phone}" rendered="#{!empty purchaseOrderRequestController.currentBill.creater.institution.phone}"/>
-                                            <h:outputLabel value="/" style="width: 15px; text-align: center" rendered="#{purchaseOrderRequestController.currentBill.creater.department.telephone1}"/>
-                                            <h:outputLabel value="#{purchaseOrderRequestController.currentBill.creater.department.telephone1}" rendered="#{!empty purchaseOrderRequestController.currentBill.creater.department.telephone1}"/>
-                                        </div>
-                                        <div >
-                                            <h:outputLabel value="Fax : &nbsp;&nbsp;&nbsp;&nbsp;#{purchaseOrderRequestController.currentBill.creater.institution.fax}" rendered="#{!empty purchaseOrderRequestController.currentBill.creater.institution.fax}"/>                                                 
-                                        </div>
-                                        <div >
-                                            <h:outputLabel value="Email : &nbsp;" rendered="#{!empty purchaseOrderRequestController.currentBill.creater.department.email}"/>
-                                            <h:outputLabel value="#{purchaseOrderRequestController.currentBill.creater.department.email}" rendered="#{!empty purchaseOrderRequestController.currentBill.creater.department.email}"/>                                                 
-                                        </div>
-                                    </div>
-                                    <div class="headingBill">
-                                        <h:outputLabel value="Purchase Order Request" style="text-decoration: underline;"/>
-                                    </div>
-                                    <div class="purchase-order">
-                                        <h:panelGrid columns="6" class="my-2 w-100">
-                                            <h:outputLabel value="Order No" />
-                                            <h:outputLabel value=":" style="width: 15px; text-align: center"/>
-                                            <h:outputLabel value="#{purchaseOrderRequestController.currentBill.deptId}" />
-                                            <h:outputLabel value="Order Department" />
-                                            <h:outputLabel value=":" style="width: 15px; text-align: center"/>
-                                            <h:outputLabel value="#{purchaseOrderRequestController.currentBill.department.name}" />
-                                            <h:outputLabel value="Supplier" />
-                                            <h:outputLabel value=":" style="width: 15px; text-align: center"/>
-                                            <h:outputLabel value="#{purchaseOrderRequestController.currentBill.toInstitution.name}" />
-                                            <h:outputLabel value="Supplier Code" />
-                                            <h:outputLabel value=":" style="width: 15px; text-align: center"/>
-                                            <h:outputLabel value="#{purchaseOrderRequestController.currentBill.toInstitution.code}" />
-                                            <h:outputLabel value="Supplier Phone" />
-                                            <h:outputLabel value=":" style="width: 15px; text-align: center"/>
-                                            <h:outputLabel value="#{purchaseOrderRequestController.currentBill.toInstitution.phone}" />
-                                            <h:outputLabel value="Supplier Address" />
-                                            <h:outputLabel value=":" style="width: 15px; text-align: center"/>
-                                            <h:outputLabel value="#{purchaseOrderRequestController.currentBill.toInstitution.address}" />
+                                <po:purchase_order_request_custom_1
+                                    rendered="#{configOptionController.getBooleanValueByKey('Pharmacy Purchase Order Request Print - A4 Paper Custom 1', true)}"
+                                    bill="#{purchaseOrderRequestController.currentBill}"
+                                    billItems="#{purchaseOrderRequestController.billItems}">
+                                </po:purchase_order_request_custom_1>
 
-                                            <h:outputLabel value="Payment Method" />
-                                            <h:outputLabel value=":" style="width: 15px; text-align: center"/>
-                                            <h:outputLabel value="#{purchaseOrderRequestController.currentBill.paymentMethod}" />
-                                            <h:outputLabel value="Consignment" />
-                                            <h:outputLabel value=":" style="width: 15px; text-align: center"/>
-                                            <h:outputLabel value="#{purchaseOrderRequestController.currentBill.consignment ? 'Yes' : 'No'}" />
-                                        </h:panelGrid>
-                                    </div>
-                                    <table style="border-collapse: collapse; width: 100%; border: 1px solid black;">
-                                        <thead>
-                                            <tr style="border: 1px solid black;">
-                                                <th style="border: 1px solid black;">Item Code</th>
-                                                <th style="border: 1px solid black;">Item Name</th>
-                                                <th style="border: 1px solid black;">Qty</th>
-                                                <th style="border: 1px solid black;">Free Qty</th>
-                                                <th style="border: 1px solid black;">Purchase Rate</th>
-                                                <th style="border: 1px solid black;">Purchase Value</th>
-                                            </tr>
-                                        </thead>
-                                        <tbody>
-                                            <ui:repeat value="#{purchaseOrderRequestController.billItems}" var="bi">
-
-                                                <h:panelGroup rendered="#{not bi.retired}" >
-
-                                                    <tr style="border: 1px solid black;">
-                                                        <td style="border: 1px solid black;"><h:outputLabel value="#{bi.item.code}"/></td>
-                                                        <td style="border: 1px solid black;"><h:outputLabel value="#{bi.item.name}"/></td>
-                                                        <td style="text-align: right; border: 1px solid black;">
-                                                            <h:outputLabel value="#{bi.billItemFinanceDetails.quantity}">
-                                                                <f:convertNumber pattern="#,##0"/>
-                                                            </h:outputLabel>
-                                                        </td>
-                                                        <td style="text-align: right; border: 1px solid black;">
-                                                            <h:outputLabel value="#{bi.billItemFinanceDetails.freeQuantity}">
-                                                                <f:convertNumber pattern="#,##0"/>
-                                                            </h:outputLabel>
-                                                        </td>
-                                                        <td style="text-align: right; border: 1px solid black;">
-                                                            <h:outputLabel value="#{bi.billItemFinanceDetails.lineGrossRate}">
-                                                                <f:convertNumber pattern="#,##0.00"/>
-                                                            </h:outputLabel>
-                                                        </td>
-                                                        <td style="text-align: right; border: 1px solid black;">
-                                                            <h:outputLabel value="#{bi.netValue}">
-                                                                <f:convertNumber pattern="#,##0.00"/>
-                                                            </h:outputLabel>
-                                                        </td>
-                                                    </tr>
-
-                                                </h:panelGroup>
-
-                                            </ui:repeat>
-                                        </tbody>
-                                        <tfoot>
-                                            <tr style="border: 1px solid black; font-weight: bold;">
-                                                <td colspan="5" style="text-align: right; border: 1px solid black;">Net Total &nbsp;</td>
-                                                <td style="text-align: right; border: 1px solid black;">
-                                                    <h:outputText value="#{purchaseOrderRequestController.currentBill.netTotal}">
-                                                        <f:convertNumber pattern="#,##0.00"/>
-                                                    </h:outputText>
-                                                </td>
-                                            </tr>
-                                        </tfoot>
-                                    </table>
-                                    <br/>
-                                    <div class="purchase-order">
-                                        <div>
-                                            <h:outputLabel value="Order Initiated By"/>
-                                            <h:outputLabel value=":" style="width: 15px; text-align: center"/>
-                                            <h:outputLabel value="#{purchaseOrderRequestController.currentBill.creater.webUserPerson.name}"/>
-                                        </div>
-                                        <div>
-                                            <h:outputLabel value="Order Finalized By"/>
-                                            <h:outputLabel value=":" style="width: 15px; text-align: center"/>
-                                            #{purchaseOrderRequestController.currentBill.checkedBy.name}
-                                        </div>
-                                        <div>
-                                            <h:outputLabel value="Order Finalized At"/>
-                                            <h:outputLabel value=":" style="width: 15px; text-align: center"/>
-                                            <h:outputLabel value="#{purchaseOrderRequestController.currentBill.checkeAt}">
-                                                <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateTimeFormat}"/>
-                                            </h:outputLabel>
-                                        </div>
-                                        <div>
-                                            <h:outputLabel value="Printed At"/>
-                                            <h:outputLabel value=":" style="width: 15px; text-align: center"/>
-                                            <h:outputLabel value="#{sessionController.currentDate}">
-                                                <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateTimeFormat}"/>
-                                            </h:outputLabel>
-                                        </div>
-                                        <div>
-                                            <h:outputLabel value="Total"/>
-                                            <h:outputLabel value=":" style="width: 15px; text-align: center"/>
-                                            <h:outputLabel value="#{purchaseOrderRequestController.currentBill.netTotal}">
-                                                <f:convertNumber pattern="#,##0.00"/>
-                                            </h:outputLabel>
-
-                                        </div>
-                                    </div>
-                                </h:panelGroup>
-
-                                <h:panelGroup  rendered="#{configOptionApplicationController.getBooleanValueByKey('Pharmacy Purchase Order Request Print - A4 Paper Custom 2')}">
-
-                                    <div class="institutionName">
-                                        <h:outputLabel value="#{purchaseOrderRequestController.currentBill.creater.institution.name}"/>
-                                    </div>
-                                    <div class="institutionContact" >
-                                        <div class="d-flex gap-2 justify-content-center">
-                                            <h:outputLabel value="#{purchaseOrderRequestController.currentBill.creater.institution.address}" rendered="#{!empty purchaseOrderRequestController.currentBill.creater.institution.address}"/>
-                                            <h:outputLabel value="Telephone : " rendered="#{!empty purchaseOrderRequestController.currentBill.creater.institution.phone or !empty purchaseOrderRequestController.currentBill.creater.department.telephone1}" />
-                                            <h:outputLabel value="#{purchaseOrderRequestController.currentBill.creater.institution.phone}" rendered="#{!empty purchaseOrderRequestController.currentBill.creater.institution.phone}"/>
-                                            <h:outputLabel value="/" style="width: 15px; text-align: center" rendered="#{purchaseOrderRequestController.currentBill.creater.department.telephone1}"/>
-                                            <h:outputLabel value="#{purchaseOrderRequestController.currentBill.creater.department.telephone1}" rendered="#{!empty purchaseOrderRequestController.currentBill.creater.department.telephone1}"/>
-                                        </div>
-                                        <div >
-                                            <h:outputLabel value="Fax : &nbsp;&nbsp;&nbsp;&nbsp;#{purchaseOrderRequestController.currentBill.creater.institution.fax}" rendered="#{!empty purchaseOrderRequestController.currentBill.creater.institution.fax}"/>                                                 
-                                        </div>
-                                        <div >
-                                            <h:outputLabel value="Email : &nbsp;" rendered="#{!empty purchaseOrderRequestController.currentBill.creater.department.email}"/>
-                                            <h:outputLabel value="#{purchaseOrderRequestController.currentBill.creater.department.email}" rendered="#{!empty purchaseOrderRequestController.currentBill.creater.department.email}"/>                                                 
-                                        </div>
-                                    </div>
-
-                                    <div class="headingBill">
-                                        <h:outputLabel value="Purchase Order Request" style="text-decoration: underline;"/>
-                                    </div>
-
-                                    <div class="purchase-order">
-                                        <h:panelGrid columns="6" class="my-2 w-100">
-                                            <h:outputLabel value="Order No" />
-                                            <h:outputLabel value=":" style="width: 15px; text-align: center"/>
-                                            <h:outputLabel value="#{purchaseOrderRequestController.currentBill.deptId}" />
-                                            <h:outputLabel value="Order Department" />
-                                            <h:outputLabel value=":" style="width: 15px; text-align: center"/>
-                                            <h:outputLabel value="#{purchaseOrderRequestController.currentBill.department.name}" />
-                                            <h:outputLabel value="Supplier" />
-                                            <h:outputLabel value=":" style="width: 15px; text-align: center"/>
-                                            <h:outputLabel value="#{purchaseOrderRequestController.currentBill.toInstitution.name}" />
-                                            <h:outputLabel value="Supplier Code" />
-                                            <h:outputLabel value=":" style="width: 15px; text-align: center"/>
-                                            <h:outputLabel value="#{purchaseOrderRequestController.currentBill.toInstitution.code}" />
-                                            <h:outputLabel value="Supplier Phone" />
-                                            <h:outputLabel value=":" style="width: 15px; text-align: center"/>
-                                            <h:outputLabel value="#{purchaseOrderRequestController.currentBill.toInstitution.phone}" />
-                                            <h:outputLabel value="Supplier Address" />
-                                            <h:outputLabel value=":" style="width: 15px; text-align: center"/>
-                                            <h:outputLabel value="#{purchaseOrderRequestController.currentBill.toInstitution.address}" />
-
-                                            <h:outputLabel value="Payment Method" />
-                                            <h:outputLabel value=":" style="width: 15px; text-align: center"/>
-                                            <h:outputLabel value="#{purchaseOrderRequestController.currentBill.paymentMethod}" />
-                                            <h:outputLabel value="Consignment" />
-                                            <h:outputLabel value=":" style="width: 15px; text-align: center"/>
-                                            <h:outputLabel value="#{purchaseOrderRequestController.currentBill.consignment ? 'Yes' : 'No'}" />
-                                        </h:panelGrid>
-                                    </div>
-
-                                    <table style="border-collapse: collapse; width: 100%; border: 1px solid black;">
-                                        <thead>
-                                            <tr style="border: 1px solid black;">
-                                                <th style="border: 1px solid black;">Item Code</th>
-                                                <th style="border: 1px solid black;">Item Name</th>
-                                                <th style="border: 1px solid black;">Qty</th>
-                                                <th style="border: 1px solid black;">Free Qty</th>
-                                                <th style="border: 1px solid black;">Purchase Rate</th>
-                                                <th style="border: 1px solid black;">Purchase Value</th>
-                                            </tr>
-                                        </thead>
-                                        <tbody>
-                                            <ui:repeat value="#{purchaseOrderRequestController.billItems}" var="bi">
-
-                                                <h:panelGroup rendered="#{not bi.retired}" >
-
-                                                    <tr style="border: 1px solid black;">
-                                                        <td style="border: 1px solid black;"><h:outputLabel value="#{bi.item.code}"/></td>
-                                                        <td style="border: 1px solid black;"><h:outputLabel value="#{bi.item.name}"/></td>
-                                                        <td style="text-align: right; border: 1px solid black;">
-                                                            <h:outputLabel value="#{bi.billItemFinanceDetails.quantity}">
-                                                                <f:convertNumber pattern="#,##0"/>
-                                                            </h:outputLabel>
-                                                        </td>
-                                                        <td style="text-align: right; border: 1px solid black;">
-                                                            <h:outputLabel value="#{bi.billItemFinanceDetails.freeQuantity}">
-                                                                <f:convertNumber pattern="#,##0"/>
-                                                            </h:outputLabel>
-                                                        </td>
-                                                        <td style="text-align: right; border: 1px solid black;">
-                                                            <h:outputLabel value="#{bi.billItemFinanceDetails.lineGrossRate}">
-                                                                <f:convertNumber pattern="#,##0.00"/>
-                                                            </h:outputLabel>
-                                                        </td>
-                                                        <td style="text-align: right; border: 1px solid black;">
-                                                            <h:outputLabel value="#{bi.netValue}">
-                                                                <f:convertNumber pattern="#,##0.00"/>
-                                                            </h:outputLabel>
-                                                        </td>
-                                                    </tr>
-
-                                                </h:panelGroup>
-
-                                            </ui:repeat>
-                                        </tbody>
-                                        <tfoot>
-                                            <tr style="border: 1px solid black; font-weight: bold;">
-                                                <td colspan="5" style="text-align: right; border: 1px solid black;">Net Total &nbsp;</td>
-                                                <td style="text-align: right; border: 1px solid black;">
-                                                    <h:outputText value="#{purchaseOrderRequestController.currentBill.netTotal}">
-                                                        <f:convertNumber pattern="#,##0.00"/>
-                                                    </h:outputText>
-                                                </td>
-                                            </tr>
-                                        </tfoot>
-                                    </table>
-
-                                    <br/>
-
-                                    <div class="purchase-order">
-                                        <div>
-                                            <h:outputLabel value="Order Initiated By"/>
-                                            <h:outputLabel value=":" style="width: 15px; text-align: center"/>
-                                            <h:outputLabel value="#{purchaseOrderRequestController.currentBill.creater.webUserPerson.name}"/>
-                                        </div>
-                                        <div>
-                                            <h:outputLabel value="Order Finalized By"/>
-                                            <h:outputLabel value=":" style="width: 15px; text-align: center"/>
-                                            #{purchaseOrderRequestController.currentBill.checkedBy.name}
-                                        </div>
-                                        <div>
-                                            <h:outputLabel value="Order Finalized At"/>
-                                            <h:outputLabel value=":" style="width: 15px; text-align: center"/>
-                                            <h:outputLabel value="#{purchaseOrderRequestController.currentBill.checkeAt}">
-                                                <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateTimeFormat}"/>
-                                            </h:outputLabel>
-                                        </div>
-                                        <div>
-                                            <h:outputLabel value="Printed At"/>
-                                            <h:outputLabel value=":" style="width: 15px; text-align: center"/>
-                                            <h:outputLabel value="#{sessionController.currentDate}">
-                                                <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateTimeFormat}"/>
-                                            </h:outputLabel>
-                                        </div>
-                                        <div>
-                                            <h:outputLabel value="Total"/>
-                                            <h:outputLabel value=":" style="width: 15px; text-align: center"/>
-                                            <h:outputLabel value="#{purchaseOrderRequestController.currentBill.netTotal}">
-                                                <f:convertNumber pattern="#,##0.00"/>
-                                            </h:outputLabel>
-
-                                        </div>
-                                    </div>
-                                </h:panelGroup>
+                                <po:purchase_order_request_custom_2
+                                    rendered="#{configOptionController.getBooleanValueByKey('Pharmacy Purchase Order Request Print - A4 Paper Custom 2', false)}"
+                                    bill="#{purchaseOrderRequestController.currentBill}"
+                                    billItems="#{purchaseOrderRequestController.billItems}">
+                                </po:purchase_order_request_custom_2>
 
                             </h:panelGroup>
                         </p:panel>
@@ -857,6 +583,77 @@
                             oncomplete="PF('emailDialog').hide();"/>
                     </div>
                 </div>
+            </h:form>
+        </p:dialog>
+
+        <!-- Purchase Order Configuration Dialog -->
+        <p:dialog id="purchaseOrderConfigDialog" 
+                  header="Purchase Order Request Printer Configuration" 
+                  widgetVar="purchaseOrderConfigDialog" 
+                  modal="true" 
+                  width="800" 
+                  height="500"
+                  resizable="true" 
+                  maximizable="true"
+                  closeOnEscape="true">
+
+            <p:ajax event="open" listener="#{purchaseOrderConfigController.loadCurrentConfig}" update="purchaseOrderConfigForm" />
+
+            <h:form id="purchaseOrderConfigForm">
+
+                <div class="row">
+                    <div class="col-md-12">
+                        <div class="card config-section">
+                            <div class="card-header">
+                                <h6><i class="fas fa-file-alt"></i> Purchase Order Paper Settings</h6>
+                            </div>
+                            <div class="card-body">
+                                <div class="mb-3">
+                                    <p:selectBooleanCheckbox 
+                                        id="custom1Paper"
+                                        value="#{purchaseOrderConfigController.custom1Paper}" />
+                                    <p:outputLabel for="custom1Paper" value="A4 Paper Custom Format 1" class="ms-2" />
+                                    <small class="form-text text-muted d-block">A4 purchase order format - Custom 1</small>
+                                </div>
+
+                                <div class="mb-3">
+                                    <p:selectBooleanCheckbox 
+                                        id="custom2Paper"
+                                        value="#{purchaseOrderConfigController.custom2Paper}" />
+                                    <p:outputLabel for="custom2Paper" value="A4 Paper Custom Format 2" class="ms-2" />
+                                    <small class="form-text text-muted d-block">A4 purchase order format - Custom 2</small>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+                <div class="row mt-4">
+                    <div class="col-12">
+                        <div class="card">
+                            <div class="card-body">
+                                <p:messages id="purchaseOrderConfigMessages" showDetail="true" closable="true" />
+                                <div class="d-flex justify-content-between align-items-center">
+                                    <div class="d-flex gap-2">
+                                        <p:commandButton 
+                                            value="Apply &amp; Close" 
+                                            icon="fas fa-save"
+                                            class="ui-button-success"
+                                            ajax="false"
+                                            action="#{purchaseOrderConfigController.saveConfig}" />
+                                        <p:commandButton 
+                                            value="Cancel" 
+                                            icon="fas fa-times"
+                                            class="ui-button-secondary"
+                                            onclick="PF('purchaseOrderConfigDialog').hide(); return false;" 
+                                            type="button" />
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
             </h:form>
         </p:dialog>
 

--- a/src/main/webapp/resources/pharmacy/history.xhtml
+++ b/src/main/webapp/resources/pharmacy/history.xhtml
@@ -32,35 +32,588 @@
 
                         </p:calendar>
                         <p:commandButton 
-                            update=":#{p:resolveFirstComponentWithId('tab',view).clientId}" 
+                            update="panelHistoryData" 
                             process="@this frmDate toDate" 
                             action="#{pharmacyController.fillDetails()}"
-                            class="ui-button-info" icon="far fa-eye" value="View Detail"/>
+                            class="ui-button-info"
+                            icon="far fa-eye" 
+                            value="View Detail"/>
                     </div>
                 </div>
             </f:facet>
 
-            <h:panelGroup 
-                rendered="#{configOptionApplicationController.getBooleanValueByKey('Pharmacy Item Details Section - Display Blocks', true)}">
-                <div class="row">
-                    <h:panelGroup 
-                        layout="block"
-                        class="col-3"
-                        id="itemDetailsBlockStocks"
-                        rendered="#{configOptionApplicationController.getBooleanValueByKey('Pharmacy Item Details Section - Display Stocks Block', true)}" >
-                        <p:panel class="w-100" style="font-size: 15px;" >
-                            <div style="background-color: #337357; padding: 10px; font-weight: bold; color: white; text-align: center;">
-                                Stock
-                            </div>
-                            <p:dataTable  value="#{pharmacyController.institutionStocks}" var="ins" class="w-100" style="padding: 0; background-color: lightgray" id="stock">
+            <h:panelGroup id="panelHistoryData" >
+                <h:panelGroup 
+                    rendered="#{configOptionApplicationController.getBooleanValueByKey('Pharmacy Item Details Section - Display Blocks', true)}">
+                    <div class="row">
+                        <h:panelGroup 
+                            layout="block"
+                            class="col-3"
+                            id="itemDetailsBlockStocks"
+                            rendered="#{configOptionApplicationController.getBooleanValueByKey('Pharmacy Item Details Section - Display Stocks Block', true)}" >
+                            <p:panel class="w-100" style="font-size: 15px;" >
+                                <div style="background-color: #337357; padding: 10px; font-weight: bold; color: white; text-align: center;">
+                                    Stock
+                                </div>
+                                <p:dataTable  value="#{pharmacyController.institutionStocks}" var="ins" class="w-100" style="padding: 0; background-color: lightgray" id="stock">
+                                    <p:columnGroup type="header">
+                                        <p:row>
+                                            <p:column class="w-75">
+                                                <f:facet name="header">
+                                                    Department Name
+                                                </f:facet>
+                                            </p:column>
+                                            <p:column style="text-align: right;" class="w-25">
+                                                <f:facet name="header">
+                                                    Qty
+                                                </f:facet>
+                                            </p:column>
+                                        </p:row>
+                                    </p:columnGroup>
+                                    <p:subTable  value="#{ins.depatmentStocks}" var="dep">
+                                        <f:facet name="header">
+                                            #{ins.institution.name}
+                                        </f:facet>
+                                        <p:column>
+                                            #{dep.department.name}
+                                        </p:column>
+                                        <p:column style="text-align: right;">
+                                            <h:outputLabel value="#{dep.stock}">       
+                                                <f:convertNumber integerOnly="true" />
+                                            </h:outputLabel> 
+                                        </p:column>
+                                        <p:columnGroup type="footer">
+                                            <p:row>
+                                                <p:column footerText="Total Stock"></p:column>
+                                                <p:column style="text-align: right;" footerText="#{ins.institutionTotal}">
+                                                    <f:facet name="footer">
+                                                        <h:outputLabel value="#{ins.institutionTotal}">
+                                                            <f:convertNumber integerOnly="true" />
+                                                        </h:outputLabel>
+                                                    </f:facet>
+                                                </p:column>
+                                            </p:row>
+                                        </p:columnGroup>
+                                    </p:subTable>  
+                                    <p:columnGroup type="footer">
+                                        <p:row>
+                                            <p:column>
+                                                <f:facet name="footer">
+                                                    Total Institution Stock
+                                                </f:facet>
+                                            </p:column>
+                                            <p:column style="text-align: right;">
+                                                <f:facet name="footer">
+                                                    <h:outputLabel id="grandTotalBlock" value="#{pharmacyController.grantStock}"> 
+                                                        <f:convertNumber integerOnly="true" />
+                                                    </h:outputLabel>
+                                                </f:facet>
+                                            </p:column>
+                                        </p:row>
+                                    </p:columnGroup>
+
+                                </p:dataTable> 
+                            </p:panel>
+                        </h:panelGroup>
+                        <h:panelGroup
+                            layout="block"
+                            class="col-3"
+                            id="itemDetailsBlockSales"
+                            rendered="#{configOptionApplicationController.getBooleanValueByKey('Pharmacy Item Details Section - Display Sale Block', true)}" >
+                            <p:panel>
+                                <div style="background-color: #337357; padding: 10px; font-weight: bold; color: white; text-align: center;">
+                                    Pharmacy Sale
+                                </div>
+                                <p:dataTable styleClass="noBorder" value="#{pharmacyController.institutionSales}" var="ins" id="phSale">
+                                    <p:columnGroup type="header">
+                                        <p:row>
+                                            <p:column class="w-50">
+                                                <f:facet name="header">
+                                                    Department Name
+                                                </f:facet>
+                                            </p:column>
+                                            <p:column class="w-25" style="text-align: right;">
+                                                <f:facet name="header">
+                                                    Qty
+                                                </f:facet>
+                                            </p:column>
+                                            <p:column class="w-25" style="text-align: right;">
+                                                <f:facet name="header">
+                                                    Value
+                                                </f:facet>
+                                            </p:column>
+                                        </p:row>
+                                    </p:columnGroup>
+                                    <p:subTable  value="#{ins.departmentSales}" var="dep">
+                                        <f:facet name="header">
+                                            #{ins.institution.name}
+                                        </f:facet>
+                                        <p:column>
+                                            #{dep.department.name}
+                                        </p:column>
+                                        <p:column style="text-align: right;">
+                                            <h:outputLabel value="#{dep.saleQty}">   
+                                                <f:convertNumber integerOnly="true" />
+                                            </h:outputLabel> 
+                                        </p:column>
+                                        <p:column style="text-align: right;">
+                                            <h:outputLabel value="#{dep.saleValue}">  
+                                                <f:convertNumber pattern="#,##0.00" />
+                                            </h:outputLabel> 
+                                        </p:column>
+                                        <p:columnGroup type="footer">
+                                            <p:row>
+                                                <p:column footerText="Total "></p:column>
+                                                <p:column style="text-align: right;" footerText="#{ins.institutionQty}">
+                                                    <f:facet name="footer">
+                                                        <h:outputLabel value="#{ins.institutionQty}">
+                                                            <f:convertNumber integerOnly="true" />
+                                                        </h:outputLabel>
+                                                    </f:facet>
+                                                </p:column>
+                                                <p:column style="text-align: right;" footerText="#{ins.institutionValue}">
+                                                    <f:facet name="footer">
+                                                        <h:outputLabel value="#{ins.institutionValue}">
+                                                            <f:convertNumber  pattern="#,##0.00" />
+                                                        </h:outputLabel>
+                                                    </f:facet>
+                                                </p:column>
+                                            </p:row>
+                                        </p:columnGroup>
+                                    </p:subTable>  
+                                    <p:columnGroup type="footer">
+                                        <p:row>
+                                            <p:column>
+                                                <f:facet name="footer">
+                                                    Total Institution
+                                                </f:facet>
+                                            </p:column>
+                                            <p:column style="text-align: right;">
+                                                <f:facet name="footer">
+                                                    <h:outputLabel  value="#{pharmacyController.grantSaleQty}">   
+                                                        <f:convertNumber integerOnly="true" />
+                                                    </h:outputLabel>
+                                                </f:facet>
+                                            </p:column>
+                                            <p:column style="text-align: right;">
+                                                <f:facet name="footer">
+                                                    <h:outputLabel  value="#{pharmacyController.grantSaleValue}">
+                                                        <f:convertNumber  pattern="#,##0.00" />
+                                                    </h:outputLabel>
+                                                </f:facet>
+                                            </p:column>
+                                        </p:row>
+                                    </p:columnGroup>
+
+                                </p:dataTable>
+                            </p:panel>
+                        </h:panelGroup>
+                        <h:panelGroup
+                            layout="block"
+                            class="col-3"
+                            id="itemDetailsBlockInpatientIssue"
+                            rendered="#{configOptionApplicationController.getBooleanValueByKey('Pharmacy Item Details Section - Display BHT Issue Block', true)}" >
+                            <p:panel>
+                                <div style="background-color: #337357; padding: 10px; font-weight: bold; color: white; text-align: center;">
+                                    BHT Issue
+                                </div>
+                                <p:dataTable styleClass="noBorder" value="#{pharmacyController.institutionBhtIssue}" var="ins" id="bht">
+                                    <p:columnGroup type="header">
+                                        <p:row>
+                                            <p:column class="w-50">
+                                                <f:facet name="header">
+                                                    Department Name
+                                                </f:facet>
+                                            </p:column>
+                                            <p:column class="w-25" style="text-align: right;">
+                                                <f:facet name="header">
+                                                    Qty
+                                                </f:facet>
+                                            </p:column>
+                                            <p:column class="w-25" style="text-align: right;">
+                                                <f:facet name="header">
+                                                    Value
+                                                </f:facet>
+                                            </p:column>
+                                        </p:row>
+                                    </p:columnGroup>
+                                    <p:subTable  value="#{ins.departmentSales}" var="dep">
+                                        <f:facet name="header">
+                                            #{ins.institution.name}
+                                        </f:facet>
+                                        <p:column>
+                                            #{dep.department.name}
+                                        </p:column>
+                                        <p:column style="text-align: right;">
+                                            <h:outputLabel value="#{dep.saleQty}">   
+                                                <f:convertNumber integerOnly="true" />
+                                            </h:outputLabel> 
+                                        </p:column>
+                                        <p:column style="text-align: right;">
+                                            <h:outputLabel value="#{dep.saleValue}">  
+                                                <f:convertNumber pattern="#,##0.00" />
+                                            </h:outputLabel> 
+                                        </p:column>
+                                        <p:columnGroup type="footer">
+                                            <p:row>
+                                                <p:column footerText="Total "></p:column>
+                                                <p:column style="text-align: right;" footerText="#{ins.institutionQty}">
+                                                    <f:facet name="footer">
+                                                        <h:outputLabel value="#{ins.institutionQty}">
+                                                            <f:convertNumber integerOnly="true" />
+                                                        </h:outputLabel>
+                                                    </f:facet>
+                                                </p:column>
+                                                <p:column style="text-align: right;" footerText="#{ins.institutionValue}">
+                                                    <f:facet name="footer">
+                                                        <h:outputLabel value="#{ins.institutionValue}">
+                                                            <f:convertNumber  pattern="#,##0.00" />
+                                                        </h:outputLabel>
+                                                    </f:facet>
+                                                </p:column>
+                                            </p:row>
+                                        </p:columnGroup>
+                                    </p:subTable>  
+                                    <p:columnGroup type="footer">
+                                        <p:row>
+                                            <p:column>
+                                                <f:facet name="footer">
+                                                    Total Institution
+                                                </f:facet>
+                                            </p:column>
+                                            <p:column style="text-align: right;">
+                                                <f:facet name="footer">
+                                                    <h:outputLabel  value="#{pharmacyController.grantBhtIssueQty}">   
+                                                        <f:convertNumber integerOnly="true" />
+                                                    </h:outputLabel>
+                                                </f:facet>
+                                            </p:column>
+                                            <p:column style="text-align: right;">
+                                                <f:facet name="footer">
+                                                    <h:outputLabel  value="#{pharmacyController.grantBhtValue}">
+                                                        <f:convertNumber  pattern="#,##0.00" />
+                                                    </h:outputLabel>
+                                                </f:facet>
+                                            </p:column>
+                                        </p:row>
+                                    </p:columnGroup>
+
+                                </p:dataTable>
+
+                            </p:panel>
+                        </h:panelGroup>
+                        <h:panelGroup
+                            layout="block"
+                            class="col-3"
+                            id="itemDetailsBlockWholesale"
+                            rendered="#{configOptionApplicationController.getBooleanValueByKey('Pharmacy Item Details Section - Display Whole Sale Block', true)}" >
+                            <p:panel>
+                                <div style="background-color: #337357; padding: 10px; font-weight: bold; color: white; text-align: center;">
+                                    Pharmacy Whole Sale
+                                </div>
+                                <p:dataTable styleClass="noBorder" value="#{pharmacyController.institutionWholeSales}" var="ins" id="phWhSale">
+                                    <p:columnGroup type="header">
+                                        <p:row>
+                                            <p:column >
+                                                <f:facet name="header">
+                                                    Department Name
+                                                </f:facet>
+                                            </p:column>
+                                            <p:column >
+                                                <f:facet name="header">
+                                                    Qty
+                                                </f:facet>
+                                            </p:column>
+                                            <p:column >
+                                                <f:facet name="header">
+                                                    Value
+                                                </f:facet>
+                                            </p:column>
+                                        </p:row>
+                                    </p:columnGroup>
+                                    <p:subTable  value="#{ins.departmentSales}" var="dep">
+                                        <f:facet name="header">
+                                            #{ins.institution.name}
+                                        </f:facet>
+                                        <p:column>
+                                            #{dep.department.name}
+                                        </p:column>
+                                        <p:column style="text-align: right;">
+                                            <h:outputLabel value="#{dep.saleQty}">   
+                                                <f:convertNumber integerOnly="true" />
+                                            </h:outputLabel> 
+                                        </p:column>
+                                        <p:column style="text-align: right;">
+                                            <h:outputLabel value="#{dep.saleValue}">  
+                                                <f:convertNumber pattern="#,##0.00" />
+                                            </h:outputLabel> 
+                                        </p:column>
+                                        <p:columnGroup type="footer">
+                                            <p:row>
+                                                <p:column footerText="Total "></p:column>
+                                                <p:column style="text-align: right;" footerText="#{ins.institutionQty}">
+                                                    <f:facet name="footer">
+                                                        <h:outputLabel value="#{ins.institutionQty}">
+                                                            <f:convertNumber integerOnly="true" />
+                                                        </h:outputLabel>
+                                                    </f:facet>
+                                                </p:column>
+                                                <p:column style="text-align: right;" footerText="#{ins.institutionValue}">
+                                                    <f:facet name="footer">
+                                                        <h:outputLabel value="#{ins.institutionValue}">
+                                                            <f:convertNumber  pattern="#,##0.00" />
+                                                        </h:outputLabel>
+                                                    </f:facet>
+                                                </p:column>
+                                            </p:row>
+                                        </p:columnGroup>
+                                    </p:subTable>  
+                                    <p:columnGroup type="footer">
+                                        <p:row>
+                                            <p:column>
+                                                <f:facet name="footer">
+                                                    Total Institution
+                                                </f:facet>
+                                            </p:column>
+                                            <p:column style="text-align: right;">
+                                                <f:facet name="footer">
+                                                    <h:outputLabel  value="#{pharmacyController.grantWholeSaleQty}">   
+                                                        <f:convertNumber integerOnly="true" />
+                                                    </h:outputLabel>
+                                                </f:facet>
+                                            </p:column>
+                                            <p:column style="text-align: right;">
+                                                <f:facet name="footer">
+                                                    <h:outputLabel  value="#{pharmacyController.grantWholeSaleValue}">
+                                                        <f:convertNumber  pattern="#,##0.00" />
+                                                    </h:outputLabel>
+                                                </f:facet>
+                                            </p:column>
+                                        </p:row>
+                                    </p:columnGroup>
+
+                                </p:dataTable>
+
+                            </p:panel>
+                        </h:panelGroup>
+                        <h:panelGroup
+                            layout="block"
+                            class="col-3"
+                            id="itemDetailsBlockIssue"
+                            rendered="#{configOptionApplicationController.getBooleanValueByKey('Pharmacy Item Details Section - Display Transfer Issue Block', true)}" >
+                            <p:panel >
+                                <div style="background-color: #337357; padding: 10px; font-weight: bold; color: white; text-align: center;">
+                                    Transfer Issue
+                                </div>
+                                <p:dataTable styleClass="noBorder" id="trIssueBlock" value="#{pharmacyController.institutionTransferIssue}" var="ins">
+                                    <p:columnGroup type="header">
+                                        <p:row>
+                                            <p:column >
+                                                <f:facet name="header">
+                                                    To Depart. Name
+                                                </f:facet>
+                                            </p:column>
+                                            <p:column style="text-align: right;">
+                                                <f:facet name="header">
+                                                    Sent Qty
+                                                </f:facet>
+                                            </p:column>
+                                            <p:column style="text-align: right;">
+                                                <f:facet name="header">
+                                                    Sent Value
+                                                </f:facet>
+                                            </p:column>
+                                        </p:row>
+                                    </p:columnGroup>
+                                    <p:subTable  value="#{ins.departmentSales}" var="dep">
+                                        <f:facet name="header">
+                                            #{ins.institution.name}
+                                        </f:facet>
+                                        <p:column>
+                                            #{dep.department.name}
+                                        </p:column>
+                                        <p:column style="text-align: right;">
+                                            <h:outputLabel value="#{dep.saleQtyAbs}">    
+                                                <f:convertNumber integerOnly="true" />
+                                            </h:outputLabel> 
+                                        </p:column>
+                                        <p:column style="text-align: right;">
+                                            <h:outputLabel value="#{dep.saleValueAbs}">    
+                                                <f:convertNumber  pattern="#,##0.00" />
+                                            </h:outputLabel> 
+                                        </p:column>
+                                        <p:columnGroup type="footer">
+                                            <p:row>
+                                                <p:column footerText="Total "></p:column>
+                                                <p:column style="text-align: right;" footerText="#{ins.institutionQty}">
+                                                    <f:facet name="footer">
+                                                        <h:outputLabel value="#{0-ins.institutionQty}">
+                                                            <f:convertNumber integerOnly="true" />
+                                                        </h:outputLabel>
+                                                    </f:facet>
+                                                </p:column>
+                                                <p:column style="text-align: right;" footerText="#{ins.institutionValue}">
+                                                    <f:facet name="footer">
+                                                        <h:outputLabel value="#{0-ins.institutionValue}">
+                                                            <f:convertNumber  pattern="#,##0.00" />
+                                                        </h:outputLabel>
+                                                    </f:facet>
+                                                </p:column>
+                                            </p:row>
+                                        </p:columnGroup>
+                                    </p:subTable>  
+                                    <p:columnGroup type="footer">
+                                        <p:row>
+                                            <p:column>
+                                                <f:facet name="footer">
+                                                    Total Institution
+                                                </f:facet>
+                                            </p:column>
+                                            <p:column style="text-align: right;">
+                                                <f:facet name="footer">
+                                                    <h:outputLabel  value="#{0-pharmacyController.grantTransferIssueQty}">
+                                                        <f:convertNumber integerOnly="true" />
+                                                    </h:outputLabel>
+                                                </f:facet>
+                                            </p:column>
+                                            <p:column style="text-align: right;">
+                                                <f:facet name="footer">
+                                                    <h:outputLabel  value="#{0-pharmacyController.grantTransferIssueValue}">
+                                                        <f:convertNumber  pattern="#,##0.00" />
+                                                    </h:outputLabel>
+                                                </f:facet>
+                                            </p:column>
+                                        </p:row>
+                                    </p:columnGroup>
+
+                                </p:dataTable>
+                            </p:panel>
+                        </h:panelGroup>
+                        <h:panelGroup
+                            layout="block"
+                            class="col-3"
+                            id="itemDetailsBlockGrn"
+                            rendered="#{configOptionApplicationController.getBooleanValueByKey('Pharmacy Item Details Section - Display GRN Block', true)}" >
+                            <p:panel>
+                                <div style="background-color: #337357; padding: 10px; font-weight: bold; color: white; text-align: center;">
+                                    GRN Details
+                                </div>
+                                <p:dataTable styleClass="noBorder" value="#{pharmacyController.grnDtos}" var="g">
+                                    <p:column headerText="GRN No">#{g.grnNo}</p:column>
+                                    <p:column headerText="Dept">#{g.departmentName}</p:column>
+                                    <p:column headerText="Date">
+                                        <h:outputLabel value="#{g.createdAt}">
+                                            <f:convertDateTime timeZone="Asia/Colombo" pattern="#{sessionController.applicationPreference.longDateFormat}" />
+                                        </h:outputLabel>
+                                    </p:column>
+                                    <p:column headerText="Qty" class="text-end">#{g.quantity}</p:column>
+                                    <p:column headerText="Value" class="text-end">
+                                        <h:outputText value="#{g.netTotal}">
+                                            <f:convertNumber pattern="#,##0.00" />
+                                        </h:outputText>
+                                    </p:column>
+                                </p:dataTable>
+                            </p:panel>
+                        </h:panelGroup>
+                        <h:panelGroup
+                            layout="block"
+                            class="col-3"
+                            id="itemDetailsBlockGrnReturn"
+                            rendered="#{configOptionApplicationController.getBooleanValueByKey('Pharmacy Item Details Section - Display GRN Return Block', true)}" >
+                            <p:panel>
+                                <div style="background-color: #337357; padding: 10px; font-weight: bold; color: white; text-align: center;">
+                                    GRN Return Details
+                                </div>
+                                <p:dataTable styleClass="noBorder" value="#{pharmacyController.grnReturnDtos}" var="g">
+                                    <p:column headerText="GRN Return No">#{g.grnReturnNo}</p:column>
+                                    <p:column headerText="Dept">#{g.departmentName}</p:column>
+                                    <p:column headerText="Date">
+                                        <h:outputLabel value="#{g.createdAt}">
+                                            <f:convertDateTime timeZone="Asia/Colombo" pattern="#{sessionController.applicationPreference.longDateFormat}" />
+                                        </h:outputLabel>
+                                    </p:column>
+                                    <p:column headerText="Qty" class="text-end">#{g.quantityReturned}</p:column>
+                                    <p:column headerText="Value" class="text-end">
+                                        <h:outputText value="#{g.returnValue}">
+                                            <f:convertNumber pattern="#,##0.00" />
+                                        </h:outputText>
+                                    </p:column>
+                                </p:dataTable>
+                            </p:panel>
+                        </h:panelGroup>
+                        <h:panelGroup
+                            layout="block"
+                            class="col-3"
+                            id="itemDetailsBlockPendingGrn"
+                            rendered="#{configOptionApplicationController.getBooleanValueByKey('Pharmacy Item Details Section - Display Pending GRN Block', true)}" >
+                            <p:panel>
+                                <div style="background-color: #337357; padding: 10px; font-weight: bold; color: white; text-align: center;">
+                                    Pending GRN Details
+                                </div>
+                                <p:dataTable styleClass="noBorder" value="#{pharmacyController.pendingGrns}" var="pendingGrn">
+                                    <p:column headerText="Order No">#{pendingGrn.bill.deptId}</p:column>
+                                    <p:column headerText="Order at">
+                                        <h:outputLabel value="#{pendingGrn.bill.createdAt}">
+                                            <f:convertDateTime timeZone="Asia/Colombo" pattern="#{sessionController.applicationPreference.longDateFormat}" />
+                                        </h:outputLabel>
+                                    </p:column>
+                                    <p:column headerText="Supplier">#{pendingGrn.bill.toInstitution.name}</p:column>
+                                    <p:column headerText="Qty Ordered" class="text-end">
+                                        <h:outputText value="#{pendingGrn.qty}">
+                                            <f:convertNumber integerOnly="true" />
+                                        </h:outputText>
+                                    </p:column>
+                                </p:dataTable>
+
+                            </p:panel>
+                        </h:panelGroup>
+                        <h:panelGroup
+                            layout="block"
+                            class="col-3"
+                            id="itemDetailsBlockPurchaseOrders"
+                            rendered="#{configOptionApplicationController.getBooleanValueByKey('Pharmacy Item Details Section - Display Purchase Orders Block', true)}" >
+                            <p:panel>
+                                <div style="background-color: #337357; padding: 10px; font-weight: bold; color: white; text-align: center;">
+                                    Purchase Order Details
+                                </div>
+                                <p:dataTable styleClass="noBorder" value="#{pharmacyController.pos}" var="po">
+                                    <p:column headerText="Order No">#{po.bill.deptId}</p:column>
+                                    <p:column headerText="Order at">
+                                        <h:outputLabel value="#{po.bill.createdAt}">
+                                            <f:convertDateTime timeZone="Asia/Colombo" pattern="#{sessionController.applicationPreference.longDateFormat}" />
+                                        </h:outputLabel>
+                                    </p:column>
+                                    <p:column headerText="Supplier">#{po.bill.toInstitution.name}</p:column>
+                                    <p:column headerText="Qty Ordered" class="text-end">
+                                        <h:outputText value="#{po.pharmaceuticalBillItem.qty}">
+                                            <f:convertNumber integerOnly="true" />
+                                        </h:outputText>
+                                    </p:column>
+                                </p:dataTable>
+
+                            </p:panel>
+                        </h:panelGroup>
+                    </div>
+                </h:panelGroup>
+                <p:tabView  
+                    rendered="#{configOptionApplicationController.getBooleanValueByKey('Pharmacy Item Details Section - Display Tabview', true)}"
+                    class="w-100"  
+                    activeIndex="0" 
+                    style="border: 1px solid lightgray; padding: 10px;">
+                    <p:tab 
+                        title="Stock" 
+                        id="itemDetailsTabStocks"
+                        rendered="#{configOptionApplicationController.getBooleanValueByKey('Pharmacy Item Details Section - Display Stocks Tab', true)}">
+                        <p:panel header="Stock">
+                            <p:dataTable styleClass="noBorder" value="#{pharmacyController.institutionStocks}" var="ins" class="w-100">
                                 <p:columnGroup type="header">
                                     <p:row>
-                                        <p:column class="w-75">
+                                        <p:column >
                                             <f:facet name="header">
                                                 Department Name
                                             </f:facet>
                                         </p:column>
-                                        <p:column style="text-align: right;" class="w-25">
+                                        <p:column style="text-align: right;">
                                             <f:facet name="header">
                                                 Qty
                                             </f:facet>
@@ -101,7 +654,7 @@
                                         </p:column>
                                         <p:column style="text-align: right;">
                                             <f:facet name="footer">
-                                                <h:outputLabel id="grandTotalBlock" value="#{pharmacyController.grantStock}"> 
+                                                <h:outputLabel id="grandTotalTab" value="#{pharmacyController.grantStock}">
                                                     <f:convertNumber integerOnly="true" />
                                                 </h:outputLabel>
                                             </f:facet>
@@ -111,498 +664,13 @@
 
                             </p:dataTable> 
                         </p:panel>
-                    </h:panelGroup>
-                    <h:panelGroup
-                        layout="block"
-                        class="col-3"
-                        id="itemDetailsBlockSales"
-                        rendered="#{configOptionApplicationController.getBooleanValueByKey('Pharmacy Item Details Section - Display Sale Block', true)}" >
-                        <p:panel>
-                            <div style="background-color: #337357; padding: 10px; font-weight: bold; color: white; text-align: center;">
-                                Pharmacy Sale
-                            </div>
-                            <p:dataTable styleClass="noBorder" value="#{pharmacyController.institutionSales}" var="ins" id="phSale">
-                                <p:columnGroup type="header">
-                                    <p:row>
-                                        <p:column class="w-50">
-                                            <f:facet name="header">
-                                                Department Name
-                                            </f:facet>
-                                        </p:column>
-                                        <p:column class="w-25" style="text-align: right;">
-                                            <f:facet name="header">
-                                                Qty
-                                            </f:facet>
-                                        </p:column>
-                                        <p:column class="w-25" style="text-align: right;">
-                                            <f:facet name="header">
-                                                Value
-                                            </f:facet>
-                                        </p:column>
-                                    </p:row>
-                                </p:columnGroup>
-                                <p:subTable  value="#{ins.departmentSales}" var="dep">
-                                    <f:facet name="header">
-                                        #{ins.institution.name}
-                                    </f:facet>
-                                    <p:column>
-                                        #{dep.department.name}
-                                    </p:column>
-                                    <p:column style="text-align: right;">
-                                        <h:outputLabel value="#{dep.saleQty}">   
-                                            <f:convertNumber integerOnly="true" />
-                                        </h:outputLabel> 
-                                    </p:column>
-                                    <p:column style="text-align: right;">
-                                        <h:outputLabel value="#{dep.saleValue}">  
-                                            <f:convertNumber pattern="#,##0.00" />
-                                        </h:outputLabel> 
-                                    </p:column>
-                                    <p:columnGroup type="footer">
-                                        <p:row>
-                                            <p:column footerText="Total "></p:column>
-                                            <p:column style="text-align: right;" footerText="#{ins.institutionQty}">
-                                                <f:facet name="footer">
-                                                    <h:outputLabel value="#{ins.institutionQty}">
-                                                        <f:convertNumber integerOnly="true" />
-                                                    </h:outputLabel>
-                                                </f:facet>
-                                            </p:column>
-                                            <p:column style="text-align: right;" footerText="#{ins.institutionValue}">
-                                                <f:facet name="footer">
-                                                    <h:outputLabel value="#{ins.institutionValue}">
-                                                        <f:convertNumber  pattern="#,##0.00" />
-                                                    </h:outputLabel>
-                                                </f:facet>
-                                            </p:column>
-                                        </p:row>
-                                    </p:columnGroup>
-                                </p:subTable>  
-                                <p:columnGroup type="footer">
-                                    <p:row>
-                                        <p:column>
-                                            <f:facet name="footer">
-                                                Total Institution
-                                            </f:facet>
-                                        </p:column>
-                                        <p:column style="text-align: right;">
-                                            <f:facet name="footer">
-                                                <h:outputLabel  value="#{pharmacyController.grantSaleQty}">   
-                                                    <f:convertNumber integerOnly="true" />
-                                                </h:outputLabel>
-                                            </f:facet>
-                                        </p:column>
-                                        <p:column style="text-align: right;">
-                                            <f:facet name="footer">
-                                                <h:outputLabel  value="#{pharmacyController.grantSaleValue}">
-                                                    <f:convertNumber  pattern="#,##0.00" />
-                                                </h:outputLabel>
-                                            </f:facet>
-                                        </p:column>
-                                    </p:row>
-                                </p:columnGroup>
 
-                            </p:dataTable>
-                        </p:panel>
-                    </h:panelGroup>
-                    <h:panelGroup
-                        layout="block"
-                        class="col-3"
-                        id="itemDetailsBlockInpatientIssue"
-                        rendered="#{configOptionApplicationController.getBooleanValueByKey('Pharmacy Item Details Section - Display BHT Issue Block', true)}" >
-                        <p:panel>
-                            <div style="background-color: #337357; padding: 10px; font-weight: bold; color: white; text-align: center;">
-                                BHT Issue
-                            </div>
-                            <p:dataTable styleClass="noBorder" value="#{pharmacyController.institutionBhtIssue}" var="ins" id="bht">
-                                <p:columnGroup type="header">
-                                    <p:row>
-                                        <p:column class="w-50">
-                                            <f:facet name="header">
-                                                Department Name
-                                            </f:facet>
-                                        </p:column>
-                                        <p:column class="w-25" style="text-align: right;">
-                                            <f:facet name="header">
-                                                Qty
-                                            </f:facet>
-                                        </p:column>
-                                        <p:column class="w-25" style="text-align: right;">
-                                            <f:facet name="header">
-                                                Value
-                                            </f:facet>
-                                        </p:column>
-                                    </p:row>
-                                </p:columnGroup>
-                                <p:subTable  value="#{ins.departmentSales}" var="dep">
-                                    <f:facet name="header">
-                                        #{ins.institution.name}
-                                    </f:facet>
-                                    <p:column>
-                                        #{dep.department.name}
-                                    </p:column>
-                                    <p:column style="text-align: right;">
-                                        <h:outputLabel value="#{dep.saleQty}">   
-                                            <f:convertNumber integerOnly="true" />
-                                        </h:outputLabel> 
-                                    </p:column>
-                                    <p:column style="text-align: right;">
-                                        <h:outputLabel value="#{dep.saleValue}">  
-                                            <f:convertNumber pattern="#,##0.00" />
-                                        </h:outputLabel> 
-                                    </p:column>
-                                    <p:columnGroup type="footer">
-                                        <p:row>
-                                            <p:column footerText="Total "></p:column>
-                                            <p:column style="text-align: right;" footerText="#{ins.institutionQty}">
-                                                <f:facet name="footer">
-                                                    <h:outputLabel value="#{ins.institutionQty}">
-                                                        <f:convertNumber integerOnly="true" />
-                                                    </h:outputLabel>
-                                                </f:facet>
-                                            </p:column>
-                                            <p:column style="text-align: right;" footerText="#{ins.institutionValue}">
-                                                <f:facet name="footer">
-                                                    <h:outputLabel value="#{ins.institutionValue}">
-                                                        <f:convertNumber  pattern="#,##0.00" />
-                                                    </h:outputLabel>
-                                                </f:facet>
-                                            </p:column>
-                                        </p:row>
-                                    </p:columnGroup>
-                                </p:subTable>  
-                                <p:columnGroup type="footer">
-                                    <p:row>
-                                        <p:column>
-                                            <f:facet name="footer">
-                                                Total Institution
-                                            </f:facet>
-                                        </p:column>
-                                        <p:column style="text-align: right;">
-                                            <f:facet name="footer">
-                                                <h:outputLabel  value="#{pharmacyController.grantBhtIssueQty}">   
-                                                    <f:convertNumber integerOnly="true" />
-                                                </h:outputLabel>
-                                            </f:facet>
-                                        </p:column>
-                                        <p:column style="text-align: right;">
-                                            <f:facet name="footer">
-                                                <h:outputLabel  value="#{pharmacyController.grantBhtValue}">
-                                                    <f:convertNumber  pattern="#,##0.00" />
-                                                </h:outputLabel>
-                                            </f:facet>
-                                        </p:column>
-                                    </p:row>
-                                </p:columnGroup>
-
-                            </p:dataTable>
-
-                        </p:panel>
-                    </h:panelGroup>
-                    <h:panelGroup
-                        layout="block"
-                        class="col-3"
-                        id="itemDetailsBlockWholesale"
-                        rendered="#{configOptionApplicationController.getBooleanValueByKey('Pharmacy Item Details Section - Display Whole Sale Block', true)}" >
-                        <p:panel>
-                            <div style="background-color: #337357; padding: 10px; font-weight: bold; color: white; text-align: center;">
-                                Pharmacy Whole Sale
-                            </div>
-                            <p:dataTable styleClass="noBorder" value="#{pharmacyController.institutionWholeSales}" var="ins" id="phWhSale">
-                                <p:columnGroup type="header">
-                                    <p:row>
-                                        <p:column >
-                                            <f:facet name="header">
-                                                Department Name
-                                            </f:facet>
-                                        </p:column>
-                                        <p:column >
-                                            <f:facet name="header">
-                                                Qty
-                                            </f:facet>
-                                        </p:column>
-                                        <p:column >
-                                            <f:facet name="header">
-                                                Value
-                                            </f:facet>
-                                        </p:column>
-                                    </p:row>
-                                </p:columnGroup>
-                                <p:subTable  value="#{ins.departmentSales}" var="dep">
-                                    <f:facet name="header">
-                                        #{ins.institution.name}
-                                    </f:facet>
-                                    <p:column>
-                                        #{dep.department.name}
-                                    </p:column>
-                                    <p:column style="text-align: right;">
-                                        <h:outputLabel value="#{dep.saleQty}">   
-                                            <f:convertNumber integerOnly="true" />
-                                        </h:outputLabel> 
-                                    </p:column>
-                                    <p:column style="text-align: right;">
-                                        <h:outputLabel value="#{dep.saleValue}">  
-                                            <f:convertNumber pattern="#,##0.00" />
-                                        </h:outputLabel> 
-                                    </p:column>
-                                    <p:columnGroup type="footer">
-                                        <p:row>
-                                            <p:column footerText="Total "></p:column>
-                                            <p:column style="text-align: right;" footerText="#{ins.institutionQty}">
-                                                <f:facet name="footer">
-                                                    <h:outputLabel value="#{ins.institutionQty}">
-                                                        <f:convertNumber integerOnly="true" />
-                                                    </h:outputLabel>
-                                                </f:facet>
-                                            </p:column>
-                                            <p:column style="text-align: right;" footerText="#{ins.institutionValue}">
-                                                <f:facet name="footer">
-                                                    <h:outputLabel value="#{ins.institutionValue}">
-                                                        <f:convertNumber  pattern="#,##0.00" />
-                                                    </h:outputLabel>
-                                                </f:facet>
-                                            </p:column>
-                                        </p:row>
-                                    </p:columnGroup>
-                                </p:subTable>  
-                                <p:columnGroup type="footer">
-                                    <p:row>
-                                        <p:column>
-                                            <f:facet name="footer">
-                                                Total Institution
-                                            </f:facet>
-                                        </p:column>
-                                        <p:column style="text-align: right;">
-                                            <f:facet name="footer">
-                                                <h:outputLabel  value="#{pharmacyController.grantWholeSaleQty}">   
-                                                    <f:convertNumber integerOnly="true" />
-                                                </h:outputLabel>
-                                            </f:facet>
-                                        </p:column>
-                                        <p:column style="text-align: right;">
-                                            <f:facet name="footer">
-                                                <h:outputLabel  value="#{pharmacyController.grantWholeSaleValue}">
-                                                    <f:convertNumber  pattern="#,##0.00" />
-                                                </h:outputLabel>
-                                            </f:facet>
-                                        </p:column>
-                                    </p:row>
-                                </p:columnGroup>
-
-                            </p:dataTable>
-
-                        </p:panel>
-                    </h:panelGroup>
-                    <h:panelGroup
-                        layout="block"
-                        class="col-3"
-                        id="itemDetailsBlockIssue"
-                        rendered="#{configOptionApplicationController.getBooleanValueByKey('Pharmacy Item Details Section - Display Transfer Issue Block', true)}" >
-                        <p:panel >
-                            <div style="background-color: #337357; padding: 10px; font-weight: bold; color: white; text-align: center;">
-                                Transfer Issue
-                            </div>
-                            <p:dataTable styleClass="noBorder" id="trIssueBlock" value="#{pharmacyController.institutionTransferIssue}" var="ins">
-                                <p:columnGroup type="header">
-                                    <p:row>
-                                        <p:column >
-                                            <f:facet name="header">
-                                                To Depart. Name
-                                            </f:facet>
-                                        </p:column>
-                                        <p:column style="text-align: right;">
-                                            <f:facet name="header">
-                                                Sent Qty
-                                            </f:facet>
-                                        </p:column>
-                                        <p:column style="text-align: right;">
-                                            <f:facet name="header">
-                                                Sent Value
-                                            </f:facet>
-                                        </p:column>
-                                    </p:row>
-                                </p:columnGroup>
-                                <p:subTable  value="#{ins.departmentSales}" var="dep">
-                                    <f:facet name="header">
-                                        #{ins.institution.name}
-                                    </f:facet>
-                                    <p:column>
-                                        #{dep.department.name}
-                                    </p:column>
-                                    <p:column style="text-align: right;">
-                                        <h:outputLabel value="#{dep.saleQtyAbs}">    
-                                            <f:convertNumber integerOnly="true" />
-                                        </h:outputLabel> 
-                                    </p:column>
-                                    <p:column style="text-align: right;">
-                                        <h:outputLabel value="#{dep.saleValueAbs}">    
-                                            <f:convertNumber  pattern="#,##0.00" />
-                                        </h:outputLabel> 
-                                    </p:column>
-                                    <p:columnGroup type="footer">
-                                        <p:row>
-                                            <p:column footerText="Total "></p:column>
-                                            <p:column style="text-align: right;" footerText="#{ins.institutionQty}">
-                                                <f:facet name="footer">
-                                                    <h:outputLabel value="#{0-ins.institutionQty}">
-                                                        <f:convertNumber integerOnly="true" />
-                                                    </h:outputLabel>
-                                                </f:facet>
-                                            </p:column>
-                                            <p:column style="text-align: right;" footerText="#{ins.institutionValue}">
-                                                <f:facet name="footer">
-                                                    <h:outputLabel value="#{0-ins.institutionValue}">
-                                                        <f:convertNumber  pattern="#,##0.00" />
-                                                    </h:outputLabel>
-                                                </f:facet>
-                                            </p:column>
-                                        </p:row>
-                                    </p:columnGroup>
-                                </p:subTable>  
-                                <p:columnGroup type="footer">
-                                    <p:row>
-                                        <p:column>
-                                            <f:facet name="footer">
-                                                Total Institution
-                                            </f:facet>
-                                        </p:column>
-                                        <p:column style="text-align: right;">
-                                            <f:facet name="footer">
-                                                <h:outputLabel  value="#{0-pharmacyController.grantTransferIssueQty}">
-                                                    <f:convertNumber integerOnly="true" />
-                                                </h:outputLabel>
-                                            </f:facet>
-                                        </p:column>
-                                        <p:column style="text-align: right;">
-                                            <f:facet name="footer">
-                                                <h:outputLabel  value="#{0-pharmacyController.grantTransferIssueValue}">
-                                                    <f:convertNumber  pattern="#,##0.00" />
-                                                </h:outputLabel>
-                                            </f:facet>
-                                        </p:column>
-                                    </p:row>
-                                </p:columnGroup>
-
-                            </p:dataTable>
-                        </p:panel>
-                    </h:panelGroup>
-                    <h:panelGroup
-                        layout="block"
-                        class="col-3"
-                        id="itemDetailsBlockGrn"
-                        rendered="#{configOptionApplicationController.getBooleanValueByKey('Pharmacy Item Details Section - Display GRN Block', true)}" >
-                        <p:panel>
-                            <div style="background-color: #337357; padding: 10px; font-weight: bold; color: white; text-align: center;">
-                                GRN Details
-                            </div>
-                            <p:dataTable styleClass="noBorder" value="#{pharmacyController.grnDtos}" var="g">
-                                <p:column headerText="GRN No">#{g.grnNo}</p:column>
-                                <p:column headerText="Dept">#{g.departmentName}</p:column>
-                                <p:column headerText="Date">
-                                    <h:outputLabel value="#{g.createdAt}">
-                                        <f:convertDateTime timeZone="Asia/Colombo" pattern="#{sessionController.applicationPreference.longDateFormat}" />
-                                    </h:outputLabel>
-                                </p:column>
-                                <p:column headerText="Qty">#{g.quantity}</p:column>
-                                <p:column headerText="Value">
-                                    <h:outputText value="#{g.netTotal}">
-                                        <f:convertNumber pattern="#,##0.00" />
-                                    </h:outputText>
-                                </p:column>
-                            </p:dataTable>
-                        </p:panel>
-                    </h:panelGroup>
-                    <h:panelGroup
-                        layout="block"
-                        class="col-3"
-                        id="itemDetailsBlockGrnReturn"
-                        rendered="#{configOptionApplicationController.getBooleanValueByKey('Pharmacy Item Details Section - Display GRN Return Block', true)}" >
-                        <p:panel>
-                            <div style="background-color: #337357; padding: 10px; font-weight: bold; color: white; text-align: center;">
-                                GRN Return Details
-                            </div>
-                            <p:dataTable styleClass="noBorder" value="#{pharmacyController.grnReturnDtos}" var="g">
-                                <p:column headerText="GRN Return No">#{g.grnReturnNo}</p:column>
-                                <p:column headerText="Dept">#{g.departmentName}</p:column>
-                                <p:column headerText="Date">
-                                    <h:outputLabel value="#{g.createdAt}">
-                                        <f:convertDateTime timeZone="Asia/Colombo" pattern="#{sessionController.applicationPreference.longDateFormat}" />
-                                    </h:outputLabel>
-                                </p:column>
-                                <p:column headerText="Qty">#{g.quantityReturned}</p:column>
-                                <p:column headerText="Value">
-                                    <h:outputText value="#{g.returnValue}">
-                                        <f:convertNumber pattern="#,##0.00" />
-                                    </h:outputText>
-                                </p:column>
-                            </p:dataTable>
-                        </p:panel>
-                    </h:panelGroup>
-                    <h:panelGroup
-                        layout="block"
-                        class="col-3"
-                        id="itemDetailsBlockPendingGrn"
-                        rendered="#{configOptionApplicationController.getBooleanValueByKey('Pharmacy Item Details Section - Display Pending GRN Block', true)}" >
-                        <p:panel>
-                            <div style="background-color: #337357; padding: 10px; font-weight: bold; color: white; text-align: center;">
-                                Pending GRN Details
-                            </div>
-                            <p:dataTable styleClass="noBorder" value="#{pharmacyController.pendingGrns}" var="pendingGrn">
-                                <p:column headerText="Order No">#{pendingGrn.bill.deptId}</p:column>
-                                <p:column headerText="Order at">
-                                    <h:outputLabel value="#{pendingGrn.bill.createdAt}">
-                                        <f:convertDateTime timeZone="Asia/Colombo" pattern="#{sessionController.applicationPreference.longDateFormat}" />
-                                    </h:outputLabel>
-                                </p:column>
-                                <p:column headerText="Supplier">#{pendingGrn.bill.toInstitution.name}</p:column>
-                                <p:column headerText="Qty Ordered">
-                                    <h:outputText value="#{pendingGrn.qty}">
-                                        <f:convertNumber integerOnly="true" />
-                                    </h:outputText>
-                                </p:column>
-                            </p:dataTable>
-
-                        </p:panel>
-                    </h:panelGroup>
-                    <h:panelGroup
-                        layout="block"
-                        class="col-3"
-                        id="itemDetailsBlockPurchaseOrders"
-                        rendered="#{configOptionApplicationController.getBooleanValueByKey('Pharmacy Item Details Section - Display Purchase Orders Block', true)}" >
-                        <p:panel>
-                            <div style="background-color: #337357; padding: 10px; font-weight: bold; color: white; text-align: center;">
-                                Purchase Order Details
-                            </div>
-                            <p:dataTable styleClass="noBorder" value="#{pharmacyController.pos}" var="po">
-                                <p:column headerText="Order No">#{po.bill.deptId}</p:column>
-                                <p:column headerText="Order at">
-                                    <h:outputLabel value="#{po.bill.createdAt}">
-                                        <f:convertDateTime timeZone="Asia/Colombo" pattern="#{sessionController.applicationPreference.longDateFormat}" />
-                                    </h:outputLabel>
-                                </p:column>
-                                <p:column headerText="Supplier">#{po.bill.toInstitution.name}</p:column>
-                                <p:column headerText="Qty Ordered">
-                                    <h:outputText value="#{po.pharmaceuticalBillItem.qty}">
-                                        <f:convertNumber integerOnly="true" />
-                                    </h:outputText>
-                                </p:column>
-                            </p:dataTable>
-
-                        </p:panel>
-                    </h:panelGroup>
-                </div>
-            </h:panelGroup>
-            <p:tabView  
-                rendered="#{configOptionApplicationController.getBooleanValueByKey('Pharmacy Item Details Section - Display Tabview', true)}"
-                class="w-100"  
-                activeIndex="0" 
-                style="border: 1px solid lightgray; padding: 10px;">
-                <p:tab 
-                    title="Stock" 
-                    id="itemDetailsTabStocks"
-                    rendered="#{configOptionApplicationController.getBooleanValueByKey('Pharmacy Item Details Section - Display Stocks Tab', true)}">
-                    <p:panel header="Stock">
-                        <p:dataTable styleClass="noBorder" value="#{pharmacyController.institutionStocks}" var="ins" class="w-100">
+                    </p:tab>
+                    <p:tab 
+                        title="Sale" 
+                        id="itemDetailsTabSales"
+                        rendered="#{configOptionApplicationController.getBooleanValueByKey('Pharmacy Item Details Section - Display Sale Tab', true)}">
+                        <p:dataTable styleClass="noBorder" value="#{pharmacyController.institutionSales}" var="ins">
                             <p:columnGroup type="header">
                                 <p:row>
                                     <p:column >
@@ -610,14 +678,19 @@
                                             Department Name
                                         </f:facet>
                                     </p:column>
-                                    <p:column style="text-align: right;">
+                                    <p:column >
                                         <f:facet name="header">
                                             Qty
                                         </f:facet>
                                     </p:column>
+                                    <p:column >
+                                        <f:facet name="header">
+                                            Value
+                                        </f:facet>
+                                    </p:column>
                                 </p:row>
                             </p:columnGroup>
-                            <p:subTable  value="#{ins.depatmentStocks}" var="dep">
+                            <p:subTable  value="#{ins.departmentSales}" var="dep">
                                 <f:facet name="header">
                                     #{ins.institution.name}
                                 </f:facet>
@@ -625,17 +698,29 @@
                                     #{dep.department.name}
                                 </p:column>
                                 <p:column style="text-align: right;">
-                                    <h:outputLabel value="#{dep.stock}">       
+                                    <h:outputLabel value="#{dep.saleQty}">   
                                         <f:convertNumber integerOnly="true" />
+                                    </h:outputLabel> 
+                                </p:column>
+                                <p:column style="text-align: right;">
+                                    <h:outputLabel value="#{dep.saleValue}">  
+                                        <f:convertNumber pattern="#,##0.00" />
                                     </h:outputLabel> 
                                 </p:column>
                                 <p:columnGroup type="footer">
                                     <p:row>
-                                        <p:column footerText="Total Stock"></p:column>
-                                        <p:column style="text-align: right;" footerText="#{ins.institutionTotal}">
+                                        <p:column footerText="Total "></p:column>
+                                        <p:column style="text-align: right;" footerText="#{ins.institutionQty}">
                                             <f:facet name="footer">
-                                                <h:outputLabel value="#{ins.institutionTotal}">
+                                                <h:outputLabel value="#{ins.institutionQty}">
                                                     <f:convertNumber integerOnly="true" />
+                                                </h:outputLabel>
+                                            </f:facet>
+                                        </p:column>
+                                        <p:column style="text-align: right;" footerText="#{ins.institutionValue}">
+                                            <f:facet name="footer">
+                                                <h:outputLabel value="#{ins.institutionValue}">
+                                                    <f:convertNumber  pattern="#,##0.00" />
                                                 </h:outputLabel>
                                             </f:facet>
                                         </p:column>
@@ -646,869 +731,795 @@
                                 <p:row>
                                     <p:column>
                                         <f:facet name="footer">
-                                            Total Institution Stock
+                                            Total Institution
                                         </f:facet>
                                     </p:column>
                                     <p:column style="text-align: right;">
                                         <f:facet name="footer">
-                                            <h:outputLabel id="grandTotalTab" value="#{pharmacyController.grantStock}">
+                                            <h:outputLabel  value="#{pharmacyController.grantSaleQty}">   
                                                 <f:convertNumber integerOnly="true" />
+                                            </h:outputLabel>
+                                        </f:facet>
+                                    </p:column>
+                                    <p:column style="text-align: right;">
+                                        <f:facet name="footer">
+                                            <h:outputLabel  value="#{pharmacyController.grantSaleValue}">
+                                                <f:convertNumber  pattern="#,##0.00" />
                                             </h:outputLabel>
                                         </f:facet>
                                     </p:column>
                                 </p:row>
                             </p:columnGroup>
 
-                        </p:dataTable> 
-                    </p:panel>
+                        </p:dataTable>                
+                    </p:tab>
+                    <p:tab 
+                        id="itemDetailsTabSaleItems"
+                        title="Sale Bill Item" 
+                        class="w-100"
+                        rendered="#{configOptionApplicationController.getBooleanValueByKey('Pharmacy Item Details Section - Display Sale Bill Item Tab', true)}">
 
-                </p:tab>
-                <p:tab 
-                    title="Sale" 
-                    id="itemDetailsTabSales"
-                    rendered="#{configOptionApplicationController.getBooleanValueByKey('Pharmacy Item Details Section - Display Sale Tab', true)}">
-                    <p:dataTable styleClass="noBorder" value="#{pharmacyController.institutionSales}" var="ins">
-                        <p:columnGroup type="header">
-                            <p:row>
-                                <p:column >
-                                    <f:facet name="header">
-                                        Department Name
-                                    </f:facet>
-                                </p:column>
-                                <p:column >
-                                    <f:facet name="header">
-                                        Qty
-                                    </f:facet>
-                                </p:column>
-                                <p:column >
-                                    <f:facet name="header">
-                                        Value
-                                    </f:facet>
-                                </p:column>
-                            </p:row>
-                        </p:columnGroup>
-                        <p:subTable  value="#{ins.departmentSales}" var="dep">
-                            <f:facet name="header">
-                                #{ins.institution.name}
-                            </f:facet>
-                            <p:column>
-                                #{dep.department.name}
+                        <p:commandButton ajax="false" icon="fas fa-file-excel"
+                                         class="ui-button-success" value="Excel" action="#{pharmacyController.createTable()}" >
+                            <p:dataExporter type="xlsx" target="tbl" fileName="Category_report"  />
+
+                        </p:commandButton>
+                        <br/>
+                        <p:dataTable id="tbl" styleClass="noBorder" value="#{pharmacyController.grns}" var="bi"
+                                     paginator="true" 
+                                     rows="10" 
+                                     paginatorPosition="bottom"
+                                     paginatorTemplate="{CurrentPageReport}  {FirstPageLink} {PreviousPageLink} {PageLinks} {NextPageLink} {LastPageLink} {RowsPerPageDropdown}"
+                                     rowsPerPageTemplate="5,10,15">
+                            <p:column >
+                                <f:facet name="header">
+                                    Ins ID
+                                </f:facet>
+                                <p:outputLabel value="#{bi.bill.insId}" />
                             </p:column>
-                            <p:column style="text-align: right;">
-                                <h:outputLabel value="#{dep.saleQty}">   
-                                    <f:convertNumber integerOnly="true" />
-                                </h:outputLabel> 
+                            <p:column >
+                                <f:facet name="header">
+                                    dept ID
+                                </f:facet>
+                                <p:outputLabel value="#{bi.bill.deptId}" />
                             </p:column>
-                            <p:column style="text-align: right;">
-                                <h:outputLabel value="#{dep.saleValue}">  
+                            <p:column >
+                                <f:facet name="header">
+                                    Department
+                                </f:facet>
+                                <p:outputLabel value="#{bi.bill.department.name}" />
+                            </p:column>
+                            <p:column >
+                                <f:facet name="header">
+                                    Qty
+                                </f:facet>
+                                <p:outputLabel value="#{bi.pharmaceuticalBillItem.qty}" />
+                            </p:column>
+
+                        </p:dataTable>
+                    </p:tab>
+                    <p:tab 
+                        id="itemDetailsTabWholesale"
+                        title="Whole Sale" rendered="#{configOptionApplicationController.getBooleanValueByKey('Pharmacy Item Details Section - Display Whole Sale Tab', true)}">
+                        <p:dataTable styleClass="noBorder" value="#{pharmacyController.institutionWholeSales}" var="ins">
+                            <p:columnGroup type="header">
+                                <p:row>
+                                    <p:column >
+                                        <f:facet name="header">
+                                            Department Name
+                                        </f:facet>
+                                    </p:column>
+                                    <p:column >
+                                        <f:facet name="header">
+                                            Qty
+                                        </f:facet>
+                                    </p:column>
+                                    <p:column >
+                                        <f:facet name="header">
+                                            Value
+                                        </f:facet>
+                                    </p:column>
+                                </p:row>
+                            </p:columnGroup>
+                            <p:subTable  value="#{ins.departmentSales}" var="dep">
+                                <f:facet name="header">
+                                    #{ins.institution.name}
+                                </f:facet>
+                                <p:column>
+                                    #{dep.department.name}
+                                </p:column>
+                                <p:column style="text-align: right;">
+                                    <h:outputLabel value="#{dep.saleQty}">   
+                                        <f:convertNumber integerOnly="true" />
+                                    </h:outputLabel> 
+                                </p:column>
+                                <p:column style="text-align: right;">
+                                    <h:outputLabel value="#{dep.saleValue}">  
+                                        <f:convertNumber pattern="#,##0.00" />
+                                    </h:outputLabel> 
+                                </p:column>
+                                <p:columnGroup type="footer">
+                                    <p:row>
+                                        <p:column footerText="Total "></p:column>
+                                        <p:column style="text-align: right;" footerText="#{ins.institutionQty}">
+                                            <f:facet name="footer">
+                                                <h:outputLabel value="#{ins.institutionQty}">
+                                                    <f:convertNumber integerOnly="true" />
+                                                </h:outputLabel>
+                                            </f:facet>
+                                        </p:column>
+                                        <p:column style="text-align: right;" footerText="#{ins.institutionValue}">
+                                            <f:facet name="footer">
+                                                <h:outputLabel value="#{ins.institutionValue}">
+                                                    <f:convertNumber  pattern="#,##0.00" />
+                                                </h:outputLabel>
+                                            </f:facet>
+                                        </p:column>
+                                    </p:row>
+                                </p:columnGroup>
+                            </p:subTable>  
+                            <p:columnGroup type="footer">
+                                <p:row>
+                                    <p:column>
+                                        <f:facet name="footer">
+                                            Total Institution
+                                        </f:facet>
+                                    </p:column>
+                                    <p:column style="text-align: right;">
+                                        <f:facet name="footer">
+                                            <h:outputLabel  value="#{pharmacyController.grantWholeSaleQty}">   
+                                                <f:convertNumber integerOnly="true" />
+                                            </h:outputLabel>
+                                        </f:facet>
+                                    </p:column>
+                                    <p:column style="text-align: right;">
+                                        <f:facet name="footer">
+                                            <h:outputLabel  value="#{pharmacyController.grantWholeSaleValue}">
+                                                <f:convertNumber  pattern="#,##0.00" />
+                                            </h:outputLabel>
+                                        </f:facet>
+                                    </p:column>
+                                </p:row>
+                            </p:columnGroup>
+
+                        </p:dataTable>                
+                    </p:tab>
+                    <p:tab 
+                        id="itemDetailsTabInpatient"
+                        title="BHT Issue"
+                        rendered="#{configOptionApplicationController.getBooleanValueByKey('Pharmacy Item Details Section - Display BHT Issue Tab', true)}">
+                        <p:dataTable styleClass="noBorder" value="#{pharmacyController.institutionBhtIssue}" var="ins">
+                            <p:columnGroup type="header">
+                                <p:row>
+                                    <p:column >
+                                        <f:facet name="header">
+                                            Department Name
+                                        </f:facet>
+                                    </p:column>
+                                    <p:column >
+                                        <f:facet name="header">
+                                            Qty
+                                        </f:facet>
+                                    </p:column>
+                                    <p:column >
+                                        <f:facet name="header">
+                                            Value
+                                        </f:facet>
+                                    </p:column>
+                                </p:row>
+                            </p:columnGroup>
+                            <p:subTable  value="#{ins.departmentSales}" var="dep">
+                                <f:facet name="header">
+                                    #{ins.institution.name}
+                                </f:facet>
+                                <p:column>
+                                    #{dep.department.name}
+                                </p:column>
+                                <p:column style="text-align: right;">
+                                    <h:outputLabel value="#{dep.saleQty}">   
+                                        <f:convertNumber integerOnly="true" />
+                                    </h:outputLabel> 
+                                </p:column>
+                                <p:column style="text-align: right;">
+                                    <h:outputLabel value="#{dep.saleValue}">  
+                                        <f:convertNumber pattern="#,##0.00" />
+                                    </h:outputLabel> 
+                                </p:column>
+                                <p:columnGroup type="footer">
+                                    <p:row>
+                                        <p:column footerText="Total "></p:column>
+                                        <p:column style="text-align: right;" footerText="#{ins.institutionQty}">
+                                            <f:facet name="footer">
+                                                <h:outputLabel value="#{ins.institutionQty}">
+                                                    <f:convertNumber integerOnly="true" />
+                                                </h:outputLabel>
+                                            </f:facet>
+                                        </p:column>
+                                        <p:column style="text-align: right;" footerText="#{ins.institutionValue}">
+                                            <f:facet name="footer">
+                                                <h:outputLabel value="#{ins.institutionValue}">
+                                                    <f:convertNumber  pattern="#,##0.00" />
+                                                </h:outputLabel>
+                                            </f:facet>
+                                        </p:column>
+                                    </p:row>
+                                </p:columnGroup>
+                            </p:subTable>  
+                            <p:columnGroup type="footer">
+                                <p:row>
+                                    <p:column>
+                                        <f:facet name="footer">
+                                            Total Institution
+                                        </f:facet>
+                                    </p:column>
+                                    <p:column style="text-align: right;">
+                                        <f:facet name="footer">
+                                            <h:outputLabel  value="#{pharmacyController.grantBhtIssueQty}">   
+                                                <f:convertNumber integerOnly="true" />
+                                            </h:outputLabel>
+                                        </f:facet>
+                                    </p:column>
+                                    <p:column style="text-align: right;">
+                                        <f:facet name="footer">
+                                            <h:outputLabel  value="#{pharmacyController.grantBhtValue}">
+                                                <f:convertNumber  pattern="#,##0.00" />
+                                            </h:outputLabel>
+                                        </f:facet>
+                                    </p:column>
+                                </p:row>
+                            </p:columnGroup>
+
+                        </p:dataTable>                
+                    </p:tab>
+                    <p:tab 
+                        id="itemDetailsTabTransferIssue"
+                        title="Transfer Issue" 
+                        rendered="#{configOptionApplicationController.getBooleanValueByKey('Pharmacy Item Details Section - Display Transfer Issue Tab', true)}">
+                        <p:dataTable styleClass="noBorder" id="trIssueTab" value="#{pharmacyController.institutionTransferIssue}" var="ins">
+                            <p:columnGroup type="header">
+                                <p:row>
+                                    <p:column >
+                                        <f:facet name="header">
+                                            To Department Name
+                                        </f:facet>
+                                    </p:column>
+                                    <p:column >
+                                        <f:facet name="header">
+                                            Sent Qty
+                                        </f:facet>
+                                    </p:column>
+                                    <p:column >
+                                        <f:facet name="header">
+                                            Sent Value
+                                        </f:facet>
+                                    </p:column>
+                                </p:row>
+                            </p:columnGroup>
+                            <p:subTable  value="#{ins.departmentSales}" var="dep">
+                                <f:facet name="header">
+                                    #{ins.institution.name}
+                                </f:facet>
+                                <p:column>
+                                    #{dep.department.name}
+                                </p:column>
+                                <p:column style="text-align: right;">
+                                    <h:outputLabel value="#{dep.saleQtyAbs}">    
+                                        <f:convertNumber integerOnly="true" />
+                                    </h:outputLabel> 
+                                </p:column>
+                                <p:column style="text-align: right;">
+                                    <h:outputLabel value="#{dep.saleValueAbs}">    
+                                        <f:convertNumber  pattern="#,##0.00" />
+                                    </h:outputLabel> 
+                                </p:column>
+                                <p:columnGroup type="footer">
+                                    <p:row>
+                                        <p:column footerText="Total "></p:column>
+                                        <p:column style="text-align: right;" footerText="#{ins.institutionQty}">
+                                            <f:facet name="footer">
+                                                <h:outputLabel value="#{0-ins.institutionQty}">
+                                                    <f:convertNumber integerOnly="true" />
+                                                </h:outputLabel>
+                                            </f:facet>
+                                        </p:column>
+                                        <p:column style="text-align: right;" footerText="#{ins.institutionValue}">
+                                            <f:facet name="footer">
+                                                <h:outputLabel value="#{0-ins.institutionValue}">
+                                                    <f:convertNumber  pattern="#,##0.00" />
+                                                </h:outputLabel>
+                                            </f:facet>
+                                        </p:column>
+                                    </p:row>
+                                </p:columnGroup>
+                            </p:subTable>  
+                            <p:columnGroup type="footer">
+                                <p:row>
+                                    <p:column>
+                                        <f:facet name="footer">
+                                            Total Institution
+                                        </f:facet>
+                                    </p:column>
+                                    <p:column style="text-align: right;">
+                                        <f:facet name="footer">
+                                            <h:outputLabel  value="#{0-pharmacyController.grantTransferIssueQty}">
+                                                <f:convertNumber integerOnly="true" />
+                                            </h:outputLabel>
+                                        </f:facet>
+                                    </p:column>
+                                    <p:column style="text-align: right;">
+                                        <f:facet name="footer">
+                                            <h:outputLabel  value="#{0-pharmacyController.grantTransferIssueValue}">
+                                                <f:convertNumber  pattern="#,##0.00" />
+                                            </h:outputLabel>
+                                        </f:facet>
+                                    </p:column>
+                                </p:row>
+                            </p:columnGroup>
+
+                        </p:dataTable>                
+                    </p:tab>
+                    <p:tab 
+                        id="itemDetailsTabTransferReceive"
+                        title="Transfer Receive"
+                        rendered="#{configOptionApplicationController.getBooleanValueByKey('Pharmacy Item Details Section - Display Transfer Receive Tab', true)}">
+                        <p:dataTable styleClass="noBorder" id="trRceive" 
+                                     value="#{pharmacyController.institutionTransferReceive}" var="ins">
+                            <p:columnGroup type="header">
+                                <p:row>
+                                    <p:column >
+                                        <f:facet name="header">
+                                            From Department Name
+                                        </f:facet>
+                                    </p:column>
+                                    <p:column >
+                                        <f:facet name="header">
+                                            Received Qty
+                                        </f:facet>
+                                    </p:column>
+                                    <p:column >
+                                        <f:facet name="header">
+                                            Received Value
+                                        </f:facet>
+                                    </p:column>
+                                </p:row>
+                            </p:columnGroup>
+                            <p:subTable  value="#{ins.departmentSales}" var="dep">
+                                <f:facet name="header">
+                                    #{ins.institution.name}
+                                </f:facet>
+                                <p:column>
+                                    #{dep.department.name}
+                                </p:column>
+                                <p:column style="text-align: right;">
+                                    <h:outputLabel value="#{dep.saleQtyAbs}"> 
+                                        <f:convertNumber integerOnly="true" />
+                                    </h:outputLabel> 
+                                </p:column>
+                                <p:column style="text-align: right;">
+                                    <h:outputLabel value="#{dep.saleValueAbs}"> 
+                                        <f:convertNumber  pattern="#,##0.00" />
+                                    </h:outputLabel> 
+                                </p:column>
+                                <p:columnGroup type="footer">
+                                    <p:row>
+                                        <p:column footerText="Total "></p:column>
+                                        <p:column style="text-align: right;" footerText="#{0-ins.institutionQty}">
+                                            <f:facet name="footer">
+                                                <h:outputLabel value="#{0-ins.institutionQty}">
+                                                    <f:convertNumber integerOnly="true" />
+                                                </h:outputLabel>
+                                            </f:facet>
+                                        </p:column>
+                                        <p:column style="text-align: right;" footerText="#{0-ins.institutionValue}">
+                                            <f:facet name="footer">
+                                                <h:outputLabel value="#{0-ins.institutionValue}">
+                                                    <f:convertNumber  pattern="#,##0.00" />
+                                                </h:outputLabel>
+                                            </f:facet>
+                                        </p:column>
+                                    </p:row>
+                                </p:columnGroup>
+                            </p:subTable>  
+                            <p:columnGroup type="footer">
+                                <p:row>
+                                    <p:column>
+                                        <f:facet name="footer">
+                                            Total Institution
+                                        </f:facet>
+                                    </p:column>
+                                    <p:column style="text-align: right;">
+                                        <f:facet name="footer">
+                                            <h:outputLabel  value="#{0-pharmacyController.grantTransferReceiveQty}">
+                                                <f:convertNumber integerOnly="true" />
+                                            </h:outputLabel>
+                                        </f:facet>
+                                    </p:column>
+                                    <p:column style="text-align: right;">
+                                        <f:facet name="footer">
+                                            <h:outputLabel  value="#{0-pharmacyController.grantTransferReceiveValue}">
+                                                <f:convertNumber  pattern="#,##0.00" />
+                                            </h:outputLabel>
+                                        </f:facet>
+                                    </p:column>
+                                </p:row>
+                            </p:columnGroup>
+
+                        </p:dataTable>                
+                    </p:tab>
+                    <p:tab 
+                        id="itemDetailsTabConsuption"
+                        title="Department Issue" 
+                        rendered="#{configOptionApplicationController.getBooleanValueByKey('Pharmacy Item Details Section - Display Department Issue Tab', true)}">
+                        <p:dataTable styleClass="noBorder" id="depIssue"
+                                     value="#{pharmacyController.institutionIssue}" var="ins">
+                            <p:columnGroup type="header">
+                                <p:row>
+                                    <p:column >
+                                        <f:facet name="header">
+                                            To Department Name
+                                        </f:facet>
+                                    </p:column>
+                                    <p:column >
+                                        <f:facet name="header">
+                                            Sent Qty
+                                        </f:facet>
+                                    </p:column>
+                                    <p:column >
+                                        <f:facet name="header">
+                                            Sent Value
+                                        </f:facet>
+                                    </p:column>
+                                </p:row>
+                            </p:columnGroup>
+                            <p:subTable  value="#{ins.departmentSales}" var="dep">
+                                <f:facet name="header">
+                                    #{ins.institution.name}
+                                </f:facet>
+                                <p:column>
+                                    #{dep.department.name}
+                                </p:column>
+                                <p:column style="text-align: right;">
+                                    <h:outputLabel value="#{dep.saleQtyAbs}">    
+                                        <f:convertNumber integerOnly="true" />
+                                    </h:outputLabel> 
+                                </p:column>
+                                <p:column style="text-align: right;">
+                                    <h:outputLabel value="#{dep.saleValueAbs}">    
+                                        <f:convertNumber  pattern="#,##0.00" />
+                                    </h:outputLabel> 
+                                </p:column>
+                                <p:columnGroup type="footer">
+                                    <p:row>
+                                        <p:column footerText="Total "></p:column>
+                                        <p:column style="text-align: right;" footerText="#{ins.institutionQty}">
+                                            <f:facet name="footer">
+                                                <h:outputLabel value="#{0-ins.institutionQty}">
+                                                    <f:convertNumber integerOnly="true" />
+                                                </h:outputLabel>
+                                            </f:facet>
+                                        </p:column>
+                                        <p:column style="text-align: right;" footerText="#{ins.institutionValue}">
+                                            <f:facet name="footer">
+                                                <h:outputLabel value="#{0-ins.institutionValue}">
+                                                    <f:convertNumber  pattern="#,##0.00" />
+                                                </h:outputLabel>
+                                            </f:facet>
+                                        </p:column>
+                                    </p:row>
+                                </p:columnGroup>
+                            </p:subTable>  
+                            <p:columnGroup type="footer">
+                                <p:row>
+                                    <p:column>
+                                        <f:facet name="footer">
+                                            Total Institution
+                                        </f:facet>
+                                    </p:column>
+                                    <p:column style="text-align: right;">
+                                        <f:facet name="footer">
+                                            <h:outputLabel  value="#{0-pharmacyController.grantIssueQty}">
+                                                <f:convertNumber integerOnly="true" />
+                                            </h:outputLabel>
+                                        </f:facet>
+                                    </p:column>
+                                    <p:column style="text-align: right;">
+                                        <f:facet name="footer">
+                                            <h:outputLabel  value="#{0-pharmacyController.grantIssueValue}">
+                                                <f:convertNumber  pattern="#,##0.00" />
+                                            </h:outputLabel>
+                                        </f:facet>
+                                    </p:column>
+                                </p:row>
+                            </p:columnGroup>
+
+                        </p:dataTable>                
+                    </p:tab>
+                    <p:tab 
+                        id="itemDetailsTabGrn"
+                        title="GRN" 
+                        rendered="#{configOptionApplicationController.getBooleanValueByKey('Pharmacy Item Details Section - Display GRN Tab', true)}">
+
+                        <p:dataTable styleClass="noBorder" id="grn" value="#{pharmacyController.grnDtos}"
+                                     var="dd2" scrollable="true"  paginator="true"
+                                     rows="10"
+                                     paginatorPosition="bottom"
+                                     paginatorTemplate="{CurrentPageReport}  {FirstPageLink} {PreviousPageLink} {PageLinks} {NextPageLink} {LastPageLink} {RowsPerPageDropdown}"
+                                     rowsPerPageTemplate="5,10,15" >
+                            <p:column headerText="GRN No">
+                                #{dd2.grnNo}
+                            </p:column>
+                            <p:column headerText="Department">
+                                #{dd2.departmentName}
+                            </p:column>
+                            <p:column headerText="Date">
+                                <h:outputLabel value="#{dd2.createdAt}" >
+                                    <f:convertDateTime  timeZone="Asia/Colombo" pattern="#{sessionController.applicationPreference.longDateFormat}" ></f:convertDateTime>
+                                </h:outputLabel>
+                            </p:column>
+                            <p:column headerText="PO No">
+                                <h:outputText value="#{dd2.poNo}" />
+                            </p:column>
+                            <p:column headerText="Supplier">
+                                <h:outputText value="#{dd2.supplierName}" />
+                            </p:column>
+                            <p:column headerText="Item">
+                                <h:outputText value="#{dd2.itemName}" />
+                            </p:column>
+                            <p:column headerText="Qty">
+                                <h:outputText value="#{dd2.quantity}" />
+                            </p:column>
+                            <p:column headerText="Fr. Qty">
+                                <h:outputText value="#{dd2.freeQuantity}" />
+                            </p:column>
+                            <p:column headerText="Purchase Rate">
+                                <h:outputText value="#{dd2.purchaseRate}">
                                     <f:convertNumber pattern="#,##0.00" />
-                                </h:outputLabel> 
+                                </h:outputText>
                             </p:column>
-                            <p:columnGroup type="footer">
-                                <p:row>
-                                    <p:column footerText="Total "></p:column>
-                                    <p:column style="text-align: right;" footerText="#{ins.institutionQty}">
-                                        <f:facet name="footer">
-                                            <h:outputLabel value="#{ins.institutionQty}">
-                                                <f:convertNumber integerOnly="true" />
-                                            </h:outputLabel>
-                                        </f:facet>
-                                    </p:column>
-                                    <p:column style="text-align: right;" footerText="#{ins.institutionValue}">
-                                        <f:facet name="footer">
-                                            <h:outputLabel value="#{ins.institutionValue}">
-                                                <f:convertNumber  pattern="#,##0.00" />
-                                            </h:outputLabel>
-                                        </f:facet>
-                                    </p:column>
-                                </p:row>
-                            </p:columnGroup>
-                        </p:subTable>  
-                        <p:columnGroup type="footer">
-                            <p:row>
-                                <p:column>
-                                    <f:facet name="footer">
-                                        Total Institution
-                                    </f:facet>
-                                </p:column>
-                                <p:column style="text-align: right;">
-                                    <f:facet name="footer">
-                                        <h:outputLabel  value="#{pharmacyController.grantSaleQty}">   
-                                            <f:convertNumber integerOnly="true" />
-                                        </h:outputLabel>
-                                    </f:facet>
-                                </p:column>
-                                <p:column style="text-align: right;">
-                                    <f:facet name="footer">
-                                        <h:outputLabel  value="#{pharmacyController.grantSaleValue}">
-                                            <f:convertNumber  pattern="#,##0.00" />
-                                        </h:outputLabel>
-                                    </f:facet>
-                                </p:column>
-                            </p:row>
-                        </p:columnGroup>
-
-                    </p:dataTable>                
-                </p:tab>
-                <p:tab 
-                    id="itemDetailsTabSaleItems"
-                    title="Sale Bill Item" 
-                    class="w-100"
-                    rendered="#{configOptionApplicationController.getBooleanValueByKey('Pharmacy Item Details Section - Display Sale Bill Item Tab', true)}">
-
-                    <p:commandButton ajax="false" icon="fas fa-file-excel"
-                                     class="ui-button-success" value="Excel" action="#{pharmacyController.createTable()}" >
-                        <p:dataExporter type="xlsx" target="tbl" fileName="Category_report"  />
-
-                    </p:commandButton>
-                    <br/>
-                    <p:dataTable id="tbl" styleClass="noBorder" value="#{pharmacyController.grns}" var="bi"
-                                 paginator="true" 
-                                 rows="10" 
-                                 paginatorPosition="bottom"
-                                 paginatorTemplate="{CurrentPageReport}  {FirstPageLink} {PreviousPageLink} {PageLinks} {NextPageLink} {LastPageLink} {RowsPerPageDropdown}"
-                                 rowsPerPageTemplate="5,10,15">
-                        <p:column >
-                            <f:facet name="header">
-                                Ins ID
-                            </f:facet>
-                            <p:outputLabel value="#{bi.bill.insId}" />
-                        </p:column>
-                        <p:column >
-                            <f:facet name="header">
-                                dept ID
-                            </f:facet>
-                            <p:outputLabel value="#{bi.bill.deptId}" />
-                        </p:column>
-                        <p:column >
-                            <f:facet name="header">
-                                Department
-                            </f:facet>
-                            <p:outputLabel value="#{bi.bill.department.name}" />
-                        </p:column>
-                        <p:column >
-                            <f:facet name="header">
-                                Qty
-                            </f:facet>
-                            <p:outputLabel value="#{bi.pharmaceuticalBillItem.qty}" />
-                        </p:column>
-
-                    </p:dataTable>
-                </p:tab>
-                <p:tab 
-                    id="itemDetailsTabWholesale"
-                    title="Whole Sale" rendered="#{configOptionApplicationController.getBooleanValueByKey('Pharmacy Item Details Section - Display Whole Sale Tab', true)}">
-                    <p:dataTable styleClass="noBorder" value="#{pharmacyController.institutionWholeSales}" var="ins">
-                        <p:columnGroup type="header">
-                            <p:row>
-                                <p:column >
-                                    <f:facet name="header">
-                                        Department Name
-                                    </f:facet>
-                                </p:column>
-                                <p:column >
-                                    <f:facet name="header">
-                                        Qty
-                                    </f:facet>
-                                </p:column>
-                                <p:column >
-                                    <f:facet name="header">
-                                        Value
-                                    </f:facet>
-                                </p:column>
-                            </p:row>
-                        </p:columnGroup>
-                        <p:subTable  value="#{ins.departmentSales}" var="dep">
-                            <f:facet name="header">
-                                #{ins.institution.name}
-                            </f:facet>
-                            <p:column>
-                                #{dep.department.name}
-                            </p:column>
-                            <p:column style="text-align: right;">
-                                <h:outputLabel value="#{dep.saleQty}">   
-                                    <f:convertNumber integerOnly="true" />
-                                </h:outputLabel> 
-                            </p:column>
-                            <p:column style="text-align: right;">
-                                <h:outputLabel value="#{dep.saleValue}">  
+                            <p:column headerText="Cost Rate per unit">
+                                <h:outputText value="#{dd2.totalCostRate}">
                                     <f:convertNumber pattern="#,##0.00" />
-                                </h:outputLabel> 
+                                </h:outputText>
                             </p:column>
-                            <p:columnGroup type="footer">
-                                <p:row>
-                                    <p:column footerText="Total "></p:column>
-                                    <p:column style="text-align: right;" footerText="#{ins.institutionQty}">
-                                        <f:facet name="footer">
-                                            <h:outputLabel value="#{ins.institutionQty}">
-                                                <f:convertNumber integerOnly="true" />
-                                            </h:outputLabel>
-                                        </f:facet>
-                                    </p:column>
-                                    <p:column style="text-align: right;" footerText="#{ins.institutionValue}">
-                                        <f:facet name="footer">
-                                            <h:outputLabel value="#{ins.institutionValue}">
-                                                <f:convertNumber  pattern="#,##0.00" />
-                                            </h:outputLabel>
-                                        </f:facet>
-                                    </p:column>
-                                </p:row>
-                            </p:columnGroup>
-                        </p:subTable>  
-                        <p:columnGroup type="footer">
-                            <p:row>
-                                <p:column>
-                                    <f:facet name="footer">
-                                        Total Institution
-                                    </f:facet>
-                                </p:column>
-                                <p:column style="text-align: right;">
-                                    <f:facet name="footer">
-                                        <h:outputLabel  value="#{pharmacyController.grantWholeSaleQty}">   
-                                            <f:convertNumber integerOnly="true" />
-                                        </h:outputLabel>
-                                    </f:facet>
-                                </p:column>
-                                <p:column style="text-align: right;">
-                                    <f:facet name="footer">
-                                        <h:outputLabel  value="#{pharmacyController.grantWholeSaleValue}">
-                                            <f:convertNumber  pattern="#,##0.00" />
-                                        </h:outputLabel>
-                                    </f:facet>
-                                </p:column>
-                            </p:row>
-                        </p:columnGroup>
-
-                    </p:dataTable>                
-                </p:tab>
-                <p:tab 
-                    id="itemDetailsTabInpatient"
-                    title="BHT Issue"
-                    rendered="#{configOptionApplicationController.getBooleanValueByKey('Pharmacy Item Details Section - Display BHT Issue Tab', true)}">
-                    <p:dataTable styleClass="noBorder" value="#{pharmacyController.institutionBhtIssue}" var="ins">
-                        <p:columnGroup type="header">
-                            <p:row>
-                                <p:column >
-                                    <f:facet name="header">
-                                        Department Name
-                                    </f:facet>
-                                </p:column>
-                                <p:column >
-                                    <f:facet name="header">
-                                        Qty
-                                    </f:facet>
-                                </p:column>
-                                <p:column >
-                                    <f:facet name="header">
-                                        Value
-                                    </f:facet>
-                                </p:column>
-                            </p:row>
-                        </p:columnGroup>
-                        <p:subTable  value="#{ins.departmentSales}" var="dep">
-                            <f:facet name="header">
-                                #{ins.institution.name}
-                            </f:facet>
-                            <p:column>
-                                #{dep.department.name}
-                            </p:column>
-                            <p:column style="text-align: right;">
-                                <h:outputLabel value="#{dep.saleQty}">   
-                                    <f:convertNumber integerOnly="true" />
-                                </h:outputLabel> 
-                            </p:column>
-                            <p:column style="text-align: right;">
-                                <h:outputLabel value="#{dep.saleValue}">  
+                            <p:column headerText="Sale Rate">
+                                <h:outputText value="#{dd2.retailSaleRate}">
                                     <f:convertNumber pattern="#,##0.00" />
-                                </h:outputLabel> 
+                                </h:outputText>
                             </p:column>
-                            <p:columnGroup type="footer">
-                                <p:row>
-                                    <p:column footerText="Total "></p:column>
-                                    <p:column style="text-align: right;" footerText="#{ins.institutionQty}">
-                                        <f:facet name="footer">
-                                            <h:outputLabel value="#{ins.institutionQty}">
-                                                <f:convertNumber integerOnly="true" />
-                                            </h:outputLabel>
-                                        </f:facet>
-                                    </p:column>
-                                    <p:column style="text-align: right;" footerText="#{ins.institutionValue}">
-                                        <f:facet name="footer">
-                                            <h:outputLabel value="#{ins.institutionValue}">
-                                                <f:convertNumber  pattern="#,##0.00" />
-                                            </h:outputLabel>
-                                        </f:facet>
-                                    </p:column>
-                                </p:row>
-                            </p:columnGroup>
-                        </p:subTable>  
-                        <p:columnGroup type="footer">
-                            <p:row>
-                                <p:column>
-                                    <f:facet name="footer">
-                                        Total Institution
-                                    </f:facet>
-                                </p:column>
-                                <p:column style="text-align: right;">
-                                    <f:facet name="footer">
-                                        <h:outputLabel  value="#{pharmacyController.grantBhtIssueQty}">   
-                                            <f:convertNumber integerOnly="true" />
-                                        </h:outputLabel>
-                                    </f:facet>
-                                </p:column>
-                                <p:column style="text-align: right;">
-                                    <f:facet name="footer">
-                                        <h:outputLabel  value="#{pharmacyController.grantBhtValue}">
-                                            <f:convertNumber  pattern="#,##0.00" />
-                                        </h:outputLabel>
-                                    </f:facet>
-                                </p:column>
-                            </p:row>
-                        </p:columnGroup>
+                            <p:column headerText="Value">
+                                <h:outputText value="#{dd2.netTotal}">
+                                    <f:convertNumber pattern="#,##0.00" />
+                                </h:outputText>
+                            </p:column>
 
-                    </p:dataTable>                
-                </p:tab>
-                <p:tab 
-                    id="itemDetailsTabTransferIssue"
-                    title="Transfer Issue" 
-                    rendered="#{configOptionApplicationController.getBooleanValueByKey('Pharmacy Item Details Section - Display Transfer Issue Tab', true)}">
-                    <p:dataTable styleClass="noBorder" id="trIssueTab" value="#{pharmacyController.institutionTransferIssue}" var="ins">
-                        <p:columnGroup type="header">
-                            <p:row>
-                                <p:column >
-                                    <f:facet name="header">
-                                        To Department Name
-                                    </f:facet>
-                                </p:column>
-                                <p:column >
-                                    <f:facet name="header">
-                                        Sent Qty
-                                    </f:facet>
-                                </p:column>
-                                <p:column >
-                                    <f:facet name="header">
-                                        Sent Value
-                                    </f:facet>
-                                </p:column>
-                            </p:row>
-                        </p:columnGroup>
-                        <p:subTable  value="#{ins.departmentSales}" var="dep">
-                            <f:facet name="header">
-                                #{ins.institution.name}
-                            </f:facet>
+                        </p:dataTable>
+                    </p:tab>
+
+                    <p:tab 
+                        id="itemDetailsTabPendingGrn"
+                        title="Pending GRN" 
+                        rendered="#{configOptionApplicationController.getBooleanValueByKey('Pharmacy Item Details Section - Display Pending GRN Tab', true)}">
+                        <p:dataTable 
+                            id="pendinggrn" 
+                            value="#{pharmacyController.pendingGrns}"
+                            var="pendingGrnRow" scrollable="true"  paginator="true"
+                            rows="10"
+                            paginatorPosition="bottom"
+                            paginatorTemplate="{CurrentPageReport}  {FirstPageLink} {PreviousPageLink} {PageLinks} {NextPageLink} {LastPageLink} {RowsPerPageDropdown}"
+                            rowsPerPageTemplate="5,10,15" >
+
+                            <p:column headerText="PO Number">
+                                #{pendingGrnRow.bill.deptId}
+                            </p:column>
+                            <p:column headerText="Department">
+                                #{pendingGrnRow.bill.department.name}
+                            </p:column>
+                            <p:column headerText="Date">
+                                <h:outputLabel value="#{pendingGrnRow.bill.createdAt}" >
+                                    <f:convertDateTime  timeZone="Asia/Colombo" pattern="#{sessionController.applicationPreference.longDateFormat}" />
+                                </h:outputLabel>
+                            </p:column>
+                            <p:column headerText="Supplier">
+                                #{pendingGrnRow.bill.toInstitution.name}
+                            </p:column>
+                            <p:column headerText="Item">
+                                #{pendingGrnRow.item.name}
+                            </p:column>
+                            <p:column headerText="Qty" class="text-end"> 
+                                #{pendingGrnRow.qty} 
+                            </p:column> 
+                        </p:dataTable>
+
+                    </p:tab>
+
+                    <p:tab
+                        title="GRN Return"
+                        id="itemDetailsTabGrnReturn"
+                        rendered="#{configOptionApplicationController.getBooleanValueByKey('Pharmacy Item Details Section - Display GRN Return Tab', true)}">
+
+                        <p:dataTable styleClass="noBorder" id="grnr" value="#{pharmacyController.grnReturnDtos}"
+                                     var="dd2" scrollable="true" paginator="true"
+                                     rows="10"
+                                     paginatorPosition="bottom"
+                                     paginatorTemplate="{CurrentPageReport}  {FirstPageLink} {PreviousPageLink} {PageLinks} {NextPageLink} {LastPageLink} {RowsPerPageDropdown}"
+                                     rowsPerPageTemplate="5,10,15" >
+                            <p:column headerText="GRN Return No">
+                                #{dd2.grnReturnNo}
+                            </p:column>
+                            <p:column headerText="Department">
+                                #{dd2.departmentName}
+                            </p:column>
+                            <p:column headerText="GRN Return at">
+                                <h:outputLabel value="#{dd2.createdAt}">
+                                    <f:convertDateTime timeZone="Asia/Colombo" pattern="#{sessionController.applicationPreference.longDateFormat}" />
+                                </h:outputLabel>
+                            </p:column>
+                            <p:column headerText="Supplier">
+                                #{dd2.supplierName}
+                            </p:column>
+                            <p:column headerText="Item">
+                                #{dd2.itemName}
+                            </p:column>
+                            <p:column headerText="Qty Returned" class="text-end"> 
+                                #{dd2.quantityReturned} 
+                            </p:column> 
+                            <p:column headerText="Free Qty Returned" class="text-end"> 
+                                #{dd2.freeQuantityReturned} 
+                            </p:column> 
+                            <p:column headerText="Purchase Rate" class="text-end"> 
+                                <h:outputText value="#{dd2.purchaseRate}"> 
+                                    <f:convertNumber pattern="#,##0.00" /> 
+                                </h:outputText> 
+                            </p:column> 
+                            <p:column headerText="Sale Rate" class="text-end"> 
+                                <h:outputText value="#{dd2.saleRate}"> 
+                                    <f:convertNumber pattern="#,##0.00" /> 
+                                </h:outputText> 
+                            </p:column> 
+                            <p:column headerText="Returned Rate" class="text-end"> 
+                                <h:outputText value="#{dd2.returnedRate}"> 
+                                    <f:convertNumber pattern="#,##0.00" /> 
+                                </h:outputText> 
+                            </p:column> 
+                            <p:column headerText="Return Value" class="text-end"> 
+                                <h:outputText value="#{dd2.returnValue}"> 
+                                    <f:convertNumber pattern="#,##0.00" /> 
+                                </h:outputText> 
+                            </p:column> 
+                        </p:dataTable>
+                    </p:tab>
+
+                    <p:tab title="Purchase Orders" rendered="#{configOptionApplicationController.getBooleanValueByKey('Pharmacy Item Details Section - Display Purchase Orders Tab', true)}">
+
+                        <p:dataTable
+                            styleClass="noBorder" 
+                            id="tblPurchaseOrders"
+                            value="#{pharmacyController.pos}" var="dd3" 
+                            rows="10" 
+                            paginator="true"
+                            paginatorPosition="bottom"
+                            paginatorTemplate="{CurrentPageReport}  {FirstPageLink} {PreviousPageLink} {PageLinks} {NextPageLink} {LastPageLink} {RowsPerPageDropdown}"
+                            rowsPerPageTemplate="5,10,15" >
+                            <p:column headerText="Order Number">
+                                #{dd3.bill.deptId}
+                            </p:column>
+                            <p:column headerText="Order Department">
+                                #{dd3.bill.department.name}
+                            </p:column>
+                            <p:column headerText="Order at">
+                                <p:outputLabel value="#{dd3.bill.createdAt}">
+                                    <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateFormat}" />
+                                </p:outputLabel>
+                            </p:column>
+                            <p:column headerText="Supplier">
+                                #{dd3.bill.toInstitution.name}
+                            </p:column>
+                            <p:column headerText="Item">
+                                #{dd3.item.name}
+                            </p:column>
+                            <p:column headerText="Qty Ordered" class="text-end"> 
+                                <h:outputText value="#{dd3.pharmaceuticalBillItem.qty}"> 
+                                    <f:convertNumber integerOnly="true" /> 
+                                </h:outputText> 
+                            </p:column> 
+                            <p:column headerText="Free Qty Ordered" class="text-end"> 
+                                <h:outputText value="#{dd3.pharmaceuticalBillItem.freeQty}"> 
+                                    <f:convertNumber integerOnly="true" /> 
+                                </h:outputText> 
+                            </p:column> 
+                        </p:dataTable>
+                    </p:tab>
+
+                    <p:tab title="Pending PO" rendered="#{configOptionApplicationController.getBooleanValueByKey('Pharmacy Item Details Section - Display Pending PO Tab', true)}">
+
+                        <p:dataTable 
+                            styleClass="noBorder" id="ppo" value="#{pharmacyController.pos}" var="dd3"
+                            rows="10"
+                            paginator="true"
+                            paginatorPosition="bottom"
+                            paginatorTemplate="{CurrentPageReport}  {FirstPageLink} {PreviousPageLink} {PageLinks} {NextPageLink} {LastPageLink} {RowsPerPageDropdown}"
+                            rowsPerPageTemplate="5,10,15" >
+                            <p:column headerText="Po No">
+                                #{dd3.bill.deptId}
+                            </p:column>
+                            <p:column headerText="PO Date">
+                                <p:outputLabel value="#{dd3.bill.createdAt}" >
+                                    <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateFormat}"></f:convertDateTime>
+                                </p:outputLabel>
+                            </p:column>
+                            <p:column headerText="Supplier">
+                                #{dd3.bill.toInstitution.name}
+                            </p:column>
+                            <p:column headerText="PO Qty" class="text-end"> 
+                                #{dd3.pharmaceuticalBillItem.qty} 
+                            </p:column> 
+                            <p:column headerText="Requested By">
+                                #{dd3.totalGrnQty}
+                            </p:column>
+                            <p:column headerText="Status">
+                                #{dd3.totalGrnQty}
+                            </p:column>
+                        </p:dataTable>
+                    </p:tab>
+
+                    <p:tab
+                        title="Direct Purchase"
+                        id="tabDirectPurchase"
+                        rendered="#{configOptionApplicationController.getBooleanValueByKey('Pharmacy Item Details Section - Display Direct Purchase Tab', true)}">
+
+                        <p:dataTable 
+                            styleClass="noBorder" 
+                            id="tblDirectPurchase" 
+                            value="#{pharmacyController.directPurchaseDtos}" var="dd3"
+                            rows="10" 
+                            paginator="true"
+                            paginatorPosition="bottom"
+                            paginatorTemplate="{CurrentPageReport}  {FirstPageLink} {PreviousPageLink} {PageLinks} {NextPageLink} {LastPageLink} {RowsPerPageDropdown}"
+                            rowsPerPageTemplate="5,10,15">
+                            <p:column headerText="Bill No">
+                                #{dd3.billDeptId}
+                            </p:column>
+                            <p:column headerText="Supplier">
+                                #{dd3.billFromInstitutionName}
+                            </p:column>
+                            <p:column headerText="Billed By">
+                                #{dd3.billCreaterName}
+                            </p:column>    
+                            <p:column headerText="Billed At">
+                                <p:outputLabel value="#{dd3.billCreatedAt}" >
+                                    <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateFormat}"></f:convertDateTime>
+                                </p:outputLabel>
+                            </p:column> 
+                            <p:column headerText="Purchase Rate" class="text-end"> 
+                                #{dd3.purchaseRate} 
+                            </p:column>     
+                            <p:column headerText="Sale Rate" class="text-end"> 
+                                #{dd3.retailRate} 
+                            </p:column>     
+                            <p:column headerText="Purchase Qty" class="text-end"> 
+                                #{dd3.qty} 
+                            </p:column>     
+                            <p:column headerText="Free Qty" class="text-end"> 
+                                #{dd3.freeQty} 
+                            </p:column>     
+                            <p:column headerText="Purchase Value" class="text-end"> 
+                                #{-dd3.billNetTotal} 
+                            </p:column>  
+                        </p:dataTable>
+                    </p:tab>
+                    <p:tab title="Pack Sizes" rendered="#{configOptionApplicationController.getBooleanValueByKey('Pharmacy Item Details Section - Display Pack Sizes Tab', true)}">
+                        <p:dataTable value="#{pharmacyController.ampps}" var="p" >
                             <p:column>
-                                #{dep.department.name}
+                                <h:outputLabel value="#{p.name}" ></h:outputLabel>
                             </p:column>
-                            <p:column style="text-align: right;">
-                                <h:outputLabel value="#{dep.saleQtyAbs}">    
-                                    <f:convertNumber integerOnly="true" />
-                                </h:outputLabel> 
-                            </p:column>
-                            <p:column style="text-align: right;">
-                                <h:outputLabel value="#{dep.saleValueAbs}">    
-                                    <f:convertNumber  pattern="#,##0.00" />
-                                </h:outputLabel> 
-                            </p:column>
-                            <p:columnGroup type="footer">
-                                <p:row>
-                                    <p:column footerText="Total "></p:column>
-                                    <p:column style="text-align: right;" footerText="#{ins.institutionQty}">
-                                        <f:facet name="footer">
-                                            <h:outputLabel value="#{0-ins.institutionQty}">
-                                                <f:convertNumber integerOnly="true" />
-                                            </h:outputLabel>
-                                        </f:facet>
-                                    </p:column>
-                                    <p:column style="text-align: right;" footerText="#{ins.institutionValue}">
-                                        <f:facet name="footer">
-                                            <h:outputLabel value="#{0-ins.institutionValue}">
-                                                <f:convertNumber  pattern="#,##0.00" />
-                                            </h:outputLabel>
-                                        </f:facet>
-                                    </p:column>
-                                </p:row>
-                            </p:columnGroup>
-                        </p:subTable>  
-                        <p:columnGroup type="footer">
-                            <p:row>
-                                <p:column>
-                                    <f:facet name="footer">
-                                        Total Institution
-                                    </f:facet>
-                                </p:column>
-                                <p:column style="text-align: right;">
-                                    <f:facet name="footer">
-                                        <h:outputLabel  value="#{0-pharmacyController.grantTransferIssueQty}">
-                                            <f:convertNumber integerOnly="true" />
-                                        </h:outputLabel>
-                                    </f:facet>
-                                </p:column>
-                                <p:column style="text-align: right;">
-                                    <f:facet name="footer">
-                                        <h:outputLabel  value="#{0-pharmacyController.grantTransferIssueValue}">
-                                            <f:convertNumber  pattern="#,##0.00" />
-                                        </h:outputLabel>
-                                    </f:facet>
-                                </p:column>
-                            </p:row>
-                        </p:columnGroup>
+                            <p:column class="text-end"> 
+                                <h:outputLabel value="#{p.dblValue}" ></h:outputLabel> 
+                            </p:column> 
 
-                    </p:dataTable>                
-                </p:tab>
-                <p:tab 
-                    id="itemDetailsTabTransferReceive"
-                    title="Transfer Receive"
-                    rendered="#{configOptionApplicationController.getBooleanValueByKey('Pharmacy Item Details Section - Display Transfer Receive Tab', true)}">
-                    <p:dataTable styleClass="noBorder" id="trRceive" 
-                                 value="#{pharmacyController.institutionTransferReceive}" var="ins">
-                        <p:columnGroup type="header">
-                            <p:row>
-                                <p:column >
-                                    <f:facet name="header">
-                                        From Department Name
-                                    </f:facet>
-                                </p:column>
-                                <p:column >
-                                    <f:facet name="header">
-                                        Received Qty
-                                    </f:facet>
-                                </p:column>
-                                <p:column >
-                                    <f:facet name="header">
-                                        Received Value
-                                    </f:facet>
-                                </p:column>
-                            </p:row>
-                        </p:columnGroup>
-                        <p:subTable  value="#{ins.departmentSales}" var="dep">
-                            <f:facet name="header">
-                                #{ins.institution.name}
-                            </f:facet>
-                            <p:column>
-                                #{dep.department.name}
-                            </p:column>
-                            <p:column style="text-align: right;">
-                                <h:outputLabel value="#{dep.saleQtyAbs}"> 
-                                    <f:convertNumber integerOnly="true" />
-                                </h:outputLabel> 
-                            </p:column>
-                            <p:column style="text-align: right;">
-                                <h:outputLabel value="#{dep.saleValueAbs}"> 
-                                    <f:convertNumber  pattern="#,##0.00" />
-                                </h:outputLabel> 
-                            </p:column>
-                            <p:columnGroup type="footer">
-                                <p:row>
-                                    <p:column footerText="Total "></p:column>
-                                    <p:column style="text-align: right;" footerText="#{0-ins.institutionQty}">
-                                        <f:facet name="footer">
-                                            <h:outputLabel value="#{0-ins.institutionQty}">
-                                                <f:convertNumber integerOnly="true" />
-                                            </h:outputLabel>
-                                        </f:facet>
-                                    </p:column>
-                                    <p:column style="text-align: right;" footerText="#{0-ins.institutionValue}">
-                                        <f:facet name="footer">
-                                            <h:outputLabel value="#{0-ins.institutionValue}">
-                                                <f:convertNumber  pattern="#,##0.00" />
-                                            </h:outputLabel>
-                                        </f:facet>
-                                    </p:column>
-                                </p:row>
-                            </p:columnGroup>
-                        </p:subTable>  
-                        <p:columnGroup type="footer">
-                            <p:row>
-                                <p:column>
-                                    <f:facet name="footer">
-                                        Total Institution
-                                    </f:facet>
-                                </p:column>
-                                <p:column style="text-align: right;">
-                                    <f:facet name="footer">
-                                        <h:outputLabel  value="#{0-pharmacyController.grantTransferReceiveQty}">
-                                            <f:convertNumber integerOnly="true" />
-                                        </h:outputLabel>
-                                    </f:facet>
-                                </p:column>
-                                <p:column style="text-align: right;">
-                                    <f:facet name="footer">
-                                        <h:outputLabel  value="#{0-pharmacyController.grantTransferReceiveValue}">
-                                            <f:convertNumber  pattern="#,##0.00" />
-                                        </h:outputLabel>
-                                    </f:facet>
-                                </p:column>
-                            </p:row>
-                        </p:columnGroup>
-
-                    </p:dataTable>                
-                </p:tab>
-                <p:tab 
-                    id="itemDetailsTabConsuption"
-                    title="Department Issue" 
-                    rendered="#{configOptionApplicationController.getBooleanValueByKey('Pharmacy Item Details Section - Display Department Issue Tab', true)}">
-                    <p:dataTable styleClass="noBorder" id="depIssue"
-                                 value="#{pharmacyController.institutionIssue}" var="ins">
-                        <p:columnGroup type="header">
-                            <p:row>
-                                <p:column >
-                                    <f:facet name="header">
-                                        To Department Name
-                                    </f:facet>
-                                </p:column>
-                                <p:column >
-                                    <f:facet name="header">
-                                        Sent Qty
-                                    </f:facet>
-                                </p:column>
-                                <p:column >
-                                    <f:facet name="header">
-                                        Sent Value
-                                    </f:facet>
-                                </p:column>
-                            </p:row>
-                        </p:columnGroup>
-                        <p:subTable  value="#{ins.departmentSales}" var="dep">
-                            <f:facet name="header">
-                                #{ins.institution.name}
-                            </f:facet>
-                            <p:column>
-                                #{dep.department.name}
-                            </p:column>
-                            <p:column style="text-align: right;">
-                                <h:outputLabel value="#{dep.saleQtyAbs}">    
-                                    <f:convertNumber integerOnly="true" />
-                                </h:outputLabel> 
-                            </p:column>
-                            <p:column style="text-align: right;">
-                                <h:outputLabel value="#{dep.saleValueAbs}">    
-                                    <f:convertNumber  pattern="#,##0.00" />
-                                </h:outputLabel> 
-                            </p:column>
-                            <p:columnGroup type="footer">
-                                <p:row>
-                                    <p:column footerText="Total "></p:column>
-                                    <p:column style="text-align: right;" footerText="#{ins.institutionQty}">
-                                        <f:facet name="footer">
-                                            <h:outputLabel value="#{0-ins.institutionQty}">
-                                                <f:convertNumber integerOnly="true" />
-                                            </h:outputLabel>
-                                        </f:facet>
-                                    </p:column>
-                                    <p:column style="text-align: right;" footerText="#{ins.institutionValue}">
-                                        <f:facet name="footer">
-                                            <h:outputLabel value="#{0-ins.institutionValue}">
-                                                <f:convertNumber  pattern="#,##0.00" />
-                                            </h:outputLabel>
-                                        </f:facet>
-                                    </p:column>
-                                </p:row>
-                            </p:columnGroup>
-                        </p:subTable>  
-                        <p:columnGroup type="footer">
-                            <p:row>
-                                <p:column>
-                                    <f:facet name="footer">
-                                        Total Institution
-                                    </f:facet>
-                                </p:column>
-                                <p:column style="text-align: right;">
-                                    <f:facet name="footer">
-                                        <h:outputLabel  value="#{0-pharmacyController.grantIssueQty}">
-                                            <f:convertNumber integerOnly="true" />
-                                        </h:outputLabel>
-                                    </f:facet>
-                                </p:column>
-                                <p:column style="text-align: right;">
-                                    <f:facet name="footer">
-                                        <h:outputLabel  value="#{0-pharmacyController.grantIssueValue}">
-                                            <f:convertNumber  pattern="#,##0.00" />
-                                        </h:outputLabel>
-                                    </f:facet>
-                                </p:column>
-                            </p:row>
-                        </p:columnGroup>
-
-                    </p:dataTable>                
-                </p:tab>
-                <p:tab 
-                    id="itemDetailsTabGrn"
-                    title="GRN" 
-                    rendered="#{configOptionApplicationController.getBooleanValueByKey('Pharmacy Item Details Section - Display GRN Tab', true)}">
-
-                    <p:dataTable styleClass="noBorder" id="grn" value="#{pharmacyController.grnDtos}"
-                                 var="dd2" scrollable="true"  paginator="true"
-                                 rows="10"
-                                 paginatorPosition="bottom"
-                                 paginatorTemplate="{CurrentPageReport}  {FirstPageLink} {PreviousPageLink} {PageLinks} {NextPageLink} {LastPageLink} {RowsPerPageDropdown}"
-                                 rowsPerPageTemplate="5,10,15" >
-                        <p:column headerText="GRN No">
-                            #{dd2.grnNo}
-                        </p:column>
-                        <p:column headerText="Department">
-                            #{dd2.departmentName}
-                        </p:column>
-                        <p:column headerText="Date">
-                            <h:outputLabel value="#{dd2.createdAt}" >
-                                <f:convertDateTime  timeZone="Asia/Colombo" pattern="#{sessionController.applicationPreference.longDateFormat}" ></f:convertDateTime>
-                            </h:outputLabel>
-                        </p:column>
-                        <p:column headerText="PO No">
-                            <h:outputText value="#{dd2.poNo}" />
-                        </p:column>
-                        <p:column headerText="Supplier">
-                            <h:outputText value="#{dd2.supplierName}" />
-                        </p:column>
-                        <p:column headerText="Item">
-                            <h:outputText value="#{dd2.itemName}" />
-                        </p:column>
-                        <p:column headerText="Qty">
-                            <h:outputText value="#{dd2.quantity}" />
-                        </p:column>
-                        <p:column headerText="Fr. Qty">
-                            <h:outputText value="#{dd2.freeQuantity}" />
-                        </p:column>
-                        <p:column headerText="Purchase Rate">
-                            <h:outputText value="#{dd2.purchaseRate}">
-                                <f:convertNumber pattern="#,##0.00" />
-                            </h:outputText>
-                        </p:column>
-                        <p:column headerText="Cost Rate per unit">
-                            <h:outputText value="#{dd2.totalCostRate}">
-                                <f:convertNumber pattern="#,##0.00" />
-                            </h:outputText>
-                        </p:column>
-                        <p:column headerText="Sale Rate">
-                            <h:outputText value="#{dd2.retailSaleRate}">
-                                <f:convertNumber pattern="#,##0.00" />
-                            </h:outputText>
-                        </p:column>
-                        <p:column headerText="Value">
-                            <h:outputText value="#{dd2.netTotal}">
-                                <f:convertNumber pattern="#,##0.00" />
-                            </h:outputText>
-                        </p:column>
-
-                    </p:dataTable>
-                </p:tab>
-
-                <p:tab 
-                    id="itemDetailsTabPendingGrn"
-                    title="Pending GRN" 
-                    rendered="#{configOptionApplicationController.getBooleanValueByKey('Pharmacy Item Details Section - Display Pending GRN Tab', true)}">
-                    <p:dataTable 
-                        id="pendinggrn" 
-                        value="#{pharmacyController.pendingGrns}"
-                        var="pendingGrnRow" scrollable="true"  paginator="true"
-                        rows="10"
-                        paginatorPosition="bottom"
-                        paginatorTemplate="{CurrentPageReport}  {FirstPageLink} {PreviousPageLink} {PageLinks} {NextPageLink} {LastPageLink} {RowsPerPageDropdown}"
-                        rowsPerPageTemplate="5,10,15" >
-
-                        <p:column headerText="PO Number">
-                            #{pendingGrnRow.bill.deptId}
-                        </p:column>
-                        <p:column headerText="Department">
-                            #{pendingGrnRow.bill.department.name}
-                        </p:column>
-                        <p:column headerText="Date">
-                            <h:outputLabel value="#{pendingGrnRow.bill.createdAt}" >
-                                <f:convertDateTime  timeZone="Asia/Colombo" pattern="#{sessionController.applicationPreference.longDateFormat}" />
-                            </h:outputLabel>
-                        </p:column>
-                        <p:column headerText="Supplier">
-                            #{pendingGrnRow.bill.toInstitution.name}
-                        </p:column>
-                        <p:column headerText="Item">
-                            #{pendingGrnRow.item.name}
-                        </p:column>
-                        <p:column headerText="Qty">
-                            #{pendingGrnRow.qty}
-                        </p:column>
-                    </p:dataTable>
-
-                </p:tab>
-
-                <p:tab
-                    title="GRN Return"
-                    id="itemDetailsTabGrnReturn"
-                    rendered="#{configOptionApplicationController.getBooleanValueByKey('Pharmacy Item Details Section - Display GRN Return Tab', true)}">
-
-                    <p:dataTable styleClass="noBorder" id="grnr" value="#{pharmacyController.grnReturnDtos}"
-                                 var="dd2" scrollable="true" paginator="true"
-                                 rows="10"
-                                 paginatorPosition="bottom"
-                                 paginatorTemplate="{CurrentPageReport}  {FirstPageLink} {PreviousPageLink} {PageLinks} {NextPageLink} {LastPageLink} {RowsPerPageDropdown}"
-                                 rowsPerPageTemplate="5,10,15" >
-                        <p:column headerText="GRN Return No">
-                            #{dd2.grnReturnNo}
-                        </p:column>
-                        <p:column headerText="Department">
-                            #{dd2.departmentName}
-                        </p:column>
-                        <p:column headerText="GRN Return at">
-                            <h:outputLabel value="#{dd2.createdAt}">
-                                <f:convertDateTime timeZone="Asia/Colombo" pattern="#{sessionController.applicationPreference.longDateFormat}" />
-                            </h:outputLabel>
-                        </p:column>
-                        <p:column headerText="Supplier">
-                            #{dd2.supplierName}
-                        </p:column>
-                        <p:column headerText="Item">
-                            #{dd2.itemName}
-                        </p:column>
-                        <p:column headerText="Qty Returned">
-                            #{dd2.quantityReturned}
-                        </p:column>
-                        <p:column headerText="Free Qty Returned">
-                            #{dd2.freeQuantityReturned}
-                        </p:column>
-                        <p:column headerText="Purchase Rate">
-                            <h:outputText value="#{dd2.purchaseRate}">
-                                <f:convertNumber pattern="#,##0.00" />
-                            </h:outputText>
-                        </p:column>
-                        <p:column headerText="Sale Rate">
-                            <h:outputText value="#{dd2.saleRate}">
-                                <f:convertNumber pattern="#,##0.00" />
-                            </h:outputText>
-                        </p:column>
-                        <p:column headerText="Returned Rate">
-                            <h:outputText value="#{dd2.returnedRate}">
-                                <f:convertNumber pattern="#,##0.00" />
-                            </h:outputText>
-                        </p:column>
-                        <p:column headerText="Return Value">
-                            <h:outputText value="#{dd2.returnValue}">
-                                <f:convertNumber pattern="#,##0.00" />
-                            </h:outputText>
-                        </p:column>
-                    </p:dataTable>
-                </p:tab>
-
-                <p:tab title="Purchase Orders" rendered="#{configOptionApplicationController.getBooleanValueByKey('Pharmacy Item Details Section - Display Purchase Orders Tab', true)}">
-
-                    <p:dataTable styleClass="noBorder" id="po" value="#{pharmacyController.pos}" var="dd3" 
-                                 rows="10" 
-                                 paginator="true"
-                                 paginatorPosition="bottom"
-                                 paginatorTemplate="{CurrentPageReport}  {FirstPageLink} {PreviousPageLink} {PageLinks} {NextPageLink} {LastPageLink} {RowsPerPageDropdown}"
-                                 rowsPerPageTemplate="5,10,15" >
-                        <p:column headerText="Order Number">
-                            #{dd3.bill.deptId}
-                        </p:column>
-                        <p:column headerText="Order Department">
-                            #{dd3.bill.department.name}
-                        </p:column>
-                        <p:column headerText="Order at">
-                            <p:outputLabel value="#{dd3.bill.createdAt}">
-                                <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateFormat}" />
-                            </p:outputLabel>
-                        </p:column>
-                        <p:column headerText="Supplier">
-                            #{dd3.bill.toInstitution.name}
-                        </p:column>
-                        <p:column headerText="Item">
-                            #{dd3.item.name}
-                        </p:column>
-                        <p:column headerText="Qty Ordered">
-                            <h:outputText value="#{dd3.pharmaceuticalBillItem.qty}">
-                                <f:convertNumber integerOnly="true" />
-                            </h:outputText>
-                        </p:column>
-                        <p:column headerText="Free Qty Ordered">
-                            <h:outputText value="#{dd3.pharmaceuticalBillItem.freeQty}">
-                                <f:convertNumber integerOnly="true" />
-                            </h:outputText>
-                        </p:column>
-                    </p:dataTable>
-                </p:tab>
-
-                <p:tab title="Pending PO" rendered="#{configOptionApplicationController.getBooleanValueByKey('Pharmacy Item Details Section - Display Pending PO Tab', true)}">
-
-                    <p:dataTable styleClass="noBorder" id="ppo" value="#{pharmacyController.pos}" var="dd3"
-                                 rows="10"
-                                 paginator="true"
-                                 paginatorPosition="bottom"
-                                 paginatorTemplate="{CurrentPageReport}  {FirstPageLink} {PreviousPageLink} {PageLinks} {NextPageLink} {LastPageLink} {RowsPerPageDropdown}"
-                                 rowsPerPageTemplate="5,10,15" >
-                        <p:column headerText="Po No">
-                            #{dd3.bill.deptId}
-                        </p:column>
-                        <p:column headerText="PO Date">
-                            <p:outputLabel value="#{dd3.bill.createdAt}" >
-                                <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateFormat}"></f:convertDateTime>
-                            </p:outputLabel>
-                        </p:column>
-                        <p:column headerText="Supplier">
-                            #{dd3.bill.toInstitution.name}
-                        </p:column>
-                        <p:column headerText="PO Qty">
-                            #{dd3.pharmaceuticalBillItem.qty}
-                        </p:column>
-                        <p:column headerText="Requested By">
-                            #{dd3.totalGrnQty}
-                        </p:column>
-                        <p:column headerText="Status">
-                            #{dd3.totalGrnQty}
-                        </p:column>
-                    </p:dataTable>
-                </p:tab>
-
-                <p:tab title="Direct Purchase" rendered="#{configOptionApplicationController.getBooleanValueByKey('Pharmacy Item Details Section - Display Direct Purchase Tab', true)}">
-
-                    <p:dataTable 
-                        styleClass="noBorder" 
-                        id="tblDirectPurchase" 
-                        value="#{pharmacyController.directPurchaseDtos}" var="dd3"
-                        rows="10" 
-                        paginator="true"
-                        paginatorPosition="bottom"
-                        paginatorTemplate="{CurrentPageReport}  {FirstPageLink} {PreviousPageLink} {PageLinks} {NextPageLink} {LastPageLink} {RowsPerPageDropdown}"
-                        rowsPerPageTemplate="5,10,15">
-                        <p:column headerText="Bill No">
-                            #{dd3.billDeptId}
-                        </p:column>
-                        <p:column headerText="Supplier">
-                            #{dd3.billFromInstitutionName}
-                        </p:column>
-                        <p:column headerText="Billed By">
-                            #{dd3.billCreaterName}
-                        </p:column>    
-                        <p:column headerText="Billed At">
-                            <p:outputLabel value="#{dd3.billCreatedAt}" >
-                                <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateFormat}"></f:convertDateTime>
-                            </p:outputLabel>
-                        </p:column> 
-                        <p:column headerText="Purchase Rate">
-                            #{dd3.purchaseRate}
-                        </p:column>    
-                        <p:column headerText="Sale Rate">
-                            #{dd3.retailRate}
-                        </p:column>    
-                        <p:column headerText="Purchase Qty">
-                            #{dd3.qty}
-                        </p:column>    
-                        <p:column headerText="Free Qty">
-                            #{dd3.freeQty}
-                        </p:column>    
-                        <p:column headerText="Purchase Value">
-                            #{-dd3.billNetTotal}
-                        </p:column> 
-                    </p:dataTable>
-                </p:tab>
-                <p:tab title="Pack Sizes" rendered="#{configOptionApplicationController.getBooleanValueByKey('Pharmacy Item Details Section - Display Pack Sizes Tab', true)}">
-                    <p:dataTable value="#{pharmacyController.ampps}" var="p" >
-                        <p:column>
-                            <h:outputLabel value="#{p.name}" ></h:outputLabel>
-                        </p:column>
-                        <p:column>
-                            <h:outputLabel value="#{p.dblValue}" ></h:outputLabel>
-                        </p:column>
-
-                    </p:dataTable>
-                </p:tab>
-            </p:tabView>
+                        </p:dataTable>
+                    </p:tab>
+                </p:tabView>
+            </h:panelGroup>
         </p:panel>
 
     </cc:implementation>

--- a/src/main/webapp/resources/pharmacy/history.xhtml
+++ b/src/main/webapp/resources/pharmacy/history.xhtml
@@ -600,6 +600,7 @@
                     class="w-100"  
                     activeIndex="0" 
                     style="border: 1px solid lightgray; padding: 10px;">
+                    
                     <p:tab 
                         title="Stock" 
                         id="itemDetailsTabStocks"
@@ -666,6 +667,7 @@
                         </p:panel>
 
                     </p:tab>
+                    
                     <p:tab 
                         title="Sale" 
                         id="itemDetailsTabSales"
@@ -753,6 +755,7 @@
 
                         </p:dataTable>                
                     </p:tab>
+                    
                     <p:tab 
                         id="itemDetailsTabSaleItems"
                         title="Sale Bill Item" 
@@ -798,6 +801,7 @@
 
                         </p:dataTable>
                     </p:tab>
+                    
                     <p:tab 
                         id="itemDetailsTabWholesale"
                         title="Whole Sale" rendered="#{configOptionApplicationController.getBooleanValueByKey('Pharmacy Item Details Section - Display Whole Sale Tab', true)}">
@@ -884,6 +888,7 @@
 
                         </p:dataTable>                
                     </p:tab>
+                    
                     <p:tab 
                         id="itemDetailsTabInpatient"
                         title="BHT Issue"
@@ -971,6 +976,7 @@
 
                         </p:dataTable>                
                     </p:tab>
+                    
                     <p:tab 
                         id="itemDetailsTabTransferIssue"
                         title="Transfer Issue" 
@@ -1058,6 +1064,7 @@
 
                         </p:dataTable>                
                     </p:tab>
+                    
                     <p:tab 
                         id="itemDetailsTabTransferReceive"
                         title="Transfer Receive"
@@ -1146,6 +1153,7 @@
 
                         </p:dataTable>                
                     </p:tab>
+                    
                     <p:tab 
                         id="itemDetailsTabConsuption"
                         title="Department Issue" 
@@ -1234,6 +1242,7 @@
 
                         </p:dataTable>                
                     </p:tab>
+                    
                     <p:tab 
                         id="itemDetailsTabGrn"
                         title="GRN" 
@@ -1394,70 +1403,74 @@
                         <p:dataTable
                             styleClass="noBorder" 
                             id="tblPurchaseOrders"
-                            value="#{pharmacyController.pos}" var="dd3" 
+                            value="#{pharmacyController.poDtos}" var="poDto" 
                             rows="10" 
                             paginator="true"
                             paginatorPosition="bottom"
                             paginatorTemplate="{CurrentPageReport}  {FirstPageLink} {PreviousPageLink} {PageLinks} {NextPageLink} {LastPageLink} {RowsPerPageDropdown}"
                             rowsPerPageTemplate="5,10,15" >
                             <p:column headerText="Order Number">
-                                #{dd3.bill.deptId}
-                            </p:column>
-                            <p:column headerText="Order Department">
-                                #{dd3.bill.department.name}
+                                <p:outputLabel value="#{poDto.billDeptId}"></p:outputLabel>
                             </p:column>
                             <p:column headerText="Order at">
-                                <p:outputLabel value="#{dd3.bill.createdAt}">
-                                    <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateFormat}" />
+                                <p:outputLabel value="#{poDto.billCreatedAt}">
+                                    <f:convertDateTime pattern="#{sessionController.applicationPreference.shortDateFormat}" />
                                 </p:outputLabel>
                             </p:column>
                             <p:column headerText="Supplier">
-                                #{dd3.bill.toInstitution.name}
+                                <p:outputLabel value="#{poDto.supplierName}"></p:outputLabel>
                             </p:column>
                             <p:column headerText="Item">
-                                #{dd3.item.name}
+                                <p:outputLabel value="#{poDto.itemName}"></p:outputLabel>
                             </p:column>
                             <p:column headerText="Qty Ordered" class="text-end"> 
-                                <h:outputText value="#{dd3.pharmaceuticalBillItem.qty}"> 
-                                    <f:convertNumber integerOnly="true" /> 
+                                <h:outputText value="#{poDto.qty}"> 
                                 </h:outputText> 
                             </p:column> 
                             <p:column headerText="Free Qty Ordered" class="text-end"> 
-                                <h:outputText value="#{dd3.pharmaceuticalBillItem.freeQty}"> 
-                                    <f:convertNumber integerOnly="true" /> 
+                                <h:outputText value="#{poDto.freeQty}"> 
+                                </h:outputText> 
+                            </p:column> 
+                            <p:column headerText="Qty Received" class="text-end"> 
+                                <h:outputText value="#{poDto.completedQty}"> 
+                                </h:outputText> 
+                            </p:column> 
+                            <p:column headerText="Free Qty Received" class="text-end"> 
+                                <h:outputText value="#{poDto.completedFreeQty}"> 
                                 </h:outputText> 
                             </p:column> 
                         </p:dataTable>
                     </p:tab>
 
-                    <p:tab title="Pending PO" rendered="#{configOptionApplicationController.getBooleanValueByKey('Pharmacy Item Details Section - Display Pending PO Tab', true)}">
-
+                    <p:tab title="Pending POs" rendered="#{configOptionApplicationController.getBooleanValueByKey('Pharmacy Item Details Section - Display Pending PO Tab', true)}">
                         <p:dataTable 
-                            styleClass="noBorder" id="ppo" value="#{pharmacyController.pos}" var="dd3"
+                            styleClass="noBorder" 
+                            id="tablePendingPos" 
+                            value="#{pharmacyController.pendingPoDtos}" 
+                            var="pendingPo"
                             rows="10"
                             paginator="true"
                             paginatorPosition="bottom"
                             paginatorTemplate="{CurrentPageReport}  {FirstPageLink} {PreviousPageLink} {PageLinks} {NextPageLink} {LastPageLink} {RowsPerPageDropdown}"
                             rowsPerPageTemplate="5,10,15" >
-                            <p:column headerText="Po No">
-                                #{dd3.bill.deptId}
+                            <p:column headerText="PO No">
+                                #{pendingPo.billDeptId}
                             </p:column>
                             <p:column headerText="PO Date">
-                                <p:outputLabel value="#{dd3.bill.createdAt}" >
-                                    <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateFormat}"></f:convertDateTime>
+                                <p:outputLabel value="#{pendingPo.billCreatedAt}">
+                                    <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateFormat}"/>
                                 </p:outputLabel>
                             </p:column>
                             <p:column headerText="Supplier">
-                                #{dd3.bill.toInstitution.name}
+                                #{pendingPo.supplierName}
                             </p:column>
                             <p:column headerText="PO Qty" class="text-end"> 
-                                #{dd3.pharmaceuticalBillItem.qty} 
+                                <h:outputText value="#{pendingPo.qty}">
+                                    <f:convertNumber integerOnly="true" />
+                                </h:outputText>
                             </p:column> 
                             <p:column headerText="Requested By">
-                                #{dd3.totalGrnQty}
-                            </p:column>
-                            <p:column headerText="Status">
-                                #{dd3.totalGrnQty}
+                                #{pendingPo.creatorName}
                             </p:column>
                         </p:dataTable>
                     </p:tab>
@@ -1507,6 +1520,7 @@
                             </p:column>  
                         </p:dataTable>
                     </p:tab>
+                    
                     <p:tab title="Pack Sizes" rendered="#{configOptionApplicationController.getBooleanValueByKey('Pharmacy Item Details Section - Display Pack Sizes Tab', true)}">
                         <p:dataTable value="#{pharmacyController.ampps}" var="p" >
                             <p:column>

--- a/src/main/webapp/resources/pharmacy/history.xhtml
+++ b/src/main/webapp/resources/pharmacy/history.xhtml
@@ -1457,40 +1457,43 @@
 
                 <p:tab title="Direct Purchase" rendered="#{configOptionApplicationController.getBooleanValueByKey('Pharmacy Item Details Section - Display Direct Purchase Tab', true)}">
 
-                    <p:dataTable styleClass="noBorder" id="dp" value="#{pharmacyController.directPurchase}" var="dd3"
-                                 rows="10" 
-                                 paginator="true"
-                                 paginatorPosition="bottom"
-                                 paginatorTemplate="{CurrentPageReport}  {FirstPageLink} {PreviousPageLink} {PageLinks} {NextPageLink} {LastPageLink} {RowsPerPageDropdown}"
-                                 rowsPerPageTemplate="5,10,15">
+                    <p:dataTable 
+                        styleClass="noBorder" 
+                        id="tblDirectPurchase" 
+                        value="#{pharmacyController.directPurchaseDtos}" var="dd3"
+                        rows="10" 
+                        paginator="true"
+                        paginatorPosition="bottom"
+                        paginatorTemplate="{CurrentPageReport}  {FirstPageLink} {PreviousPageLink} {PageLinks} {NextPageLink} {LastPageLink} {RowsPerPageDropdown}"
+                        rowsPerPageTemplate="5,10,15">
                         <p:column headerText="Bill No">
-                            #{dd3.bill.deptId}
+                            #{dd3.billDeptId}
                         </p:column>
                         <p:column headerText="Supplier">
-                            #{dd3.bill.fromInstitution.name}
+                            #{dd3.billFromInstitutionName}
                         </p:column>
                         <p:column headerText="Billed By">
-                            #{dd3.bill.creater.webUserPerson.name}
+                            #{dd3.billCreaterName}
                         </p:column>    
                         <p:column headerText="Billed At">
-                            <p:outputLabel value="#{dd3.bill.createdAt}" >
+                            <p:outputLabel value="#{dd3.billCreatedAt}" >
                                 <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateFormat}"></f:convertDateTime>
                             </p:outputLabel>
                         </p:column> 
                         <p:column headerText="Purchase Rate">
-                            #{dd3.pharmaceuticalBillItem.purchaseRate}
+                            #{dd3.purchaseRate}
                         </p:column>    
                         <p:column headerText="Sale Rate">
-                            #{dd3.pharmaceuticalBillItem.retailRate}
+                            #{dd3.retailRate}
                         </p:column>    
                         <p:column headerText="Purchase Qty">
-                            #{dd3.pharmaceuticalBillItem.qty}
+                            #{dd3.qty}
                         </p:column>    
                         <p:column headerText="Free Qty">
-                            #{dd3.pharmaceuticalBillItem.freeQty}
+                            #{dd3.freeQty}
                         </p:column>    
                         <p:column headerText="Purchase Value">
-                            #{-dd3.netValue}
+                            #{-dd3.billNetTotal}
                         </p:column> 
                     </p:dataTable>
                 </p:tab>

--- a/src/main/webapp/resources/pharmacy/purchase_order_request_custom_1.xhtml
+++ b/src/main/webapp/resources/pharmacy/purchase_order_request_custom_1.xhtml
@@ -1,0 +1,158 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:cc="http://xmlns.jcp.org/jsf/composite"
+      xmlns:h="http://xmlns.jcp.org/jsf/html"
+      xmlns:p="http://primefaces.org/ui"
+      xmlns:f="http://xmlns.jcp.org/jsf/core"
+      xmlns:ui="http://xmlns.jcp.org/jsf/facelets">
+
+    <!-- INTERFACE -->
+    <cc:interface>
+        <cc:attribute name="bill" required="true" />
+        <cc:attribute name="billItems" required="true" />
+    </cc:interface>
+
+    <!-- IMPLEMENTATION -->
+    <cc:implementation>
+        <h:outputStylesheet library="css" name="pharmacyA4.css"/>
+
+        <div class="institutionName">
+            <h:outputLabel value="#{cc.attrs.bill.creater.institution.name}"/>
+        </div>
+        <div class="institutionContact" >
+            <div class="d-flex gap-2 justify-content-center">
+                <h:outputLabel value="#{cc.attrs.bill.creater.institution.address}" rendered="#{!empty cc.attrs.bill.creater.institution.address}"/>
+                <h:outputLabel value="Telephone : " rendered="#{!empty cc.attrs.bill.creater.institution.phone or !empty cc.attrs.bill.creater.department.telephone1}" />
+                <h:outputLabel value="#{cc.attrs.bill.creater.institution.phone}" rendered="#{!empty cc.attrs.bill.creater.institution.phone}"/>
+                <h:outputLabel value="/" style="width: 15px; text-align: center" rendered="#{cc.attrs.bill.creater.department.telephone1}"/>
+                <h:outputLabel value="#{cc.attrs.bill.creater.department.telephone1}" rendered="#{!empty cc.attrs.bill.creater.department.telephone1}"/>
+            </div>
+            <div >
+                <h:outputLabel value="Fax : &nbsp;&nbsp;&nbsp;&nbsp;#{cc.attrs.bill.creater.institution.fax}" rendered="#{!empty cc.attrs.bill.creater.institution.fax}"/>
+            </div>
+            <div >
+                <h:outputLabel value="Email : &nbsp;" rendered="#{!empty cc.attrs.bill.creater.department.email}"/>
+                <h:outputLabel value="#{cc.attrs.bill.creater.department.email}" rendered="#{!empty cc.attrs.bill.creater.department.email}"/>
+            </div>
+        </div>
+        <div class="headingBill">
+            <h:outputLabel value="Purchase Order Request" style="text-decoration: underline;"/>
+        </div>
+        <div class="purchase-order">
+            <h:panelGrid columns="6" class="my-2 w-100">
+                <h:outputLabel value="Order No" />
+                <h:outputLabel value=":" style="width: 15px; text-align: center"/>
+                <h:outputLabel value="#{cc.attrs.bill.deptId}" />
+                <h:outputLabel value="Order Department" />
+                <h:outputLabel value=":" style="width: 15px; text-align: center"/>
+                <h:outputLabel value="#{cc.attrs.bill.department.name}" />
+                <h:outputLabel value="Supplier" />
+                <h:outputLabel value=":" style="width: 15px; text-align: center"/>
+                <h:outputLabel value="#{cc.attrs.bill.toInstitution.name}" />
+                <h:outputLabel value="Supplier Code" />
+                <h:outputLabel value=":" style="width: 15px; text-align: center"/>
+                <h:outputLabel value="#{cc.attrs.bill.toInstitution.code}" />
+                <h:outputLabel value="Supplier Phone" />
+                <h:outputLabel value=":" style="width: 15px; text-align: center"/>
+                <h:outputLabel value="#{cc.attrs.bill.toInstitution.phone}" />
+                <h:outputLabel value="Supplier Address" />
+                <h:outputLabel value=":" style="width: 15px; text-align: center"/>
+                <h:outputLabel value="#{cc.attrs.bill.toInstitution.address}" />
+
+                <h:outputLabel value="Payment Method" />
+                <h:outputLabel value=":" style="width: 15px; text-align: center"/>
+                <h:outputLabel value="#{cc.attrs.bill.paymentMethod}" />
+                <h:outputLabel value="Consignment" />
+                <h:outputLabel value=":" style="width: 15px; text-align: center"/>
+                <h:outputLabel value="#{cc.attrs.bill.consignment ? 'Yes' : 'No'}" />
+            </h:panelGrid>
+        </div>
+        <table style="border-collapse: collapse; width: 100%; border: 1px solid black;">
+            <thead>
+                <tr style="border: 1px solid black;">
+                    <th style="border: 1px solid black;">Item Code</th>
+                    <th style="border: 1px solid black;">Item Name</th>
+                    <th style="border: 1px solid black;">Qty</th>
+                    <th style="border: 1px solid black;">Free Qty</th>
+                    <th style="border: 1px solid black;">Purchase Rate</th>
+                    <th style="border: 1px solid black;">Purchase Value</th>
+                </tr>
+            </thead>
+            <tbody>
+                <ui:repeat value="#{cc.attrs.billItems}" var="bi">
+                    <h:panelGroup rendered="#{not bi.retired}" >
+                        <tr style="border: 1px solid black;">
+                            <td style="border: 1px solid black;"><h:outputLabel value="#{bi.item.code}"/></td>
+                            <td style="border: 1px solid black;"><h:outputLabel value="#{bi.item.name}"/></td>
+                            <td style="text-align: right; border: 1px solid black;">
+                                <h:outputLabel value="#{bi.billItemFinanceDetails.quantity}">
+                                    <f:convertNumber pattern="#,##0"/>
+                                </h:outputLabel>
+                            </td>
+                            <td style="text-align: right; border: 1px solid black;">
+                                <h:outputLabel value="#{bi.billItemFinanceDetails.freeQuantity}">
+                                    <f:convertNumber pattern="#,##0"/>
+                                </h:outputLabel>
+                            </td>
+                            <td style="text-align: right; border: 1px solid black;">
+                                <h:outputLabel value="#{bi.billItemFinanceDetails.lineGrossRate}">
+                                    <f:convertNumber pattern="#,##0.00"/>
+                                </h:outputLabel>
+                            </td>
+                            <td style="text-align: right; border: 1px solid black;">
+                                <h:outputLabel value="#{bi.netValue}">
+                                    <f:convertNumber pattern="#,##0.00"/>
+                                </h:outputLabel>
+                            </td>
+                        </tr>
+                    </h:panelGroup>
+                </ui:repeat>
+            </tbody>
+            <tfoot>
+                <tr style="border: 1px solid black; font-weight: bold;">
+                    <td colspan="5" style="text-align: right; border: 1px solid black;">Net Total &nbsp;</td>
+                    <td style="text-align: right; border: 1px solid black;">
+                        <h:outputText value="#{cc.attrs.bill.netTotal}">
+                            <f:convertNumber pattern="#,##0.00"/>
+                        </h:outputText>
+                    </td>
+                </tr>
+            </tfoot>
+        </table>
+        <br/>
+        <div class="purchase-order">
+            <div>
+                <h:outputLabel value="Order Initiated By"/>
+                <h:outputLabel value=":" style="width: 15px; text-align: center"/>
+                <h:outputLabel value="#{cc.attrs.bill.creater.webUserPerson.name}"/>
+            </div>
+            <div>
+                <h:outputLabel value="Order Finalized By"/>
+                <h:outputLabel value=":" style="width: 15px; text-align: center"/>
+                #{cc.attrs.bill.checkedBy.name}
+            </div>
+            <div>
+                <h:outputLabel value="Order Finalized At"/>
+                <h:outputLabel value=":" style="width: 15px; text-align: center"/>
+                <h:outputLabel value="#{cc.attrs.bill.checkeAt}">
+                    <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateTimeFormat}"/>
+                </h:outputLabel>
+            </div>
+            <div>
+                <h:outputLabel value="Printed At"/>
+                <h:outputLabel value=":" style="width: 15px; text-align: center"/>
+                <h:outputLabel value="#{sessionController.currentDate}">
+                    <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateTimeFormat}"/>
+                </h:outputLabel>
+            </div>
+            <div>
+                <h:outputLabel value="Total"/>
+                <h:outputLabel value=":" style="width: 15px; text-align: center"/>
+                <h:outputLabel value="#{cc.attrs.bill.netTotal}">
+                    <f:convertNumber pattern="#,##0.00"/>
+                </h:outputLabel>
+            </div>
+        </div>
+    </cc:implementation>
+</html>

--- a/src/main/webapp/resources/pharmacy/purchase_order_request_custom_2.xhtml
+++ b/src/main/webapp/resources/pharmacy/purchase_order_request_custom_2.xhtml
@@ -1,0 +1,163 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:cc="http://xmlns.jcp.org/jsf/composite"
+      xmlns:h="http://xmlns.jcp.org/jsf/html"
+      xmlns:p="http://primefaces.org/ui"
+      xmlns:f="http://xmlns.jcp.org/jsf/core"
+      xmlns:ui="http://xmlns.jcp.org/jsf/facelets">
+
+    <!-- INTERFACE -->
+    <cc:interface>
+        <cc:attribute name="bill" required="true" />
+        <cc:attribute name="billItems" required="true" />
+    </cc:interface>
+
+    <!-- IMPLEMENTATION -->
+    <cc:implementation>
+        <h:outputStylesheet library="css" name="pharmacyA4.css"/>
+
+        <div class="institutionName">
+            <h:outputLabel value="#{cc.attrs.bill.creater.institution.name}"/>
+        </div>
+        <div class="institutionContact" >
+            <div class="d-flex gap-2 justify-content-center">
+                <h:outputLabel value="#{cc.attrs.bill.creater.institution.address}" rendered="#{!empty cc.attrs.bill.creater.institution.address}"/>
+                <h:outputLabel value="Telephone : " rendered="#{!empty cc.attrs.bill.creater.institution.phone or !empty cc.attrs.bill.creater.department.telephone1}" />
+                <h:outputLabel value="#{cc.attrs.bill.creater.institution.phone}" rendered="#{!empty cc.attrs.bill.creater.institution.phone}"/>
+                <h:outputLabel value="/" style="width: 15px; text-align: center" rendered="#{cc.attrs.bill.creater.department.telephone1}"/>
+                <h:outputLabel value="#{cc.attrs.bill.creater.department.telephone1}" rendered="#{!empty cc.attrs.bill.creater.department.telephone1}"/>
+            </div>
+            <div >
+                <h:outputLabel value="Fax : &nbsp;&nbsp;&nbsp;&nbsp;#{cc.attrs.bill.creater.institution.fax}" rendered="#{!empty cc.attrs.bill.creater.institution.fax}"/>
+            </div>
+            <div >
+                <h:outputLabel value="Email : &nbsp;" rendered="#{!empty cc.attrs.bill.creater.department.email}"/>
+                <h:outputLabel value="#{cc.attrs.bill.creater.department.email}" rendered="#{!empty cc.attrs.bill.creater.department.email}"/>
+            </div>
+        </div>
+
+        <div class="headingBill">
+            <h:outputLabel value="Purchase Order Request" style="text-decoration: underline;"/>
+        </div>
+
+        <div class="purchase-order">
+            <h:panelGrid columns="6" class="my-2 w-100">
+                <h:outputLabel value="Order No" />
+                <h:outputLabel value=":" style="width: 15px; text-align: center"/>
+                <h:outputLabel value="#{cc.attrs.bill.deptId}" />
+                <h:outputLabel value="Order Department" />
+                <h:outputLabel value=":" style="width: 15px; text-align: center"/>
+                <h:outputLabel value="#{cc.attrs.bill.department.name}" />
+                <h:outputLabel value="Supplier" />
+                <h:outputLabel value=":" style="width: 15px; text-align: center"/>
+                <h:outputLabel value="#{cc.attrs.bill.toInstitution.name}" />
+                <h:outputLabel value="Supplier Code" />
+                <h:outputLabel value=":" style="width: 15px; text-align: center"/>
+                <h:outputLabel value="#{cc.attrs.bill.toInstitution.code}" />
+                <h:outputLabel value="Supplier Phone" />
+                <h:outputLabel value=":" style="width: 15px; text-align: center"/>
+                <h:outputLabel value="#{cc.attrs.bill.toInstitution.phone}" />
+                <h:outputLabel value="Supplier Address" />
+                <h:outputLabel value=":" style="width: 15px; text-align: center"/>
+                <h:outputLabel value="#{cc.attrs.bill.toInstitution.address}" />
+
+                <h:outputLabel value="Payment Method" />
+                <h:outputLabel value=":" style="width: 15px; text-align: center"/>
+                <h:outputLabel value="#{cc.attrs.bill.paymentMethod}" />
+                <h:outputLabel value="Consignment" />
+                <h:outputLabel value=":" style="width: 15px; text-align: center"/>
+                <h:outputLabel value="#{cc.attrs.bill.consignment ? 'Yes' : 'No'}" />
+            </h:panelGrid>
+        </div>
+
+        <table style="border-collapse: collapse; width: 100%; border: 1px solid black;">
+            <thead>
+                <tr style="border: 1px solid black;">
+                    <th style="border: 1px solid black;">Item Code</th>
+                    <th style="border: 1px solid black;">Item Name</th>
+                    <th style="border: 1px solid black;">Qty</th>
+                    <th style="border: 1px solid black;">Free Qty</th>
+                    <th style="border: 1px solid black;">Purchase Rate</th>
+                    <th style="border: 1px solid black;">Purchase Value</th>
+                </tr>
+            </thead>
+            <tbody>
+                <ui:repeat value="#{cc.attrs.billItems}" var="bi">
+                    <h:panelGroup rendered="#{not bi.retired}" >
+                        <tr style="border: 1px solid black;">
+                            <td style="border: 1px solid black;"><h:outputLabel value="#{bi.item.code}"/></td>
+                            <td style="border: 1px solid black;"><h:outputLabel value="#{bi.item.name}"/></td>
+                            <td style="text-align: right; border: 1px solid black;">
+                                <h:outputLabel value="#{bi.billItemFinanceDetails.quantity}">
+                                    <f:convertNumber pattern="#,##0"/>
+                                </h:outputLabel>
+                            </td>
+                            <td style="text-align: right; border: 1px solid black;">
+                                <h:outputLabel value="#{bi.billItemFinanceDetails.freeQuantity}">
+                                    <f:convertNumber pattern="#,##0"/>
+                                </h:outputLabel>
+                            </td>
+                            <td style="text-align: right; border: 1px solid black;">
+                                <h:outputLabel value="#{bi.billItemFinanceDetails.lineGrossRate}">
+                                    <f:convertNumber pattern="#,##0.00"/>
+                                </h:outputLabel>
+                            </td>
+                            <td style="text-align: right; border: 1px solid black;">
+                                <h:outputLabel value="#{bi.netValue}">
+                                    <f:convertNumber pattern="#,##0.00"/>
+                                </h:outputLabel>
+                            </td>
+                        </tr>
+                    </h:panelGroup>
+                </ui:repeat>
+            </tbody>
+            <tfoot>
+                <tr style="border: 1px solid black; font-weight: bold;">
+                    <td colspan="5" style="text-align: right; border: 1px solid black;">Net Total &nbsp;</td>
+                    <td style="text-align: right; border: 1px solid black;">
+                        <h:outputText value="#{cc.attrs.bill.netTotal}">
+                            <f:convertNumber pattern="#,##0.00"/>
+                        </h:outputText>
+                    </td>
+                </tr>
+            </tfoot>
+        </table>
+
+        <br/>
+
+        <div class="purchase-order">
+            <div>
+                <h:outputLabel value="Order Initiated By"/>
+                <h:outputLabel value=":" style="width: 15px; text-align: center"/>
+                <h:outputLabel value="#{cc.attrs.bill.creater.webUserPerson.name}"/>
+            </div>
+            <div>
+                <h:outputLabel value="Order Finalized By"/>
+                <h:outputLabel value=":" style="width: 15px; text-align: center"/>
+                #{cc.attrs.bill.checkedBy.name}
+            </div>
+            <div>
+                <h:outputLabel value="Order Finalized At"/>
+                <h:outputLabel value=":" style="width: 15px; text-align: center"/>
+                <h:outputLabel value="#{cc.attrs.bill.checkeAt}">
+                    <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateTimeFormat}"/>
+                </h:outputLabel>
+            </div>
+            <div>
+                <h:outputLabel value="Printed At"/>
+                <h:outputLabel value=":" style="width: 15px; text-align: center"/>
+                <h:outputLabel value="#{sessionController.currentDate}">
+                    <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateTimeFormat}"/>
+                </h:outputLabel>
+            </div>
+            <div>
+                <h:outputLabel value="Total"/>
+                <h:outputLabel value=":" style="width: 15px; text-align: center"/>
+                <h:outputLabel value="#{cc.attrs.bill.netTotal}">
+                    <f:convertNumber pattern="#,##0.00"/>
+                </h:outputLabel>
+            </div>
+        </div>
+    </cc:implementation>
+</html>

--- a/tmp_bill1.txt
+++ b/tmp_bill1.txt
@@ -1,0 +1,259 @@
+ * Dr M H B Ariyaratne
+ * buddhika.ari@gmail.com
+ */
+package com.divudi.core.entity;
+
+import com.divudi.core.data.BillClassType;
+import com.divudi.core.data.BillType;
+import com.divudi.core.data.BillTypeAtomic;
+import static com.divudi.core.data.BillTypeAtomic.PHARMACY_GRN_RETURN;
+import com.divudi.core.data.IdentifiableWithNameOrCode;
+import com.divudi.core.data.PaymentMethod;
+import com.divudi.core.data.inward.SurgeryBillType;
+import com.divudi.core.data.lab.PatientInvestigationStatus;
+import com.divudi.core.entity.cashTransaction.CashTransaction;
+import com.divudi.core.entity.hr.BankAccount;
+import com.divudi.core.entity.membership.MembershipScheme;
+import com.divudi.core.entity.pharmacy.StockVarientBillItem;
+import java.io.Serializable;
+import java.lang.reflect.Field;
+import java.text.DateFormat;
+import java.text.DecimalFormat;
+import java.text.SimpleDateFormat;
+import java.util.*;
+import javax.persistence.CascadeType;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.Inheritance;
+import javax.persistence.Lob;
+import javax.persistence.ManyToOne;
+import javax.persistence.OneToMany;
+import javax.persistence.OneToOne;
+import javax.persistence.OrderBy;
+import javax.persistence.Temporal;
+import javax.persistence.Transient;
+
+import static com.divudi.core.util.CommonFunctions.formatDate;
+import javax.persistence.JoinColumn;
+
+/**
+ * @author buddhika
+ */
+@Entity
+@Inheritance
+public class Bill implements Serializable, RetirableEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO)
+    Long id;
+
+    static final long serialVersionUID = 1L;
+
+    @ManyToOne
+    private Item item;
+    @ManyToOne
+    private MembershipScheme membershipScheme;
+    @Deprecated
+    @OneToOne
+    private CashTransaction cashTransaction;
+    @OneToMany(mappedBy = "bill", fetch = FetchType.LAZY)
+    private List<StockVarientBillItem> stockVarientBillItems = new ArrayList<>();
+    @OneToMany(mappedBy = "backwardReferenceBill", fetch = FetchType.LAZY)
+    private List<Bill> forwardReferenceBills = new ArrayList<>();
+    @OneToMany(mappedBy = "forwardReferenceBill", fetch = FetchType.LAZY)
+    private List<Bill> backwardReferenceBills = new ArrayList<>();
+    @OneToMany(mappedBy = "billedBill", fetch = FetchType.LAZY)
+    private List<Bill> returnPreBills = new ArrayList<>();
+    @OneToMany(mappedBy = "billedBill", fetch = FetchType.LAZY)
+    private List<Bill> returnBhtIssueBills = new ArrayList<>();
+    @OneToMany(mappedBy = "referenceBill", fetch = FetchType.LAZY)
+    private List<Bill> returnCashBills = new ArrayList<>();
+    @OneToMany(mappedBy = "referenceBill", fetch = FetchType.LAZY)
+    private List<Bill> cashBillsPre = new ArrayList<>();
+    @OneToMany(mappedBy = "referenceBill", fetch = FetchType.LAZY)
+    private List<Bill> cashBillsOpdPre = new ArrayList<>();
+    @OneToMany(mappedBy = "billedBill", fetch = FetchType.LAZY)
+    private List<Bill> refundBills = new ArrayList<>();
+
+    @OneToOne
+    private OnlineBooking onlineBooking;
+
+    @Enumerated(EnumType.STRING)
+    protected BillClassType billClassType;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Category category;
+    @Transient
+    boolean transError;
+
+    private String ipOpOrCc;
+
+    @OneToMany(mappedBy = "bill", cascade = CascadeType.ALL, fetch = FetchType.LAZY, orphanRemoval = true)
+    private List<Payment> payments = new ArrayList<>();
+    @OneToMany(mappedBy = "bill", cascade = CascadeType.ALL, fetch = FetchType.LAZY, orphanRemoval = true)
+    private List<BillFee> billFees = new ArrayList<>();
+    @OneToMany(mappedBy = "bill", cascade = CascadeType.ALL, fetch = FetchType.LAZY, orphanRemoval = true)
+    @OrderBy("inwardChargeType, searialNo")
+    private List<BillItem> billItems;
+
+    @OneToMany(mappedBy = "expenseBill", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+    @OrderBy("searialNo")
+    private List<BillItem> billExpenses;
+
+    @OneToMany(mappedBy = "bill", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+    private List<BillComponent> billComponents = new ArrayList<>();
+    ////////////////////////////////////////////////
+    @Lob
+    private String comments;
+    @Lob
+    private String paymentMemo;
+    @Lob
+    private String indication;
+    // Bank Detail
+    private String creditCardRefNo;
+    private String chequeRefNo;
+    private boolean creditBill;
+    private boolean consignment;
+    private int creditDuration;
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Institution bank;
+    @Temporal(javax.persistence.TemporalType.DATE)
+    private Date chequeDate;
+    //Approve
+    @ManyToOne(fetch = FetchType.LAZY)
+    private WebUser approveUser;
+    @Temporal(javax.persistence.TemporalType.TIMESTAMP)
+    private Date approveAt;
+    //Pharmacy
+    @Temporal(javax.persistence.TemporalType.DATE)
+    private Date invoiceDate;
+    //Theater
+    @Temporal(javax.persistence.TemporalType.TIMESTAMP)
+    private Date acceptedAt;
+    @Temporal(javax.persistence.TemporalType.TIMESTAMP)
+    private Date releasedAt;
+    //Enum
+    @Enumerated(EnumType.STRING)
+    private BillType billType;
+    @Enumerated(EnumType.STRING)
+    private BillTypeAtomic billTypeAtomic;
+    @Enumerated(EnumType.STRING)
+    private PaymentMethod paymentMethod;
+    @ManyToOne(fetch = FetchType.LAZY)
+    private BillItem singleBillItem;
+    @ManyToOne(fetch = FetchType.LAZY)
+    private BillSession singleBillSession;
+    String qutationNumber;
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Institution referredByInstitution;
+    @Column
+    private String referenceNumber; //referenceNumber
+
+    //Values
+    private double margin;
+
+    private double total;
+    private double netTotal;
+    private double discount;
+    private double vat;
+    private double vatPlusNetTotal;
+
+    @Transient
+    private double absoluteNetTotal;
+
+    private double discountPercent;
+
+    private double billTotal;
+    private double paidAmount;
+    private double settledAmountByPatient;
+    private double settledAmountBySponsor;
+    private double refundAmount;
+    private double balance;
+    private double serviceCharge;
+    private Double tax = 0.0;
+    private Double cashPaid = 0.0;
+    private Double cashBalance = 0.0;
+    private double saleValue = 0.0f;
+    private double freeValue = 0.0f;
+    private double performInstitutionFee;
+    private double staffFee;
+    private double billerFee;
+    private double grantTotal;
+    private double expenseTotal;
+    private double expensesTotalConsideredForCosting;
+    private double expensesTotalNotConsideredForCosting;
+    //with minus tax and discount
+    private double grnNetTotal;
+
+    private double hospitalFee;
+    private double collctingCentreFee;
+    private double professionalFee;
+
+    //Institution
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Institution paymentSchemeInstitution;
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Institution collectingCentre;
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Institution institution;
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Institution fromInstitution;
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Institution toInstitution;
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Institution creditCompany;
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Institution referenceInstitution;
+    //Departments
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Department referringDepartment;
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Department department;
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Department fromDepartment;
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Department toDepartment;
+    //Bill
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Bill billedBill;
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Bill cancelledBill;
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Bill refundedBill;
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Bill reactivatedBill;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Bill referenceBill;
+    //Id's
+    private String deptId;
+    private String insId;
+    private String catId;
+    private String sessionId;
+    @Deprecated
+    private String bookingId;
+    private String invoiceNumber;
+    @Transient
+    private int intInvoiceNumber;
+    //Staff
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Staff staff;
+    @ManyToOne(fetch = FetchType.LAZY)
+    private WebUser webUser;
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Staff fromStaff;
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Staff toStaff;
+    //Booleans
+    private boolean paid;
+    private boolean cancelled;
+    private boolean refunded;
+    private boolean reactivated;
+    //Created Properties
+    @ManyToOne(fetch = FetchType.LAZY)

--- a/tmp_enum1.txt
+++ b/tmp_enum1.txt
@@ -1,0 +1,219 @@
+ * Open Hospital Management Information System
+ * Dr M H B Ariyaratne
+ * buddhika.ari@gmail.com
+ */
+package com.divudi.bean.common;
+
+import com.divudi.core.data.*;
+import com.divudi.core.data.ScheduledProcess;
+import com.divudi.core.data.ScheduledFrequency;
+import com.divudi.core.data.analytics.ReportTemplateColumn;
+import com.divudi.core.data.analytics.ReportTemplateFilter;
+import com.divudi.core.data.hr.*;
+import com.divudi.core.data.inward.AdmissionStatus;
+import com.divudi.core.data.inward.AdmissionTypeEnum;
+import com.divudi.core.data.inward.InwardChargeType;
+import com.divudi.core.data.inward.PatientEncounterComponentType;
+import com.divudi.core.data.lab.PatientInvestigationStatus;
+import com.divudi.core.data.lab.Priority;
+import com.divudi.core.data.lab.SearchDateType;
+import com.divudi.core.data.lab.TestHistoryType;
+import com.divudi.core.entity.PaymentScheme;
+import com.divudi.core.entity.Person;
+import com.divudi.service.BillService;
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+import javax.annotation.PostConstruct;
+import javax.ejb.EJB;
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.context.SessionScoped;
+import javax.inject.Inject;
+import javax.inject.Named;
+
+/**
+ *
+ * @author safrin
+ */
+@Named
+@ApplicationScoped
+public class EnumController implements Serializable {
+
+    @EJB
+    BillService billService;
+
+    @Inject
+    ConfigOptionApplicationController configOptionApplicationController;
+
+    private PaymentScheme paymentScheme;
+    private List<Class<? extends Enum<?>>> enumList;
+    List<PaymentMethod> paymentMethodsForOpdBilling;
+    private List<PaymentMethod> paymentMethodsForPharmacyPurchase;
+    List<PaymentMethod> paymentMethodsForChanneling;
+    List<PaymentMethod> paymentMethodsForChannelSettling;
+    List<PaymentMethod> paymentMethodsForPharmacyBilling;
+    private List<PaymentMethod> paymentMethodsForMultiplePaymentMethod;
+    private List<PaymentMethod> paymentMethodsForPatientDepositRefund;
+    private List<PaymentMethod> paymentMethodsForPatientDepositCancel;
+    private List<PaymentMethod> paymentMethodsForStaffCreditSettle;
+    private List<PaymentMethod> paymentMethodsForPatientDeposit;
+    private List<PaymentMethod> paymentMethodsForOpdBillCanceling;
+    SessionNumberType[] sessionNumberTypes;
+    private List<PatientInvestigationStatus> patientInvestigationStatuses;
+    private List<PaymentMethod> paymentTypeOfPaymentMethods;
+
+    private List<PatientInvestigationStatus> availableStatusforCancel;
+
+    private List<BillTypeAtomic> allUtilizedBillTypeAtomics;
+    private List<BillTypeAtomic> allUtilizedBillTypeAtomicsForPharmacy;
+
+    @PostConstruct
+    public void init() {
+        enumList = new ArrayList<>();
+        enumList.add(PaymentMethod.class);
+        enumList.add(PaperType.class);
+        enumList.add(ItemType.class);
+        enumList.add(DiscountType.class);
+    }
+    
+
+    public Sex[] getSex() {
+        return Sex.values();
+    }
+
+    public List<PaymentMethod> getPaymentMethodsForOpdBilling() {
+        if (paymentMethodsForOpdBilling == null) {
+            fillPaymentMethodsForOpdBilling();
+        }
+        return paymentMethodsForOpdBilling;
+    }
+
+    public List<PaymentMethod> getPaymentMethodsForPackageBilling() {
+        if (paymentMethodsForOpdBilling == null) {
+            fillPaymentMethodsForPackageBilling();
+        }
+        return paymentMethodsForOpdBilling;
+    }
+
+    public List<PaymentMethod> getPaymentMethodsForPackageBillingWIthoutMultiple() {
+        if (paymentMethodsForOpdBilling == null) {
+            fillPaymentMethodsForPackageBilling();
+        }
+        try {
+            paymentMethodsForOpdBilling.remove(PaymentMethod.MultiplePaymentMethods);
+        } catch (Exception e) {
+
+        }
+        return paymentMethodsForOpdBilling;
+    }
+
+    public void resetPaymentMethods() {
+        paymentMethodsForOpdBilling = null;
+        paymentMethodsForChanneling = null;
+    }
+
+    public void fillPaymentMethodsForPatientDeposit() {
+        paymentMethodsForPatientDeposit = new ArrayList<>();
+        for (PaymentMethod pm : PaymentMethod.values()) {
+            boolean include = configOptionApplicationController.getBooleanValueByKey(pm.getLabel() + " is available for Patient Deposit", true);
+            if (include) {
+                paymentMethodsForPatientDeposit.add(pm);
+            }
+        }
+    }
+
+    public void fillPaymentMethodsForOpdBilling() {
+        paymentMethodsForOpdBilling = new ArrayList<>();
+        for (PaymentMethod pm : PaymentMethod.values()) {
+            boolean include = configOptionApplicationController.getBooleanValueByKey(pm.getLabel() + " is available for OPD Billing", true);
+            if (include) {
+                paymentMethodsForOpdBilling.add(pm);
+            }
+        }
+    }
+
+    public void fillPaymentMethodsFoPharmacyPurchase() {
+        paymentMethodsForPharmacyPurchase = new ArrayList<>();
+        for (PaymentMethod pm : PaymentMethod.values()) {
+            boolean include = configOptionApplicationController.getBooleanValueByKey(pm.getLabel() + " is available for Pharmacy Purchase", true);
+            if (include) {
+                paymentMethodsForPharmacyPurchase.add(pm);
+            }
+        }
+    }
+
+    public void fillPaymentMethodsForPackageBilling() {
+        paymentMethodsForOpdBilling = new ArrayList<>();
+        for (PaymentMethod pm : PaymentMethod.values()) {
+            boolean include = configOptionApplicationController.getBooleanValueByKey(pm.getLabel() + " is available for Package Billing", true);
+            if (include) {
+                paymentMethodsForOpdBilling.add(pm);
+            }
+        }
+    }
+
+    public List<PaymentMethod> getPaymentMethodsForChanneling() {
+        if (paymentMethodsForChanneling == null) {
+            fillPaymentMethodsForChanneling();
+        }
+        return paymentMethodsForChanneling;
+    }
+
+    public List<InvestigationReportType> getInvestigationReportTypes() {
+        return Arrays.asList(InvestigationReportType.values());
+    }
+
+    public List<PaymentMethod> getPaymentMethodsForChannelSettling() {
+        if (paymentMethodsForChannelSettling == null) {
+            fillPaymentMethodsForChannelSettling();
+        }
+        return paymentMethodsForChannelSettling;
+    }
+
+    public void fillPaymentMethodsForChanneling() {
+        paymentMethodsForChanneling = new ArrayList<>();
+        for (PaymentMethod pm : PaymentMethod.values()) {
+            boolean include = configOptionApplicationController.getBooleanValueByKey(pm.getLabel() + " is available for Channeling", true);
+            if (include) {
+                paymentMethodsForChanneling.add(pm);
+            }
+        }
+    }
+
+    public void fillPaymentMethodsForChannelSettling() {
+        paymentMethodsForChannelSettling = new ArrayList<>();
+        for (PaymentMethod pm : PaymentMethod.values()) {
+            if (!pm.equals(PaymentMethod.OnCall)) {
+                boolean include = configOptionApplicationController.getBooleanValueByKey(pm.getLabel() + " is available for Channeling", true);
+                if (include) {
+                    paymentMethodsForChannelSettling.add(pm);
+                }
+            }
+        }
+    }
+
+    public List<PaymentMethod> getPaymentMethodsForPharmacyBilling() {
+        if (paymentMethodsForPharmacyBilling == null) {
+            fillPaymentMethodsForPharmacyBilling();
+        }
+        return paymentMethodsForPharmacyBilling;
+    }
+
+    public List<PaymentMethod> getPaymentMethodsForPharmacyBillCancellations() {
+        List<PaymentMethod> paymentMethodsForPharmacyBillCancellations = new ArrayList<>();
+        if (paymentMethodsForPharmacyBilling == null) {
+            fillPaymentMethodsForPharmacyBilling();
+        }
+        if (paymentMethodsForPharmacyBilling == null) {
+            paymentMethodsForPharmacyBilling = new ArrayList<>();
+        }
+        if (paymentMethodsForPharmacyBilling.isEmpty()) {
+            paymentMethodsForPharmacyBilling.add(PaymentMethod.Cash);
+            paymentMethodsForPharmacyBilling.add(PaymentMethod.Card);
+        }
+        paymentMethodsForPharmacyBillCancellations.addAll(paymentMethodsForPharmacyBilling);
+        try {
+            paymentMethodsForPharmacyBillCancellations.remove(PaymentMethod.MultiplePaymentMethods);
+        } catch (Exception e) {

--- a/tmp_enum2.txt
+++ b/tmp_enum2.txt
@@ -1,0 +1,321 @@
+            System.err.println("e = " + e);
+        }
+        return paymentMethodsForPharmacyBillCancellations;
+    }
+
+    public void fillPaymentMethodsForPharmacyBilling() {
+        paymentMethodsForPharmacyBilling = new ArrayList<>();
+        for (PaymentMethod pm : PaymentMethod.values()) {
+            boolean include = configOptionApplicationController.getBooleanValueByKey(pm.getLabel() + " is available for Pharmacy Billing", true);
+            if (include) {
+                paymentMethodsForPharmacyBilling.add(pm);
+            }
+        }
+    }
+
+    public List<PaymentMethod> getPaymentTypeOfPaymentMethods(PaymentType paymentType) {
+        paymentTypeOfPaymentMethods = new ArrayList<>();
+        for (PaymentMethod pm : PaymentMethod.asList()) {
+            if (pm.getPaymentType() == paymentType) {
+                paymentTypeOfPaymentMethods.add(pm);
+            }
+        }
+        return paymentTypeOfPaymentMethods;
+    }
+
+    public void setPaymentTypeOfPaymentMethods(List<PaymentMethod> paymentTypeOfPaymentMethods) {
+        this.paymentTypeOfPaymentMethods = paymentTypeOfPaymentMethods;
+    }
+
+    public List<SearchDateType> getSearchDateTypes() {
+        return Arrays.asList(SearchDateType.values());
+    }
+
+    public List<String> getEnumValues(String enumClassName) {
+        try {
+            Class<?> enumClass = Class.forName(enumClassName);
+            if (enumClass.isEnum()) {
+                Object[] enumConstants = enumClass.getEnumConstants();
+                return Arrays.stream(enumConstants)
+                        .map(e -> ((Enum<?>) e).name())
+                        .collect(Collectors.toList());
+            }
+        } catch (ClassNotFoundException e) {
+            return new ArrayList<>();
+        }
+        return new ArrayList<>();
+    }
+
+    public <E extends Enum<E>> E getEnumValue(Class<E> enumType, String enumName) {
+        for (E enumConstant : enumType.getEnumConstants()) {
+            if (enumConstant.name().equals(enumName)) {
+                return enumConstant;
+            }
+        }
+        return null; // Return null if no match is found
+    }
+
+    public List<Priority> getPriorities() {
+        return Arrays.asList(Priority.values());
+    }
+
+    public List<CategoryType> getCategoryTypes() {
+        return Arrays.asList(CategoryType.values());
+    }
+
+    public List<HistoryType> getHistoryTypes() {
+        return Arrays.asList(HistoryType.values());
+    }
+
+    public List<ScheduledProcess> getScheduledProcesses() {
+        return Arrays.asList(ScheduledProcess.values());
+    }
+    
+     public List<EmployeeStatus> getEmploymentStatuses() {
+        return Arrays.asList(EmployeeStatus.values());
+    }
+
+    public List<ScheduledFrequency> getScheduledFrequencies() {
+        return Arrays.asList(ScheduledFrequency.values());
+    }
+
+    public Dashboard[] getDashboardTypes() {
+        return Dashboard.values();
+    }
+
+    public SessionNumberType[] getSessionNumberTypes() {
+        sessionNumberTypes = SessionNumberType.values();
+        return sessionNumberTypes;
+    }
+
+    public List<PatientInvestigationStatus> getPatientInvestigationStatuses() {
+        patientInvestigationStatuses = Arrays.asList(PatientInvestigationStatus.values());
+        return patientInvestigationStatuses;
+    }
+
+    public List<LoginPage> getLoginPages() {
+        return Arrays.asList(LoginPage.values());
+    }
+
+    public List<ReportViewType> getReportViewTypes() {
+        return Arrays.asList(ReportViewType.values());
+    }
+
+    public List<ReportViewType> getPharmacyIncomeReportViewTypes() {
+        return Arrays.asList(
+                ReportViewType.BY_BILL,
+                ReportViewType.BY_BILL_TYPE,
+                ReportViewType.BY_DISCOUNT_TYPE_AND_ADMISSION_TYPE,
+                ReportViewType.BY_BILL_TYPE_AND_DISCOUNT_TYPE_AND_ADMISSION_TYPE
+//                ReportViewType.BY_ITEM
+        );
+    }
+    
+    public List<ReportViewType> getPharmacyProcurementByBillItemViewTypes() {
+        return Arrays.asList(
+                ReportViewType.BY_BILL,
+                ReportViewType.BY_BILL_ITEM
+        );
+    }
+
+    public List<ReportViewType> getPharmacyIncomeCostReportViewTypes() {
+        return Arrays.asList(
+                ReportViewType.BY_BILL,
+                ReportViewType.BY_BILL_ITEM,
+                ReportViewType.BY_BILL_TYPE
+        );
+    }
+
+    public ItemListingStrategy[] getItemListingStrategys() {
+        return ItemListingStrategy.values();
+    }
+
+    public SymanticType[] getSymanticTypes() {
+        return SymanticType.values();
+    }
+
+    public ItemListingStrategy[] getOpdItemListingStrategys() {
+        ItemListingStrategy[] sts
+                = {ItemListingStrategy.ALL_ITEMS,
+                    ItemListingStrategy.SITE_FEE_ITEMS,
+                    ItemListingStrategy.ITEMS_OF_LOGGED_DEPARTMENT,
+                    ItemListingStrategy.ITEMS_OF_LOGGED_INSTITUTION,
+                    ItemListingStrategy.ITEMS_MAPPED_TO_LOGGED_DEPARTMENT,
+                    ItemListingStrategy.ITEMS_MAPPED_TO_LOGGED_INSTITUTION};
+        return sts;
+    }
+
+    public ItemListingStrategy[] getCcItemListingStrategys() {
+        ItemListingStrategy[] sts
+                = {ItemListingStrategy.ALL_ITEMS,
+                    ItemListingStrategy.ITEMS_OF_SELECTED_DEPARTMENT,
+                    ItemListingStrategy.ITEMS_OF_SELECTED_INSTITUTIONS,
+                    ItemListingStrategy.ITEMS_MAPPED_TO_SELECTED_DEPARTMENT,
+                    ItemListingStrategy.ITEMS_MAPPED_TO_SELECTED_INSTITUTION,
+                    ItemListingStrategy.ITEMS_OF_LOGGED_DEPARTMENT,
+                    ItemListingStrategy.ITEMS_OF_LOGGED_INSTITUTION,
+                    ItemListingStrategy.ITEMS_MAPPED_TO_LOGGED_DEPARTMENT,
+                    ItemListingStrategy.ITEMS_MAPPED_TO_LOGGED_INSTITUTION};
+        return sts;
+    }
+
+    public ItemListingStrategy[] getInwardItemListingStrategys() {
+        ItemListingStrategy[] sts
+                = {ItemListingStrategy.ALL_ITEMS,
+                    ItemListingStrategy.ITEMS_OF_LOGGED_DEPARTMENT,
+                    ItemListingStrategy.ITEMS_OF_LOGGED_INSTITUTION,
+                    ItemListingStrategy.ITEMS_MAPPED_TO_LOGGED_DEPARTMENT,
+                    ItemListingStrategy.ITEMS_MAPPED_TO_LOGGED_INSTITUTION};
+        return sts;
+    }
+
+    public RestAuthenticationType[] getRestAuthenticationTypes() {
+        return RestAuthenticationType.values();
+    }
+
+    public BillItemStatus[] getBillItemStatuses() {
+        return BillItemStatus.values();
+    }
+
+    public AdmissionStatus[] getAdmissionStatuses() {
+        return AdmissionStatus.values();
+    }
+
+    public CssVerticalAlign[] getCssVerticalAlign() {
+        return CssVerticalAlign.values();
+    }
+
+    public DepartmentListMethod[] getDepartmentListMethods() {
+        return DepartmentListMethod.values();
+    }
+
+    public DepartmentType[] getDepartmentType() {
+        return DepartmentType.values();
+    }
+
+    public ApplicationInstitution[] getApplicationInstitutions() {
+        return ApplicationInstitution.values();
+    }
+
+    public PaperType[] getPaperTypes() {
+        return PaperType.values();
+    }
+
+    public ReportItemType[] getReportItemTypes() {
+        Person p;
+        return ReportItemType.values();
+    }
+
+    public LeaveType[] getLeaveType() {
+        LeaveType[] ltp = {LeaveType.Annual,
+            LeaveType.AnnualHalf,
+            LeaveType.Casual,
+            LeaveType.CasualHalf,
+            LeaveType.DutyLeave,
+            LeaveType.DutyLeaveHalf,
+            LeaveType.Lieu,
+            LeaveType.LieuHalf,
+            LeaveType.Maternity1st,
+            LeaveType.Maternity2nd,
+            LeaveType.Medical,
+            LeaveType.No_Pay,
+            LeaveType.No_Pay_Half};
+        return ltp;
+    }
+
+    public Times[] getTimeses() {
+        return new Times[]{Times.inTime, Times.outTime};
+    }
+
+    public void setSessionNumberTypes(SessionNumberType[] sessionNumberTypes) {
+        this.sessionNumberTypes = sessionNumberTypes;
+    }
+
+    public FeeType[] getFeeTypes() {
+        return FeeType.values();
+    }
+
+    public DayType[] getDayTypes() {
+        return DayType.values();
+    }
+
+    public DayType[] getDayTypeForShift() {
+        DayType[] dayTypes = {DayType.Normal, DayType.DayOff, DayType.SleepingDay, DayType.Poya};
+
+        return dayTypes;
+    }
+
+    public DayType[] getDayTypesForPh() {
+        DayType[] dayTypes = {DayType.MurchantileHoliday, DayType.Poya, DayType.PublicHoliday};
+
+        return dayTypes;
+    }
+
+    public InvestigationItemType[] getInvestigationItemTypes() {
+        return InvestigationItemType.values();
+    }
+
+    public InvestigationItemValueType[] getInvestigationItemValueTypes() {
+        return InvestigationItemValueType.values();
+    }
+
+    public PaysheetComponentType[] getAddingComponentTypes() {
+        return PaysheetComponentType.addition.children();
+
+    }
+
+    public BillType[] getBillTypes() {
+        return BillType.values();
+    }
+
+    public BillTypeAtomic[] getBillTypesAtomic() {
+        return BillTypeAtomic.values();
+    }
+
+    public List<BillTypeAtomic> getBillTypesAtomicForLabTests() {
+        List<BillTypeAtomic> btas = new ArrayList<>();
+        btas.add(BillTypeAtomic.CC_BILL);
+        btas.add(BillTypeAtomic.CC_BILL_CANCELLATION);
+        btas.add(BillTypeAtomic.CC_BILL_REFUND);
+        btas.add(BillTypeAtomic.OPD_BILL_WITH_PAYMENT);
+        btas.add(BillTypeAtomic.OPD_BILL_CANCELLATION);
+        btas.add(BillTypeAtomic.OPD_BILL_CANCELLATION_DURING_BATCH_BILL_CANCELLATION);
+        btas.add(BillTypeAtomic.OPD_BILL_REFUND);
+        btas.add(BillTypeAtomic.INWARD_SERVICE_BILL);
+        btas.add(BillTypeAtomic.INWARD_SERVICE_BILL_CANCELLATION);
+        btas.add(BillTypeAtomic.INWARD_SERVICE_BILL_REFUND);
+        return btas;
+    }
+
+    public List<BillTypeAtomic> getBillTypesAtomic(String query) {
+        return Arrays.stream(BillTypeAtomic.values())
+                .filter(bt -> bt.getLabel().toLowerCase().contains(query.toLowerCase()))
+                .collect(Collectors.toList());
+    }
+
+    public List<String> completeBillTypeAtomics(String query) {
+        return Arrays.stream(BillTypeAtomic.values())
+                .map(Enum::toString) // Using toString() to get the string representation of the enum
+                .filter(name -> name.toLowerCase().contains(query.toLowerCase()))
+                .collect(Collectors.toList());
+    }
+
+    public List<String> completeReportTemplateColumns(String query) {
+        return Arrays.stream(ReportTemplateColumn.values())
+                .map(ReportTemplateColumn::getLabel) // Using getLabel() to get the user-friendly string
+                .filter(label -> label.toLowerCase().contains(query.toLowerCase())) // Filtering based on query
+                .collect(Collectors.toList()); // Collecting results into a List
+    }
+
+    public List<String> completeReportTemplateFilters(String query) {
+        return Arrays.stream(ReportTemplateFilter.values())
+                .map(ReportTemplateFilter::getLabel) // Using getLabel() to get the user-friendly string
+                .filter(label -> label.toLowerCase().contains(query.toLowerCase())) // Filtering based on query
+                .collect(Collectors.toList()); // Collecting results into a List
+    }
+
+    public StaffWelfarePeriod[] getStaffWelfarePeriods() {
+        return StaffWelfarePeriod.values();
+    }
+
+    public BillClassType[] getBillClassTypes() {

--- a/tmp_enum3.txt
+++ b/tmp_enum3.txt
@@ -1,0 +1,371 @@
+    public BillClassType[] getBillClassTypes() {
+        return BillClassType.values();
+    }
+
+    public CalculationType[] getCalculationTypes() {
+        return CalculationType.values();
+    }
+
+    public PaysheetComponentType[] getDiductionComponentTypes() {
+        return PaysheetComponentType.subtraction.children();
+
+    }
+
+    public PaysheetComponentType[] getPaysheetComponentTypes() {
+        List<PaysheetComponentType> list = new ArrayList<>();
+
+        for (PaysheetComponentType pct : PaysheetComponentType.addition.children()) {
+            list.add(pct);
+        }
+
+        for (PaysheetComponentType pct : PaysheetComponentType.subtraction.children()) {
+            list.add(pct);
+        }
+
+        return list.toArray(new PaysheetComponentType[list.size()]);
+    }
+
+    public List<PaysheetComponentType> getPaysheetComponentTypesUserDefinded() {
+        return PaysheetComponentType.addition.getUserDefinedComponents();
+    }
+
+    public List<PaysheetComponentType> getPaysheetComponentTypesSystemDefinded() {
+        return PaysheetComponentType.addition.getSystemDefinedComponents();
+    }
+
+    public Title[] getTitle() {
+        return Title.values();
+    }
+
+    public Title[] getTitleDoctor() {
+        Title[] tem = {
+            Title.Dr,
+            Title.DrMrs,
+            Title.DrMs,
+            Title.DrMiss,
+            Title.Prof,
+            Title.ProfMrs,
+            Title.Mr,
+            Title.Ms,
+            Title.Miss,
+            Title.Mrs,
+            Title.Other,};
+        return tem;
+    }
+
+    public Sex[] getGender() {
+        Sex[] sexes = {Sex.Male, Sex.Female};
+        return sexes;
+    }
+
+    public PaymentMethod[] getPaymentMethodForAdmission() {
+        PaymentMethod[] tmp = {PaymentMethod.Credit, PaymentMethod.Cash};
+        return tmp;
+    }
+
+    public InwardChargeType[] getInwardChargeTypes() {
+        return InwardChargeType.values();
+    }
+
+    public InwardChargeType[] getInwardChargeTypesForSetting() {
+        return InwardChargeType.values();
+    }
+
+    public PatientEncounterComponentType[] getPatientEncounterComponentTypes() {
+        return PatientEncounterComponentType.values();
+    }
+
+    public BillType[] getCashFlowBillTypes() {
+        BillType[] b = {
+            BillType.OpdBill,
+            BillType.PaymentBill,
+            BillType.PettyCash,
+            BillType.CashRecieveBill,
+            BillType.AgentPaymentReceiveBill,
+            BillType.InwardPaymentBill,
+            BillType.PharmacySale,
+            BillType.ChannelCash,
+            BillType.ChannelPaid,
+            BillType.GrnPaymentPre,
+            BillType.CollectingCentrePaymentReceiveBill,//            BillType.PharmacyPurchaseBill,
+        //            BillType.GrnPayment,
+        };
+
+        return b;
+    }
+
+    public BillType[] getCashFlowBillTypesCashier() {
+        BillType[] b = {
+            BillType.OpdBill,
+            BillType.PaymentBill,
+            BillType.PettyCash,
+            BillType.CashRecieveBill,
+            BillType.AgentPaymentReceiveBill,
+            BillType.InwardPaymentBill,
+            BillType.PharmacySale,
+            BillType.GrnPaymentPre,
+            BillType.CollectingCentrePaymentReceiveBill,};
+
+        return b;
+    }
+
+    public BillType[] getCashFlowBillTypesChannel() {
+        BillType[] b = {
+            BillType.ChannelCash,
+            BillType.ChannelPaid,
+            BillType.ChannelProPayment,
+            BillType.ChannelIncomeBill,
+            BillType.ChannelExpenesBill,};
+
+        return b;
+    }
+
+    public BillType[] getStoreBillTypes() {
+
+        BillType[] b = {
+            BillType.StoreGrnBill,
+            BillType.StoreGrnReturn,
+            BillType.StoreOrder,
+            BillType.StoreOrderApprove,
+            BillType.StorePre,
+            BillType.StorePurchase,
+            BillType.StoreSale,
+            BillType.StoreAdjustment,
+            BillType.StorePurchaseReturn,
+            BillType.StoreTransferRequest,
+            BillType.StoreTransferIssue,};
+
+        return b;
+    }
+
+    public BillType[] getPharmacyBillTypes() {
+        BillType[] b = {
+            BillType.PharmacyGrnBill,
+            BillType.PharmacyGrnReturn,
+            BillType.PharmacyReturnWithoutTraising,
+            BillType.PharmacyOrder,
+            BillType.PharmacyOrderApprove,
+            BillType.PharmacyPre,
+            BillType.PharmacyPurchaseBill,
+            BillType.PharmacySale,
+            BillType.PharmacyAdjustment,
+            BillType.PurchaseReturn,
+            BillType.GrnPaymentPre,
+            BillType.PharmacyTransferRequest,
+            BillType.PharmacyTransferIssue,
+            BillType.PharmacyWholeSale,
+            BillType.PharmacyIssue,
+            BillType.PharmacyTransferReceive};
+
+        return b;
+    }
+
+    public BillType[] getPharmacyBillTypes2() {
+        BillType[] b = {
+            BillType.PharmacySale,
+            BillType.PharmacyAdjustment,
+            BillType.PharmacyTransferIssue,
+            BillType.PharmacyIssue,
+            BillType.PharmacyBhtPre};
+
+        return b;
+    }
+
+    public BillType[] getPharmacyBillTypesForMovementReports() {
+        BillType[] b = {
+            BillType.PharmacySale,
+            BillType.PharmacyAdjustment,
+            BillType.PharmacyTransferIssue,
+            BillType.PharmacyIssue,
+            BillType.PharmacyBhtPre};
+        return b;
+    }
+
+    public BillType[] getPharmacyBillTypes3() {
+        BillType[] b = {
+            BillType.PharmacyPre,
+            BillType.PharmacyWholesalePre,
+            BillType.PharmacyAdjustment,
+            BillType.PharmacyTransferIssue,
+            BillType.PharmacyIssue,
+            BillType.PharmacyBhtPre};
+
+        return b;
+    }
+
+    public BillType[] getPharmacyBillTypes4() {
+        BillType[] b = {
+                BillType.PharmacyPre,
+                BillType.PharmacyWholesalePre,
+                BillType.PharmacyAdjustment,
+                BillType.PharmacyTransferIssue,
+                BillType.PharmacyIssue,
+                BillType.PharmacyBhtPre,
+                BillType.PharmacyDisposalIssue};
+
+        return b;
+    }
+
+    public BillType[] getPharmacySaleBillTypes() {
+        BillType[] bt = {
+            BillType.PharmacySale,
+            BillType.PharmacyWholeSale,};
+        return bt;
+    }
+
+    public PaymentMethod[] getPaymentMethods() {
+        PaymentMethod[] p = {
+            PaymentMethod.Cash,
+            PaymentMethod.Card,
+            PaymentMethod.Cheque,
+            PaymentMethod.Slip,
+            PaymentMethod.Credit,
+            PaymentMethod.ewallet,
+            PaymentMethod.Staff_Welfare,
+            PaymentMethod.PatientDeposit,
+            PaymentMethod.MultiplePaymentMethods};
+
+        return p;
+    }
+
+    public PaymentMethod[] getPaymentMethodsForIncome() {
+        PaymentMethod[] p = {
+            PaymentMethod.Cash,
+            PaymentMethod.Card,
+            PaymentMethod.Cheque,
+            PaymentMethod.Slip};
+
+        return p;
+    }
+
+    public PaymentMethod[] getPaymentMethodsExceptMultiple() {
+        PaymentMethod[] p = {
+            PaymentMethod.Cash,
+            PaymentMethod.Card,
+            PaymentMethod.Cheque,
+            PaymentMethod.Slip,
+            PaymentMethod.Credit,
+            PaymentMethod.ewallet,
+            PaymentMethod.PatientDeposit};
+        return p;
+    }
+
+    public InwardChargeType getInaChargeType(String name) {
+        for (InwardChargeType chargeType : InwardChargeType.values()) {
+            if (chargeType.getLabel().equalsIgnoreCase(name)) {
+                return chargeType;
+            }
+        }
+        return null; // or throw an exception if an unknown name is not acceptable
+    }
+
+    public PaymentMethod[] getPaymentMethodsNonCreditExceptMultiple() {
+        PaymentMethod[] p = {
+            PaymentMethod.Cash,
+            PaymentMethod.Card,
+            PaymentMethod.Cheque,
+            PaymentMethod.Slip,
+            PaymentMethod.ewallet,
+            PaymentMethod.Staff,
+            PaymentMethod.PatientDeposit};
+        return p;
+    }
+
+    public List<PaymentMethod> getPaymentMethodsNonCreditExceptMultiple(List<PaymentMethod> pm) {
+        List<PaymentMethod> paymentMethod = new ArrayList<>();
+        if (pm == null) {
+            paymentMethod.add(PaymentMethod.Cash);
+            paymentMethod.add(PaymentMethod.Card);
+            paymentMethod.add(PaymentMethod.Cheque);
+            paymentMethod.add(PaymentMethod.Slip);
+            paymentMethod.add(PaymentMethod.ewallet);
+            paymentMethod.add(PaymentMethod.Staff);
+            paymentMethod.add(PaymentMethod.PatientDeposit);
+        } else {
+            paymentMethod.addAll(pm);
+            paymentMethod.remove(PaymentMethod.MultiplePaymentMethods);
+        }
+        return paymentMethod;
+    }
+
+    public PaymentMethod[] getPaymentMethodsforAgencyManagement() {
+        PaymentMethod[] pm = {
+            PaymentMethod.Card,
+            PaymentMethod.Cash,
+            PaymentMethod.Cheque,
+            PaymentMethod.Slip
+        };
+
+        return pm;
+    }
+
+    public PaymentMethod[] getCollectingCentrePaymentMethods() {
+        PaymentMethod[] p = {
+            PaymentMethod.Agent,};
+        return p;
+    }
+
+    public PaymentMethod[] getPaymentMethodsWithoutCredit() {
+        PaymentMethod[] p = {PaymentMethod.Cash,
+            PaymentMethod.Card,
+            PaymentMethod.Cheque,
+            PaymentMethod.Slip,
+            PaymentMethod.ewallet};
+        return p;
+    }
+
+    public PaymentMethod[] getPaymentMethodsForSupplierPayments() {
+        PaymentMethod[] p = {PaymentMethod.Cash,
+            PaymentMethod.Card,
+            PaymentMethod.Cheque,
+            PaymentMethod.Slip,
+            PaymentMethod.IOU};
+        return p;
+    }
+
+    public PaymentMethod[] getPaymentMethodsForIwardDeposit() {
+        PaymentMethod[] p = {PaymentMethod.Cash,
+            PaymentMethod.Card,
+            PaymentMethod.Cheque,
+            PaymentMethod.Slip,
+            PaymentMethod.ewallet,
+            PaymentMethod.PatientDeposit,
+            PaymentMethod.OnlineSettlement};
+        return p;
+    }
+
+    public PaymentMethod[] getPaymentMethodsForIou() {
+        PaymentMethod[] p = {PaymentMethod.Cash,
+            PaymentMethod.Cheque,
+            PaymentMethod.Slip};
+        return p;
+    }
+
+    public PaymentMethod[] getPaymentMethodsForIouSettle() {
+        PaymentMethod[] p = {PaymentMethod.Cash,
+            PaymentMethod.Cheque,
+            PaymentMethod.IOU,
+            PaymentMethod.Voucher,
+            PaymentMethod.Slip};
+        return p;
+    }
+
+    @Deprecated // Use getPaymentMethodsForPharmacyBilling
+    public PaymentMethod[] PaymentMethodsForPharmacyRetailSale() {
+        PaymentMethod[] p = {
+            PaymentMethod.Cash,
+            PaymentMethod.Card,
+            PaymentMethod.Credit,
+            PaymentMethod.Cheque,
+            PaymentMethod.Slip,
+            PaymentMethod.MultiplePaymentMethods};
+        return p;
+    }
+
+    public PaymentMethod[] getPaymentMethodsForPo() {
+        PaymentMethod[] p = {PaymentMethod.Cash, PaymentMethod.Credit, PaymentMethod.Cheque, PaymentMethod.Slip};
+        return p;
+    }
+
+    public List<PaymentMethod> getPaymentMethodsForPurchases() {
+        return PaymentMethod.getMethodsByContext(PaymentContext.PURCHASES);

--- a/tmp_enum4.txt
+++ b/tmp_enum4.txt
@@ -1,0 +1,162 @@
+        return PaymentMethod.getMethodsByContext(PaymentContext.PURCHASES);
+    }
+
+    public CreditDuration[] getCreditDuration() {
+        CreditDuration[] c = {CreditDuration.D30, CreditDuration.D60, CreditDuration.D90};
+
+        return c;
+    }
+
+    public PaymentMethod[] getPaymentMethodsForChannel() {
+        PaymentMethod[] p = {PaymentMethod.OnCall, PaymentMethod.Cash, PaymentMethod.Agent, PaymentMethod.Staff, PaymentMethod.Card, PaymentMethod.Cheque, PaymentMethod.Slip};
+        return p;
+    }
+
+    public PaymentMethod[] getPaymentMethodsForMakingProfessionalPayments() {
+        PaymentMethod[] p = {PaymentMethod.Cash, PaymentMethod.Cheque, PaymentMethod.Slip};
+        return p;
+    }
+
+    public PaymentMethod[] getPaymentMethodsForChannelSettle() {
+        PaymentMethod[] p = {PaymentMethod.Cash, PaymentMethod.Card};
+        return p;
+    }
+
+    public PaymentMethod[] getPaymentMethodsForChannelAgentSettle() {
+        PaymentMethod[] p = {PaymentMethod.Cash, PaymentMethod.Agent};
+        return p;
+    }
+
+    public List<ItemBarcodeGenerationStrategy> getItemBarcodeGenerationStrategies() {
+        return Arrays.asList(ItemBarcodeGenerationStrategy.values());
+    }
+
+    public PaymentMethod[] getAllPaymentMethods() {
+        return PaymentMethod.values();
+    }
+
+    public List<BankAccountType> getBankAccountTypes() {
+        return BankAccountType.getAllValues();
+    }
+
+    public List<PaymentMethod> getActivePaymentMethods() {
+        return PaymentMethod.getActivePaymentMethods();
+    }
+
+    public BillType[] getChannelType() {
+        BillType[] bt = {BillType.Channel, BillType.XrayScan};
+        return bt;
+    }
+
+//    public boolean checkPaymentScheme(PaymentScheme scheme, String paymentMathod) {
+//        if (scheme != null && scheme.getPaymentMethod() != null) {
+//            //System.err.println("Payment Scheme : " + scheme.getPaymentMethod());
+//            //System.err.println("Payment Method : " + PaymentMethod.valueOf(paymentMathod));
+//            if (scheme.getPaymentMethod().equals(PaymentMethod.valueOf(paymentMathod))) {
+//                //System.err.println("Returning True");
+//                return true;
+//            } else {
+//                return false;
+//            }
+//        }
+//
+//        return false;
+//
+//    }
+//    public boolean checkPaymentScheme(String paymentMathod) {
+//        if (getPaymentScheme() != null && getPaymentScheme().getPaymentMethod() != null) {
+//            //System.err.println("Payment Scheme : " +getPaymentScheme().getPaymentMethod());
+//            //System.err.println("Payment Method : " + PaymentMethod.valueOf(paymentMathod));
+//            if (getPaymentScheme().getPaymentMethod().equals(PaymentMethod.valueOf(paymentMathod))) {
+//                //System.err.println("Returning True");
+//                return true;
+//            } else {
+//                return false;
+//            }
+//        }
+//
+//        return false;
+//
+//    }
+    public boolean checkPaymentMethod(PaymentMethod paymentMethod, String paymentMathodStr) {
+        if (paymentMethod != null) {
+            //System.err.println("Payment method : " + paymentMethod);
+            //System.err.println("Payment Method String : " + PaymentMethod.valueOf(paymentMathodStr));
+            if (paymentMethod.equals(PaymentMethod.valueOf(paymentMathodStr))) {
+                //System.err.println("Returning True");
+                return true;
+            } else {
+                return false;
+            }
+        }
+
+        return false;
+
+    }
+
+    public AdmissionTypeEnum[] getAdmissionTypeEnum() {
+        return AdmissionTypeEnum.values();
+    }
+
+    public MessageType[] getSmsType() {
+        return MessageType.values();
+    }
+
+    /**
+     * Creates a new instance of EnumController
+     */
+    public EnumController() {
+    }
+
+    public PaymentScheme getPaymentScheme() {
+        return paymentScheme;
+    }
+
+    public void setPaymentScheme(PaymentScheme paymentScheme) {
+        this.paymentScheme = paymentScheme;
+    }
+
+    public List<PaymentMethod> getPaymentMethodsForPatientDeposit() {
+        paymentMethodsForPatientDeposit = new ArrayList<>();
+        for (PaymentMethod pm : PaymentMethod.values()) {
+            boolean include = configOptionApplicationController.getBooleanValueByKey(pm.getLabel() + " is available for Patient Deposit", true);
+            if (include) {
+                paymentMethodsForPatientDeposit.add(pm);
+            }
+        }
+        return paymentMethodsForPatientDeposit;
+    }
+
+    public void setPaymentMethodsForPatientDeposit(List<PaymentMethod> paymentMethodsForPatientDeposit) {
+        this.paymentMethodsForPatientDeposit = paymentMethodsForPatientDeposit;
+    }
+
+    public List<PaymentMethod> getPaymentMethodsForStaffCreditSettle() {
+        paymentMethodsForStaffCreditSettle = new ArrayList<>();
+        for (PaymentMethod pm : PaymentMethod.values()) {
+            boolean include = configOptionApplicationController.getBooleanValueByKey(pm.getLabel() + " is available for Staff Credit Settle", true);
+            if (include) {
+                paymentMethodsForStaffCreditSettle.add(pm);
+            }
+        }
+        return paymentMethodsForStaffCreditSettle;
+    }
+
+    public void setPaymentMethodsForStaffCreditSettle(List<PaymentMethod> paymentMethodsForStaffCreditSettle) {
+        this.paymentMethodsForStaffCreditSettle = paymentMethodsForStaffCreditSettle;
+    }
+
+    public List<PaymentMethod> getPaymentMethodsForPatientDepositRefund() {
+        paymentMethodsForPatientDepositRefund = new ArrayList<>();
+        for (PaymentMethod pm : PaymentMethod.values()) {
+            boolean include = configOptionApplicationController.getBooleanValueByKey(pm.getLabel() + " is available for Patient Deposit Return", true);
+            if (include) {
+                paymentMethodsForPatientDepositRefund.add(pm);
+            }
+        }
+        return paymentMethodsForPatientDepositRefund;
+    }
+
+    public void setPaymentMethodsForPatientDepositRefund(List<PaymentMethod> paymentMethodsForPatientDepositRefund) {
+        this.paymentMethodsForPatientDepositRefund = paymentMethodsForPatientDepositRefund;
+    }

--- a/tmp_enum5.txt
+++ b/tmp_enum5.txt
@@ -1,0 +1,43 @@
+    public void setPaymentMethodsForMultiplePaymentMethod(List<PaymentMethod> paymentMethodsForMultiplePaymentMethod) {
+        this.paymentMethodsForMultiplePaymentMethod = paymentMethodsForMultiplePaymentMethod;
+    }
+
+    public List<PatientInvestigationStatus> getAvailableStatusforCancel() {
+        availableStatusforCancel = new ArrayList<>();
+        availableStatusforCancel.add(PatientInvestigationStatus.ORDERED);
+        availableStatusforCancel.add(PatientInvestigationStatus.SAMPLE_GENERATED);
+        availableStatusforCancel.add(PatientInvestigationStatus.SAMPLE_COLLECTED);
+        availableStatusforCancel.add(PatientInvestigationStatus.SAMPLE_SENT);
+        availableStatusforCancel.add(PatientInvestigationStatus.SAMPLE_REJECTED);
+        return availableStatusforCancel;
+    }
+
+    public void setAvailableStatusforCancel(List<PatientInvestigationStatus> availableStatusforCancel) {
+        this.availableStatusforCancel = availableStatusforCancel;
+    }
+
+    public List<PaymentMethod> getPaymentMethodsForPharmacyPurchase() {
+        if (paymentMethodsForPharmacyPurchase == null) {
+            fillPaymentMethodsFoPharmacyPurchase();
+        }
+        return paymentMethodsForPharmacyPurchase;
+    }
+
+    public InvestigationItemType getInvestigationItemType(String name) {
+        for (InvestigationItemType type : InvestigationItemType.values()) {
+            if (type.toString().equalsIgnoreCase(name.trim())) {
+                return type;
+            }
+        }
+        return null;
+    }
+
+    public InvestigationItemValueType getInvestigationItemValueType(String name) {
+        for (InvestigationItemValueType type : InvestigationItemValueType.values()) {
+            if (type.toString().equalsIgnoreCase(name)) {
+                return type;
+            }
+        }
+        return null;
+    }
+

--- a/tmp_opd_snip.txt
+++ b/tmp_opd_snip.txt
@@ -1,0 +1,91 @@
+                                                    <f:facet name="header">No</f:facet>
+                                                        #{rowIndex+1}
+                                                </p:column>
+                                                <p:column>
+                                                    <f:facet name="header">Name</f:facet>
+                                                        #{bix.item.name}
+                                                </p:column>
+
+                                            </p:dataTable>
+                                        </p:tab>
+
+
+                                    </p:tabView>
+                                </h:panelGroup>
+                            </div>
+                            <div class="col-md-6" >
+
+                                <p:panel class="mb-2" id="payment">
+                                    <f:facet name="header" >
+                                        <h:outputText styleClass="fa fa-money-bill-wave" /> 
+                                        <h:outputText value="Payment Details" class="mx-4"></h:outputText>
+                                    </f:facet>
+                                    <div class="row my-1"  >
+                                        <div class="col-5" >
+                                            <p:selectOneMenu   
+                                                id="pay"
+                                                class="w-100"
+                                                value="#{opdBillController.paymentMethod}"
+                                                >     
+                                                <f:selectItems 
+                                                    value="#{enumController.paymentMethodsForOpdBilling}"  
+                                                    var="pm"
+                                                    itemLabel="#{pm.label}"
+                                                    itemValue="#{pm}"/>
+                                                <p:ajax process="@this cmbPs" 
+                                                        update=":#{p:resolveFirstComponentWithId('pBillDetails',view).clientId}  tblBillItem paymentDetails"
+                                                        event="change"
+                                                        listener="#{opdBillController.listnerForPaymentMethodChange()}"/>
+                                            </p:selectOneMenu>
+                                        </div>
+
+                                        <div class="col-7 " >
+                                            <h:panelGrid columns="3" class="m-1 w-100">
+                                                <p:commandButton 
+                                                    value="Settle"
+                                                    style="float: right;"
+                                                    ajax="false"
+                                                    icon="fa fa-check"
+                                                    action="#{opdBillController.settleOpdBill()}"
+                                                    onclick="if (!confirm('Are you sure you want to Settle This Bill ?'))
+                                                                return false;"
+                                                    class="ui-button-success mx-2 w-100">
+                                                </p:commandButton>
+
+                                                <p:commandButton 
+                                                    style="float: right;"
+                                                    value="Lookup" 
+                                                    ajax="false"
+                                                    icon="fa fa-search"
+                                                    class="ui-button-warning mx-1 w-100" 
+                                                    action="#{opdBillController.navigateToSearchPatients()}" 
+                                                    >
+                                                </p:commandButton>
+                                                <p:commandButton 
+                                                    style="float: right;"
+                                                    value="Profile" 
+                                                    ajax="false"
+                                                    icon="fa fa-user"
+                                                    class="ui-button-warning  w-100" 
+                                                    action="#{patientController.navigateToOpdPatientProfile()}" 
+                                                    >
+                                                    <f:setPropertyActionListener 
+                                                        value="#{opdBillController.patient}" 
+                                                        target="#{patientController.current}" ></f:setPropertyActionListener>
+                                                </p:commandButton>
+
+                                            </h:panelGrid>
+                                        </div>
+                                    </div>
+
+                                    <div>
+                                        <h:panelGroup id="paymentDetails"  >
+
+                                            <h:panelGroup
+                                                class="row"
+                                                layout="block"  
+                                                rendered="#{opdBillController.paymentMethod eq 'Staff'}" >
+                                                <div class="my-1" id="staffCredit">
+                                                    <div class="row mt-1">
+                                                        <div class="col-12">
+                                                            <p:autoComplete  

--- a/tmp_pharm_snip.txt
+++ b/tmp_pharm_snip.txt
@@ -1,0 +1,41 @@
+                                        required="true"
+                                        class="w-100"
+                                        inputStyleClass="w-100"
+                                        requiredMessage="Supplier is Required"
+                                        completeMethod="#{dealerController.completeActiveDealor}"
+                                        var="vt" itemLabel="#{vt.name}" itemValue="#{vt}" >
+                                        <f:ajax
+                                            event="itemSelect" 
+                                            execute="@this" 
+                                            render=":#{p:resolveFirstComponentWithId('exDItem',view).clientId}" 
+                                            />
+                                    </p:autoComplete>
+
+                                    <p:outputLabel value="Payment Method"
+                                                   class="form-label"
+                                                   for="cmbPs"></p:outputLabel>
+                                    <p:selectOneMenu class="w-100"  id="cmbPs" value="#{purchaseOrderRequestController.currentBill.paymentMethod}">    
+                                        <f:selectItem itemLabel="Select Payment method"/>
+                                        <f:selectItems value="#{enumController.paymentMethodsForPurchases}">
+                                        </f:selectItems>
+                                        <p:ajax process="@this" update="po" event="change"/>
+                                        <p:ajax process="@this" update="duration" event="itemSelect" />
+                                    </p:selectOneMenu>
+
+
+                                    <h:panelGroup rendered="#{purchaseOrderRequestController.currentBill.paymentMethod eq 'Credit'}" id="duration" >
+                                        <div class="d-flex" >
+                                            <div class="ui-inputgroup mx-1 my-1">
+                                                <p:inputText  
+                                                    onfocus="this.select();"  
+                                                    value="#{purchaseOrderRequestController.currentBill.creditDuration}"
+                                                    style="width: 10em;">
+                                                </p:inputText>
+                                                <div class="ui-inputgroup-addon">Days</div>
+                                            </div>
+                                        </div>
+                                    </h:panelGroup>
+
+                                    <p:spacer 
+                                        rendered="#{configOptionApplicationController.getBooleanValueByKey('Enable Consignment in Pharmacy Purchasing', true)}"
+                                        class="my-4"></p:spacer>

--- a/tmp_pm1.txt
+++ b/tmp_pm1.txt
@@ -1,0 +1,109 @@
+
+import java.util.List;
+import java.util.Arrays;
+import java.util.stream.Collectors;
+import java.lang.reflect.Field;
+
+public enum PaymentMethod {
+    OnCall("On Call", PaymentType.NONE, PaymentContext.ACCEPTING_PAYMENTS_FOR_CHANNELLING),
+    Cash("Cash", PaymentType.NON_CREDIT, PaymentContext.PURCHASES, PaymentContext.ACCEPTING_PAYMENTS, PaymentContext.CREDIT_SETTLEMENTS, PaymentContext.ACCEPTING_PAYMENTS_FOR_CHANNELLING),
+    Card("Credit Card", PaymentType.NON_CREDIT, PaymentContext.PURCHASES, PaymentContext.ACCEPTING_PAYMENTS, PaymentContext.ACCEPTING_PAYMENTS_FOR_CHANNELLING),
+    MultiplePaymentMethods("Multiple Payment Methods", PaymentType.NON_CREDIT, PaymentContext.ACCEPTING_PAYMENTS),
+    Staff("Staff Credit", PaymentType.CREDIT, PaymentContext.ACCEPTING_PAYMENTS, PaymentContext.ACCEPTING_PAYMENTS_FOR_CHANNELLING),
+    Credit("Credit", PaymentType.CREDIT, PaymentContext.ACCEPTING_PAYMENTS, PaymentContext.ACCEPTING_PAYMENTS_FOR_CHANNELLING, PaymentContext.PURCHASES),
+    Staff_Welfare("Staff Welfare", PaymentType.NON_CREDIT, PaymentContext.ACCEPTING_PAYMENTS, PaymentContext.ACCEPTING_PAYMENTS_FOR_CHANNELLING),
+    Voucher("Voucher", PaymentType.NON_CREDIT, PaymentContext.ACCEPTING_PAYMENTS, PaymentContext.ACCEPTING_PAYMENTS_FOR_CHANNELLING), // Assuming deprecated
+    IOU("IOU", PaymentType.NON_CREDIT, PaymentContext.ACCEPTING_PAYMENTS, PaymentContext.ACCEPTING_PAYMENTS_FOR_CHANNELLING),
+    Agent("Agent Payment", PaymentType.NON_CREDIT, PaymentContext.ACCEPTING_PAYMENTS, PaymentContext.ACCEPTING_PAYMENTS_FOR_CHANNELLING),
+    Cheque("Cheque", PaymentType.NON_CREDIT, PaymentContext.PURCHASES, PaymentContext.ACCEPTING_PAYMENTS, PaymentContext.ACCEPTING_PAYMENTS_FOR_CHANNELLING),
+    Slip("Slip Payment", PaymentType.NON_CREDIT, PaymentContext.PURCHASES, PaymentContext.ACCEPTING_PAYMENTS, PaymentContext.ACCEPTING_PAYMENTS_FOR_CHANNELLING, PaymentContext.CREDIT_SETTLEMENTS),
+    ewallet("e-Wallet Payment", PaymentType.NON_CREDIT, PaymentContext.PURCHASES, PaymentContext.ACCEPTING_PAYMENTS, PaymentContext.ACCEPTING_PAYMENTS_FOR_CHANNELLING, PaymentContext.CREDIT_SETTLEMENTS),
+    PatientDeposit("Patient Deposit", PaymentType.NON_CREDIT, PaymentContext.ACCEPTING_PAYMENTS, PaymentContext.ACCEPTING_PAYMENTS_FOR_CHANNELLING),
+    PatientPoints("Patient Points", PaymentType.NON_CREDIT, PaymentContext.ACCEPTING_PAYMENTS, PaymentContext.ACCEPTING_PAYMENTS_FOR_CHANNELLING, PaymentContext.CREDIT_SETTLEMENTS),
+    OnlineSettlement("Online Settlement", PaymentType.NON_CREDIT, PaymentContext.ACCEPTING_PAYMENTS),
+    None("None", PaymentType.NONE, PaymentContext.PURCHASES, PaymentContext.ACCEPTING_PAYMENTS, PaymentContext.CREDIT_SETTLEMENTS),
+    OnlineBookingAgent("OnlineBooking Agent", PaymentType.NONE, PaymentContext.PURCHASES, PaymentContext.ACCEPTING_PAYMENTS, PaymentContext.CREDIT_SETTLEMENTS),
+    @Deprecated
+    YouOweMe("You Owe Me", PaymentType.NON_CREDIT, PaymentContext.ACCEPTING_PAYMENTS); // Assuming deprecated
+
+    private final String label;
+    private final PaymentType paymentType;
+    private final List<PaymentContext> contexts;
+
+    PaymentMethod(String label, PaymentType paymentType, PaymentContext... contexts) {
+        this.label = label;
+        this.paymentType = paymentType;
+        this.contexts = Arrays.asList(contexts);
+    }
+
+    public String getLabel() {
+        return label;
+    }
+
+    public PaymentType getPaymentType() {
+        return paymentType;
+    }
+
+    public List<PaymentContext> getContexts() {
+        return contexts;
+    }
+
+    public static List<PaymentMethod> getMethodsByContext(PaymentContext context) {
+        return Arrays.stream(PaymentMethod.values())
+                .filter(pm -> pm.contexts.contains(context) && !isDeprecated(pm))
+                .collect(Collectors.toList());
+    }
+
+    public static List<PaymentMethod> getMethodsByType(PaymentType type) {
+        return Arrays.stream(PaymentMethod.values())
+                .filter(pm -> pm.paymentType == type)
+                .collect(Collectors.toList());
+    }
+
+    private static boolean isDeprecated(PaymentMethod method) {
+        try {
+            Field field = PaymentMethod.class.getField(method.name());
+            return field.isAnnotationPresent(Deprecated.class);
+        } catch (NoSuchFieldException e) {
+            return false; // Should not happen unless enum name is incorrect
+        }
+    }
+
+    public static List<PaymentMethod> getActivePaymentMethods() {
+        return Arrays.stream(PaymentMethod.values())
+                .filter(pm -> !isDeprecated(pm))
+                .collect(Collectors.toList());
+    }
+
+    public String getInHandLabel() {
+        switch (this) {
+            case Agent:
+                return "Agent Payment Received";
+            case Card:
+                return "Credit Card Received";
+            case Cash:
+                return "Cash in hand";
+            case Cheque:
+                return "Cheque Received";
+            case Credit:
+                return "Credit Received";
+            case OnCall:
+                return "On Call (Credit) Received";
+            case OnlineSettlement:
+                return "Online Settlement Received";
+            case Slip:
+                return "Slip Payment Received";
+            case Staff:
+                return "Staff Payment Received";
+            case ewallet:
+                return "e-Wallet Payment Received";
+            default:
+                return this.toString();
+        }
+    }
+
+    public static List<PaymentMethod> asList() {
+        return Arrays.asList(PaymentMethod.values());
+    }
+
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Two A4 custom Purchase Order print layouts with a settings dialog to toggle formats.
  - Item History button in GRN Costing; history data now served via faster DTOs; direct purchases show creator name.

- UI Changes
  - Payment method dropdowns for Purchase/Direct Purchase now use GRN-specific options.
  - Replaced “Duplicate” with “Delete” action in GRN Costing items.

- Improvements
  - GRN costing: per-item profit margins, PO reconciliation, smarter edit loading with in-memory expense deduplication.
  - More reliable direct-purchase settlement timing and tracking of remaining/completed quantities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->