### PR TITLE
15744 retail rate of pack should be displayed on direct purchase print

### DIFF
--- a/src/main/resources/META-INF/persistence.xml
+++ b/src/main/resources/META-INF/persistence.xml
@@ -2,7 +2,7 @@
 <persistence version="2.2" xmlns="http://java.sun.com/xml/ns/persistence" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/persistence http://xmlns.jcp.org/xml/ns/persistence/persistence_2_2.xsd">
     <persistence-unit name="hmisPU" transaction-type="JTA">
         <provider>org.eclipse.persistence.jpa.PersistenceProvider</provider>
-        <jta-data-source>${JDBC_DATASOURCE}</jta-data-source>
+        <jta-data-source>jdbc/ruhunu</jta-data-source>
         <exclude-unlisted-classes>false</exclude-unlisted-classes>
         <properties>
             <property name="eclipselink.logging.level.sql" value="SEVERE"/>
@@ -11,7 +11,7 @@
     </persistence-unit>
 
     <persistence-unit name="hmisAuditPU" transaction-type="JTA">
-        <jta-data-source>${JDBC_AUDIT_DATASOURCE}</jta-data-source>
+        <jta-data-source>jdbc/ruhunuAudit</jta-data-source>
         <exclude-unlisted-classes>false</exclude-unlisted-classes>
         <properties>
             <property name="eclipselink.logging.level.sql" value="SEVERE"/>

--- a/src/main/resources/META-INF/persistence.xml
+++ b/src/main/resources/META-INF/persistence.xml
@@ -2,16 +2,15 @@
 <persistence version="2.2" xmlns="http://java.sun.com/xml/ns/persistence" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/persistence http://xmlns.jcp.org/xml/ns/persistence/persistence_2_2.xsd">
     <persistence-unit name="hmisPU" transaction-type="JTA">
         <provider>org.eclipse.persistence.jpa.PersistenceProvider</provider>
-        <jta-data-source>jdbc/ruhunu</jta-data-source>
+        <jta-data-source>${JDBC_DATASOURCE}</jta-data-source>
         <exclude-unlisted-classes>false</exclude-unlisted-classes>
         <properties>
             <property name="eclipselink.logging.level.sql" value="SEVERE"/>
             <property name="eclipselink.logging.level" value="SEVERE"/>
         </properties>
     </persistence-unit>
-
     <persistence-unit name="hmisAuditPU" transaction-type="JTA">
-        <jta-data-source>jdbc/ruhunuAudit</jta-data-source>
+        <jta-data-source>${JDBC_AUDIT_DATASOURCE}</jta-data-source>
         <exclude-unlisted-classes>false</exclude-unlisted-classes>
         <properties>
             <property name="eclipselink.logging.level.sql" value="SEVERE"/>

--- a/src/main/webapp/pharmacy/pharmacy_transfer_issue.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_transfer_issue.xhtml
@@ -253,27 +253,28 @@
 
                         <p:ajax event="rowSelect" update=":#{p:resolveFirstComponentWithId('btnReplace',view).clientId}"/>
 
-                        <p:column headerText="Item Name">
+                        <p:column headerText="Item Name" width="#{configOptionApplicationController.getShortTextValueByKey('Pharmaceutical Item Name Column width', '15em')}">
                             <h:outputText value="#{sStock.itemBatch.item.name}"/>
                         </p:column>
 
-                        <p:column headerText="Batch No">
+                        <p:column headerText="Batch No"  width="#{configOptionApplicationController.getShortTextValueByKey('Pharmaceutical Batch Column width', '5em')}">
                             <h:outputText value="#{sStock.itemBatch.batchNo}"/>
                         </p:column>
 
-                        <p:column headerText="Expiry Date">
+                        <p:column headerText="Expiry Date"  width="#{configOptionApplicationController.getShortTextValueByKey('Pharmaceutical Item Expiary Column width', '5em')}">
                             <h:outputText value="#{sStock.itemBatch.dateOfExpire}">
                                 <f:convertDateTime pattern="MM/yyyy"/>
                             </h:outputText>
                         </p:column>
 
