### PR TITLE
15654 r d should be displayed before the ins and department code

### DIFF
--- a/src/main/java/com/divudi/bean/common/ConfigOptionApplicationController.java
+++ b/src/main/java/com/divudi/bean/common/ConfigOptionApplicationController.java
@@ -159,6 +159,8 @@ public class ConfigOptionApplicationController implements Serializable {
         // These options enable configurable bill numbering strategies across different bill types
         // Future development: Apply these patterns to additional bill types as needed
 
+        getShortTextValueByKey("Bill Number Delimiter", "/");
+
         // Generic bill numbering strategies (for backward compatibility)
         getBooleanValueByKey("Bill Number Generation Strategy for Department ID is Prefix Dept Ins Year Count", false);
         getBooleanValueByKey("Bill Number Generation Strategy for Department ID is Prefix Ins Year Count", false);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a configurable Bill Number Delimiter in Pharmacy settings (default “/”).
  * Applied the chosen delimiter consistently across all bill number formats (yearly, department/institution, payment types, OPD/inpatient, batches).
  * Ensures existing bill numbers remain compatible while enabling customization of formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->