### PR TITLE
[HOTFIX] Fix Hospital Fee calculation using adjusted values

### DIFF
--- a/src/main/java/com/divudi/bean/inward/BhtSummeryController.java
+++ b/src/main/java/com/divudi/bean/inward/BhtSummeryController.java
@@ -1905,14 +1905,14 @@ public class BhtSummeryController implements Serializable {
 
             if (cit.getInwardChargeType() == InwardChargeType.ProfessionalCharge) {
                 updateProBillFee(temBi);
-                temProfFee += cit.getTotal();
+                temProfFee += cit.getAdjustedTotal();
             } else {
                 if (configOptionApplicationController.getBooleanValueByKey("Create Professional Bill Fees For Assistant Chargers", false)) {
                     if (cit.getInwardChargeType() == InwardChargeType.DoctorAndNurses) {
                         updateProBillFeeForDocAndNeurses(temBi);;
                     }
                 }
-                temHosFee += cit.getTotal();
+                temHosFee += cit.getAdjustedTotal();
             }
 
             if (cit.getInwardChargeType() == InwardChargeType.RoomCharges) {
@@ -1946,14 +1946,14 @@ public class BhtSummeryController implements Serializable {
 
             if (cit.getInwardChargeType() == InwardChargeType.ProfessionalCharge) {
                 updateProTempBillFee(temBi);
-                temProfFee += cit.getTotal();
+                temProfFee += cit.getAdjustedTotal();
             } else {
                 if (configOptionApplicationController.getBooleanValueByKey("Create Professional Bill Fees For Assistant Chargers", false)) {
                     if (cit.getInwardChargeType() == InwardChargeType.DoctorAndNurses) {
                         updateProTempBillFeeForDocAndNeurses(temBi);;
                     }
                 }
-                temHosFee += cit.getTotal();
+                temHosFee += cit.getAdjustedTotal();
             }
 
             if (cit.getInwardChargeType() == InwardChargeType.RoomCharges) {
@@ -1989,9 +1989,9 @@ public class BhtSummeryController implements Serializable {
 
             if (cit.getInwardChargeType() == InwardChargeType.ProfessionalCharge) {
                 updateProBillFee(temBi);
-                temProfFee += cit.getTotal();
+                temProfFee += cit.getAdjustedTotal();
             } else {
-                temHosFee += cit.getTotal();
+                temHosFee += cit.getAdjustedTotal();
             }
 
             if (cit.getInwardChargeType() == InwardChargeType.RoomCharges) {


### PR DESCRIPTION
## 🚨 Critical Hotfix for Development Branch

**Fixes:** #16291
**Production PR:** #16292

### Problem
The Final Bill (InwardFinalBill) stores **incorrect Hospital Fee** in the database. While Net Total is calculated correctly, the Hospital Fee field uses gross values instead of adjusted values.

### Changes Made
**File:** `src/main/java/com/divudi/bean/inward/BhtSummeryController.java`

Changed 6 instances from `cit.getTotal()` → `cit.getAdjustedTotal()`:
- `saveBillItem()`: Lines 1902, 1909
- `saveTempBillItem()`: Lines 1943, 1950
- `saveOriginalBillItem()`: Lines 1986, 1988

### Testing Required
- [ ] Create new final bill with adjustments/discounts
- [ ] Verify Hospital Fee calculations
- [ ] Run unit tests
- [ ] Run integration tests

### Cherry-Picked From
- **Source:** hotfix/hospital-fee-calculation-fix
- **Original Branch:** southernlanka-prod

### QA Checklist
- [ ] Code review completed
- [ ] Tests passed
- [ ] Tech lead approval

**Priority:** Critical
**Type:** Hotfix