### PR TITLE
Fix links on pharmacy search page

### DIFF
--- a/src/main/webapp/resources/pharmacy/search/adjustment.xhtml
+++ b/src/main/webapp/resources/pharmacy/search/adjustment.xhtml
@@ -26,7 +26,7 @@
             </f:facet>
 
             <p:column>
-                <p:commandButton ajax="false" action="/pharmacy/pharmacy_reprint_adjustment" value="View BIll">
+                <p:commandButton ajax="false" action="/pharmacy/pharmacy_reprint_adjustment?faces-redirect=true" value="View BIll">
                     <f:setPropertyActionListener value="#{bill}" target="#{pharmacyBillSearch.bill}"/>
                 </p:commandButton>
             </p:column>

--- a/src/main/webapp/resources/pharmacy/search/grn_payment.xhtml
+++ b/src/main/webapp/resources/pharmacy/search/grn_payment.xhtml
@@ -43,7 +43,7 @@
 
 
             <p:column headerText="GRN NO" >
-                <h:commandLink action="/dealerPayment/bill_dealor_all" value="#{bill.referenceBill.deptId}">
+                <h:commandLink action="/dealerPayment/bill_dealor_all?faces-redirect=true" value="#{bill.referenceBill.deptId}">
                     <h:outputLabel  ></h:outputLabel>
                     <f:setPropertyActionListener value="#{bill}" target="#{supplierPaymentController.current}"/>
                     <f:setPropertyActionListener value="#{bill.billItems}" target="#{supplierPaymentController.billItems}"/>
@@ -51,7 +51,7 @@
                 </h:commandLink>
             </p:column>      
             <p:column headerText="GRN Date">
-                <h:commandLink action="/dealerPayment/bill_dealor_all" value="#{bill.referenceBill.createdAt}">
+                <h:commandLink action="/dealerPayment/bill_dealor_all?faces-redirect=true" value="#{bill.referenceBill.createdAt}">
                     <h:outputLabel  ></h:outputLabel>
                     <f:setPropertyActionListener value="#{bill}" target="#{supplierPaymentController.current}"/>
                     <f:setPropertyActionListener value="#{bill.billItems}" target="#{supplierPaymentController.billItems}"/>
@@ -59,7 +59,7 @@
                 </h:commandLink>
             </p:column>    
             <p:column headerText="Invoice NO" >
-                <h:commandLink action="/dealerPayment/bill_dealor_all" value="#{bill.deptId}">
+                <h:commandLink action="/dealerPayment/bill_dealor_all?faces-redirect=true" value="#{bill.deptId}">
                     <h:outputLabel  ></h:outputLabel>
                     <f:setPropertyActionListener value="#{bill}" target="#{supplierPaymentController.current}"/>
                     <f:setPropertyActionListener value="#{bill.billItems}" target="#{supplierPaymentController.billItems}"/>
@@ -67,7 +67,7 @@
                 </h:commandLink>
             </p:column>  
             <p:column headerText="Invoice Date" >
-                <h:commandLink action="/dealerPayment/bill_dealor_all" value="#{bill.billTime}">
+                <h:commandLink action="/dealerPayment/bill_dealor_all?faces-redirect=true" value="#{bill.billTime}">
                     <h:outputLabel  value="#{bill.billTime}">
                         <f:convertDateTime  timeZone="Asia/Colombo" pattern="#{sessionController.applicationPreference.shortDateFormat}" />
                     </h:outputLabel>                    
@@ -77,7 +77,7 @@
                 </h:commandLink>
             </p:column>
             <p:column headerText="Delaor Name">
-                <h:commandLink action="/dealerPayment/bill_dealor_all" value="#{bill.toInstitution.name}">
+                <h:commandLink action="/dealerPayment/bill_dealor_all?faces-redirect=true" value="#{bill.toInstitution.name}">
                     <h:outputLabel  ></h:outputLabel>
                     <f:setPropertyActionListener value="#{bill}" target="#{supplierPaymentController.current}"/>
                     <f:setPropertyActionListener value="#{bill.billItems}" target="#{supplierPaymentController.billItems}"/>
@@ -85,7 +85,7 @@
                 </h:commandLink>
             </p:column>
             <p:column headerText="Billed At"  >
