### PR TITLE
14567 3 cashier details report pharmacy accepeted bills not show

### DIFF
--- a/agents/prompts/Cashier Summaries.txt
+++ b/agents/prompts/Cashier Summaries.txt
@@ -1,0 +1,12 @@
+14567-3-cashier-details-report-pharmacy-accepeted-bills-not-show
+
+When a Pharmacy Pre Bills is raised, stock transactions happen. But payments are NOT yet accepted.
+
+These bills with the status of payment are listed in these pages
+
+http://localhost:8080/rh/faces/pharmacy/pharmacy_search_sale_pre_bill.xhtml - To Search Such Bills. It lists the related Payment Bills when present. This is listing as expected
+
+This is the page such bills are listed to make a payment
+http://localhost:8080/rh/faces/pharmacy/pharmacy_search_pre_bill.xhtml
+
+the Search Token Bills , Search Not Paid Tokens buttons are not listing as expected since last few updates.

--- a/src/main/java/com/divudi/bean/common/SearchController.java
+++ b/src/main/java/com/divudi/bean/common/SearchController.java
@@ -8872,13 +8872,23 @@ public class SearchController implements Serializable {
         }
 
         if (getSearchKeyword().getNetTotal() != null && !getSearchKeyword().getNetTotal().trim().equals("")) {
-            sql += " and  ((token.bill.netTotal) = :netTotal )";
-            parameters.put("netTotal", "%" + getSearchKeyword().getNetTotal().trim().toUpperCase() + "%");
+            try {
+                Double netTotal = Double.parseDouble(getSearchKeyword().getNetTotal().trim());
+                sql += " and  ((token.bill.netTotal) = :netTotal )";
+                parameters.put("netTotal", netTotal);
+            } catch (NumberFormatException e) {
+                // Ignore invalid number format
+            }
         }
 
         if (getSearchKeyword().getTotal() != null && !getSearchKeyword().getTotal().trim().equals("")) {
-            sql += " and  ((token.bill.total) like :total )";
-            parameters.put("total", "%" + getSearchKeyword().getTotal().trim().toUpperCase() + "%");
+            try {
+                Double total = Double.parseDouble(getSearchKeyword().getTotal().trim());
+                sql += " and  ((token.bill.total) = :total )";
+                parameters.put("total", total);
+            } catch (NumberFormatException e) {
+                // Ignore invalid number format
+            }
         }
 
         if (getSearchKeyword().getTokenNumber() != null && !getSearchKeyword().getTokenNumber().trim().equals("")) {
@@ -8926,13 +8936,23 @@ public class SearchController implements Serializable {
         }
 
         if (getSearchKeyword().getNetTotal() != null && !getSearchKeyword().getNetTotal().trim().equals("")) {
-            sql += " and  ((token.bill.netTotal) = :netTotal )";
-            parameters.put("netTotal", "%" + getSearchKeyword().getNetTotal().trim().toUpperCase() + "%");
+            try {
+                Double netTotal = Double.parseDouble(getSearchKeyword().getNetTotal().trim());
+                sql += " and  ((token.bill.netTotal) = :netTotal )";
+                parameters.put("netTotal", netTotal);
+            } catch (NumberFormatException e) {
+                // Ignore invalid number format
+            }
         }
 
         if (getSearchKeyword().getTotal() != null && !getSearchKeyword().getTotal().trim().equals("")) {
-            sql += " and  ((token.bill.total) like :total )";
-            parameters.put("total", "%" + getSearchKeyword().getTotal().trim().toUpperCase() + "%");
+            try {
+                Double total = Double.parseDouble(getSearchKeyword().getTotal().trim());
+                sql += " and  ((token.bill.total) = :total )";
+                parameters.put("total", total);
+            } catch (NumberFormatException e) {
+                // Ignore invalid number format
+            }
         }
 
         if (getSearchKeyword().getTokenNumber() != null && !getSearchKeyword().getTokenNumber().trim().equals("")) {

--- a/src/main/java/com/divudi/bean/common/SearchController.java
+++ b/src/main/java/com/divudi/bean/common/SearchController.java
@@ -4418,12 +4418,6 @@ public class SearchController implements Serializable {
         jpql += " order by b.createdAt desc";
         
 
-        System.out.println("=== DEBUG: createRequestTableDto ===");
-        System.out.println("JPQL: " + jpql);
-        System.out.println("Params: " + params);
-        System.out.println("From Date: " + getFromDate());
-        System.out.println("To Date: " + getToDate());
-        System.out.println("Department: " + getSessionController().getDepartment());
         
         transferRequestDtos = (List<PharmacyTransferRequestListDTO>) billFacade.findLightsByJpql(jpql, params, TemporalType.TIMESTAMP, 50);
         
@@ -8995,16 +8989,15 @@ public class SearchController implements Serializable {
                 normalBills.add(bill);
             }
         }
-
         return normalBills;
     }
 
     public void fillPharmacyPreBillsToAcceptAtCashier() {
         bills = null;
-        String sql;
-        Map temMap = new HashMap();
+        String jpql;
+        Map params = new HashMap();
 
-        sql = "select b from PreBill b "
+        jpql = "select b from PreBill b "
                 + " where b.billTypeAtomic = :billTypeAtomic "
                 + " and b.institution=:ins "
                 + " and b.billedBill is null "
@@ -9013,15 +9006,14 @@ public class SearchController implements Serializable {
                 + " and b.deptId is not null "
                 + " and b.cancelled=false";
 
-        sql += createPharmacyPayKeyword(temMap);
-        sql += " order by b.createdAt desc  ";
+        jpql += createPharmacyPayKeyword(params);
+        jpql += " order by b.createdAt desc  ";
 //
-        temMap.put("billTypeAtomic", BillTypeAtomic.PHARMACY_RETAIL_SALE_PRE_TO_SETTLE_AT_CASHIER);
-        temMap.put("toDate", getToDate());
-        temMap.put("fromDate", getFromDate());
-        temMap.put("ins", getSessionController().getInstitution());
-
-        List<Bill> allBills = getBillFacade().findByJpqlWithoutCache(sql, temMap, TemporalType.TIMESTAMP, 25);
+        params.put("billTypeAtomic", BillTypeAtomic.PHARMACY_RETAIL_SALE_PRE_TO_SETTLE_AT_CASHIER);
+        params.put("toDate", getToDate());
+        params.put("fromDate", getFromDate());
+        params.put("ins", getSessionController().getInstitution());
+        List<Bill> allBills = getBillFacade().findByJpqlWithoutCache(jpql, params, TemporalType.TIMESTAMP, 25);
         bills = filterNomarlBillsOnly(allBills);
     }
 

--- a/src/main/java/com/divudi/bean/pharmacy/DirectPurchaseReturnWorkflowController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/DirectPurchaseReturnWorkflowController.java
@@ -1423,6 +1423,9 @@ public class DirectPurchaseReturnWorkflowController implements Serializable {
         currentBill.setCreater(sessionController.getLoggedUser());
         currentBill.setInstitution(sessionController.getInstitution());
         currentBill.setDepartment(sessionController.getDepartment());
+        
+        //Copy Payment Method from Direct Purchase
+        currentBill.setPaymentMethod(originalDirectPurchase.getPaymentMethod());
 
         // Generate items from Direct Purchase (similar to legacy prepareReturnBill)
         // generateItemsFromDirectPurchase(); commented out as this method is NOT working correctly

--- a/src/main/java/com/divudi/bean/pharmacy/GrnReturnWorkflowController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/GrnReturnWorkflowController.java
@@ -1419,6 +1419,9 @@ public class GrnReturnWorkflowController implements Serializable {
         currentBill.setCreater(sessionController.getLoggedUser());
         currentBill.setInstitution(sessionController.getInstitution());
         currentBill.setDepartment(sessionController.getDepartment());
+        
+        //Copy Payment Method Details from GRN to GRN Return
+        currentBill.setPaymentMethod(originalGrn.getPaymentMethod());
 
         // Generate items from GRN (similar to legacy prepareReturnBill)
         // generateItemsFromGrn(); commendted out as this method is NOT working correctl

--- a/src/main/webapp/pharmacy/pharmacy_bill_pre_settle.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_bill_pre_settle.xhtml
@@ -228,13 +228,13 @@
                                             
                                         </h:panelGrid>
                                         
-                                        <h:panelGroup rendered="#{!configOptionApplicationController.getBooleanValueByKey('Enable token system in sale for cashier', false)}">
+                                        <h:panelGroup rendered="#{!configOptionController.getBooleanValueByKey('Enable token system in sale for cashier', false)}">
                                             <div style="height: 105px">
 
                                             </div>
                                         </h:panelGroup>
                                         
-                                        <h:panelGrid rendered="#{configOptionApplicationController.getBooleanValueByKey('Enable token system in sale for cashier', false)}" columns="3" style="width: 100%">
+                                        <h:panelGrid rendered="#{configOptionController.getBooleanValueByKey('Enable token system in sale for cashier', false)}" columns="3" style="width: 100%">
                                             <h:outputLabel value="Token" ></h:outputLabel>
                                             <h:outputLabel value=":" style="width: 40px; text-align: center"></h:outputLabel>
                                             <h:outputLabel value="#{pharmacyPreSettleController.findTokenFromBill(pharmacyPreSettleController.preBill).tokenNumber}" ></h:outputLabel>
@@ -341,8 +341,8 @@
                             </div>
                             <div>
                                 <p:commandButton ajax="false" icon="fas fa-search" class="ui-button-warning mx-2" value="Back to token bill Search" actionListener="#{pharmacyBillSearch.recreateModel()}" action="pharmacy_search_pre_bill">
-                                    <f:actionListener rendered="#{!configOptionApplicationController.getBooleanValueByKey('Enable token system in sale for cashier', false)}" binding="#{searchController.fillPharmacyPreBillsToAcceptAtCashier()}"></f:actionListener>
-                                    <f:actionListener rendered="#{configOptionApplicationController.getBooleanValueByKey('Enable token system in sale for cashier', false)}" binding="#{searchController.fillPharmacyPreBillsToAcceptAtCashierInTokenSystem()}"></f:actionListener>
+                                    <f:actionListener rendered="#{!configOptionController.getBooleanValueByKey('Enable token system in sale for cashier', false)}" binding="#{searchController.fillPharmacyPreBillsToAcceptAtCashier()}"></f:actionListener>
+                                    <f:actionListener rendered="#{configOptionController.getBooleanValueByKey('Enable token system in sale for cashier', false)}" binding="#{searchController.fillPharmacyPreBillsToAcceptAtCashierInTokenSystem()}"></f:actionListener>
                                 </p:commandButton>
                                 <p:commandButton 
                                     value="New Pharmacy Token"

--- a/src/main/webapp/pharmacy/pharmacy_bill_retail_sale_2.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_bill_retail_sale_2.xhtml
@@ -27,7 +27,7 @@
                             <p:commandButton icon="fas fa-file-invoice" class="mx-2" value="Sale 2" action="/pharmacy/pharmacy_bill_retail_sale_1?faces-redirect=true" rendered="#{webUserController.hasPrivilege('PharmacySale')}" actionListener="#{pharmacySaleController1.pharmacyRetailSale()}" />
                             <p:commandButton icon="fas fa-file-invoice" disabled="true" value="Sale 3" action="/pharmacy/pharmacy_bill_retail_sale_2?faces-redirect=true" rendered="#{webUserController.hasPrivilege('PharmacySale')}" actionListener="#{pharmacySaleController2.pharmacyRetailSale()}" />
                             <p:commandButton icon="fas fa-file-invoice" class="mx-2" value="Sale 4" action="/pharmacy/pharmacy_bill_retail_sale_3?faces-redirect=true" rendered="#{webUserController.hasPrivilege('PharmacySale')}" actionListener="#{pharmacySaleController3.pharmacyRetailSale()}" />
-                            <h:panelGroup rendered="#{configOptionApplicationController.getBooleanValueByKey('Enable token system in sale for cashier', false)}" class="mx-4">
+                            <h:panelGroup rendered="#{configOptionController.getBooleanValueByKey('Enable token system in sale for cashier', false)}" class="mx-4">
                                 <p:outputLabel value="Counter" ></p:outputLabel>
                                 <p:selectOneMenu class="mx-2" value="#{pharmacySaleController2.counter}" >
                                     <f:selectItem itemLabel="Any" ></f:selectItem>

--- a/src/main/webapp/pharmacy/pharmacy_bill_retail_sale_for_cashier.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_bill_retail_sale_for_cashier.xhtml
@@ -508,7 +508,7 @@
                                     accesskey="a"
                                     id="btnPrintToken"
                                     value="Print Token"
-                                    rendered="#{configOptionApplicationController.getBooleanValueByKey('Enable token system in sale for cashier', false)}"
+                                    rendered="#{configOptionController.getBooleanValueByKey('Enable token system in sale for cashier', false)}"
                                     ajax="false"
                                     icon="fa fa-print"
                                     class="ui-button-info m-1"
@@ -567,7 +567,7 @@
                             id="billAndTokenPrint">
                             <h:panelGroup 
                                 layout="block"
-                                rendered="#{pharmacySaleController.printBill ne null and configOptionApplicationController.getBooleanValueByKey('Enable token system in sale for cashier', false)}"
+                                rendered="#{pharmacySaleController.printBill ne null and configOptionController.getBooleanValueByKey('Enable token system in sale for cashier', false)}"
                                 style="page-break-after: always!important;"
                                 id="tokenPrint">
                                 <h:panelGroup 

--- a/src/main/webapp/pharmacy/pharmacy_bill_retail_sale_for_cashier_1.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_bill_retail_sale_for_cashier_1.xhtml
@@ -32,7 +32,7 @@
                             <p:commandButton icon="fas fa-file-invoice" disabled="true" class="mx-2" value="Sale 2" action="/pharmacy/pharmacy_bill_retail_sale_for_cashier_1" rendered="#{webUserController.hasPrivilege('PharmacySale')}" actionListener="#{pharmacySaleController1.pharmacyRetailSale()}" />
                             <p:commandButton icon="fas fa-file-invoice" value="Sale 3" action="/pharmacy/pharmacy_bill_retail_sale_for_cashier_2" rendered="#{webUserController.hasPrivilege('PharmacySale')}" actionListener="#{pharmacySaleController2.pharmacyRetailSale()}" />
                             <p:commandButton icon="fas fa-file-invoice" value="Sale 4" class="mx-2" action="/pharmacy/pharmacy_bill_retail_sale_for_cashier_3" rendered="#{webUserController.hasPrivilege('PharmacySale')}" actionListener="#{pharmacySaleController3.pharmacyRetailSale()}" />
-                            <h:panelGroup rendered="#{configOptionApplicationController.getBooleanValueByKey('Enable token system in sale for cashier', false)}" class="mx-4">
+                            <h:panelGroup rendered="#{configOptionController.getBooleanValueByKey('Enable token system in sale for cashier', false)}" class="mx-4">
                                 <p:outputLabel value="Counter" ></p:outputLabel>
                                 <p:selectOneMenu class="mx-2" value="#{pharmacySaleController1.counter}" >
                                     <f:selectItem itemLabel="Any" ></f:selectItem>

--- a/src/main/webapp/pharmacy/pharmacy_bill_retail_sale_for_cashier_3.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_bill_retail_sale_for_cashier_3.xhtml
@@ -35,7 +35,7 @@
                             <p:commandButton icon="fas fa-file-invoice" value="Sale 3" action="/pharmacy/pharmacy_bill_retail_sale_for_cashier_2" rendered="#{webUserController.hasPrivilege('PharmacySale')}" actionListener="#{pharmacySaleController2.pharmacyRetailSale()}" />
                             <p:commandButton icon="fas fa-file-invoice" class="mx-2" disabled="true" value="Sale 4" action="/pharmacy/pharmacy_bill_retail_sale_for_cashier_3" rendered="#{webUserController.hasPrivilege('PharmacySale')}" actionListener="#{pharmacySaleController3.pharmacyRetailSale()}" />
 
-                            <h:panelGroup rendered="#{configOptionApplicationController.getBooleanValueByKey('Enable token system in sale for cashier', false)}" class="mx-4">
+                            <h:panelGroup rendered="#{configOptionController.getBooleanValueByKey('Enable token system in sale for cashier', false)}" class="mx-4">
                                 <p:outputLabel value="Counter" ></p:outputLabel>
                                 <p:selectOneMenu class="mx-2" value="#{pharmacySaleController3.counter}" >
                                     <f:selectItem itemLabel="Any" ></f:selectItem>

--- a/src/main/webapp/pharmacy/pharmacy_direct_purchase_return_form.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_direct_purchase_return_form.xhtml
@@ -349,7 +349,7 @@
                                         required="true"
                                         requiredMessage="Please select a payment method">
                                         <f:selectItem itemLabel="Select payment method"/>
-                                        <f:selectItems value="#{enumController.paymentMethodsWithoutCredit}"/>
+                                        <f:selectItems value="#{enumController.paymentMethodsForGrn}"/>
                                         <p:ajax process="cmbPaymentMethod" update="paymentMethodDetails" />
                                     </p:selectOneMenu>
                                 </h:panelGroup>

--- a/src/main/webapp/pharmacy/pharmacy_direct_purchase_return_request.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_direct_purchase_return_request.xhtml
@@ -19,10 +19,10 @@
                     <div class="col-2">
                         <h:panelGrid columns="1" class="w-100" >
                             <h:outputLabel value="From Date"/>
-                            <p:calendar class="w-100" inputStyleClass="w-100" id="fromDate" value="#{searchController.fromDate}" navigator="false" pattern="#{sessionController.applicationPreference.longDateTimeFormat}" >      
+                            <p:calendar class="w-100" inputStyleClass="w-100" id="fromDate" value="#{searchController.fromDate}" navigator="false" pattern="#{sessionController.applicationPreference.shortDateTimeFormat}" >      
                             </p:calendar>
                             <h:outputLabel value="To Date"/>
-                            <p:calendar class="w-100" inputStyleClass="w-100" id="toDate" value="#{searchController.toDate}" navigator="false" pattern="#{sessionController.applicationPreference.longDateTimeFormat}" >                                                                              
+                            <p:calendar class="w-100" inputStyleClass="w-100" id="toDate" value="#{searchController.toDate}" navigator="false" pattern="#{sessionController.applicationPreference.shortDateTimeFormat}" >                                                                              
                             </p:calendar>
                             <h:outputLabel/>
                             <h:outputLabel value="Purchase No"/>
@@ -67,6 +67,7 @@
                     </div>
                     <div class="col-10">
                         <p:dataTable 
+                            id="tblBills"
                             value="#{searchController.bills}" 
                             var="p"
                             class="w-100 va-top"
@@ -108,44 +109,53 @@
                             </p:column>
 
                             <p:column 
+                                id="colDpDetails"
                                 headerText="Purchase Details" 
                                 width="16em">
                                 <div class="d-flex flex-column">
                                     <div class="mb-1">
                                         <h:outputText styleClass="fw-bold text-primary" value="#{p.createdAt}">
-                                            <f:convertDateTime timeZone="Asia/Colombo" pattern="#{sessionController.applicationPreference.longDateTimeFormat}" />
+                                            <f:convertDateTime timeZone="Asia/Colombo" pattern="#{sessionController.applicationPreference.shortDateTimeFormat}" />
                                         </h:outputText>
                                         <br/>
-                                        <h:outputText styleClass="text-muted small" value="by #{p.creater.webUserPerson.name}" />
+                                        <i class="fas fa-user text-muted me-1"></i>
+                                        <h:outputText styleClass="text-muted small" value="#{p.creater.webUserPerson.name}" />
+                                    </div>
+                                    <div class="mb-1">
+                                        <i class="fas fa-credit-card text-info me-1"></i>
+                                        <h:outputText styleClass="text-info fw-bold" value="#{p.paymentMethod}" />
                                     </div>
                                     <h:panelGroup rendered="#{p.cancelled}">
                                         <div class="mb-1">
                                             <h:outputText styleClass="text-danger fw-bold" value="Cancelled at " />
                                             <h:outputText styleClass="text-danger" value="#{p.cancelledBill.createdAt}">
-                                                <f:convertDateTime timeZone="Asia/Colombo" pattern="#{sessionController.applicationPreference.longDateTimeFormat}" />
+                                                <f:convertDateTime timeZone="Asia/Colombo" pattern="#{sessionController.applicationPreference.shortDateTimeFormat}" />
                                             </h:outputText>
                                             <br/>
-                                            <h:outputText styleClass="text-danger small" value="by #{p.cancelledBill.creater.webUserPerson.name}" />
+                                            <i class="fas fa-user text-danger me-1"></i>
+                                            <h:outputText styleClass="text-danger small" value="#{p.cancelledBill.creater.webUserPerson.name}" />
                                         </div>
                                     </h:panelGroup>
                                     <h:panelGroup rendered="#{p.refunded}">
                                         <div class="mb-1">
                                             <h:outputText styleClass="text-danger fw-bold" value="Refunded at " />
                                             <h:outputText styleClass="text-danger" value="#{p.refundedBill.createdAt}">
-                                                <f:convertDateTime timeZone="Asia/Colombo" pattern="#{sessionController.applicationPreference.longDateTimeFormat}" />
+                                                <f:convertDateTime timeZone="Asia/Colombo" pattern="#{sessionController.applicationPreference.shortDateTimeFormat}" />
                                             </h:outputText>
                                             <br/>
-                                            <h:outputText styleClass="text-danger small" value="by #{p.refundedBill.creater.webUserPerson.name}" />
+                                            <i class="fas fa-user text-danger me-1"></i>
+                                            <h:outputText styleClass="text-danger small" value="#{p.refundedBill.creater.webUserPerson.name}" />
                                         </div>
                                     </h:panelGroup>
                                     <h:panelGroup rendered="#{p.fullReturned}">
                                         <div class="mb-1">
                                             <h:outputText styleClass="text-success fw-bold" value="Fully Returned at " />
                                             <h:outputText styleClass="text-success" value="#{p.fullReturnedAt}">
-                                                <f:convertDateTime timeZone="Asia/Colombo" pattern="#{sessionController.applicationPreference.longDateTimeFormat}" />
+                                                <f:convertDateTime timeZone="Asia/Colombo" pattern="#{sessionController.applicationPreference.shortDateTimeFormat}" />
                                             </h:outputText>
                                             <br/>
-                                            <h:outputText styleClass="text-success small" value="by #{p.fullReturnedBy.webUserPerson.name}" />
+                                            <i class="fas fa-user text-success me-1"></i>
+                                            <h:outputText styleClass="text-success small" value="#{p.fullReturnedBy.webUserPerson.name}" />
                                         </div>
                                     </h:panelGroup>
                                 </div>

--- a/src/main/webapp/pharmacy/pharmacy_fast_retail_sale_for_cashier.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_fast_retail_sale_for_cashier.xhtml
@@ -802,7 +802,7 @@
 
                                                     </p:panel>
 
-                                                    <p:panel rendered="#{configOptionApplicationController.getBooleanValueByKey('Enable token system in sale for cashier', false)}">
+                                                    <p:panel rendered="#{configOptionController.getBooleanValueByKey('Enable token system in sale for cashier', false)}">
                                                         <f:facet name="header">
                                                             <h:outputText styleClass="fas fa-ticket-alt" />
                                                             <h:outputLabel value="Token Management" class="mx-4"></h:outputLabel>
@@ -919,7 +919,7 @@
                                         accesskey="a"
                                         id="btnPrintToken"
                                         value="Print Token"
-                                        rendered="#{configOptionApplicationController.getBooleanValueByKey('Enable token system in sale for cashier', false)}"
+                                        rendered="#{configOptionController.getBooleanValueByKey('Enable token system in sale for cashier', false)}"
                                         ajax="false"
                                         icon="fa fa-print"
                                         class="ui-button-info m-1"
@@ -1004,7 +1004,7 @@
                             </div>
 
                             <h:panelGroup id="billAndTokenPrint">
-                                <h:panelGroup  rendered="#{pharmacyFastRetailSaleForCashierController.printBill ne null and configOptionApplicationController.getBooleanValueByKey('Enable token system in sale for cashier', false)}"  id="TokenPreview" class="m-2">
+                                <h:panelGroup  rendered="#{pharmacyFastRetailSaleForCashierController.printBill ne null and configOptionController.getBooleanValueByKey('Enable token system in sale for cashier', false)}"  id="TokenPreview" class="m-2">
                                     <h:panelGroup id="gpBillPreviewFiveFiveToken" rendered="#{sessionController.departmentPreference.pharmacyBillPaperType eq 'FiveFivePaper'}">
                                         <div >
                                             <h:panelGroup rendered="#{sessionController.loggedPreference.pharmacyBillPrabodha eq false}">

--- a/src/main/webapp/pharmacy/pharmacy_grn_return_form.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_grn_return_form.xhtml
@@ -347,7 +347,7 @@
                                         required="true"
                                         requiredMessage="Please select a payment method">
                                         <f:selectItem itemLabel="Select payment method"/>
-                                        <f:selectItems value="#{enumController.paymentMethodsWithoutCredit}"/>
+                                        <f:selectItems value="#{enumController.paymentMethodsForGrn}"/>
                                         <p:ajax process="cmbPaymentMethod" update="paymentDetails" />
                                     </p:selectOneMenu>
                                     <p:message for="cmbPaymentMethod" />

--- a/src/main/webapp/pharmacy/pharmacy_grn_return_request.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_grn_return_request.xhtml
@@ -19,10 +19,10 @@
                     <div class="col-2">
                         <h:panelGrid columns="1" class="w-100" >
                             <h:outputLabel value="From Date"/>
-                            <p:calendar class="w-100" inputStyleClass="w-100" id="fromDate" value="#{searchController.fromDate}" navigator="false" pattern="#{sessionController.applicationPreference.longDateTimeFormat}" >      
+                            <p:calendar class="w-100" inputStyleClass="w-100" id="fromDate" value="#{searchController.fromDate}" navigator="false" pattern="#{sessionController.applicationPreference.shortDateTimeFormat}" >      
                             </p:calendar>
                             <h:outputLabel value="To Date"/>
-                            <p:calendar class="w-100" inputStyleClass="w-100" id="toDate" value="#{searchController.toDate}" navigator="false" pattern="#{sessionController.applicationPreference.longDateTimeFormat}" >                                                                              
+                            <p:calendar class="w-100" inputStyleClass="w-100" id="toDate" value="#{searchController.toDate}" navigator="false" pattern="#{sessionController.applicationPreference.shortDateTimeFormat}" >                                                                              
                             </p:calendar>
                             <h:outputLabel/>
                             <h:outputLabel value="Grn No"/>
@@ -66,6 +66,7 @@
                     </div>
                     <div class="col-10">
                         <p:dataTable 
+                            id="tblBills"
                             value="#{searchController.bills}" 
                             var="p"
                             class="w-100 va-top"
@@ -116,24 +117,31 @@
 
 
                             <p:column 
+                                id="colPoDetails"
                                 headerText="PO Details" 
                                 width="16em">
                                 <div class="d-flex flex-column">
                                     <div class="mb-1">
                                         <h:outputText styleClass="fw-bold text-primary" value="#{p.referenceBill.createdAt}">
-                                            <f:convertDateTime timeZone="Asia/Colombo" pattern="#{sessionController.applicationPreference.longDateTimeFormat}" />
+                                            <f:convertDateTime timeZone="Asia/Colombo" pattern="#{sessionController.applicationPreference.shortDateTimeFormat}" />
                                         </h:outputText>
                                         <br/>
-                                        <h:outputText styleClass="text-muted small" value="by #{p.referenceBill.creater.webUserPerson.name}" />
+                                        <i class="fas fa-user text-muted me-1"></i>
+                                        <h:outputText styleClass="text-muted small" value="#{p.referenceBill.creater.webUserPerson.name}" />
+                                    </div>
+                                    <div class="mb-1">
+                                        <i class="fas fa-credit-card text-info me-1"></i>
+                                        <h:outputText styleClass="text-info fw-bold" value="#{p.referenceBill.paymentMethod}" />
                                     </div>
                                     <h:panelGroup rendered="#{p.referenceBill.cancelled}">
                                         <div class="mb-1">
                                             <h:outputText styleClass="text-danger fw-bold" value="Cancelled at " />
                                             <h:outputText styleClass="text-danger" value="#{p.referenceBill.cancelledBill.createdAt}">
-                                                <f:convertDateTime timeZone="Asia/Colombo" pattern="#{sessionController.applicationPreference.longDateTimeFormat}" />
+                                                <f:convertDateTime timeZone="Asia/Colombo" pattern="#{sessionController.applicationPreference.shortDateTimeFormat}" />
                                             </h:outputText>
                                             <br/>
-                                            <h:outputText styleClass="text-danger small" value="by #{p.referenceBill.cancelledBill.creater.webUserPerson.name}" />
+                                            <i class="fas fa-user text-danger me-1"></i>
+                                            <h:outputText styleClass="text-danger small" value="#{p.referenceBill.cancelledBill.creater.webUserPerson.name}" />
                                         </div>
                                     </h:panelGroup>
                                 </div>
@@ -141,43 +149,52 @@
                             
                             <p:column 
                                 headerText="GRN Details" 
+                                id="colGrnDetails"
                                 width="16em">
                                 <div class="d-flex flex-column">
                                     <div class="mb-1">
                                         <h:outputText styleClass="fw-bold text-primary" value="#{p.createdAt}">
-                                            <f:convertDateTime timeZone="Asia/Colombo" pattern="#{sessionController.applicationPreference.longDateTimeFormat}" />
+                                            <f:convertDateTime timeZone="Asia/Colombo" pattern="#{sessionController.applicationPreference.shortDateTimeFormat}" />
                                         </h:outputText>
                                         <br/>
-                                        <h:outputText styleClass="text-muted small" value="by #{p.creater.webUserPerson.name}" />
+                                        <i class="fas fa-user text-muted me-1"></i>
+                                        <h:outputText styleClass="text-muted small" value="#{p.creater.webUserPerson.name}" />
+                                    </div>
+                                    <div class="mb-1">
+                                        <i class="fas fa-credit-card text-info me-1"></i>
+                                        <h:outputText styleClass="text-info fw-bold" value="#{p.paymentMethod}" />
                                     </div>
                                     <h:panelGroup rendered="#{p.cancelled}">
                                         <div class="mb-1">
                                             <h:outputText styleClass="text-danger fw-bold" value="Cancelled at " />
                                             <h:outputText styleClass="text-danger" value="#{p.cancelledBill.createdAt}">
-                                                <f:convertDateTime timeZone="Asia/Colombo" pattern="#{sessionController.applicationPreference.longDateTimeFormat}" />
+                                                <f:convertDateTime timeZone="Asia/Colombo" pattern="#{sessionController.applicationPreference.shortDateTimeFormat}" />
                                             </h:outputText>
                                             <br/>
-                                            <h:outputText styleClass="text-danger small" value="by #{p.cancelledBill.creater.webUserPerson.name}" />
+                                            <i class="fas fa-user text-danger me-1"></i>
+                                            <h:outputText styleClass="text-danger small" value="#{p.cancelledBill.creater.webUserPerson.name}" />
                                         </div>
                                     </h:panelGroup>
                                     <h:panelGroup rendered="#{p.refunded}">
                                         <div class="mb-1">
                                             <h:outputText styleClass="text-danger fw-bold" value="Refunded at " />
                                             <h:outputText styleClass="text-danger" value="#{p.refundedBill.createdAt}">
-                                                <f:convertDateTime timeZone="Asia/Colombo" pattern="#{sessionController.applicationPreference.longDateTimeFormat}" />
+                                                <f:convertDateTime timeZone="Asia/Colombo" pattern="#{sessionController.applicationPreference.shortDateTimeFormat}" />
                                             </h:outputText>
                                             <br/>
-                                            <h:outputText styleClass="text-danger small" value="by #{p.refundedBill.creater.webUserPerson.name}" />
+                                            <i class="fas fa-user text-danger me-1"></i>
+                                            <h:outputText styleClass="text-danger small" value="#{p.refundedBill.creater.webUserPerson.name}" />
                                         </div>
                                     </h:panelGroup>
                                     <h:panelGroup rendered="#{p.fullReturned}">
                                         <div class="mb-1">
                                             <h:outputText styleClass="text-success fw-bold" value="Fully Returned at " />
                                             <h:outputText styleClass="text-success" value="#{p.fullReturnedAt}">
-                                                <f:convertDateTime timeZone="Asia/Colombo" pattern="#{sessionController.applicationPreference.longDateTimeFormat}" />
+                                                <f:convertDateTime timeZone="Asia/Colombo" pattern="#{sessionController.applicationPreference.shortDateTimeFormat}" />
                                             </h:outputText>
                                             <br/>
-                                            <h:outputText styleClass="text-success small" value="by #{p.fullReturnedBy.webUserPerson.name}" />
+                                            <i class="fas fa-user text-success me-1"></i>
+                                            <h:outputText styleClass="text-success small" value="#{p.fullReturnedBy.webUserPerson.name}" />
                                         </div>
                                     </h:panelGroup>
                                 </div>

--- a/src/main/webapp/pharmacy/pharmacy_search_pre_bill.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_search_pre_bill.xhtml
@@ -43,8 +43,8 @@
 
                                 <h:outputLabel value="Bill No"/>
                                 <p:inputText autocomplete="off" class="w-100" value="#{searchController.searchKeyword.billNo}" />
-                                <h:outputLabel rendered="#{configOptionApplicationController.getBooleanValueByKey('Enable token system in sale for cashier', false)}" value="Token Number"/>
-                                <p:inputText autocomplete="off" class="w-100" rendered="#{configOptionApplicationController.getBooleanValueByKey('Enable token system in sale for cashier', false)}" value="#{searchController.searchKeyword.tokenNumber}" />
+                                <h:outputLabel rendered="#{configOptionController.getBooleanValueByKey('Enable token system in sale for cashier', false)}" value="Token Number"/>
+                                <p:inputText autocomplete="off" class="w-100" rendered="#{configOptionController.getBooleanValueByKey('Enable token system in sale for cashier', false)}" value="#{searchController.searchKeyword.tokenNumber}" />
                                 <h:outputLabel value="Patient Name"/>
                                 <p:inputText autocomplete="off" class="w-100" value="#{searchController.searchKeyword.patientName}" />
                                 <h:outputLabel value="Total"/>
@@ -64,7 +64,7 @@
                                     class="ui-button-success w-100 mt-3"
                                     icon="fas fa-search"
                                     ajax="false"
-                                    rendered="#{!configOptionApplicationController.getBooleanValueByKey('Enable token system in sale for cashier', false)}"
+                                    rendered="#{!configOptionController.getBooleanValueByKey('Enable token system in sale for cashier', false)}"
                                     value="Search Normal Bills"
                                     action="#{searchController.fillPharmacyPreBillsToAcceptAtCashier}"/>
 
@@ -73,7 +73,7 @@
                                     class="ui-button-success w-100 mt-3"
                                     icon="fas fa-search"
                                     ajax="false"
-                                    rendered="#{configOptionApplicationController.getBooleanValueByKey('Enable token system in sale for cashier', false)}"
+                                    rendered="#{configOptionController.getBooleanValueByKey('Enable token system in sale for cashier', false)}"
                                     value="Search Token Bills"
                                     action="#{searchController.fillPharmacyPreBillsToAcceptAtCashierInTokenSystem()}">
                                 </p:commandButton>
@@ -81,7 +81,7 @@
                                 <p:commandButton
                                     ajax="false"
                                     class=" ui-button-warning w-100 my-1"
-                                    rendered="#{configOptionApplicationController.getBooleanValueByKey('Enable token system in sale for cashier', false)}"
+                                    rendered="#{configOptionController.getBooleanValueByKey('Enable token system in sale for cashier', false)}"
                                     icon="fas fa-search"
                                     value="Search Paid Only Tokens"
                                     action="#{searchController.fillPharmacyPaidPreBillsToAcceptAtCashierInTokenSystem(true)}"/>
@@ -89,7 +89,7 @@
                                 <p:commandButton
                                     ajax="false"
                                     class=" ui-button-warning w-100 my-1"
-                                    rendered="#{configOptionApplicationController.getBooleanValueByKey('Enable token system in sale for cashier', false)}"
+                                    rendered="#{configOptionController.getBooleanValueByKey('Enable token system in sale for cashier', false)}"
                                     icon="fas fa-search"
                                     value="Search Not Paid Tokens"
                                     action="#{searchController.fillPharmacyPaidPreBillsToAcceptAtCashierInTokenSystem(false)}"/>
@@ -97,7 +97,7 @@
                                 <p:commandButton
                                     ajax="false"
                                     class=" ui-button-warning w-100 my-1"
-                                    rendered="#{!configOptionApplicationController.getBooleanValueByKey('Enable token system in sale for cashier', false)}"
+                                    rendered="#{!configOptionController.getBooleanValueByKey('Enable token system in sale for cashier', false)}"
                                     icon="fas fa-search"
                                     value="Search Not Paid Only"
                                     action="#{searchController.fillPharmacyPreBillsToAcceptAtCashierNotPaid()}"/>
@@ -105,7 +105,7 @@
                                     ajax="false"
                                     class=" ui-button-warning w-100"
                                     icon="fas fa-search"
-                                    rendered="#{!configOptionApplicationController.getBooleanValueByKey('Enable token system in sale for cashier', false)}"
+                                    rendered="#{!configOptionController.getBooleanValueByKey('Enable token system in sale for cashier', false)}"
                                     value="Search Paid Only"
                                     action="#{searchController.fillPharmacyPreBillsToAcceptAtCashierGetPaid()}"/>
                                 <h:outputLabel/>
@@ -114,7 +114,7 @@
                                     ajax="false"            
                                     class="ui-button-secondary w-100 my-4"
                                     icon="fa-solid fa-desktop"
-                                    rendered="#{configOptionApplicationController.getBooleanValueByKey('Enable token system in sale for cashier', false)}"
+                                    rendered="#{configOptionController.getBooleanValueByKey('Enable token system in sale for cashier', false)}"
                                     value=" View In Display"
                                     action="/token/pharmacy_tokens_called_sale_for_cashier?faces-redirect=true"
                                     actionListener="#{tokenController.fillSaleForCashierCalledBillsTokens()}"
@@ -190,7 +190,7 @@
                                             </h:outputLabel>
                                         </h:panelGroup>
                                     </p:column>
-                                    <p:column width="8em" headerText="Token Number" rendered="#{configOptionApplicationController.getBooleanValueByKey('Enable token system in sale for cashier', false)}">
+                                    <p:column width="8em" headerText="Token Number" rendered="#{configOptionController.getBooleanValueByKey('Enable token system in sale for cashier', false)}">
                                         <p:tag class="px-3" style="font-size: 15px" value="#{pharmacyPreSettleController.findTokenFromBill(bill).tokenNumber}" severity="success"></p:tag>                                        
 
                                     </p:column>
@@ -203,7 +203,7 @@
 
                                     </p:column>
 
-                                    <p:column headerText="Accept" width="10%" rendered="#{!configOptionApplicationController.getBooleanValueByKey('Enable token system in sale for cashier', false)}">
+                                    <p:column headerText="Accept" width="10%" rendered="#{!configOptionController.getBooleanValueByKey('Enable token system in sale for cashier', false)}">
                                         <p:commandButton
                                             ajax="false"
                                             value="Accept Payment"
@@ -212,7 +212,7 @@
                                         </p:commandButton>
                                     </p:column>
 
-                                    <p:column rendered="#{configOptionApplicationController.getBooleanValueByKey('Enable token system in sale for cashier', false)}" headerText="Actions" style="text-align: center" width="10%" class="align-item-center justify-content-center">
+                                    <p:column rendered="#{configOptionController.getBooleanValueByKey('Enable token system in sale for cashier', false)}" headerText="Actions" style="text-align: center" width="10%" class="align-item-center justify-content-center">
 
                                         <div class="row">
                                             <div class="col-12 d-flex justify-content-center align-items-center">

--- a/src/main/webapp/pharmacy/printing/retail_sale_for_cashier.xhtml
+++ b/src/main/webapp/pharmacy/printing/retail_sale_for_cashier.xhtml
@@ -42,7 +42,7 @@
                                     accesskey="a"
                                     id="btnPrintToken"
                                     value="Print Token"
-                                    rendered="#{configOptionApplicationController.getBooleanValueByKey('Enable token system in sale for cashier', false)}"
+                                    rendered="#{configOptionController.getBooleanValueByKey('Enable token system in sale for cashier', false)}"
                                     ajax="false"
                                     icon="fa fa-print"
                                     class="ui-button-info m-1"

--- a/src/main/webapp/pharmacy/printing/settle_retail_sale_for_cashier.xhtml
+++ b/src/main/webapp/pharmacy/printing/settle_retail_sale_for_cashier.xhtml
@@ -37,13 +37,13 @@
 
                             <!-- Conditional action listeners based on token system configuration -->
                             <p:commandButton
-                                rendered="#{!configOptionApplicationController.getBooleanValueByKey('Enable token system in sale for cashier', false)}"
+                                rendered="#{!configOptionController.getBooleanValueByKey('Enable token system in sale for cashier', false)}"
                                 style="display: none;"
                                 actionListener="#{searchController.fillPharmacyPreBillsToAcceptAtCashier}" >
                             </p:commandButton>
 
                             <p:commandButton
-                                rendered="#{configOptionApplicationController.getBooleanValueByKey('Enable token system in sale for cashier', false)}"
+                                rendered="#{configOptionController.getBooleanValueByKey('Enable token system in sale for cashier', false)}"
                                 style="display: none;"
                                 actionListener="#{searchController.fillPharmacyPreBillsToAcceptAtCashierInTokenSystem}" >
                             </p:commandButton>

--- a/src/main/webapp/pharmacy/purchase_returns_and_cancellations_index.xhtml
+++ b/src/main/webapp/pharmacy/purchase_returns_and_cancellations_index.xhtml
@@ -30,10 +30,10 @@
                                 <p:commandButton 
                                     value="Return Received Goods (Legacy)" 
                                     ajax="false"
+                                    rendered="#{configOptionApplicationController.getBooleanValueByKey('Pharmacy GRN Return - Legacy Method is available', true) and webUserController.hasPrivilege('ReturnReceviedGoods')}"
                                     action="#{searchController.navigateToReturnReceivedGoods()}"
                                     class="ui-button-info w-100"
-                                    icon="fas fa-undo-alt"
-                                    rendered="#{webUserController.hasPrivilege('ReturnReceviedGoods')}" />
+                                    icon="fas fa-undo-alt" />
                                 <p:commandButton 
                                     value="Create GRN Return" 
                                     ajax="false"

--- a/src/main/webapp/pharmacy/view/pharmacy_pre_bill_view.xhtml
+++ b/src/main/webapp/pharmacy/view/pharmacy_pre_bill_view.xhtml
@@ -57,7 +57,7 @@
                                             accesskey="a"
                                             id="btnPrintToken"
                                             value="Print Token"
-                                            rendered="#{configOptionApplicationController.getBooleanValueByKey('Enable token system in sale for cashier', false)}"
+                                            rendered="#{configOptionController.getBooleanValueByKey('Enable token system in sale for cashier', false)}"
                                             ajax="false"
                                             class="ui-button-info m-1"
                                             <p:printer target="tokenPrint" ></p:printer>
@@ -89,7 +89,7 @@
 
                                         <p:commandButton
                                             value="Token"
-                                            rendered="#{configOptionApplicationController.getBooleanValueByKey('Enable token system in sale for cashier', false)}"
+                                            rendered="#{configOptionController.getBooleanValueByKey('Enable token system in sale for cashier', false)}"
                                             ajax="false"
                                             icon="fa fa-print"
                                             class="ui-button-warning m-1"
@@ -138,7 +138,7 @@
                             <h:panelGroup id="billAndTokenPrintOriginal" rendered="#{webUserController.hasPrivilege('PrintOriginalPharmacyBillFromReprint')}">
                                 <h:panelGroup 
                                     layout="block"
-                                    rendered="#{billSearch.bill ne null and configOptionApplicationController.getBooleanValueByKey('Enable token system in sale for cashier', false)}"
+                                    rendered="#{billSearch.bill ne null and configOptionController.getBooleanValueByKey('Enable token system in sale for cashier', false)}"
                                     style="page-break-after: always!important;"
                                     id="tokenPrintOriginal">
                                     <h:panelGroup 
@@ -211,7 +211,7 @@
                             <h:panelGroup id="billAndTokenPrint">
                                 <h:panelGroup 
                                     layout="block"
-                                    rendered="#{billSearch.bill ne null and configOptionApplicationController.getBooleanValueByKey('Enable token system in sale for cashier', false)}"
+                                    rendered="#{billSearch.bill ne null and configOptionController.getBooleanValueByKey('Enable token system in sale for cashier', false)}"
                                     style="page-break-after: always!important;"
                                     id="tokenPrint">
                                     <h:panelGroup 

--- a/src/main/webapp/resources/pharmacy/sale_for_cashier_bill_five_five_custom_1.xhtml
+++ b/src/main/webapp/resources/pharmacy/sale_for_cashier_bill_five_five_custom_1.xhtml
@@ -85,7 +85,7 @@
                 <!-- Separator Line -->
                 <div class="separator"></div>
 
-                <h:panelGroup rendered="#{configOptionApplicationController.getBooleanValueByKey('Enable token system in sale for cashier', false)}">
+                <h:panelGroup rendered="#{configOptionController.getBooleanValueByKey('Enable token system in sale for cashier', false)}">
                     <div class="billline">
                         <h:outputLabel value="#{pharmacyPreSettleController.findTokenFromBill(cc.attrs.bill.referenceBill).tokenNumber}" style="font-size: 30px;
                                        display: inline-block;


### PR DESCRIPTION
Closes #14567

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Pharmacy Pre-Settle view now shows Token Date and Token Time.
  - GRN/Direct Purchase return requests display payment method and clearer user info with icons.

- Improvements
  - More accurate numeric filtering in cashier/token searches (exact match when numeric).
  - Return bills inherit payment method from original documents.
  - Aligned payment method options for GRN/Direct Purchase returns.
  - Unified configuration source controlling token-related UI.
  - Shorter date-time format across GRN/Direct Purchase return requests.
  - “Return Received Goods (Legacy)” button now respects configuration and privilege.

- Documentation
  - Added guidance on Pharmacy Pre Bills, listings, and token-related search behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->