### PR TITLE
user-configurable column visibility and page size

### DIFF
--- a/src/main/java/com/divudi/bean/common/UserSettingsController.java
+++ b/src/main/java/com/divudi/bean/common/UserSettingsController.java
@@ -607,6 +607,87 @@ public class UserSettingsController implements Serializable {
         saveColumnVisibility("pharmacy_grn_return_request", settings);
     }
 
+    // Pharmacy GRN List For Return Column Visibility Properties
+    // These properties provide JSF-compatible getter/setter pairs for the specific page
+
+    public boolean isPharmacyGrnListForReturnDistributorVisible() {
+        return isColumnVisible("pharmacy_grn_list_for_return", "distributor");
+    }
+
+    public void setPharmacyGrnListForReturnDistributorVisible(boolean visible) {
+        ColumnVisibilitySettings settings = getColumnVisibility("pharmacy_grn_list_for_return");
+        settings.setColumnVisible("distributor", visible);
+        saveColumnVisibility("pharmacy_grn_list_for_return", settings);
+    }
+
+    public boolean isPharmacyGrnListForReturnPoNoVisible() {
+        return isColumnVisible("pharmacy_grn_list_for_return", "poNo");
+    }
+
+    public void setPharmacyGrnListForReturnPoNoVisible(boolean visible) {
+        ColumnVisibilitySettings settings = getColumnVisibility("pharmacy_grn_list_for_return");
+        settings.setColumnVisible("poNo", visible);
+        saveColumnVisibility("pharmacy_grn_list_for_return", settings);
+    }
+
+    public boolean isPharmacyGrnListForReturnGrnNoVisible() {
+        return isColumnVisible("pharmacy_grn_list_for_return", "grnNo");
+    }
+
+    public void setPharmacyGrnListForReturnGrnNoVisible(boolean visible) {
+        ColumnVisibilitySettings settings = getColumnVisibility("pharmacy_grn_list_for_return");
+        settings.setColumnVisible("grnNo", visible);
+        saveColumnVisibility("pharmacy_grn_list_for_return", settings);
+    }
+
+    public boolean isPharmacyGrnListForReturnGrnAtVisible() {
+        return isColumnVisible("pharmacy_grn_list_for_return", "grnAt");
+    }
+
+    public void setPharmacyGrnListForReturnGrnAtVisible(boolean visible) {
+        ColumnVisibilitySettings settings = getColumnVisibility("pharmacy_grn_list_for_return");
+        settings.setColumnVisible("grnAt", visible);
+        saveColumnVisibility("pharmacy_grn_list_for_return", settings);
+    }
+
+    public boolean isPharmacyGrnListForReturnGrnByVisible() {
+        return isColumnVisible("pharmacy_grn_list_for_return", "grnBy");
+    }
+
+    public void setPharmacyGrnListForReturnGrnByVisible(boolean visible) {
+        ColumnVisibilitySettings settings = getColumnVisibility("pharmacy_grn_list_for_return");
+        settings.setColumnVisible("grnBy", visible);
+        saveColumnVisibility("pharmacy_grn_list_for_return", settings);
+    }
+    
+    public boolean isPharmacyGrnListForReturnPoValueVisible() {
+        return isColumnVisible("pharmacy_grn_list_for_return", "poValue");
+    }
+
+    public void setPharmacyGrnListForReturnPoValueVisible(boolean visible) {
+        ColumnVisibilitySettings settings = getColumnVisibility("pharmacy_grn_list_for_return");
+        settings.setColumnVisible("poValue", visible);
+        saveColumnVisibility("pharmacy_grn_list_for_return", settings);
+    }
+
+    public boolean isPharmacyGrnListForReturnGrnValueVisible() {
+        return isColumnVisible("pharmacy_grn_list_for_return", "grnValue");
+    }
+
+    public void setPharmacyGrnListForReturnGrnValueVisible(boolean visible) {
+        ColumnVisibilitySettings settings = getColumnVisibility("pharmacy_grn_list_for_return");
+        settings.setColumnVisible("grnValue", visible);
+        saveColumnVisibility("pharmacy_grn_list_for_return", settings);
+    }
+
+    public int getPharmacyGrnListForReturnPageSize() {
+        return getPageSize("pharmacy_grn_list_for_return", 10);
+    }
+
+    public void setPharmacyGrnListForReturnPageSize(int pagesize) {
+        savePageSize("pharmacy_grn_list_for_return", pagesize);
+    }
+    
     // Stock Ledger Column Visibility Properties
     // These properties provide JSF-compatible getter/setter pairs for the stock ledger report page
 

