### PR TITLE
Limit cancellation payment correction to selected period

### DIFF
--- a/src/main/webapp/dataAdmin/admin_functions.xhtml
+++ b/src/main/webapp/dataAdmin/admin_functions.xhtml
@@ -47,20 +47,55 @@
                     </div>
 
                     <p:accordionPanel >
-                    <p:tab 
-                        id="tabStaff"
-                        title="Staff" >
-                        <table class="table table-sm table-bordered w-100">
-                            <thead class="table-light">
-                                <tr>
-                                    <th style="width: 15%;">Name</th>
-                                    <th style="width: 30%;">Description</th>
-                                    <th style="width: 10%;">Action</th>
-                                    <th style="width: 45%;">Output</th>
-                                </tr>
-                            </thead>
-                            <tbody>
-                                <tr>
+                        <p:tab
+                            id="tabBillValueCorrection"
+                            title="Bill Value Correction" >
+                            <table class="table table-sm table-bordered w-100">
+                                <thead class="table-light">
+                                    <tr>
+                                        <th style="width: 15%;">Name</th>
+                                        <th style="width: 30%;">Description</th>
+                                        <th style="width: 10%;">Action</th>
+                                        <th style="width: 45%;">Output</th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    <tr>
+                                        <td><strong>Correct Payment Signs</strong></td>
+                                        <td>
+                                            Ensures cancellation and refund bill payments store negative paid values.
+                                            Positive amounts are converted to negative values to reflect returning money
+                                            accurately.
+                                        </td>
+                                        <td>
+                                            <p:commandButton
+                                                action="#{dataAdministrationController.correctCancellationAndRefundPaymentValues()}"
+                                                ajax="false"
+                                                value="Correct Payment Values"
+                                                styleClass="ui-button-danger m-1"
+                                                icon="pi pi-minus-circle" />
+                                        </td>
+                                        <td>
+                                            #{billController.output}
+                                        </td>
+                                    </tr>
+                                </tbody>
+                            </table>
+                        </p:tab>
+                        <p:tab
+                            id="tabStaff"
+                            title="Staff" >
+                            <table class="table table-sm table-bordered w-100">
+                                <thead class="table-light">
+                                    <tr>
+                                        <th style="width: 15%;">Name</th>
+                                        <th style="width: 30%;">Description</th>
+                                        <th style="width: 10%;">Action</th>
+                                        <th style="width: 45%;">Output</th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    <tr>
                                     <td><strong>Add WebUser Codes (from Username)</strong></td>
                                     <td>
                                         Assign username as code for all WebUsers where the code is empty. Skips users with existing non-empty codes.


### PR DESCRIPTION
## Summary
- apply the admin page from/to date filters when loading cancellation and refund bills for sign correction
- include the selected createdAt range in the correction output for operator awareness

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ef3a1080f0832fa76207cf912a86d0