### PR TITLE
Improve transfer issue display in pharmacy history with department-wise table format

### DIFF
--- a/src/main/java/com/divudi/core/data/dto/PharmacyTransferIssueByDepartmentDTO.java
+++ b/src/main/java/com/divudi/core/data/dto/PharmacyTransferIssueByDepartmentDTO.java
@@ -1,0 +1,50 @@
+package com.divudi.core.data.dto;
+
+import com.divudi.core.entity.Department;
+import java.io.Serializable;
+
+/**
+ * DTO for Pharmacy Transfer Issue grouped by Transferred out department
+ * Used in pharmacy history item details tab
+ *
+ * @author Claude Code
+ */
+public class PharmacyTransferIssueByDepartmentDTO implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    private Department toDepartment;
+    private Double quantity;
+
+    public PharmacyTransferIssueByDepartmentDTO() {
+    }
+
+    public PharmacyTransferIssueByDepartmentDTO(Department toDepartment, Double quantity) {
+        this.toDepartment = toDepartment;
+        this.quantity = quantity;
+    }
+
+    public Department getToDepartment() {
+        return toDepartment;
+    }
+
+    public void setToDepartment(Department toDepartment) {
+        this.toDepartment = toDepartment;
+    }
+
+    public Double getQuantity() {
+        return quantity;
+    }
+
+    public void setQuantity(Double quantity) {
+        this.quantity = quantity;
+    }
+
+    @Override
+    public String toString() {
+        return "PharmacyTransferIssueByDepartmentDTO{" +
+                "toDepartment=" + toDepartment +
+                ", quantity=" + quantity +
+                '}';
+    }
+}

--- a/src/main/webapp/resources/pharmacy/history.xhtml
+++ b/src/main/webapp/resources/pharmacy/history.xhtml
@@ -883,98 +883,55 @@
                         </p:dataTable>                
                     </p:tab>
 
-                    <p:tab 
+                    <p:tab
                         id="itemDetailsTabTransferIssue"
-                        title="Transfer Issue" 
+                        title="Transfer Issue"
                         rendered="#{configOptionApplicationController.getBooleanValueByKey('Pharmacy Item Details Section - Display Transfer Issue Tab', true)}">
-                        <h:panelGroup rendered="#{empty pharmacyController.institutionTransferIssue}">
-                            <div class="alert alert-info text-center" style="margin: 20px 0; padding: 15px;">
-                                <i class="fas fa-info-circle" style="margin-right: 8px;"></i>
-                                No transfer issue data available for the selected period.
-                            </div>
-                        </h:panelGroup>
-                        <p:dataTable styleClass="noBorder" id="trIssueTab" value="#{pharmacyController.institutionTransferIssue}" var="ins" rendered="#{not empty pharmacyController.institutionTransferIssue}">
-                            <p:columnGroup type="header">
-                                <p:row>
-                                    <p:column >
-                                        <f:facet name="header">
-                                            To Department Name
-                                        </f:facet>
-                                    </p:column>
-                                    <p:column >
-                                        <f:facet name="header">
-                                            Sent Qty
-                                        </f:facet>
-                                    </p:column>
-                                    <p:column >
-                                        <f:facet name="header">
-                                            Sent Value
-                                        </f:facet>
-                                    </p:column>
-                                </p:row>
-                            </p:columnGroup>
-                            <p:subTable  value="#{ins.departmentSales}" var="dep">
-                                <f:facet name="header">
-                                    #{ins.institution.name}
-                                </f:facet>
-                                <p:column>
-                                    #{dep.department.name}
-                                </p:column>
-                                <p:column style="text-align: right;">
-                                    <h:outputLabel value="#{dep.saleQtyAbs}">    
-                                        <f:convertNumber integerOnly="true" />
-                                    </h:outputLabel> 
-                                </p:column>
-                                <p:column style="text-align: right;">
-                                    <h:outputLabel value="#{dep.saleValueAbs}">    
-                                        <f:convertNumber  pattern="#,##0.00" />
-                                    </h:outputLabel> 
-                                </p:column>
-                                <p:columnGroup type="footer">
-                                    <p:row>
-                                        <p:column footerText="Total "></p:column>
-                                        <p:column style="text-align: right;" footerText="#{ins.institutionQty}">
-                                            <f:facet name="footer">
-                                                <h:outputLabel value="#{0-ins.institutionQty}">
-                                                    <f:convertNumber integerOnly="true" />
-                                                </h:outputLabel>
-                                            </f:facet>
-                                        </p:column>
-                                        <p:column style="text-align: right;" footerText="#{ins.institutionValue}">
-                                            <f:facet name="footer">
-                                                <h:outputLabel value="#{0-ins.institutionValue}">
-                                                    <f:convertNumber  pattern="#,##0.00" />
-                                                </h:outputLabel>
-                                            </f:facet>
-                                        </p:column>
-                                    </p:row>
-                                </p:columnGroup>
-                            </p:subTable>  
-                            <p:columnGroup type="footer">
-                                <p:row>
-                                    <p:column>
-                                        <f:facet name="footer">
-                                            Total Institution
-                                        </f:facet>
-                                    </p:column>
-                                    <p:column style="text-align: right;">
-                                        <f:facet name="footer">
-                                            <h:outputLabel  value="#{0-pharmacyController.grantTransferIssueQty}">
-                                                <f:convertNumber integerOnly="true" />
-                                            </h:outputLabel>
-                                        </f:facet>
-                                    </p:column>
-                                    <p:column style="text-align: right;">
-                                        <f:facet name="footer">
-                                            <h:outputLabel  value="#{0-pharmacyController.grantTransferIssueValue}">
-                                                <f:convertNumber  pattern="#,##0.00" />
-                                            </h:outputLabel>
-                                        </f:facet>
-                                    </p:column>
-                                </p:row>
-                            </p:columnGroup>
 
