### PR TITLE
13509 need to enter free qty without qty

### DIFF
--- a/developer_docs/config/printer-configuration-system.md
+++ b/developer_docs/config/printer-configuration-system.md
@@ -102,6 +102,26 @@ The Pharmacy Printer Configuration System provides a unified interface for manag
 - `Pharmacy Transfer Request Receipt is Custom 1`
 - `Pharmacy Transfer Request Receipt is Custom 2`
 
+### 5. Direct Purchase Configuration
+
+**Pages:**
+- `direct_purchase.xhtml` - Main direct purchase page
+
+**Configuration Options:**
+- A4 Paper Format (direct_purhcase component)
+- A4 Paper Format with Details (direct_purhcase_detailed component)
+- Custom Format 1 (direct_purhcase_with_costing_custom_1 component)
+- Custom Format 2 (direct_purhcase_with_costing_custom_2 component)
+
+**Configuration Keys (Department-specific via ConfigOptionController):**
+- `Direct Purchase Bill Print - A4` (default: true)
+- `Direct Purchase Bill Print - A4 Details` (default: false)
+- `Direct Purchase Bill Print - Custom 1` (default: false)
+- `Direct Purchase Bill Print - Custom 2` (default: false)
+
+**Settings Button Location:**
+Settings button is placed in the print preview section (`printPreview = true`) alongside the Print and New Bill buttons, allowing users to configure print formats while reviewing the output.
+
 ## Implementation Guide
 
 ### Adding Settings to a New Page
@@ -109,14 +129,41 @@ The Pharmacy Printer Configuration System provides a unified interface for manag
 #### 1. Frontend Implementation (XHTML)
 
 **Step 1: Add Settings Button**
+
+⚠️ **Important**: Settings buttons should be placed in the **printing/preview section** where `printPreview = true`, not in the main billing interface where `printPreview = false`. This ensures settings are accessible when users are reviewing print formats.
+
 ```xhtml
-<p:commandButton
-    rendered="#{webUserController.hasPrivilege('ChangeReceiptPrintingPaperTypes')}"
-    value="Settings"
-    icon="fas fa-cog"
-    class="ui-button-secondary mx-1"
-    type="button"
-    onclick="PF('yourModuleConfigDialog').show();" />
+<!-- Place in the print preview section header -->
+<h:panelGroup rendered="#{yourController.printPreview}">
+    <p:panel>
+        <f:facet name="header">
+            <div class="d-flex align-items-center justify-content-between">
+                <div>
+                    <!-- Print preview title -->
+                </div>
+                <div>
+                    <p:commandButton
+                        value="Print"
+                        ajax="false"
+                        action="#"
+                        class="ui-button-info mx-2"
+                        icon="fas fa-print">
+                        <p:printer target="printTarget" />
+                    </p:commandButton>
+                    <p:commandButton
+                        rendered="#{webUserController.hasPrivilege('ChangeReceiptPrintingPaperTypes')}"
+                        value="Settings"
+                        icon="fas fa-cog"
+                        class="ui-button-secondary mx-1"
+                        type="button"
+                        onclick="PF('yourModuleConfigDialog').show();" />
+                    <!-- Other action buttons -->
+                </div>
+            </div>
+        </f:facet>
+        <!-- Print preview content -->
+    </p:panel>
+</h:panelGroup>
 ```
 
 **Step 2: Add Configuration Dialog**

--- a/src/main/java/com/divudi/bean/pharmacy/PharmacyDirectPurchaseController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacyDirectPurchaseController.java
@@ -239,19 +239,19 @@ public class PharmacyDirectPurchaseController implements Serializable {
         }
 
         // Set PharmaceuticalBillItem basic values - calculations will be done by calculateItemTotals()
-        pbi.setQty(f.getQuantityByUnits().doubleValue());
-        pbi.setFreeQty(f.getFreeQuantityByUnits().doubleValue());
+        pbi.setQty(BigDecimalUtil.valueOrZero(f.getQuantityByUnits()).doubleValue());
+        pbi.setFreeQty(BigDecimalUtil.valueOrZero(f.getFreeQuantityByUnits()).doubleValue());
 
         if (item instanceof Ampp) {
-            pbi.setQtyPacks(f.getQuantity().doubleValue());
+            pbi.setQtyPacks(BigDecimalUtil.valueOrZero(f.getQuantity()).doubleValue());
             // Use null-safe free quantity to avoid NPEs
             pbi.setFreeQtyPacks(BigDecimalUtil.valueOrZero(f.getFreeQuantity()).doubleValue());
-            pbi.setPurchaseRatePack(f.getLineGrossRate().doubleValue());
+            pbi.setPurchaseRatePack(BigDecimalUtil.valueOrZero(f.getLineGrossRate()).doubleValue());
             pbi.setRetailRatePack(BigDecimalUtil.valueOrZero(f.getRetailSaleRate()).doubleValue());
         } else {
-            pbi.setQtyPacks(f.getQuantityByUnits().doubleValue());
-            pbi.setFreeQtyPacks(f.getFreeQuantityByUnits().doubleValue());
-            pbi.setPurchaseRatePack(f.getLineGrossRate().doubleValue());
+            pbi.setQtyPacks(BigDecimalUtil.valueOrZero(f.getQuantityByUnits()).doubleValue());
+            pbi.setFreeQtyPacks(BigDecimalUtil.valueOrZero(f.getFreeQuantityByUnits()).doubleValue());
+            pbi.setPurchaseRatePack(BigDecimalUtil.valueOrZero(f.getLineGrossRate()).doubleValue());
             pbi.setRetailRatePack(BigDecimalUtil.valueOrZero(f.getRetailSaleRatePerUnit()).doubleValue());
         }
 
@@ -262,18 +262,18 @@ public class PharmacyDirectPurchaseController implements Serializable {
             if (unitsPerPack.compareTo(BigDecimal.ZERO) == 0) {
                 unitsPerPack = BigDecimal.ONE; // Avoid division by zero
             }
-            BigDecimal unitPurchaseRate = f.getGrossRate().divide(unitsPerPack, 4, RoundingMode.HALF_UP);
+            BigDecimal unitPurchaseRate = BigDecimalUtil.valueOrZero(f.getGrossRate()).divide(unitsPerPack, 4, RoundingMode.HALF_UP);
             pbi.setPurchaseRate(unitPurchaseRate.doubleValue());
         } else {
             // For AMP: grossRate is already unit price
-            pbi.setPurchaseRate(f.getGrossRate().doubleValue());
+            pbi.setPurchaseRate(BigDecimalUtil.valueOrZero(f.getGrossRate()).doubleValue());
         }
         pbi.setRetailRate(BigDecimalUtil.valueOrZero(f.getRetailSaleRatePerUnit()).doubleValue());
         pbi.setRetailRateInUnit(BigDecimalUtil.valueOrZero(f.getRetailSaleRatePerUnit()).doubleValue());
 
         // Set BillItem basic rate fields - calculations will be done by calculateItemTotals()
-        getCurrentBillItem().setRate(f.getLineGrossRate().doubleValue());
-        getCurrentBillItem().setQty(f.getQuantity().doubleValue());
+        getCurrentBillItem().setRate(BigDecimalUtil.valueOrZero(f.getLineGrossRate()).doubleValue());
+        getCurrentBillItem().setQty(BigDecimalUtil.valueOrZero(f.getQuantity()).doubleValue());
 
         // Calculate item totals using internal logic
         calculateItemTotals(getCurrentBillItem());
@@ -1208,8 +1208,8 @@ public class PharmacyDirectPurchaseController implements Serializable {
         BigDecimal pbiPurchaseValue = BigDecimalUtil.multiply(qtyByUnits, grossRatePerUnit);
         BigDecimal pbiRetailValue = BigDecimalUtil.multiply(qtyByUnits, retailRatePerUnit);
 
-        pbi.setPurchaseValue(pbiPurchaseValue.doubleValue());
-        pbi.setRetailValue(pbiRetailValue.doubleValue());
+        pbi.setPurchaseValue(BigDecimalUtil.valueOrZero(pbiPurchaseValue).doubleValue());
+        pbi.setRetailValue(BigDecimalUtil.valueOrZero(pbiRetailValue).doubleValue());
 
     }
 
