### PR TITLE
Improve disposal issue history display with department grouping

### DIFF
--- a/src/main/java/com/divudi/bean/pharmacy/PharmacyController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacyController.java
@@ -5368,18 +5368,19 @@ public class PharmacyController implements Serializable {
     public void fillDetails() {
         createInstitutionStockDto();
         createDepartmentSaleDto();
+        createInstitutionBhtIssue();
         createDepartmentTransferIssueDto();
         createDepartmentTransferReceiveDto();
-        createInstitutionBhtIssue();
         createInstitutionTransferIssue();
         createInstitutionTransferReceive();
+        createInstitutionIssue();
         createPendingGrnTable();
         createGrnTable();
         createGrnReturnTable();
         createPoTableDto();
         createPendingPoDto();
         createDirectPurchaseTableDto();
-        createInstitutionIssue();
+        
     }
 
     @Deprecated // Use fillDetails

--- a/src/main/java/com/divudi/core/data/dto/PharmacyDisposeIssueByDepartmentDTO.java
+++ b/src/main/java/com/divudi/core/data/dto/PharmacyDisposeIssueByDepartmentDTO.java
@@ -1,0 +1,50 @@
+package com.divudi.core.data.dto;
+
+import com.divudi.core.entity.Department;
+import java.io.Serializable;
+
+/**
+ * DTO for Pharmacy Dispose Issue grouped by Issue department
+ * Used in pharmacy history item details tab
+ *
+ * @author Claude Code
+ */
+public class PharmacyDisposeIssueByDepartmentDTO implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    private Department issueDepartment;
+    private Double quantity;
+
+    public PharmacyDisposeIssueByDepartmentDTO() {
+    }
+
+    public PharmacyDisposeIssueByDepartmentDTO(Department issueDepartment, Double quantity) {
+        this.issueDepartment = issueDepartment;
+        this.quantity = quantity;
+    }
+
+    public Department getIssueDepartment() {
+        return issueDepartment;
+    }
+
+    public void setIssueDepartment(Department issueDepartment) {
+        this.issueDepartment = issueDepartment;
+    }
+
+    public Double getQuantity() {
+        return quantity;
+    }
+
+    public void setQuantity(Double quantity) {
+        this.quantity = quantity;
+    }
+
+    @Override
+    public String toString() {
+        return "PharmacyDisposeIssueByDepartmentDTO{" +
+                "issueDepartment=" + issueDepartment +
+                ", quantity=" + quantity +
+                '}';
+    }
+}

--- a/src/main/resources/META-INF/persistence.xml
+++ b/src/main/resources/META-INF/persistence.xml
@@ -2,7 +2,7 @@
 <persistence version="2.2" xmlns="http://java.sun.com/xml/ns/persistence" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/persistence http://xmlns.jcp.org/xml/ns/persistence/persistence_2_2.xsd">
     <persistence-unit name="hmisPU" transaction-type="JTA">
         <provider>org.eclipse.persistence.jpa.PersistenceProvider</provider>
-        <jta-data-source>${JDBC_DATASOURCE}</jta-data-source>
+        <jta-data-source>jdbc/ruhunu</jta-data-source>
         <exclude-unlisted-classes>false</exclude-unlisted-classes>
         <properties>
             <property name="eclipselink.logging.level.sql" value="SEVERE"/>
@@ -10,7 +10,7 @@
         </properties>
     </persistence-unit>
     <persistence-unit name="hmisAuditPU" transaction-type="JTA">
-        <jta-data-source>${JDBC_AUDIT_DATASOURCE}</jta-data-source>
+        <jta-data-source>jdbc/ruhunuAudit</jta-data-source>
         <exclude-unlisted-classes>false</exclude-unlisted-classes>
         <properties>
             <property name="eclipselink.logging.level.sql" value="SEVERE"/>

--- a/src/main/resources/META-INF/persistence.xml
+++ b/src/main/resources/META-INF/persistence.xml
@@ -2,7 +2,7 @@
 <persistence version="2.2" xmlns="http://java.sun.com/xml/ns/persistence" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/persistence http://xmlns.jcp.org/xml/ns/persistence/persistence_2_2.xsd">
     <persistence-unit name="hmisPU" transaction-type="JTA">
         <provider>org.eclipse.persistence.jpa.PersistenceProvider</provider>
