### PR TITLE
#15573 need to improve purchase order request reprint bill

### DIFF
--- a/src/main/webapp/pharmacy/pharmacy_reprint_order_request.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_reprint_order_request.xhtml
@@ -130,9 +130,6 @@
 
                         <p:panel header="Purchase Order Reprint">
                             <div class="d-flex justify-content-center border border-light boder-1">
-                                <!--                                <h:panelGroup id="gpBillPreview" style="width: 212mm;">
-                                                                    <ph:po bill="#{pharmacyBillSearch.bill}" reprint="true"/>
-                                                                </h:panelGroup> -->
 
                                 <h:panelGroup id="gpBillPreview" style="width: 212mm;">
 

--- a/src/main/webapp/pharmacy/pharmacy_reprint_order_request.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_reprint_order_request.xhtml
@@ -130,31 +130,29 @@
 
                         <p:panel header="Purchase Order Reprint">
                             <div class="d-flex justify-content-center border border-light boder-1">
-<!--                                <h:panelGroup id="gpBillPreview" style="width: 212mm;">
-                                    <ph:po bill="#{pharmacyBillSearch.bill}" reprint="true"/>
-                                </h:panelGroup> -->
-                                
+                                <!--                                <h:panelGroup id="gpBillPreview" style="width: 212mm;">
+                                                                    <ph:po bill="#{pharmacyBillSearch.bill}" reprint="true"/>
+                                                                </h:panelGroup> -->
+
                                 <h:panelGroup id="gpBillPreview" style="width: 212mm;">
 
-                                <ph:po_custom_1
-                                    rendered="#{configOptionController.getBooleanValueByKey('Pharmacy Purchase Order Request Print - A4 Paper Custom 1', true)}"
-                                    bill="#{pharmacyBillSearch.bill.referenceBill}" reprint="true" controller="#{purchaseOrderController}"/>
+                                    <ph:purchase_order_request_custom_1
+                                        rendered="#{configOptionController.getBooleanValueByKey('Pharmacy Purchase Order Request Print - A4 Paper Custom 1', true)}"
+                                        bill="#{pharmacyBillSearch.bill}" reprint="true"
+                                        billItems="#{pharmacyBillSearch.billItems}"/>
 
-                                <ph:po_custom_2
-                                    rendered="#{configOptionController.getBooleanValueByKey('Pharmacy Purchase Order Request Print - A4 Paper Custom 2', true)}"
-                                    bill="#{pharmacyBillSearch.bill.referenceBill}" reprint="true" controller="#{purchaseOrderController}"/>
-
-                                <ph:po_custom_3_letter
-                                    rendered="#{configOptionController.getBooleanValueByKey('Pharmacy Purchase Order Request Print - Letter Paper Format', true)}"
-                                    bill="#{pharmacyBillSearch.bill.referenceBill}" reprint="true" controller="#{purchaseOrderController}"/>
-
-                            </h:panelGroup>
+                                    <ph:purchase_order_request_custom_2
+                                        rendered="#{configOptionController.getBooleanValueByKey('Pharmacy Purchase Order Request Print - A4 Paper Custom 2', false)}"
+                                        bill="#{pharmacyBillSearch.bill}" reprint="true"
+                                        billItems="#{pharmacyBillSearch.billItems}"/>     
+                                    
+                                </h:panelGroup>
                             </div>
                         </p:panel>
 
                     </p:panel>
                 </h:form>
-                
+
                 <!-- Purchase Order Configuration Dialog -->
                 <p:dialog id="purchaseOrderReprintConfigDialog"
                           header="Purchase Order Approving Reprint Configuration"
@@ -193,14 +191,6 @@
                                             <small class="form-text text-muted d-block">A4 purchase order format - Custom 2</small>
                                         </div>
 
-                                        <div class="mb-3">
-                                            <p:selectBooleanCheckbox
-                                                id="letterPaper"
-                                                value="#{purchaseOrderConfigController.letterPaper}" />
-                                            <p:outputLabel for="letterPaper" value="Letter Paper Format" class="ms-2" />
-                                            <small class="form-text text-muted d-block">Purchase order format - Letter Paper</small>
-                                        </div>
-
                                     </div>
                                 </div>
                             </div>
@@ -234,7 +224,7 @@
 
                     </h:form>
                 </p:dialog>
