### PR TITLE
#15567 improving pharmacy accept sale for cashier bill reprint

### DIFF
--- a/src/main/webapp/pharmacy/pharmacy_reprint_bill_sale_cashier.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_reprint_bill_sale_cashier.xhtml
@@ -42,6 +42,15 @@
                                         >
                                     </p:commandButton>
 
+                                    <p:commandButton
+                                        rendered="#{webUserController.hasPrivilege('ChangeReceiptPrintingPaperTypes')}"
+                                        value="Settings"
+                                        icon="fas fa-cog"
+                                        class="ui-button-secondary mx-1"
+                                        type="button"
+                                        onclick="PF('settleReprintConfigDialog').show();" >
+                                    </p:commandButton>
+
                                     <p:commandButton 
                                         value="Reprint" 
                                         icon="fa fa-print"
@@ -124,11 +133,34 @@
                                 </div>
                             </h:panelGroup> 
 
+                            <h:panelGroup rendered="#{configOptionController.getBooleanValueByKey('Pharmacy accept payment for sale for cashier bill with Items is PosPaper Custom 1',true)}">
+                                <div>
+                                    <ph:saleBill_Pos_paper_Custom_1 bill="#{pharmacyBillSearch.bill}"></ph:saleBill_Pos_paper_Custom_1>
+                                </div>
+                            </h:panelGroup>
+
+                            <h:panelGroup rendered="#{configOptionController.getBooleanValueByKey('Pharmacy accept payment for sale for cashier Bill is Custom 1',true)}"> 
+                                <div>
+                                    <ph:sale_for_cashier_bill_five_five_custom_1 bill="#{pharmacyBillSearch.bill}"/>
+                                </div>
+                            </h:panelGroup>
+
+                            <h:panelGroup rendered="#{configOptionController.getBooleanValueByKey('Pharmacy accept payment for sale for cashier Bill is Custom 2',true)}"> 
+                                <div>
+                                    <ph:sale_for_cashier_bill_five_five_custom_2 bill="#{pharmacyBillSearch.bill}"/>
+                                </div>
+                            </h:panelGroup>
+
                             <h:panelGroup rendered="#{configOptionApplicationController.getBooleanValueByKey('Pharmacy accept payment for sale for cashier Bill is FiveFiveCustom3',false)}"> 
                                 <div>
                                     <ph:sale_for_cashier_bill_five_five_custom_3 bill="#{pharmacyBillSearch.bill}"/>
                                 </div>
                             </h:panelGroup>
+
+                            <h:panelGroup rendered="#{configOptionController.getBooleanValueByKey('Pharmacy accept payment for sale for cashier Bill is PosHeaderPaper',true)}">
+                                <ph:saleBill_Header bill="#{pharmacyBillSearch.bill}"></ph:saleBill_Header>
+                            </h:panelGroup>
+
                         </h:panelGroup>
 
                         <!-- Reprint Section (With Duplicate Text) -->
@@ -139,15 +171,142 @@
                                 </div>
                             </h:panelGroup> 
 
+                            <h:panelGroup rendered="#{configOptionController.getBooleanValueByKey('Pharmacy accept payment for sale for cashier bill with Items is PosPaper Custom 1',true)}">
+                                <div>
+                                    <ph:saleBill_Pos_paper_Custom_1 bill="#{pharmacyBillSearch.bill}" duplicate="true"></ph:saleBill_Pos_paper_Custom_1>
+                                </div>
+                            </h:panelGroup>
+
+                            <h:panelGroup rendered="#{configOptionController.getBooleanValueByKey('Pharmacy accept payment for sale for cashier Bill is Custom 1',true)}"> 
+                                <div>
+                                    <ph:sale_for_cashier_bill_five_five_custom_1 bill="#{pharmacyBillSearch.bill}" duplicate="true"/>
+                                </div>
+                            </h:panelGroup>
+
+                            <h:panelGroup rendered="#{configOptionController.getBooleanValueByKey('Pharmacy accept payment for sale for cashier Bill is Custom 2',true)}"> 
+                                <div>
+                                    <ph:sale_for_cashier_bill_five_five_custom_2 bill="#{pharmacyBillSearch.bill}" duplicate="true"/>
+                                </div>
+                            </h:panelGroup>
+
                             <h:panelGroup rendered="#{configOptionApplicationController.getBooleanValueByKey('Pharmacy accept payment for sale for cashier Bill is FiveFiveCustom3',false)}"> 
                                 <div>
                                     <ph:sale_for_cashier_bill_five_five_custom_3 bill="#{pharmacyBillSearch.bill}" duplicate="true"/>
                                 </div>
                             </h:panelGroup>
+
+                            <h:panelGroup rendered="#{configOptionController.getBooleanValueByKey('Pharmacy accept payment for sale for cashier Bill is PosHeaderPaper',true)}">
+                                <ph:saleBill_Header bill="#{pharmacyBillSearch.bill}" duplicate="true"></ph:saleBill_Header>
+                            </h:panelGroup>
+
                         </h:panelGroup>
                     </p:panel>
 
                 </h:form>
