### PR TITLE
docs: clarify disbursement sign normalization (BillTypeAtomic)

### DIFF
--- a/developer_docs/pharmacy/disbursement-sign-normalization.md
+++ b/developer_docs/pharmacy/disbursement-sign-normalization.md
@@ -1,0 +1,44 @@
+# Pharmacy Disbursement Sign Normalization
+
+Overview
+- Clarifies sign conventions for pharmacy disbursement/transfer/disposal flows to avoid ambiguous instructions like “get absolute value first and then negate”.
+- Documents the mapping used by `DataAdministrationController` helpers:
+  - `isBillAndItemTotalsPositive(BillTypeAtomic)` – expected sign for Bill/BillItem gross/net totals.
+  - `isFinanceValueNegative(BillTypeAtomic)` – expected sign for finance values (purchase/retail/cost).
+
+Definitions
+- Bill/Item Totals: gross/net totals at Bill and BillItem scopes.
+- Finance Values: purchase/retail/cost value aggregations at BillFinanceDetails/BillItemFinanceDetails/PharmaceuticalBillItem.
+
+Sign Rules by Flow (BillTypeAtomic)
+- Positive totals: values are shown/stored as positive numbers.
+- Negative totals: values are shown/stored as negative numbers (e.g., returns/refunds as outflows vs inflows depending on domain policy).
+
+Bill/Item Totals (gross/net)
+- Positive: `PHARMACY_ISSUE`, `PHARMACY_DIRECT_ISSUE`, `PHARMACY_DISPOSAL_ISSUE`, `PHARMACY_RECEIVE_CANCELLED`.
+- Negative: `PHARMACY_ISSUE_CANCELLED`, `PHARMACY_ISSUE_RETURN`, `PHARMACY_DIRECT_ISSUE_CANCELLED`, `PHARMACY_DISPOSAL_ISSUE_CANCELLED`, `PHARMACY_DISPOSAL_ISSUE_RETURN`, `PHARMACY_RECEIVE`, `PHARMACY_RECEIVE_PRE`.
+
+Finance Values (purchase/retail/cost)
+- Negative (stock-out / issue flows): `PHARMACY_ISSUE`, `PHARMACY_DIRECT_ISSUE`, `PHARMACY_DISPOSAL_ISSUE`, `PHARMACY_RECEIVE_CANCELLED`.
+- Positive (receive/returns/refunds): `PHARMACY_ISSUE_CANCELLED`, `PHARMACY_ISSUE_RETURN`, `PHARMACY_DIRECT_ISSUE_CANCELLED`, `PHARMACY_DISPOSAL_ISSUE_CANCELLED`, `PHARMACY_DISPOSAL_ISSUE_RETURN`, `PHARMACY_RECEIVE`, `PHARMACY_RECEIVE_PRE`.
+
+Implementation Pattern
+1) Normalize with absolute value
+2) Apply sign based on mapping above
+
+Example
+```
+BigDecimal applySign(BigDecimal v, boolean negative) {
+  if (v == null) return null;
+  BigDecimal abs = v.abs();
+  return negative ? abs.negate() : abs;
+}
+```
+
+Consistency Across Layers
+- BillFinanceDetails gross/net header totals MUST follow the same sign convention as Bill and BillItem totals.
+- Do NOT force all header totals positive; derive sign from `isBillAndItemTotalsPositive(...)`.
+
+Display vs Storage
+- UI may display absolute values for readability (e.g., reports), but persisted/calculated values must follow the above conventions.
+

--- a/src/main/webapp/pharmacy/reports/disbursement_reports/pharmacy_report_transfer_issue_bill_item.xhtml
+++ b/src/main/webapp/pharmacy/reports/disbursement_reports/pharmacy_report_transfer_issue_bill_item.xhtml
@@ -277,39 +277,45 @@
                                             </h:outputLabel>
                                         </f:facet>
                                     </p:column>
