### PR TITLE
Fix Critical Issue

### DIFF
--- a/src/main/java/com/divudi/bean/common/ExcelController.java
+++ b/src/main/java/com/divudi/bean/common/ExcelController.java
@@ -197,6 +197,9 @@ public class ExcelController {
             case "ChannelBookingsCancellation":
                 return addDataToExcelForChannelBookingsCancellation(dataSheet, startRow, addingBundle);
             case "cashierSummaryOpd":
+            case "OutpatientCreditSettling":
+            case "OutpatientCreditSettlingCancel":
+            case "OutpatientCreditSettlingAdjustments":
                 return addDataToExcelForcashierSummaryOpd(dataSheet, startRow, addingBundle);
         }
         return startRow++;


### PR DESCRIPTION
Added missing bundle types to Excel export:
- OutpatientCreditSettling
- OutpatientCreditSettlingCancel
- OutpatientCreditSettlingAdjustments

These sections were appearing in the page view but were missing from the Excel export, causing discrepancies. They now use the same export method as cashierSummaryOpd since they share the same data structure.

Closes #16620

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for exporting outpatient credit settling operations, cancellations, and adjustments to Excel reports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->