-                
+
             </ui:define>
 
         </ui:composition>

--- a/src/main/webapp/resources/pharmacy/po_custom_3_letter.xhtml
+++ b/src/main/webapp/resources/pharmacy/po_custom_3_letter.xhtml
@@ -54,7 +54,7 @@
 
             <div>
                 <table class="table table-borderless">
-                    <tr>
+                    <tr style="line-height: 13px">
                         <!-- Left column -->
                         <td>Supplier Name</td>
                         <td>:</td>
@@ -67,7 +67,7 @@
 
                     </tr>
 
-                    <tr>
+                    <tr style="line-height: 13px">
                         <td>P.O. No</td>
                         <td>:</td>
                         <td><h:outputLabel value="#{cc.attrs.bill.deptId}" /></td>
@@ -77,7 +77,7 @@
                         <td><h:outputLabel value="#{cc.attrs.bill.department.name}" /></td>
                     </tr>
 
-                    <tr>
+                    <tr style="line-height: 13px">
                         <td>Consignment</td>
                         <td>:</td>
                         <td><h:outputLabel value="#{cc.attrs.bill.consignment ? 'Yes' : 'No'}" /></td>
@@ -91,7 +91,7 @@
                         </td>
                     </tr>
 
-                    <tr>
+                    <tr style="line-height: 13px">
                         <td>Payment Method</td>
                         <td>:</td>
                         <td><h:outputLabel value="#{cc.attrs.bill.paymentMethod}" /></td>

--- a/src/main/webapp/resources/pharmacy/purchase_order_request_custom_1.xhtml
+++ b/src/main/webapp/resources/pharmacy/purchase_order_request_custom_1.xhtml
@@ -11,173 +11,177 @@
     <cc:interface>
         <cc:attribute name="bill" required="true" />
         <cc:attribute name="billItems" required="true" />
+        <cc:attribute name="reprint"/>
     </cc:interface>
 
     <!-- IMPLEMENTATION -->
     <cc:implementation>
-        <h:outputStylesheet library="css" name="pharmacyA4.css"/>
+        <h:outputStylesheet library="css" name="pharmacyLetter.css"/>
+        <div style="width: 212mm; height: 275mm; padding-left: 0px">
 
-        <div class="institutionName">
-            <h:outputLabel value="#{cc.attrs.bill.creater.institution.name}"/>
-            <br/>
-            <h:outputLabel value="#{cc.attrs.bill.creater.department.name}"/>
-        </div>
-        <div class="institutionContact" >
-            <div class="d-flex gap-2 justify-content-center">
-                <h:outputLabel value="#{cc.attrs.bill.creater.department.address}" rendered="#{!empty cc.attrs.bill.creater.department.address}"/>
+            <div class="institutionName">
+                <h:outputLabel value="#{cc.attrs.bill.creater.institution.name}"/>
+                <br/>
+                <h:outputLabel value="#{cc.attrs.bill.creater.department.name}"/>
             </div>
-            <div class="d-flex gap-2 justify-content-center">
-                <h:outputLabel value="Telephone : " rendered="#{!empty cc.attrs.bill.creater.department.telephone1}" />
-                <h:outputLabel value="#{cc.attrs.bill.creater.department.telephone1}" rendered="#{!empty cc.attrs.bill.creater.department.telephone1}"/>
-                <h:outputLabel value="/" style="width: 15px; text-align: center" rendered="#{cc.attrs.bill.creater.department.telephone2}"/>
-                <h:outputLabel value="#{cc.attrs.bill.creater.department.telephone2}" rendered="#{!empty cc.attrs.bill.creater.department.telephone2}"/>
+            <div class="institutionContact" >
+                <div class="d-flex gap-2 justify-content-center">
+                    <h:outputLabel value="#{cc.attrs.bill.creater.department.address}" rendered="#{!empty cc.attrs.bill.creater.department.address}"/>
+                </div>
+                <div class="d-flex gap-2 justify-content-center">
+                    <h:outputLabel value="Telephone : " rendered="#{!empty cc.attrs.bill.creater.department.telephone1}" />
+                    <h:outputLabel value="#{cc.attrs.bill.creater.department.telephone1}" rendered="#{!empty cc.attrs.bill.creater.department.telephone1}"/>
+                    <h:outputLabel value="/" style="width: 15px; text-align: center" rendered="#{!empty cc.attrs.bill.creater.department.telephone2}"/>
+                    <h:outputLabel value="#{cc.attrs.bill.creater.department.telephone2}" rendered="#{!empty cc.attrs.bill.creater.department.telephone2}"/>
+                </div>
+                <div >
+                    <h:outputLabel value="Fax : &nbsp;&nbsp;&nbsp;&nbsp;#{cc.attrs.bill.creater.department.fax}" rendered="#{!empty cc.attrs.bill.creater.department.fax}"/>
+                </div>
+                <div >
+                    <h:outputLabel value="Email : &nbsp;" rendered="#{!empty cc.attrs.bill.creater.department.email}"/>
+                    <h:outputLabel value="#{cc.attrs.bill.creater.department.email}" rendered="#{!empty cc.attrs.bill.creater.department.email}"/>
+                </div>
             </div>