-                        <p:column headerText="Available Qty">
+                        <p:column headerText="Available Qty"  width="#{configOptionApplicationController.getShortTextValueByKey('Pharmaceutical Item Quentity Column width', '6em')}">
                             <h:outputText value="#{sStock.stock}">
                                 <f:convertNumber pattern="#,###.#"/>
                             </h:outputText>
                         </p:column>
 
                         <p:column 
+                            width="#{configOptionApplicationController.getShortTextValueByKey('Pharmaceutical Item Quentity Column width', '6em')}"
                             rendered="#{configOptionApplicationController.getBooleanValueByKey('Stock Transaction - Show Rate and Value', false) and webUserController.hasPrivilege('StockTransactionViewRates')}"
                             headerText="Purchase Rate">
                             <h:outputText value="#{sStock.itemBatch.purcahseRate}">
@@ -282,6 +283,7 @@
                         </p:column>
 
                         <p:column 
+                            width="#{configOptionApplicationController.getShortTextValueByKey('Pharmaceutical Item Quentity Column width', '6em')}"
                             rendered="#{configOptionApplicationController.getBooleanValueByKey('Stock Transaction - Show Rate and Value', false) and webUserController.hasPrivilege('StockTransactionViewRates')}"
                             headerText="Retail Rate">
                             <h:outputText value="#{sStock.itemBatch.retailsaleRate}">
@@ -289,7 +291,9 @@
                             </h:outputText>
                         </p:column>
 
-                        <p:column headerText="Action">
+                        <p:column
+                            width="10"
+                            headerText="Action">
                             <p:commandButton
                                 id="btnReplace"
                                 value="Replace"

--- a/src/main/webapp/resources/pharmacy/direct_purhcase.xhtml
+++ b/src/main/webapp/resources/pharmacy/direct_purhcase.xhtml
@@ -137,8 +137,14 @@
                         rendered="#{cc.attrs.ShowRetailValue}">
                         <f:facet name="header">Re. Rate</f:facet>
                         <h:outputLabel value="#{bip.item.class.simpleName eq 'Ampp' 
-                                                ? (bip.billItemFinanceDetails.retailSaleRatePerUnit * (empty bip.billItemFinanceDetails.unitsPerPack ? 1 : bip.billItemFinanceDetails.unitsPerPack))
-                                                : bip.billItemFinanceDetails.retailSaleRatePerUnit}">
+                                                ? ((empty bip.billItemFinanceDetails.retailSaleRatePerUnit or bip.billItemFinanceDetails.retailSaleRatePerUnit == 0)
+                                                    ? bip.billItemFinanceDetails.retailSaleRate
+                                                    : (bip.billItemFinanceDetails.retailSaleRatePerUnit * ((empty bip.billItemFinanceDetails.unitsPerPack or bip.billItemFinanceDetails.unitsPerPack == 0)
+                                                        ? (empty bip.item.dblValue ? 1 : bip.item.dblValue)
+                                                        : bip.billItemFinanceDetails.unitsPerPack)))
+                                                : ((empty bip.billItemFinanceDetails.retailSaleRatePerUnit or bip.billItemFinanceDetails.retailSaleRatePerUnit == 0)
+                                                    ? bip.billItemFinanceDetails.retailSaleRate
+                                                    : bip.billItemFinanceDetails.retailSaleRatePerUnit)}">
                             <f:convertNumber pattern="#,##0.00" />
                         </h:outputLabel>
                     </p:column>

--- a/src/main/webapp/resources/pharmacy/direct_purhcase.xhtml
+++ b/src/main/webapp/resources/pharmacy/direct_purhcase.xhtml
@@ -136,7 +136,9 @@
                         class="text-end #{configOptionApplicationController.getBooleanValueByKey('Print RetailValue in Direct Purchase Bill', true) ? 'showRetailValue' : 'hideRetailValue' }"
                         rendered="#{cc.attrs.ShowRetailValue}">
                         <f:facet name="header">Re. Rate</f:facet>
-                        <h:outputLabel value="#{bip.billItemFinanceDetails.retailSaleRate}">
+                        <h:outputLabel value="#{bip.item.class.simpleName eq 'Ampp' 
+                                                ? (bip.billItemFinanceDetails.retailSaleRatePerUnit * (empty bip.billItemFinanceDetails.unitsPerPack ? 1 : bip.billItemFinanceDetails.unitsPerPack))
+                                                : bip.billItemFinanceDetails.retailSaleRatePerUnit}">
                             <f:convertNumber pattern="#,##0.00" />
                         </h:outputLabel>
                     </p:column>

