### PR TITLE
✅ Global Delete Prevention Implemented Successfully!

### DIFF
--- a/src/main/java/com/divudi/data/PreventDeleteSessionCustomizer.java
+++ b/src/main/java/com/divudi/data/PreventDeleteSessionCustomizer.java
@@ -1,0 +1,42 @@
+package com.divudi.data;
+
+import org.eclipse.persistence.config.SessionCustomizer;
+import org.eclipse.persistence.descriptors.ClassDescriptor;
+import org.eclipse.persistence.descriptors.DescriptorEvent;
+import org.eclipse.persistence.descriptors.DescriptorEventAdapter;
+import org.eclipse.persistence.sessions.Session;
+
+/**
+ * EclipseLink SessionCustomizer that prevents all DELETE operations globally.
+ *
+ * This customizer registers a preDelete event listener on all entities to block
+ * any delete operations including:
+ * - Direct EntityManager.remove() calls
+ * - Cascade deletes
+ * - Orphan removals
+ *
+ * To enable/disable, add/remove the following property in persistence.xml:
+ * <property name="eclipselink.session.customizer"
+ *           value="com.divudi.data.PreventDeleteSessionCustomizer"/>
+ *
+ * @author HMIS Development Team
+ */
+public class PreventDeleteSessionCustomizer implements SessionCustomizer {
+
+    @Override
+    public void customize(Session session) throws Exception {
+        // Apply delete prevention to all entity descriptors
+        for (ClassDescriptor descriptor : session.getDescriptors().values()) {
+            descriptor.getEventManager().addListener(new DescriptorEventAdapter() {
+                @Override
+                public void preDelete(DescriptorEvent event) {
+                    String entityName = event.getObject().getClass().getSimpleName();
+                    throw new IllegalStateException(
+                        "Delete operation not allowed for entity: " + entityName +
+                        ". All delete operations are globally disabled."
+                    );
+                }
+            });
+        }
+    }
+}

--- a/src/main/resources/META-INF/persistence.xml
+++ b/src/main/resources/META-INF/persistence.xml
@@ -7,6 +7,7 @@
         <properties>
             <property name="eclipselink.logging.level.sql" value="SEVERE"/>
             <property name="eclipselink.logging.level" value="SEVERE"/>
+            <property name="eclipselink.session.customizer" value="com.divudi.data.PreventDeleteSessionCustomizer"/>
         </properties>
     </persistence-unit>
 
@@ -16,6 +17,7 @@
         <properties>
             <property name="eclipselink.logging.level.sql" value="SEVERE"/>
             <property name="eclipselink.logging.level" value="SEVERE"/>
+            <property name="eclipselink.session.customizer" value="com.divudi.data.PreventDeleteSessionCustomizer"/>
         </properties>
     </persistence-unit>
 </persistence>


### PR DESCRIPTION
  What Was Done

  1. Created Session Customizer Class

  File: src/main/java/com/divudi/data/PreventDeleteSessionCustomizer.java:1
  - Implements SessionCustomizer interface
  - Registers a preDelete event listener on all entity descriptors
  - Throws IllegalStateException for any delete attempt
  - Includes comprehensive documentation

  2. Updated persistence.xml

  File: src/main/resources/META-INF/persistence.xml:10 and :19
  - Added eclipselink.session.customizer property to both persistence units:
    - hmisPU (main database)
    - hmisAuditPU (audit database)

  How It Works

  Now ALL delete operations are blocked globally:
  - ✅ Direct EntityManager.remove() calls
  - ✅ Cascade deletes (CascadeType.ALL, CascadeType.REMOVE)
  - ✅ Orphan removals (orphanRemoval = true)

  Any attempt to delete will throw:
  IllegalStateException: Delete operation not allowed for entity: [EntityName]. All delete operations are globally
  disabled.

  To Enable/Disable

  Disable delete prevention (allow deletes):
  - Simply remove or comment out the eclipselink.session.customizer property from persistence.xml

  Enable delete prevention (current state):
  - Property is active in both persistence units

  The solution is now active and will take effect on the next application deployment!
Closes #16145