### PR TITLE
Closes #14609

### DIFF
--- a/src/main/webapp/pharmacy/pharmacy_grn_return_request.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_grn_return_request.xhtml
@@ -113,7 +113,7 @@
                             </p:column>
 
 
-                            <p:column 
+                            <p:column
                                 id="colPoDetails"
                                 headerText="PO Details">
                                 <div class="d-flex flex-column">
@@ -140,11 +140,20 @@
                                             <h:outputText styleClass="text-danger small" value="#{p.referenceBill.cancelledBill.creater.webUserPerson.name}" />
                                         </div>
                                     </h:panelGroup>
+                                    <div class="mt-2">
+                                        <p:commandButton
+                                            id="btnViewPo"
+                                            title="View PO"
+                                            ajax="false"
+                                            icon="pi pi-eye"
+                                            styleClass="ui-button-sm ui-button-info"
+                                            action="#{billSearch.navigateToViewBillByAtomicBillTypeByBillId(p.referenceBill.id)}" />
+                                    </div>
                                 </div>
                             </p:column>
                             
-                            <p:column 
-                                headerText="GRN Details" 
+                            <p:column
+                                headerText="GRN Details"
                                 id="colGrnDetails">
                                 <div class="d-flex flex-column">
                                     <div class="mb-1">
@@ -192,6 +201,15 @@
                                             <h:outputText styleClass="text-success small" value="#{p.fullReturnedBy.webUserPerson.name}" />
                                         </div>
                                     </h:panelGroup>
+                                    <div class="mt-2">
+                                        <p:commandButton
+                                            id="btnViewGrn"
+                                            title="View GRN"
+                                            ajax="false"
+                                            icon="pi pi-eye"
+                                            styleClass="ui-button-sm ui-button-success"
+                                            action="#{billSearch.navigateToViewBillByAtomicBillTypeByBillId(p.id)}" />
+                                    </div>
                                 </div>
                             </p:column>
 


### PR DESCRIPTION
  1. PO Details Column (line 143-151): Added a "View PO" button with:
    - Icon: pi pi-eye
    - Style: ui-button-sm ui-button-info (blue button)
    - Navigation: Uses billSearch.navigateToViewBillByAtomicBillTypeByBillId(p.referenceBill.id) to route to the correct PO preview page based on atomic bill type
  2. GRN Details Column (line 204-212): Added a "View GRN" button with:
    - Icon: pi pi-eye
    - Style: ui-button-sm ui-button-success (green button)
    - Navigation: Uses billSearch.navigateToViewBillByAtomicBillTypeByBillId(p.id) to route to the correct GRN preview page based on atomic bill type

  Both buttons use the centralized atomic bill type routing system from BillSearch.navigateToViewBillByAtomicBillType(), which automatically routes users to the appropriate
  print/preview page based on the bill's type (e.g., PHARMACY_GRN, PHARMACY_ORDER, etc.).

Closes #14609