-            <div >
-                <h:outputLabel value="Fax : &nbsp;&nbsp;&nbsp;&nbsp;#{cc.attrs.bill.creater.department.fax}" rendered="#{!empty cc.attrs.bill.creater.department.fax}"/>
+            <div class="headingBill">
+                <h:outputLabel value="Purchase Order Request" style="text-decoration: underline;"/>
+                <br/>
+                <h:outputLabel value="**Reprint**" rendered="#{cc.attrs.reprint eq true}"/>
             </div>
-            <div >
-                <h:outputLabel value="Email : &nbsp;" rendered="#{!empty cc.attrs.bill.creater.department.email}"/>
-                <h:outputLabel value="#{cc.attrs.bill.creater.department.email}" rendered="#{!empty cc.attrs.bill.creater.department.email}"/>
-            </div>
-        </div>
-        <div class="headingBill">
-            <h:outputLabel value="Purchase Order Request" style="text-decoration: underline;"/>
-        </div>
-        <div class="purchase-order">
-            <h:panelGrid columns="6" class="mt-2 w-100">
-                <h:outputLabel value="Order No" />
-                <h:outputLabel value=":" style="width: 15px; text-align: center"/>
-                <h:outputLabel value="#{cc.attrs.bill.deptId}" />
-                <h:outputLabel value="Order Department" />
-                <h:outputLabel value=":" style="width: 15px; text-align: center"/>
-                <h:outputLabel value="#{cc.attrs.bill.department.name}" />
-                <h:outputLabel value="Supplier" />
-                <h:outputLabel value=":" style="width: 15px; text-align: center"/>
-                <h:outputLabel value="#{cc.attrs.bill.toInstitution.name}" />
-                <h:outputLabel value="Supplier Code" />
-                <h:outputLabel value=":" style="width: 15px; text-align: center"/>
-                <h:outputLabel value="#{cc.attrs.bill.toInstitution.code}" />
-                <h:outputLabel value="Supplier Phone" />
-                <h:outputLabel value=":" style="width: 15px; text-align: center"/>
-                <h:outputLabel value="#{cc.attrs.bill.toInstitution.phone}" />
-                <h:outputLabel value="Supplier Address" />
-                <h:outputLabel value=":" style="width: 15px; text-align: center"/>
-                <h:outputLabel value="#{cc.attrs.bill.toInstitution.address}" />
+            <div class="purchase-order">
+                <h:panelGrid columns="6" class="mt-2 w-100">
+                    <h:outputLabel value="Order No" />
+                    <h:outputLabel value=":" style="width: 15px; text-align: center"/>
+                    <h:outputLabel value="#{cc.attrs.bill.deptId}" />
+                    <h:outputLabel value="Order Department" />
+                    <h:outputLabel value=":" style="width: 15px; text-align: center"/>
+                    <h:outputLabel value="#{cc.attrs.bill.department.name}" />
+                    <h:outputLabel value="Supplier" />
+                    <h:outputLabel value=":" style="width: 15px; text-align: center"/>
+                    <h:outputLabel value="#{cc.attrs.bill.toInstitution.name}" />
+                    <h:outputLabel value="Supplier Code" />
+                    <h:outputLabel value=":" style="width: 15px; text-align: center"/>
+                    <h:outputLabel value="#{cc.attrs.bill.toInstitution.code}" />
+                    <h:outputLabel value="Supplier Phone" />
+                    <h:outputLabel value=":" style="width: 15px; text-align: center"/>
+                    <h:outputLabel value="#{cc.attrs.bill.toInstitution.phone}" />
+                    <h:outputLabel value="Supplier Address" />
+                    <h:outputLabel value=":" style="width: 15px; text-align: center"/>
+                    <h:outputLabel value="#{cc.attrs.bill.toInstitution.address}" />
 
