### PR TITLE
Handle null pre-bill identifiers during printing

### DIFF
--- a/src/main/java/com/divudi/bean/pharmacy/PharmacySaleController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacySaleController.java
@@ -2065,7 +2065,12 @@ public class PharmacySaleController implements Serializable, ControllerWithPatie
 
         savePreBillFinallyForRetailSaleForCashier(pt);
         savePreBillItemsFinally(tmpBillItems);
-        setPrintBill(getBillFacade().find(getPreBill().getId()));
+        Long id = getPreBill().getId();
+        if (id == null) {
+            JsfUtil.addErrorMessage("Pre-bill is not persisted; cannot load for printing");
+            return;
+        }
+        setPrintBill(getBillFacade().find(id));
         if (configOptionApplicationController.getBooleanValueByKey("Create Token At Pharmacy Sale For Cashier") || configOptionApplicationController.getBooleanValueByKey("Enable token system in sale for cashier", false)) {
             if (getPatient() != null) {
                 Token t = tokenController.findPharmacyTokens(getPreBill());


### PR DESCRIPTION
## Summary
- guard against null identifiers when loading the pre-bill for printing during settlement
- surface a user-facing error message when the pre-bill has not been persisted yet

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68c86df9512c832fb661b1d3b625aa09