### PR TITLE
Ajex event on blur and on focus combination gives a loop of focus and…

### DIFF
--- a/src/main/webapp/pharmacy/direct_purchase.xhtml
+++ b/src/main/webapp/pharmacy/direct_purchase.xhtml
@@ -114,7 +114,6 @@
                                             id="txtQty"
                                             class="w-100 m-1 text-end"
                                             autocomplete="off"
-                                            onfocus="this.select()"
                                             value="#{pharmacyDirectPurchaseController.currentBillItem.billItemFinanceDetails.quantity}">
                                             <!--<f:convertNumber integerOnly="#{!pharmacyDirectPurchaseController.currentBillItem.item.allowFractions}" />-->
                                             <p:ajax
@@ -136,7 +135,6 @@
                                             autocomplete="off"
                                             id="txtFreeQty"
                                             class="w-100 m-1 text-end"
-                                            onfocus="this.select()"
                                             value="#{pharmacyDirectPurchaseController.currentBillItem.billItemFinanceDetails.freeQuantity}">
                                             <!--<f:convertNumber integerOnly="#{!pharmacyDirectPurchaseController.currentBillItem.item.allowFractions}" />-->
                                             <p:ajax
@@ -156,7 +154,6 @@
                                         <p:inputText
                                             id="txtPrate"
                                             autocomplete="off"
-                                            onfocus="this.select()"
                                             class="w-100 m-1 text-end"
                                             value="#{pharmacyDirectPurchaseController.currentBillItem.billItemFinanceDetails.lineGrossRate}">
                                             <p:ajax 


### PR DESCRIPTION
… blur and user can not enter numbers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Modified input field behavior in the pharmacy purchase form: removed auto-select-on-focus functionality from quantity and price fields. Users can now manually select text as needed rather than having it automatically selected upon focus.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->