### PR TITLE
Update old analytics bills page

### DIFF
--- a/src/main/java/com/divudi/bean/common/BillSearch.java
+++ b/src/main/java/com/divudi/bean/common/BillSearch.java
@@ -3981,6 +3981,44 @@ public class BillSearch implements Serializable {
         return navigateToViewBillByAtomicBillType();
     }
 
+    public String navigateToManageBillByAtomicBillTypeByBillId(Long BillId) {
+        System.out.println("navigateToManageBillByAtomicBillTypeByBillId");
+        System.out.println("BillId = " + BillId);
+        if (BillId == null) {
+            JsfUtil.addErrorMessage("Bill ID is required");
+            return null;
+        }
+
+        Bill foundBill = billFacade.find(BillId);
+        System.out.println("foundBill = " + foundBill);
+        if (foundBill == null) {
+            JsfUtil.addErrorMessage("Bill not found");
+            return null;
+        }
+
+        this.bill = foundBill;
+        return navigateToManageBillByAtomicBillType();
+    }
+
+    public String navigateToAdminBillByAtomicBillTypeByBillId(Long BillId) {
+        System.out.println("navigateToAdminBillByAtomicBillTypeByBillId");
+        System.out.println("BillId = " + BillId);
+        if (BillId == null) {
+            JsfUtil.addErrorMessage("Bill ID is required");
+            return null;
+        }
+
+        Bill foundBill = billFacade.find(BillId);
+        System.out.println("foundBill = " + foundBill);
+        if (foundBill == null) {
+            JsfUtil.addErrorMessage("Bill not found");
+            return null;
+        }
+
+        this.bill = foundBill;
+        return navigateToAdminBillByAtomicBillType();
+    }
+
     public String navigateToViewBillByAtomicBillTypeBySelectedId() {
         System.out.println("navigateToViewBillByAtomicBillTypeBySelectedId called");
         System.out.println("selectedBillId = " + selectedBillId);

--- a/src/main/java/com/divudi/bean/common/SearchController.java
+++ b/src/main/java/com/divudi/bean/common/SearchController.java
@@ -12564,19 +12564,19 @@ public class SearchController implements Serializable {
         StringBuilder jpql = new StringBuilder(
             "SELECT new com.divudi.core.data.dto.BillListReportDTO("
             + "b.id, "
-            + "b.deptId, "
-            + "b.billClassType, "  // billClass is a trasnsient attribute
+            + "COALESCE(b.deptId, ''), "
+            + "COALESCE(b.billClassType, ''), "  // billClass is a trasnsient attribute
             + "b.billTypeAtomic, "  // billTypeAtomic enum - DTO will convert to string
             + "b.paymentMethod, "  // paymentMethod enum - DTO will convert to string
-            + "b.patient.person.name, " // b.patient.person.nameWithTitle is a transient
+            + "COALESCE(b.patient.person.name, ''), " // b.patient.person.nameWithTitle is a transient
             + "b.createdAt, "
-            + "b.creater.name, "
-            + "b.retired, "
-            + "b.cancelled, "
-            + "b.refunded, "
-            + "b.total, "
-            + "b.discount, "
-            + "b.netTotal) "
+            + "COALESCE(b.creater.name, ''), "
+            + "COALESCE(b.retired, false), "
+            + "COALESCE(b.cancelled, false), "
+            + "COALESCE(b.refunded, false), "
+            + "COALESCE(b.total, 0), "
+            + "COALESCE(b.discount, 0), "
+            + "COALESCE(b.netTotal, 0)) "
             + "FROM Bill b "
             + "WHERE 1=1 "
         );

--- a/src/main/webapp/analytics/bills_dto.xhtml
+++ b/src/main/webapp/analytics/bills_dto.xhtml
@@ -281,6 +281,33 @@
                                     </f:facet>
                                 </p:column>
 
+                                <p:column headerText="Actions" exportable="false" width="9em">
+                                    <p:commandButton
+                                        title="View"
+                                        icon="fa fa-eye"
+                                        class="m-1 ui-button-info"
+                                        action="#{billSearch.navigateToViewBillByAtomicBillTypeByBillId(dto.billId)}"
+                                        ajax="false">
+                                    </p:commandButton>
+
+                                    <p:commandButton
+                                        title="Manage"
+                                        icon="fa fa-tools"
+                                        class="m-1 ui-button-warning"
+                                        action="#{billSearch.navigateToManageBillByAtomicBillTypeByBillId(dto.billId)}"
+                                        ajax="false">
+                                    </p:commandButton>
+
+                                    <p:commandButton
+                                        title="Admin"
+                                        icon="fa fa-shield-alt"
+                                        class="m-1 ui-button-danger"
+                                        action="#{billSearch.navigateToAdminBillByAtomicBillTypeByBillId(dto.billId)}"
+                                        ajax="false"
+                                        rendered="#{webUserController.hasPrivilege('Developers')}">
+                                    </p:commandButton>
+                                </p:column>
+
                             </p:dataTable>
 
                         </div>


### PR DESCRIPTION
Fixed two critical issues in the optimized bills analytics page:

1. Added COALESCE to DTO query to prevent null exclusions
   - Bills with null patient, creator, or other fields were being excluded
   - Applied COALESCE to all nullable fields (deptId, billClassType, patient.person.name, creater.name, status flags, and amounts)
   - Ensures all bills are included in the report regardless of null values

2. Added missing action buttons (View, Manage, Admin)
   - Created new navigation methods in BillSearch: navigateToManageBillByAtomicBillTypeByBillId() and navigateToAdminBillByAtomicBillTypeByBillId()
   - Added Actions column to bills_dto.xhtml with View, Manage, and Admin buttons
   - Admin button restricted to Developers privilege
   - All buttons use Bill ID for DTO pattern compatibility

The DTO-based page now has feature parity with the legacy page while maintaining performance benefits.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added bill export capabilities in JSON, PDF, and Excel formats for enhanced data sharing and archival.
  * Introduced comprehensive financial reporting suite including itemized sales summaries, income breakdowns by category, and detailed cashier reports.
  * Added quick-action buttons (View, Manage, Admin) to bill listings for streamlined navigation.
  * Enabled analytics downloads for bills and associated line items.
  * Added ability to navigate to related purchase orders from bill records.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->