-                <h:outputLabel value="Payment Method" />
-                <h:outputLabel value=":" style="width: 15px; text-align: center"/>
-                <h:outputLabel value="#{cc.attrs.bill.paymentMethod}" />
-                <h:outputLabel value="Consignment" />
-                <h:outputLabel value=":" style="width: 15px; text-align: center"/>
-                <h:outputLabel value="#{cc.attrs.bill.consignment ? 'Yes' : 'No'}" />
+                    <h:outputLabel value="Payment Method" />
+                    <h:outputLabel value=":" style="width: 15px; text-align: center"/>
+                    <h:outputLabel value="#{cc.attrs.bill.paymentMethod}" />
+                    <h:outputLabel value="Consignment" />
+                    <h:outputLabel value=":" style="width: 15px; text-align: center"/>
+                    <h:outputLabel value="#{cc.attrs.bill.consignment ? 'Yes' : 'No'}" />
 
-            </h:panelGrid>
+                </h:panelGrid>
 
-        </div>
-        <table style="border-collapse: collapse; width: 100%; border: 1px solid black;" class="mt-2 mb-2">
-            <thead>
-                <tr style="border: 1px solid black;">
-                    <th style="border: 1px solid black;">Item Code</th>
-                    <th style="border: 1px solid black;">Item Name</th>
-                    <th style="border: 1px solid black;">Qty</th>
-                    <th style="border: 1px solid black;">Free Qty</th>
-                    <th style="border: 1px solid black;">Purchase Rate</th>
-                    <th style="border: 1px solid black;">Purchase Value</th>
-                </tr>
-            </thead>
-            <tbody>
-                <ui:repeat value="#{cc.attrs.billItems}" var="bi">
-                    <h:panelGroup rendered="#{not bi.retired}" >
-                        <tr style="border: 1px solid black;">
-                            <td style="border: 1px solid black;"><h:outputLabel value="#{bi.item.code}"/></td>
-                            <td style="border: 1px solid black;"><h:outputLabel value="#{bi.item.name}"/></td>
-                            <td style="text-align: right; border: 1px solid black;">
-                                <h:outputLabel value="#{bi.billItemFinanceDetails.quantity}">
-                                    <f:convertNumber pattern="#,##0"/>
-                                </h:outputLabel>
-                            </td>
-                            <td style="text-align: right; border: 1px solid black;">
-                                <h:outputLabel value="#{bi.billItemFinanceDetails.freeQuantity}">
-                                    <f:convertNumber pattern="#,##0"/>
-                                </h:outputLabel>
-                            </td>
-                            <td style="text-align: right; border: 1px solid black;">
-                                <h:outputLabel value="#{bi.billItemFinanceDetails.lineGrossRate}">
-                                    <f:convertNumber pattern="#,##0.00"/>
-                                </h:outputLabel>
-                            </td>
-                            <td style="text-align: right; border: 1px solid black;">
-                                <h:outputLabel value="#{bi.netValue}">
-                                    <f:convertNumber pattern="#,##0.00"/>
-                                </h:outputLabel>
-                            </td>
-                        </tr>
-                    </h:panelGroup>
-                </ui:repeat>
-            </tbody>
-            <tfoot>
-                <tr style="border: 1px solid black; font-weight: bold;">
-                    <td colspan="5" style="text-align: right; border: 1px solid black;">Net Total &nbsp;</td>
-                    <td style="text-align: right; border: 1px solid black;">
-                        <h:outputText value="#{cc.attrs.bill.netTotal}">
-                            <f:convertNumber pattern="#,##0.00"/>
-                        </h:outputText>
-                    </td>
-                </tr>
-            </tfoot>
-        </table>
-
-        <div style="font-size: 17px">
-            <h:outputLabel value="Comments" />
-            <h:outputLabel value=":" style="width: 15px; text-align: center"/>
-            <h:outputLabel value="#{cc.attrs.bill.comments}" />
-        </div>
-        <div class="row">
-            <div class="col-5">
-                <h:outputLabel value="Order Initiated By : &nbsp;"/>
-                <h:outputLabel value="#{cc.attrs.bill.creater.name}"/>
             </div>
