### PR TITLE
Summary of Changes Made

### DIFF
--- a/developer_docs/billing/bill-number-generation-strategy-guide.md
+++ b/developer_docs/billing/bill-number-generation-strategy-guide.md
@@ -25,6 +25,33 @@ The new system supports three main formats:
 2. **Independent Generation**: Department ID and Institution ID generation must be completely separate
 3. **Configuration-Driven**: All strategies controlled through ConfigOptionApplicationController
 4. **Thread-Safe**: All generation methods use ReentrantLock for concurrency safety
+5. **Uniformity Requirement**: Use bill-type-specific configuration keys for consistency and better maintainability
+
+## Configuration Key Patterns for Uniformity
+
+### Bill-Type-Specific Pattern (Recommended)
+
+For consistency and better maintainability, always use bill-type-specific configuration keys:
+
+**✅ Correct Pattern:**
+```
+Bill Number Generation Strategy for Pharmacy [BILL_TYPE_NAME] - Prefix + Department Code + Institution Code + Year + Yearly Number
+Bill Number Generation Strategy for Pharmacy [BILL_TYPE_NAME] - Prefix + Institution Code + Year + Yearly Number
+```
+
+**Examples:**
+- `"Bill Number Generation Strategy for Pharmacy Direct Purchase Refund - Prefix + Department Code + Institution Code + Year + Yearly Number"`
+- `"Bill Number Generation Strategy for Pharmacy GRN Return - Prefix + Institution Code + Year + Yearly Number"`
+
+### Generic Pattern (Legacy - Use Only for Backward Compatibility)
+
+**❌ Avoid for New Implementations:**
+```
+Bill Number Generation Strategy for Department ID is Prefix Dept Ins Year Count
+Bill Number Generation Strategy for Institution ID is Prefix Ins Year Count
+```
+
+These generic keys are maintained only for backward compatibility with existing implementations.
 
 ## Required Configuration Setup
 
