### PR TITLE
5250 requested list button was not working

### DIFF
--- a/agents/prompts/disbursement.txt
+++ b/agents/prompts/disbursement.txt
@@ -1,0 +1,10 @@
+in page - D:\Development\rh\src\main\webapp\pharmacy\pharmacy_purhcase_order_request.xhtml
+
+We need to have a printer configuration button to configure all the following
+
+#{configOptionController.getBooleanValueByKey('Pharmacy Purchase Order Request Print - A4 Paper Custom 1',true)}
+#{configOptionController.getBooleanValueByKey('Pharmacy Purchase Order Request Print - A4 Paper Custom 2',true)}
+
+Please add the same controller if possible. If not, you can create a new controller
+
+

--- a/src/main/java/com/divudi/bean/common/SearchController.java
+++ b/src/main/java/com/divudi/bean/common/SearchController.java
@@ -19955,5 +19955,14 @@ public class SearchController implements Serializable {
         return redacted;
     }
 
+    /**
+     * Navigates to the pharmacy transfer request list page and refreshes the data.
+     * This ensures users see up-to-date fullyIssued status after completing an issue operation.
+     */
+    public String navigateToRequestListAndRefresh() {
+        createRequestTableDto();
+        return "pharmacy_transfer_request_list";
+    }
+
     // </editor-fold>
 }

