### PR TITLE
Improve Transfer Request bill number generation strategy

### DIFF
--- a/src/main/java/com/divudi/bean/common/ConfigOptionApplicationController.java
+++ b/src/main/java/com/divudi/bean/common/ConfigOptionApplicationController.java
@@ -180,6 +180,10 @@ public class ConfigOptionApplicationController implements Serializable {
         getBooleanValueByKey("Bill Number Generation Strategy for Pharmacy GRN Return - Prefix + Department Code + Institution Code + Year + Yearly Number", false);
         getBooleanValueByKey("Bill Number Generation Strategy for Pharmacy GRN Return - Prefix + Institution Code + Year + Yearly Number", false);
 
+        // Bill-type-specific numbering strategies for Transfer Receive (TR)
+        getBooleanValueByKey("Bill Number Generation Strategy for Pharmacy Transfer Receive - Prefix + Department Code + Institution Code + Year + Yearly Number", false);
+        getBooleanValueByKey("Bill Number Generation Strategy for Pharmacy Transfer Receive - Prefix + Institution Code + Year + Yearly Number", false);
+
         // Bill Number Suffix Configuration Options - Default suffixes for different bill types
         // These provide default values when bill number suffix configurations are empty
         getShortTextValueByKey("Bill Number Suffix for Purchase Order Request", "POR");
@@ -190,6 +194,7 @@ public class ConfigOptionApplicationController implements Serializable {
         getShortTextValueByKey("Bill Number Suffix for GRN", "GRN");
         getShortTextValueByKey("Bill Number Suffix for PHARMACY_DIRECT_PURCHASE", "DP");
         getShortTextValueByKey("Bill Number Suffix for PHARMACY_DIRECT_PURCHASE_CANCELLED", "C-DP");
+        getShortTextValueByKey("Bill Number Suffix for PHARMACY_RECEIVE", "TR");
 
     }
 

--- a/src/main/java/com/divudi/bean/common/ConfigOptionApplicationController.java
+++ b/src/main/java/com/divudi/bean/common/ConfigOptionApplicationController.java
@@ -184,6 +184,10 @@ public class ConfigOptionApplicationController implements Serializable {
         getBooleanValueByKey("Bill Number Generation Strategy for Pharmacy Transfer Receive - Prefix + Department Code + Institution Code + Year + Yearly Number", false);
         getBooleanValueByKey("Bill Number Generation Strategy for Pharmacy Transfer Receive - Prefix + Institution Code + Year + Yearly Number", false);
 
+        // Bill-type-specific numbering strategies for Transfer Request (TRQ)
+        getBooleanValueByKey("Bill Number Generation Strategy for Pharmacy Transfer Request - Prefix + Department Code + Institution Code + Year + Yearly Number", false);
+        getBooleanValueByKey("Bill Number Generation Strategy for Pharmacy Transfer Request - Prefix + Institution Code + Year + Yearly Number", false);
+
         // Bill Number Suffix Configuration Options - Default suffixes for different bill types
         // These provide default values when bill number suffix configurations are empty
         getShortTextValueByKey("Bill Number Suffix for Purchase Order Request", "POR");
@@ -195,6 +199,8 @@ public class ConfigOptionApplicationController implements Serializable {
         getShortTextValueByKey("Bill Number Suffix for PHARMACY_DIRECT_PURCHASE", "DP");
         getShortTextValueByKey("Bill Number Suffix for PHARMACY_DIRECT_PURCHASE_CANCELLED", "C-DP");
         getShortTextValueByKey("Bill Number Suffix for PHARMACY_RECEIVE", "TR");
+        getShortTextValueByKey("Bill Number Suffix for PHARMACY_TRANSFER_REQUEST", "PHTRQ");
+        getShortTextValueByKey("Bill Number Suffix for PHARMACY_TRANSFER_REQUEST_PRE", "PHTRQ-PRE");
 
     }
 

--- a/src/main/java/com/divudi/bean/pharmacy/TransferRequestController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/TransferRequestController.java
@@ -303,15 +303,44 @@ public class TransferRequestController implements Serializable {
         newApprovedBill.setCreatedAt(new Date());
         newApprovedBill.setCreater(sessionController.getLoggedUser());
 
-        String requestId = billNumberBean.departmentBillNumberGeneratorYearlyByFromDepartmentAndToDepartment(
-                newApprovedBill.getDepartment(),
-                newApprovedBill.getToDepartment(),
-                BillTypeAtomic.PHARMACY_TRANSFER_REQUEST);
-
         newApprovedBill.setBillDate(new Date());
         newApprovedBill.setBillTime(new Date());
-        newApprovedBill.setDeptId(requestId);
-        newApprovedBill.setInsId(requestId);
+        boolean useDeptInsFormat = configOptionApplicationController.getBooleanValueByKey(
+                "Bill Number Generation Strategy for Pharmacy Transfer Request - Prefix + Department Code + Institution Code + Year + Yearly Number", false);
+        boolean useInsFormat = configOptionApplicationController.getBooleanValueByKey(
+                "Bill Number Generation Strategy for Pharmacy Transfer Request - Prefix + Institution Code + Year + Yearly Number", false);
+
+        String legacyRequestId = null;
+        if (!useDeptInsFormat && !useInsFormat) {
+            legacyRequestId = billNumberBean.departmentBillNumberGeneratorYearlyByFromDepartmentAndToDepartment(
+                    newApprovedBill.getDepartment(),
+                    newApprovedBill.getToDepartment(),
+                    BillTypeAtomic.PHARMACY_TRANSFER_REQUEST);
+        }
+
+        String deptId;
+        if (useDeptInsFormat) {
+            deptId = billNumberBean.departmentBillNumberGeneratorYearlyWithPrefixDeptInsYearCount(
+                    newApprovedBill.getDepartment(), BillTypeAtomic.PHARMACY_TRANSFER_REQUEST);
+        } else if (useInsFormat) {
+            deptId = billNumberBean.departmentBillNumberGeneratorYearlyWithPrefixInsYearCountInstitutionWide(
+                    newApprovedBill.getDepartment(), BillTypeAtomic.PHARMACY_TRANSFER_REQUEST);
+        } else {
+            deptId = legacyRequestId;
+        }
+
+        String insId;
+        if (useInsFormat) {
+            insId = billNumberBean.institutionBillNumberGeneratorYearlyWithPrefixInsYearCountInstitutionWide(
+                    newApprovedBill.getDepartment(), BillTypeAtomic.PHARMACY_TRANSFER_REQUEST);
+        } else if (useDeptInsFormat) {
+            insId = deptId;
+        } else {
+            insId = legacyRequestId;
+        }
+
+        newApprovedBill.setDeptId(deptId);
+        newApprovedBill.setInsId(insId);
         newApprovedBill.setBillTypeAtomic(BillTypeAtomic.PHARMACY_TRANSFER_REQUEST);
         newApprovedBill.setBillType(BillType.PharmacyTransferRequest);
         newApprovedBill.setApproveAt(new Date());
@@ -400,8 +429,36 @@ public class TransferRequestController implements Serializable {
             getBillFacade().edit(getTransferRequestBillPre());
         }
 
-        getBill().setDeptId(getBillNumberBean().institutionBillNumberGenerator(getSessionController().getDepartment(), BillType.PharmacyTransferRequest, BillClassType.BilledBill, BillNumberSuffix.PHTRQ));
-        getBill().setInsId(getBillNumberBean().institutionBillNumberGenerator(getSessionController().getInstitution(), BillType.PharmacyTransferRequest, BillClassType.BilledBill, BillNumberSuffix.PHTRQ));
+        boolean useDeptInsFormat = configOptionApplicationController.getBooleanValueByKey(
+                "Bill Number Generation Strategy for Pharmacy Transfer Request - Prefix + Department Code + Institution Code + Year + Yearly Number", false);
+        boolean useInsFormat = configOptionApplicationController.getBooleanValueByKey(
+                "Bill Number Generation Strategy for Pharmacy Transfer Request - Prefix + Institution Code + Year + Yearly Number", false);
+
+        String deptId;
+        if (useDeptInsFormat) {
+            deptId = getBillNumberBean().departmentBillNumberGeneratorYearlyWithPrefixDeptInsYearCount(
+                    getSessionController().getDepartment(), BillTypeAtomic.PHARMACY_TRANSFER_REQUEST);
+        } else if (useInsFormat) {
+            deptId = getBillNumberBean().departmentBillNumberGeneratorYearlyWithPrefixInsYearCountInstitutionWide(
+                    getSessionController().getDepartment(), BillTypeAtomic.PHARMACY_TRANSFER_REQUEST);
+        } else {
+            deptId = getBillNumberBean().institutionBillNumberGenerator(
+                    getSessionController().getDepartment(), BillType.PharmacyTransferRequest, BillClassType.BilledBill, BillNumberSuffix.PHTRQ);
+        }
+
+        String insId;
+        if (useInsFormat) {
+            insId = getBillNumberBean().institutionBillNumberGeneratorYearlyWithPrefixInsYearCountInstitutionWide(
+                    getSessionController().getDepartment(), BillTypeAtomic.PHARMACY_TRANSFER_REQUEST);
+        } else if (useDeptInsFormat) {
+            insId = deptId;
+        } else {
+            insId = getBillNumberBean().institutionBillNumberGenerator(
+                    getSessionController().getInstitution(), BillType.PharmacyTransferRequest, BillClassType.BilledBill, BillNumberSuffix.PHTRQ);
+        }
+
+        getBill().setDeptId(deptId);
+        getBill().setInsId(insId);
 
         getBill().setCreater(getSessionController().getLoggedUser());
         getBill().setCreatedAt(Calendar.getInstance().getTime());
@@ -459,10 +516,6 @@ public class TransferRequestController implements Serializable {
     }
 
     public void saveTransferRequestPreBillAndBillItems() {
-        String requestPreBillId = billNumberBean.departmentBillNumberGeneratorYearlyByFromDepartmentAndToDepartment(
-                getSessionController().getDepartment(),
-                getToDepartment(),
-                BillTypeAtomic.PHARMACY_TRANSFER_REQUEST_PRE);
         getTransferRequestBillPre().setBillTypeAtomic(BillTypeAtomic.PHARMACY_TRANSFER_REQUEST_PRE);
         getTransferRequestBillPre().setBillType(BillType.PharmacyTransferRequest);
         getTransferRequestBillPre().setToDepartment(getToDepartment());
@@ -484,8 +537,43 @@ public class TransferRequestController implements Serializable {
         if (getTransferRequestBillPre().getId() == null) {
             getBillFacade().create(getTransferRequestBillPre());
         }
-        getTransferRequestBillPre().setDeptId(requestPreBillId);
-        getTransferRequestBillPre().setInsId(requestPreBillId);
+
+        boolean useDeptInsFormat = configOptionApplicationController.getBooleanValueByKey(
+                "Bill Number Generation Strategy for Pharmacy Transfer Request - Prefix + Department Code + Institution Code + Year + Yearly Number", false);
+        boolean useInsFormat = configOptionApplicationController.getBooleanValueByKey(
+                "Bill Number Generation Strategy for Pharmacy Transfer Request - Prefix + Institution Code + Year + Yearly Number", false);
+
+        String legacyRequestId = null;
+        if (!useDeptInsFormat && !useInsFormat) {
+            legacyRequestId = billNumberBean.departmentBillNumberGeneratorYearlyByFromDepartmentAndToDepartment(
+                    getSessionController().getDepartment(),
+                    getToDepartment(),
+                    BillTypeAtomic.PHARMACY_TRANSFER_REQUEST_PRE);
+        }
+
+        String deptId;
+        if (useDeptInsFormat) {
+            deptId = billNumberBean.departmentBillNumberGeneratorYearlyWithPrefixDeptInsYearCount(
+                    getSessionController().getDepartment(), BillTypeAtomic.PHARMACY_TRANSFER_REQUEST_PRE);
+        } else if (useInsFormat) {
+            deptId = billNumberBean.departmentBillNumberGeneratorYearlyWithPrefixInsYearCountInstitutionWide(
+                    getSessionController().getDepartment(), BillTypeAtomic.PHARMACY_TRANSFER_REQUEST_PRE);
+        } else {
+            deptId = legacyRequestId;
+        }
+
+        String insId;
+        if (useInsFormat) {
+            insId = billNumberBean.institutionBillNumberGeneratorYearlyWithPrefixInsYearCountInstitutionWide(
+                    getSessionController().getDepartment(), BillTypeAtomic.PHARMACY_TRANSFER_REQUEST_PRE);
+        } else if (useDeptInsFormat) {
+            insId = deptId;
+        } else {
+            insId = legacyRequestId;
+        }
+
+        getTransferRequestBillPre().setDeptId(deptId);
+        getTransferRequestBillPre().setInsId(insId);
         getTransferRequestBillPre().setCreater(getSessionController().getLoggedUser());
         getTransferRequestBillPre().setCreatedAt(Calendar.getInstance().getTime());
         getBillFacade().edit(getTransferRequestBillPre());


### PR DESCRIPTION
## Summary
- Implemented configurable bill number generation strategies for PHARMACY_TRANSFER_REQUEST and PHARMACY_TRANSFER_REQUEST_PRE
- Added prefix+dept+ins+year and prefix+ins+year strategy options
- Updated TransferRequestController in multiple methods with new configurable approach
- Maintains backward compatibility with existing installations
- Uses existing PHARMACY_TRANSFER_REQUEST and PHARMACY_TRANSFER_REQUEST_PRE BillTypeAtomic without any changes

## Test plan
- [ ] Test new bill number generation strategies with different configurations
- [ ] Verify backward compatibility with existing installations
- [ ] Test transfer request bill creation with new number formats

🤖 Generated with [Claude Code](https://claude.ai/code)