--- a/src/main/webapp/pharmacy/pharmacy_grn_list_for_return.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_grn_list_for_return.xhtml
@@ -61,12 +61,13 @@
                         </h:panelGrid>
                     </div>
                     <div class="col-11">
-                        <p:dataTable 
+                        <p:dataTable
+                            id="grnList"
                             value="#{searchController.bills}" 
                             var="p"
                             class="w-100"
                             paginator="true"
-                            rows="10"
+                            rows="#{userSettingsController.pharmacyGrnListForReturnPageSize}"
                             rowIndexVar="n"
                             paginatorPosition="bottom"
                             paginatorTemplate="{CurrentPageReport} {FirstPageLink} {PreviousPageLink} {PageLinks} {NextPageLink} {LastPageLink} {RowsPerPageDropdown}"
@@ -79,7 +80,8 @@
                                 headerText="Distributor" 
                                 sortBy="#{p.fromInstitution.name}" 
                                 filterBy="#{p.fromInstitution.name}" 
-                                filterMatchMode="contains">
+                                filterMatchMode="contains"
+                                rendered="#{userSettingsController.pharmacyGrnListForReturnDistributorVisible}">
                                 <h:outputText value="#{p.fromInstitution.name}" />
                             </p:column>
 
@@ -88,7 +90,8 @@
                                 width="8em" 
                                 sortBy="#{p.referenceBill.deptId}" 
                                 filterBy="#{p.referenceBill.deptId}" 
-                                filterMatchMode="contains">
+                                filterMatchMode="contains"
+                                rendered="#{userSettingsController.pharmacyGrnListForReturnPoNoVisible}">
                                 <h:outputText value="#{p.referenceBill.deptId}" />
                             </p:column>
 
@@ -97,14 +100,16 @@
                                 width="8em" 
                                 sortBy="#{p.deptId}" 
                                 filterBy="#{p.deptId}" 
-                                filterMatchMode="contains">
+                                filterMatchMode="contains"
+                                rendered="#{userSettingsController.pharmacyGrnListForReturnGrnNoVisible}">
                                 <h:outputText value="#{p.deptId}" />
                             </p:column>
 
                             <p:column 
                                 headerText="GRN at" 
                                 width="10em" 
-                                sortBy="#{p.createdAt}">
+                                sortBy="#{p.createdAt}"
+                                rendered="#{userSettingsController.pharmacyGrnListForReturnGrnAtVisible}">
                                 <h:outputText value="#{p.createdAt}">
                                     <f:convertDateTime timeZone="Asia/Colombo" pattern="#{sessionController.applicationPreference.longDateTimeFormat}" />
                                 </h:outputText>
@@ -136,7 +141,8 @@
                                 width="6em" 
                                 sortBy="#{p.creater.webUserPerson.name}" 
                                 filterBy="#{p.creater.webUserPerson.name}" 
-                                filterMatchMode="contains">
+                                filterMatchMode="contains"
+                                rendered="#{userSettingsController.pharmacyGrnListForReturnGrnByVisible}">
                                 <h:outputText value="#{p.creater.webUserPerson.name}" />
                                 <h:panelGroup rendered="#{p.cancelled}">
                                     <br/>
@@ -161,7 +167,8 @@
                                 sortBy="#{p.referenceBill.netTotal}" 
                                 filterBy="#{p.referenceBill.netTotal}" 
                                 filterMatchMode="equals"
-                                styleClass="text-end">
+                                styleClass="text-end"
+                                rendered="#{userSettingsController.pharmacyGrnListForReturnPoValueVisible}">
                                 <h:outputText value="#{p.referenceBill.netTotal}">
                                     <f:convertNumber pattern="#,##0.00" />
                                 </h:outputText>
@@ -173,7 +180,8 @@
                                 sortBy="#{p.netTotal}" 
                                 filterBy="#{p.netTotal}" 
                                 filterMatchMode="equals" 
