### PR TITLE
Fix GitHub issue #16592

### DIFF
--- a/src/main/java/com/divudi/bean/pharmacy/SaleReturnController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/SaleReturnController.java
@@ -529,6 +529,32 @@ public class SaleReturnController implements Serializable, com.divudi.bean.commo
         return false;
     }
 
+    /**
+     * Validates if the credit bill has been fully or partially settled.
+     * Prevents returns for bills where credit companies have already made payments.
+     *
+     * @return true if credit is settled (validation fails), false if not settled (validation passes)
+     */
+    private boolean isCreditSettled() {
+        if (getBill() == null) {
+            return false; // No bill to validate
+        }
+
+        // Check if this is a credit bill
+        if (getBill().getPaymentMethod() != PaymentMethod.Credit) {
+            return false; // Not a credit bill, allow return
+        }
+
+        // Check if credit has been settled (fully or partially)
+        // Any positive value in these fields indicates settlement has occurred
+        boolean hasSettlement =
+            (getBill().getPaidAmount() > 0.01) ||
+            (getBill().getSettledAmountByPatient() > 0.01) ||
+            (getBill().getSettledAmountBySponsor() > 0.01);
+
+        return hasSettlement;
+    }
+
     public void settle() {
         if (getReturnBill().getTotal() == 0) {
             JsfUtil.addErrorMessage("Total is Zero cant' return");
@@ -546,6 +572,12 @@ public class SaleReturnController implements Serializable, com.divudi.bean.commo
                 JsfUtil.addErrorMessage("Item '" + bi.getItem().getName() + "' is not allowed to be returned. Refunds are not permitted for this item.");
                 return;
             }
+        }
+
+        // Check if credit bill has been settled (fully or partially)
+        if (isCreditSettled()) {
+            JsfUtil.addErrorMessage("Cannot return this bill. The credit has been fully or partially settled by the credit company.");
+            return;
         }
 
         if (returnPaymentMethod == null) {


### PR DESCRIPTION
Closes #16592

Added validation in SaleReturnController to prevent returns of pharmacy retail bills when the credit has been fully or partially settled by the credit company.

Changes:
- Added isCreditSettled() validation method to check if a credit bill has any settlement (paidAmount, settledAmountByPatient, or settledAmountBySponsor > 0)
- Integrated validation into settle() method to block returns with appropriate error message
- Ensures financial integrity by preventing returns after credit companies have made payments

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**Bug Fixes**
- Implemented enhanced validation to prevent pharmacy sale returns for credit bills that have already been settled. The system now properly detects when credit bills have been fully or partially paid and blocks the return process, displaying an appropriate error message to prevent erroneous return transactions from being processed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->