### PR TITLE
Summary

### DIFF
--- a/src/main/webapp/pharmacy/reports/summary_reports/daily_stock_values_report.xhtml
+++ b/src/main/webapp/pharmacy/reports/summary_reports/daily_stock_values_report.xhtml
@@ -164,7 +164,9 @@
                                 <h:outputLabel value="Opening Stock"></h:outputLabel>
                             </td>
                             <td class="text-end">
-                                <h:outputLabel value="#{pharmacySummaryReportController.dailyStockBalanceReport.openingStockValue}" class="me-4"></h:outputLabel>
+                                <h:outputLabel value="#{pharmacySummaryReportController.dailyStockBalanceReport.openingStockValue}" class="me-4">
+                                    <f:convertNumber pattern="#,##0.00"></f:convertNumber>
+                                </h:outputLabel>
                             </td>
                         </tr>
 
@@ -305,7 +307,9 @@
                                 <h:outputLabel value="Closing Stock"></h:outputLabel>
                             </td>
                             <td class="text-end">
-                                <h:outputLabel value="#{pharmacySummaryReportController.dailyStockBalanceReport.closingStockValue}" class="me-4"></h:outputLabel>
+                                <h:outputLabel value="#{pharmacySummaryReportController.dailyStockBalanceReport.closingStockValue}" class="me-4">
+                                    <f:convertNumber pattern="#,##0.00"></f:convertNumber>
+                                </h:outputLabel>
                             </td>
                         </tr>
                     </table>


### PR DESCRIPTION
  I've successfully updated the Daily Stock Values Report to calculate and
  display Opening Stock Value and Closing Stock Value at Retail Sale Rate
  (instead of Purchase Rate). Here's what was implemented:

  Changes Made:

  1. PharmacySummaryReportController.java (/home/buddhika/development/rh/src /main/java/com/divudi/bean/pharmacy/PharmacySummaryReportController.java):

    - Added import: StockHistoryFacade (line 31)
    - Added EJB injection: StockHistoryFacade stockHistoryFacade (lines 137-138)
    - Added new method: calculateStockValueAtRetailRate(Date date, Department dept) (lines 387-479)
        - This method calculates stock value at retail rate by querying StockHistory table
      - Uses the same logic as calculateStockTotals in PharmacyReportController but specifically for retail rate - Queries for the latest stock quantities before a given date - Multiplies stock quantities by retailsaleRate from ItemBatch - Filters for positive stock quantities only - Returns the total retail value for the department
    - Updated method: processDailyStockBalanceReport() (lines 334-385)
        - Line 355-356: Calculate Opening Stock Value using calculateStockValueAtRetailRate(fromDate, department)
      - Line 380-381: Calculate Closing Stock Value using calculateStockValueAtRetailRate(toDate, department) - Removed dependency on HistoricalRecord for stock values
  2. daily_stock_values_report.xhtml (/home/buddhika/development/rh/src/main /webapp/pharmacy/reports/summary_reports/daily_stock_values_report.xhtml):

    - Lines 167-169: Added number formatting to Opening Stock display (<f:convertNumber pattern="#,##0.00"/>)
    - Lines 310-312: Added number formatting to Closing Stock display (<f:convertNumber pattern="#,##0.00"/>)

  How It Works:

  The new implementation calculates stock values at retail rate based on
  department-level calculations:

  - Opening Stock: Calculates the total retail value of all stock items in the department at the beginning of the selected date
  - Closing Stock: Calculates the total retail value of all stock items in the department at the end of the selected date (fromDate + 1 day)

  Both values now show formatted numbers with thousand separators and 2
  decimal places (e.g., 1,234,567.89).

  This matches the approach used in the Cost of Goods Sold Report which also
   calculates stock values at different rates (Purchase, Cost, and Retail).

Closes #10333

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Updated stock value calculation methodology in pharmacy summary reports

* **UI/UX**
  * Enhanced decimal formatting for stock values in daily reports for improved readability

<!-- end of auto-generated comment: release notes by coderabbit.ai -->