### PR TITLE
15291 direct purchase return stock management is wrong

### DIFF
--- a/src/main/java/com/divudi/bean/pharmacy/DirectPurchaseReturnWorkflowController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/DirectPurchaseReturnWorkflowController.java
@@ -40,6 +40,7 @@ import com.divudi.service.PaymentService;
 
 import java.io.Serializable;
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.HashMap;
@@ -1334,13 +1335,13 @@ public class DirectPurchaseReturnWorkflowController implements Serializable {
                 && fd.getLineGrossRate() != null) {
             if (originalBillItem.getItem() instanceof Ampp) {
                 if (fd.getUnitsPerPack() != null && fd.getUnitsPerPack().compareTo(BigDecimal.ZERO) != 0) {
-                    rate = fd.getLineGrossRate().divide(fd.getUnitsPerPack());
+                    rate = fd.getLineGrossRate().divide(fd.getUnitsPerPack(), 4, RoundingMode.HALF_UP);
                 } else {
                     rate = fd.getLineGrossRate();
                 }
             } else if (originalBillItem.getItem() instanceof Vmpp) {
                 if (fd.getUnitsPerPack() != null && fd.getUnitsPerPack().compareTo(BigDecimal.ZERO) != 0) {
-                    rate = fd.getLineGrossRate().divide(fd.getUnitsPerPack());
+                    rate = fd.getLineGrossRate().divide(fd.getUnitsPerPack(), 4, RoundingMode.HALF_UP);
                 } else {
                     rate = fd.getLineGrossRate();
                 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved return-rate calculations for direct purchase returns: selection is now configuration-driven, respects product type differences (per-unit vs per-pack handling), applies rounding, and defaults missing rates to zero to avoid nulls—resulting in more accurate and consistent return amounts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->