@@ -1379,9 +1379,9 @@ public class PharmacyDirectPurchaseController implements Serializable {
         // For purchase bills, legacy controller logic keeps totals negative.
         // Compute final net as line net + tax - discount + bill expenses considered for costing, then set negative on Bill.
         BigDecimal finalNet = netTotalLines.add(billTax).subtract(billDiscount).add(billExpenseConsidered);
-        getBill().setTotal(-netTotalLines.doubleValue());
-        getBill().setNetTotal(-finalNet.doubleValue());
-        getBill().setSaleValue(totalRetail.doubleValue());
+        getBill().setTotal(-BigDecimalUtil.valueOrZero(netTotalLines).doubleValue());
+        getBill().setNetTotal(-BigDecimalUtil.valueOrZero(finalNet).doubleValue());
+        getBill().setSaleValue(BigDecimalUtil.valueOrZero(totalRetail).doubleValue());
 
         // Ensure and populate BillFinanceDetails
         BillFinanceDetails bfd = getBill().getBillFinanceDetails();

--- a/src/main/java/com/divudi/bean/pharmacy/PharmacyDirectPurchaseController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacyDirectPurchaseController.java
@@ -197,6 +197,11 @@ public class PharmacyDirectPurchaseController implements Serializable {
 
         // Setup basic quantity and rate fields for AMP/AMPP handling
         BigDecimal qty = BigDecimalUtil.valueOrZero(f.getQuantity());
+
+        // Ensure free quantity is properly initialized when left blank
+        if (f.getFreeQuantity() == null) {
+            f.setFreeQuantity(BigDecimal.ZERO);
+        }
         BigDecimal freeQty = BigDecimalUtil.valueOrZero(f.getFreeQuantity());
 
         if (item instanceof Ampp) {
@@ -309,6 +314,13 @@ public class PharmacyDirectPurchaseController implements Serializable {
         if (bi == null || bi.getBillItemFinanceDetails() == null) {
             return;
         }
+
+        // Ensure free quantity is properly initialized when left blank
+        BillItemFinanceDetails f = bi.getBillItemFinanceDetails();
+        if (f.getFreeQuantity() == null) {
+            f.setFreeQuantity(BigDecimal.ZERO);
+        }
+
         // Recalculate item totals when free quantity changes
         calculateItemTotals(bi);
     }
@@ -1119,6 +1131,10 @@ public class PharmacyDirectPurchaseController implements Serializable {
         f.setLineCost(itemNet);
 
         // Ensure unit-based calculations are updated for UI display
+        // Ensure free quantity is properly initialized when left blank
+        if (f.getFreeQuantity() == null) {
+            f.setFreeQuantity(BigDecimal.ZERO);
+        }
         BigDecimal freeQty = BigDecimalUtil.valueOrZero(f.getFreeQuantity());
         BigDecimal unitsPerPack = BigDecimalUtil.valueOrZero(f.getUnitsPerPack());
 
@@ -1553,6 +1569,11 @@ public class PharmacyDirectPurchaseController implements Serializable {
 
         if (totalCost.compareTo(BigDecimal.ZERO) == 0) {
             return BigDecimal.ZERO;
+        }
+
+        // Ensure free quantity is properly initialized when left blank
+        if (freeQty == null) {
+            freeQty = BigDecimal.ZERO;
         }
 
         // Total Potential Income from qty + free qty multiplied by retail rate

--- a/src/main/java/com/divudi/bean/pharmacy/PharmacyRetailConfigController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacyRetailConfigController.java
@@ -83,6 +83,12 @@ public class PharmacyRetailConfigController implements Serializable {
     private boolean transferIssuePosHeaderPaper;
     private boolean transferIssueTemplate;
 
+    // Direct Purchase Settings
+    private boolean directPurchaseA4Paper;
+    private boolean directPurchaseA4Details;
+    private boolean directPurchaseCustom1;
+    private boolean directPurchaseCustom2;
+
     public PharmacyRetailConfigController() {
     }
     
@@ -148,6 +154,12 @@ public class PharmacyRetailConfigController implements Serializable {
         transferIssuePosPaper = configOptionController.getBooleanValueByKey("Pharmacy Transfer Issue POS Paper", false);
         transferIssuePosHeaderPaper = configOptionController.getBooleanValueByKey("Pharmacy Transfer Issue Bill is PosHeaderPaper", false);
         transferIssueTemplate = configOptionController.getBooleanValueByKey("Pharmacy Transfer Issue Bill is Template", false);
+
+        // Direct Purchase Settings
+        directPurchaseA4Paper = configOptionController.getBooleanValueByKey("Direct Purchase Bill Print - A4", true);
+        directPurchaseA4Details = configOptionController.getBooleanValueByKey("Direct Purchase Bill Print - A4 Details", false);
+        directPurchaseCustom1 = configOptionController.getBooleanValueByKey("Direct Purchase Bill Print - Custom 1", false);
+        directPurchaseCustom2 = configOptionController.getBooleanValueByKey("Direct Purchase Bill Print - Custom 2", false);
     }
 
     /**
@@ -213,6 +225,12 @@ public class PharmacyRetailConfigController implements Serializable {
             configOptionController.setBooleanValueByKey("Pharmacy Transfer Issue Bill is PosHeaderPaper", transferIssuePosHeaderPaper);
             configOptionController.setBooleanValueByKey("Pharmacy Transfer Issue Bill is Template", transferIssueTemplate);
 
+            // Direct Purchase Settings
+            configOptionController.setBooleanValueByKey("Direct Purchase Bill Print - A4", directPurchaseA4Paper);
+            configOptionController.setBooleanValueByKey("Direct Purchase Bill Print - A4 Details", directPurchaseA4Details);
+            configOptionController.setBooleanValueByKey("Direct Purchase Bill Print - Custom 1", directPurchaseCustom1);
+            configOptionController.setBooleanValueByKey("Direct Purchase Bill Print - Custom 2", directPurchaseCustom2);
+
             JsfUtil.addSuccessMessage("Configuration saved successfully");
 
             // Reload current values to ensure consistency
@@ -242,6 +260,27 @@ public class PharmacyRetailConfigController implements Serializable {
 
         } catch (Exception e) {
             JsfUtil.addErrorMessage("Error saving Transfer Issue configuration: " + e.getMessage());
+        }
+    }
+
+    /**
+     * Save Direct Purchase configuration changes specifically
+     */
+    public void saveDirectPurchaseConfig() {
+        try {
+            // Direct Purchase Settings
+            configOptionController.setBooleanValueByKey("Direct Purchase Bill Print - A4", directPurchaseA4Paper);
+            configOptionController.setBooleanValueByKey("Direct Purchase Bill Print - A4 Details", directPurchaseA4Details);
+            configOptionController.setBooleanValueByKey("Direct Purchase Bill Print - Custom 1", directPurchaseCustom1);
+            configOptionController.setBooleanValueByKey("Direct Purchase Bill Print - Custom 2", directPurchaseCustom2);
+
+            JsfUtil.addSuccessMessage("Direct Purchase configuration saved successfully");
+
+            // Reload current values to ensure consistency
+            loadCurrentConfig();
+
+        } catch (Exception e) {
+            JsfUtil.addErrorMessage("Error saving Direct Purchase configuration: " + e.getMessage());
         }
     }
 
@@ -566,6 +605,39 @@ public class PharmacyRetailConfigController implements Serializable {
 
     public void setTransferIssueTemplate(boolean transferIssueTemplate) {
         this.transferIssueTemplate = transferIssueTemplate;
+    }
+
+    // Direct Purchase Getters and Setters
+    public boolean isDirectPurchaseA4Paper() {
+        return directPurchaseA4Paper;
+    }
+
+    public void setDirectPurchaseA4Paper(boolean directPurchaseA4Paper) {
+        this.directPurchaseA4Paper = directPurchaseA4Paper;
+    }
+
+    public boolean isDirectPurchaseA4Details() {
+        return directPurchaseA4Details;
+    }
+
+    public void setDirectPurchaseA4Details(boolean directPurchaseA4Details) {
+        this.directPurchaseA4Details = directPurchaseA4Details;
+    }
+
+    public boolean isDirectPurchaseCustom1() {
+        return directPurchaseCustom1;
+    }
+
+    public void setDirectPurchaseCustom1(boolean directPurchaseCustom1) {
+        this.directPurchaseCustom1 = directPurchaseCustom1;
+    }
+
+    public boolean isDirectPurchaseCustom2() {
+        return directPurchaseCustom2;
+    }
+
+    public void setDirectPurchaseCustom2(boolean directPurchaseCustom2) {
+        this.directPurchaseCustom2 = directPurchaseCustom2;
     }
 
 }

--- a/src/main/java/com/divudi/service/pharmacy/PharmacyCostingService.java
+++ b/src/main/java/com/divudi/service/pharmacy/PharmacyCostingService.java
@@ -152,16 +152,16 @@ public class PharmacyCostingService {
 
         pbi.setRetailRate(rrPerUnit);
         pbi.setRetailRateInUnit(rrPerUnit);
-        pbi.setRetailRatePack(retailRate.doubleValue());
+        pbi.setRetailRatePack(BigDecimalUtil.valueOrZero(retailRate).doubleValue());
 
-        pbi.setRetailPackValue(retailValue.doubleValue());
-        pbi.setRetailValue(retailValue.doubleValue());
+        pbi.setRetailPackValue(BigDecimalUtil.valueOrZero(retailValue).doubleValue());
+        pbi.setRetailValue(BigDecimalUtil.valueOrZero(retailValue).doubleValue());
 
         pbi.setPurchaseRate(prPerUnit);
-        pbi.setPurchaseRatePack(lineGrossRate.doubleValue());
+        pbi.setPurchaseRatePack(BigDecimalUtil.valueOrZero(lineGrossRate).doubleValue());
 
-        pbi.setPurchaseRatePackValue(lineGrossTotal.doubleValue());
-        pbi.setPurchaseValue(lineGrossTotal.doubleValue());
+        pbi.setPurchaseRatePackValue(BigDecimalUtil.valueOrZero(lineGrossTotal).doubleValue());
+        pbi.setPurchaseValue(BigDecimalUtil.valueOrZero(lineGrossTotal).doubleValue());
     }
 
     
@@ -251,16 +251,16 @@ public class PharmacyCostingService {
 
         pbi.setRetailRate(rrPerUnit);
         pbi.setRetailRateInUnit(rrPerUnit);
-        pbi.setRetailRatePack(retailRate.doubleValue());
+        pbi.setRetailRatePack(BigDecimalUtil.valueOrZero(retailRate).doubleValue());
 
-        pbi.setRetailPackValue(retailValue.doubleValue());
-        pbi.setRetailValue(retailValue.doubleValue());
+        pbi.setRetailPackValue(BigDecimalUtil.valueOrZero(retailValue).doubleValue());
+        pbi.setRetailValue(BigDecimalUtil.valueOrZero(retailValue).doubleValue());
 
         pbi.setPurchaseRate(prPerUnit);
-        pbi.setPurchaseRatePack(lineGrossRate.doubleValue());
+        pbi.setPurchaseRatePack(BigDecimalUtil.valueOrZero(lineGrossRate).doubleValue());
 
-        pbi.setPurchaseRatePackValue(lineGrossTotal.doubleValue());
-        pbi.setPurchaseValue(lineGrossTotal.doubleValue());
+        pbi.setPurchaseRatePackValue(BigDecimalUtil.valueOrZero(lineGrossTotal).doubleValue());
+        pbi.setPurchaseValue(BigDecimalUtil.valueOrZero(lineGrossTotal).doubleValue());
     }
 
     
@@ -497,8 +497,8 @@ public class PharmacyCostingService {
         // Note: Expenses "considered for costing" are already included in line item netTotals
         // from the distribution process, so they don't need to be added again here
         
-        bill.setNetTotal(totalNetTotal.doubleValue());
-        bill.setTotal(totalGrossTotal.doubleValue());
+        bill.setNetTotal(BigDecimalUtil.valueOrZero(totalNetTotal).doubleValue());
+        bill.setTotal(BigDecimalUtil.valueOrZero(totalGrossTotal).doubleValue());
     }
 
     public void addPharmaceuticalBillItemQuantitiesFromBillItemFinanceDetailQuantities(PharmaceuticalBillItem pbi, BillItemFinanceDetails bifd) {
@@ -519,10 +519,10 @@ public class PharmacyCostingService {
             upp = BigDecimal.ONE;
         }
 
-        pbi.setQty(qty.multiply(upp).doubleValue());
-        pbi.setFreeQty(freeQty.multiply(upp).doubleValue());
-        pbi.setQtyPacks(qty.doubleValue());
-        pbi.setFreeQtyPacks(freeQty.doubleValue());
+        pbi.setQty(BigDecimalUtil.valueOrZero(qty.multiply(upp)).doubleValue());
+        pbi.setFreeQty(BigDecimalUtil.valueOrZero(freeQty.multiply(upp)).doubleValue());
+        pbi.setQtyPacks(BigDecimalUtil.valueOrZero(qty).doubleValue());
+        pbi.setFreeQtyPacks(BigDecimalUtil.valueOrZero(freeQty).doubleValue());
 
         BigDecimal totalQty = Optional.ofNullable(bifd.getTotalQuantity()).orElse(BigDecimal.ZERO);
 
@@ -767,9 +767,9 @@ public class PharmacyCostingService {
         BigDecimal finalNetTotal = lineNetTotal.add(BigDecimal.valueOf(currentBillExpensesTotal));
         System.out.println("DEBUG: SERVICE - finalNetTotal (lineNetTotal + expenses): " + finalNetTotal);
         
-        bill.setTotal(lineGrossTotal.doubleValue());
-        bill.setNetTotal(finalNetTotal.doubleValue());
-        bill.setSaleValue(totalRetail.doubleValue());
+        bill.setTotal(BigDecimalUtil.valueOrZero(lineGrossTotal).doubleValue());
+        bill.setNetTotal(BigDecimalUtil.valueOrZero(finalNetTotal).doubleValue());
+        bill.setSaleValue(BigDecimalUtil.valueOrZero(totalRetail).doubleValue());
         
         System.out.println("DEBUG: SERVICE - Bill.netTotal set to: " + bill.getNetTotal());
         System.out.println("DEBUG: SERVICE - Bill.total set to: " + bill.getTotal());
@@ -972,9 +972,9 @@ public class PharmacyCostingService {
         BigDecimal finalNetTotal = lineNetTotal.add(BigDecimal.valueOf(currentBillExpensesTotal));
         System.out.println("DEBUG: SERVICE - finalNetTotal (lineNetTotal + expenses): " + finalNetTotal);
         
-        bill.setTotal(lineGrossTotal.doubleValue());
-        bill.setNetTotal(finalNetTotal.doubleValue());
-        bill.setSaleValue(totalRetail.doubleValue());
+        bill.setTotal(BigDecimalUtil.valueOrZero(lineGrossTotal).doubleValue());
+        bill.setNetTotal(BigDecimalUtil.valueOrZero(finalNetTotal).doubleValue());
+        bill.setSaleValue(BigDecimalUtil.valueOrZero(totalRetail).doubleValue());
         
         System.out.println("DEBUG: SERVICE - Bill.netTotal set to: " + bill.getNetTotal());
         System.out.println("DEBUG: SERVICE - Bill.total set to: " + bill.getTotal());
@@ -1122,9 +1122,9 @@ public class PharmacyCostingService {
             totalTax = totalTax.add(Optional.ofNullable(f.getTotalTax()).orElse(BigDecimal.ZERO));
         }
 
-        bill.setTotal(grossTotal.doubleValue());
-        bill.setNetTotal(netTotal.doubleValue());
-        bill.setSaleValue(totalRetail.doubleValue());
+        bill.setTotal(BigDecimalUtil.valueOrZero(grossTotal).doubleValue());
+        bill.setNetTotal(BigDecimalUtil.valueOrZero(netTotal).doubleValue());
+        bill.setSaleValue(BigDecimalUtil.valueOrZero(totalRetail).doubleValue());
 
         BillFinanceDetails bfd = bill.getBillFinanceDetails();
         if (bfd == null) {
@@ -1334,9 +1334,9 @@ public class PharmacyCostingService {
             totalTax = totalTax.add(Optional.ofNullable(f.getTotalTax()).orElse(BigDecimal.ZERO));
         }
 
-        bill.setTotal(grossTotal.doubleValue());
-        bill.setNetTotal(netTotal.doubleValue());
-        bill.setSaleValue(totalRetail.doubleValue());
+        bill.setTotal(BigDecimalUtil.valueOrZero(grossTotal).doubleValue());
+        bill.setNetTotal(BigDecimalUtil.valueOrZero(netTotal).doubleValue());
+        bill.setSaleValue(BigDecimalUtil.valueOrZero(totalRetail).doubleValue());
 
         BillFinanceDetails bfd = bill.getBillFinanceDetails();
         if (bfd == null) {

--- a/src/main/resources/META-INF/persistence.xml
+++ b/src/main/resources/META-INF/persistence.xml
@@ -2,7 +2,7 @@
 <persistence version="2.2" xmlns="http://java.sun.com/xml/ns/persistence" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/persistence http://xmlns.jcp.org/xml/ns/persistence/persistence_2_2.xsd">
     <persistence-unit name="hmisPU" transaction-type="JTA">
         <provider>org.eclipse.persistence.jpa.PersistenceProvider</provider>
-        <jta-data-source>${JDBC_DATASOURCE}</jta-data-source>
+        <jta-data-source>jdbc/ruhunu</jta-data-source>
         <exclude-unlisted-classes>false</exclude-unlisted-classes>
         <properties>
             <property name="eclipselink.logging.level.sql" value="SEVERE"/>
@@ -10,7 +10,7 @@
         </properties>
     </persistence-unit>
     <persistence-unit name="hmisAuditPU" transaction-type="JTA">
-        <jta-data-source>${JDBC_AUDIT_DATASOURCE}</jta-data-source>
+        <jta-data-source>jdbc/ruhunuAudit</jta-data-source>
         <exclude-unlisted-classes>false</exclude-unlisted-classes>
         <properties>
             <property name="eclipselink.logging.level.sql" value="SEVERE"/>

--- a/src/main/resources/META-INF/persistence.xml
+++ b/src/main/resources/META-INF/persistence.xml
@@ -2,7 +2,7 @@
 <persistence version="2.2" xmlns="http://java.sun.com/xml/ns/persistence" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/persistence http://xmlns.jcp.org/xml/ns/persistence/persistence_2_2.xsd">
     <persistence-unit name="hmisPU" transaction-type="JTA">
         <provider>org.eclipse.persistence.jpa.PersistenceProvider</provider>
-        <jta-data-source>jdbc/ruhunu</jta-data-source>
+        <jta-data-source>${JDBC_DATASOURCE}</jta-data-source>
         <exclude-unlisted-classes>false</exclude-unlisted-classes>
         <properties>
             <property name="eclipselink.logging.level.sql" value="SEVERE"/>
@@ -10,7 +10,7 @@
         </properties>
     </persistence-unit>
     <persistence-unit name="hmisAuditPU" transaction-type="JTA">
-        <jta-data-source>jdbc/ruhunuAudit</jta-data-source>
+        <jta-data-source>${JDBC_AUDIT_DATASOURCE}</jta-data-source>
         <exclude-unlisted-classes>false</exclude-unlisted-classes>
         <properties>
             <property name="eclipselink.logging.level.sql" value="SEVERE"/>

--- a/src/main/webapp/pharmacy/direct_purchase.xhtml
+++ b/src/main/webapp/pharmacy/direct_purchase.xhtml
@@ -20,6 +20,7 @@
                                 <h:outputText class="mx-4" value="Pharmacy Direct Purchase" />
                             </div>
                             <div>
+
                                 <p:commandButton
                                     id="btnSettle"
                                     value="Settle"
@@ -762,8 +763,6 @@
                             </p:panel>
                         </div>
                     </div>
-
-
                     <div class="row" >
                         <div class="col-12" >
                             <h:panelGroup id="purchaseHistory">
@@ -771,12 +770,6 @@
                             </h:panelGroup>
                         </div>
                     </div>
-
-
-
-
-
-
                 </p:panel>
             </h:panelGroup>
             <h:panelGroup rendered="#{pharmacyDirectPurchaseController.printPreview}">
@@ -797,6 +790,13 @@
                                     <p:printer target="gpBillPreview" ></p:printer>
                                 </p:commandButton>
                                 <p:commandButton
+                                    rendered="#{webUserController.hasPrivilege('ChangeReceiptPrintingPaperTypes')}"
+                                    value="Settings"
+                                    icon="fas fa-cog"
+                                    class="ui-button-secondary mx-1"
+                                    type="button"
+                                    onclick="PF('directPurchaseConfigDialog').show();" />
+                                <p:commandButton
                                     ajax="false"
                                     class="ui-button-success"
                                     icon="fa fa-plus"
@@ -808,35 +808,119 @@
                     </f:facet>
 
                     <h:panelGroup id="gpBillPreview" >
-                        <!-- Main receipt format - always shown -->
-                        <h:panelGroup rendered="true">
-                            <pharmacy:direct_purhcase_with_costing
-                                bill="#{pharmacyDirectPurchaseController.bill}"
-                                ShowProfit="#{configOptionApplicationController.getBooleanValueByKey('Show Profit % in Direct Purchase Bill', true)}"
-                                ShowRetailValue="#{configOptionApplicationController.getBooleanValueByKey('Show Retail Value in Direct Purchase Bill', true)}">
-                            </pharmacy:direct_purhcase_with_costing>
-                        </h:panelGroup>
+                        <pharmacy:direct_purhcase
+                            rendered="#{configOptionController.getBooleanValueByKey('Direct Purchase Bill Print - A4', true)}"
+                            bill="#{pharmacyDirectPurchaseController.bill}"
+                            ShowProfit="#{configOptionApplicationController.getBooleanValueByKey('Show Profit % in Direct Purchase Bill', true)}"
+                            ShowRetailValue="#{configOptionApplicationController.getBooleanValueByKey('Show Retail Value in Direct Purchase Bill', true)}">
+                        </pharmacy:direct_purhcase>
+                        <pharmacy:direct_purhcase_with_costing
+                            rendered="#{configOptionController.getBooleanValueByKey('Direct Purchase Bill Print - A4 Details ',true)}"
+                            bill="#{pharmacyDirectPurchaseController.bill}"
+                            ShowProfit="#{configOptionApplicationController.getBooleanValueByKey('Show Profit % in Direct Purchase Bill', true)}"
+                            ShowRetailValue="#{configOptionApplicationController.getBooleanValueByKey('Show Retail Value in Direct Purchase Bill', true)}">
+                        </pharmacy:direct_purhcase_with_costing>
+                        <pharmacy:direct_purhcase_with_costing_custom_1
+                            rendered="#{configOptionController.getBooleanValueByKey('Direct Purchase Bill Print - Custom 1',true)}"
+                            bill="#{pharmacyDirectPurchaseController.bill}"
+                            ShowProfit="#{configOptionApplicationController.getBooleanValueByKey('Show Profit % in Direct Purchase Bill', true)}"
+                            ShowRetailValue="#{configOptionApplicationController.getBooleanValueByKey('Show Retail Value in Direct Purchase Bill', true)}">
+                        </pharmacy:direct_purhcase_with_costing_custom_1>
+                        <pharmacy:direct_purhcase_with_costing_custom_2
+                            rendered="#{configOptionController.getBooleanValueByKey('Direct Purchase Bill Print - Custom 2',true)}"
+                            bill="#{pharmacyDirectPurchaseController.bill}"
+                            ShowProfit="#{configOptionApplicationController.getBooleanValueByKey('Show Profit % in Direct Purchase Bill', true)}"
+                            ShowRetailValue="#{configOptionApplicationController.getBooleanValueByKey('Show Retail Value in Direct Purchase Bill', true)}">
+                        </pharmacy:direct_purhcase_with_costing_custom_2>
 
-                        <!-- Additional formats for development - shown only when toggle is enabled -->
-                        <h:panelGroup rendered="#{pharmacyDirectPurchaseController.showAllBillFormats}">
-                            <pharmacy:direct_purhcase
-                                bill="#{pharmacyDirectPurchaseController.bill}"
-                                ShowProfit="#{configOptionApplicationController.getBooleanValueByKey('Show Profit % in Direct Purchase Bill', true)}"
-                                ShowRetailValue="#{configOptionApplicationController.getBooleanValueByKey('Show Retail Value in Direct Purchase Bill', true)}">
-                            </pharmacy:direct_purhcase>
-                        </h:panelGroup>
                     </h:panelGroup>
 
                     <ph:bill_finance_details bill="#{pharmacyDirectPurchaseController.bill}" ></ph:bill_finance_details>
 
                 </p:panel>
-
-
             </h:panelGroup>
 
+            <!-- Direct Purchase Configuration Dialog -->
+            <p:dialog id="directPurchaseConfigDialog"
+                      header="Direct Purchase Printer Configuration"
+                      widgetVar="directPurchaseConfigDialog"
+                      modal="true"
+                      width="600"
+                      height="500"
+                      resizable="true"
+                      maximizable="true"
+                      closeOnEscape="true">
 
+                <p:ajax event="open" listener="#{pharmacyRetailConfigController.loadCurrentConfig}" update="directPurchaseConfigForm" />
 
+                <h:form id="directPurchaseConfigForm">
+                    <div class="row">
+                        <div class="col-12">
+                            <div class="card config-section">
+                                <div class="card-header">
+                                    <h6><i class="fas fa-file-alt"></i> Direct Purchase Paper Settings</h6>
+                                </div>
+                                <div class="card-body">
+                                    <div class="mb-3">
+                                        <p:selectBooleanCheckbox
+                                            id="directPurchaseA4Paper"
+                                            value="#{pharmacyRetailConfigController.directPurchaseA4Paper}" />
+                                        <p:outputLabel for="directPurchaseA4Paper" value="A4 Paper Format" class="ms-2" />
+                                        <small class="form-text text-muted d-block">Standard A4 paper format for direct purchase bills</small>
+                                    </div>
+                                    <div class="mb-3">
+                                        <p:selectBooleanCheckbox
+                                            id="directPurchaseA4Details"
+                                            value="#{pharmacyRetailConfigController.directPurchaseA4Details}" />
+                                        <p:outputLabel for="directPurchaseA4Details" value="A4 Paper Format with Details" class="ms-2" />
+                                        <small class="form-text text-muted d-block">A4 format with detailed information display</small>
+                                    </div>
+                                    <div class="mb-3">
+                                        <p:selectBooleanCheckbox
+                                            id="directPurchaseCustom1"
+                                            value="#{pharmacyRetailConfigController.directPurchaseCustom1}" />
+                                        <p:outputLabel for="directPurchaseCustom1" value="Custom Format 1" class="ms-2" />
+                                        <small class="form-text text-muted d-block">Custom paper format 1 with costing details</small>
+                                    </div>
+                                    <div class="mb-3">
+                                        <p:selectBooleanCheckbox
+                                            id="directPurchaseCustom2"
+                                            value="#{pharmacyRetailConfigController.directPurchaseCustom2}" />
+                                        <p:outputLabel for="directPurchaseCustom2" value="Custom Format 2" class="ms-2" />
+                                        <small class="form-text text-muted d-block">Custom paper format 2 with costing details</small>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
 
+                    <div class="row mt-4">
+                        <div class="col-12">
+                            <div class="card">
+                                <div class="card-body">
+                                    <p:messages id="directPurchaseConfigMessages" showDetail="true" closable="true" />
+                                    <div class="d-flex justify-content-between align-items-center">
+                                        <div class="d-flex gap-2">
+                                            <p:commandButton
+                                                value="Apply &amp; Close"
+                                                icon="fas fa-save"
+                                                class="ui-button-success"
+                                                ajax="false"
+                                                action="#{pharmacyRetailConfigController.saveDirectPurchaseConfig}" />
+                                            <p:commandButton
+                                                value="Cancel"
+                                                icon="fas fa-times"
+                                                class="ui-button-secondary"
+                                                onclick="PF('directPurchaseConfigDialog').hide(); return false;"
+                                                type="button" />
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </h:form>
+            </p:dialog>
 
         </h:form>
     </ui:define>

--- a/src/main/webapp/pharmacy/direct_purchase.xhtml
+++ b/src/main/webapp/pharmacy/direct_purchase.xhtml
@@ -809,13 +809,13 @@
 
                     <h:panelGroup id="gpBillPreview" >
                         <pharmacy:direct_purhcase
-                            rendered="#{configOptionController.getBooleanValueByKey('Direct Purchase Bill Print - A4', true)}"
+                            rendered="#{configOptionApplicationController.getBooleanValueByKey('Direct Purchase Bill Print - A4', true)}"
                             bill="#{pharmacyDirectPurchaseController.bill}"
                             ShowProfit="#{configOptionApplicationController.getBooleanValueByKey('Show Profit % in Direct Purchase Bill', true)}"
                             ShowRetailValue="#{configOptionApplicationController.getBooleanValueByKey('Show Retail Value in Direct Purchase Bill', true)}">
                         </pharmacy:direct_purhcase>
                         <pharmacy:direct_purhcase_with_costing
-                            rendered="#{configOptionController.getBooleanValueByKey('Direct Purchase Bill Print - A4 Details ',true)}"
+                            rendered="#{configOptionController.getBooleanValueByKey('Direct Purchase Bill Print - A4 Details',true)}"
                             bill="#{pharmacyDirectPurchaseController.bill}"
                             ShowProfit="#{configOptionApplicationController.getBooleanValueByKey('Show Profit % in Direct Purchase Bill', true)}"
                             ShowRetailValue="#{configOptionApplicationController.getBooleanValueByKey('Show Retail Value in Direct Purchase Bill', true)}">

--- a/src/main/webapp/pharmacy/direct_purchase.xhtml
+++ b/src/main/webapp/pharmacy/direct_purchase.xhtml
@@ -797,15 +797,6 @@
                                     <p:printer target="gpBillPreview" ></p:printer>
                                 </p:commandButton>
                                 <p:commandButton
-                                    value="#{pharmacyDirectPurchaseController.showAllBillFormats ? 'Hide' : 'Show'} All Formats"
-                                    icon="fas fa-eye"
-                                    id="btnTogglePrintAll"
-                                    class="ui-button-secondary mx-1"
-                                    ajax="false"
-                                    action="#{pharmacyDirectPurchaseController.toggleShowAllBillFormats}"
-                                    rendered="#{webUserController.hasPrivilege('Developers')}"
-                                    title="Toggle visibility of all bill formats for development" />
-                                <p:commandButton
                                     ajax="false"
                                     class="ui-button-success"
                                     icon="fa fa-plus"

--- a/src/main/webapp/resources/pharmacy/direct_purhcase.xhtml
+++ b/src/main/webapp/resources/pharmacy/direct_purhcase.xhtml
@@ -146,7 +146,7 @@
                         style="padding: 4px; width: 6em;" 
                         class="text-end #{configOptionApplicationController.getBooleanValueByKey('Print Profit % in Direct Purchase Bill', true) ? 'showProfit' : 'hideProfit' }">
                         <f:facet name="header">Profit %</f:facet>
-                        <h:outputText id="profMargin" value="#{pharmacyDirectPurchaseController.calculateProfitMargin(bip)}" >
+                        <h:outputText id="profMargin" value="#{bip.billItemFinanceDetails.profitMargin}" >
                             <f:convertNumber pattern="0.0" ></f:convertNumber>
                         </h:outputText>
                     </p:column>

--- a/src/main/webapp/resources/pharmacy/direct_purhcase_with_costing.xhtml
+++ b/src/main/webapp/resources/pharmacy/direct_purhcase_with_costing.xhtml
@@ -143,7 +143,7 @@
                         style="padding: 4px; width: 6em;" 
                         class="text-end #{configOptionApplicationController.getBooleanValueByKey('Print Profit % in Direct Purchase Bill', true) ? 'showProfit' : 'hideProfit' }">
                         <f:facet name="header">Profit %</f:facet>
-                        <h:outputText id="profMargin" value="#{pharmacyDirectPurchaseController.calculateProfitMargin(bip)}" >
+                        <h:outputText id="profMargin" value="#{bip.billItemFinanceDetails.profitMargin}" >
                             <f:convertNumber pattern="0.0" ></f:convertNumber>
                         </h:outputText>
                     </p:column>

--- a/src/main/webapp/resources/pharmacy/direct_purhcase_with_costing_custom_1.xhtml
+++ b/src/main/webapp/resources/pharmacy/direct_purhcase_with_costing_custom_1.xhtml
@@ -143,7 +143,7 @@
                         style="padding: 4px; width: 6em;" 
                         class="text-end #{configOptionApplicationController.getBooleanValueByKey('Print Profit % in Direct Purchase Bill', true) ? 'showProfit' : 'hideProfit' }">
                         <f:facet name="header">Profit %</f:facet>
-                        <h:outputText id="profMargin" value="#{pharmacyDirectPurchaseController.calculateProfitMargin(bip)}" >
+                        <h:outputText id="profMargin" value="#{bip.billItemFinanceDetails.profitMargin}" >
                             <f:convertNumber pattern="0.0" ></f:convertNumber>
                         </h:outputText>
                     </p:column>

--- a/src/main/webapp/resources/pharmacy/direct_purhcase_with_costing_custom_1.xhtml
+++ b/src/main/webapp/resources/pharmacy/direct_purhcase_with_costing_custom_1.xhtml
@@ -1,0 +1,310 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:cc="http://xmlns.jcp.org/jsf/composite"
+      xmlns:h="http://xmlns.jcp.org/jsf/html"
+      xmlns:p="http://primefaces.org/ui"
+      xmlns:f="http://xmlns.jcp.org/jsf/core">
+
+    <!-- INTERFACE -->
+    <cc:interface>
+        <cc:attribute name="bill" type="com.divudi.core.entity.Bill"/>
+        <cc:attribute name="ShowProfit" type="java.lang.Boolean"/>
+        <cc:attribute name="ShowRetailValue" type="java.lang.Boolean"/>
+    </cc:interface>
+
+    <!-- IMPLEMENTATION -->
+    <cc:implementation>
+
+        <!--        <div class="a4bill">-->
+        <div class="purhcaseBill"
+             style="font-family: sans-serif!important;
+             border: none!important;
+             margin-top: 10px;
+             height: 210mm;">
+            <div class=" mt-3" style="
+                 text-align: center!important;
+                 font-weight: bold!important;
+                 font-size: 23px!important;
+                 font-weight: bolder;
+                 font-family: monospace;
+                 text-transform: capitalize!important;">
+                <h:outputLabel value="#{cc.attrs.bill.creater.department.printingName}"/>
+            </div>
+            <div style="position: relative!important;
+                 text-align: center!important;
+                 font-size: 16px!important;
+                 font-family:monospace;" >
+                <div>
+                    <h:outputLabel value="#{cc.attrs.bill.creater.department.address}"/>
+                </div>
+            </div>
+
+            <div style="text-align: center!important;
+                 font-weight: bold!important;
+                 font-size: 18px!important;
+                 font-weight: bold;">
+                <h:outputLabel value="PURCHASE BILL"   />                           
+            </div>
+
+            <div style="margin-left: 3%; margin-right: 3%; margin-top: 6px;">
+                <h:panelGrid columns="4" style="font-size: 16px; font-family: sans; min-width: 100%!important;">    
+                    <h:outputLabel value="Purchase Date" class="billDetailsFiveFive"/>
+                    <h:outputLabel value="#{cc.attrs.bill.createdAt}" class="billDetailsFiveFive">
+                        <f:convertDateTime  timeZone="Asia/Colombo" pattern="#{sessionController.applicationPreference.shortDateFormat}" />
+                    </h:outputLabel>
+
+                    <h:outputLabel value="Direct GRN No" class="billDetailsFiveFive"/>
+                    <h:outputLabel value="#{cc.attrs.bill.deptId}" class="billDetailsFiveFive"/>
+
+                    <h:outputLabel value="Invoice Date" class="billDetailsFiveFive"/>
+                    <h:outputLabel value="#{cc.attrs.bill.invoiceDate}" class="billDetailsFiveFive">
+                        <f:convertDateTime  timeZone="Asia/Colombo" pattern="#{sessionController.applicationPreference.shortDateFormat}" />
+                    </h:outputLabel>
+
+                    <h:outputLabel value="Invoice No" class="billDetailsFiveFive"/>  
+                    <h:outputLabel value="#{cc.attrs.bill.invoiceNumber}" class="billDetailsFiveFive"/> 
+
+                    <h:outputLabel value="Supplier" class="billDetailsFiveFive"/>
+                    <h:outputLabel value="#{cc.attrs.bill.fromInstitution.name}" class="billDetailsFiveFive"/>
+                    <h:outputLabel value="Consignment" class="billDetailsFiveFive"/>
+                    <h:outputLabel value="#{cc.attrs.bill.consignment ? 'Yes' : 'No'}" class="billDetailsFiveFive"/>
+
+                </h:panelGrid>
+            </div>
+
+            <p:spacer height="15px"/>
+            <div>
+                <p:dataTable 
+                    rowIndexVar="rowIndex"
+                    value="#{cc.attrs.bill.billItems}" 
+                    var="bip"
+                    style="font-size: 16px; margin-left: 3%; margin-right: 3%;">
+                    <p:column style="padding: 4px;">
+                        <f:facet name="header">Item</f:facet>
+                        <h:outputText value="#{bip.item.name}" ></h:outputText>
+                        <h:outputText value=" (#{bip.item.code})" ></h:outputText>
+                    </p:column>
+
+                    <p:column  style="padding: 4px; width: 6em;">
+                        <f:facet name="header">Expiry</f:facet>
+                        <h:outputLabel value="#{bip.pharmaceuticalBillItem.doe}">
+                            <f:convertDateTime  timeZone="Asia/Colombo" pattern="#{sessionController.applicationPreference.shortDateFormat}" />
+                        </h:outputLabel>
+                    </p:column>                                 
+
+                    <p:column style="padding: 4px; width: 3em;" class="text-end">
+                        <f:facet name="header">QTY</f:facet>
+                        <h:outputLabel value="#{bip.billItemFinanceDetails.quantity}">
+                            <f:convertNumber pattern="#,##0" />
+                        </h:outputLabel>
+                    </p:column>
+
+                    <p:column style="padding: 4px; width: 3em;" class="text-end">
+                        <f:facet name="header">Free</f:facet>
+                        <h:outputLabel value="#{bip.billItemFinanceDetails.freeQuantity}">
+                            <f:convertNumber pattern="#,##0" />
+                        </h:outputLabel>
+
+                    </p:column>
+
+                    <p:column style="padding: 4px; width: 6em;" class="text-end">
+                        <f:facet name="header">P. Rate</f:facet>
+                        <h:outputLabel value="#{bip.billItemFinanceDetails.lineGrossRate}">
+                            <f:convertNumber pattern="#,##0.00" />
+                        </h:outputLabel>
+                    </p:column>
+
+                    <p:column style="padding: 4px; width: 6em;" class="text-end">
+                        <f:facet name="header">Discount Rate</f:facet>
+                        <h:outputLabel value="#{bip.billItemFinanceDetails.lineDiscountRate}">
+                            <f:convertNumber pattern="#,##0.00" />
+                        </h:outputLabel>
+                    </p:column>
+
+                    <p:column style="padding: 4px; width: 6em;" class="text-end">
+                        <f:facet name="header">Net P. Value</f:facet>
+                        <h:outputLabel value="#{bip.billItemFinanceDetails.lineNetTotal}">
+                            <f:convertNumber pattern="#,##0.00" />
+                        </h:outputLabel>
+                    </p:column>
+                    <p:column  
+                        style="padding: 4px; width: 6em;" 
+                        class="text-end #{configOptionApplicationController.getBooleanValueByKey('Print RetailValue in Direct Purchase Bill', true) ? 'showRetailValue' : 'hideRetailValue' }"
+                        rendered="#{cc.attrs.ShowRetailValue}">
+                        <f:facet name="header">Re. Rate</f:facet>
+                        <h:outputLabel value="#{bip.billItemFinanceDetails.retailSaleRate}">
+                            <f:convertNumber pattern="#,##0.00" />
+                        </h:outputLabel>
+                    </p:column>
+
+                    <p:column  
+                        rendered="#{cc.attrs.ShowProfit}"
+                        style="padding: 4px; width: 6em;" 
+                        class="text-end #{configOptionApplicationController.getBooleanValueByKey('Print Profit % in Direct Purchase Bill', true) ? 'showProfit' : 'hideProfit' }">
+                        <f:facet name="header">Profit %</f:facet>
+                        <h:outputText id="profMargin" value="#{pharmacyDirectPurchaseController.calculateProfitMargin(bip)}" >
+                            <f:convertNumber pattern="0.0" ></f:convertNumber>
+                        </h:outputText>
+                    </p:column>
+
+                    <p:columnGroup type="footer">
+                        <p:row style="padding: 4px; width: 8em;">
+                            <p:column style="padding: 4px; width: 6em;" colspan="6" footerText="Gross Total"/>
+                            <p:column style="padding: 4px; width: 6em;" footerText="#{0-cc.attrs.bill.total}"  class="text-end">
+                                <f:facet name="footer">
+                                    <h:outputLabel value="#{0-cc.attrs.bill.total}">
+                                        <f:convertNumber pattern="#,##0.00" />
+                                    </h:outputLabel>
+                                </f:facet>
+                            </p:column>
+                            <p:column style="padding: 4px; width: 6em;" footerText="#{0-cc.attrs.bill.saleValue}"  class="text-end #{configOptionApplicationController.getBooleanValueByKey('Print RetailValue in Direct Purchase Bill', true) ? 'showRetailValue' : 'hideRetailValue' }">
+                                <f:facet name="footer">
+                                    <h:outputLabel value="#{cc.attrs.bill.saleValue}">
+                                        <f:convertNumber pattern="#,##0.00" />
+                                    </h:outputLabel>
+                                </f:facet>
+                            </p:column>
+                        </p:row>
+
+                        <!-- Expense Total considered for costing -->
+                        <p:row>
+                            <p:column style="padding: 4px; width: 6em;" colspan="6" footerText="Expense Total considered for costing"/>
+                            <p:column style="padding: 4px; width: 6em;" class="text-end">
+                                <f:facet name="footer">
+                                    <h:outputLabel value="#{cc.attrs.bill.expensesTotalConsideredForCosting}">
+                                        <f:convertNumber pattern="#,##0.00" />
+                                    </h:outputLabel>
+                                </f:facet>
+                            </p:column>
+                        </p:row>
+
+                        <p:row rendered="#{cc.attrs.bill.expenseTotal ne null and cc.attrs.bill.expenseTotal != 0}">
+                            <p:column style="padding: 4px; width: 6em;" colspan="6" footerText="Expense Total"/>
+                            <p:column style="padding: 4px; width: 6em;" footerText="#{0-cc.attrs.bill.total}" class="text-end">
+                                <f:facet name="footer">
+                                    <h:outputLabel value="#{0-cc.attrs.bill.expenseTotal}">
+                                        <f:convertNumber pattern="#,##0.00" />
+                                    </h:outputLabel>
+                                </f:facet>
+                            </p:column>
+
+                        </p:row>
+
+                        <p:row>
+                            <p:column  style="padding: 4px; width: 6em;" colspan="6" footerText="Tax"/>
+                            <p:column style="padding: 4px; width: 6em;" footerText="#{cc.attrs.bill.tax}" class="text-end">
+                                <f:facet name="footer">
+                                    <h:outputLabel value="#{cc.attrs.bill.tax}">
+                                        <f:convertNumber pattern="#,##0.00" />
+                                    </h:outputLabel>
+                                </f:facet>
+                            </p:column>
+
+                        </p:row>
+                        <p:row>
+                            <p:column style="padding: 4px; width: 6em;" colspan="6" footerText="Discount"/>
+                            <p:column style="padding: 4px; width: 6em;" footerText="#{0-cc.attrs.bill.discount}" class="text-end">
+                                <f:facet name="footer">
+                                    <h:outputLabel value="#{0-cc.attrs.bill.discount}">
+                                        <f:convertNumber pattern="#,##0.00" />
+                                    </h:outputLabel>
+                                </f:facet>
+                            </p:column>
+
+                        </p:row>
+                        <p:row>
+                            <p:column style="padding: 4px; width: 6em;" colspan="6" footerText="Net Total"/>
+                            <p:column style="padding: 4px; width: 6em;" footerText="#{0-cc.attrs.bill.netTotal}" class="text-end">
+                                <f:facet name="footer">
+                                    <h:outputLabel value="#{0-cc.attrs.bill.netTotal}">
+                                        <f:convertNumber pattern="#,##0.00" />
+                                    </h:outputLabel>
+                                </f:facet>
+                            </p:column>
+                        </p:row>
+
+                        <!-- Expense Total Not considered for Costing -->
+                        <p:row>
+                            <p:column style="padding: 4px; width: 6em;" colspan="6" footerText="Expense Total Not considered for Costing"/>
+                            <p:column style="padding: 4px; width: 6em;" class="text-end">
+                                <f:facet name="footer">
+                                    <h:outputLabel value="#{cc.attrs.bill.expensesTotalNotConsideredForCosting}">
+                                        <f:convertNumber pattern="#,##0.00" />
+                                    </h:outputLabel>
+                                </f:facet>
+                            </p:column>
+                        </p:row>
+                    </p:columnGroup>
+                </p:dataTable>
+            </div>
+
+            <p:spacer height="5px"/>
+
+            <div class="preparedBy" style="margin-left: 3%; margin-right: 3%;">
+                <h:outputLabel value="Prepared By : #{cc.attrs.bill.creater.webUserPerson.nameWithTitle}"/>
+            </div>
+
+            <div style="margin-left: 3%; margin-right: 3%;">
+                <h:outputLabel value="Received By : "/>
+            </div>
+
+            <hr style="font-size: 16px; margin-left: 3%; margin-right: 3%;"/>
+            <div style="margin-left: 3%; margin-right: 3%;font-size: 15px;">
+                <h4 style="color: #000000; text-align: center " >
+                    <h:outputLabel value="Payment Voucher" style="text-decoration: underline;"/>
+                </h4>
+
+                <div class="d-flex justify-content-between">
+                    <div class="d-flex gap-2"> 
+                        <h:outputLabel value="Payee : " style="text-align: right!important;"/>
+                        <h:outputLabel value="#{cc.attrs.bill.fromInstitution.name}"/>
+                    </div>
+
+                    <h:outputLabel value="Date :"  style="position: relative; margin-right: 30%!important;" />
+                </div>
+                <div>
+                    <br></br>
+                    <h:outputLabel value="Prepared By :" /> 
+                    <h:outputLabel value="................................................................."/>
+                    <br></br>                
+                    <br></br>         
+                    <h:outputLabel value="Approved By :"/>
+                    <h:outputLabel value="................................................................."/>
+                    <br></br>                                      
+                    <br></br>
+                    <h:outputLabel value="Authorized By :"/>
+                    <h:outputLabel value="................................................................"/>
+                    <br></br>
+                    <br></br>
+
+                    <div class="d-flex justify-content-between">
+                        <div class="d-flex gap-2">
+                            <h:outputLabel value="Cheque No :"/>
+                            <h:outputLabel value="...................................................................."/>
+                        </div>
+                        <h:outputLabel value="Amount : Rs. ................" style="position: relative; margin-right: 19%!important;"/>
+                    </div>
+
+                    <br></br>
+                    <br></br>                    
+                    <h:outputLabel value="Received with thanks sum of Rupees  .................................................................................................................................................. "/>
+                    <h:outputLabel value="#{cc.attrs.bill.creater.institution.name}"></h:outputLabel>
+                    <br></br>
+
+                    <div>
+                        <h:outputLabel value="Stamp : " style="position: relative; left: 70%; "/>
+                        <div style="position: relative; border: 1px black dashed!important;height: 60px;width: 50px; left: 75%;">
+                        </div>
+                        <h:outputLabel value="Date : " style="position: relative; left: 70%;"/>
+                        <br></br>
+                        <h:outputLabel value="Name : " style="position: relative; left: 70%;"/>
+                    </div>
+                </div>
+
+            </div>
+
+        </div>
+
+    </cc:implementation>
+</html>

--- a/src/main/webapp/resources/pharmacy/direct_purhcase_with_costing_custom_2.xhtml
+++ b/src/main/webapp/resources/pharmacy/direct_purhcase_with_costing_custom_2.xhtml
@@ -143,7 +143,7 @@
                         style="padding: 4px; width: 6em;" 
                         class="text-end #{configOptionApplicationController.getBooleanValueByKey('Print Profit % in Direct Purchase Bill', true) ? 'showProfit' : 'hideProfit' }">
                         <f:facet name="header">Profit %</f:facet>
-                        <h:outputText id="profMargin" value="#{pharmacyDirectPurchaseController.calculateProfitMargin(bip)}" >
+                        <h:outputText id="profMargin" value="#{bip.billItemFinanceDetails.profitMargin}" >
                             <f:convertNumber pattern="0.0" ></f:convertNumber>
                         </h:outputText>
                     </p:column>

--- a/src/main/webapp/resources/pharmacy/direct_purhcase_with_costing_custom_2.xhtml
+++ b/src/main/webapp/resources/pharmacy/direct_purhcase_with_costing_custom_2.xhtml
@@ -1,0 +1,310 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:cc="http://xmlns.jcp.org/jsf/composite"
+      xmlns:h="http://xmlns.jcp.org/jsf/html"
+      xmlns:p="http://primefaces.org/ui"
+      xmlns:f="http://xmlns.jcp.org/jsf/core">
+
+    <!-- INTERFACE -->
+    <cc:interface>
+        <cc:attribute name="bill" type="com.divudi.core.entity.Bill"/>
+        <cc:attribute name="ShowProfit" type="java.lang.Boolean"/>
+        <cc:attribute name="ShowRetailValue" type="java.lang.Boolean"/>
+    </cc:interface>
+
+    <!-- IMPLEMENTATION -->
+    <cc:implementation>
+
+        <!--        <div class="a4bill">-->
+        <div class="purhcaseBill"
+             style="font-family: sans-serif!important;
+             border: none!important;
+             margin-top: 10px;
+             height: 210mm;">
+            <div class=" mt-3" style="
+                 text-align: center!important;
+                 font-weight: bold!important;
+                 font-size: 23px!important;
+                 font-weight: bolder;
+                 font-family: monospace;
+                 text-transform: capitalize!important;">
+                <h:outputLabel value="#{cc.attrs.bill.creater.department.printingName}"/>
+            </div>
+            <div style="position: relative!important;
+                 text-align: center!important;
+                 font-size: 16px!important;
+                 font-family:monospace;" >
+                <div>
+                    <h:outputLabel value="#{cc.attrs.bill.creater.department.address}"/>
+                </div>
+            </div>
+
+            <div style="text-align: center!important;
+                 font-weight: bold!important;
+                 font-size: 18px!important;
+                 font-weight: bold;">
+                <h:outputLabel value="PURCHASE BILL"   />                           
+            </div>
+
+            <div style="margin-left: 3%; margin-right: 3%; margin-top: 6px;">
+                <h:panelGrid columns="4" style="font-size: 16px; font-family: sans; min-width: 100%!important;">    
+                    <h:outputLabel value="Purchase Date" class="billDetailsFiveFive"/>
+                    <h:outputLabel value="#{cc.attrs.bill.createdAt}" class="billDetailsFiveFive">
+                        <f:convertDateTime  timeZone="Asia/Colombo" pattern="#{sessionController.applicationPreference.shortDateFormat}" />
+                    </h:outputLabel>
+
+                    <h:outputLabel value="Direct GRN No" class="billDetailsFiveFive"/>
+                    <h:outputLabel value="#{cc.attrs.bill.deptId}" class="billDetailsFiveFive"/>
+
+                    <h:outputLabel value="Invoice Date" class="billDetailsFiveFive"/>
+                    <h:outputLabel value="#{cc.attrs.bill.invoiceDate}" class="billDetailsFiveFive">
+                        <f:convertDateTime  timeZone="Asia/Colombo" pattern="#{sessionController.applicationPreference.shortDateFormat}" />
+                    </h:outputLabel>
+
+                    <h:outputLabel value="Invoice No" class="billDetailsFiveFive"/>  
+                    <h:outputLabel value="#{cc.attrs.bill.invoiceNumber}" class="billDetailsFiveFive"/> 
+
+                    <h:outputLabel value="Supplier" class="billDetailsFiveFive"/>
+                    <h:outputLabel value="#{cc.attrs.bill.fromInstitution.name}" class="billDetailsFiveFive"/>
+                    <h:outputLabel value="Consignment" class="billDetailsFiveFive"/>
+                    <h:outputLabel value="#{cc.attrs.bill.consignment ? 'Yes' : 'No'}" class="billDetailsFiveFive"/>
+
+                </h:panelGrid>
+            </div>
+
+            <p:spacer height="15px"/>
+            <div>
+                <p:dataTable 
+                    rowIndexVar="rowIndex"
+                    value="#{cc.attrs.bill.billItems}" 
+                    var="bip"
+                    style="font-size: 16px; margin-left: 3%; margin-right: 3%;">
+                    <p:column style="padding: 4px;">
+                        <f:facet name="header">Item</f:facet>
+                        <h:outputText value="#{bip.item.name}" ></h:outputText>
+                        <h:outputText value=" (#{bip.item.code})" ></h:outputText>
+                    </p:column>
+
+                    <p:column  style="padding: 4px; width: 6em;">
+                        <f:facet name="header">Expiry</f:facet>
+                        <h:outputLabel value="#{bip.pharmaceuticalBillItem.doe}">
+                            <f:convertDateTime  timeZone="Asia/Colombo" pattern="#{sessionController.applicationPreference.shortDateFormat}" />
+                        </h:outputLabel>
+                    </p:column>                                 
+
+                    <p:column style="padding: 4px; width: 3em;" class="text-end">
+                        <f:facet name="header">QTY</f:facet>
+                        <h:outputLabel value="#{bip.billItemFinanceDetails.quantity}">
+                            <f:convertNumber pattern="#,##0" />
+                        </h:outputLabel>
+                    </p:column>
+
+                    <p:column style="padding: 4px; width: 3em;" class="text-end">
+                        <f:facet name="header">Free</f:facet>
+                        <h:outputLabel value="#{bip.billItemFinanceDetails.freeQuantity}">
+                            <f:convertNumber pattern="#,##0" />
+                        </h:outputLabel>
+
+                    </p:column>
+
+                    <p:column style="padding: 4px; width: 6em;" class="text-end">
+                        <f:facet name="header">P. Rate</f:facet>
+                        <h:outputLabel value="#{bip.billItemFinanceDetails.lineGrossRate}">
+                            <f:convertNumber pattern="#,##0.00" />
+                        </h:outputLabel>
+                    </p:column>
+
+                    <p:column style="padding: 4px; width: 6em;" class="text-end">
+                        <f:facet name="header">Discount Rate</f:facet>
+                        <h:outputLabel value="#{bip.billItemFinanceDetails.lineDiscountRate}">
+                            <f:convertNumber pattern="#,##0.00" />
+                        </h:outputLabel>
+                    </p:column>
+
+                    <p:column style="padding: 4px; width: 6em;" class="text-end">
+                        <f:facet name="header">Net P. Value</f:facet>
+                        <h:outputLabel value="#{bip.billItemFinanceDetails.lineNetTotal}">
+                            <f:convertNumber pattern="#,##0.00" />
+                        </h:outputLabel>
+                    </p:column>
+                    <p:column  
+                        style="padding: 4px; width: 6em;" 
+                        class="text-end #{configOptionApplicationController.getBooleanValueByKey('Print RetailValue in Direct Purchase Bill', true) ? 'showRetailValue' : 'hideRetailValue' }"
+                        rendered="#{cc.attrs.ShowRetailValue}">
+                        <f:facet name="header">Re. Rate</f:facet>
+                        <h:outputLabel value="#{bip.billItemFinanceDetails.retailSaleRate}">
+                            <f:convertNumber pattern="#,##0.00" />
+                        </h:outputLabel>
+                    </p:column>
+
+                    <p:column  
+                        rendered="#{cc.attrs.ShowProfit}"
+                        style="padding: 4px; width: 6em;" 
+                        class="text-end #{configOptionApplicationController.getBooleanValueByKey('Print Profit % in Direct Purchase Bill', true) ? 'showProfit' : 'hideProfit' }">
+                        <f:facet name="header">Profit %</f:facet>
+                        <h:outputText id="profMargin" value="#{pharmacyDirectPurchaseController.calculateProfitMargin(bip)}" >
+                            <f:convertNumber pattern="0.0" ></f:convertNumber>
+                        </h:outputText>
+                    </p:column>
+
+                    <p:columnGroup type="footer">
+                        <p:row style="padding: 4px; width: 8em;">
+                            <p:column style="padding: 4px; width: 6em;" colspan="6" footerText="Gross Total"/>
+                            <p:column style="padding: 4px; width: 6em;" footerText="#{0-cc.attrs.bill.total}"  class="text-end">
+                                <f:facet name="footer">
+                                    <h:outputLabel value="#{0-cc.attrs.bill.total}">
+                                        <f:convertNumber pattern="#,##0.00" />
+                                    </h:outputLabel>
+                                </f:facet>
+                            </p:column>
+                            <p:column style="padding: 4px; width: 6em;" footerText="#{0-cc.attrs.bill.saleValue}"  class="text-end #{configOptionApplicationController.getBooleanValueByKey('Print RetailValue in Direct Purchase Bill', true) ? 'showRetailValue' : 'hideRetailValue' }">
+                                <f:facet name="footer">
+                                    <h:outputLabel value="#{cc.attrs.bill.saleValue}">
+                                        <f:convertNumber pattern="#,##0.00" />
+                                    </h:outputLabel>
+                                </f:facet>
+                            </p:column>
+                        </p:row>
+
+                        <!-- Expense Total considered for costing -->
+                        <p:row>
+                            <p:column style="padding: 4px; width: 6em;" colspan="6" footerText="Expense Total considered for costing"/>
+                            <p:column style="padding: 4px; width: 6em;" class="text-end">
+                                <f:facet name="footer">
+                                    <h:outputLabel value="#{cc.attrs.bill.expensesTotalConsideredForCosting}">
+                                        <f:convertNumber pattern="#,##0.00" />
+                                    </h:outputLabel>
+                                </f:facet>
+                            </p:column>
+                        </p:row>
+
+                        <p:row rendered="#{cc.attrs.bill.expenseTotal ne null and cc.attrs.bill.expenseTotal != 0}">
+                            <p:column style="padding: 4px; width: 6em;" colspan="6" footerText="Expense Total"/>
+                            <p:column style="padding: 4px; width: 6em;" footerText="#{0-cc.attrs.bill.total}" class="text-end">
+                                <f:facet name="footer">
+                                    <h:outputLabel value="#{0-cc.attrs.bill.expenseTotal}">
+                                        <f:convertNumber pattern="#,##0.00" />
+                                    </h:outputLabel>
+                                </f:facet>
+                            </p:column>
+
+                        </p:row>
+
+                        <p:row>
+                            <p:column  style="padding: 4px; width: 6em;" colspan="6" footerText="Tax"/>
+                            <p:column style="padding: 4px; width: 6em;" footerText="#{cc.attrs.bill.tax}" class="text-end">
+                                <f:facet name="footer">
+                                    <h:outputLabel value="#{cc.attrs.bill.tax}">
+                                        <f:convertNumber pattern="#,##0.00" />
+                                    </h:outputLabel>
+                                </f:facet>
+                            </p:column>
+
+                        </p:row>
+                        <p:row>
+                            <p:column style="padding: 4px; width: 6em;" colspan="6" footerText="Discount"/>
+                            <p:column style="padding: 4px; width: 6em;" footerText="#{0-cc.attrs.bill.discount}" class="text-end">
+                                <f:facet name="footer">
+                                    <h:outputLabel value="#{0-cc.attrs.bill.discount}">
+                                        <f:convertNumber pattern="#,##0.00" />
+                                    </h:outputLabel>
+                                </f:facet>
+                            </p:column>
+
+                        </p:row>
+                        <p:row>
+                            <p:column style="padding: 4px; width: 6em;" colspan="6" footerText="Net Total"/>
+                            <p:column style="padding: 4px; width: 6em;" footerText="#{0-cc.attrs.bill.netTotal}" class="text-end">
+                                <f:facet name="footer">
+                                    <h:outputLabel value="#{0-cc.attrs.bill.netTotal}">
+                                        <f:convertNumber pattern="#,##0.00" />
+                                    </h:outputLabel>
+                                </f:facet>
+                            </p:column>
+                        </p:row>
+
+                        <!-- Expense Total Not considered for Costing -->
+                        <p:row>
+                            <p:column style="padding: 4px; width: 6em;" colspan="6" footerText="Expense Total Not considered for Costing"/>
+                            <p:column style="padding: 4px; width: 6em;" class="text-end">
+                                <f:facet name="footer">
+                                    <h:outputLabel value="#{cc.attrs.bill.expensesTotalNotConsideredForCosting}">
+                                        <f:convertNumber pattern="#,##0.00" />
+                                    </h:outputLabel>
+                                </f:facet>
+                            </p:column>
+                        </p:row>
+                    </p:columnGroup>
+                </p:dataTable>
+            </div>
+
+            <p:spacer height="5px"/>
+
+            <div class="preparedBy" style="margin-left: 3%; margin-right: 3%;">
+                <h:outputLabel value="Prepared By : #{cc.attrs.bill.creater.webUserPerson.nameWithTitle}"/>
+            </div>
+
+            <div style="margin-left: 3%; margin-right: 3%;">
+                <h:outputLabel value="Received By : "/>
+            </div>
+
+            <hr style="font-size: 16px; margin-left: 3%; margin-right: 3%;"/>
+            <div style="margin-left: 3%; margin-right: 3%;font-size: 15px;">
+                <h4 style="color: #000000; text-align: center " >
+                    <h:outputLabel value="Payment Voucher" style="text-decoration: underline;"/>
+                </h4>
+
+                <div class="d-flex justify-content-between">
+                    <div class="d-flex gap-2"> 
+                        <h:outputLabel value="Payee : " style="text-align: right!important;"/>
+                        <h:outputLabel value="#{cc.attrs.bill.fromInstitution.name}"/>
+                    </div>
+
+                    <h:outputLabel value="Date :"  style="position: relative; margin-right: 30%!important;" />
+                </div>
+                <div>
+                    <br></br>
+                    <h:outputLabel value="Prepared By :" /> 
+                    <h:outputLabel value="................................................................."/>
+                    <br></br>                
+                    <br></br>         
+                    <h:outputLabel value="Approved By :"/>
+                    <h:outputLabel value="................................................................."/>
+                    <br></br>                                      
+                    <br></br>
+                    <h:outputLabel value="Authorized By :"/>
+                    <h:outputLabel value="................................................................"/>
+                    <br></br>
+                    <br></br>
+
+                    <div class="d-flex justify-content-between">
+                        <div class="d-flex gap-2">
+                            <h:outputLabel value="Cheque No :"/>
+                            <h:outputLabel value="...................................................................."/>
+                        </div>
+                        <h:outputLabel value="Amount : Rs. ................" style="position: relative; margin-right: 19%!important;"/>
+                    </div>
+
+                    <br></br>
+                    <br></br>                    
+                    <h:outputLabel value="Received with thanks sum of Rupees  .................................................................................................................................................. "/>
+                    <h:outputLabel value="#{cc.attrs.bill.creater.institution.name}"></h:outputLabel>
+                    <br></br>
+
+                    <div>
+                        <h:outputLabel value="Stamp : " style="position: relative; left: 70%; "/>
+                        <div style="position: relative; border: 1px black dashed!important;height: 60px;width: 50px; left: 75%;">
+                        </div>
+                        <h:outputLabel value="Date : " style="position: relative; left: 70%;"/>
+                        <br></br>
+                        <h:outputLabel value="Name : " style="position: relative; left: 70%;"/>
+                    </div>
+                </div>
+
+            </div>
+
+        </div>
+
+    </cc:implementation>
+</html>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added Direct Purchase print Settings in the print-preview with options: A4 Paper, A4 Details, Custom 1, Custom 2 and a Settings dialog to save/apply them.
  - Added new Direct Purchase print templates (costing variants and two customizable templates).
  - Added Settle and New Direct Purchase Bill header actions.

- Bug Fixes
  - Strengthened quantity/free-quantity validation and prevented negative/free-quantity issues.
  - Stabilized monetary and total calculations to avoid null-related errors.
  - Profit % now displays stored profit values for consistent printouts.

- Documentation
  - Expanded Printer Configuration docs with Direct Purchase setup, guidance, and troubleshooting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->