### PR TITLE
Problem Analysis

### DIFF
--- a/src/main/java/com/divudi/bean/pharmacy/PharmacyStockTakeController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacyStockTakeController.java
@@ -145,6 +145,9 @@ public class PharmacyStockTakeController implements Serializable {
         snapshotBill.setCreater(sessionController.getLoggedUser());
         double total = 0.0;
         for (Stock s : stocks) {
+            if (s == null) {
+                continue;
+            }
             BillItem bi = new BillItem();
             bi.setBill(snapshotBill);
             if (s.getItemBatch() == null) {


### PR DESCRIPTION
  The NullPointerException was occurring when the "Generate Stock Count
  Bill" button was clicked because:

  1. The JPQL query at line 127-131 retrieves a list of Stock objects
  2. In rare cases, the query result list might contain null entries
  3. The code was immediately accessing properties of Stock objects without first checking if the stock object itself was null
  4. This caused the NPE at the original line 172 when trying to call s.getItemBatch()

  Fix Applied

  I added a null check at the very beginning of the loop (lines 148-150):

  if (s == null) {
      continue;
  }

  This ensures that any null Stock entries are safely skipped before
  attempting to access their properties.

  Testing

  To test the fix:

  1. Redeploy your application or restart your server to pick up the code changes
  2. Navigate to http://localhost:8080/rh/faces/pharmacy/pharmacy_stock_take.xhtml
  3. Select a department
  4. Click "Generate Stock Count Bill"

  The error should no longer occur. If there are no valid stock items with
  quantity > 0 for the selected department, you'll see the message "No stock
   available" instead of an error.

  The fix follows the defensive programming pattern already used throughout
  the method for checking itemBatch and item nullability.