### PR TITLE
Fix Online Settlement column visibility flag

### DIFF
--- a/src/main/webapp/resources/ezcomp/bundles/opdCredit.xhtml
+++ b/src/main/webapp/resources/ezcomp/bundles/opdCredit.xhtml
@@ -245,7 +245,7 @@
                     </f:facet>
                 </p:column>
 
-                <p:column  class="text-end"  headerText="Online Settlement" sortBy="#{row.onlineSettlementValue}" filterBy="#{row.onlineSettlementValue}"  rendered="#{cc.attrs.bundle.hasOnCallTransaction}" >
+                <p:column  class="text-end"  headerText="Online Settlement" sortBy="#{row.onlineSettlementValue}" filterBy="#{row.onlineSettlementValue}"  rendered="#{cc.attrs.bundle.hasOnlineSettlementTransaction}" >
                     <h:outputText value="#{row.onlineSettlementValue}" >
                         <f:convertNumber pattern="#,##0.00" ></f:convertNumber>
                     </h:outputText>

--- a/src/main/webapp/resources/ezcomp/bundles/opdCreditCancelled.xhtml
+++ b/src/main/webapp/resources/ezcomp/bundles/opdCreditCancelled.xhtml
@@ -235,7 +235,7 @@
                     </f:facet>
                 </p:column>
 
-                <p:column  class="text-end"  headerText="Online Settlement" sortBy="#{row.onlineSettlementValue}" filterBy="#{row.onlineSettlementValue}"  rendered="#{cc.attrs.bundle.hasOnCallTransaction}" >
+                <p:column  class="text-end"  headerText="Online Settlement" sortBy="#{row.onlineSettlementValue}" filterBy="#{row.onlineSettlementValue}"  rendered="#{cc.attrs.bundle.hasOnlineSettlementTransaction}" >
                     <h:outputText value="#{row.onlineSettlementValue}" >
                         <f:convertNumber pattern="#,##0.00" ></f:convertNumber>
                     </h:outputText>

--- a/src/main/webapp/resources/ezcomp/bundles/opdCreditRefund.xhtml
+++ b/src/main/webapp/resources/ezcomp/bundles/opdCreditRefund.xhtml
@@ -235,7 +235,7 @@
                     </f:facet>
                 </p:column>
 
-                <p:column  class="text-end"  headerText="Online Settlement" sortBy="#{row.onlineSettlementValue}" filterBy="#{row.onlineSettlementValue}"  rendered="#{cc.attrs.bundle.hasOnCallTransaction}" >
+                <p:column  class="text-end"  headerText="Online Settlement" sortBy="#{row.onlineSettlementValue}" filterBy="#{row.onlineSettlementValue}"  rendered="#{cc.attrs.bundle.hasOnlineSettlementTransaction}" >
                     <h:outputText value="#{row.onlineSettlementValue}" >
                         <f:convertNumber pattern="#,##0.00" ></f:convertNumber>
                     </h:outputText>


### PR DESCRIPTION
Updated the rendered attribute for the Online Settlement column from hasOnCallTransaction to hasOnlineSettlementTransaction in three bundle files to ensure the column displays only when online settlement transactions exist.

Files modified:
- opdCredit.xhtml:248
- opdCreditCancelled.xhtml:238
- opdCreditRefund.xhtml:238

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Updated Online Settlement column visibility conditions across multiple transaction report views (credit transactions, cancellations, and refunds) to correctly reflect settlement transaction status
* Added footer summaries displaying formatted currency totals for Online Settlement columns in transaction cancellation and refund reports to provide summary information

<!-- end of auto-generated comment: release notes by coderabbit.ai -->