### PR TITLE
Fix the is operator

### DIFF
--- a/src/main/webapp/credit/credit_company_bill_opd_combined.xhtml
+++ b/src/main/webapp/credit/credit_company_bill_opd_combined.xhtml
@@ -236,6 +236,12 @@
                                                     rendered="#{cashRecieveBillController.current.paymentMethod eq 'Slip'}">
                                                     <pa:slipDetailsAsOnlyPayment paymentMethodData="#{cashRecieveBillController.paymentMethodData}"/>
                                                 </h:panelGroup>
+
+                                                <h:panelGroup
+                                                    id="ewallet"
+                                                    rendered="#{cashRecieveBillController.current.paymentMethod eq 'ewallet'}">
+                                                    <pa:ewalletDetailsAsOnlyPayment paymentMethodData="#{cashRecieveBillController.paymentMethodData}"/>
+                                                </h:panelGroup>
                                             </h:panelGroup>
                                         </div>
                                     </div>

--- a/src/main/webapp/credit/credit_compnay_bill_opd.xhtml
+++ b/src/main/webapp/credit/credit_compnay_bill_opd.xhtml
@@ -217,10 +217,16 @@
                                                     <pa:chequeDetailsAsOnlyPayment paymentMethodData="#{cashRecieveBillController.paymentMethodData}"/>
                                                 </h:panelGroup>
 
-                                                <h:panelGroup 
-                                                    id="slip" 
+                                                <h:panelGroup
+                                                    id="slip"
                                                     rendered="#{cashRecieveBillController.current.paymentMethod eq 'Slip'}">
                                                     <pa:slipDetailsAsOnlyPayment paymentMethodData="#{cashRecieveBillController.paymentMethodData}"/>
+                                                </h:panelGroup>
+
+                                                <h:panelGroup
+                                                    id="ewallet"
+                                                    rendered="#{cashRecieveBillController.current.paymentMethod eq 'ewallet'}">
+                                                    <pa:ewalletDetailsAsOnlyPayment paymentMethodData="#{cashRecieveBillController.paymentMethodData}"/>
                                                 </h:panelGroup>
                                             </h:panelGroup>
                                         </div>

--- a/src/main/webapp/credit/credit_compnay_bill_payment_inward.xhtml
+++ b/src/main/webapp/credit/credit_compnay_bill_payment_inward.xhtml
@@ -219,10 +219,16 @@
                                                     <pa:chequeDetailsAsOnlyPayment paymentMethodData="#{cashRecieveBillController.paymentMethodData}"/>
                                                 </h:panelGroup>
 
-                                                <h:panelGroup 
-                                                    id="slip" 
+                                                <h:panelGroup
+                                                    id="slip"
                                                     rendered="#{cashRecieveBillController.current.paymentMethod eq 'Slip'}">
                                                     <pa:slipDetailsAsOnlyPayment paymentMethodData="#{cashRecieveBillController.paymentMethodData}"/>
+                                                </h:panelGroup>
+
+                                                <h:panelGroup
+                                                    id="ewallet"
+                                                    rendered="#{cashRecieveBillController.current.paymentMethod eq 'ewallet'}">
+                                                    <pa:ewalletDetailsAsOnlyPayment paymentMethodData="#{cashRecieveBillController.paymentMethodData}"/>
                                                 </h:panelGroup>
                                             </h:panelGroup>
                                         </div>

--- a/src/main/webapp/credit/credit_compnay_bill_pharmacy.xhtml
+++ b/src/main/webapp/credit/credit_compnay_bill_pharmacy.xhtml
@@ -232,6 +232,12 @@
                                                     rendered="#{cashRecieveBillController.current.paymentMethod eq 'Slip'}">
                                                     <pa:slipDetailsAsOnlyPayment paymentMethodData="#{cashRecieveBillController.paymentMethodData}"/>
                                                 </h:panelGroup>
+
+                                                <h:panelGroup
+                                                    id="ewallet"
+                                                    rendered="#{cashRecieveBillController.current.paymentMethod eq 'ewallet'}">
+                                                    <pa:ewalletDetailsAsOnlyPayment paymentMethodData="#{cashRecieveBillController.paymentMethodData}"/>
+                                                </h:panelGroup>
                                             </h:panelGroup>
                                         </div>
                                     </div>

--- a/src/main/webapp/credit/credit_compnay_package_bill_opd.xhtml
+++ b/src/main/webapp/credit/credit_compnay_package_bill_opd.xhtml
@@ -209,10 +209,16 @@
                                                 <pa:cheque paymentMethodData="#{cashRecieveBillController.paymentMethodData}"/>
                                             </h:panelGroup>
 
-                                            <h:panelGroup 
-                                                id="slip" 
+                                            <h:panelGroup
+                                                id="slip"
                                                 rendered="#{cashRecieveBillController.current.paymentMethod eq 'Slip'}">
                                                 <pa:slip paymentMethodData="#{cashRecieveBillController.paymentMethodData}"/>
+                                            </h:panelGroup>
+
+                                            <h:panelGroup
+                                                id="ewallet"
+                                                rendered="#{cashRecieveBillController.current.paymentMethod eq 'ewallet'}">
+                                                <pa:ewallet paymentMethodData="#{cashRecieveBillController.paymentMethodData}"/>
                                             </h:panelGroup>
                                         </h:panelGroup>
                                     </div>


### PR DESCRIPTION
Closes #16582

Fixed issue where eWallet payment method did not display required input fields (Bank/Institution, Reference No., Comments) in credit settlement interfaces. Added eWallet conditional rendering section to all credit settlement XHTML files to match existing Card, Cheque, and Slip patterns.

Modified files:
- credit_company_bill_opd_combined.xhtml (Combined OPD)
- credit_compnay_bill_opd.xhtml (OPD)
- credit_compnay_bill_pharmacy.xhtml (Pharmacy)
- credit_compnay_bill_payment_inward.xhtml (Inward)
- credit_compnay_package_bill_opd.xhtml (Package)

Impact: Users can now select eWallet and enter payment details when settling credit bills through any credit company payment interface.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added eWallet as a new payment method option across billing and payment interfaces. The eWallet payment option is now available for OPD billing, pharmacy billing, package OPD billing, and payment inward transactions, with appropriate payment details displayed when the payment method is selected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->