### PR TITLE
Ensure pharmacy transfer requests keep positive totals

### DIFF
--- a/src/main/java/com/divudi/bean/pharmacy/TransferRequestController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/TransferRequestController.java
@@ -10,6 +10,7 @@ import com.divudi.bean.common.SessionController;
 
 import com.divudi.core.data.*;
 import com.divudi.core.entity.*;
+import com.divudi.core.util.BigDecimalUtil;
 import com.divudi.core.util.CommonFunctions;
 import com.divudi.ejb.BillNumberGenerator;
 import com.divudi.ejb.PharmacyBean;
@@ -45,6 +46,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import javax.ejb.EJB;
 import javax.enterprise.context.SessionScoped;
 import javax.inject.Inject;
@@ -242,14 +244,14 @@ public class TransferRequestController implements Serializable {
 
         updateFinancials(fd);
         getBillItems().add(bi);
-        pharmacyCostingService.calculateBillTotalsFromItemsForTransferOuts(getTransferRequestBillPre(), getBillItems());
+        recalculateTransferRequestBillTotals();
 
         currentBillItem = null;
     }
 
     public void onEdit(BillItem tmp) {
         updateFinancials(tmp.getBillItemFinanceDetails());
-        pharmacyCostingService.calculateBillTotalsFromItemsForTransferOuts(getTransferRequestBillPre(), getBillItems());
+        recalculateTransferRequestBillTotals();
     }
 
     public void displayItemDetails(BillItem bi) {
@@ -635,7 +637,7 @@ public class TransferRequestController implements Serializable {
             return "";
         }
         billItems = fetchBillItems(getTransferRequestBillPre());
-        pharmacyCostingService.calculateBillTotalsFromItemsForTransferOuts(getTransferRequestBillPre(), billItems);
+        calculateBillTotalsFromItemsForTransferRequests(getTransferRequestBillPre(), billItems);
         LOGGER.log(Level.FINE, "Editing transfer request with {0} items", billItems.size());
         setToDepartment(getTransferRequestBillPre().getToDepartment());
         return "/pharmacy/pharmacy_transfer_request?faces-redirect=true";
@@ -731,7 +733,7 @@ public class TransferRequestController implements Serializable {
         for (BillItem bi : getBillItems()) {
             bi.setSearialNo(serialNo++);
         }
-        pharmacyCostingService.calculateBillTotalsFromItemsForTransferOuts(getTransferRequestBillPre(), getBillItems());
+        recalculateTransferRequestBillTotals();
 
     }
 
@@ -1084,7 +1086,7 @@ public class TransferRequestController implements Serializable {
         }
 
         pharmacyCostingService.recalculateFinancialsBeforeAddingBillItem(fd);
-        pharmacyCostingService.calculateBillTotalsFromItemsForTransferOuts(getTransferRequestBillPre(), getBillItems());
+        recalculateTransferRequestBillTotals();
     }
 
     // ChatGPT contributed - Recalculate item totals when gross rate changes
@@ -1095,7 +1097,7 @@ public class TransferRequestController implements Serializable {
 
         BillItemFinanceDetails fd = bi.getBillItemFinanceDetails();
         pharmacyCostingService.recalculateFinancialsBeforeAddingBillItem(fd);
-        pharmacyCostingService.calculateBillTotalsFromItemsForTransferOuts(getTransferRequestBillPre(), getBillItems());
+        recalculateTransferRequestBillTotals();
     }
 
     // ************************************
@@ -1112,7 +1114,7 @@ public class TransferRequestController implements Serializable {
         }
         updateFinancials(fd);
         pharmacyCostingService.recalculateFinancialsBeforeAddingBillItem(fd);