--- a/src/main/webapp/resources/pharmacy/direct_purhcase_with_costing.xhtml
+++ b/src/main/webapp/resources/pharmacy/direct_purhcase_with_costing.xhtml
@@ -134,8 +134,14 @@
                         rendered="#{cc.attrs.ShowRetailValue}">
                         <f:facet name="header">Re. Rate</f:facet>
                         <h:outputLabel value="#{bip.item.class.simpleName eq 'Ampp' 
-                                                ? (bip.billItemFinanceDetails.retailSaleRatePerUnit * (empty bip.billItemFinanceDetails.unitsPerPack ? 1 : bip.billItemFinanceDetails.unitsPerPack))
-                                                : bip.billItemFinanceDetails.retailSaleRatePerUnit}">
+                                                ? ((empty bip.billItemFinanceDetails.retailSaleRatePerUnit or bip.billItemFinanceDetails.retailSaleRatePerUnit == 0)
+                                                    ? bip.billItemFinanceDetails.retailSaleRate
+                                                    : (bip.billItemFinanceDetails.retailSaleRatePerUnit * ((empty bip.billItemFinanceDetails.unitsPerPack or bip.billItemFinanceDetails.unitsPerPack == 0)
+                                                        ? (empty bip.item.dblValue ? 1 : bip.item.dblValue)
+                                                        : bip.billItemFinanceDetails.unitsPerPack)))
+                                                : ((empty bip.billItemFinanceDetails.retailSaleRatePerUnit or bip.billItemFinanceDetails.retailSaleRatePerUnit == 0)
+                                                    ? bip.billItemFinanceDetails.retailSaleRate
+                                                    : bip.billItemFinanceDetails.retailSaleRatePerUnit)}">
                             <f:convertNumber pattern="#,##0.00" />
                         </h:outputLabel>
                     </p:column>

--- a/src/main/webapp/resources/pharmacy/direct_purhcase_with_costing.xhtml
+++ b/src/main/webapp/resources/pharmacy/direct_purhcase_with_costing.xhtml
@@ -133,7 +133,9 @@
                         class="text-end #{configOptionApplicationController.getBooleanValueByKey('Print RetailValue in Direct Purchase Bill', true) ? 'showRetailValue' : 'hideRetailValue' }"
                         rendered="#{cc.attrs.ShowRetailValue}">
                         <f:facet name="header">Re. Rate</f:facet>
-                        <h:outputLabel value="#{bip.billItemFinanceDetails.retailSaleRate}">
+                        <h:outputLabel value="#{bip.item.class.simpleName eq 'Ampp' 
+                                                ? (bip.billItemFinanceDetails.retailSaleRatePerUnit * (empty bip.billItemFinanceDetails.unitsPerPack ? 1 : bip.billItemFinanceDetails.unitsPerPack))
+                                                : bip.billItemFinanceDetails.retailSaleRatePerUnit}">
                             <f:convertNumber pattern="#,##0.00" />
                         </h:outputLabel>
                     </p:column>

--- a/src/main/webapp/resources/pharmacy/direct_purhcase_with_costing_custom_1.xhtml
+++ b/src/main/webapp/resources/pharmacy/direct_purhcase_with_costing_custom_1.xhtml
@@ -134,8 +134,14 @@
                         rendered="#{cc.attrs.ShowRetailValue}">
                         <f:facet name="header">Re. Rate</f:facet>
                         <h:outputLabel value="#{bip.item.class.simpleName eq 'Ampp' 
