### PR TITLE
Fix: Hospital Fee calculation in Final Bill using adjusted values

### DIFF
--- a/src/main/java/com/divudi/bean/inward/BhtSummeryController.java
+++ b/src/main/java/com/divudi/bean/inward/BhtSummeryController.java
@@ -1905,14 +1905,14 @@ public class BhtSummeryController implements Serializable {
 
             if (cit.getInwardChargeType() == InwardChargeType.ProfessionalCharge) {
                 updateProBillFee(temBi);
-                temProfFee += cit.getTotal();
+                temProfFee += cit.getAdjustedTotal();
             } else {
                 if (configOptionApplicationController.getBooleanValueByKey("Create Professional Bill Fees For Assistant Chargers", false)) {
                     if (cit.getInwardChargeType() == InwardChargeType.DoctorAndNurses) {
                         updateProBillFeeForDocAndNeurses(temBi);;
                     }
                 }
-                temHosFee += cit.getTotal();
+                temHosFee += cit.getAdjustedTotal();
             }
 
             if (cit.getInwardChargeType() == InwardChargeType.RoomCharges) {
@@ -1946,14 +1946,14 @@ public class BhtSummeryController implements Serializable {
 
             if (cit.getInwardChargeType() == InwardChargeType.ProfessionalCharge) {
                 updateProTempBillFee(temBi);
-                temProfFee += cit.getTotal();
+                temProfFee += cit.getAdjustedTotal();
             } else {
                 if (configOptionApplicationController.getBooleanValueByKey("Create Professional Bill Fees For Assistant Chargers", false)) {
                     if (cit.getInwardChargeType() == InwardChargeType.DoctorAndNurses) {
                         updateProTempBillFeeForDocAndNeurses(temBi);;
                     }
                 }
-                temHosFee += cit.getTotal();
+                temHosFee += cit.getAdjustedTotal();
             }
 
             if (cit.getInwardChargeType() == InwardChargeType.RoomCharges) {
@@ -1989,9 +1989,9 @@ public class BhtSummeryController implements Serializable {
 
             if (cit.getInwardChargeType() == InwardChargeType.ProfessionalCharge) {
                 updateProBillFee(temBi);
-                temProfFee += cit.getTotal();
+                temProfFee += cit.getAdjustedTotal();
             } else {
-                temHosFee += cit.getTotal();
+                temHosFee += cit.getAdjustedTotal();
             }
 
             if (cit.getInwardChargeType() == InwardChargeType.RoomCharges) {


### PR DESCRIPTION
## Fix Hospital Fee Calculation Bug

### Problem
Final Bill stores incorrect Hospital Fee value in database. The field uses gross totals instead of adjusted totals (after discounts/adjustments).

### Impact
- Net Total calculation is correct
- Hospital Fee field shows wrong value (inflated)
- Professional Fee may also be affected

### Solution
**File:** `src/main/java/com/divudi/bean/inward/BhtSummeryController.java`

Changed calculation to use adjusted totals instead of gross totals in 3 methods:
- `saveBillItem()`: Lines 1902, 1909
- `saveTempBillItem()`: Lines 1943, 1950  
- `saveOriginalBillItem()`: Lines 1986, 1988

**Change:** `cit.getTotal()` → `cit.getAdjustedTotal()`

### Testing Checklist
- [ ] Create new final bill with adjustments/discounts
- [ ] Verify Hospital Fee = Sum of adjusted charges (excluding professional)
- [ ] Verify Professional Fee = Sum of adjusted professional charges
- [ ] Verify Net Total = Hospital Fee + Professional Fee - Discount
- [ ] Test multiple discount scenarios
- [ ] Run unit tests
- [ ] Run integration tests

### Notes
- Cherry-picked from production fix
- Same issue exists in both branches
- Low risk change (only affects summary fields)

**Priority:** High
**Type:** Bug Fix
**Branch:** development

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected billing calculations to use adjusted charge amounts instead of raw amounts for professional charges, hospital fees, and room charges across all bill types (final, provisional, and original invoices).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->