### PR TITLE
16504 - Unnecessary data was displayed in discharge, not discharge status

### DIFF
--- a/src/main/webapp/inward/inward_bill_intrim.xhtml
+++ b/src/main/webapp/inward/inward_bill_intrim.xhtml
@@ -57,7 +57,7 @@
                                 <p:column headerText="Discharged" style="padding: 6px; width: 10em;">
                                     <div class="d-flex justify-content-center">
                                         <span class="#{myItem.discharged ? 'discharged-badge' : 'not-discharged-badge'}">
-                                            #{myItem.discharged ? 'Discharged' : 'Not Yet'}
+                                            #{myItem.discharged ? 'Discharged' : 'Not Discharged'}
                                         </span>
                                     </div>
                                 </p:column>

--- a/src/main/webapp/inward/inward_bill_intrim_estimate.xhtml
+++ b/src/main/webapp/inward/inward_bill_intrim_estimate.xhtml
@@ -53,7 +53,7 @@
                             <p:column headerText="Discharged" style="padding: 6px; width: 10em;">
                                 <div class="d-flex justify-content-center">
                                     <span class="#{myItem.discharged ? 'discharged-badge' : 'not-discharged-badge'}">
-                                        #{myItem.discharged ? 'Discharged' : 'Not Yet'}
+                                        #{myItem.discharged ? 'Discharged' : 'Not Discharged'}
                                     </span>
                                 </div>
                             </p:column>

--- a/src/main/webapp/inward/inward_bill_outside_charge.xhtml
+++ b/src/main/webapp/inward/inward_bill_outside_charge.xhtml
@@ -68,7 +68,7 @@
                                     <p:column headerText="Discharged" style="padding: 6px; width: 10em;">
                                         <div class="d-flex justify-content-center">
                                             <span class="#{myItem.discharged ? 'discharged-badge' : 'not-discharged-badge'}">
-                                                #{myItem.discharged ? 'Discharged' : 'Not Yet'}
+                                                #{myItem.discharged ? 'Discharged' : 'Not Discharged'}
                                             </span>
                                         </div>
                                     </p:column>

--- a/src/main/webapp/inward/inward_bill_professional.xhtml
+++ b/src/main/webapp/inward/inward_bill_professional.xhtml
@@ -65,7 +65,7 @@
                                 <p:column headerText="Discharged" style="padding: 6px; width: 10em;">
                                     <div class="d-flex justify-content-center">
                                         <span class="#{apt2.discharged ? 'discharged-badge' : 'not-discharged-badge'}">
-                                            #{apt2.discharged ? 'Discharged' : 'Not Yet'}
+                                            #{apt2.discharged ? 'Discharged' : 'Not Discharged'}
                                         </span>
                                     </div>
                                 </p:column>

--- a/src/main/webapp/inward/inward_bill_professional_estimate.xhtml
+++ b/src/main/webapp/inward/inward_bill_professional_estimate.xhtml
@@ -67,7 +67,7 @@
                                 <p:column headerText="Discharged" style="padding: 6px; width: 10em;">
                                     <div class="d-flex justify-content-center">
                                             <span class="#{apt2.discharged ? 'discharged-badge' : 'not-discharged-badge'}">
-                                                #{apt2.discharged ? 'Discharged' : 'Not Yet'}
+                                                #{apt2.discharged ? 'Discharged' : 'Not Discharged'}
                                             </span>
                                         </div>
                                 </p:column>

--- a/src/main/webapp/inward/inward_bill_service.xhtml
+++ b/src/main/webapp/inward/inward_bill_service.xhtml
@@ -69,7 +69,7 @@
                                     <p:column headerText="Discharged" style="padding: 6px; width: 10em;">
                                         <div class="d-flex justify-content-center">
                                             <span class="#{apt2.discharged ? 'discharged-badge' : 'not-discharged-badge'}">
-                                                #{apt2.discharged ? 'Discharged' : 'Not Yet'}
+                                                #{apt2.discharged ? 'Discharged' : 'Not Discharged'}
                                             </span>
                                         </div>
                                     </p:column>

--- a/src/main/webapp/inward/inward_edit_bht.xhtml
+++ b/src/main/webapp/inward/inward_edit_bht.xhtml
@@ -71,7 +71,7 @@
                                     <p:column headerText="Discharged" style="padding: 6px; width: 10em;">
                                         <div class="d-flex justify-content-center">
                                             <span class="#{myItem.discharged ? 'discharged-badge' : 'not-discharged-badge'}">
-                                                #{myItem.discharged ? 'Discharged' : 'Not Yet'}
+                                                #{myItem.discharged ? 'Discharged' : 'Not Discharged'}
                                             </span>
                                         </div>
                                     </p:column>

--- a/src/main/webapp/inward/inward_room_change.xhtml
+++ b/src/main/webapp/inward/inward_room_change.xhtml
@@ -63,7 +63,7 @@
                         <p:column headerText="Discharged" style="padding: 6px; width: 10em;">
                             <div class="d-flex justify-content-center">
                                 <span class="#{myItem.discharged ? 'discharged-badge' : 'not-discharged-badge'}">
-                                    #{myItem.discharged ? 'Discharged' : 'Not Yet'}
+                                    #{myItem.discharged ? 'Discharged' : 'Not Discharged'}
                                 </span>
                             </div>
                         </p:column>