-                <h:commandLink action="/dealerPayment/bill_dealor_all" value="#{bill.createdAt}">
+                <h:commandLink action="/dealerPayment/bill_dealor_all?faces-redirect=true" value="#{bill.createdAt}">
                     <h:outputLabel value="#{bill.createdAt}" >
                         <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateTimeFormat}"/>
                     </h:outputLabel>
@@ -108,14 +108,14 @@
                 </h:panelGroup>
             </p:column>                 
             <p:column headerText="Billed By" >
-                <h:commandLink action="/dealerPayment/bill_dealor_all" value="#{bill.creater}">
+                <h:commandLink action="/dealerPayment/bill_dealor_all?faces-redirect=true" value="#{bill.creater}">
                     <f:setPropertyActionListener value="#{bill}" target="#{pharmacyBillSearch.bill}"/>
                     <f:setPropertyActionListener value="#{bill.billItems}" target="#{supplierPaymentController.billItems}"/>
                     <f:setPropertyActionListener value="true" target="#{supplierPaymentController.printPreview}"/>
                 </h:commandLink>
             </p:column>               
             <p:column headerText="Payment Method"  >
-                <h:commandLink action="/dealerPayment/bill_dealor_all" value="#{bill.paymentMethod}">
+                <h:commandLink action="/dealerPayment/bill_dealor_all?faces-redirect=true" value="#{bill.paymentMethod}">
                     <f:setPropertyActionListener value="#{bill}" target="#{supplierPaymentController.current}"/>
                     <f:setPropertyActionListener value="#{bill.billItems}" target="#{supplierPaymentController.billItems}"/>
                     <f:setPropertyActionListener value="true" target="#{supplierPaymentController.printPreview}"/>

--- a/src/main/webapp/resources/pharmacy/search/grn_return_without_traising.xhtml
+++ b/src/main/webapp/resources/pharmacy/search/grn_return_without_traising.xhtml
@@ -31,21 +31,21 @@
             </f:facet>
 
             <p:column headerText="GRN Return No" >
-                <h:commandLink action="/pharmacy/pharmacy_return_withouttresing" value="#{bill.deptId}">
+                <h:commandLink action="/pharmacy/pharmacy_return_withouttresing?faces-redirect=true" value="#{bill.deptId}">
                     <h:outputLabel  ></h:outputLabel>
                     <f:setPropertyActionListener value="#{bill}" target="#{pharmacyReturnwithouttresing.printBill}"/>
                     <f:setPropertyActionListener value="true" target="#{pharmacyReturnwithouttresing.billPreview}"/>
                 </h:commandLink>
-            </p:column> 
+            </p:column>
             <p:column headerText="Delaor Name" >
-                <h:commandLink action="/pharmacy/pharmacy_return_withouttresing" value="#{bill.toInstitution.name}">
+                <h:commandLink action="/pharmacy/pharmacy_return_withouttresing?faces-redirect=true" value="#{bill.toInstitution.name}">
                     <h:outputLabel  ></h:outputLabel>
                     <f:setPropertyActionListener value="#{bill}" target="#{pharmacyReturnwithouttresing.printBill}"/>
                     <f:setPropertyActionListener value="true" target="#{pharmacyReturnwithouttresing.billPreview}"/>
                 </h:commandLink>
             </p:column>
             <p:column headerText="Billed At"  >
-                <h:commandLink action="/pharmacy/pharmacy_return_withouttresing" >
+                <h:commandLink action="/pharmacy/pharmacy_return_withouttresing?faces-redirect=true" >
                     <h:outputLabel value="#{bill.createdAt}" >
                         <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateTimeFormat}"/>
                     </h:outputLabel>
@@ -65,9 +65,9 @@
                         <f:convertDateTime pattern="dd MMM yyyy hh mm a"/>
                     </h:outputLabel>
                 </h:panelGroup>
-            </p:column>                 
+            </p:column>
             <p:column headerText="Billed By" >
