### PR TITLE
16053 purchase orders configuration required to prevent duplicate entries

### DIFF
--- a/src/main/java/com/divudi/bean/pharmacy/PurchaseOrderRequestController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PurchaseOrderRequestController.java
@@ -570,7 +570,7 @@ public class PurchaseOrderRequestController implements Serializable {
         }
 
         if (preventDuplicates && skippedCount > 0) {
-            JsfUtil.addWarningMessage(skippedCount + " duplicate item(s) were skipped. Items already in the purchase order were not added again.");
+            JsfUtil.addErrorMessage(skippedCount + " duplicate item(s) were skipped. Items already in the purchase order were not added again.");
         }
 
         calculateBillTotals();


### PR DESCRIPTION
  Implementation Complete

  I've successfully implemented the configuration option to prevent
  duplicate items in Purchase Orders. Here's what was done:

  Changes Made

  File Modified: /home/buddhika/development/rh/src/main/java/com/divudi/bean
  /pharmacy/PurchaseOrderRequestController.java

  1. Modified addItem() method (line 198-217)

  - Added duplicate check before adding an item
  - If configuration is enabled and item already exists, displays error
  message: "This item has already been added to the purchase order. Please
  update the quantity of the existing item instead of adding it again."
  - Prevents adding the duplicate item

  2. Modified generateBillComponentsForAllSupplierItems() method (line 
  527-577)

  - Added duplicate check when adding multiple items at once
  - Skips duplicate items and keeps count
  - Shows warning message if duplicates were skipped: "X duplicate item(s)
  were skipped. Items already in the purchase order were not added again."

  Configuration Option

  Configuration Key: "Prevent Duplicate Items in Purchase Orders"
  Default Value: false (disabled by default to maintain backward
  compatibility)

  How to Enable

  Administrators can enable this feature through the application
  configuration settings:
  1. Go to System Configuration
  2. Add or update the boolean configuration: "Prevent Duplicate Items in 
  Purchase Orders"
  3. Set value to true

  Behavior

  When Enabled (true):
  - Single item addition (Add button) will show an error and prevent
  duplicate
  - Bulk additions ("Add All" and "Add Items Below ROL") will skip
  duplicates and show a warning message

  When Disabled (false - default):
  - No validation occurs
  - Users can add the same item multiple times (existing behavior)

  Testing Required

  To test this implementation:
  1. Enable the configuration option
  2. Try adding the same item twice using the individual "Add" button →
  Should show error
  3. Try adding items in bulk where some already exist → Should skip
  duplicates and show warning
  4. Disable the configuration option
  5. Verify the old behavior still works (can add duplicates)

  The implementation follows the existing pattern used in the codebase for
  configuration-based validations and maintains backward compatibility by
  defaulting to false.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added duplicate-item prevention for purchase orders. When the "Prevent Duplicate Items in Purchase Orders" setting is enabled, attempts to add an already-present item are blocked and an error is shown.
  * Batch creation now skips duplicate items and displays a summary warning indicating how many items were skipped during the operation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->