### PR TITLE
Summary of the Problem and Solution

### DIFF
--- a/src/main/java/com/divudi/bean/pharmacy/PharmacyController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacyController.java
@@ -3185,9 +3185,13 @@ public class PharmacyController implements Serializable {
                     cell.setCellStyle(headerStyle);
                 }
 
-                for (Map.Entry<String, List<DepartmentCategoryWiseItems>> categoryEntry : deptEntry.getValue().entrySet()) {
+                Map<String, List<DepartmentCategoryWiseItems>> categoryMap = deptEntry.getValue();
+                if (categoryMap == null) continue;
+
+                for (Map.Entry<String, List<DepartmentCategoryWiseItems>> categoryEntry : categoryMap.entrySet()) {
                     String categoryName = categoryEntry.getKey();
                     List<DepartmentCategoryWiseItems> items = categoryEntry.getValue();
+                    if (items == null || items.isEmpty()) continue;
 
                     Row categoryRow = sheet.createRow(rowIndex++);
                     Cell categoryCell = categoryRow.createCell(0);
@@ -3196,6 +3200,7 @@ public class PharmacyController implements Serializable {
                     sheet.addMergedRegion(new CellRangeAddress(rowIndex - 1, rowIndex - 1, 0, 4));
 
                     for (DepartmentCategoryWiseItems item : items) {
+                        if (item == null) continue;
                         Row dataRow = sheet.createRow(rowIndex++);
                         dataRow.createCell(0).setCellValue(item.getItem() != null ? item.getItem().getName() : "");
                         dataRow.createCell(1).setCellValue(item.getPurchaseRate() != null ? item.getPurchaseRate() : 0.0);
@@ -3295,6 +3300,14 @@ public class PharmacyController implements Serializable {
             com.itextpdf.text.Font normalFont = FontFactory.getFont(FontFactory.HELVETICA, 10);
             DecimalFormat decimalFormat = new DecimalFormat("#,##0.00");
 
+            if (departmentCategoryMap == null || departmentCategoryMap.isEmpty()) {
+                document.add(new Paragraph("No data available for the selected criteria.", normalFont));
+                document.close();
+                out.flush();
+                context.responseComplete();
+                return;
+            }
+
             for (Map.Entry<String, Map<String, List<DepartmentCategoryWiseItems>>> deptEntry : departmentCategoryMap.entrySet()) {
                 String departmentName = deptEntry.getKey();
                 document.add(new Paragraph("Department: " + departmentName, boldFont));
@@ -3311,9 +3324,13 @@ public class PharmacyController implements Serializable {
                     table.addCell(cell);
                 }
 
-                for (Map.Entry<String, List<DepartmentCategoryWiseItems>> categoryEntry : deptEntry.getValue().entrySet()) {
+                Map<String, List<DepartmentCategoryWiseItems>> categoryMap = deptEntry.getValue();
+                if (categoryMap == null) continue;
+
+                for (Map.Entry<String, List<DepartmentCategoryWiseItems>> categoryEntry : categoryMap.entrySet()) {
                     String categoryName = categoryEntry.getKey();
                     List<DepartmentCategoryWiseItems> items = categoryEntry.getValue();
+                    if (items == null || items.isEmpty()) continue;
 
                     PdfPCell categoryCell = new PdfPCell(new Phrase(categoryName, boldFont));
                     categoryCell.setColspan(5);
@@ -3321,11 +3338,12 @@ public class PharmacyController implements Serializable {
                     table.addCell(categoryCell);
 
                     for (DepartmentCategoryWiseItems item : items) {
+                        if (item == null) continue;
                         table.addCell(new PdfPCell(new Phrase(item.getItem() != null ? item.getItem().getName() : "", normalFont)));
-                        table.addCell(new PdfPCell(new Phrase(decimalFormat.format(item.getPurchaseRate()), normalFont)));
+                        table.addCell(new PdfPCell(new Phrase(item.getPurchaseRate() != null ? decimalFormat.format(item.getPurchaseRate()) : "0.00", normalFont)));
                         table.addCell(new PdfPCell(new Phrase(String.valueOf(item.getQty()), normalFont)));
                         table.addCell(new PdfPCell(new Phrase(decimalFormat.format(item.getCostRate() != null ? item.getCostRate() * item.getQty() : 0.0), normalFont)));
-                        table.addCell(new PdfPCell(new Phrase(decimalFormat.format(item.getNetTotal()), normalFont)));
+                        table.addCell(new PdfPCell(new Phrase(item.getNetTotal() != null ? decimalFormat.format(item.getNetTotal()) : "0.00", normalFont)));
                     }
 
                     table.addCell(new PdfPCell(new Phrase("", normalFont)));


### PR DESCRIPTION
  The Problem:
  The Excel file generated for "by category" consumption reports was
  corrupted and couldn't be opened because:

  1. String values were being set on numeric-formatted cells: The code was calling methods like getCategoryCostTotalForConsumptionReport() and getDepartmentTotalForConsumptionReport() that return formatted String values (e.g., "1,234.56"), but then setting these String values directly on Excel cells that had numeric formatting applied (amountStyle).
  2. Excel format conflict: When a cell has numeric formatting but receives a String value, it can cause file corruption because Excel expects numeric data for numeric-formatted cells.

  The Solution:
  I replaced all instances where formatted String values were being set on
  numeric cells with the actual numeric Double values:

  1. Fixed category total calculations (PharmacyController.java:3198-3209):
    - Changed from setCellValue(getCategoryCostTotalForConsumptionReport(...))
    - To: Direct calculation using departmentTotals map and setCellValue(categoryCostTotal)
  2. Fixed department total calculations (PharmacyController.java:3215-3232):
    - Changed from setCellValue(getDepartmentCostTotalForConsumptionReport(...))
    - To: Stream-based calculation of departmentTotals and setCellValue(deptCostTotal)
  3. Fixed final total calculations (PharmacyController.java:3237-3242):
    - Changed from setCellValue(String.format("%.2f", totalCostValue))
    - To: Direct setCellValue(totalCostValue) with proper styling

  Files Modified:
  - /home/buddhika/development/rh/src/main/java/com/divudi/bean/pharmacy/Pha rmacyController.java

  The fix ensures that all numeric cells receive proper Double values
  instead of formatted Strings, which will resolve the Excel file corruption
   issue. Users should now be able to download and open the Excel file
  successfully when using the "by category" report type.

Closes #16323

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Refined calculations so category and department totals in pharmacy consumption report exports are now driven by in-memory aggregates for consistent aggregation.
  * Improved numeric formatting and cell typing for cost, purchase rate, and totals to ensure accurate numeric values in exported reports.

* **Bug Fixes**
  * Empty-report case handled to emit a header-only sheet and avoid invalid exports.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->