### PR TITLE
Add Favourite Medicines feature to OPD Visit

### DIFF
--- a/src/main/webapp/emr/opd_visit.xhtml
+++ b/src/main/webapp/emr/opd_visit.xhtml
@@ -427,6 +427,8 @@
                                                     <h:outputText styleClass="fas fa-pills"/>
                                                     <p:outputLabel class="mx-4" value="Medicines" />
 
+                                                    <p:commandButton value="Add Favourite" process="@this" class='ui-button-success' icon='fas fa-star' style="float: right; margin-right: 5px;" update="#{p:resolveFirstComponentWithId('medicines',view).clientId} #{p:resolveFirstComponentWithId('msg',view).clientId}" action="#{patientEncounterController.addFavouriteMedicines(patientController.current)}"/>
+
                                                     <p:commandButton value="Refill" process="@this" class='ui-button-warning' icon='fas fa-fill' style="float: right;" update="#{p:resolveFirstComponentWithId('medicines',view).clientId} #{p:resolveFirstComponentWithId('msg',view).clientId}" action="#{patientEncounterController.fillMedicines(patientController.current)}"/>
 
                                                 </f:facet>


### PR DESCRIPTION
Implements 3-tier priority lookup for favourite medicines:
1. By weight formula (under construction - skipped)
2. By patient weight group (primary method)
3. By patient age group (fallback)

Backend changes:
- Added addFavouriteMedicines() method in PatientEncounterController
- Integrates with existing FavouriteController for template lookup
- Creates prescriptions with full details (dose, frequency, duration)
- Shows contextual success/warning messages

Frontend changes:
- Added "Add Favourite" button next to Refill in medicines panel
- Uses success styling (green) with star icon
- Updates medicines list and shows appropriate feedback

Closes #16627