-                <h:commandLink action="/pharmacy/pharmacy_return_withouttresing" >
+                <h:commandLink action="/pharmacy/pharmacy_return_withouttresing?faces-redirect=true" >
                     <h:outputLabel value="#{bill.creater.webUserPerson.name}" >                                      
                     </h:outputLabel>
                     <f:setPropertyActionListener value="#{bill}" target="#{pharmacyReturnwithouttresing.printBill}"/>
@@ -93,7 +93,7 @@
                 </h:commandLink>
             </p:column>                               -->
             <p:column headerText="Net Return Value" style="text-align: right;"  >
-                <h:commandLink action="/pharmacy/pharmacy_return_withouttresing" >
+                <h:commandLink action="/pharmacy/pharmacy_return_withouttresing?faces-redirect=true" >
                     <h:outputLabel value="#{bill.netTotal}" >
                         <f:convertNumber pattern="#,##0.00"/>
                     </h:outputLabel>
@@ -101,9 +101,9 @@
                     <f:setPropertyActionListener value="true" target="#{pharmacyReturnwithouttresing.billPreview}"/>
                 </h:commandLink>
             </p:column>
-            
+
             <p:column headerText="Retail Sale Value" style="text-align: right;"  >
-                <h:commandLink action="/pharmacy/pharmacy_return_withouttresing" >
+                <h:commandLink action="/pharmacy/pharmacy_return_withouttresing?faces-redirect=true" >
                     <h:outputLabel value="#{bill.pharmacyBill.saleValue}" >
                         <f:convertNumber pattern="#,##0.00"/>
                     </h:outputLabel>

--- a/src/main/webapp/resources/pharmacy/search/pharmacy_transfer_recieve.xhtml
+++ b/src/main/webapp/resources/pharmacy/search/pharmacy_transfer_recieve.xhtml
@@ -29,7 +29,7 @@
                 <h:outputLabel value="Pharmacy Transfer Receive"/>
             </f:facet>
             <p:column>
-                <p:commandButton ajax="false" value="View Bill" action="pharmacy_reprint_transfer_receive">
+                <p:commandButton ajax="false" value="View Bill" action="pharmacy_reprint_transfer_receive?faces-redirect=true">
                     <f:setPropertyActionListener target="#{pharmacyBillSearch.bill}" value="#{bill}"/>
                 </p:commandButton>
             </p:column>

--- a/src/main/webapp/resources/pharmacy/search/pharmacy_whole_sale.xhtml
+++ b/src/main/webapp/resources/pharmacy/search/pharmacy_whole_sale.xhtml
@@ -38,7 +38,7 @@
             </f:facet>
 
             <p:column>
-                <p:commandButton ajax="false" action="/pharmacy/pharmacy_reprint_bill" value="View BIll">
+                <p:commandButton ajax="false" action="/pharmacy/pharmacy_reprint_bill?faces-redirect=true" value="View BIll">
                     <f:setPropertyActionListener value="#{bill}" target="#{pharmacyBillSearch.bill}"/>
                 </p:commandButton>
             </p:column>

--- a/src/main/webapp/resources/pharmacy/search/po_approve.xhtml
+++ b/src/main/webapp/resources/pharmacy/search/po_approve.xhtml
@@ -32,37 +32,37 @@
             </f:facet>
 
             <p:column headerText="PO NO"  >
-                <h:commandLink action="/pharmacy/pharmacy_reprint_po" value="#{bill.deptId}">
+                <h:commandLink action="/pharmacy/pharmacy_reprint_po?faces-redirect=true" value="#{bill.deptId}">
                     <h:outputLabel  ></h:outputLabel>
                     <f:setPropertyActionListener value="#{bill}" target="#{pharmacyBillSearch.bill}"/>
                 </h:commandLink>
             </p:column>
             <p:column headerText="Requested No"  >
-                <h:commandLink action="/pharmacy/pharmacy_reprint_po" value="#{bill.referenceBill.deptId}">
+                <h:commandLink action="/pharmacy/pharmacy_reprint_po?faces-redirect=true" value="#{bill.referenceBill.deptId}">
                     <h:outputLabel  ></h:outputLabel>
                     <f:setPropertyActionListener value="#{bill}" target="#{pharmacyBillSearch.bill}"/>
                 </h:commandLink>
             </p:column>            
             <p:column headerText="Requested From" >