-        <jta-data-source>jdbc/ruhunu</jta-data-source>
+        <jta-data-source>${JDBC_DATASOURCE}</jta-data-source>
         <exclude-unlisted-classes>false</exclude-unlisted-classes>
         <properties>
             <property name="eclipselink.logging.level.sql" value="SEVERE"/>
@@ -10,7 +10,7 @@
         </properties>
     </persistence-unit>
     <persistence-unit name="hmisAuditPU" transaction-type="JTA">
-        <jta-data-source>jdbc/ruhunuAudit</jta-data-source>
+        <jta-data-source>${JDBC_AUDIT_DATASOURCE}</jta-data-source>
         <exclude-unlisted-classes>false</exclude-unlisted-classes>
         <properties>
             <property name="eclipselink.logging.level.sql" value="SEVERE"/>

--- a/src/main/webapp/resources/pharmacy/history.xhtml
+++ b/src/main/webapp/resources/pharmacy/history.xhtml
@@ -978,99 +978,48 @@
                         </div>
                     </p:tab>
 
-                    <p:tab 
+                    <p:tab
                         id="itemDetailsTabConsuption"
-                        title="Dicard" 
+                        title="Dicard"
                         rendered="#{configOptionApplicationController.getBooleanValueByKey('Pharmacy Item Details Section - Display Department Issue Tab', true)}">
-                        <h:panelGroup rendered="#{empty pharmacyController.institutionIssue}">
+                        <h:panelGroup rendered="#{empty pharmacyController.disposeIssuesByDepartment}">
                             <div class="alert alert-info text-center" style="margin: 20px 0; padding: 15px;">
                                 <i class="fas fa-info-circle" style="margin-right: 8px;"></i>
-                                No department issue data available for the selected period.
+                                No dispose issue data available for the selected period.
                             </div>
                         </h:panelGroup>
-                        <p:dataTable styleClass="noBorder" id="depIssue"
-                                     value="#{pharmacyController.institutionIssue}" var="ins" rendered="#{not empty pharmacyController.institutionIssue}">
-                            <p:columnGroup type="header">
-                                <p:row>
-                                    <p:column >
-                                        <f:facet name="header">
-                                            To Department Name
-                                        </f:facet>
-                                    </p:column>
-                                    <p:column >
-                                        <f:facet name="header">
-                                            Sent Qty
-                                        </f:facet>
-                                    </p:column>
-                                    <p:column >
-                                        <f:facet name="header">
-                                            Sent Value
-                                        </f:facet>
-                                    </p:column>
-                                </p:row>
-                            </p:columnGroup>
-                            <p:subTable  value="#{ins.departmentSales}" var="dep">
-                                <f:facet name="header">
-                                    #{ins.institution.name}
-                                </f:facet>
-                                <p:column>
-                                    #{dep.department.name}
-                                </p:column>
-                                <p:column style="text-align: right;">
-                                    <h:outputLabel value="#{dep.saleQtyAbs}">    
-                                        <f:convertNumber integerOnly="true" />
-                                    </h:outputLabel> 
-                                </p:column>
-                                <p:column style="text-align: right;">
-                                    <h:outputLabel value="#{dep.saleValueAbs}">    
-                                        <f:convertNumber  pattern="#,##0.00" />
-                                    </h:outputLabel> 
-                                </p:column>
-                                <p:columnGroup type="footer">
-                                    <p:row>
-                                        <p:column footerText="Total "></p:column>
-                                        <p:column style="text-align: right;" footerText="#{ins.institutionQty}">
-                                            <f:facet name="footer">
-                                                <h:outputLabel value="#{0-ins.institutionQty}">
+                        <h:panelGroup rendered="#{not empty pharmacyController.disposeIssuesByDepartment}">
+                            <table class="table table-striped table-bordered" id="tblDisposeIssueHistoryInTabs">
+                                <thead class="table-dark">
+                                    <tr>
+                                        <th>Issue department</th>
+                                        <th class="text-end">Quantity</th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    <ui:repeat value="#{pharmacyController.disposeIssuesByDepartment}" var="disposeDto">
+                                        <tr>
+                                            <td><h:outputText value="#{disposeDto.issueDepartment.name}"/></td>
+                                            <td class="text-end">
+                                                <h:outputText value="#{disposeDto.quantity}">
                                                     <f:convertNumber integerOnly="true" />
