### PR TITLE
Fix issue from ticket number

### DIFF
--- a/src/main/webapp/reports/inventoryReports/consumption.xhtml
+++ b/src/main/webapp/reports/inventoryReports/consumption.xhtml
@@ -293,46 +293,6 @@
                                         </h:outputLabel>
                                     </p:column>
                                     <p:columnGroup type="footer">
-                                        <p:row>
-                                            <p:column colspan="1">
-                                                <f:facet name="footer">
-                                                    <h:outputLabel value="Total" style="font-weight: bold;"/>
-                                                </f:facet>
-                                            </p:column>
-                                            <p:column style="text-align: right; font-weight: bold;">
-                                                <f:facet name="footer">
-                                                    <h:outputLabel
-                                                        value="#{pharmacyController.pharmacyTotals.get(map.key)[0]}">
-                                                        <f:convertNumber pattern="#,##0.00"/>
-                                                    </h:outputLabel>
-                                                </f:facet>
-                                            </p:column>
-                                            <p:column style="text-align: right; font-weight: bold;">
-                                                <f:facet name="footer">
-                                                    <h:outputLabel
-                                                        value="#{pharmacyController.pharmacyTotals.get(map.key)[1]}">
-                                                        <f:convertNumber pattern="#,##0.00"/>
-                                                    </h:outputLabel>
-                                                </f:facet>
-                                            </p:column>
-                                            <p:column style="text-align: right; font-weight: bold;">
-                                                <f:facet name="footer">
-                                                    <h:outputLabel
-                                                        value="#{pharmacyController.pharmacyTotals.get(map.key)[2]}">
-                                                        <f:convertNumber pattern="#,##0.00"/>
-                                                    </h:outputLabel>
-                                                </f:facet>
-                                            </p:column>
-                                            <p:column style="text-align: right; font-weight: bold;">
-                                                <f:facet name="footer">
-                                                    <h:outputLabel
-                                                        value="#{pharmacyController.pharmacyTotals.get(map.key)[3]}">
-                                                        <f:convertNumber pattern="#,##0.00"/>
-                                                    </h:outputLabel>
-                                                </f:facet>
-                                            </p:column>
-                                        </p:row>
-
                                         <p:row rendered="#{status.last}">
                                             <p:column colspan="1">
                                                 <f:facet name="footer">


### PR DESCRIPTION
Removed the redundant department-level total row from the consumption summary report. The report was displaying two "Total" rows when viewing single department or last department results, causing confusion.

Changes:
- Removed per-department total row that used pharmacyTotals.get(map.key)
- Kept the grand total row that appears at the end (status.last)
- Users now see only one clear "Total" row showing overall totals

Closes #16656

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Simplified the Department Summary footer in Consumption Reports by removing per-department total aggregations (Purchase Value, Cost Value, Retail Value, and Net Total). The footer now displays only overall totals, improving report clarity and reducing visual complexity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->