--- a/src/main/java/com/divudi/bean/pharmacy/TransferReceiveController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/TransferReceiveController.java
@@ -97,6 +97,8 @@ public class TransferReceiveController implements Serializable {
 
     @Inject
     private PharmacyCalculation pharmacyCalculation;
+    @Inject
+    private com.divudi.bean.common.SearchController searchController;
     private List<Bill> bills;
     private SearchKeyword searchKeyword;
     private BillItem selectedBillItem;
@@ -162,6 +164,11 @@ public class TransferReceiveController implements Serializable {
         fromDate = null;
         toDate = null;
         selectedBillItem = null;
+
+        // Refresh the issued list data to show updated fullyIssued status
+        if (searchController != null) {
+            searchController.createIssueTable();
+        }
     }
 
     public TransferReceiveController() {

--- a/src/main/resources/META-INF/persistence.xml
+++ b/src/main/resources/META-INF/persistence.xml
@@ -2,7 +2,7 @@
 <persistence version="2.2" xmlns="http://java.sun.com/xml/ns/persistence" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/persistence http://xmlns.jcp.org/xml/ns/persistence/persistence_2_2.xsd">
     <persistence-unit name="hmisPU" transaction-type="JTA">
         <provider>org.eclipse.persistence.jpa.PersistenceProvider</provider>
-        <jta-data-source>${JDBC_DATASOURCE}</jta-data-source>
+        <jta-data-source>jdbc/ruhunu</jta-data-source>
         <exclude-unlisted-classes>false</exclude-unlisted-classes>
         <properties>
             <property name="eclipselink.logging.level.sql" value="SEVERE"/>
@@ -10,7 +10,7 @@
         </properties>
     </persistence-unit>
     <persistence-unit name="hmisAuditPU" transaction-type="JTA">
-        <jta-data-source>${JDBC_AUDIT_DATASOURCE}</jta-data-source>
+        <jta-data-source>jdbc/ruhunuAudit</jta-data-source>
         <exclude-unlisted-classes>false</exclude-unlisted-classes>
         <properties>
             <property name="eclipselink.logging.level.sql" value="SEVERE"/>

--- a/src/main/resources/META-INF/persistence.xml
+++ b/src/main/resources/META-INF/persistence.xml
@@ -2,7 +2,7 @@
 <persistence version="2.2" xmlns="http://java.sun.com/xml/ns/persistence" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/persistence http://xmlns.jcp.org/xml/ns/persistence/persistence_2_2.xsd">
     <persistence-unit name="hmisPU" transaction-type="JTA">
         <provider>org.eclipse.persistence.jpa.PersistenceProvider</provider>
-        <jta-data-source>jdbc/ruhunu</jta-data-source>
+        <jta-data-source>${JDBC_DATASOURCE}</jta-data-source>
         <exclude-unlisted-classes>false</exclude-unlisted-classes>
         <properties>
             <property name="eclipselink.logging.level.sql" value="SEVERE"/>
@@ -10,7 +10,7 @@
         </properties>
     </persistence-unit>
     <persistence-unit name="hmisAuditPU" transaction-type="JTA">
-        <jta-data-source>jdbc/ruhunuAudit</jta-data-source>
+        <jta-data-source>${JDBC_AUDIT_DATASOURCE}</jta-data-source>
         <exclude-unlisted-classes>false</exclude-unlisted-classes>
         <properties>
             <property name="eclipselink.logging.level.sql" value="SEVERE"/>

--- a/src/main/webapp/pharmacy/pharmacy_transfer_issue.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_transfer_issue.xhtml
@@ -155,6 +155,7 @@
                             <f:facet name="header" >                                  
                                 <h:outputText value="Issue Details" ></h:outputText>
                                 <p:commandButton  
+                                    id="btnSettleIssue"
                                     value="Issue" 
                                     icon="fas fa-check" 
                                     action="#{transferIssueController.settle}" 
@@ -367,12 +368,12 @@
             </p:panel>
             <p:panel rendered="#{transferIssueController.printPreview}">
                 <div class="d-flex justify-content-between mb-2">
-                    <p:commandButton 
-                        ajax="false" 
+                    <p:commandButton
+                        ajax="false"
                         icon="fas fa-list"
                         class="ui-button-warning"
-                        action="pharmacy_transfer_request_list" 
-                        actionListener="#{transferIssueController.makeNull()}" 
+                        action="#{searchController.navigateToRequestListAndRefresh()}"
+                        actionListener="#{transferIssueController.makeNull()}"
                         value="Requested List"/>
 
                     <div class="d-flex">

--- a/src/main/webapp/pharmacy/pharmacy_transfer_issued_list.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_transfer_issued_list.xhtml
@@ -86,6 +86,7 @@
                                 </p:commandButton>
 
                                 <p:commandButton 
+                                    id="btnToReceive"
                                     ajax="false"
                                     value="Receive"
                                     class="ui-button-warning mx-2"

--- a/src/main/webapp/pharmacy/pharmacy_transfer_receive.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_transfer_receive.xhtml
@@ -14,6 +14,7 @@
                     <f:facet name="header" >                                  
 
                         <p:commandButton  
+                            id="btnSettleReceive"
                             value="Receive" 
                             icon="fas fa-check"
                             style="float: right;"


### PR DESCRIPTION
  Summary

  https://youtu.be/84qYfBdWARY

  I found and fixed the same issue that existed with the receive process. The problem was that after completing a
  receive operation and returning to the issued list, the search data wasn't being refreshed to reflect the updated
  fullyIssued status.

  The Problem

  1. The "btnToReceive" button had the correct disable logic: disabled="#{p.cancelled or p.fullyIssued}"
  2. The backend logic for setting fullyIssued = true was working correctly in the settle() method when all items
  were received
  3. However, when users clicked "Issued List" to return from the receive page, the cached search data still showed
  the old status

  The Solution

  As requested, I modified the existing navigation method instead of creating a new one:

  1. Enhanced the makeNull() method in TransferReceiveController.java:158-170 to also refresh the issued list data:
  public void makeNull() {
      issuedBill = null;
      receivedBill = null;
      printPreview = false;
      fromDate = null;
      toDate = null;
      selectedBillItem = null;

      // Refresh the issued list data to show updated fullyIssued status
      if (searchController != null) {
          searchController.createIssueTable();
      }
  }
  2. Added SearchController injection in TransferReceiveController.java:100-101 to enable the refresh:
  @Inject
  private com.divudi.bean.common.SearchController searchController;

  How It Works Now

  1. User clicks "Receive" button for an issued transfer → navigates to receive page
  2. User receives items and clicks "Receive" button → completes the receiving process
  3. Backend properly updates fullyIssued = true when all items are received (using isAlreadyReceived() method)
  4. User sees print preview and clicks "Issued List" button
  5. NEW: The button calls makeNull() which now also refreshes the issued list data via
  searchController.createIssueTable()
  6. User returns to issued list with up-to-date fullyIssued status
  7. Button is now properly disabled for fully received transfers

  The fix ensures that the "btnToReceive" button will be disabled immediately after users return to the issued list
  page, showing the current status from the database rather than stale cached data.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - “Requested List” now refreshes after settling an issue, ensuring issuance status displays correctly.
- Chores
  - Added stable IDs to key pharmacy action buttons (Issue, Receive) to support automation and integrations.
  - Updated internal prompt content to guide printer configuration for purchase order requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->