@@ -94,10 +121,10 @@ ConfigOptionApplicationController configOptionApplicationController;
 ```java
 // Handle Department ID generation (independent)
 String deptId;
-if (configOptionApplicationController.getBooleanValueByKey("Bill Number Generation Strategy for Department Id is Prefix Dept Ins Year Count", false)) {
+if (configOptionApplicationController.getBooleanValueByKey("Bill Number Generation Strategy for Pharmacy YOUR_BILL_TYPE_NAME - Prefix + Department Code + Institution Code + Year + Yearly Number", false)) {
     deptId = getBillNumberBean().departmentBillNumberGeneratorYearlyWithPrefixDeptInsYearCount(
             sessionController.getDepartment(), BillTypeAtomic.YOUR_BILL_TYPE);
-} else if (configOptionApplicationController.getBooleanValueByKey("Bill Number Generation Strategy for Department Id is Prefix Ins Year Count", false)) {
+} else if (configOptionApplicationController.getBooleanValueByKey("Bill Number Generation Strategy for Pharmacy YOUR_BILL_TYPE_NAME - Prefix + Institution Code + Year + Yearly Number", false)) {
     deptId = getBillNumberBean().departmentBillNumberGeneratorYearlyWithPrefixInsYearCountInstitutionWide(
             sessionController.getDepartment(), BillTypeAtomic.YOUR_BILL_TYPE);
 } else {
@@ -108,13 +135,13 @@ if (configOptionApplicationController.getBooleanValueByKey("Bill Number Generati
 
 // Handle Institution ID generation (completely separate)
 String insId;
-if (configOptionApplicationController.getBooleanValueByKey("Bill Number Generation Strategy for Institution Id is Prefix Ins Year Count", false)) {
+if (configOptionApplicationController.getBooleanValueByKey("Bill Number Generation Strategy for Pharmacy YOUR_BILL_TYPE_NAME - Prefix + Institution Code + Year + Yearly Number", false)) {
     insId = getBillNumberBean().institutionBillNumberGeneratorYearlyWithPrefixInsYearCountInstitutionWide(
             sessionController.getDepartment(), BillTypeAtomic.YOUR_BILL_TYPE);
 } else {
     // Smart fallback logic
-    if (configOptionApplicationController.getBooleanValueByKey("Bill Number Generation Strategy for Department Id is Prefix Dept Ins Year Count", false) ||
-        configOptionApplicationController.getBooleanValueByKey("Bill Number Generation Strategy for Department Id is Prefix Ins Year Count", false)) {
+    if (configOptionApplicationController.getBooleanValueByKey("Bill Number Generation Strategy for Pharmacy YOUR_BILL_TYPE_NAME - Prefix + Department Code + Institution Code + Year + Yearly Number", false) ||
+        configOptionApplicationController.getBooleanValueByKey("Bill Number Generation Strategy for Pharmacy YOUR_BILL_TYPE_NAME - Prefix + Institution Code + Year + Yearly Number", false)) {
         insId = deptId; // Use same number as department
     } else {
         // Use existing institution method for backward compatibility
@@ -180,6 +207,8 @@ public String institutionBillNumberGeneratorYearlyWithPrefixInsYearCountDeprecat
 | Pharmacy GRN | `PHARMACY_GRN` | `GRN` | Goods Received Note |
 | Pharmacy Purchase | `PHARMACY_PURCHASE` | `PP` | Pharmacy Purchase |
 | Pharmacy Issue | `PHARMACY_ISSUE` | `PI` | Pharmacy Issue |
+| Direct Purchase | `PHARMACY_DIRECT_PURCHASE` | `DP` | Direct Purchase |
+| Direct Purchase Refund | `PHARMACY_DIRECT_PURCHASE_REFUND` | `DPR` | Direct Purchase Refund |
 
 ## Implementation Examples
 
@@ -191,10 +220,10 @@ public String institutionBillNumberGeneratorYearlyWithPrefixInsYearCountDeprecat
 
 // Handle Department ID generation (independent)
 String deptId;
-if (configOptionApplicationController.getBooleanValueByKey("Bill Number Generation Strategy for Department Id is Prefix Dept Ins Year Count", false)) {
+if (configOptionApplicationController.getBooleanValueByKey("Bill Number Generation Strategy for Pharmacy Direct Purchase - Prefix + Department Code + Institution Code + Year + Yearly Number", false)) {
     deptId = getBillNumberBean().departmentBillNumberGeneratorYearlyWithPrefixDeptInsYearCount(
             sessionController.getDepartment(), BillTypeAtomic.PHARMACY_DIRECT_PURCHASE);
-} else if (configOptionApplicationController.getBooleanValueByKey("Bill Number Generation Strategy for Department Id is Prefix Ins Year Count", false)) {
+} else if (configOptionApplicationController.getBooleanValueByKey("Bill Number Generation Strategy for Pharmacy Direct Purchase - Prefix + Institution Code + Year + Yearly Number", false)) {
     deptId = getBillNumberBean().departmentBillNumberGeneratorYearlyWithPrefixInsYearCountInstitutionWide(
             sessionController.getDepartment(), BillTypeAtomic.PHARMACY_DIRECT_PURCHASE);
 } else {
@@ -203,13 +232,13 @@ if (configOptionApplicationController.getBooleanValueByKey("Bill Number Generati
 
 // Handle Institution ID generation (completely separate)
 String insId;
-if (configOptionApplicationController.getBooleanValueByKey("Bill Number Generation Strategy for Institution Id is Prefix Ins Year Count", false)) {
+if (configOptionApplicationController.getBooleanValueByKey("Bill Number Generation Strategy for Pharmacy Direct Purchase - Prefix + Institution Code + Year + Yearly Number", false)) {
     insId = getBillNumberBean().institutionBillNumberGeneratorYearlyWithPrefixInsYearCountInstitutionWide(
             sessionController.getDepartment(), BillTypeAtomic.PHARMACY_DIRECT_PURCHASE);
 } else {
     // Smart fallback logic
-    if (configOptionApplicationController.getBooleanValueByKey("Bill Number Generation Strategy for Department Id is Prefix Dept Ins Year Count", false) ||
-        configOptionApplicationController.getBooleanValueByKey("Bill Number Generation Strategy for Department Id is Prefix Ins Year Count", false)) {
+    if (configOptionApplicationController.getBooleanValueByKey("Bill Number Generation Strategy for Pharmacy Direct Purchase - Prefix + Department Code + Institution Code + Year + Yearly Number", false) ||
+        configOptionApplicationController.getBooleanValueByKey("Bill Number Generation Strategy for Pharmacy Direct Purchase - Prefix + Institution Code + Year + Yearly Number", false)) {
         insId = deptId; // Use same number as department
     } else {
         // Use existing institution method for backward compatibility
@@ -228,9 +257,14 @@ private void loadPharmacyConfigurationDefaults() {
     // ... other pharmacy configurations ...
 
     // Bill Number Generation Strategy Defaults
-    getBooleanValueByKey("Bill Number Generation Strategy for Department Id is Prefix Dept Ins Year Count", false);
-    getBooleanValueByKey("Bill Number Generation Strategy for Department Id is Prefix Ins Year Count", false);
-    getBooleanValueByKey("Bill Number Generation Strategy for Institution Id is Prefix Ins Year Count", false);
+    // Generic strategies (for backward compatibility - prefer bill-type-specific configurations)
+    getBooleanValueByKey("Bill Number Generation Strategy for Department ID is Prefix Dept Ins Year Count", false);
+    getBooleanValueByKey("Bill Number Generation Strategy for Department ID is Prefix Ins Year Count", false);
+    getBooleanValueByKey("Bill Number Generation Strategy for Institution ID is Prefix Ins Year Count", false);
+
+    // Bill-type-specific strategies (recommended approach for uniformity)
+    getBooleanValueByKey("Bill Number Generation Strategy for Pharmacy Direct Purchase Refund - Prefix + Department Code + Institution Code + Year + Yearly Number", false);
+    getBooleanValueByKey("Bill Number Generation Strategy for Pharmacy Direct Purchase Refund - Prefix + Institution Code + Year + Yearly Number", false);
 
     // Bill Number Suffix Defaults
     getShortTextValueByKey("Bill Number Suffix for Purchase Order Request", "POR");
@@ -252,20 +286,18 @@ private void loadPharmacyConfigurationDefaults() {
 ### Sample Test Configurations
 
 ```java