-                                                </h:outputLabel>
-                                            </f:facet>
-                                        </p:column>
-                                        <p:column style="text-align: right;" footerText="#{ins.institutionValue}">
-                                            <f:facet name="footer">
-                                                <h:outputLabel value="#{0-ins.institutionValue}">
-                                                    <f:convertNumber  pattern="#,##0.00" />
-                                                </h:outputLabel>
-                                            </f:facet>
-                                        </p:column>
-                                    </p:row>
-                                </p:columnGroup>
-                            </p:subTable>  
-                            <p:columnGroup type="footer">
-                                <p:row>
-                                    <p:column>
-                                        <f:facet name="footer">
-                                            Total Institution
-                                        </f:facet>
-                                    </p:column>
-                                    <p:column style="text-align: right;">
-                                        <f:facet name="footer">
-                                            <h:outputLabel  value="#{0-pharmacyController.grantIssueQty}">
+                                                </h:outputText>
+                                            </td>
+                                        </tr>
+                                    </ui:repeat>
+                                </tbody>
+                                <tfoot class="table-dark">
+                                    <tr>
+                                        <th>Total</th>
+                                        <th class="text-end">
+                                            <h:outputText value="#{pharmacyController.totalDisposeIssuesByDepartmentQuantity}">
                                                 <f:convertNumber integerOnly="true" />
-                                            </h:outputLabel>
-                                        </f:facet>
-                                    </p:column>
-                                    <p:column style="text-align: right;">
-                                        <f:facet name="footer">
-                                            <h:outputLabel  value="#{0-pharmacyController.grantIssueValue}">
-                                                <f:convertNumber  pattern="#,##0.00" />
-                                            </h:outputLabel>
-                                        </f:facet>
-                                    </p:column>
-                                </p:row>
-                            </p:columnGroup>
-
-                        </p:dataTable>                
+                                            </h:outputText>
+                                        </th>
+                                    </tr>
+                                </tfoot>
+                            </table>
+                        </h:panelGroup>                
                     </p:tab>
 
                     <p:tab 

--- a/src/main/webapp/resources/pharmacy/history.xhtml
+++ b/src/main/webapp/resources/pharmacy/history.xhtml
@@ -980,7 +980,7 @@
 
                     <p:tab 
                         id="itemDetailsTabConsuption"
-                        title="Department Issue" 
+                        title="Dicard" 
                         rendered="#{configOptionApplicationController.getBooleanValueByKey('Pharmacy Item Details Section - Display Department Issue Tab', true)}">
                         <h:panelGroup rendered="#{empty pharmacyController.institutionIssue}">
                             <div class="alert alert-info text-center" style="margin: 20px 0; padding: 15px;">


### PR DESCRIPTION
## Summary
- Implements department-grouped disposal issue history view following established patterns
- Creates PharmacyDisposeIssueByDepartmentDTO for structured data representation
- Updates consumption tab (itemDetailsTabConsuption) to use simple HTML table format
- Filters by PHARMACY_DISPOSAL_ISSUE, PHARMACY_DISPOSAL_ISSUE_CANCELLED, and PHARMACY_DISPOSAL_ISSUE_RETURN bill types
- Shows issue department and quantity columns with total footer
- Ensures proper filtering by bill.fromDepartment matching sessionController.department

## Test plan
- [ ] Verify disposal issue data displays correctly in consumption tab
- [ ] Test department filtering works as expected
- [ ] Confirm bill type filtering includes all specified disposal issue types
- [ ] Validate total calculation accuracy
- [ ] Check responsive table layout and styling

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Pharmacy History now shows disposal issues by department with per-department quantities and an overall total.
- Style
  - Simplified the Department Issue tab into a compact, easy-to-scan table and updated empty-state messaging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->