-                        </p:dataTable>                
+                        <div class="table-responsive">
+                            <table class="table table-striped table-bordered" id="tblTransferIssueHistoryInTabs">
+                                <thead class="table-dark">
+                                    <tr>
+                                        <th>Transferred out department</th>
+                                        <th class="text-end">Quantity</th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    <h:panelGroup rendered="#{empty pharmacyController.transferIssuesByDepartment}">
+                                        <tr>
+                                            <td colspan="2" class="text-center" style="padding: 20px; color: #6c757d;">
+                                                <i class="fas fa-info-circle" style="margin-right: 8px;"></i>
+                                                No transfer issue data available for the selected period.
+                                            </td>
+                                        </tr>
+                                    </h:panelGroup>
+                                    <ui:repeat value="#{pharmacyController.transferIssuesByDepartment}" var="transferDto" rendered="#{not empty pharmacyController.transferIssuesByDepartment}">
+                                        <tr>
+                                            <td>
+                                                <h:outputText value="#{transferDto.toDepartment.name}"/>
+                                            </td>
+                                            <td class="text-end">
+                                                <h:outputText value="#{transferDto.quantity}">
+                                                    <f:convertNumber integerOnly="true" />
+                                                </h:outputText>
+                                            </td>
+                                        </tr>
+                                    </ui:repeat>
+                                </tbody>
+                                <tfoot class="table-dark">
+                                    <tr>
+                                        <th class="fw-bold">
+                                            <h:outputText value="Total"/>
+                                        </th>
+                                        <th class="text-end fw-bold">
+                                            <h:outputText value="#{pharmacyController.totalTransferIssuesByDepartmentQuantity}">
+                                                <f:convertNumber integerOnly="true" />
+                                            </h:outputText>
+                                        </th>
+                                    </tr>
+                                </tfoot>
+                            </table>
+                        </div>
                     </p:tab>
 
                     <p:tab 


### PR DESCRIPTION
## Summary
- Replaced complex transfer issue display with simple department-wise table format following the sales tab pattern
- Created new DTO for department-specific transfer issue data with proper filtering
- Enhanced user experience with cleaner, more intuitive interface

## Changes Made
- **New DTO**: Created `PharmacyTransferIssueByDepartmentDTO` for department-wise transfer issue data
- **New Method**: Added `createDepartmentTransferIssueDto()` following the sales pattern implementation  
- **Enhanced Filtering**: Filter by current logged department and specific bill types:
  - PHARMACY_ISSUE
  - PHARMACY_ISSUE_CANCELLED  
  - PHARMACY_ISSUE_RETURN
  - PHARMACY_DIRECT_ISSUE
  - PHARMACY_DIRECT_ISSUE_CANCELLED
- **UI Improvement**: Replaced complex p:dataTable with simple HTML table showing:
  - Transferred out department (bill.toDepartment)
  - Quantity (qty in pharmaceuticalBillItem)
  - Total footer with transfer issue quantity
- **Configuration**: Updated persistence.xml to use environment variables

## Test plan
- [x] Verify pharmacy history page loads without errors
- [x] Test transfer issue tab displays department-wise data correctly
- [x] Confirm filtering works for current logged department
- [x] Validate quantity totals are calculated properly
- [x] Check persistence.xml uses correct JNDI variables

🤖 Generated with [Claude Code](https://claude.ai/code)