### PR TITLE
Fix disposal issue receipt config key lookups

### DIFF
--- a/src/main/webapp/pharmacy/pharmacy_reprint_bill_unit_issue.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_reprint_bill_unit_issue.xhtml
@@ -72,15 +72,15 @@
                         <h:panelGroup id="gpBillPreview" >
                             <ph:pharmacy_issue_receipt
                                 duplicate="true"
-                                rendered="#{configOptionController.getBooleanValueByKey('Pharmacy DIsposal Issue Receipt is A4 Paper',true)}"
+                                rendered="#{configOptionController.getBooleanValueByKey('Pharmacy Disposal Issue Receipt is A4 Paper',true)}"
                                 bill="#{pharmacyBillSearch.bill}"/>
                             <ph:pharmacy_issue_receipt_custom_1
                                 duplicate="true"
-                                rendered="#{configOptionController.getBooleanValueByKey('Pharmacy DIsposal Issue Receipt is Custom 1',false)}"
+                                rendered="#{configOptionController.getBooleanValueByKey('Pharmacy Disposal Issue Receipt is Custom 1',false)}"
                                 bill="#{pharmacyBillSearch.bill}"/>
                             <ph:pharmacy_issue_receipt_custom_2
                                 duplicate="true"
-                                rendered="#{configOptionController.getBooleanValueByKey('Pharmacy DIsposal Issue Receipt is Custom 2',false)}"
+                                rendered="#{configOptionController.getBooleanValueByKey('Pharmacy Disposal Issue Receipt is Custom 2',false)}"
                                 bill="#{pharmacyBillSearch.bill}"/>
                         </h:panelGroup>
                         <div class="row">


### PR DESCRIPTION
## Summary
- correct the configuration key spelling for disposal issue receipt templates in the pharmacy reprint view so saved settings load properly

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f15e45f87c832f97b46d17d664c7e9