### PR TITLE
Fixed - Sample Rejection Validation Update.

### DIFF
--- a/src/main/java/com/divudi/bean/lab/PatientInvestigationController.java
+++ b/src/main/java/com/divudi/bean/lab/PatientInvestigationController.java
@@ -540,8 +540,11 @@ public class PatientInvestigationController implements Serializable {
         for (PatientSample ps : canSentOutLabSamples) {
             if (outLabDepartment.getDepartmentType() == DepartmentType.External_Lab) {
                 ps.setOutsourced(true);
+                ps.setSampleSent(true);
             } else {
                 ps.setOutsourced(false);
+                ps.setSampleSent(true);
+                ps.setSampleSentAt(new Date());
             }
             ps.setOutsourceSampleTransporter(sampleTransportedToLabByStaff);
             ps.setOutsourceInstitution(outLabInstitution);
@@ -2331,6 +2334,10 @@ public class PatientInvestigationController implements Serializable {
                 JsfUtil.addErrorMessage("This Sample (" + ps.getId() + ") is Already Sent OutLab");
                 return;
             }
+            if (ps.getStatus() == PatientInvestigationStatus.SAMPLE_SENT_TO_INTERNAL_LAB) {
+                JsfUtil.addErrorMessage("This Sample (" + ps.getId() + ") is Already Sent Internal Lab");
+                return;
+            }
 
             String jpql = "SELECT r "
                     + " FROM PatientReport r "
@@ -2348,6 +2355,11 @@ public class PatientInvestigationController implements Serializable {
                 return;
             }
 
+            if (! ps.getDepartment().getId().equals(sessionController.getDepartment().getId())) {
+                JsfUtil.addErrorMessage("This Sample (" + ps.getId() + ") is not in your Department. You Cant't Reject.");
+                return;
+            }
+            
             canRejectSamples.add(ps);
 
         }

--- a/src/main/webapp/lab/generate_barcode_p.xhtml
+++ b/src/main/webapp/lab/generate_barcode_p.xhtml
@@ -520,6 +520,7 @@
                                         id="sendSampleDept"
                                         var="c"
                                         class="w-100">
+                                        <f:selectItem itemLabel="Select To Department"/>
                                         <f:selectItems 
                                             value="#{departmentController.getInstitutionAllLabTypesDepartments(patientInvestigationController.outLabInstitution)}" 
                                             var="odpt" 

--- a/src/main/webapp/lab/generate_barcode_p.xhtml
+++ b/src/main/webapp/lab/generate_barcode_p.xhtml
@@ -291,7 +291,7 @@
 
                                     <hr/>
 
-                                    <p:commandButton 
+<!--                                    <p:commandButton 
                                         rendered="#{patientInvestigationController.listingEntity eq 'PATIENT_INVESTIGATIONS'}"
                                         id="btnGenerateBarcodes"
                                         value="Generate Barcodes"
@@ -300,7 +300,7 @@
                                         title="Generate Barcodes"
                                         icon="pi pi-barcode"
                                         styleClass="w-100 ui-button-success" >
-                                    </p:commandButton>
+                                    </p:commandButton>-->
 
                                     <p:commandButton 
                                         disabled="#{patientInvestigationController.listingEntity ne 'PATIENT_SAMPLES'}"


### PR DESCRIPTION
closes #15419
Signed-off-by: DamithDeshan <hkddrajapaksha@gmail.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Bug Fixes
  - Ensured samples sent to labs are consistently marked as sent, with timestamps recorded for internal lab sends.
  - Added safeguards to prevent rejecting samples already sent to the internal lab.
  - Enforced department ownership: rejection is blocked if the sample is not in the current department.

- UI
  - Hid the “Generate Barcodes” button from the barcode page.
  - Added a “Select To Department” placeholder to the Sending Department dropdown in the Send Out Lab dialog for clearer selection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->