-                <h:commandLink action="/pharmacy/pharmacy_reprint_po" value="#{bill.department.name}">
+                <h:commandLink action="/pharmacy/pharmacy_reprint_po?faces-redirect=true" value="#{bill.department.name}">
                     <h:outputLabel  ></h:outputLabel>
                     <f:setPropertyActionListener value="#{bill}" target="#{pharmacyBillSearch.bill}"/>
                 </h:commandLink>
             </p:column>   
             <p:column headerText="Requested Person" >
-                <h:commandLink action="/pharmacy/pharmacy_reprint_po" value="#{bill.referenceBill.creater.webUserPerson.name}">
+                <h:commandLink action="/pharmacy/pharmacy_reprint_po?faces-redirect=true" value="#{bill.referenceBill.creater.webUserPerson.name}">
                     <h:outputLabel  ></h:outputLabel>
                     <f:setPropertyActionListener value="#{bill}" target="#{pharmacyBillSearch.bill}"/>
                 </h:commandLink>
             </p:column>
             <p:column headerText="Delaor Name" >
-                <h:commandLink action="/pharmacy/pharmacy_reprint_po" value="#{bill.toInstitution.name}">
+                <h:commandLink action="/pharmacy/pharmacy_reprint_po?faces-redirect=true" value="#{bill.toInstitution.name}">
                     <h:outputLabel  ></h:outputLabel>
                     <f:setPropertyActionListener value="#{bill}" target="#{pharmacyBillSearch.bill}"/>
                 </h:commandLink>
             </p:column>
             <p:column headerText="Billed At"  >
-                <h:commandLink action="pharmacy_reprint_grn_return" >
+                <h:commandLink action="pharmacy_reprint_grn_return?faces-redirect=true" >
                     <h:outputLabel value="#{bill.createdAt}" >
                         <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateTimeFormat}"/>
                     </h:outputLabel>
@@ -83,7 +83,7 @@
                 </h:panelGroup>
             </p:column>                 
             <p:column headerText="Approved By" >
-                <h:commandLink action="pharmacy_reprint_grn_return" >
+                <h:commandLink action="pharmacy_reprint_grn_return?faces-redirect=true" >
                     <h:outputLabel value="#{bill.creater.webUserPerson.name}" >                                      
                     </h:outputLabel>
                     <f:setPropertyActionListener value="#{bill}" target="#{pharmacyBillSearch.bill}"/>
@@ -102,13 +102,13 @@
                 </h:panelGroup>
             </p:column>        
             <p:column headerText="Payment Method">
-                <h:commandLink action="/pharmacy/pharmacy_reprint_po" >
+                <h:commandLink action="/pharmacy/pharmacy_reprint_po?faces-redirect=true" >
                     <h:outputLabel value="#{bill.paymentMethod}" ></h:outputLabel>
                     <f:setPropertyActionListener value="#{bill}" target="#{pharmacyBillSearch.bill}"/>
                 </h:commandLink>
             </p:column>                               
             <p:column headerText="Net Value" >
-                <h:commandLink action="/pharmacy/pharmacy_reprint_po" >
+                <h:commandLink action="/pharmacy/pharmacy_reprint_po?faces-redirect=true" >
                     <h:outputLabel value="#{bill.netTotal}" >
                         <f:convertNumber pattern="#,##0.00"/>
                     </h:outputLabel>

--- a/src/main/webapp/resources/pharmacy/search/po_request.xhtml
+++ b/src/main/webapp/resources/pharmacy/search/po_request.xhtml
@@ -30,7 +30,7 @@
             </f:facet>
             
             <p:column headerText="Req No" >
-                <h:commandLink action="pharmacy_reprint_order_request" value="#{bill.insId}">
+                <h:commandLink action="pharmacy_reprint_order_request?faces-redirect=true" value="#{bill.insId}">
                     <h:outputLabel  ></h:outputLabel>
                     <f:setPropertyActionListener value="#{bill}" target="#{pharmacyBillSearch.bill}"/>
                 </h:commandLink>
@@ -38,19 +38,19 @@
 
             
             <p:column headerText="Requested From"  >