+
+                <!-- Configuration Dialog -->
+                <p:dialog id="settleReprintConfigDialog"
+                          header="Pharmacy Settle Payment Reprint Configuration"
+                          widgetVar="settleReprintConfigDialog"
+                          modal="true"
+                          width="700"
+                          height="500"
+                          resizable="true"
+                          maximizable="true"
+                          closeOnEscape="true">
+
+                    <p:ajax event="open" listener="#{pharmacyRetailConfigController.loadCurrentConfig}" update="settleConfigForm" />
+
+                    <h:form id="settleConfigForm">
+
+                        <div class="row">
+                            <div class="col-12">
+                                <div class="card config-section">
+                                    <div class="card-header">
+                                        <h6><i class="fas fa-file-alt"></i> Settle Payment Bill Reprint Paper Settings</h6>
+                                    </div>
+                                    <div class="card-body">
+                                        <div class="mb-3">
+                                            <p:selectBooleanCheckbox
+                                                id="settlePosPaper"
+                                                value="#{pharmacyRetailConfigController.settlePaymentPosPaper}" />
+                                            <p:outputLabel for="settlePosPaper" value="POS Paper with Items" class="ms-2" />
+                                            <small class="form-text text-muted d-block">Standard thermal printer paper format with item details</small>
+                                        </div>
+
+                                        <div class="mb-3">
+                                            <p:selectBooleanCheckbox
+                                                id="settlePosPaperCustom1"
+                                                value="#{pharmacyRetailConfigController.settlePaymentPosPaperCustom1}" />
+                                            <p:outputLabel for="settlePosPaperCustom1" value="POS Paper Custom 1 with Items" class="ms-2" />
+                                            <small class="form-text text-muted d-block">Custom thermal printer paper format with item details</small>
+                                        </div>
+
+                                        <div class="mb-3">
+                                            <p:selectBooleanCheckbox
+                                                id="settleCustom1"
+                                                value="#{pharmacyRetailConfigController.settlePaymentCustom1}" />
+                                            <p:outputLabel for="settleCustom1" value="Custom Format 1" class="ms-2" />
+                                            <small class="form-text text-muted d-block">Custom settle payment template design 1</small>
+                                        </div>
+
+                                        <div class="mb-3">
+                                            <p:selectBooleanCheckbox
+                                                id="settleCustom2"
+                                                value="#{pharmacyRetailConfigController.settlePaymentCustom2}" />
+                                            <p:outputLabel for="settleCustom2" value="Custom Format 2" class="ms-2" />
+                                            <small class="form-text text-muted d-block">Custom settle payment template design 2</small>
+                                        </div>
+
+                                        <div class="mb-3">
+                                            <p:selectBooleanCheckbox
+                                                id="settleCustom3"
+                                                value="#{pharmacyRetailConfigController.settlePaymentCustom3}" />
+                                            <p:outputLabel for="settleCustom3" value="Custom Format 3" class="ms-2" />
+                                            <small class="form-text text-muted d-block">Custom settle payment template design 3</small>
+                                        </div>
+
+                                        <div class="mb-3">
+                                            <p:selectBooleanCheckbox
+                                                id="settlePosHeaderPaper"
+                                                value="#{pharmacyRetailConfigController.settlePaymentPosHeaderPaper}" />
+                                            <p:outputLabel for="settlePosHeaderPaper" value="POS Paper with Header" class="ms-2" />
+                                            <small class="form-text text-muted d-block">POS paper with pre-printed header space</small>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+
+                        <div class="row mt-4">
+                            <div class="col-12">
+                                <div class="card">
+                                    <div class="card-body">
+                                        <p:messages id="settleReprintConfigMessages" showDetail="true" closable="true" />
+                                        <div class="d-flex justify-content-between align-items-center">
+                                            <div class="d-flex gap-2">
+                                                <p:commandButton
+                                                    value="Apply &amp; Close"
+                                                    icon="fas fa-save"
+                                                    class="ui-button-success"
+                                                    ajax="false"
+                                                    action="#{pharmacyRetailConfigController.saveConfig}" />
+                                                <p:commandButton
+                                                    value="Cancel"
+                                                    icon="fas fa-times"
+                                                    class="ui-button-secondary"
+                                                    onclick="PF('settleReprintConfigDialog').hide(); return false;"
+                                                    type="button" />
+                                            </div>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+
+                    </h:form>
+                </p:dialog>
+
             </ui:define>
         </ui:composition>
     </h:body>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added a Settings button in Reprint to configure Pharmacy Settle Payment Reprint Settings.
  - New dialog to choose receipt formats: POS paper with items, Custom 1–3, and POS header paper, with helper descriptions.
  - Apply & Close and Cancel actions with feedback messages.

- Enhancements
  - Expanded Original and Reprint sections to support additional receipt layouts and duplicate print variants.
  - Visibility now respects selected receipt settings to streamline printing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->