### PR TITLE
Fix Critical Issue

### DIFF
--- a/src/main/java/com/divudi/bean/common/BillSearch.java
+++ b/src/main/java/com/divudi/bean/common/BillSearch.java
@@ -133,6 +133,7 @@ import org.primefaces.model.DefaultStreamedContent;
 import org.primefaces.model.StreamedContent;
 
 import java.nio.charset.StandardCharsets;
+import com.google.gson.Gson;
 
 /**
  * @author Buddhika
@@ -377,6 +378,11 @@ public class BillSearch implements Serializable {
 
     private Payment payment;
     private int billItemSize;
+
+    // Change From Institution properties
+    private Institution newFromInstitution;
+    private Department newFromDepartment;
+    private String changeFromInstitutionReason;
 
     public String navigateToBillPaymentOpdBill() {
         return "bill_payment_opd?faces-redirect=true";
@@ -6732,6 +6738,145 @@ public class BillSearch implements Serializable {
 
     public String navigateToPharmacyStockAdjustmentBillReprint() {
         return "/pharmacy/adjustments/reprint/pharmacy_stock_adjustment_reprint?faces-redirect=true";
+    }
+
+    // Change From Institution methods
+    public String navigateToChangeFromInstitution() {
+        if (bill == null) {
+            JsfUtil.addErrorMessage("No Bill selected");
+            return "";
+        }
+        viewingBill = bill;
+        newFromInstitution = null;
+        newFromDepartment = null;
+        changeFromInstitutionReason = null;
+        return "/opd/view/bill_change_from_institution?faces-redirect=true";
+    }
+
+    public String changeFromInstitution() {
+        if (bill == null) {
+            JsfUtil.addErrorMessage("No Bill selected");
+            return "";
+        }
+        if (newFromInstitution == null) {
+            JsfUtil.addErrorMessage("Please select a new From Institution");
+            return "";
+        }
+        if (changeFromInstitutionReason == null || changeFromInstitutionReason.trim().isEmpty()) {
+            JsfUtil.addErrorMessage("Please provide a reason for the change");
+            return "";
+        }
+
+        try {
+            // Create audit event - Before state
+            AuditEvent auditEvent = new AuditEvent();
+            auditEvent.setEventStatus("Started");
+            Date startTime = new Date();
+            auditEvent.setEventDataTime(startTime);
+
+            if (sessionController != null && sessionController.getDepartment() != null) {
+                auditEvent.setDepartmentId(sessionController.getDepartment().getId());
+            }
+            if (sessionController != null && sessionController.getInstitution() != null) {
+                auditEvent.setInstitutionId(sessionController.getInstitution().getId());
+            }
+            if (sessionController != null && sessionController.getLoggedUser() != null) {
+                auditEvent.setWebUserId(sessionController.getLoggedUser().getId());
+            }
+
+            auditEvent.setEventTrigger("Change From Institution: " + changeFromInstitutionReason);
+            auditEvent.setEntityType("Bill");
+            auditEvent.setObjectId(bill.getId());
+
+            // Capture before state
+            Map<String, Object> beforeState = new HashMap<>();
+            beforeState.put("billId", bill.getId());
+            beforeState.put("billNumber", bill.getDeptId());
+            beforeState.put("fromInstitutionId", bill.getFromInstitution() != null ? bill.getFromInstitution().getId() : null);
+            beforeState.put("fromInstitutionName", bill.getFromInstitution() != null ? bill.getFromInstitution().getName() : null);
+            beforeState.put("fromDepartmentId", bill.getFromDepartment() != null ? bill.getFromDepartment().getId() : null);
+            beforeState.put("fromDepartmentName", bill.getFromDepartment() != null ? bill.getFromDepartment().getName() : null);
+            beforeState.put("reason", changeFromInstitutionReason);
+
+            Gson gson = new Gson();
+            auditEvent.setBeforeJson(gson.toJson(beforeState));
+
+            // Make the change
+            Institution oldFromInstitution = bill.getFromInstitution();
+            Department oldFromDepartment = bill.getFromDepartment();
+
+            bill.setFromInstitution(newFromInstitution);
+            bill.setFromDepartment(newFromDepartment);
+
+            // Save the bill
+            billFacade.edit(bill);
+
+            // Capture after state
+            Map<String, Object> afterState = new HashMap<>();
+            afterState.put("billId", bill.getId());
+            afterState.put("billNumber", bill.getDeptId());
+            afterState.put("fromInstitutionId", bill.getFromInstitution() != null ? bill.getFromInstitution().getId() : null);
+            afterState.put("fromInstitutionName", bill.getFromInstitution() != null ? bill.getFromInstitution().getName() : null);
+            afterState.put("fromDepartmentId", bill.getFromDepartment() != null ? bill.getFromDepartment().getId() : null);
+            afterState.put("fromDepartmentName", bill.getFromDepartment() != null ? bill.getFromDepartment().getName() : null);
+            afterState.put("reason", changeFromInstitutionReason);
+
+            auditEvent.setAfterJson(gson.toJson(afterState));
+
+            // Complete audit event
+            Date endTime = new Date();
+            auditEvent.setEventEndTime(endTime);
+            auditEvent.setEventDuration(endTime.getTime() - startTime.getTime());
+            auditEvent.setEventStatus("Completed");
+
+            auditEventApplicationController.logAuditEvent(auditEvent);
+
+            String changeMessage = "From Institution changed from '"
+                + (oldFromInstitution != null ? oldFromInstitution.getName() : "None")
+                + "' to '"
+                + newFromInstitution.getName() + "'";
+
+            JsfUtil.addSuccessMessage(changeMessage);
+
+            // Update viewing bill
+            viewingBill = bill;
+
+            // Clear the change fields
+            newFromInstitution = null;
+            newFromDepartment = null;
+            changeFromInstitutionReason = null;
+
+            return navigateToAdminBill();
+
+        } catch (Exception e) {
+            JsfUtil.addErrorMessage("Error changing From Institution: " + e.getMessage());
+            return "";
+        }
+    }
+
+    // Getters and Setters for change from institution properties
+    public Institution getNewFromInstitution() {
+        return newFromInstitution;
+    }
+
+    public void setNewFromInstitution(Institution newFromInstitution) {
+        this.newFromInstitution = newFromInstitution;
+    }
+
+    public Department getNewFromDepartment() {
+        return newFromDepartment;
+    }
+
+    public void setNewFromDepartment(Department newFromDepartment) {
+        this.newFromDepartment = newFromDepartment;
+    }
+
+    public String getChangeFromInstitutionReason() {
+        return changeFromInstitutionReason;
+    }
+
+    public void setChangeFromInstitutionReason(String changeFromInstitutionReason) {
+        this.changeFromInstitutionReason = changeFromInstitutionReason;
     }
 
 }

--- a/src/main/webapp/opd/view/bill_admin.xhtml
+++ b/src/main/webapp/opd/view/bill_admin.xhtml
@@ -458,6 +458,27 @@
 
                                     </p:tab>
 
+                                    <p:tab title="Functions" >
+                                        <p:panel header="Administrative Functions">
+                                            <div class="p-grid">
+                                                <div class="p-col-12 p-md-6 p-lg-4 mb-3">
+                                                    <p:commandButton
+                                                        value="Change From Institution"
+                                                        icon="pi pi-building"
+                                                        styleClass="ui-button-warning"
+                                                        action="#{billSearch.navigateToChangeFromInstitution()}"
+                                                        ajax="false"
+                                                        rendered="#{webUserController.hasPrivilege('Developers')}"
+                                                        style="width: 100%;">
+                                                        <f:setPropertyActionListener
+                                                            value="#{billSearch.viewingBill}"
+                                                            target="#{billSearch.bill}" />
+                                                    </p:commandButton>
+                                                </div>
+                                            </div>
+                                        </p:panel>
+                                    </p:tab>
+
                                 </p:tabView>
 
 

--- a/src/main/webapp/opd/view/bill_change_from_institution.xhtml
+++ b/src/main/webapp/opd/view/bill_change_from_institution.xhtml
@@ -1,0 +1,151 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
+      xmlns:p="http://primefaces.org/ui"
+      xmlns:h="http://xmlns.jcp.org/jsf/html"
+      xmlns:f="http://xmlns.jcp.org/jsf/core">
+
+    <h:body>
+        <ui:composition template="/resources/template/template.xhtml">
+
+            <ui:define name="content">
+                <h:form>
+                    <p:panel >
+                        <f:facet name="header">
+                            <div class="d-flex justify-content-between">
+                                <p:outputLabel value="Change From Institution" class="mt-2"></p:outputLabel>
+                                <p:commandButton
+                                    value="Back to Bill Admin"
+                                    action="#{billSearch.navigateToAdminBill()}"
+                                    ajax="false"
+                                    icon="pi pi-arrow-left"
+                                    styleClass="ui-button-secondary"></p:commandButton>
+                            </div>
+                        </f:facet>
+
+                        <div class="row">
+                            <div class="col-12">
+                                <p:panel header="Bill Summary">
+                                    <p:panelGrid
+                                        columns="4"
+                                        styleClass="w-100"
+                                        columnClasses="w-15,w-35,w-15,w-35"
+                                        layout="tabular">
+
+                                        <h:outputLabel value="Bill Number:" />
+                                        <h:outputText value="#{billSearch.bill.deptId}" />
+                                        <h:outputLabel value="Bill Type:" />
+                                        <h:outputText value="#{billSearch.bill.billTypeAtomic}" />
+
+                                        <h:outputLabel value="Net Total:" />
+                                        <h:outputText value="#{billSearch.bill.netTotal}">
+                                            <f:convertNumber pattern="#,##0.00"/>
+                                        </h:outputText>
+                                        <h:outputLabel value="Created At:" />
+                                        <h:outputText value="#{billSearch.bill.createdAt}">
+                                            <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateTimeFormat}" />
+                                        </h:outputText>
+
+                                        <h:outputLabel value="Patient:" />
+                                        <h:outputText value="#{billSearch.bill.patient.person.name}" rendered="#{billSearch.bill.patient ne null}"/>
+                                        <h:outputLabel value="Created By:" />
+                                        <h:outputText value="#{billSearch.bill.creater.webUserPerson.name}" />
+
+                                    </p:panelGrid>
+                                </p:panel>
+
+                                <p:panel header="Current From Institution Details" styleClass="mt-3">
+                                    <p:panelGrid
+                                        columns="2"
+                                        styleClass="w-100"
+                                        columnClasses="w-25,w-75"
+                                        layout="tabular">
+
+                                        <h:outputLabel value="Current From Institution:" />
+                                        <h:outputText value="#{billSearch.bill.fromInstitution.name}" rendered="#{billSearch.bill.fromInstitution ne null}"/>
+                                        <h:outputText value="(Not Set)" rendered="#{billSearch.bill.fromInstitution eq null}" styleClass="text-muted"/>
+
+                                        <h:outputLabel value="Current From Department:" />
+                                        <h:outputText value="#{billSearch.bill.fromDepartment.name}" rendered="#{billSearch.bill.fromDepartment ne null}"/>
+                                        <h:outputText value="(Not Set)" rendered="#{billSearch.bill.fromDepartment eq null}" styleClass="text-muted"/>
+
+                                    </p:panelGrid>
+                                </p:panel>
+
+                                <p:panel header="Change From Institution" styleClass="mt-3">
+                                    <div class="ui-fluid">
+                                        <div class="p-field mb-3">
+                                            <h:outputLabel for="newFromInstitution" value="Select New From Institution:" />
+                                            <p:autoComplete
+                                                id="newFromInstitution"
+                                                class="w-100"
+                                                inputStyleClass="w-100"
+                                                forceSelection="true"
+                                                completeMethod="#{institutionController.completeIns}"
+                                                var="ins"
+                                                itemLabel="#{ins.name}"
+                                                itemValue="#{ins}"
+                                                value="#{billSearch.newFromInstitution}">
+                                                <p:ajax event="itemSelect"/>
+                                            </p:autoComplete>
+                                        </div>
+
+                                        <div class="p-field mb-3">
+                                            <h:outputLabel for="newFromDepartment" value="Select New From Department (Optional):" />
+                                            <p:autoComplete
+                                                id="newFromDepartment"
+                                                class="w-100"
+                                                inputStyleClass="w-100"
+                                                forceSelection="true"
+                                                completeMethod="#{departmentController.completeDept}"
+                                                var="dept"
+                                                itemLabel="#{dept.name}"
+                                                itemValue="#{dept}"
+                                                value="#{billSearch.newFromDepartment}"/>
+                                        </div>
+
+                                        <div class="p-field mb-3">
+                                            <h:outputLabel for="changeReason" value="Reason for Change:" />
+                                            <p:inputTextarea
+                                                id="changeReason"
+                                                value="#{billSearch.changeFromInstitutionReason}"
+                                                rows="3"
+                                                class="w-100"
+                                                placeholder="Please provide a reason for this change..."
+                                                required="true"
+                                                requiredMessage="Reason is required"/>
+                                        </div>
+
+                                        <div class="p-field text-center mt-4">
+                                            <p:commandButton
+                                                value="Confirm Change"
+                                                icon="pi pi-check"
+                                                styleClass="ui-button-success m-1"
+                                                action="#{billSearch.changeFromInstitution()}"
+                                                ajax="false"
+                                                style="width: 200px;">
+                                            </p:commandButton>
+                                            <p:commandButton
+                                                value="Cancel"
+                                                action="#{billSearch.navigateToAdminBill()}"
+                                                ajax="false"
+                                                icon="pi pi-times"
+                                                styleClass="ui-button-secondary m-1"
+                                                style="width: 200px;"
+                                                immediate="true"></p:commandButton>
+                                        </div>
+                                    </div>
+                                </p:panel>
+
+                            </div>
+                        </div>
+
+                    </p:panel>
+                </h:form>
+            </ui:define>
+
+        </ui:composition>
+
+    </h:body>
+</html>


### PR DESCRIPTION
Added new "Functions" tab to bill admin page with "Change From Institution" feature. Admins can now modify the fromInstitution and fromDepartment fields on bills with full audit logging. All changes require a justification reason and are logged to the audit events table with before/after state snapshots.

Features:
- New Functions tab in bill_admin.xhtml
- Dedicated bill_change_from_institution.xhtml page with institution selector
- Full audit trail with before/after JSON snapshots
- Validation requiring reason for change
- Restricted to users with Developers privilege

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added capability for authorized users to change the "From Institution" and associated department for a bill.
  * New "Change From Institution" interface with autocomplete selectors for selecting the new institution and optional department.
  * Requires documentation of reason for change with full audit trail capturing before and after states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->