-                                styleClass="text-end">
+                                styleClass="text-end"
+                                rendered="#{userSettingsController.pharmacyGrnListForReturnGrnValueVisible}">
                                 <h:outputText value="#{p.netTotal}">
                                     <f:convertNumber pattern="#,##0.00" />
                                 </h:outputText>
@@ -242,6 +250,49 @@
 
                             </p:column>
                         </p:dataTable>
+                        
+                        <!-- Column Visibility Settings - Subtle placement -->
+                        <div class="mt-3 pt-2" style="border-top: 1px solid #e9ecef;">
+                            <p:panel id="panelColumnToggler" toggleable="true" collapsed="true" styleClass="ui-panel-sm">
+                                <f:facet name="header">
+                                    <span style="font-size: 0.85rem; color: #6c757d;">
+                                        <i class="fas fa-eye me-1" style="font-size: 0.75rem;"></i>
+                                        Customize Columns
+                                    </span>
+                                </f:facet>
+                                
+                                <div class="d-flex flex-wrap gap-2" style="font-size: 0.8rem;">
+                                    <p:selectBooleanCheckbox value="#{userSettingsController.pharmacyGrnListForReturnDistributorVisible}"
+                                                            itemLabel="Distributor">
+                                        <p:ajax process="@this" update=":#{p:resolveFirstComponentWithId('grnList',view).clientId}" />
+                                    </p:selectBooleanCheckbox>
+                                    <p:selectBooleanCheckbox value="#{userSettingsController.pharmacyGrnListForReturnPoNoVisible}"
+                                                             itemLabel="PO No">
+                                        <p:ajax process="@this" update=":#{p:resolveFirstComponentWithId('grnList',view).clientId}" />
+                                    </p:selectBooleanCheckbox>                                  
+                                    <p:selectBooleanCheckbox value="#{userSettingsController.pharmacyGrnListForReturnGrnNoVisible}"
+                                                               itemLabel="GRN No">
+                                        <p:ajax process="@this" update=":#{p:resolveFirstComponentWithId('grnList',view).clientId}" />
+                                    </p:selectBooleanCheckbox> 
+                                    <p:selectBooleanCheckbox value="#{userSettingsController.pharmacyGrnListForReturnGrnAtVisible}"
+                                                             itemLabel="Grn at">
+                                        <p:ajax process="@this" update=":#{p:resolveFirstComponentWithId('grnList',view).clientId}" />
+                                    </p:selectBooleanCheckbox>
+                                    <p:selectBooleanCheckbox value="#{userSettingsController.pharmacyGrnListForReturnGrnByVisible}"
+                                                             itemLabel="Grn by">
+                                        <p:ajax process="@this" update=":#{p:resolveFirstComponentWithId('grnList',view).clientId}" />
+                                    </p:selectBooleanCheckbox>
+                                    <p:selectBooleanCheckbox value="#{userSettingsController.pharmacyGrnListForReturnPoValueVisible}"
+                                                               itemLabel="PO Value">
+                                        <p:ajax process="@this" update=":#{p:resolveFirstComponentWithId('grnList',view).clientId}" />
+                                    </p:selectBooleanCheckbox>
+                                    <p:selectBooleanCheckbox value="#{userSettingsController.pharmacyGrnListForReturnGrnValueVisible}"
+                                                               itemLabel="GRN Value">
+                                        <p:ajax process="@this" update=":#{p:resolveFirstComponentWithId('grnList',view).clientId}" />
+                                    </p:selectBooleanCheckbox>
+                                </div>
+                            </p:panel>
+                        </div>
 
                     </div>
                 </div>


### PR DESCRIPTION
- User-configurable column visibility and page size,
- There must be data in the table, when there is no data in the table page size does not change.
- Not quite sure about integrating to the page controller.

- Sort order preference is not implemented.

Signed-off-by: OsaVS <41975253+OsaVS@users.noreply.github.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Customizable columns for Pharmacy GRN Return list: Users can now show or hide individual columns (Distributor, PO Number, GRN Number, GRN Date, GRN By, PO Value, GRN Value) via a new "Customize Columns" panel.
  * Adjustable page size: The number of rows displayed per page in the GRN Return list is now user-configurable, replacing the fixed setting.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->