### PR TITLE
fixed the enter key not triggered

### DIFF
--- a/src/main/webapp/inward/pharmacy_bill_issue_bht.xhtml
+++ b/src/main/webapp/inward/pharmacy_bill_issue_bht.xhtml
@@ -357,7 +357,7 @@
                                 <p:focus id="focusQty" for="txtQty" ></p:focus>
                                 <p:focus id="focusItem" for="acStock" ></p:focus>
                             </p:panel>
-
+                            <p:defaultCommand target="btnAdd"> </p:defaultCommand>
                             <p:panel header="Bill Items" id="pBis" class="my-1">
 
                                 <p:dataTable


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Pharmacy bill form now supports pressing Enter to directly trigger the Add button action, streamlining bill item data entry and reducing navigation steps for improved user efficiency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->