-                <h:commandLink action="pharmacy_reprint_order_request" value="#{bill.department.name}">
+                <h:commandLink action="pharmacy_reprint_order_request?faces-redirect=true" value="#{bill.department.name}">
                     <h:outputLabel  ></h:outputLabel>
                     <f:setPropertyActionListener value="#{bill}" target="#{pharmacyBillSearch.bill}"/>
                 </h:commandLink>
             </p:column>                 
             <p:column headerText="Delaor Name"  >
-                <h:commandLink action="pharmacy_reprint_order_request" value="#{bill.toInstitution.name}">
+                <h:commandLink action="pharmacy_reprint_order_request?faces-redirect=true" value="#{bill.toInstitution.name}">
                     <h:outputLabel  ></h:outputLabel>
                     <f:setPropertyActionListener value="#{bill}" target="#{pharmacyBillSearch.bill}"/>
                 </h:commandLink>
             </p:column>
             <p:column headerText="Billed At"  >
-                <h:commandLink action="pharmacy_reprint_order_request" >
+                <h:commandLink action="pharmacy_reprint_order_request?faces-redirect=true" >
                     <h:outputLabel value="#{bill.createdAt}" >
                         <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateTimeFormat}"/>
                     </h:outputLabel>
@@ -71,7 +71,7 @@
                 </h:panelGroup>
             </p:column>                 
             <p:column headerText="Requested By" >
-                <h:commandLink action="pharmacy_reprint_order_request" >
+                <h:commandLink action="pharmacy_reprint_order_request?faces-redirect=true" >
                     <h:outputLabel value="#{bill.creater.webUserPerson.name}" >                                      
                     </h:outputLabel>
                     <f:setPropertyActionListener value="#{bill}" target="#{pharmacyBillSearch.bill}"/>
@@ -91,13 +91,13 @@
             </p:column>                       
 
             <p:column headerText="Payment Method">
-                <h:commandLink action="pharmacy_reprint_order_request" >
+                <h:commandLink action="pharmacy_reprint_order_request?faces-redirect=true" >
                     <h:outputLabel value="#{bill.paymentMethod}" ></h:outputLabel>
                     <f:setPropertyActionListener value="#{bill}" target="#{pharmacyBillSearch.bill}"/>
                 </h:commandLink>
             </p:column>                               
             <p:column headerText="Net Value" filterBy="#{bill.netTotal}" style="text-align: right;"  >
-                <h:commandLink action="pharmacy_reprint_order_request" >
+                <h:commandLink action="pharmacy_reprint_order_request?faces-redirect=true" >
                     <h:outputLabel value="#{bill.netTotal}" >
                         <f:convertNumber pattern="#,##0.00"/>
                     </h:outputLabel>

--- a/src/main/webapp/resources/pharmacy/search/pre_bill.xhtml
+++ b/src/main/webapp/resources/pharmacy/search/pre_bill.xhtml
@@ -111,7 +111,7 @@
 
                     <p:commandButton 
                         value="Cancelled" 
-                        action="pharmacy_reprint_bill_pre" 
+                        action="pharmacy_reprint_bill_pre?faces-redirect=true" 
                         styleClass="ui-button-danger btn-sm"
                         icon="fa fa-times-circle"
                         rendered="#{bill.cancelled}"
@@ -121,7 +121,7 @@
 
                     <p:commandButton 
                         value="Refunded" 
-                        action="pharmacy_reprint_bill_pre" 
+                        action="pharmacy_reprint_bill_pre?faces-redirect=true" 
                         styleClass="ui-button-warning btn-sm"
                         icon="fa fa-undo"
                         rendered="#{bill.refunded}"

--- a/src/main/webapp/resources/pharmacy/search/sale.xhtml
+++ b/src/main/webapp/resources/pharmacy/search/sale.xhtml
@@ -39,20 +39,20 @@
             </f:facet>
             <p:column>
                
-                 <p:commandButton action="pharmacy_reprint_bill_sale" ajax="false" value="View Billed Bill">
+                 <p:commandButton action="pharmacy_reprint_bill_sale?faces-redirect=true" ajax="false" value="View Billed Bill">
                     <f:setPropertyActionListener value="#{bill}" target="#{pharmacyBillSearch.bill}"/>
                 </p:commandButton>
             </p:column>
             
             <p:column headerText="BILL NO" sortBy="#{bill.deptId}" filterBy="#{bill.deptId}" filterMatchMode="contains" >
