### PR TITLE
Add Config button and page metadata registration for pharmacy transfe…

### DIFF
--- a/src/main/java/com/divudi/bean/pharmacy/TransferIssueForRequestsController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/TransferIssueForRequestsController.java
@@ -5,7 +5,12 @@
 package com.divudi.bean.pharmacy;
 
 import com.divudi.bean.common.BillController;
+import com.divudi.bean.common.PageMetadataRegistry;
 import com.divudi.bean.common.SessionController;
+import com.divudi.core.data.OptionScope;
+import com.divudi.core.data.admin.ConfigOptionInfo;
+import com.divudi.core.data.admin.PageMetadata;
+import com.divudi.core.data.admin.PrivilegeInfo;
 import com.divudi.core.util.JsfUtil;
 import com.divudi.core.data.BillClassType;
 import com.divudi.core.data.BillNumberSuffix;
@@ -41,6 +46,7 @@ import java.util.Calendar;
 import java.util.Date;
 import java.util.List;
 import java.util.Optional;
+import javax.annotation.PostConstruct;
 import javax.ejb.EJB;
 import javax.enterprise.context.SessionScoped;
 import javax.inject.Inject;
@@ -83,6 +89,8 @@ public class TransferIssueForRequestsController implements Serializable {
     private ConfigOptionApplicationController configOptionApplicationController;
     @Inject
     private VmpController vmpController;
+    @Inject
+    private PageMetadataRegistry pageMetadataRegistry;
 
     private Bill requestedBill;
     // Bill id used when navigating from DTO tables
@@ -1307,6 +1315,181 @@ public class TransferIssueForRequestsController implements Serializable {
         bItem.setItem(referenceItem.getItem());
         bItem.setReferanceBillItem(referenceItem);
         getBillItems().add(bItem);
+    }
+
+    @PostConstruct
+    public void init() {
+        registerPageMetadata();
+    }
+
+    /**
+     * Register page metadata for the admin configuration interface
+     */
+    private void registerPageMetadata() {
+        if (pageMetadataRegistry == null) {
+            return;
+        }
+
+        // Register pharmacy_transfer_issue.xhtml
+        PageMetadata issueMetadata = new PageMetadata();
+        issueMetadata.setPagePath("pharmacy/pharmacy_transfer_issue");
+        issueMetadata.setPageName("Pharmacy Transfer Issue");
+        issueMetadata.setDescription("Issue pharmacy items for approved transfer requests");
+        issueMetadata.setControllerClass("TransferIssueForRequestsController");
+
+        // Configuration Options
+        issueMetadata.addConfigOption(new ConfigOptionInfo(
+            "Stock Transaction - Show Rate and Value",
+            "Controls visibility of rate and value information in stock transactions",
+            "Lines 119, 133, 279, 288 (XHTML): Rate and value columns in tables",
+            OptionScope.APPLICATION
+        ));
+
+        issueMetadata.addConfigOption(new ConfigOptionInfo(
+            "Pharmacy Transfer Issue - Show Rate and Value",
+            "Controls visibility of rate and value fields specific to transfer issues",
+            "Lines 123, 178-179 (XHTML): Rate and value input fields",
+            OptionScope.APPLICATION
+        ));
+
+        issueMetadata.addConfigOption(new ConfigOptionInfo(
+            "Pharmaceutical Item Name Column width",
+            "Sets the column width for item names in pharmaceutical tables",
+            "Line 257 (XHTML): Item name column width",
+            OptionScope.APPLICATION
+        ));
+
+        issueMetadata.addConfigOption(new ConfigOptionInfo(
+            "Pharmaceutical Batch Column width",
+            "Sets the column width for batch number in pharmaceutical tables",
+            "Line 261 (XHTML): Batch column width",
+            OptionScope.APPLICATION
+        ));
+
+        issueMetadata.addConfigOption(new ConfigOptionInfo(
+            "Pharmaceutical Item Expiary Column width",
+            "Sets the column width for expiry date in pharmaceutical tables",
+            "Line 265 (XHTML): Expiry date column width",
+            OptionScope.APPLICATION
+        ));
+
+        issueMetadata.addConfigOption(new ConfigOptionInfo(
+            "Pharmaceutical Item Quentity Column width",
+            "Sets the column width for quantity in pharmaceutical tables",
+            "Lines 271, 278, 287 (XHTML): Quantity column width",
+            OptionScope.APPLICATION
+        ));
+
+        issueMetadata.addConfigOption(new ConfigOptionInfo(
+            "Pharmacy Transfer Issue A4 Paper",
+            "Uses A4 paper format for transfer issue receipts",
+            "Line 404 (XHTML): Receipt format selection",
+            OptionScope.APPLICATION
+        ));
+
+        issueMetadata.addConfigOption(new ConfigOptionInfo(
+            "Pharmacy Transfer Issue A4 Paper Detailed",
+            "Uses detailed A4 paper format for transfer issue receipts",
+            "Line 410 (XHTML): Receipt format selection",
+            OptionScope.APPLICATION
+        ));
+
+        issueMetadata.addConfigOption(new ConfigOptionInfo(
+            "Pharmacy Transfer Issue Bill is Letter Paper Custom 1",
+            "Uses custom letter paper format for transfer issue receipts",
+            "Line 416 (XHTML): Receipt format selection",
+            OptionScope.APPLICATION
+        ));
+
+        issueMetadata.addConfigOption(new ConfigOptionInfo(
+            "Pharmacy Transfer Issue POS Paper",
+            "Uses POS paper format for transfer issue receipts",
+            "Line 422 (XHTML): Receipt format selection",
+            OptionScope.APPLICATION
+        ));
+
+        issueMetadata.addConfigOption(new ConfigOptionInfo(
+            "Pharmacy Transfer Issue Bill is PosHeaderPaper",
+            "Uses POS header paper format for transfer issue receipts",
+            "Line 427 (XHTML): Receipt format selection",
+            OptionScope.APPLICATION
+        ));
+
+        issueMetadata.addConfigOption(new ConfigOptionInfo(
+            "Pharmacy Transfer Issue Bill is Template",
+            "Uses template format for transfer issue receipts",
+            "Line 433 (XHTML): Receipt format selection",
+            OptionScope.APPLICATION
+        ));
+
+        issueMetadata.addConfigOption(new ConfigOptionInfo(
+            "Pharmacy Transfer is by Purchase Rate",
+            "Uses purchase rate for transfer pricing calculations",
+            "Line 842 (Controller): Transfer rate determination",
+            OptionScope.APPLICATION
+        ));
+
+        issueMetadata.addConfigOption(new ConfigOptionInfo(
+            "Pharmacy Transfer is by Cost Rate",
+            "Uses cost rate for transfer pricing calculations",
+            "Line 843 (Controller): Transfer rate determination",
+            OptionScope.APPLICATION
+        ));
+
+        issueMetadata.addConfigOption(new ConfigOptionInfo(
+            "Pharmacy Transfer is by Retail Rate",
+            "Uses retail rate for transfer pricing calculations",
+            "Line 844 (Controller): Transfer rate determination",
+            OptionScope.APPLICATION
+        ));
+
+        // Privileges
+        issueMetadata.addPrivilege(new PrivilegeInfo(
+            "Admin",
+            "Administrative access to configuration interface",
+            "Config button visibility"
+        ));
+
+        issueMetadata.addPrivilege(new PrivilegeInfo(
+            "StockTransactionViewRates",
+            "View rate and value information in stock transactions",
+            "Lines 119, 133, 279, 288 (XHTML): Rate and value columns visibility"
+        ));
+
+        issueMetadata.addPrivilege(new PrivilegeInfo(
+            "PharmacyTransferViewRates",
+            "View rate and value information in pharmacy transfers",
+            "Lines 123, 178-179 (XHTML): Transfer rate and value visibility"
+        ));
+
+        issueMetadata.addPrivilege(new PrivilegeInfo(
+            "ChangeReceiptPrintingPaperTypes",
+            "Access to receipt printing configuration settings",
+            "Line 392 (XHTML): Settings button visibility"
+        ));
+
+        pageMetadataRegistry.registerPage(issueMetadata);
+
+        // Register pharmacy_transfer_issued_list.xhtml
+        PageMetadata issuedListMetadata = new PageMetadata();
+        issuedListMetadata.setPagePath("pharmacy/pharmacy_transfer_issued_list");
+        issuedListMetadata.setPageName("Pharmacy Transfer Issued List");
+        issuedListMetadata.setDescription("List of issued pharmacy transfers awaiting receipt");
+        issuedListMetadata.setControllerClass("SearchController");
+
+        issuedListMetadata.addPrivilege(new PrivilegeInfo(
+            "Admin",
+            "Administrative access to configuration interface",
+            "Config button visibility"
+        ));
+
+        issuedListMetadata.addPrivilege(new PrivilegeInfo(
+            "PharmacyTransferViewRates",
+            "View transfer values in the issued list",
+            "Line 128 (XHTML): Transfer value column visibility"
+        ));
+
+        pageMetadataRegistry.registerPage(issuedListMetadata);
     }
 
 }