--- a/src/main/webapp/inward/inward_room_change_guardian.xhtml
+++ b/src/main/webapp/inward/inward_room_change_guardian.xhtml
@@ -64,7 +64,7 @@
                         <p:column headerText="Discharged" style="padding: 6px; width: 10em;">
                             <div class="d-flex justify-content-center">
                                 <span class="#{myItem.discharged ? 'discharged-badge' : 'not-discharged-badge'}">
-                                    #{myItem.discharged ? 'Discharged' : 'Not Yet'}
+                                    #{myItem.discharged ? 'Discharged' : 'Not Discharged'}
                                 </span>
                             </div>
                         </p:column>

--- a/src/main/webapp/inward/inward_timed_service_consume.xhtml
+++ b/src/main/webapp/inward/inward_timed_service_consume.xhtml
@@ -66,7 +66,7 @@
                                 <p:column headerText="Discharged" style="padding: 6px; width: 10em;">
                                     <div class="d-flex justify-content-center">
                                         <span class="#{myItem.discharged ? 'discharged-badge' : 'not-discharged-badge'}">
-                                            #{myItem.discharged ? 'Discharged' : 'Not Yet'}
+                                            #{myItem.discharged ? 'Discharged' : 'Not Discharged'}
                                         </span>
                                     </div>
                                 </p:column>

--- a/src/main/webapp/inward/pharmacy_bill_issue_bht.xhtml
+++ b/src/main/webapp/inward/pharmacy_bill_issue_bht.xhtml
@@ -63,7 +63,7 @@
                         <p:column headerText="Discharged" style="padding: 6px; width: 10em;">
                             <div class="d-flex justify-content-center">
                                 <span class="#{apt2.discharged ? 'discharged-badge' : 'not-discharged-badge'}">
-                                    #{apt2.discharged ? 'Discharged' : 'Not Yet'}
+                                    #{apt2.discharged ? 'Discharged' : 'Not Discharged'}
                                 </span>
                             </div>
                         </p:column>

--- a/src/main/webapp/inward/send_confermation_mail_to_company.xhtml
+++ b/src/main/webapp/inward/send_confermation_mail_to_company.xhtml
@@ -55,7 +55,7 @@
                                     <p:column headerText="Discharged" style="padding: 6px; width: 10em;">
                                         <div class="d-flex justify-content-center">
                                             <span class="#{myItem.discharged ? 'discharged-badge' : 'not-discharged-badge'}">
-                                                #{myItem.discharged ? 'Discharged' : 'Not Yet'}
+                                                #{myItem.discharged ? 'Discharged' : 'Not Discharged'}
                                             </span>
                                         </div>
                                     </p:column>

--- a/src/main/webapp/store/store_retail_sale_bht.xhtml
+++ b/src/main/webapp/store/store_retail_sale_bht.xhtml
@@ -57,7 +57,7 @@
                                     <p:column headerText="Discharged" style="padding: 6px; width: 10em;">
                                         <div class="d-flex justify-content-center">
                                             <span class="#{apt2.discharged ? 'discharged-badge' : 'not-discharged-badge'}">
-                                                #{apt2.discharged ? 'Discharged' : 'Not Yet'}
+                                                #{apt2.discharged ? 'Discharged' : 'Not Discharged'}
                                             </span>
                                         </div>
                                     </p:column>

--- a/src/main/webapp/theater/inward_bill_surgery.xhtml
+++ b/src/main/webapp/theater/inward_bill_surgery.xhtml
@@ -62,7 +62,7 @@
                         <p:column headerText="Discharged" style="padding: 6px; width: 10em;">
                             <div class="d-flex justify-content-center">
                                 <span class="#{apt2.discharged ? 'discharged-badge' : 'not-discharged-badge'}">
-                                    #{apt2.discharged ? 'Discharged' : 'Not Yet'}
+                                    #{apt2.discharged ? 'Discharged' : 'Not Discharged'}
                                 </span>
                             </div>
                         </p:column>

--- a/src/main/webapp/theater/inward_bill_surgery_issue.xhtml
+++ b/src/main/webapp/theater/inward_bill_surgery_issue.xhtml
@@ -74,7 +74,7 @@
                             <p:column headerText="Discharged" style="padding: 6px; width: 10em;">
                                 <div class="d-flex justify-content-center">
                                     <span class="#{apt2.patientEncounter.discharged ? 'discharged-badge' : 'not-discharged-badge'}">
-                                        #{apt2.patientEncounter.discharged ? 'Discharged' : 'Not Yet'}
+                                        #{apt2.patientEncounter.discharged ? 'Discharged' : 'Not Discharged'}
                                     </span>
                                 </div>
                             </p:column>

--- a/src/main/webapp/ward/ward_pharmacy_bht_issue_request_bill.xhtml
+++ b/src/main/webapp/ward/ward_pharmacy_bht_issue_request_bill.xhtml
@@ -109,7 +109,7 @@
                                         <p:column headerText="Discharged" style="padding: 6px; width: 10em;">
                                             <div class="d-flex justify-content-center">
                                                 <span class="#{apt2.discharged ? 'discharged-badge' : 'not-discharged-badge'}">
-                                                    #{apt2.discharged ? 'Discharged' : 'Not Yet'}
+                                                    #{apt2.discharged ? 'Discharged' : 'Not Discharged'}
                                                 </span>
                                             </div>
                                         </p:column>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Updated discharge status display across multiple pages: replaced previous badge rendering with a single consistent inline badge. Status now shows "Discharged" or "Not Discharged" with distinct styled appearances (red for discharged, blue for not discharged), improving visual clarity and consistency. Minor formatting and an inline preview section were added in one view.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->