### PR TITLE
Add Config button and page metadata registration for pharmacy return …

### DIFF
--- a/src/main/java/com/divudi/bean/pharmacy/PreReturnController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PreReturnController.java
@@ -5,13 +5,18 @@
 package com.divudi.bean.pharmacy;
 
 import com.divudi.bean.common.ConfigOptionApplicationController;
+import com.divudi.bean.common.PageMetadataRegistry;
 import com.divudi.bean.common.SessionController;
 import com.divudi.core.util.JsfUtil;
 import com.divudi.core.data.BillClassType;
 import com.divudi.core.data.BillNumberSuffix;
 import com.divudi.core.data.BillType;
 import com.divudi.core.data.BillTypeAtomic;
+import com.divudi.core.data.OptionScope;
 import com.divudi.core.data.PaymentMethod;
+import com.divudi.core.data.admin.ConfigOptionInfo;
+import com.divudi.core.data.admin.PageMetadata;
+import com.divudi.core.data.admin.PrivilegeInfo;
 import com.divudi.ejb.BillNumberGenerator;
 import com.divudi.ejb.PharmacyBean;
 import com.divudi.ejb.PharmacyCalculation;
@@ -30,6 +35,7 @@ import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.List;
+import javax.annotation.PostConstruct;
 import javax.ejb.EJB;
 import javax.enterprise.context.SessionScoped;
 import javax.inject.Inject;