-        pharmacyCostingService.calculateBillTotalsFromItemsForTransferOuts(getTransferRequestBillPre(), getBillItems());
+        recalculateTransferRequestBillTotals();
     }
 
     public void onCurrentLineGrossRateChange() {
@@ -1126,7 +1128,190 @@ public class TransferRequestController implements Serializable {
         }
         updateFinancials(fd);
         pharmacyCostingService.recalculateFinancialsBeforeAddingBillItem(fd);
-        pharmacyCostingService.calculateBillTotalsFromItemsForTransferOuts(getTransferRequestBillPre(), getBillItems());
+        recalculateTransferRequestBillTotals();
+    }
+
+    private void recalculateTransferRequestBillTotals() {
+        calculateBillTotalsFromItemsForTransferRequests(getTransferRequestBillPre(), getBillItems());
+    }
+
+    private void calculateBillTotalsFromItemsForTransferRequests(Bill billForRequest, List<BillItem> requestBillItems) {
+        if (billForRequest == null) {
+            return;
+        }
+
+        List<BillItem> itemsToProcess = requestBillItems != null ? requestBillItems : new ArrayList<>();
+
+        int serialNo = 0;
+
+        BigDecimal billDiscount = BigDecimal.valueOf(billForRequest.getDiscount());
+        BigDecimal billExpense = BigDecimal.valueOf(billForRequest.getExpenseTotal());
+        BigDecimal billTax = BigDecimal.valueOf(billForRequest.getTax());
+        BigDecimal billCost = billDiscount.subtract(billExpense.add(billTax));
+
+        BigDecimal totalLineDiscounts = BigDecimal.ZERO;
+        BigDecimal totalLineExpenses = BigDecimal.ZERO;
+        BigDecimal totalLineCosts = BigDecimal.ZERO;
+        BigDecimal totalTaxLines = BigDecimal.ZERO;
+        BigDecimal totalFreeItemValue = BigDecimal.ZERO;
+        BigDecimal totalPurchase = BigDecimal.ZERO;
+        BigDecimal totalRetail = BigDecimal.ZERO;
+        BigDecimal totalWholesale = BigDecimal.ZERO;
+        BigDecimal totalQty = BigDecimal.ZERO;
+        BigDecimal totalFreeQty = BigDecimal.ZERO;
+        BigDecimal totalQtyAtomic = BigDecimal.ZERO;
+        BigDecimal totalFreeQtyAtomic = BigDecimal.ZERO;
+        BigDecimal grossTotal = BigDecimal.ZERO;
+        BigDecimal lineGrossTotalSum = BigDecimal.ZERO;
+        BigDecimal netTotal = BigDecimal.ZERO;
+        BigDecimal lineNetTotalSum = BigDecimal.ZERO;
+        BigDecimal totalDiscount = BigDecimal.ZERO;
+        BigDecimal totalExpense = BigDecimal.ZERO;
+        BigDecimal totalCost = BigDecimal.ZERO;
+        BigDecimal totalTax = BigDecimal.ZERO;
+
+        for (BillItem bi : itemsToProcess) {
+            if (bi == null) {
+                continue;
+            }
+
+            PharmaceuticalBillItem pbi = bi.getPharmaceuticalBillItem();
+            BillItemFinanceDetails f = bi.getBillItemFinanceDetails();
+
+            if (pbi == null || f == null) {
+                continue;
+            }
+
+            bi.setSearialNo(serialNo++);
+
+            BigDecimal qty = Optional.ofNullable(f.getQuantity()).orElse(BigDecimal.valueOf(bi.getQty()));
+            BigDecimal grossRate = Optional.ofNullable(f.getLineGrossRate()).orElse(BigDecimal.ZERO);
+            BigDecimal netRate = Optional.ofNullable(f.getLineNetRate()).orElse(grossRate);
+
+            if (f.getLineGrossTotal() == null || f.getLineGrossTotal().compareTo(BigDecimal.ZERO) == 0) {
+                f.setLineGrossTotal(grossRate.multiply(qty));
+            }
+
+            if (f.getGrossTotal() == null || f.getGrossTotal().compareTo(BigDecimal.ZERO) == 0) {
+                f.setGrossTotal(f.getLineGrossTotal());
+            }
+
+            if (f.getLineNetTotal() == null || f.getLineNetTotal().compareTo(BigDecimal.ZERO) == 0) {
+                f.setLineNetTotal(f.getLineGrossTotal());
+            }
+
+            if (f.getNetTotal() == null || f.getNetTotal().compareTo(BigDecimal.ZERO) == 0) {
+                f.setNetTotal(f.getLineNetTotal());
+            }
+
+            BigDecimal lineGrossTotal = Optional.ofNullable(f.getLineGrossTotal()).orElse(BigDecimal.ZERO);
+            BigDecimal lineNetTotal = Optional.ofNullable(f.getLineNetTotal()).orElse(lineGrossTotal);
+            BigDecimal netTotalForItem = Optional.ofNullable(f.getNetTotal()).orElse(lineNetTotal);
+
+            bi.setRate(netRate.doubleValue());
+            bi.setNetRate(netRate.doubleValue());
+            bi.setGrossValue(lineGrossTotal.doubleValue());
+            bi.setNetValue(lineNetTotal.doubleValue());
+
+            BigDecimal freeQty = Optional.ofNullable(f.getFreeQuantity()).orElse(BigDecimal.ZERO);
+            BigDecimal qtyTotal = qty.add(freeQty);
+
+            BigDecimal costRate = Optional.ofNullable(f.getLineCostRate()).orElse(BigDecimal.ZERO);
+            BigDecimal retailRate = Optional.ofNullable(f.getRetailSaleRate()).orElse(BigDecimal.ZERO);
+            BigDecimal wholesaleRate = Optional.ofNullable(f.getWholesaleRate()).orElse(BigDecimal.ZERO);
+
+            BigDecimal retailValue = retailRate.multiply(qtyTotal);
+            BigDecimal wholesaleValue = wholesaleRate.multiply(qtyTotal);
+            BigDecimal freeItemValue = costRate.multiply(freeQty);
+
+            totalLineDiscounts = totalLineDiscounts.add(Optional.ofNullable(f.getLineDiscount()).orElse(BigDecimal.ZERO));
+            totalLineExpenses = totalLineExpenses.add(Optional.ofNullable(f.getLineExpense()).orElse(BigDecimal.ZERO));
+            totalTaxLines = totalTaxLines.add(Optional.ofNullable(f.getLineTax()).orElse(BigDecimal.ZERO));
+            totalLineCosts = totalLineCosts.add(Optional.ofNullable(f.getLineCost()).orElse(BigDecimal.ZERO));
+            totalFreeItemValue = totalFreeItemValue.add(freeItemValue);
+            totalPurchase = totalPurchase.add(Optional.ofNullable(f.getGrossTotal()).orElse(lineGrossTotal));
+            totalRetail = totalRetail.add(retailValue);
+            totalWholesale = totalWholesale.add(wholesaleValue);
+            totalQty = totalQty.add(qty);
+            totalFreeQty = totalFreeQty.add(freeQty);
+            totalQtyAtomic = totalQtyAtomic.add(Optional.ofNullable(f.getQuantityByUnits()).orElse(BigDecimal.ZERO));
+            totalFreeQtyAtomic = totalFreeQtyAtomic.add(Optional.ofNullable(f.getFreeQuantityByUnits()).orElse(BigDecimal.ZERO));
+            grossTotal = grossTotal.add(lineNetTotal);
+            lineGrossTotalSum = lineGrossTotalSum.add(lineGrossTotal);
+            netTotal = netTotal.add(netTotalForItem);
+            lineNetTotalSum = lineNetTotalSum.add(lineNetTotal);
+            totalDiscount = totalDiscount.add(Optional.ofNullable(f.getTotalDiscount()).orElse(BigDecimal.ZERO));
+            totalExpense = totalExpense.add(Optional.ofNullable(f.getTotalExpense()).orElse(BigDecimal.ZERO));
+            totalCost = totalCost.add(Optional.ofNullable(f.getTotalCost()).orElse(BigDecimal.ZERO));
+            totalTax = totalTax.add(Optional.ofNullable(f.getTotalTax()).orElse(BigDecimal.ZERO));
+
+            if (pbi != null) {
+                if (f.getValueAtPurchaseRate() != null) {
+                    pbi.setPurchaseValue(f.getValueAtPurchaseRate().doubleValue());
+                }
+                if (f.getValueAtRetailRate() != null) {
+                    pbi.setRetailValue(f.getValueAtRetailRate().doubleValue());
+                }
+            }
+        }
+
+        billForRequest.setTotal(BigDecimalUtil.valueOrZero(grossTotal).doubleValue());
+        billForRequest.setNetTotal(BigDecimalUtil.valueOrZero(netTotal).doubleValue());
+        billForRequest.setSaleValue(BigDecimalUtil.valueOrZero(totalRetail).doubleValue());
+
+        BillFinanceDetails bfd = billForRequest.getBillFinanceDetails();
+        if (bfd == null) {
+            bfd = new BillFinanceDetails(billForRequest);
+            billForRequest.setBillFinanceDetails(bfd);
+        }
+
+        bfd.setBillDiscount(billDiscount);
+        bfd.setBillExpense(billExpense);
+        bfd.setBillTaxValue(billTax);
+        bfd.setBillCostValue(billCost);
+        bfd.setLineDiscount(totalLineDiscounts);
+        bfd.setLineExpense(totalLineExpenses);
+        bfd.setItemTaxValue(totalTaxLines);
+        bfd.setLineCostValue(totalLineCosts);
+        bfd.setTotalDiscount(totalDiscount);
+        bfd.setTotalExpense(totalExpense);
+        bfd.setTotalTaxValue(totalTax);
+
+        BigDecimal sumCostFromItems = BigDecimal.ZERO;
+        BigDecimal sumPurchaseFromItems = BigDecimal.ZERO;
+        BigDecimal sumRetailFromItems = BigDecimal.ZERO;
+        for (BillItem it : itemsToProcess) {
+            if (it == null || it.getBillItemFinanceDetails() == null) {
+                continue;
+            }
+            BillItemFinanceDetails fd = it.getBillItemFinanceDetails();
+            sumCostFromItems = sumCostFromItems.add(Optional.ofNullable(fd.getValueAtCostRate()).orElse(BigDecimal.ZERO));
+            sumPurchaseFromItems = sumPurchaseFromItems.add(Optional.ofNullable(fd.getValueAtPurchaseRate()).orElse(BigDecimal.ZERO));
+            sumRetailFromItems = sumRetailFromItems.add(Optional.ofNullable(fd.getValueAtRetailRate()).orElse(BigDecimal.ZERO));
+
+            if (it.getPharmaceuticalBillItem() != null) {
+                if (fd.getValueAtPurchaseRate() != null) {
+                    it.getPharmaceuticalBillItem().setPurchaseValue(fd.getValueAtPurchaseRate().doubleValue());
+                }
+                if (fd.getValueAtRetailRate() != null) {
+                    it.getPharmaceuticalBillItem().setRetailValue(fd.getValueAtRetailRate().doubleValue());
+                }
+            }
+        }
+
+        bfd.setTotalCostValue(sumCostFromItems);
+        bfd.setTotalOfFreeItemValues(totalFreeItemValue);
+        bfd.setTotalPurchaseValue(sumPurchaseFromItems);
+        bfd.setTotalRetailSaleValue(sumRetailFromItems);
+        bfd.setTotalWholesaleValue(totalWholesale);
+        bfd.setTotalQuantity(totalQty);
+        bfd.setTotalFreeQuantity(totalFreeQty);
+        bfd.setTotalQuantityInAtomicUnitOfMeasurement(totalQtyAtomic);
+        bfd.setTotalFreeQuantityInAtomicUnitOfMeasurement(totalFreeQtyAtomic);
+        bfd.setGrossTotal(grossTotal);
+        bfd.setLineGrossTotal(lineGrossTotalSum);
+        bfd.setNetTotal(netTotal);
+        bfd.setLineNetTotal(lineNetTotalSum);
     }
 
     private BigDecimal determineTransferRate(Item item) {


### PR DESCRIPTION
## Summary
- stop using the shared transfer-out total calculator for request bills so controller recalculations stay positive
- add a controller-specific total calculation routine that preserves positive bill, item, and finance detail values for requests

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ea879893a8832f86efdf8705d519b6