-                <h:commandLink action="pharmacy_reprint_bill_sale" value="#{bill.deptId}">
+                <h:commandLink action="pharmacy_reprint_bill_sale?faces-redirect=true" value="#{bill.deptId}">
                     <h:outputLabel  ></h:outputLabel>
                     <f:setPropertyActionListener value="#{bill}" target="#{pharmacyBillSearch.bill}"/>
                 </h:commandLink>
             </p:column>    
 
             <p:column headerText="Billed At" sortBy="#{bill.createdAt}"  >
-                <h:commandLink action="pharmacy_reprint_bill_sale" >
+                <h:commandLink action="pharmacy_reprint_bill_sale?faces-redirect=true" >
                     <h:outputLabel value="#{bill.createdAt}" >
                         <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateTimeFormat}"/>
                     </h:outputLabel>
@@ -73,7 +73,7 @@
                 </h:panelGroup>
             </p:column>                 
             <p:column headerText="Billed By" sortBy="#{bill.creater.webUserPerson.name}" filterBy="#{bill.creater.webUserPerson.name}" filterMatchMode="contains">
-                <h:commandLink action="pharmacy_reprint_bill_sale" >
+                <h:commandLink action="pharmacy_reprint_bill_sale?faces-redirect=true" >
                     <h:outputLabel value="#{bill.creater.webUserPerson.name}" >                                      
                     </h:outputLabel>
                     <f:setPropertyActionListener value="#{bill}" target="#{pharmacyBillSearch.bill}"/>
@@ -98,13 +98,13 @@
                             <f:selectItems value="#{enumController.paymentMethods}" />
                         </p:selectOneMenu>
                     </f:facet>
-                <h:commandLink action="pharmacy_reprint_bill_sale" >
+                <h:commandLink action="pharmacy_reprint_bill_sale?faces-redirect=true" >
                     <h:outputLabel value="#{bill.paymentMethod}" ></h:outputLabel>
                     <f:setPropertyActionListener value="#{bill}" target="#{pharmacyBillSearch.bill}"/>
                 </h:commandLink>
             </p:column>                               
             <p:column headerText="Net Value" style="text-align: right;" sortBy="#{bill.netTotal}"  >
-                <h:commandLink action="pharmacy_reprint_bill_sale" >
+                <h:commandLink action="pharmacy_reprint_bill_sale?faces-redirect=true" >
                     <h:outputLabel value="#{bill.netTotal}" >
                         <f:convertNumber pattern="#,##0.00"/>
                     </h:outputLabel>


### PR DESCRIPTION
- Updated grn_return_without_traising.xhtml: Added faces-redirect=true to all pharmacy_return_withouttresing links (5 locations)
- Updated grn_payment.xhtml: Added faces-redirect=true to all bill_dealor_all links (8 locations)
- Updated po_request.xhtml: Added faces-redirect=true to all pharmacy_reprint_order_request links (6 locations)
- Updated po_approve.xhtml: Added faces-redirect=true to pharmacy_reprint_po and pharmacy_reprint_grn_return links (8 locations)
- Updated sale.xhtml: Added faces-redirect=true to all pharmacy_reprint_bill_sale links (6 locations)
- Updated pharmacy_whole_sale.xhtml: Added faces-redirect=true to pharmacy_reprint_bill link (1 location)
- Updated adjustment.xhtml: Added faces-redirect=true to pharmacy_reprint_adjustment link (1 location)
- Updated pharmacy_transfer_recieve.xhtml: Added faces-redirect=true to pharmacy_reprint_transfer_receive link (1 location)
- Updated pre_bill.xhtml: Added faces-redirect=true to pharmacy_reprint_bill_pre links (2 locations)

This ensures proper URL redirects and clean browser history in pharmacy search pages.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced navigation behavior across multiple pharmacy search modules (Adjustment, GRN Payment, GRN Return, Transfer Receipt, Wholesale, PO Approval, PO Request, Pre-Bill, and Sales). Improvements provide more consistent page navigation patterns and better browser history management when navigating between search results and detail views.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->