### PR TITLE
16346 amp names without codes not listed in po creation and direct purchase

### DIFF
--- a/src/main/resources/META-INF/persistence.xml
+++ b/src/main/resources/META-INF/persistence.xml
@@ -2,7 +2,7 @@
 <persistence version="2.2" xmlns="http://java.sun.com/xml/ns/persistence" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/persistence http://xmlns.jcp.org/xml/ns/persistence/persistence_2_2.xsd">
     <persistence-unit name="hmisPU" transaction-type="JTA">
         <provider>org.eclipse.persistence.jpa.PersistenceProvider</provider>
-        <jta-data-source>jdbc/asiriAzure</jta-data-source>
+        <jta-data-source>${JDBC_DATASOURCE}</jta-data-source>
         <exclude-unlisted-classes>false</exclude-unlisted-classes>
         <properties>
             <property name="eclipselink.logging.level.sql" value="SEVERE"/>
@@ -10,7 +10,7 @@
         </properties>
     </persistence-unit>
     <persistence-unit name="hmisAuditPU" transaction-type="JTA">
-        <jta-data-source>jdbc/rhAuditDS</jta-data-source>
+        <jta-data-source>${JDBC_AUDIT_DATASOURCE}</jta-data-source>
         <exclude-unlisted-classes>false</exclude-unlisted-classes>
         <properties>
             <property name="eclipselink.logging.level.sql" value="SEVERE"/>

--- a/src/main/webapp/pharmacy/admin/amp.xhtml
+++ b/src/main/webapp/pharmacy/admin/amp.xhtml
@@ -44,18 +44,7 @@
 
                         </p:commandButton>
 
-                        <!-- Bulk Code Generation Button -->
-                        <p:commandButton
-                            id="btnBulkCodeGen"
-                            icon="fa fa-magic"
-                            value="Generate All Codes"
-                            title="Generate codes for all AMPs that need them"
-                            onclick="return confirm('Are you sure you want to generate codes for all AMPs? This action cannot be undone.');"
-                            action="#{ampController.performBulkCodeGeneration()}"
-                            update="acAmp msg @form"
-                            process="btnBulkCodeGen"
-                            class="m-1 ui-button-info w-25">
-                        </p:commandButton>
+
 
 
 
@@ -139,10 +128,10 @@
                                     </div>
                                 </h:panelGroup>
                                 <p:inputText autocomplete="off" id="txtName"
-                                           value="#{ampController.current.name}"
-                                           placeholder="Enter full product name"
-                                           styleClass="longText" class="w-100"
-                                           required="true" />
+                                             value="#{ampController.current.name}"
+                                             placeholder="Enter full product name"
+                                             styleClass="longText" class="w-100"
+                                             required="true" />
 
 
                                 <!-- Code field with enhanced descriptions -->
@@ -157,19 +146,19 @@
                                 <h:panelGroup id="codePanel" class="w-100">
                                     <div class="input-group">
                                         <p:inputText id="code" autocomplete="off"
-                                                   value="#{ampController.current.code}"
-                                                   placeholder="Enter unique code"
-                                                   styleClass="#{ampController.duplicateCode ? 'is-invalid' : ''}"
-                                                   maxlength="20">
+                                                     value="#{ampController.current.code}"
+                                                     placeholder="Enter unique code"
+                                                     styleClass="#{ampController.duplicateCode ? 'is-invalid' : ''}"
+                                                     maxlength="20">
                                             <p:ajax event="blur" process="@this" update="codePanel msg btnSave codeValidationMsg" listener="#{ampController.checkCodeDuplicate}" />
                                         </p:inputText>
                                         <p:commandButton id="generateCode" value="Generate"
-                                                       title="Generate unique code automatically"
-                                                       action="#{ampController.generateCode()}"
-                                                       process="generateCode codePanel"
-                                                       update="codePanel msg btnSave codeValidationMsg"
-                                                       class="ui-button-secondary"
-                                                       icon="pi pi-refresh" />
+                                                         title="Generate unique code automatically"
+                                                         action="#{ampController.generateCode()}"
+                                                         process="generateCode codePanel"
+                                                         update="codePanel msg btnSave codeValidationMsg"
+                                                         class="ui-button-secondary"
+                                                         icon="pi pi-refresh" />
                                     </div>
 
                                     <!-- Code validation feedback -->
@@ -193,9 +182,9 @@
                                     </div>
                                 </h:panelGroup>
                                 <p:inputText autocomplete="off"
-                                           value="#{ampController.current.barcode}"
-                                           placeholder="Enter product barcode"
-                                           class="w-100" />
+                                             value="#{ampController.current.barcode}"
+                                             placeholder="Enter product barcode"
+                                             class="w-100" />
 
                                 <!-- VMP field with description -->
                                 <h:panelGroup class="w-100">
@@ -359,6 +348,20 @@
 
             </p:panel>
         </h:form>
+        <h:form >
+            <!-- Bulk Code Generation Button -->
+            <p:commandButton
+                id="btnBulkCodeGen"
+                icon="fa fa-magic"
+                value="Generate All Codes"
+                title="Generate codes for all AMPs that need them"
+                onclick="return confirm('Are you sure you want to generate codes for all AMPs? This action cannot be undone.');"
+                action="#{ampController.performBulkCodeGeneration()}"
+                ajax="false"
+                class="m-1 ui-button-warning w-25">
+            </p:commandButton>
+        </h:form>
+
 
     </ui:define>
 


### PR DESCRIPTION
Closes #16346 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **UI Changes**
  * Relocated Bulk Code Generation button to a separate section at the bottom of the AMP management panel.
  * Updated button styling from info to warning appearance.

* **Bug Fixes**
  * Improved search functionality to properly handle missing codes and barcodes in auto-complete queries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->