### PR TITLE
Add Config feature to Pharmacy Bill Accept Payment page

### DIFF
--- a/src/main/java/com/divudi/bean/pharmacy/PharmacyPreSettleController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacyPreSettleController.java
@@ -74,11 +74,17 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.List;
+import javax.annotation.PostConstruct;
 import javax.ejb.EJB;
 import javax.enterprise.context.SessionScoped;
 import javax.inject.Inject;
 import javax.inject.Named;
 import org.primefaces.event.TabChangeEvent;
+import com.divudi.bean.common.PageMetadataRegistry;
+import com.divudi.core.data.OptionScope;
+import com.divudi.core.data.admin.ConfigOptionInfo;
+import com.divudi.core.data.admin.PageMetadata;
+import com.divudi.core.data.admin.PrivilegeInfo;
 
 /**
  *
@@ -108,6 +114,8 @@ public class PharmacyPreSettleController implements Serializable, ControllerWith
     FinancialTransactionController financialTransactionController;
     @Inject
     DrawerController drawerController;
+    @Inject
+    PageMetadataRegistry pageMetadataRegistry;
 ////////////////////////
     @EJB
     DiscountSchemeValidationService discountSchemeValidationService;
@@ -171,6 +179,73 @@ public class PharmacyPreSettleController implements Serializable, ControllerWith
     double total;
     Double editingQty;
     private Token token;
+
+    @PostConstruct
+    public void init() {
+        registerPageMetadata();
+    }
+
+    /**
+     * Register page metadata for the admin configuration interface
+     */
+    private void registerPageMetadata() {
+        if (pageMetadataRegistry == null) {
+            return;
+        }
+
+        PageMetadata metadata = new PageMetadata();
+        metadata.setPagePath("pharmacy/pharmacy_bill_pre_settle");
+        metadata.setPageName("Pharmacy Bill Accept Payment (Pre-Settle)");
+        metadata.setDescription("Accept payment for pharmacy retail bills created in sale for cashier mode");
+        metadata.setControllerClass("PharmacyPreSettleController");
+
+        // Configuration Options from XHTML
+        metadata.addConfigOption(new ConfigOptionInfo(
+            "Enable token system in sale for cashier",
+            "Enables token number display and token system functionality for pharmacy retail sales",
+            "Lines 240, 246, 353, 354 (XHTML): Token panel visibility and navigation",
+            OptionScope.APPLICATION
+        ));
+
+        metadata.addConfigOption(new ConfigOptionInfo(
+            "Pharmacy accept payment for sale for cashier bill with Items is PosPaper",
+            "Uses POS paper format with items for pharmacy retail sale bills",
+            "Line 365 (XHTML): Bill preview format selection",
+            OptionScope.APPLICATION
+        ));
+
+        metadata.addConfigOption(new ConfigOptionInfo(
+            "Pharmacy accept payment for sale for cashier Bill is FiveFiveCustom3",
+            "Uses FiveFiveCustom3 format for pharmacy retail sale bills",
+            "Line 371 (XHTML): Bill preview format selection",
+            OptionScope.APPLICATION
+        ));
+
+        metadata.addConfigOption(new ConfigOptionInfo(
+            "Pharmacy accept payment for sale for cashier Bill is PosHeaderPaper",
+            "Uses POS header paper format for pharmacy retail sale bills",
+            "Line 377 (XHTML): Bill preview format selection",
+            OptionScope.APPLICATION
+        ));
+
+        // Configuration Options from Controller
+        metadata.addConfigOption(new ConfigOptionInfo(
+            "Pharmacy billing can be done after shift start",
+            "Allows pharmacy billing operations to be performed after the shift has started",
+            "Lines 1507, 1596, 1987 (Controller): Shift timing validation",
+            OptionScope.APPLICATION
+        ));
+
+        // Privileges
+        metadata.addPrivilege(new PrivilegeInfo(
+            "Admin",
+            "Administrative access to system configuration and page settings",
+            "Lines 22-32 (XHTML): Config button visibility"
+        ));
+
+        // Register the metadata
+        pageMetadataRegistry.registerPage(metadata);
+    }
 
     public double calculatRemainForMultiplePaymentTotal() {
 

--- a/src/main/webapp/pharmacy/pharmacy_bill_pre_settle.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_bill_pre_settle.xhtml
@@ -12,15 +12,29 @@
         <ui:composition template="/resources/template/template.xhtml">
             <ui:define name="content">
                 <h:form >
-                    <p:panel 
+                    <p:panel
                         rendered="#{!pharmacyPreSettleController.billPreview}"
                         class="w-100 m-1">
                         <f:facet name="header" >
-                            <h:outputLabel value="Pharmacy Bill Accept Payment" ></h:outputLabel> 
-                            <p:commandButton 
+                            <h:outputLabel value="Pharmacy Bill Accept Payment" ></h:outputLabel>
+
+                            <!-- Config Button (Admin Only) -->
+                            <h:panelGroup rendered="#{webUserController.hasPrivilege('Admin')}">
+                                <p:commandButton
+                                    value="Config"
+                                    icon="fa fa-cog"
+                                    title="Page Configuration Management"
+                                    action="#{pageAdminController.navigateToPageAdmin('pharmacy/pharmacy_bill_pre_settle')}"
+                                    ajax="false"
+                                    styleClass="ui-button-secondary ui-button-sm p-button-outlined"
+                                    style="float: right; margin-right: 5px; font-size: 0.8rem; padding: 0.25rem 0.5rem;">
+                                </p:commandButton>
+                            </h:panelGroup>
+
+                            <p:commandButton
                                 icon="fa fa-undo"
                                 style="float: right;"
-                                ajax="false" 
+                                ajax="false"
                                 value="Back To Search"
                                 action="pharmacy_search_pre_bill"/>
                         </f:facet>


### PR DESCRIPTION
This commit implements the page configuration tracking system for the Pharmacy Bill Accept Payment (Pre-Settle) page, allowing administrators to view and manage configuration options and privileges used on this page.

Changes:
1. Added Config button to pharmacy_bill_pre_settle.xhtml header (admin-only)
2. Added page metadata registration to PharmacyPreSettleController
3. Registered 5 configuration options:
   - Enable token system in sale for cashier
   - Pharmacy accept payment bill format options (3 formats)
   - Pharmacy billing can be done after shift start
4. Registered Admin privilege for config button visibility

The Config button provides administrators quick access to the admin configuration interface where they can modify page-specific settings.

Implements: Page Configuration Tracking system
Related: developer_docs/admin/config-button-implementation-guide.md