### PR TITLE
Create a  Cancel button to pharmacy credit bill

### DIFF
--- a/src/main/java/com/divudi/bean/common/CreditCompanyBillSearch.java
+++ b/src/main/java/com/divudi/bean/common/CreditCompanyBillSearch.java
@@ -434,6 +434,40 @@ public class CreditCompanyBillSearch implements Serializable {
 
     }
 
+    public void cancelPharmacyCreditCompanyPaymentBill() {
+        if (getBill() != null && getBill().getId() != null && getBill().getId() != 0) {
+            if (errorCheck()) {
+                return;
+            }
+
+            CancelledBill cb = createCancelBill(BillNumberSuffix.PHACCPAYCAN);
+
+            //Copy & paste
+            //  if (webUserController.hasPrivilege("LabBillCancelling")) {
+            if (true) {
+                cb.setBillTypeAtomic(BillTypeAtomic.PHARMACY_CREDIT_COMPANY_PAYMENT_CANCELLATION);
+                getCancelledBillFacade().create(cb);
+                cancelBillItems(cb);
+                getBill().setCancelled(true);
+                getBill().setCancelledBill(cb);
+                getBilledBillFacade().edit(getBill());
+                JsfUtil.addSuccessMessage("Cancelled");
+                WebUser wb = getCashTransactionBean().saveBillCashOutTransaction(cb, getSessionController().getLoggedUser());
+                getSessionController().setLoggedUser(wb);
+                paymentService.createPayment(cb, getPaymentMethodData());
+                printPreview = true;
+                paymentMethodData = null;
+            } else {
+                getEjbApplication().getBillsToCancel().add(cb);
+                JsfUtil.addSuccessMessage("Awaiting Cancellation");
+            }
+
+        } else {
+            JsfUtil.addErrorMessage("No Bill to cancel");
+        }
+
+    }
+
     public void listnerForPaymentMethodChange(Bill b) {
         if (getPaymentMethod() == PaymentMethod.PatientDeposit) {
             getPaymentMethodData().getPatient_deposit().setPatient(b.getPatientEncounter().getPatient());

--- a/src/main/java/com/divudi/core/data/BillNumberSuffix.java
+++ b/src/main/java/com/divudi/core/data/BillNumberSuffix.java
@@ -49,6 +49,7 @@ public enum BillNumberSuffix {
     PHISSUEREQ,//Pharmacy Issue Request
     PHISSCAN,//Pharmacy Issue Cancel
     PHISSRET,//Pharmacy Issue Return
+    PHACCPAYCAN,//Pharmacy Credit Company Payment Cancel
     STISSUE,//Store Issue
     STTISSUECAN,//Store Issue can
     PHRET,

--- a/src/main/webapp/credit/credit_company_bill_pharmacy_cancel.xhtml
+++ b/src/main/webapp/credit/credit_company_bill_pharmacy_cancel.xhtml
@@ -1,0 +1,108 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
+      xmlns:p="http://primefaces.org/ui"
+      xmlns:h="http://xmlns.jcp.org/jsf/html"
+      xmlns:f="http://xmlns.jcp.org/jsf/core"
+      xmlns:bi="http://xmlns.jcp.org/jsf/composite/bill">
+    <h:body>
+        <ui:composition template="/resources/template/template.xhtml">
+            <ui:define name="content">
+                <h:form>
+                    <h:panelGroup rendered="#{!creditCompanyBillSearch.printPreview}" styleClass="alignTop" >
+                        <p:panel  header="Pharmacy Credit Bill Cancellation">
+                            <f:facet name="header">
+                                <div class="d-flex justify-content-between">
+                                    <h:outputText value="Pharmacy Credit Bill Cancellation" class="mt-2"/>
+                                    <div class="d-flex gap-4">
+                                        <p:inputText value="#{creditCompanyBillSearch.comment}" style="width: 500px;" placeholder="Enter a comment"/>
+                                        <p:commandButton 
+                                            ajax="false"
+                                            value="Cancel Bill"
+                                            icon="fa fa-cancel"
+                                            class="ui-button-danger"
+                                            style="width: 150px;"
+                                            action="#{creditCompanyBillSearch.cancelPharmacyCreditCompanyPaymentBill()}" >
+                                        </p:commandButton>
+                                    </div>
+                                </div>
+                            </f:facet>
+
+                            <div class="row">
+                                <div class="col-2">
+                                    <p:panel>
+                                        <f:facet name="header">
+                                            <h:outputText styleClass="fas fa-money-bill"></h:outputText>
+                                            <h:outputLabel value="Payment Mode" class="mx-2"></h:outputLabel>
+                                        </f:facet>
+                                        <p:selectOneMenu style="width: 300px;" id="cmbPs" value="#{creditCompanyBillSearch.paymentMethod}" required="true"  >
+                                            <f:selectItems value="#{enumController.paymentMethodsWithoutCredit}"/>
+                                        </p:selectOneMenu>
+                                    </p:panel>
+                                </div>
+                                <div class="col-6">
+                                    <p:panel header="Credit Company Detail">
+                                        <p:panelGrid columns="2">
+                                            <h:outputLabel value="Company Name:" ></h:outputLabel>
+                                            <h:outputLabel value="#{creditCompanyBillSearch.bill.toInstitution.name }" ></h:outputLabel>                                        
+                                        </p:panelGrid>
+                                    </p:panel>
+                                </div>
+                                <div class="col-4">
+                                    <p:panel header="Bill Detail">
+                                        <p:panelGrid columns="2">
+                                            <h:outputLabel value="Bill No :" ></h:outputLabel>
+                                            <h:outputLabel value="#{creditCompanyBillSearch.bill.deptId}" ></h:outputLabel>                                  
+                                            <h:outputLabel value="Net Total :" ></h:outputLabel>
+                                            <h:outputLabel value="#{creditCompanyBillSearch.bill.netTotal}" >
+                                                <f:convertNumber pattern="#,##0.00"/>
+                                            </h:outputLabel>
+
+                                        </p:panelGrid>
+                                    </p:panel>
+                                </div>
+                            </div>
+
+                            <p:panel header="Bill Item Detail" class="mt-3">
+                                <p:dataTable rowIndexVar="rowIndex" value="#{creditCompanyBillSearch.billItems}" var="b" >
+                                    <p:column>
+                                        <f:facet name="header">
+                                            <p:outputLabel value="No"/>
+                                        </f:facet>
+                                        <p:outputLabel value="#{rowIndex+1}"/>
+                                    </p:column>
+                                    <p:column >    
+                                        <f:facet name="header">
+                                            <p:outputLabel value="Bill No"/>
+                                        </f:facet>
+                                        <p:outputLabel value="#{b.referenceBill.deptId}"/>
+                                    </p:column>                                    
+                                    <p:column headerText="Credit Company">
+                                        <p:outputLabel value="#{b.referenceBill.toInstitution.name}"/>
+                                    </p:column>                                    
+                                    <p:column headerText="Net Total">
+                                        <p:outputLabel value="#{b.netValue}"> 
+                                            <f:convertNumber pattern="#,##0.00"/>
+                                        </p:outputLabel>
+                                    </p:column>
+                                </p:dataTable>
+                            </p:panel>
+
+
+                        </p:panel>
+
+
+                    </h:panelGroup>
+
+
+                    <h:panelGroup rendered="#{creditCompanyBillSearch.printPreview}" >
+                        <bi:CreditReceiveBill controller="#{creditCompanyBillSearch}"  bill="#{creditCompanyBillSearch.bill}" dup="false"/> 
+                    </h:panelGroup>
+
+
+                </h:form>                
+            </ui:define>
+        </ui:composition>
+    </h:body>
+</html>

--- a/src/main/webapp/credit/credit_compnay_bill_pharmacy.xhtml
+++ b/src/main/webapp/credit/credit_compnay_bill_pharmacy.xhtml
@@ -260,11 +260,13 @@
                             class="ui-button-warning mx-3 my-3">
                         </p:commandButton>
                            <p:commandButton
-                               value="Cancel"
-                               icon="fa fa-cancel"
+                               value="To Cancel Bill"
+                               disabled="#{cashRecieveBillController.current.cancelled eq true or cashRecieveBillController.current.refunded eq true}"
+                               icon="pi pi-times"
                                ajax="false"
-                               action="#" 
-                               styleClass="ui-button-danger mx-3 my-3">  
+                               action="credit_company_bill_pharmacy_cancel" 
+                               styleClass="ui-button-danger mx-3 my-3">
+                               <f:setPropertyActionListener value="#{cashRecieveBillController.current}" target="#{creditCompanyBillSearch.bill}" ></f:setPropertyActionListener>
                         </p:commandButton>
                         <p:commandButton value="Print"
                                          icon="fa fa-print"

--- a/src/main/webapp/credit/credit_compnay_bill_pharmacy.xhtml
+++ b/src/main/webapp/credit/credit_compnay_bill_pharmacy.xhtml
@@ -259,11 +259,18 @@
                             icon="fa fa-plus"
                             class="ui-button-warning mx-3 my-3">
                         </p:commandButton>
+                           <p:commandButton
+                               value="Cancel"
+                               icon="fa fa-cancel"
+                               ajax="false"
+                               action="#" 
+                               styleClass="ui-button-danger mx-3 my-3">  
+                        </p:commandButton>
                         <p:commandButton value="Print"
                                          icon="fa fa-print"
                                          styleClass="ui-button-info"
                                          ajax="false"
-                                         class="ui-button-info  mx-3 my-3"
+                                         class="ui-button-info mx-3 my-3"
                                          >
                             <p:printer target="gpBillPreview"/>
                         </p:commandButton>

--- a/src/main/webapp/payments/pay_index.xhtml
+++ b/src/main/webapp/payments/pay_index.xhtml
@@ -124,11 +124,13 @@
                                         <p:commandButton class="w-100" ajax="false" value="Inward Due Age" action="/credit/inward_due_age_credit_company?faces-redirect=true" />
                                         <p:commandButton class="w-100" ajax="false" value="Inward Payment by BHT" action="/credit/credit_compnay_bill_inward?faces-redirect=true" />
                                         <p:commandButton class="w-100" ajax="false" value="Inward Payment by Company" action="/credit/credit_compnay_bill_payment_inward?faces-redirect=true" />
+                                        <p:separator></p:separator>
                                         <!-- Pharmacy -->
                                         <p:commandButton class="w-100" ajax="false" value="Pharmacy Due Search" action="/credit/credit_company_pharmacy_due?faces-redirect=true" />
                                         <p:commandButton class="w-100" ajax="false" value="Pharmacy Due Age" action="/credit/credit_company_pharmacy_due_age?faces-redirect=true" />
                                         <p:commandButton class="w-100" ajax="false" value="Pharmacy Payment by Bill" action="/credit/credit_compnay_bill_pharmacy?faces-redirect=true" />
                                         <p:commandButton class="w-100" ajax="false" value="Pharmacy Payment by Company" action="/credit/credit_compnay_bill_pharmacy_all?faces-redirect=true" />
+                                        <p:separator></p:separator>
                                         <!-- Additional Links -->
                                         <p:commandButton class="w-100" ajax="false" value="Credit Reports" action="/credit/credit_reports?faces-redirect=true" />
                                         <p:commandButton class="w-100" ajax="false" value="Payment Done Search" action="/credit/credit_company_bill_search?faces-redirect=true" actionListener="#{searchController.makeListNull}" />

--- a/src/main/webapp/pharmacy/pharmacy_bill_retail_sale.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_bill_retail_sale.xhtml
@@ -967,35 +967,59 @@
                                                                         rendered="#{pharmacySaleController.paymentMethod eq 'Credit'}" >
                                                                         <div class="my-1" id="credit">
                                                                             <div class="row">
-                                                                                <div class="col-12 d-flex ">
-                                                                                    <p:autoComplete
-                                                                                        id="creditCompany"
-                                                                                        class="w-100 -mx-2"
-                                                                                        inputStyleClass="form-control"
-                                                                                        forceSelection="true"
-                                                                                        value="#{pharmacySaleController.toInstitution}"
-                                                                                        completeMethod="#{institutionController.completeCreditCompany}"
-                                                                                        var="ix"
-                                                                                        minQueryLength="2"
-                                                                                        placeholder="Company (Type at least 4 letters to search)"
-                                                                                        itemLabel="#{ix.name}"
-                                                                                        itemValue="#{ix}"
-                                                                                        size="10"  >
+                                                                                <div class="col-12">
+                                                                                    <div class="d-flex gap-2">
+                                                                                        <p:autoComplete
+                                                                                            id="creditCompany"
+                                                                                            class="w-100 -mx-2"
+                                                                                            inputStyleClass="form-control"
+                                                                                            forceSelection="true"
+                                                                                            value="#{pharmacySaleController.paymentMethodData.credit.institution}"
+                                                                                            completeMethod="#{institutionController.completeCreditCompany}"
+                                                                                            var="ix"
+                                                                                            minQueryLength="2"
+                                                                                            placeholder="Company (Type at least 4 letters to search)"
+                                                                                            itemLabel="#{ix.name}"
+                                                                                            itemValue="#{ix}"
+                                                                                            size="10"  >
 
-                                                                                        <f:ajax
-                                                                                            event="itemSelect"
-                                                                                            listener="#{pharmacySaleController.calTotal()}"
-                                                                                            execute="@this"
-                                                                                            render=":#{p:resolveFirstComponentWithId('panelBillDetails',view).clientId}"/>
-                                                                                    </p:autoComplete>
-                                                                                    <p:commandLink
-                                                                                        id="btnAddNewCreditCom"
-                                                                                        value="(+)"
-                                                                                        class="mx-3 mt-1"
-                                                                                        title="Add New Credit Company"
-                                                                                        ajax="false"
-                                                                                        action="#{navigationController.navigateToCreditCompany()}"
-                                                                                        actionListener="#{creditCompanyController.prepareAdd()}" />
+                                                                                            <f:ajax
+                                                                                                event="itemSelect"
+                                                                                                listener="#{pharmacySaleController.calTotal()}"
+                                                                                                execute="@this"
+                                                                                                render=":#{p:resolveFirstComponentWithId('panelBillDetails',view).clientId}"/>
+                                                                                        </p:autoComplete>
+
+                                                                                        <p:inputText
+                                                                                            id="polNo"
+                                                                                            style="width: 100px;"
+                                                                                            value="#{pharmacySaleController.paymentMethodData.credit.referralNo}"
+                                                                                            placeholder="Policy NO" >
+                                                                                        </p:inputText>
+
+                                                                                        <p:inputText
+                                                                                            id="refNo"
+                                                                                            style="width: 100px;"
+                                                                                            value="#{pharmacySaleController.paymentMethodData.credit.referenceNo}"
+                                                                                            placeholder="Reference NO" >
+                                                                                        </p:inputText>
+
+                                                                                        <p:inputText
+                                                                                            id="memo"
+                                                                                            style="width: 300px;"
+                                                                                            value="#{pharmacySaleController.paymentMethodData.credit.comment}"
+                                                                                            placeholder="Memo" >
+                                                                                        </p:inputText>
+
+                                                                                        <p:commandLink
+                                                                                            id="btnAddNewCreditCom"
+                                                                                            value="(+)"
+                                                                                            class="mx-3 mt-1"
+                                                                                            title="Add New Credit Company"
+                                                                                            ajax="false"
+                                                                                            action="#{navigationController.navigateToCreditCompany()}"
+                                                                                            actionListener="#{creditCompanyController.prepareAdd()}" />
+                                                                                    </div>
                                                                                 </div>
                                                                             </div>
                                                                         </div>

--- a/src/main/webapp/resources/ezcomp/menu.xhtml
+++ b/src/main/webapp/resources/ezcomp/menu.xhtml
@@ -1501,8 +1501,6 @@
                         rendered="#{webUserController.hasPrivilege('PaymentBilling')}" >
                     </p:menuitem>
 
-                    <!--                    agency management command link-->
-
                     <p:menuitem  
                         ajax="false"  
                         action="/agency_management/index?faces-redirect=true"
@@ -1518,7 +1516,6 @@
                         icon="fa-solid fa-globe"
                         rendered="#{webUserController.hasPrivilege('PaymentBilling')}" >
                     </p:menuitem>
-
 
                     <p:menuitem
                         ajax="false"
@@ -1536,7 +1533,6 @@
                         rendered="#{webUserController.hasPrivilege('PharmacyDealerDueSearch')}" ></p:menuitem>
 
                     <p:submenu label="Cash">
-
                         <p:menuitem  
                             ajax="false"  
                             action="/payments/recieve_index?faces-redirect=true"


### PR DESCRIPTION
Add  Cancel Button in Pharmacy credit bill

<img width="1414" height="693" alt="image" src="https://github.com/user-attachments/assets/86fe7b7a-b80a-43d7-892e-6e04a36152d5" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a Cancel Bill option in the Pharmacy Credit Bill print preview to allow cancelling/aborting a pharmacy credit payment and a dedicated pharmacy credit-cancellation view.
  - Added fields (Policy NO, Reference NO, Memo) and improved credit-company input flow on the pharmacy retail sale payment form.
  - Added separators on the Payments index to better group credit/company actions.

- **Style**
  - Fixed spacing in the Print button’s styling for visual consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->