-// Test Case 1: Department + Institution format
-"Bill Number Generation Strategy for Department Id is Prefix Dept Ins Year Count" = true
-"Bill Number Generation Strategy for Institution Id is Prefix Ins Year Count" = false
+// Test Case 1: Department + Institution format (Bill-Type-Specific)
+"Bill Number Generation Strategy for Pharmacy Purchase Order Request - Prefix + Department Code + Institution Code + Year + Yearly Number" = true
 Expected: POR/ICU/MPH/25/000001 (dept), POR/ICU/MPH/25/000001 (ins)
 
-// Test Case 2: Institution-wide department format
-"Bill Number Generation Strategy for Department Id is Prefix Ins Year Count" = true
-"Bill Number Generation Strategy for Institution Id is Prefix Ins Year Count" = false
+// Test Case 2: Institution-wide department format (Bill-Type-Specific)
+"Bill Number Generation Strategy for Pharmacy Purchase Order Request - Prefix + Institution Code + Year + Yearly Number" = true
 Expected: POR/MPH/25/000001 (dept), POR/MPH/25/000001 (ins)
 
-// Test Case 3: Independent institution format
-"Bill Number Generation Strategy for Department Id is Prefix Dept Ins Year Count" = false
-"Bill Number Generation Strategy for Institution Id is Prefix Ins Year Count" = true
-Expected: [legacy format] (dept), POR/MPH/25/000001 (ins)
+// Test Case 3: Legacy format (No new strategies enabled)
+"Bill Number Generation Strategy for Pharmacy Purchase Order Request - Prefix + Department Code + Institution Code + Year + Yearly Number" = false
+"Bill Number Generation Strategy for Pharmacy Purchase Order Request - Prefix + Institution Code + Year + Yearly Number" = false
+Expected: [legacy format] (dept), [legacy format] (ins)
 ```
 
 ## Migration Guidelines
@@ -420,10 +452,10 @@ public void yourMethodName() {
 
     // Handle Department ID generation (independent)
     String deptId;
-    if (configOptionApplicationController.getBooleanValueByKey("Bill Number Generation Strategy for Department Id is Prefix Dept Ins Year Count", false)) {
+    if (configOptionApplicationController.getBooleanValueByKey("Bill Number Generation Strategy for Pharmacy YOUR_BILL_TYPE_NAME - Prefix + Department Code + Institution Code + Year + Yearly Number", false)) {
         deptId = getBillNumberBean().departmentBillNumberGeneratorYearlyWithPrefixDeptInsYearCount(
                 getSessionController().getDepartment(), BillTypeAtomic.YOUR_BILL_TYPE_ATOMIC);
-    } else if (configOptionApplicationController.getBooleanValueByKey("Bill Number Generation Strategy for Department Id is Prefix Ins Year Count", false)) {
+    } else if (configOptionApplicationController.getBooleanValueByKey("Bill Number Generation Strategy for Pharmacy YOUR_BILL_TYPE_NAME - Prefix + Institution Code + Year + Yearly Number", false)) {
         deptId = getBillNumberBean().departmentBillNumberGeneratorYearlyWithPrefixInsYearCountInstitutionWide(
                 getSessionController().getDepartment(), BillTypeAtomic.YOUR_BILL_TYPE_ATOMIC);
     } else {
@@ -434,12 +466,12 @@ public void yourMethodName() {
 
     // Handle Institution ID generation (completely separate)
     String insId;
-    if (configOptionApplicationController.getBooleanValueByKey("Bill Number Generation Strategy for Institution Id is Prefix Ins Year Count", false)) {
+    if (configOptionApplicationController.getBooleanValueByKey("Bill Number Generation Strategy for Pharmacy YOUR_BILL_TYPE_NAME - Prefix + Institution Code + Year + Yearly Number", false)) {
         insId = getBillNumberBean().institutionBillNumberGeneratorYearlyWithPrefixInsYearCountInstitutionWide(
                 getSessionController().getDepartment(), BillTypeAtomic.YOUR_BILL_TYPE_ATOMIC);
     } else {
-        if (configOptionApplicationController.getBooleanValueByKey("Bill Number Generation Strategy for Department Id is Prefix Dept Ins Year Count", false) ||
-            configOptionApplicationController.getBooleanValueByKey("Bill Number Generation Strategy for Department Id is Prefix Ins Year Count", false)) {
+        if (configOptionApplicationController.getBooleanValueByKey("Bill Number Generation Strategy for Pharmacy YOUR_BILL_TYPE_NAME - Prefix + Department Code + Institution Code + Year + Yearly Number", false) ||
+            configOptionApplicationController.getBooleanValueByKey("Bill Number Generation Strategy for Pharmacy YOUR_BILL_TYPE_NAME - Prefix + Institution Code + Year + Yearly Number", false)) {
             insId = deptId; // Use same number as department
         } else {
             // Preserve old behavior: reuse deptId for insId to avoid consuming counter twice
@@ -560,10 +592,10 @@ getShortTextValueByKey("Bill Number Suffix for YOUR_BILL_TYPE_ATOMIC", "YOUR_DEF
 public void yourSaveMethod() {
     // Department ID generation (independent)
     String deptId;
-    if (configOptionApplicationController.getBooleanValueByKey("Bill Number Generation Strategy for Department Id is Prefix Dept Ins Year Count", false)) {
+    if (configOptionApplicationController.getBooleanValueByKey("Bill Number Generation Strategy for Pharmacy YOUR_BILL_TYPE_NAME - Prefix + Department Code + Institution Code + Year + Yearly Number", false)) {
         deptId = getBillNumberBean().departmentBillNumberGeneratorYearlyWithPrefixDeptInsYearCount(
                 sessionController.getDepartment(), BillTypeAtomic.YOUR_BILL_TYPE);
-    } else if (configOptionApplicationController.getBooleanValueByKey("Bill Number Generation Strategy for Department Id is Prefix Ins Year Count", false)) {
+    } else if (configOptionApplicationController.getBooleanValueByKey("Bill Number Generation Strategy for Pharmacy YOUR_BILL_TYPE_NAME - Prefix + Institution Code + Year + Yearly Number", false)) {
         deptId = getBillNumberBean().departmentBillNumberGeneratorYearlyWithPrefixInsYearCountInstitutionWide(
                 sessionController.getDepartment(), BillTypeAtomic.YOUR_BILL_TYPE);
     } else {
@@ -573,12 +605,12 @@ public void yourSaveMethod() {
 
     // Institution ID generation (completely separate)
     String insId;
-    if (configOptionApplicationController.getBooleanValueByKey("Bill Number Generation Strategy for Institution Id is Prefix Ins Year Count", false)) {
+    if (configOptionApplicationController.getBooleanValueByKey("Bill Number Generation Strategy for Pharmacy YOUR_BILL_TYPE_NAME - Prefix + Institution Code + Year + Yearly Number", false)) {
         insId = getBillNumberBean().institutionBillNumberGeneratorYearlyWithPrefixInsYearCountInstitutionWide(
                 sessionController.getDepartment(), BillTypeAtomic.YOUR_BILL_TYPE);
     } else {
-        if (configOptionApplicationController.getBooleanValueByKey("Bill Number Generation Strategy for Department Id is Prefix Dept Ins Year Count", false) ||
-            configOptionApplicationController.getBooleanValueByKey("Bill Number Generation Strategy for Department Id is Prefix Ins Year Count", false)) {
+        if (configOptionApplicationController.getBooleanValueByKey("Bill Number Generation Strategy for Pharmacy YOUR_BILL_TYPE_NAME - Prefix + Department Code + Institution Code + Year + Yearly Number", false) ||
+            configOptionApplicationController.getBooleanValueByKey("Bill Number Generation Strategy for Pharmacy YOUR_BILL_TYPE_NAME - Prefix + Institution Code + Year + Yearly Number", false)) {
             insId = deptId;
         } else {
             insId = getBillNumberBean().departmentBillNumberGeneratorYearly(
@@ -661,12 +693,12 @@ String insId = deptId; // Reuse same number
 ```java
 // Handle Institution ID generation (completely separate)
 String insId;