-                                                ? (bip.billItemFinanceDetails.retailSaleRatePerUnit * (empty bip.billItemFinanceDetails.unitsPerPack ? 1 : bip.billItemFinanceDetails.unitsPerPack))
-                                                : bip.billItemFinanceDetails.retailSaleRatePerUnit}">
+                                                ? ((empty bip.billItemFinanceDetails.retailSaleRatePerUnit or bip.billItemFinanceDetails.retailSaleRatePerUnit == 0)
+                                                    ? bip.billItemFinanceDetails.retailSaleRate
+                                                    : (bip.billItemFinanceDetails.retailSaleRatePerUnit * ((empty bip.billItemFinanceDetails.unitsPerPack or bip.billItemFinanceDetails.unitsPerPack == 0)
+                                                        ? (empty bip.item.dblValue ? 1 : bip.item.dblValue)
+                                                        : bip.billItemFinanceDetails.unitsPerPack)))
+                                                : ((empty bip.billItemFinanceDetails.retailSaleRatePerUnit or bip.billItemFinanceDetails.retailSaleRatePerUnit == 0)
+                                                    ? bip.billItemFinanceDetails.retailSaleRate
+                                                    : bip.billItemFinanceDetails.retailSaleRatePerUnit)}">
                             <f:convertNumber pattern="#,##0.00" />
                         </h:outputLabel>
                     </p:column>

--- a/src/main/webapp/resources/pharmacy/direct_purhcase_with_costing_custom_1.xhtml
+++ b/src/main/webapp/resources/pharmacy/direct_purhcase_with_costing_custom_1.xhtml
@@ -133,7 +133,9 @@
                         class="text-end #{configOptionApplicationController.getBooleanValueByKey('Print RetailValue in Direct Purchase Bill', true) ? 'showRetailValue' : 'hideRetailValue' }"
                         rendered="#{cc.attrs.ShowRetailValue}">
                         <f:facet name="header">Re. Rate</f:facet>
-                        <h:outputLabel value="#{bip.billItemFinanceDetails.retailSaleRate}">
+                        <h:outputLabel value="#{bip.item.class.simpleName eq 'Ampp' 
+                                                ? (bip.billItemFinanceDetails.retailSaleRatePerUnit * (empty bip.billItemFinanceDetails.unitsPerPack ? 1 : bip.billItemFinanceDetails.unitsPerPack))
+                                                : bip.billItemFinanceDetails.retailSaleRatePerUnit}">
                             <f:convertNumber pattern="#,##0.00" />
                         </h:outputLabel>
                     </p:column>

--- a/src/main/webapp/resources/pharmacy/direct_purhcase_with_costing_custom_2.xhtml
+++ b/src/main/webapp/resources/pharmacy/direct_purhcase_with_costing_custom_2.xhtml
@@ -134,8 +134,14 @@
                         rendered="#{cc.attrs.ShowRetailValue}">
                         <f:facet name="header">Re. Rate</f:facet>
                         <h:outputLabel value="#{bip.item.class.simpleName eq 'Ampp' 
-                                                ? (bip.billItemFinanceDetails.retailSaleRatePerUnit * (empty bip.billItemFinanceDetails.unitsPerPack ? 1 : bip.billItemFinanceDetails.unitsPerPack))
-                                                : bip.billItemFinanceDetails.retailSaleRatePerUnit}">
+                                                ? ((empty bip.billItemFinanceDetails.retailSaleRatePerUnit or bip.billItemFinanceDetails.retailSaleRatePerUnit == 0)
+                                                    ? bip.billItemFinanceDetails.retailSaleRate
+                                                    : (bip.billItemFinanceDetails.retailSaleRatePerUnit * ((empty bip.billItemFinanceDetails.unitsPerPack or bip.billItemFinanceDetails.unitsPerPack == 0)
+                                                        ? (empty bip.item.dblValue ? 1 : bip.item.dblValue)
+                                                        : bip.billItemFinanceDetails.unitsPerPack)))
+                                                : ((empty bip.billItemFinanceDetails.retailSaleRatePerUnit or bip.billItemFinanceDetails.retailSaleRatePerUnit == 0)
+                                                    ? bip.billItemFinanceDetails.retailSaleRate
+                                                    : bip.billItemFinanceDetails.retailSaleRatePerUnit)}">
                             <f:convertNumber pattern="#,##0.00" />
                         </h:outputLabel>
                     </p:column>

--- a/src/main/webapp/resources/pharmacy/direct_purhcase_with_costing_custom_2.xhtml
+++ b/src/main/webapp/resources/pharmacy/direct_purhcase_with_costing_custom_2.xhtml
@@ -133,7 +133,9 @@
                         class="text-end #{configOptionApplicationController.getBooleanValueByKey('Print RetailValue in Direct Purchase Bill', true) ? 'showRetailValue' : 'hideRetailValue' }"
                         rendered="#{cc.attrs.ShowRetailValue}">
                         <f:facet name="header">Re. Rate</f:facet>
