### PR TITLE
Fix SQL injection in admission patient search

### DIFF
--- a/src/main/java/com/divudi/bean/inward/AdmissionPatientChangeController.java
+++ b/src/main/java/com/divudi/bean/inward/AdmissionPatientChangeController.java
@@ -93,12 +93,13 @@ public class AdmissionPatientChangeController implements Serializable, Controlle
             sql = "select c from Admission c "
                     + " where c.retired=false "
                     + " and c.discharged=false "
-                    + " and ((c.bhtNo) like '%" + query.toUpperCase() + "%' "
-                    + " or (c.patient.person.name) like '%" + query.toUpperCase() + "%' "
-                    + " or (c.patient.phn) =:q )"
+                    + " and (upper(c.bhtNo) like :qLike "
+                    + " or upper(c.patient.person.name) like :qLike "
+                    + " or upper(c.patient.phn) = :qExact )"
                     + " order by c.bhtNo";
 
-            h.put("q", query.toUpperCase());
+            h.put("qLike", "%" + query.toUpperCase() + "%");
+            h.put("qExact", query.toUpperCase());
             suggestions = admissionFacade.findByJpql(sql, h, 20);
         }
         return suggestions;


### PR DESCRIPTION
Replace direct string concatenation with parameterized JPQL queries in AdmissionPatientChangeController.completeAdmission() method. User input is now properly escaped using named parameters (:qLike, :qExact) instead of being directly concatenated into the query string.

Security improvements:
- Use upper() on entity fields for case-insensitive matching
- Build wildcard values safely in HashMap
- Eliminate SQL injection attack vector in BHT and patient name search

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced admission patient search functionality with improved matching capabilities. Searches for patient identifiers and phone numbers are now case-insensitive and more flexible, providing a better user experience when locating admission records.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->