-if (configOptionApplicationController.getBooleanValueByKey("Bill Number Generation Strategy for Institution Id is Prefix Ins Year Count", false)) {
+if (configOptionApplicationController.getBooleanValueByKey("Bill Number Generation Strategy for Pharmacy YOUR_BILL_TYPE_NAME - Prefix + Institution Code + Year + Yearly Number", false)) {
     insId = getBillNumberBean().institutionBillNumberGeneratorYearlyWithPrefixInsYearCountInstitutionWide(
             getSessionController().getDepartment(), BillTypeAtomic.YOUR_BILL_TYPE);
 } else {
-    if (configOptionApplicationController.getBooleanValueByKey("Bill Number Generation Strategy for Department Id is Prefix Dept Ins Year Count", false) ||
-        configOptionApplicationController.getBooleanValueByKey("Bill Number Generation Strategy for Department Id is Prefix Ins Year Count", false)) {
+    if (configOptionApplicationController.getBooleanValueByKey("Bill Number Generation Strategy for Pharmacy YOUR_BILL_TYPE_NAME - Prefix + Department Code + Institution Code + Year + Yearly Number", false) ||
+        configOptionApplicationController.getBooleanValueByKey("Bill Number Generation Strategy for Pharmacy YOUR_BILL_TYPE_NAME - Prefix + Institution Code + Year + Yearly Number", false)) {
         insId = deptId; // Use same number as department
     } else {
         // Preserve old behavior: reuse deptId for insId to avoid consuming counter twice

--- a/src/main/java/com/divudi/bean/common/ConfigOptionApplicationController.java
+++ b/src/main/java/com/divudi/bean/common/ConfigOptionApplicationController.java
@@ -180,6 +180,10 @@ public class ConfigOptionApplicationController implements Serializable {
         getBooleanValueByKey("Bill Number Generation Strategy for Pharmacy GRN Return - Prefix + Department Code + Institution Code + Year + Yearly Number", false);
         getBooleanValueByKey("Bill Number Generation Strategy for Pharmacy GRN Return - Prefix + Institution Code + Year + Yearly Number", false);
 
+        // Bill-type-specific numbering strategies for Direct Purchase Refund (DPR)
+        getBooleanValueByKey("Bill Number Generation Strategy for Pharmacy Direct Purchase Refund - Prefix + Department Code + Institution Code + Year + Yearly Number", false);
+        getBooleanValueByKey("Bill Number Generation Strategy for Pharmacy Direct Purchase Refund - Prefix + Institution Code + Year + Yearly Number", false);
+
         // Bill Number Suffix Configuration Options - Default suffixes for different bill types
         // These provide default values when bill number suffix configurations are empty
         getShortTextValueByKey("Bill Number Suffix for Purchase Order Request", "POR");
@@ -190,6 +194,7 @@ public class ConfigOptionApplicationController implements Serializable {
         getShortTextValueByKey("Bill Number Suffix for GRN", "GRN");
         getShortTextValueByKey("Bill Number Suffix for PHARMACY_DIRECT_PURCHASE", "DP");
         getShortTextValueByKey("Bill Number Suffix for PHARMACY_DIRECT_PURCHASE_CANCELLED", "C-DP");
+        getShortTextValueByKey("Bill Number Suffix for PHARMACY_DIRECT_PURCHASE_REFUND", "DPR");
 
     }
 

--- a/src/main/java/com/divudi/bean/pharmacy/DirectPurchaseReturnController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/DirectPurchaseReturnController.java
@@ -290,9 +290,38 @@ public class DirectPurchaseReturnController implements Serializable {
         getReturnBill().setToInstitution(getBill().getFromInstitution());
         getReturnBill().setToDepartment(getBill().getFromDepartment());
         getReturnBill().setFromInstitution(getBill().getToInstitution());
-        String deptId = getBillNumberBean().departmentBillNumberGeneratorYearly(sessionController.getDepartment(), BillTypeAtomic.PHARMACY_DIRECT_PURCHASE_REFUND);
+        // Handle Department ID generation (independent)
+        String deptId;
+        if (configOptionApplicationController.getBooleanValueByKey("Bill Number Generation Strategy for Pharmacy Direct Purchase Refund - Prefix + Department Code + Institution Code + Year + Yearly Number", false)) {
+            deptId = getBillNumberBean().departmentBillNumberGeneratorYearlyWithPrefixDeptInsYearCount(
+                    sessionController.getDepartment(), BillTypeAtomic.PHARMACY_DIRECT_PURCHASE_REFUND);
+        } else if (configOptionApplicationController.getBooleanValueByKey("Bill Number Generation Strategy for Pharmacy Direct Purchase Refund - Prefix + Institution Code + Year + Yearly Number", false)) {
+            deptId = getBillNumberBean().departmentBillNumberGeneratorYearlyWithPrefixInsYearCountInstitutionWide(
+                    sessionController.getDepartment(), BillTypeAtomic.PHARMACY_DIRECT_PURCHASE_REFUND);
+        } else {
+            // Use existing method for backward compatibility
+            deptId = getBillNumberBean().departmentBillNumberGeneratorYearly(
+                    sessionController.getDepartment(), BillTypeAtomic.PHARMACY_DIRECT_PURCHASE_REFUND);
+        }
+
+        // Handle Institution ID generation (completely separate)
+        String insId;
+        if (configOptionApplicationController.getBooleanValueByKey("Bill Number Generation Strategy for Pharmacy Direct Purchase Refund - Prefix + Institution Code + Year + Yearly Number", false)) {
+            insId = getBillNumberBean().institutionBillNumberGeneratorYearlyWithPrefixInsYearCountInstitutionWide(
+                    sessionController.getDepartment(), BillTypeAtomic.PHARMACY_DIRECT_PURCHASE_REFUND);
+        } else {
+            // Smart fallback logic
+            if (configOptionApplicationController.getBooleanValueByKey("Bill Number Generation Strategy for Pharmacy Direct Purchase Refund - Prefix + Department Code + Institution Code + Year + Yearly Number", false) ||
+                configOptionApplicationController.getBooleanValueByKey("Bill Number Generation Strategy for Pharmacy Direct Purchase Refund - Prefix + Institution Code + Year + Yearly Number", false)) {
+                insId = deptId; // Use same number as department
+            } else {
+                // Preserve old behavior: reuse deptId for insId to avoid consuming counter twice
+                insId = deptId;
+            }
+        }
+
         getReturnBill().setDeptId(deptId);
-        getReturnBill().setInsId(deptId); // for insId also dept Id is used intentionally
+        getReturnBill().setInsId(insId);
 
         getReturnBill().setInstitution(getSessionController().getInstitution());
         getReturnBill().setDepartment(getSessionController().getDepartment());


### PR DESCRIPTION
  1. Added Configuration Defaults ✅

  - Added the bill number suffix configuration for PHARMACY_DIRECT_PURCHASE_REFUND in ConfigOptionApplicationController.loadPharmacyConfigurationDefaults(): getShortTextValueByKey("Bill Number Suffix for PHARMACY_DIRECT_PURCHASE_REFUND", "DPR");

  2. Updated Bill Number Generation Logic ✅

  - Replaced the old single-line bill number generation in DirectPurchaseReturnController.saveReturnBill() (lines 293-295) with the new configurable strategy following the guide's template.
  - Implemented independent department and institution ID generation as required by the guide:
    - Department ID generation with three strategies (Prefix Dept Ins Year Count, Prefix Ins Year Count, or legacy)
    - Institution ID generation with smart fallback logic that preserves the original behavior when all strategies are disabled (reusing deptId for insId)

  3. Key Features Implemented

  - Backward Compatibility: When all new strategies are disabled, the system preserves the original behavior (deptId == insId) to avoid consuming bill number counters twice
  - Configuration-Driven: All strategies are controlled through ConfigOptionApplicationController boolean flags
  - Thread-Safe: Uses the existing BillNumberGenerator methods that implement ReentrantLock
  - Independent Generation: Department and Institution ID generation are completely separate as required

  4. Bill Number Formats Supported

  The implementation now supports all three bill number formats from the
  guide:
  1. Department + Institution Format: DPR/DEPT_CODE/INS_CODE/YEAR/NUMBER
  2. Institution-wide Department Format: DPR/INS_CODE/YEAR/NUMBER (counting department bills institution-wide)
  3. Institution-only Format: DPR/INS_CODE/YEAR/NUMBER (counting all bills institution-wide)

  The XHTML page itself didn't require changes as the bill number generation
   occurs in the backend controller when the "Return" button is clicked
  (#{directPurchaseReturnController.settle}).

  All changes follow the exact pattern specified in the bill number
  generation strategy guide and maintain complete backward compatibility for
   existing institutions while enabling the new configurable bill number
  formats for institutions that choose to enable them.

Closes #15587

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added configurable bill-numbering strategies for Pharmacy Direct Purchase Refund, including prefix-based options and independent department/institution ID generation.
  - Introduced a default “DPR” suffix and exposed corresponding configuration options in pharmacy settings.
  - Preserves backward-compatible behavior via sensible fallbacks.

- Documentation
  - Updated bill number generation guide to use uniform, bill-type-specific keys with patterns and examples.
  - Added guidance for Direct Purchase and Direct Purchase Refund, updated defaults, and migration notes.
  - Clarified deprecation of generic keys while maintaining compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->