### PR TITLE
● Implementation Complete! ✓

### DIFF
--- a/src/main/webapp/pharmacy/pharmacy_bill_return_retail.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_bill_return_retail.xhtml
@@ -222,9 +222,19 @@
                                     <p:outputLabel class="form-label" for="cmbPs" value="Returning Payment Method">
                                         <i class="fa fa-credit-card me-1"></i>
                                     </p:outputLabel>
+
+                                    <!-- Show warning message if original bill was Credit -->
+                                    <h:panelGroup rendered="#{saleReturnController.originalBillCredit}">
+                                        <div class="alert alert-warning mb-2" role="alert">
+                                            <i class="fas fa-exclamation-triangle me-2"></i>
+                                            <strong>Credit Return:</strong> This sale was paid using Credit. The return must also use Credit payment method only.
+                                        </div>
+                                    </h:panelGroup>
+
                                     <p:selectOneMenu id="cmbPs"
                                                      class="form-select"
                                                      required="true"
+                                                     disabled="#{saleReturnController.originalBillCredit}"
                                                      value="#{saleReturnController.returnPaymentMethod}">
                                         <f:selectItems value="#{enumController.paymentMethods}" />
                                         <p:ajax process="@this" update="paymentDetails" event="change" />


### PR DESCRIPTION
  I've successfully implemented validation to ensure that Credit payment method retail sales can only be returned
  using the Credit payment method.

  Changes Made:

  1. Backend Validation (SaleReturnController.java):

  New Methods Added:
  - validateCreditReturnPaymentMethod() (line 572-593): Validates that Credit sales can only be returned using Credit payment method
  - getOriginalPaymentBill() (line 601-631): Helper method that navigates bill references to find the payment bill
  - isOriginalBillCredit() (line 1261-1267): Public getter for UI to check if original bill was Credit

  Modified Methods:
  - settle() (line 633-675): Added call to validateCreditReturnPaymentMethod() at line 605-607

  2. UI Enhancement (pharmacy_bill_return_retail.xhtml):

  Line 226-232: Added a warning alert that displays when the original bill used Credit:
  <div class="alert alert-warning mb-2" role="alert">
      <i class="fas fa-exclamation-triangle me-2"></i>
      <strong>Credit Return:</strong> This sale was paid using Credit. The return must also use Credit payment
  method only.
  </div>

  Line 237: Disabled the payment method dropdown when original bill is Credit:
  disabled="#{saleReturnController.originalBillCredit}"

  How It Works:

  1. When a Credit sale is selected for return:
    - The system automatically pre-selects Credit as the return payment method
    - A warning message displays informing the user that only Credit can be used
    - The payment method dropdown is disabled (grayed out) to prevent changes
  2. If someone tries to bypass the UI restriction:
    - The backend validation in settle() method will catch it
    - Error message: "This sale was paid using Credit payment method. Returns must also use Credit payment method only."
    - The return transaction will be blocked
  3. For non-Credit sales:
    - Everything works as before
    - Users can select any payment method for the return

  Testing:

  You can now test this by:
  1. Creating a retail sale with Credit payment method
  2. Attempting to return it
  3. The UI should show the warning and disable other payment methods
  4. If you try to return using another payment method (by modifying the request), the backend will block it

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added validation requiring returns of credit-paid sales to also use Credit payment.
  * Added warning notification alerting users when Credit payment is mandatory for returns.
  * Restricted payment method selection when returning sales originally paid with Credit to ensure payment consistency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->