### PR TITLE
Fixed -  Remove the display of recently logged in departments on the department selection page for login

### DIFF
--- a/src/main/java/com/divudi/bean/common/SessionController.java
+++ b/src/main/java/com/divudi/bean/common/SessionController.java
@@ -1229,7 +1229,7 @@ public class SessionController implements Serializable, HttpSessionListener {
                     loggableInstitutions = fillLoggableInstitutions();
 
                     // Load recently used departments
-                    recentDepartments = fillRecentDepartmentsForUser(u);
+                    //recentDepartments = fillRecentDepartmentsForUser(u);
                     userIcons = userIconController.fillUserIcons(u, department);
                     setLogged(Boolean.TRUE);
                     setActivated(u.isActivated());
@@ -2727,7 +2727,8 @@ public class SessionController implements Serializable, HttpSessionListener {
 
     public List<Department> getRecentDepartments() {
         if (recentDepartments == null) {
-            recentDepartments = fillRecentDepartmentsForUser(getLoggedUser());
+            recentDepartments = new ArrayList<>();
+            //recentDepartments = fillRecentDepartmentsForUser(getLoggedUser());
         }
         return recentDepartments;
     }

--- a/src/main/webapp/resources/ezcomp/select_department.xhtml
+++ b/src/main/webapp/resources/ezcomp/select_department.xhtml
@@ -28,13 +28,13 @@
                             <p>Select Department</p>
                         </div>
                         <div>
-                            <h:panelGroup rendered="#{not empty sessionController.recentDepartments}">
+<!--                            <h:panelGroup rendered="#{not empty sessionController.recentDepartments}">
                                 <div class="d-flex flex-wrap justify-content-center mb-3">
                                     <ui:repeat value="#{sessionController.recentDepartments}" var="rd">
                                         <p:commandButton value="#{rd.name}" action="#{sessionController.selectDepartmentFromHistory(rd)}" ajax="false" class="m-1"/>
                                     </ui:repeat>
                                 </div>
-                            </h:panelGroup>
+                            </h:panelGroup>-->
                             <p:selectOneMenu
                                 value="#{sessionController.department}"
                                 filter="true"


### PR DESCRIPTION
Remove the display of recently logged in departments on the department selection page for login

closes #16228
Signed-off-by: DamithDeshan <hkddrajapaksha@gmail.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Disabled the recent departments feature. Users will no longer see their recently used departments when selecting a department.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->