### PR TITLE
Add confirmation dialogs to settlement buttons

### DIFF
--- a/src/main/webapp/pharmacy/pharmacy_direct_purchase_return_form.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_direct_purchase_return_form.xhtml
@@ -306,13 +306,15 @@
                                                 rendered="#{directPurchaseReturnWorkflowController.currentBill.checkedBy eq null 
                                                             and webUserController.hasPrivilege('FinalizeDirectPurchaseReturn')}">
                                             </p:commandButton>
-                                            <p:commandButton 
-                                                value="Approve" 
+                                            <p:commandButton
+                                                value="Approve"
                                                 action="#{directPurchaseReturnWorkflowController.approve}"
                                                 ajax="false"
-                                                icon="fas fa-check-circle" 
+                                                icon="fas fa-check-circle"
                                                 class="ui-button-success mx-1"
-                                                rendered="#{directPurchaseReturnWorkflowController.currentBill.checkedBy ne null and (directPurchaseReturnWorkflowController.currentBill.completed eq false or directPurchaseReturnWorkflowController.currentBill.completed eq null) and webUserController.hasPrivilege('ApproveDirectPurchaseReturn')}">
+                                                rendered="#{directPurchaseReturnWorkflowController.currentBill.checkedBy ne null and (directPurchaseReturnWorkflowController.currentBill.completed eq false or directPurchaseReturnWorkflowController.currentBill.completed eq null) and webUserController.hasPrivilege('ApproveDirectPurchaseReturn')}"
+                                                onclick="if (!confirm('Are you sure you want to approve this direct purchase return?'))
+                                                            return false;">
                                             </p:commandButton>
                                         </div>
                                     </div>

--- a/src/main/webapp/pharmacy/pharmacy_grn_approval_finalized.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_grn_approval_finalized.xhtml
@@ -20,7 +20,9 @@
                         class="ui-button-success"
                         icon="fas fa-check"
                         ajax="false"
-                        style="float: right;">
+                        style="float: right;"
+                        onclick="if (!confirm('Are you sure you want to settle this GRN?'))
+                                    return false;">
                     </p:commandButton>
                 </f:facet>
                 <h:panelGroup >

--- a/src/main/webapp/pharmacy/pharmacy_grn_return_approval.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_grn_return_approval.xhtml
@@ -25,7 +25,11 @@
                                 <h:outputText value="#{r.deptId}" />
                             </p:column>
                             <p:column headerText="Approve">
-                                <p:commandButton value="Approve" action="#{grnReturnApprovalController.approveReturn(r)}" update="@form"/>
+                                <p:commandButton value="Approve"
+                                                 action="#{grnReturnApprovalController.approveReturn(r)}"
+                                                 update="@form"
+                                                 onclick="if (!confirm('Are you sure you want to approve this GRN return?'))
+                                                             return false;"/>
                             </p:column>
                         </p:dataTable>
                     </p:panel>

--- a/src/main/webapp/pharmacy/pharmacy_transfer_receive_approval.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_transfer_receive_approval.xhtml
@@ -31,7 +31,9 @@
                             class="ui-button-success mx-1"
                             icon="fas fa-check"
                             ajax="false"
-                            style="float: right;">
+                            style="float: right;"
+                            onclick="if (!confirm('Are you sure you want to settle this transfer receive?'))
+                                        return false;">
                         </p:commandButton>
 
 


### PR DESCRIPTION
Added confirmation dialogs to the following pages:
- GRN Approval (pharmacy_grn_approval_finalized.xhtml) - Settle button
- Transfer Receive Approval (pharmacy_transfer_receive_approval.xhtml) - Settle button
- GRN Return Approval (pharmacy_grn_return_approval.xhtml) - Approve button
- Direct Purchase Return Approval (pharmacy_direct_purchase_return_form.xhtml) - Approve button

All confirmations use simple JavaScript confirm() dialogs to prevent accidental clicks on critical settlement and approval actions.

Note: Direct Purchase and Transfer Issue pages already had confirmations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**New Features**
- Added user confirmation prompts to critical action buttons across pharmacy modules, including Approve buttons in Direct Purchase Return and GRN Return forms, and Settle buttons in GRN Approval Finalization and Transfer Receive modules. These confirmation dialogs require users to explicitly confirm their intent before executing these important actions, helping prevent accidental submissions and ensuring safer form processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->