@@ -69,6 +75,94 @@ public class PreReturnController implements Serializable {
     private PharmacyBean pharmacyBean;
     @EJB
     private BillItemFacade billItemFacade;
+    @Inject
+    PageMetadataRegistry pageMetadataRegistry;
+
+    @PostConstruct
+    public void init() {
+        registerPageMetadata();
+    }
+
+    /**
+     * Register page metadata for the admin configuration interface
+     */
+    private void registerPageMetadata() {
+        if (pageMetadataRegistry == null) {
+            return;
+        }
+
+        PageMetadata metadata = new PageMetadata();
+        metadata.setPagePath("pharmacy/pharmacy_bill_return_pre");
+        metadata.setPageName("Pharmacy Pre Bill Return (Items Only)");
+        metadata.setDescription("Return items from pharmacy pre bills without processing refund payments");
+        metadata.setControllerClass("PreReturnController");
+
+        // Configuration Options
+        metadata.addConfigOption(new ConfigOptionInfo(
+            "Display a link to navigate to original pharmacy retail sale bill at the time of return items",
+            "Shows a button to view the original sale bill during the return process",
+            "Line 227 (XHTML): View Sale Bill button visibility in print preview",
+            OptionScope.APPLICATION
+        ));
+
+        metadata.addConfigOption(new ConfigOptionInfo(
+            "Pharmacy Retail Sale Return Bill is Five Five Custom 3 Paper",
+            "Uses 5.5 inch custom format 3 for return bill printing",
+            "Line 247 (XHTML): Print format selection for return bills",
+            OptionScope.APPLICATION
+        ));
+
+        metadata.addConfigOption(new ConfigOptionInfo(
+            "Pharmacy Retail Sale Return Bill is POS Header Paper",
+            "Uses POS header paper format for return bill printing",
+            "Line 253 (XHTML): Print format selection for return bills",
+            OptionScope.APPLICATION
+        ));
+
+        metadata.addConfigOption(new ConfigOptionInfo(
+            "Pharmacy Retail Sale Return Bill is POS Paper Custom 1 Paper",
+            "Uses POS paper custom 1 format for return bill printing",
+            "Line 259 (XHTML): Print format selection for return bills",
+            OptionScope.APPLICATION
+        ));
+
+        metadata.addConfigOption(new ConfigOptionInfo(
+            "Bill Number Generation Strategy for Pharmacy Sale Return Items only - Prefix + Department Code + Institution Code + Year + Yearly Number",
+            "Bill number format: Prefix-DeptCode-InsCode-Year-Number (e.g., PHRET-PH-HOS-2025-001)",
+            "Line 165 (Controller): Return bill department ID generation",
+            OptionScope.APPLICATION
+        ));
+
+        metadata.addConfigOption(new ConfigOptionInfo(
+            "Bill Number Generation Strategy for Pharmacy Sale Return Items only - Prefix + Institution Code + Department Code + Year + Yearly Number",
+            "Bill number format: Prefix-InsCode-DeptCode-Year-Number (e.g., PHRET-HOS-PH-2025-001)",
+            "Line 168 (Controller): Return bill department ID generation",
+            OptionScope.APPLICATION
+        ));
+
+        metadata.addConfigOption(new ConfigOptionInfo(
+            "Bill Number Generation Strategy for Pharmacy Sale Return Items only - Prefix + Institution Code + Year + Yearly Number",
+            "Bill number format: Prefix-InsCode-Year-Number (e.g., PHRET-HOS-2025-001) - institution-wide numbering",
+            "Line 171 (Controller): Return bill department and institution ID generation",
+            OptionScope.APPLICATION
+        ));
+
+        // Privileges
+        metadata.addPrivilege(new PrivilegeInfo(
+            "Admin",
+            "Administrative access to system configuration and page settings",
+            "Config button visibility (added via implementation)"
+        ));
+
+        metadata.addPrivilege(new PrivilegeInfo(
+            "ChangeReceiptPrintingPaperTypes",
+            "Ability to change receipt printing paper format settings",
+            "Line 217 (XHTML): Settings button visibility for paper format configuration"
+        ));
+
+        // Register the metadata
+        pageMetadataRegistry.registerPage(metadata);
+    }
 
     public String navigateToReturnRetailSaleItemsOnly() {
         Bill tmpBill = bill;

--- a/src/main/java/com/divudi/bean/pharmacy/SaleReturnController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/SaleReturnController.java
@@ -6,11 +6,16 @@ package com.divudi.bean.pharmacy;
 
 import com.divudi.bean.cashTransaction.DrawerController;
 import com.divudi.bean.common.ConfigOptionApplicationController;
+import com.divudi.bean.common.PageMetadataRegistry;
 import com.divudi.bean.common.SessionController;
 import com.divudi.core.util.JsfUtil;
 import com.divudi.core.data.BillType;
 import com.divudi.core.data.BillTypeAtomic;
+import com.divudi.core.data.OptionScope;
 import com.divudi.core.data.PaymentMethod;
+import com.divudi.core.data.admin.ConfigOptionInfo;
+import com.divudi.core.data.admin.PageMetadata;
+import com.divudi.core.data.admin.PrivilegeInfo;
 import com.divudi.core.data.dataStructure.ComponentDetail;
 import com.divudi.core.data.dataStructure.PaymentMethodData;
 import com.divudi.ejb.BillNumberGenerator;
@@ -40,6 +45,7 @@ import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.List;
+import javax.annotation.PostConstruct;
 import javax.ejb.EJB;
 import javax.enterprise.context.SessionScoped;
 import javax.inject.Inject;
@@ -96,8 +102,124 @@ public class SaleReturnController implements Serializable, com.divudi.bean.commo
     StaffService staffBean;
     @EJB
     PaymentService paymentService;
+    @Inject
+    PageMetadataRegistry pageMetadataRegistry;
 
     PaymentMethodData paymentMethodData;
+
+    @PostConstruct
+    public void init() {
+        registerPageMetadata();
+    }
+
+    /**
+     * Register page metadata for the admin configuration interface
+     */
+    private void registerPageMetadata() {
+        if (pageMetadataRegistry == null) {
+            return;
+        }
+
+        PageMetadata metadata = new PageMetadata();
+        metadata.setPagePath("pharmacy/pharmacy_bill_return_retail");
+        metadata.setPageName("Pharmacy Retail Sale Return (Items and Payments)");
+        metadata.setDescription("Accept return items and process refund payments for pharmacy retail sales");
+        metadata.setControllerClass("SaleReturnController");
+
+        // Configuration Options
+        metadata.addConfigOption(new ConfigOptionInfo(
+            "Pharmacy Retail Sale Return Bill is POS Paper",
+            "Uses standard POS paper format for return bill printing",
+            "Line 363 (XHTML): Print format selection for return bills",
+            OptionScope.APPLICATION
+        ));
+
+        metadata.addConfigOption(new ConfigOptionInfo(
+            "Pharmacy Retail Sale Return Bill is Five Five Paper",
+            "Uses standard 5x5 inch paper format for return bill printing",
+            "Line 368 (XHTML): Print format selection for return bills",
+            OptionScope.APPLICATION
+        ));
+
+        metadata.addConfigOption(new ConfigOptionInfo(
+            "Pharmacy Retail Sale Return Bill is POS Header Paper",
+            "Uses POS header paper format for return bill printing",
+            "Line 374 (XHTML): Print format selection for return bills",
+            OptionScope.APPLICATION
+        ));
+
+        metadata.addConfigOption(new ConfigOptionInfo(
+            "Pharmacy Retail Sale Return Bill is Five Five Custom 3 Paper",
+            "Uses 5.5 inch custom format 3 for return bill printing",
+            "Line 378 (XHTML): Print format selection for return bills",
+            OptionScope.APPLICATION
+        ));
+
+        metadata.addConfigOption(new ConfigOptionInfo(
+            "Pharmacy Retail Sale Return Bill is POS Paper Custom 1 Paper",
+            "Uses POS paper custom 1 format for return bill printing",
+            "Line 382 (XHTML): Print format selection for return bills",
+            OptionScope.APPLICATION
+        ));
+
+        metadata.addConfigOption(new ConfigOptionInfo(
+            "Bill Number Generation Strategy for Pharmacy Sale Refund Pre Bill - Prefix + Department Code + Institution Code + Year + Yearly Number",
+            "Pre-bill number format: Prefix-DeptCode-InsCode-Year-Number (e.g., PHREFPRE-PH-HOS-2025-001)",
+            "Line 274 (Controller): Return pre-bill department ID generation",
+            OptionScope.APPLICATION
+        ));
+
+        metadata.addConfigOption(new ConfigOptionInfo(
+            "Bill Number Generation Strategy for Pharmacy Sale Refund Pre Bill - Prefix + Institution Code + Department Code + Year + Yearly Number",
+            "Pre-bill number format: Prefix-InsCode-DeptCode-Year-Number (e.g., PHREFPRE-HOS-PH-2025-001)",
+            "Line 277 (Controller): Return pre-bill department ID generation",
+            OptionScope.APPLICATION
+        ));
+
+        metadata.addConfigOption(new ConfigOptionInfo(
+            "Bill Number Generation Strategy for Pharmacy Sale Refund Pre Bill - Prefix + Institution Code + Year + Yearly Number",
+            "Pre-bill number format: Prefix-InsCode-Year-Number (e.g., PHREFPRE-HOS-2025-001) - institution-wide numbering",
+            "Line 280 (Controller): Return pre-bill department and institution ID generation",
+            OptionScope.APPLICATION
+        ));
+
+        metadata.addConfigOption(new ConfigOptionInfo(
+            "Bill Number Generation Strategy for Pharmacy Sale Return Items and Payments - Prefix + Department Code + Institution Code + Year + Yearly Number",
+            "Final return bill number format: Prefix-DeptCode-InsCode-Year-Number (e.g., PHREF-PH-HOS-2025-001)",
+            "Line 334 (Controller): Final return bill department ID generation",
+            OptionScope.APPLICATION
+        ));
+
+        metadata.addConfigOption(new ConfigOptionInfo(
+            "Bill Number Generation Strategy for Pharmacy Sale Return Items and Payments - Prefix + Institution Code + Department Code + Year + Yearly Number",
+            "Final return bill number format: Prefix-InsCode-DeptCode-Year-Number (e.g., PHREF-HOS-PH-2025-001)",
+            "Line 337 (Controller): Final return bill department ID generation",
+            OptionScope.APPLICATION
+        ));
+
+        metadata.addConfigOption(new ConfigOptionInfo(
+            "Bill Number Generation Strategy for Pharmacy Sale Return Items and Payments - Prefix + Institution Code + Year + Yearly Number",
+            "Final return bill number format: Prefix-InsCode-Year-Number (e.g., PHREF-HOS-2025-001) - institution-wide numbering",
+            "Line 340 (Controller): Final return bill department and institution ID generation",
+            OptionScope.APPLICATION
+        ));
+
+        // Privileges
+        metadata.addPrivilege(new PrivilegeInfo(
+            "Admin",
+            "Administrative access to system configuration and page settings",
+            "Config button visibility (added via implementation)"
+        ));
+
+        metadata.addPrivilege(new PrivilegeInfo(
+            "ChangeReceiptPrintingPaperTypes",
+            "Ability to change receipt printing paper format settings",
+            "Lines 332, 392 (XHTML): Settings button visibility for paper format configuration"
+        ));
+
+        // Register the metadata
+        pageMetadataRegistry.registerPage(metadata);
+    }
 
     public String navigateToReturnItemsAndPaymentsForPharmacyRetailSale() {
         if (bill == null) {

--- a/src/main/webapp/pharmacy/pharmacy_bill_return_pre.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_bill_return_pre.xhtml
@@ -17,9 +17,22 @@
                             <div>
                                 <h:outputText styleClass="fas fa-pills"></h:outputText>
                                 <h:outputLabel value="Pharmacy Item Return" class="mx-3"></h:outputLabel>
-                                <!--                                <p:commandButton 
+
+                                <!-- Config Button (Admin Only) -->
+                                <h:panelGroup rendered="#{webUserController.hasPrivilege('Admin')}">
+                                    <p:commandButton
+                                        value="Config"
+                                        icon="fa fa-cog"
+                                        title="Page Configuration Management"
+                                        action="#{pageAdminController.navigateToPageAdmin('pharmacy/pharmacy_bill_return_pre')}"
+                                        ajax="false"
+                                        styleClass="ui-button-secondary ui-button-sm p-button-outlined"
+                                        style="font-size: 0.8rem; padding: 0.25rem 0.5rem;">
+                                    </p:commandButton>
+                                </h:panelGroup>
+                                <!--                                <p:commandButton
                                                                     ajax="false"
-                                                                    value="Back to Reprint" 
+                                                                    value="Back to Reprint"
                                                                     class="ui-button-secondary mx-2"
                                                                     icon="fa fa-arrow-left"
                                                                     action="#{pharmacyBillSearch.navigateBackToReprintBill()}" />-->

--- a/src/main/webapp/pharmacy/pharmacy_bill_return_retail.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_bill_return_retail.xhtml
@@ -14,10 +14,26 @@
                 <p:panel class="w-100">
                     <f:facet name="header" >
                         <div class="d-flex justify-content-between align-items-center">
-                            <h:outputText value="Accept Return Items &amp; Repay" ></h:outputText>
-                            <p:commandButton 
+                            <div>
+                                <h:outputText value="Accept Return Items &amp; Repay" ></h:outputText>
+
+                                <!-- Config Button (Admin Only) -->
+                                <h:panelGroup rendered="#{webUserController.hasPrivilege('Admin')}">
+                                    <p:commandButton
+                                        value="Config"
+                                        icon="fa fa-cog"
+                                        title="Page Configuration Management"
+                                        action="#{pageAdminController.navigateToPageAdmin('pharmacy/pharmacy_bill_return_retail')}"
+                                        ajax="false"
+                                        styleClass="ui-button-secondary ui-button-sm p-button-outlined mx-2"
+                                        style="font-size: 0.8rem; padding: 0.25rem 0.5rem;">
+                                    </p:commandButton>
+                                </h:panelGroup>
+                            </div>
+
+                            <p:commandButton
                                 ajax="false"
-                                value="Back to Reprint" 
+                                value="Back to Reprint"
                                 class="ui-button-secondary"
                                 icon="fa fa-arrow-left"
                                 action="#{pharmacyBillSearch.navigateBackToReprintBill()}" />


### PR DESCRIPTION
…pages

Implemented configuration management interface for pharmacy return pages:
- pharmacy_bill_return_pre.xhtml (Items Only Return)
- pharmacy_bill_return_retail.xhtml (Items and Payments Return)

Changes:
1. Added Admin-only Config button to both XHTML pages for easy access to configuration settings
2. Registered page metadata in PreReturnController with 7 configuration options and 2 privileges
3. Registered page metadata in SaleReturnController with 11 configuration options and 2 privileges

Configuration options include:
- Print format selections (POS Paper, Five Five Custom 3, POS Header, etc.)
- Bill number generation strategies (3 formats for each bill type)
- Navigation to original sale bill display option

Privileges tracked:
- Admin: Config button visibility and system configuration access
- ChangeReceiptPrintingPaperTypes: Paper format settings management

This provides administrators with centralized visibility and control over all configuration options and privileges used by the pharmacy return processes.