### PR TITLE
Add configuration management for pharmacy disposal pages

### DIFF
--- a/src/main/java/com/divudi/bean/pharmacy/IssueReturnController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/IssueReturnController.java
@@ -7,7 +7,13 @@ package com.divudi.bean.pharmacy;
 import com.divudi.bean.common.PriceMatrixController;
 import com.divudi.bean.common.SessionController;
 import com.divudi.bean.common.ConfigOptionApplicationController;
+import com.divudi.bean.common.ConfigOptionController;
+import com.divudi.bean.common.PageMetadataRegistry;
 import com.divudi.bean.inward.InwardBeanController;
+import com.divudi.core.data.OptionScope;
+import com.divudi.core.data.admin.ConfigOptionInfo;
+import com.divudi.core.data.admin.PageMetadata;
+import com.divudi.core.data.admin.PrivilegeInfo;
 import com.divudi.core.data.BillClassType;
 import com.divudi.core.data.BillNumberSuffix;
 import com.divudi.core.data.BillType;
@@ -39,6 +45,7 @@ import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.List;
+import javax.annotation.PostConstruct;
 import javax.ejb.EJB;
 import javax.enterprise.context.Dependent;
 import javax.enterprise.context.SessionScoped;
@@ -77,7 +84,11 @@ public class IssueReturnController implements Serializable {
     @Inject
     private ConfigOptionApplicationController configOptionApplicationController;
     @Inject
+    private ConfigOptionController configOptionController;
+    @Inject
     private DisposalReturnWorkflowController disposalReturnWorkflowController;
+    @Inject
+    private PageMetadataRegistry pageMetadataRegistry;
 
     private Bill originalBill;
     private Bill returnBill;
@@ -88,6 +99,98 @@ public class IssueReturnController implements Serializable {
     private List<BillItem> returnBillItems;
 
     private List<BillItem> selectedBillItems;
+
+    @PostConstruct
+    public void init() {
+        registerPageMetadata();
+    }
+
+    /**
+     * Register page metadata for the admin configuration interface
+     */
+    private void registerPageMetadata() {
+        if (pageMetadataRegistry == null) {
+            return;
+        }
+
+        PageMetadata metadata = new PageMetadata();
+        metadata.setPagePath("pharmacy/pharmacy_bill_return_issue");
+        metadata.setPageName("Pharmacy Disposal Issue Return");
+        metadata.setDescription("Return of previously issued pharmacy disposal items back to issuing department");
+        metadata.setControllerClass("IssueReturnController");
+
+        // Configuration Options - Print Formats
+        metadata.addConfigOption(new ConfigOptionInfo(
+            "Pharmacy Bill Return Issue Receipt is A4 Paper",
+            "Uses A4 paper format for bill return issue receipts (default format)",
+            OptionScope.APPLICATION
+        ));
+
+        metadata.addConfigOption(new ConfigOptionInfo(
+            "Pharmacy Bill Return Issue Receipt is Custom 1",
+            "Uses Custom format 1 for bill return issue receipts",
+            OptionScope.APPLICATION
+        ));
+
+        metadata.addConfigOption(new ConfigOptionInfo(
+            "Pharmacy Bill Return Issue Receipt is Custom 2",
+            "Uses Custom format 2 for bill return issue receipts",
+            OptionScope.APPLICATION
+        ));
+
+        // Configuration Options - Bill Number Generation Strategies
+        metadata.addConfigOption(new ConfigOptionInfo(
+            "Bill Number Generation Strategy for Pharmacy Issue Return - Prefix + Department Code + Institution Code + Year + Yearly Number",
+            "Generates bill numbers for issue returns in format: Prefix-DeptCode-InstCode-Year-Number (e.g., PIR-PHARM-001-2024-0001)",
+            OptionScope.APPLICATION
+        ));
+
+        metadata.addConfigOption(new ConfigOptionInfo(
+            "Bill Number Generation Strategy for Pharmacy Issue Return - Prefix + Institution Code + Department Code + Year + Yearly Number",
+            "Generates bill numbers for issue returns in format: Prefix-InstCode-DeptCode-Year-Number (e.g., PIR-001-PHARM-2024-0001)",
+            OptionScope.APPLICATION
+        ));
+
+        metadata.addConfigOption(new ConfigOptionInfo(
+            "Bill Number Generation Strategy for Pharmacy Issue Return - Prefix + Institution Code + Year + Yearly Number",
+            "Generates bill numbers for issue returns in format: Prefix-InstCode-Year-Number (e.g., PIR-001-2024-0001) - institution-wide counter",
+            OptionScope.APPLICATION
+        ));
+
+        // Privileges
+        metadata.addPrivilege(new PrivilegeInfo(
+            "Admin",
+            "Administrative access to page configuration management - displays the Config button"
+        ));
+
+        metadata.addPrivilege(new PrivilegeInfo(
+            "CreateDisposalReturn",
+            "Permission to create new disposal return requests from issued bills"
+        ));
+
+        metadata.addPrivilege(new PrivilegeInfo(
+            "FinalizeDisposalReturn",
+            "Permission to finalize disposal return requests, marking them ready for approval"
+        ));
+
+        metadata.addPrivilege(new PrivilegeInfo(
+            "ApproveDisposalReturn",
+            "Permission to approve and settle disposal return requests, completing the return process"
+        ));
+
+        metadata.addPrivilege(new PrivilegeInfo(
+            "ViewDisposalReturn",
+            "Permission to view completed disposal return records"
+        ));
+
+        metadata.addPrivilege(new PrivilegeInfo(
+            "ChangeReceiptPrintingPaperTypes",
+            "Permission to access printer configuration settings dialog for changing bill return issue receipt paper formats"
+        ));
+
+        // Register the metadata
+        pageMetadataRegistry.registerPage(metadata);
+    }
 
     public void saveDisposalIssueReturnBill() {
         // No validation required for saving drafts - users can save incomplete data

--- a/src/main/java/com/divudi/bean/pharmacy/PharmacyIssueController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacyIssueController.java
@@ -9,6 +9,11 @@ import com.divudi.bean.common.BillBeanController;
 import com.divudi.bean.common.SessionController;
 import com.divudi.bean.common.ConfigOptionApplicationController;
 import com.divudi.bean.common.ConfigOptionController;
+import com.divudi.bean.common.PageMetadataRegistry;
+import com.divudi.core.data.OptionScope;
+import com.divudi.core.data.admin.ConfigOptionInfo;
+import com.divudi.core.data.admin.PageMetadata;
+import com.divudi.core.data.admin.PrivilegeInfo;
 
 import com.divudi.bean.membership.PaymentSchemeController;
 import com.divudi.bean.store.StoreIssueController;
@@ -64,6 +69,7 @@ import java.util.Optional;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.concurrent.ConcurrentHashMap;
 import javax.persistence.TemporalType;
+import javax.annotation.PostConstruct;
 import javax.ejb.EJB;
 import javax.enterprise.context.SessionScoped;
 import javax.faces.event.AjaxBehaviorEvent;
@@ -98,6 +104,158 @@ public class PharmacyIssueController implements Serializable {
      * Creates a new instance of PharmacySaleController
      */
     public PharmacyIssueController() {
+    }
+
+    @PostConstruct
+    public void init() {
+        registerPageMetadata();
+    }
+
+    /**
+     * Register page metadata for the admin configuration interface
+     */
+    private void registerPageMetadata() {
+        if (pageMetadataRegistry == null) {
+            return;
+        }
+
+        PageMetadata metadata = new PageMetadata();
+        metadata.setPagePath("pharmacy/pharmacy_issue");
+        metadata.setPageName("Pharmacy Disposal Issue");
+        metadata.setDescription("Direct issue of pharmacy items (medicines/devices) as disposal to departments");
+        metadata.setControllerClass("PharmacyIssueController");
+
+        // Configuration Options - Rate and Value Display
+        metadata.addConfigOption(new ConfigOptionInfo(
+            "Consumption - Show Rate and Value",
+            "Controls visibility of purchase rate, retail rate, cost rate, and their corresponding values in autocomplete dropdown, input fields, bill items table, and totals section",
+            OptionScope.APPLICATION
+        ));
+
+        // Configuration Options - Print Formats
+        metadata.addConfigOption(new ConfigOptionInfo(
+            "Pharmacy DIsposal Issue Receipt is A4 Paper",
+            "Uses A4 paper format for disposal issue receipts (default format)",
+            OptionScope.APPLICATION
+        ));
+
+        metadata.addConfigOption(new ConfigOptionInfo(
+            "Pharmacy DIsposal Issue Receipt is Custom 1",
+            "Uses Custom format 1 for disposal issue receipts",
+            OptionScope.APPLICATION
+        ));
+
+        metadata.addConfigOption(new ConfigOptionInfo(
+            "Pharmacy DIsposal Issue Receipt is Custom 2",
+            "Uses Custom format 2 for disposal issue receipts",
+            OptionScope.APPLICATION
+        ));
+
+        // Configuration Options - Search Settings
+        metadata.addConfigOption(new ConfigOptionInfo(
+            "Search Items by Item Code",
+            "Enables searching for items by their code in autocomplete fields",
+            OptionScope.APPLICATION
+        ));
+
+        metadata.addConfigOption(new ConfigOptionInfo(
+            "Search Items by Generic Name",
+            "Enables searching for items by their generic name in autocomplete fields",
+            OptionScope.APPLICATION
+        ));
+
+        metadata.addConfigOption(new ConfigOptionInfo(
+            "Restrict Consumption to Stock Availability",
+            "Restricts item selection to only items with available stock",
+            OptionScope.APPLICATION
+        ));
+
+        // Configuration Options - Bill Number Generation Strategies
+        metadata.addConfigOption(new ConfigOptionInfo(
+            "Bill Number Generation Strategy for Pharmacy Disposal Issue - Prefix + Department Code + Institution Code + Year + Yearly Number",
+            "Generates bill numbers in format: Prefix-DeptCode-InstCode-Year-Number (e.g., PDI-PHARM-001-2024-0001)",
+            OptionScope.APPLICATION
+        ));
+
+        metadata.addConfigOption(new ConfigOptionInfo(
+            "Bill Number Generation Strategy for Pharmacy Disposal Issue - Prefix + Institution Code + Department Code + Year + Yearly Number",
+            "Generates bill numbers in format: Prefix-InstCode-DeptCode-Year-Number (e.g., PDI-001-PHARM-2024-0001)",
+            OptionScope.APPLICATION
+        ));
+
+        metadata.addConfigOption(new ConfigOptionInfo(
+            "Bill Number Generation Strategy for Pharmacy Disposal Issue - Prefix + Institution Code + Year + Yearly Number",
+            "Generates bill numbers in format: Prefix-InstCode-Year-Number (e.g., PDI-001-2024-0001) - institution-wide counter",
+            OptionScope.APPLICATION
+        ));
+
+        metadata.addConfigOption(new ConfigOptionInfo(
+            "Bill Number Generation Strategy for Disposal Issue - Separate Bill Numbers for Logged Department",
+            "Generates separate bill number sequences based on the logged-in user's department",
+            OptionScope.APPLICATION
+        ));
+
+        metadata.addConfigOption(new ConfigOptionInfo(
+            "Bill Number Generation Strategy for Disposal Issue - Separate Bill Numbers for Issuing Department",
+            "Generates separate bill number sequences based on the department receiving the issue",
+            OptionScope.APPLICATION
+        ));
+
+        metadata.addConfigOption(new ConfigOptionInfo(
+            "Bill Number Generation Strategy for Disposal Issue - Separate Bill Numbers for Logged and Issuing Department Combination",
+            "Generates separate bill number sequences based on the combination of logged and issuing departments",
+            OptionScope.APPLICATION
+        ));
+
+        // Configuration Options - Business Logic
+        metadata.addConfigOption(new ConfigOptionInfo(
+            "Add quantity from multiple batches in pharmacy disposal issue",
+            "Allows adding quantities from multiple batches of the same item to a single bill line",
+            OptionScope.APPLICATION
+        ));
+
+        metadata.addConfigOption(new ConfigOptionInfo(
+            "Pharmacy Disposal is by Purchase Rate",
+            "Uses purchase rate for calculating disposal issue values (default rate type)",
+            OptionScope.APPLICATION
+        ));
+
+        metadata.addConfigOption(new ConfigOptionInfo(
+            "Pharmacy Disposal is by Cost Rate",
+            "Uses cost rate for calculating disposal issue values",
+            OptionScope.APPLICATION
+        ));
+
+        metadata.addConfigOption(new ConfigOptionInfo(
+            "Pharmacy Disposal is by Retail Rate",
+            "Uses retail rate for calculating disposal issue values",
+            OptionScope.APPLICATION
+        ));
+
+        metadata.addConfigOption(new ConfigOptionInfo(
+            "Add the Institution Code to the Bill Number Generator",
+            "Includes institution code in the generated bill numbers",
+            OptionScope.APPLICATION
+        ));
+
+        // Privileges
+        metadata.addPrivilege(new PrivilegeInfo(
+            "Admin",
+            "Administrative access to page configuration management - displays the Config button"
+        ));
+
+        metadata.addPrivilege(new PrivilegeInfo(
+            "ConsumptionViewRates",
+            "Permission to view purchase rates, retail rates, cost rates, and their corresponding values throughout the disposal issue interface"
+        ));
+
+        metadata.addPrivilege(new PrivilegeInfo(
+            "ChangeReceiptPrintingPaperTypes",
+            "Permission to access printer configuration settings dialog for changing disposal issue receipt paper formats"
+        ));
+
+        // Register the metadata
+        pageMetadataRegistry.registerPage(metadata);
     }
 
     @Inject
@@ -136,6 +294,8 @@ public class PharmacyIssueController implements Serializable {
     private PharmacyController pharmacyController;
     @Inject
     private StockController stockController;
+    @Inject
+    private PageMetadataRegistry pageMetadataRegistry;
 
     @EJB
     private CashTransactionBean cashTransactionBean;

--- a/src/main/webapp/pharmacy/pharmacy_bill_return_issue.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_bill_return_issue.xhtml
@@ -15,6 +15,21 @@
 
             <ui:define name="content">
                 <h:form>
+                    <!-- Config Button (Admin Only) -->
+                    <div class="d-flex justify-content-start mb-2">
+                        <h:panelGroup rendered="#{webUserController.hasPrivilege('Admin')}">
+                            <p:commandButton
+                                value="Config"
+                                icon="fa fa-cog"
+                                title="Page Configuration Management"
+                                action="#{pageAdminController.navigateToPageAdmin('pharmacy/pharmacy_bill_return_issue')}"
+                                ajax="false"
+                                styleClass="ui-button-secondary ui-button-sm p-button-outlined"
+                                style="font-size: 0.8rem; padding: 0.25rem 0.5rem;">
+                            </p:commandButton>
+                        </h:panelGroup>
+                    </div>
+
                     <h:panelGroup rendered="#{!issueReturnController.printPreview}">
                         <!-- Page Header -->
                         <p:panel styleClass="mb-3">

--- a/src/main/webapp/pharmacy/pharmacy_issue.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_issue.xhtml
@@ -14,6 +14,21 @@
                 <h:form id="bill">
                     <p:growl id="panelError" />
 
+                    <!-- Config Button (Admin Only) -->
+                    <div class="d-flex justify-content-start mb-2">
+                        <h:panelGroup rendered="#{webUserController.hasPrivilege('Admin')}">
+                            <p:commandButton
+                                value="Config"
+                                icon="fa fa-cog"
+                                title="Page Configuration Management"
+                                action="#{pageAdminController.navigateToPageAdmin('pharmacy/pharmacy_issue')}"
+                                ajax="false"
+                                styleClass="ui-button-secondary ui-button-sm p-button-outlined"
+                                style="font-size: 0.8rem; padding: 0.25rem 0.5rem;">
+                            </p:commandButton>
+                        </h:panelGroup>
+                    </div>
+
                     <p:panel rendered="#{!pharmacyIssueController.billPreview}">
                         <h:panelGroup class="row" rendered="#{pharmacyIssueController.toDepartment eq null or pharmacyIssueController.toDepartment eq sessionController.loggedUser.department}">
                             <p:panel>


### PR DESCRIPTION
Implemented page configuration tracking and admin interface access for:
- pharmacy/pharmacy_issue.xhtml (Pharmacy Disposal Issue)
- pharmacy/pharmacy_bill_return_issue.xhtml (Pharmacy Disposal Issue Return)

Changes:
1. Added Config button to both XHTML pages (admin-only visibility)
2. Registered page metadata in PharmacyIssueController:
   - 16 configuration options (rate display, print formats, search settings, bill generation strategies, business logic)
   - 3 privileges (Admin, ConsumptionViewRates, ChangeReceiptPrintingPaperTypes)
3. Registered page metadata in IssueReturnController:
   - 6 configuration options (print formats, bill generation strategies)
   - 6 privileges (Admin, CreateDisposalReturn, FinalizeDisposalReturn, ApproveDisposalReturn, ViewDisposalReturn, ChangeReceiptPrintingPaperTypes)

Features:
- Administrators can now click Config button to access page-specific configuration management
- All configuration options and privileges are documented and accessible through admin interface
- Supports centralized configuration management across the application