### PR TITLE
About: replace remote 'latest version' lookup with embedded build met…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -453,6 +453,29 @@
     
     <build>
         <plugins>
+            <!-- Embed Git / build metadata for About page (no runtime network calls) -->
+            <plugin>
+                <groupId>pl.project13.maven</groupId>
+                <artifactId>git-commit-id-plugin</artifactId>
+                <version>4.9.10</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>revision</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <generateGitPropertiesFile>true</generateGitPropertiesFile>
+                    <includeOnlyProperties>
+                        <includeOnlyProperty>^git.commit.id.abbrev$</includeOnlyProperty>
+                        <includeOnlyProperty>^git.branch$</includeOnlyProperty>
+                        <includeOnlyProperty>^git.build.time$</includeOnlyProperty>
+                    </includeOnlyProperties>
+                    <dateFormat>yyyy-MM-dd HH:mm:ss 'UTC'</dateFormat>
+                    <dateFormatTimeZone>UTC</dateFormatTimeZone>
+                </configuration>
+            </plugin>
             <!-- Maven Compiler Plugin for JDK 11 with Java 8 Compatibility -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/src/main/webapp/about_software.xhtml
+++ b/src/main/webapp/about_software.xhtml
@@ -39,15 +39,12 @@
                                 <h:outputLabel class="mx-2 h6" value="Current version" />
                                 <h:outputLabel class="mx-2 h6" value=":" />
                                 <h:outputLabel class="mx-2 h6" value="#{versionController.systemVersion}" />
-                                <h:outputLabel class="mx-2 h6" value="Latest version" />
+                                <h:outputLabel class="mx-2 h6" value="Build time" />
                                 <h:outputLabel class="mx-2 h6" value=": " />
-                                <h:outputLabel class="mx-2 h6" value="#{versionController.latestVersion}" />
-                                <h:outputLabel class="mx-2 h6" value="Last update" />
-                                <h:outputLabel class="mx-2 h6" value=": " />
-                                <h:outputLabel class="mx-2 h6" value="#{configOptionApplicationController.getShortTextValueByKey('About Page - Last Update','')}" />
+                                <h:outputLabel class="mx-2 h6" value="#{versionController.gitBuildTime}" />
                                 <h:outputLabel class="mx-2 h6" value="Last commit" />
                                 <h:outputLabel class="mx-2 h6" value=": " />
-                                <h:outputLabel class="mx-2 h6" value="#{configOptionApplicationController.getShortTextValueByKey('About Page - Last Commit','')}" />
+                                <h:outputLabel class="mx-2 h6" value="#{versionController.gitCommitIdAbbrev} (#{versionController.gitBranch})" />
                             </h:panelGrid>
                         </div>
                     </div>


### PR DESCRIPTION
…adata

- Add git-commit-id-plugin to generate git.properties
- Read commit, branch, build time in VersionController
- Show Build time + Last commit on About page

Refs #15598

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - About page now displays build time, Git commit (short hash), and branch.
  - Updated About page labels to reflect build and commit details; removed previous “Latest version”/“Last update” fields.

- Chores
  - Build process now embeds Git metadata to support displaying commit and build information on the About page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->