-            <div class="col-2"></div>
-            <div class="col-5" style="text-align: right;">
-                <h:outputLabel style="text-align: right" value="Order Initiated At : &nbsp;"/>
-                <h:outputLabel value="#{cc.attrs.bill.createdAt}">
-                    <f:convertDateTime pattern="dd/MMM/yyyy HH:mm" />
+            <table style="border-collapse: collapse; width: 100%; border: 1px solid black;" class="mt-2 mb-2">
+                <thead>
+                    <tr style="border: 1px solid black;">
+                        <th style="border: 1px solid black;">Item Code</th>
+                        <th style="border: 1px solid black;">Item Name</th>
+                        <th style="border: 1px solid black;">Qty</th>
+                        <th style="border: 1px solid black;">Free Qty</th>
+                        <th style="border: 1px solid black;">Purchase Rate</th>
+                        <th style="border: 1px solid black;">Purchase Value</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <ui:repeat value="#{cc.attrs.billItems}" var="bi">
+                        <h:panelGroup rendered="#{not bi.retired}" >
+                            <tr style="border: 1px solid black;">
+                                <td style="border: 1px solid black;"><h:outputLabel value="#{bi.item.code}"/></td>
+                                <td style="border: 1px solid black;"><h:outputLabel value="#{bi.item.name}"/></td>
+                                <td style="text-align: right; border: 1px solid black;">
+                                    <h:outputLabel value="#{bi.billItemFinanceDetails.quantity}">
+                                        <f:convertNumber pattern="#,##0"/>
+                                    </h:outputLabel>
+                                </td>
+                                <td style="text-align: right; border: 1px solid black;">
+                                    <h:outputLabel value="#{bi.billItemFinanceDetails.freeQuantity}">
+                                        <f:convertNumber pattern="#,##0"/>
+                                    </h:outputLabel>
+                                </td>
+                                <td style="text-align: right; border: 1px solid black;">
+                                    <h:outputLabel value="#{bi.billItemFinanceDetails.lineGrossRate}">
+                                        <f:convertNumber pattern="#,##0.00"/>
+                                    </h:outputLabel>
+                                </td>
+                                <td style="text-align: right; border: 1px solid black;">
+                                    <h:outputLabel value="#{bi.netValue}">
+                                        <f:convertNumber pattern="#,##0.00"/>
+                                    </h:outputLabel>
+                                </td>
+                            </tr>
+                        </h:panelGroup>
+                    </ui:repeat>
+                </tbody>
+                <tfoot>
+                    <tr style="border: 1px solid black; font-weight: bold;">
+                        <td colspan="5" style="text-align: right; border: 1px solid black;">Net Total &nbsp;</td>
+                        <td style="text-align: right; border: 1px solid black;">
+                            <h:outputText value="#{cc.attrs.bill.netTotal}">
+                                <f:convertNumber pattern="#,##0.00"/>
+                            </h:outputText>
+                        </td>
+                    </tr>
+                </tfoot>
+            </table>
+
+            <div style="font-size: 17px">
+                <h:outputLabel value="Comments" />
+                <h:outputLabel value=":" style="width: 15px; text-align: center"/>
+                <h:outputLabel value="#{cc.attrs.bill.comments}" />
+            </div>
+            <div class="row">
+                <div class="col-5">
+                    <h:outputLabel value="Order Initiated By : &nbsp;"/>
+                    <h:outputLabel value="#{cc.attrs.bill.creater.name}"/>
+                </div>
+                <div class="col-2"></div>
+                <div class="col-5" style="text-align: right;">
+                    <h:outputLabel style="text-align: right" value="Order Initiated At : &nbsp;"/>
+                    <h:outputLabel value="#{cc.attrs.bill.createdAt}">
+                        <f:convertDateTime pattern="dd/MMM/yyyy HH:mm" />
+                    </h:outputLabel>
+                </div>
+            </div>
+            <div class="row">
+                <div class="col-5">
+                    <h:outputLabel value="Order Finalized By : &nbsp;"/>
+                    <h:outputLabel value="#{cc.attrs.bill.checkedBy.name}"/>
+                </div>
+                <div class="col-2"></div>
+                <div class="col-5" style="text-align: right;">
+                    <h:outputLabel style="text-align: right" value="Order Finalized At : &nbsp;"/>
+                    <h:outputLabel value="#{cc.attrs.bill.checkeAt}">
+                        <f:convertDateTime pattern="dd/MMM/yyyy HH:mm" />
+                    </h:outputLabel>
+                </div>
+            </div>
+            <div class="row">
+                <div class="col-5">
+                    <h:outputLabel value="Printed By : &nbsp;"/>
+                    <h:outputLabel value="#{sessionController.loggedUser.name}"/>
+                </div>
+                <div class="col-2"></div>
+                <div class="col-5" style="text-align: right;" >
+                    <h:outputLabel style="text-align: right" value="Printed At : &nbsp;"/>
+                    <h:outputLabel value="#{sessionController.currentDate}" >
+                        <f:convertDateTime pattern="dd/MMM/yyyy HH:mm" />
+                    </h:outputLabel>
+                </div>
+            </div>
+            <div style="font-size: 17px">
+                <h:outputLabel value="Total"/>
+                <h:outputLabel value=":" style="width: 15px; text-align: center"/>
+                <h:outputLabel value="#{cc.attrs.bill.netTotal}">
+                    <f:convertNumber pattern="#,##0.00"/>
                 </h:outputLabel>
             </div>
         </div>