-                        <h:outputLabel value="#{bip.billItemFinanceDetails.retailSaleRate}">
+                        <h:outputLabel value="#{bip.item.class.simpleName eq 'Ampp' 
+                                                ? (bip.billItemFinanceDetails.retailSaleRatePerUnit * (empty bip.billItemFinanceDetails.unitsPerPack ? 1 : bip.billItemFinanceDetails.unitsPerPack))
+                                                : bip.billItemFinanceDetails.retailSaleRatePerUnit}">
                             <f:convertNumber pattern="#,##0.00" />
                         </h:outputLabel>
                     </p:column>

--- a/src/main/webapp/resources/pharmacy/direct_purhcase_with_costing_custom_letter.xhtml
+++ b/src/main/webapp/resources/pharmacy/direct_purhcase_with_costing_custom_letter.xhtml
@@ -140,7 +140,9 @@
                         class="text-end #{configOptionApplicationController.getBooleanValueByKey('Print RetailValue in Direct Purchase Bill', true) ? 'showRetailValue' : 'hideRetailValue' }"
                         rendered="#{cc.attrs.ShowRetailValue}">
                         <f:facet name="header">Re. Rate</f:facet>
-                        <h:outputLabel value="#{bip.billItemFinanceDetails.retailSaleRate}">
+                        <h:outputLabel value="#{bip.item.class.simpleName eq 'Ampp' 
+                                                ? (bip.billItemFinanceDetails.retailSaleRatePerUnit * (empty bip.billItemFinanceDetails.unitsPerPack ? 1 : bip.billItemFinanceDetails.unitsPerPack))
+                                                : bip.billItemFinanceDetails.retailSaleRatePerUnit}">
                             <f:convertNumber pattern="#,##0.00" />
                         </h:outputLabel>
                     </p:column>

--- a/src/main/webapp/resources/pharmacy/direct_purhcase_with_costing_custom_letter.xhtml
+++ b/src/main/webapp/resources/pharmacy/direct_purhcase_with_costing_custom_letter.xhtml
@@ -141,8 +141,14 @@
                         rendered="#{cc.attrs.ShowRetailValue}">
                         <f:facet name="header">Re. Rate</f:facet>
                         <h:outputLabel value="#{bip.item.class.simpleName eq 'Ampp' 
-                                                ? (bip.billItemFinanceDetails.retailSaleRatePerUnit * (empty bip.billItemFinanceDetails.unitsPerPack ? 1 : bip.billItemFinanceDetails.unitsPerPack))
-                                                : bip.billItemFinanceDetails.retailSaleRatePerUnit}">
+                                                ? ((empty bip.billItemFinanceDetails.retailSaleRatePerUnit or bip.billItemFinanceDetails.retailSaleRatePerUnit == 0)
+                                                    ? bip.billItemFinanceDetails.retailSaleRate
+                                                    : (bip.billItemFinanceDetails.retailSaleRatePerUnit * ((empty bip.billItemFinanceDetails.unitsPerPack or bip.billItemFinanceDetails.unitsPerPack == 0)
+                                                        ? (empty bip.item.dblValue ? 1 : bip.item.dblValue)
+                                                        : bip.billItemFinanceDetails.unitsPerPack)))
+                                                : ((empty bip.billItemFinanceDetails.retailSaleRatePerUnit or bip.billItemFinanceDetails.retailSaleRatePerUnit == 0)
+                                                    ? bip.billItemFinanceDetails.retailSaleRate
+                                                    : bip.billItemFinanceDetails.retailSaleRatePerUnit)}">
                             <f:convertNumber pattern="#,##0.00" />
                         </h:outputLabel>
                     </p:column>


### PR DESCRIPTION
Closes #15744


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected displayed retail rate calculation in Direct Purchase views to account for per-unit and units-per-pack for a specific item type across standard, costing, and custom variants (including letter format).

* **UI Improvements**
  * Adjusted column widths in pharmacy transfer/issue dialogs and stock views for more consistent table layout.

* **Style**
  * Minor whitespace cleanup in a configuration file; no functional impact.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->