--- a/src/main/java/com/divudi/bean/pharmacy/TransferReceiveController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/TransferReceiveController.java
@@ -4,8 +4,13 @@
  */
 package com.divudi.bean.pharmacy;
 
+import com.divudi.bean.common.PageMetadataRegistry;
 import com.divudi.bean.common.SessionController;
 import com.divudi.bean.common.ConfigOptionApplicationController;
+import com.divudi.core.data.OptionScope;
+import com.divudi.core.data.admin.ConfigOptionInfo;
+import com.divudi.core.data.admin.PageMetadata;
+import com.divudi.core.data.admin.PrivilegeInfo;
 import com.divudi.core.util.JsfUtil;
 import com.divudi.core.data.BillClassType;
 import java.util.HashMap;
@@ -47,6 +52,7 @@ import java.util.Calendar;
 import java.util.Date;
 import java.util.List;
 import java.util.Optional;
+import javax.annotation.PostConstruct;
 import javax.ejb.EJB;
 import javax.enterprise.context.SessionScoped;
 import javax.inject.Inject;
@@ -98,6 +104,9 @@ public class TransferReceiveController implements Serializable {
 
     @Inject
     private PharmacyCalculation pharmacyCalculation;
+
+    @Inject
+    private PageMetadataRegistry pageMetadataRegistry;
     @Inject
     private com.divudi.bean.common.SearchController searchController;
     private List<Bill> bills;
@@ -1454,6 +1463,98 @@ public class TransferReceiveController implements Serializable {
     public String toggleShowAllBillFormats() {
         this.showAllBillFormats = !this.showAllBillFormats;
         return "";
+    }
+
+    @PostConstruct
+    public void init() {
+        registerPageMetadata();
+    }
+
+    /**
+     * Register page metadata for the admin configuration interface
+     */
+    private void registerPageMetadata() {
+        if (pageMetadataRegistry == null) {
+            return;
+        }
+
+        // Register pharmacy_transfer_receive.xhtml
+        PageMetadata receiveMetadata = new PageMetadata();
+        receiveMetadata.setPagePath("pharmacy/pharmacy_transfer_receive");
+        receiveMetadata.setPageName("Pharmacy Transfer Receive");
+        receiveMetadata.setDescription("Receive and confirm pharmacy items from transfer issues");
+        receiveMetadata.setControllerClass("TransferReceiveController");
+
+        // Configuration Options
+        receiveMetadata.addConfigOption(new ConfigOptionInfo(
+            "Report Font Size of Item List in Pharmacy Disbursement Reports",
+            "Sets the font size for item lists in pharmacy disbursement reports",
+            "Line 41 (XHTML): DataTable font size styling",
+            OptionScope.APPLICATION
+        ));
+
+        receiveMetadata.addConfigOption(new ConfigOptionInfo(
+            "Pharmacy Transfer Receive Receipt is A4",
+            "Uses A4 paper format for transfer receive receipts",
+            "Line 232 (XHTML): Receipt format selection",
+            OptionScope.APPLICATION
+        ));
+
+        receiveMetadata.addConfigOption(new ConfigOptionInfo(
+            "Pharmacy Transfer Receive Bill is Template",
+            "Uses template format for transfer receive bills",
+            "Line 240 (XHTML): Bill format selection",
+            OptionScope.APPLICATION
+        ));
+
+        receiveMetadata.addConfigOption(new ConfigOptionInfo(
+            "Pharmacy Transfer Receive Receipt is Letter Paper Custom 1",
+            "Uses custom letter paper format for transfer receive receipts",
+            "Line 246 (XHTML): Receipt format selection",
+            OptionScope.APPLICATION
+        ));
+
+        receiveMetadata.addConfigOption(new ConfigOptionInfo(
+            "Pharmacy Transfer Receive Receipt is A4 Detailed",
+            "Uses detailed A4 paper format for transfer receive receipts",
+            "Line 252 (XHTML): Receipt format selection",
+            OptionScope.APPLICATION
+        ));
+
+        receiveMetadata.addConfigOption(new ConfigOptionInfo(
+            "Pharmacy Transfer Receive Receipt is A4 Custom 1",
+            "Uses A4 Custom Format 1 for transfer receive receipts",
+            "Line 258 (XHTML): Receipt format selection",
+            OptionScope.APPLICATION
+        ));
+
+        receiveMetadata.addConfigOption(new ConfigOptionInfo(
+            "Pharmacy Transfer Receive Receipt is A4 Custom 2",
+            "Uses A4 Custom Format 2 for transfer receive receipts",
+            "Line 264 (XHTML): Receipt format selection",
+            OptionScope.APPLICATION
+        ));
+
+        // Privileges
+        receiveMetadata.addPrivilege(new PrivilegeInfo(
+            "Admin",
+            "Administrative access to configuration interface",
+            "Config button visibility"
+        ));
+
+        receiveMetadata.addPrivilege(new PrivilegeInfo(
+            "PharmacyTransferViewRates",
+            "View rate and value information in pharmacy transfers",
+            "Lines 75, 81, 105, 124-125, 129-130, 181-182, 186-187, 191-192 (XHTML): Rate and value visibility"
+        ));
+
+        receiveMetadata.addPrivilege(new PrivilegeInfo(
+            "ChangeReceiptPrintingPaperTypes",
+            "Access to receipt printing configuration settings",
+            "Line 212 (XHTML): Settings button visibility"
+        ));
+
+        pageMetadataRegistry.registerPage(receiveMetadata);
     }
 
 }

--- a/src/main/java/com/divudi/bean/pharmacy/TransferRequestController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/TransferRequestController.java
@@ -5,10 +5,14 @@
 package com.divudi.bean.pharmacy;
 
 import com.divudi.bean.common.NotificationController;
+import com.divudi.bean.common.PageMetadataRegistry;
 import com.divudi.bean.common.SearchController;
 import com.divudi.bean.common.SessionController;
 
 import com.divudi.core.data.*;
+import com.divudi.core.data.admin.ConfigOptionInfo;
+import com.divudi.core.data.admin.PageMetadata;
+import com.divudi.core.data.admin.PrivilegeInfo;
 import com.divudi.core.entity.*;
 import com.divudi.core.util.BigDecimalUtil;
 import com.divudi.core.util.CommonFunctions;
@@ -47,6 +51,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import javax.annotation.PostConstruct;
 import javax.ejb.EJB;
 import javax.enterprise.context.SessionScoped;
 import javax.inject.Inject;
@@ -100,6 +105,8 @@ public class TransferRequestController implements Serializable {
     private SearchController searchController;
     @Inject
     private ConfigOptionApplicationController configOptionApplicationController;
+    @Inject
+    private PageMetadataRegistry pageMetadataRegistry;
     // </editor-fold>
 
     // <editor-fold defaultstate="collapsed" desc="Class Variables">
@@ -1372,6 +1379,206 @@ public class TransferRequestController implements Serializable {
     public String toggleShowAllBillFormats() {
         this.showAllBillFormats = !this.showAllBillFormats;
         return "";
+    }
+
+    @PostConstruct
+    public void init() {
+        registerPageMetadata();
+    }
+
+    /**
+     * Register page metadata for the admin configuration interface
+     */
+    private void registerPageMetadata() {
+        if (pageMetadataRegistry == null) {
+            return;
+        }
+
+        // Register pharmacy_transfer_request.xhtml
+        PageMetadata requestMetadata = new PageMetadata();
+        requestMetadata.setPagePath("pharmacy/pharmacy_transfer_request");
+        requestMetadata.setPageName("Pharmacy Transfer Request");
+        requestMetadata.setDescription("Create and manage pharmacy transfer requests between departments");
+        requestMetadata.setControllerClass("TransferRequestController");
+
+        // Configuration Options
+        requestMetadata.addConfigOption(new ConfigOptionInfo(
+            "Stock Request - Show Rate and Value",
+            "Controls visibility of rate and value fields in transfer request forms",
+            "Lines 169, 179, 251, 258, 292-294 (XHTML): Rate/value input fields and display",
+            OptionScope.APPLICATION
+        ));
+
+        requestMetadata.addConfigOption(new ConfigOptionInfo(
+            "Pharmacy Transfer Request Receipt is A4",
+            "Uses A4 paper format for transfer request receipts",
+            "Line 347 (XHTML): Receipt format selection",
+            OptionScope.APPLICATION
+        ));
+
+        requestMetadata.addConfigOption(new ConfigOptionInfo(
+            "Pharmacy Transfer Request Receipt is Custom 1",
+            "Uses Custom Format 1 for transfer request receipts",
+            "Line 351 (XHTML): Receipt format selection",
+            OptionScope.APPLICATION
+        ));
+
+        requestMetadata.addConfigOption(new ConfigOptionInfo(
+            "Pharmacy Transfer Request Receipt is Custom 2",
+            "Uses Custom Format 2 for transfer request receipts",
+            "Line 356 (XHTML): Receipt format selection",
+            OptionScope.APPLICATION
+        ));
+
+        requestMetadata.addConfigOption(new ConfigOptionInfo(
+            "Bill Number Generation Strategy for Pharmacy Transfer Request - Prefix + Department Code + Institution Code + Year + Yearly Number",
+            "Bill numbering format: Prefix-DeptCode-InstCode-Year-Number",
+            "Lines 421, 531 (Controller): Bill number generation logic",
+            OptionScope.APPLICATION
+        ));
+
+        requestMetadata.addConfigOption(new ConfigOptionInfo(
+            "Bill Number Generation Strategy for Pharmacy Transfer Request - Prefix + Institution Code + Year + Yearly Number",
+            "Bill numbering format: Prefix-InstCode-Year-Number",
+            "Lines 423, 533 (Controller): Bill number generation logic",
+            OptionScope.APPLICATION
+        ));
+
+        requestMetadata.addConfigOption(new ConfigOptionInfo(
+            "Bill Number Generation Strategy for Pharmacy Transfer Request - Prefix + Institution Code + Department Code + Year + Yearly Number",
+            "Bill numbering format: Prefix-InstCode-DeptCode-Year-Number",
+            "Lines 430, 548 (Controller): Bill number generation logic",
+            OptionScope.APPLICATION
+        ));
+
+        requestMetadata.addConfigOption(new ConfigOptionInfo(
+            "Pharmacy Transfer is by Purchase Rate",
+            "Uses purchase rate for transfer pricing calculations",
+            "Line 1328 (Controller): Transfer rate determination",
+            OptionScope.APPLICATION
+        ));
+
+        requestMetadata.addConfigOption(new ConfigOptionInfo(
+            "Pharmacy Transfer is by Cost Rate",
+            "Uses cost rate for transfer pricing calculations",
+            "Line 1329 (Controller): Transfer rate determination",
+            OptionScope.APPLICATION
+        ));
+
+        requestMetadata.addConfigOption(new ConfigOptionInfo(
+            "Pharmacy Transfer is by Retail Rate",
+            "Uses retail rate for transfer pricing calculations",
+            "Line 1330 (Controller): Transfer rate determination",
+            OptionScope.APPLICATION
+        ));
+
+        // Privileges
+        requestMetadata.addPrivilege(new PrivilegeInfo(
+            "Admin",
+            "Administrative access to configuration interface",
+            "Config button visibility"
+        ));
+
+        requestMetadata.addPrivilege(new PrivilegeInfo(
+            "StockRequestViewRates",
+            "View rate and value information in stock requests",
+            "Lines 169, 179, 251, 258, 292-294 (XHTML): Rate and value fields visibility"
+        ));
+
+        requestMetadata.addPrivilege(new PrivilegeInfo(
+            "ChangeReceiptPrintingPaperTypes",
+            "Access to receipt printing configuration settings",
+            "Line 319 (XHTML): Settings button visibility"
+        ));
+
+        pageMetadataRegistry.registerPage(requestMetadata);
+
+        // Register pharmacy_transfer_request_approval.xhtml
+        PageMetadata approvalMetadata = new PageMetadata();
+        approvalMetadata.setPagePath("pharmacy/pharmacy_transfer_request_approval");
+        approvalMetadata.setPageName("Pharmacy Transfer Request Approval");
+        approvalMetadata.setDescription("Approve transfer requests from other departments");
+        approvalMetadata.setControllerClass("TransferRequestController");
+
+        approvalMetadata.addConfigOption(new ConfigOptionInfo(
+            "Pharmacy Transfer Request Receipt is A4",
+            "Uses A4 paper format for transfer request receipts",
+            "Line 174 (XHTML): Receipt format selection",
+            OptionScope.APPLICATION
+        ));
+
+        approvalMetadata.addConfigOption(new ConfigOptionInfo(
+            "Pharmacy Transfer Request Receipt is Custom 1",
+            "Uses Custom Format 1 for transfer request receipts",
+            "Line 178 (XHTML): Receipt format selection",
+            OptionScope.APPLICATION
+        ));
+
+        approvalMetadata.addConfigOption(new ConfigOptionInfo(
+            "Pharmacy Transfer Request Receipt is Custom 2",
+            "Uses Custom Format 2 for transfer request receipts",
+            "Line 183 (XHTML): Receipt format selection",
+            OptionScope.APPLICATION
+        ));
+
+        approvalMetadata.addPrivilege(new PrivilegeInfo(
+            "Admin",
+            "Administrative access to configuration interface",
+            "Config button visibility"
+        ));
+
+        approvalMetadata.addPrivilege(new PrivilegeInfo(
+            "ChangeReceiptPrintingPaperTypes",
+            "Access to receipt printing configuration settings",
+            "Line 150 (XHTML): Settings button visibility"
+        ));
+
+        pageMetadataRegistry.registerPage(approvalMetadata);
+
+        // Register pharmacy_transfer_request_list_to_finalize.xhtml
+        PageMetadata finalizeListMetadata = new PageMetadata();
+        finalizeListMetadata.setPagePath("pharmacy/pharmacy_transfer_request_list_to_finalize");
+        finalizeListMetadata.setPageName("Pharmacy Transfer Requests to Finalize");
+        finalizeListMetadata.setDescription("List of saved transfer requests that need to be finalized");
+        finalizeListMetadata.setControllerClass("SearchController");
+
+        finalizeListMetadata.addPrivilege(new PrivilegeInfo(
+            "Admin",
+            "Administrative access to configuration interface",
+            "Config button visibility"
+        ));
+
+        pageMetadataRegistry.registerPage(finalizeListMetadata);
+
+        // Register pharmacy_transfer_request_list_to_approve.xhtml
+        PageMetadata approveListMetadata = new PageMetadata();
+        approveListMetadata.setPagePath("pharmacy/pharmacy_transfer_request_list_to_approve");
+        approveListMetadata.setPageName("Pharmacy Transfer Requests to Approve");
+        approveListMetadata.setDescription("List of finalized transfer requests awaiting approval");
+        approveListMetadata.setControllerClass("SearchController");
+
+        approveListMetadata.addPrivilege(new PrivilegeInfo(
+            "Admin",
+            "Administrative access to configuration interface",
+            "Config button visibility"
+        ));
+
+        pageMetadataRegistry.registerPage(approveListMetadata);
+
+        // Register pharmacy_transfer_request_list.xhtml
+        PageMetadata requestListMetadata = new PageMetadata();
+        requestListMetadata.setPagePath("pharmacy/pharmacy_transfer_request_list");
+        requestListMetadata.setPageName("Pharmacy Transfer Request List");
+        requestListMetadata.setDescription("List of approved transfer requests ready for issue");
+        requestListMetadata.setControllerClass("SearchController");
+
+        requestListMetadata.addPrivilege(new PrivilegeInfo(
+            "Admin",
+            "Administrative access to configuration interface",
+            "Config button visibility"
+        ));
+
+        pageMetadataRegistry.registerPage(requestListMetadata);
     }
 
 }

--- a/src/main/webapp/pharmacy/pharmacy_transfer_issue.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_transfer_issue.xhtml
@@ -8,6 +8,21 @@
                 xmlns:ph="http://xmlns.jcp.org/jsf/composite/pharmacy">
 
     <ui:define name="subcontent">
+        <!-- Admin Config Button (Admin Only) -->
+        <div class="d-flex justify-content-start mb-2">
+            <h:panelGroup rendered="#{webUserController.hasPrivilege('Admin')}">
+                <p:commandButton
+                    value="Config"
+                    icon="fa fa-cog"
+                    title="Page Configuration Management"
+                    action="#{pageAdminController.navigateToPageAdmin('pharmacy/pharmacy_transfer_issue')}"
+                    ajax="false"
+                    styleClass="ui-button-secondary ui-button-sm p-button-outlined"
+                    style="font-size: 0.8rem; padding: 0.25rem 0.5rem;">
+                </p:commandButton>
+            </h:panelGroup>
+        </div>
+
         <h:form>
 
             <p:panel rendered="#{!transferIssueForRequestsController.printPreview}">

--- a/src/main/webapp/pharmacy/pharmacy_transfer_issued_list.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_transfer_issued_list.xhtml
@@ -7,6 +7,21 @@
                 xmlns:f="http://xmlns.jcp.org/jsf/core">
 
     <ui:define name="subcontent">
+        <!-- Admin Config Button (Admin Only) -->
+        <div class="d-flex justify-content-start mb-2">
+            <h:panelGroup rendered="#{webUserController.hasPrivilege('Admin')}">
+                <p:commandButton
+                    value="Config"
+                    icon="fa fa-cog"
+                    title="Page Configuration Management"
+                    action="#{pageAdminController.navigateToPageAdmin('pharmacy/pharmacy_transfer_issued_list')}"
+                    ajax="false"
+                    styleClass="ui-button-secondary ui-button-sm p-button-outlined"
+                    style="font-size: 0.8rem; padding: 0.25rem 0.5rem;">
+                </p:commandButton>
+            </h:panelGroup>
+        </div>
+
         <h:form>
             <p:panel>
 

--- a/src/main/webapp/pharmacy/pharmacy_transfer_receive.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_transfer_receive.xhtml
@@ -8,6 +8,21 @@
                 xmlns:ph="http://xmlns.jcp.org/jsf/composite/pharmacy">
 
     <ui:define name="subcontent">
+        <!-- Admin Config Button (Admin Only) -->
+        <div class="d-flex justify-content-start mb-2">
+            <h:panelGroup rendered="#{webUserController.hasPrivilege('Admin')}">
+                <p:commandButton
+                    value="Config"
+                    icon="fa fa-cog"
+                    title="Page Configuration Management"
+                    action="#{pageAdminController.navigateToPageAdmin('pharmacy/pharmacy_transfer_receive')}"
+                    ajax="false"
+                    styleClass="ui-button-secondary ui-button-sm p-button-outlined"
+                    style="font-size: 0.8rem; padding: 0.25rem 0.5rem;">
+                </p:commandButton>
+            </h:panelGroup>
+        </div>
+
         <h:form>
             <p:panel rendered="#{!transferReceiveController.printPreview}">
                 <p:panel>

--- a/src/main/webapp/pharmacy/pharmacy_transfer_request.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_transfer_request.xhtml
@@ -8,6 +8,21 @@
                 xmlns:ph="http://xmlns.jcp.org/jsf/composite/pharmacy">
 
     <ui:define name="subcontent">
+        <!-- Admin Config Button (Admin Only) -->
+        <div class="d-flex justify-content-start mb-2">
+            <h:panelGroup rendered="#{webUserController.hasPrivilege('Admin')}">
+                <p:commandButton
+                    value="Config"
+                    icon="fa fa-cog"
+                    title="Page Configuration Management"
+                    action="#{pageAdminController.navigateToPageAdmin('pharmacy/pharmacy_transfer_request')}"
+                    ajax="false"
+                    styleClass="ui-button-secondary ui-button-sm p-button-outlined"
+                    style="font-size: 0.8rem; padding: 0.25rem 0.5rem;">
+                </p:commandButton>
+            </h:panelGroup>
+        </div>
+
         <h:form>
             <p:panel rendered="#{!transferRequestController.printPreview}">
                 <h:panelGroup  class="row" rendered="#{transferRequestController.toDepartment eq null or transferRequestController.toDepartment  eq sessionController.loggedUser.department}">

--- a/src/main/webapp/pharmacy/pharmacy_transfer_request_approval.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_transfer_request_approval.xhtml
@@ -7,6 +7,21 @@
                 xmlns:f="http://xmlns.jcp.org/jsf/core"
                 xmlns:ph="http://xmlns.jcp.org/jsf/composite/pharmacy">
     <ui:define name="subcontent">
+        <!-- Admin Config Button (Admin Only) -->
+        <div class="d-flex justify-content-start mb-2">
+            <h:panelGroup rendered="#{webUserController.hasPrivilege('Admin')}">
+                <p:commandButton
+                    value="Config"
+                    icon="fa fa-cog"
+                    title="Page Configuration Management"
+                    action="#{pageAdminController.navigateToPageAdmin('pharmacy/pharmacy_transfer_request_approval')}"
+                    ajax="false"
+                    styleClass="ui-button-secondary ui-button-sm p-button-outlined"
+                    style="font-size: 0.8rem; padding: 0.25rem 0.5rem;">
+                </p:commandButton>
+            </h:panelGroup>
+        </div>
+
         <h:form>
             <p:panel rendered="#{!transferRequestController.printPreview}">
                 <p:panel rendered="#{transferRequestController.toDepartment ne null }">

--- a/src/main/webapp/pharmacy/pharmacy_transfer_request_list.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_transfer_request_list.xhtml
@@ -7,6 +7,21 @@
                 xmlns:f="http://xmlns.jcp.org/jsf/core">
 
     <ui:define name="subcontent">
+        <!-- Admin Config Button (Admin Only) -->
+        <div class="d-flex justify-content-start mb-2">
+            <h:panelGroup rendered="#{webUserController.hasPrivilege('Admin')}">
+                <p:commandButton
+                    value="Config"
+                    icon="fa fa-cog"
+                    title="Page Configuration Management"
+                    action="#{pageAdminController.navigateToPageAdmin('pharmacy/pharmacy_transfer_request_list')}"
+                    ajax="false"
+                    styleClass="ui-button-secondary ui-button-sm p-button-outlined"
+                    style="font-size: 0.8rem; padding: 0.25rem 0.5rem;">
+                </p:commandButton>
+            </h:panelGroup>
+        </div>
+
         <h:form>
             <p:panel >
                 <f:facet name="header">

--- a/src/main/webapp/pharmacy/pharmacy_transfer_request_list_to_approve.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_transfer_request_list_to_approve.xhtml
@@ -7,6 +7,21 @@
                 xmlns:f="http://xmlns.jcp.org/jsf/core">
 
     <ui:define name="subcontent">
+        <!-- Admin Config Button (Admin Only) -->
+        <div class="d-flex justify-content-start mb-2">
+            <h:panelGroup rendered="#{webUserController.hasPrivilege('Admin')}">
+                <p:commandButton
+                    value="Config"
+                    icon="fa fa-cog"
+                    title="Page Configuration Management"
+                    action="#{pageAdminController.navigateToPageAdmin('pharmacy/pharmacy_transfer_request_list_to_approve')}"
+                    ajax="false"
+                    styleClass="ui-button-secondary ui-button-sm p-button-outlined"
+                    style="font-size: 0.8rem; padding: 0.25rem 0.5rem;">
+                </p:commandButton>
+            </h:panelGroup>
+        </div>
+
         <h:form>
             <p:panel>
                 <f:facet name="header">

--- a/src/main/webapp/pharmacy/pharmacy_transfer_request_list_to_finalize.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_transfer_request_list_to_finalize.xhtml
@@ -7,6 +7,21 @@
                 xmlns:f="http://xmlns.jcp.org/jsf/core">
 
     <ui:define name="subcontent">
+        <!-- Admin Config Button (Admin Only) -->
+        <div class="d-flex justify-content-start mb-2">
+            <h:panelGroup rendered="#{webUserController.hasPrivilege('Admin')}">
+                <p:commandButton
+                    value="Config"
+                    icon="fa fa-cog"
+                    title="Page Configuration Management"
+                    action="#{pageAdminController.navigateToPageAdmin('pharmacy/pharmacy_transfer_request_list_to_finalize')}"
+                    ajax="false"
+                    styleClass="ui-button-secondary ui-button-sm p-button-outlined"
+                    style="font-size: 0.8rem; padding: 0.25rem 0.5rem;">
+                </p:commandButton>
+            </h:panelGroup>
+        </div>
+
         <h:form>
             <p:panel>
                 <f:facet name="header">


### PR DESCRIPTION
…r pages

- Added Config button to 8 pharmacy transfer pages for admin access
- Registered page metadata in 3 controllers (TransferRequestController, TransferIssueForRequestsController, TransferReceiveController)
- Documented all configuration options and privileges used by each page
- Config options include: transfer pricing methods, receipt formats, bill numbering, rate visibility settings
- Privileges include: Admin, StockRequestViewRates, StockTransactionViewRates, PharmacyTransferViewRates, ChangeReceiptPrintingPaperTypes

Pages modified:
- pharmacy_transfer_request.xhtml
- pharmacy_transfer_request_list_to_finalize.xhtml
- pharmacy_transfer_request_list_to_approve.xhtml
- pharmacy_transfer_request_approval.xhtml
- pharmacy_transfer_request_list.xhtml
- pharmacy_transfer_issue.xhtml
- pharmacy_transfer_issued_list.xhtml
- pharmacy_transfer_receive.xhtml

Closes #16771