-                                    <p:column style="text-align: right; border-left: 2px solid #007bff;">
+                                    <p:column style="text-align: right; border-left: 2px solid #007bff;"
+                                              rendered="#{configOptionApplicationController.getBooleanValueByKey('Pharmacy Disbursement Reports - Display Cost Rate', true)}">
                                         <f:facet name="footer">
                                             <h:outputLabel value="Cost:" styleClass="text-muted small">
                                             </h:outputLabel>
                                         </f:facet>
                                     </p:column>
-                                    <p:column style="text-align: right;">
+                                    <p:column style="text-align: right;"
+                                              rendered="#{configOptionApplicationController.getBooleanValueByKey('Pharmacy Disbursement Reports - Display Cost Value', true)}">
                                         <f:facet name="footer">
                                             <h:outputLabel value="#{reportsTransfer.costValue}" styleClass="text-success font-weight-bold">
                                                 <f:convertNumber pattern="#,##0.00"/>
                                             </h:outputLabel>
                                         </f:facet>
                                     </p:column>
-                                    <p:column style="text-align: right; border-left: 1px solid #dee2e6;">
+                                    <p:column style="text-align: right; border-left: 1px solid #dee2e6;"
+                                              rendered="#{configOptionApplicationController.getBooleanValueByKey('Pharmacy Disbursement Reports - Display Retail Sale Rate', true)}">
                                         <f:facet name="footer">
                                             <h:outputLabel value="Retail:" styleClass="text-muted small">
                                             </h:outputLabel>
                                         </f:facet>
                                     </p:column>
-                                    <p:column style="text-align: right;">
+                                    <p:column style="text-align: right;"
+                                              rendered="#{configOptionApplicationController.getBooleanValueByKey('Pharmacy Disbursement Reports - Display Retail Sale Value', true)}">
                                         <f:facet name="footer">
                                             <h:outputLabel value="#{reportsTransfer.retailValue}" styleClass="text-success font-weight-bold">
                                                 <f:convertNumber pattern="#,##0.00"/>
                                             </h:outputLabel>
                                         </f:facet>
                                     </p:column>
-                                    <p:column style="text-align: right; border-left: 1px solid #dee2e6;">
+                                    <p:column style="text-align: right; border-left: 1px solid #dee2e6;"
+                                              rendered="#{configOptionApplicationController.getBooleanValueByKey('Pharmacy Disbursement Reports - Display Purchase Rate', true)}">
                                         <f:facet name="footer">
                                             <h:outputLabel value="Purchase:" styleClass="text-muted small">
                                             </h:outputLabel>
                                         </f:facet>
                                     </p:column>
-                                    <p:column style="text-align: right;">
+                                    <p:column style="text-align: right;"
+                                              rendered="#{configOptionApplicationController.getBooleanValueByKey('Pharmacy Disbursement Reports - Display Purchase Value', true)}">
                                         <f:facet name="footer">
                                             <h:outputLabel value="#{reportsTransfer.purchaseValue}" styleClass="text-success font-weight-bold">
                                                 <f:convertNumber pattern="#,##0.00"/>
@@ -317,7 +323,7 @@
                                         </f:facet>
                                     </p:column>
                                     <p:column style="text-align: right; border-left: 1px solid #dee2e6;"
-                                              rendered="#{configOptionApplicationController.getBooleanValueByKey('Pharmacy Disbursement Reports - Display Transfer Value', true)}">
+                                              rendered="#{configOptionApplicationController.getBooleanValueByKey('Pharmacy Disbursement Reports - Display Transfer Rate', true)}">
                                         <f:facet name="footer">
                                             <h:outputLabel value="Transfer:" styleClass="text-muted small">
                                             </h:outputLabel>


### PR DESCRIPTION
Clarify pharmacy disbursement sign-normalization (BillTypeAtomic)

- Adds developer documentation at developer_docs/pharmacy/disbursement-sign-normalization.md
  - Maps BillTypeAtomic → sign for Bill/BillItem totals and finance values
  - Shows applySign pattern (abs + sign) and consistency requirements
  - Notes for display vs storage and keeping header totals consistent

This is documentation-only; no behavior changes.

Closes #15781