### PR TITLE
16575 bug missing data in consumption by category report downloads pharmacy module

### DIFF
--- a/src/main/resources/META-INF/persistence.xml
+++ b/src/main/resources/META-INF/persistence.xml
@@ -2,7 +2,7 @@
 <persistence version="2.2" xmlns="http://java.sun.com/xml/ns/persistence" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/persistence http://xmlns.jcp.org/xml/ns/persistence/persistence_2_2.xsd">
     <persistence-unit name="hmisPU" transaction-type="JTA">
         <provider>org.eclipse.persistence.jpa.PersistenceProvider</provider>
-        <jta-data-source>jdbc/rhDS</jta-data-source>
+        <jta-data-source>${JDBC_DATASOURCE}</jta-data-source>
         <exclude-unlisted-classes>false</exclude-unlisted-classes>
         <properties>
             <property name="eclipselink.logging.level.sql" value="SEVERE"/>
@@ -10,7 +10,7 @@
         </properties>
     </persistence-unit>
     <persistence-unit name="hmisAuditPU" transaction-type="JTA">
-        <jta-data-source>jdbc/rhAuditDS</jta-data-source>
+        <jta-data-source>${JDBC_AUDIT_DATASOURCE}</jta-data-source>
         <exclude-unlisted-classes>false</exclude-unlisted-classes>
         <properties>
             <property name="eclipselink.logging.level.sql" value="SEVERE"/>


### PR DESCRIPTION
✅ https://github.com/hmislk/hmis/issues/16575 Issues Fixed
  1. Column Headers Corrected

  Before (Excel):
  - Category, Rate, Quantity, Cost Value, Value

  After (Excel & PDF):
  - Category, Qty, Purchase Value, Cost Value, Retail Value, Net Total

  2. Added Missing Columns

  - ✅ Purchase Value - Now included using item.getTotalPurchaseValue()
  - ✅ Retail Value - Now included using item.getTotalRetailValue()

  3. Fixed Zero Values Issue

  Before:
  - Used manual calculations like item.getCostRate() * item.getQty() which
  caused zero values
  - Used individual rates instead of pre-calculated totals

  After:
  - Uses pre-calculated total values:
    - item.getTotalPurchaseValue()
    - item.getTotalCostValue()
    - item.getTotalRetailValue()
    - item.getNetTotal()

  4. Fixed Department and Category Totals

  Before:
  - Only showed Cost Value and Net Total in exports
  - Missing Purchase Value and Retail Value totals

  After:
  - All totals now include all columns:
    - Category totals: Purchase Value, Cost Value, Retail Value, Net Total
    - Department totals: Purchase Value, Cost Value, Retail Value, Net Total

    - Grand totals: Purchase Value, Cost Value, Retail Value, Net Total

  5. Updated Column Layout

  - Excel: Extended from 5 to 6 columns with proper merged regions
  - PDF: Extended from 5 to 6 columns with adjusted widths {3, 1, 2, 2, 2,
  2}

  Files Modified:

  - /home/buddhika/development/rh/src/main/java/com/divudi/bean/pharmacy/Pha
  rmacyController.java
    - exportConsumptionReportCategoryWiseToExcel() method (lines ~3128-3276)
    - exportConsumptionReportCategoryWiseToPdf() method (lines ~3278-3381)

  Data Consistency Achieved:

  The Excel and PDF exports now exactly match the web display table
  structure, showing:
  - Item Name (Category breakdown)
  - Qty (Quantity issued)
  - Purchase Value (Qty × Purchase Rate)
  - Cost Value (Qty × Cost Rate)
  - Retail Value (Qty × Retail Rate)
  - Net Total (Financial billing amount)

  All totals are now correctly calculated and displayed at category,
  department, and grand total levels for both export formats.

Closes https://github.com/hmislk/hmis/issues/16575


Signed-off-by: Dr M H B Ariyaratne <buddhika.ari@gmail.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced Category Wise Consumption report exports with expanded financial metrics: added separate Purchase Value, Cost Value, Retail Value, and Net Total columns alongside existing Category and Quantity data.
  * Updated category, department, and grand total sections to display comprehensive financial breakdowns across all new metrics in Excel and PDF exports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->