### PR TITLE
Fix the is operator

### DIFF
--- a/src/main/java/com/divudi/bean/pharmacy/PharmacyBillSearch.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacyBillSearch.java
@@ -4332,6 +4332,11 @@ public class PharmacyBillSearch implements Serializable {
             JsfUtil.addErrorMessage("Cancelled bills cannot be returned");
             return null;
         }
+        // Check if credit has been partially or fully settled
+        if (bill.getPaidAmount() > 0) {
+            JsfUtil.addErrorMessage("Cannot return items for bills with partially or fully settled credit. Please contact the administrator.");
+            return null;
+        }
         // Set the bill in PreReturnController and navigate directly to return process
         preReturnController.setBill(bill);
         return "/pharmacy/pharmacy_bill_return_pre?faces-redirect=true";
@@ -4348,6 +4353,11 @@ public class PharmacyBillSearch implements Serializable {
         }
         if (bill.isCancelled()) {
             JsfUtil.addErrorMessage("Cancelled bills cannot be returned");
+            return null;
+        }
+        // Check if credit has been partially or fully settled
+        if (bill.getPaidAmount() > 0) {
+            JsfUtil.addErrorMessage("Cannot return items for bills with partially or fully settled credit. Please contact the administrator.");
             return null;
         }
         // Set the bill in SaleReturnController and navigate directly to return process

--- a/src/main/java/com/divudi/bean/pharmacy/PreReturnController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PreReturnController.java
@@ -209,6 +209,11 @@ public class PreReturnController implements Serializable {
     StaffService staffBean;
 
     public void settle() {
+        // Check if credit has been partially or fully settled
+        if (bill != null && bill.getPaidAmount() > 0) {
+            JsfUtil.addErrorMessage("Cannot return items for bills with partially or fully settled credit. Please contact the administrator.");
+            return;
+        }
 
         if (getReturnBill().getTotal() == 0) {
             JsfUtil.addErrorMessage("Total is Zero cant' return");

--- a/src/main/java/com/divudi/bean/pharmacy/SaleReturnController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/SaleReturnController.java
@@ -108,6 +108,11 @@ public class SaleReturnController implements Serializable, com.divudi.bean.commo
             JsfUtil.addErrorMessage("Cancelled Bills CAN NOT BE returned");
             return null;
         }
+        // Check if credit has been partially or fully settled
+        if (bill.getPaidAmount() > 0) {
+            JsfUtil.addErrorMessage("Cannot return items for bills with partially or fully settled credit. Please contact the administrator.");
+            return null;
+        }
         returnBill = null;
         finalReturnBill = null;
         printPreview = false;
@@ -530,6 +535,12 @@ public class SaleReturnController implements Serializable, com.divudi.bean.commo
     }
 
     public void settle() {
+        // Check if credit has been partially or fully settled
+        if (bill != null && bill.getPaidAmount() > 0) {
+            JsfUtil.addErrorMessage("Cannot return items for bills with partially or fully settled credit. Please contact the administrator.");
+            return;
+        }
+
         if (getReturnBill().getTotal() == 0) {
             JsfUtil.addErrorMessage("Total is Zero cant' return");
             return;


### PR DESCRIPTION
Closes #16597

- Added validation to prevent bill returns when credit has been partially or fully settled
- Implemented checks in PreReturnController.settle() to block return processing
- Added validation in PharmacyBillSearch navigation methods (navigateToReturnItemsOnly, navigateToReturnGoodsAndPayment)
- Added validation in SaleReturnController methods for consistency across both pre and retail return flows
- Validation checks bill.getPaidAmount() > 0 to identify settled credits
- Displays clear error message directing users to contact administrator
- Ensures feature parity with retail page validation requirements

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Added validation to prevent returning items from partially or fully settled bills. System now displays an error message when users attempt to return items from bills with any payment already received, protecting transaction integrity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->