-        <div class="row">
-            <div class="col-5">
-                <h:outputLabel value="Order Finalized By : &nbsp;"/>
-                <h:outputLabel value="#{cc.attrs.bill.checkedBy.name}"/>
-            </div>
-            <div class="col-2"></div>
-            <div class="col-5" style="text-align: right;">
-                <h:outputLabel style="text-align: right" value="Order Finalized At : &nbsp;"/>
-                <h:outputLabel value="#{cc.attrs.bill.checkeAt}">
-                    <f:convertDateTime pattern="dd/MMM/yyyy HH:mm" />
-                </h:outputLabel>
-            </div>
-        </div>
-        <div class="row">
-            <div class="col-5">
-                <h:outputLabel value="Printed By : &nbsp;"/>
-                <h:outputLabel value="#{sessionController.loggedUser.name}"/>
-            </div>
-            <div class="col-2"></div>
-            <div class="col-5" style="text-align: right;" >
-                <h:outputLabel style="text-align: right" value="Printed At : &nbsp;"/>
-                <h:outputLabel value="#{sessionController.currentDate}" >
-                    <f:convertDateTime pattern="dd/MMM/yyyy HH:mm" />
-                </h:outputLabel>
-            </div>
-        </div>
-        <div style="font-size: 17px">
-            <h:outputLabel value="Total"/>
-            <h:outputLabel value=":" style="width: 15px; text-align: center"/>
-            <h:outputLabel value="#{cc.attrs.bill.netTotal}">
-                <f:convertNumber pattern="#,##0.00"/>
-            </h:outputLabel>
-        </div>
-
     </cc:implementation>
 </html>

--- a/src/main/webapp/resources/pharmacy/purchase_order_request_custom_2.xhtml
+++ b/src/main/webapp/resources/pharmacy/purchase_order_request_custom_2.xhtml
@@ -11,6 +11,7 @@
     <cc:interface>
         <cc:attribute name="bill" required="true" />
         <cc:attribute name="billItems" required="true" />
+        <cc:attribute name="reprint"/>
     </cc:interface>
 
     <!-- IMPLEMENTATION -->
@@ -39,6 +40,8 @@
 
         <div class="headingBill">
             <h:outputLabel value="Purchase Order Request" style="text-decoration: underline;"/>
+            <br/>
+            <h:outputLabel value="**Reprint**" rendered="#{cc.attrs.reprint eq true}"/>
         </div>
 
         <div class="purchase-order">


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added optional “Reprint” label on purchase order printouts; reprint flag now controls its display.
  - Unified reprint display into a single preview panel with configurable custom layouts.

- UI/Style
  - Default for one custom layout changed to off; print layout standardized to letter size with improved spacing and line-height tweaks.
  - Reorganized headers, supplier/payment/consignment details, and totals for clarity.
  - Removed the “Letter Paper Format” option from settings.

- Chores
  - Removed legacy rendering variants and cleaned up obsolete layout artifacts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->