### PR TITLE
17087 - Cancelled Bills Without Sending to Lab Are Still Displayed in External Report

### DIFF
--- a/src/main/java/com/divudi/bean/common/ReportsController.java
+++ b/src/main/java/com/divudi/bean/common/ReportsController.java
@@ -4756,6 +4756,8 @@ public class ReportsController implements Serializable {
                 + "LEFT JOIN PatientInvestigation pi ON pi.billItem = billItem "
                 + "WHERE bill.billTypeAtomic IN :bts "
                 + "AND billItem.item is not null "
+                + "AND billItem.bill.cancelled =:canceled "
+                + "AND billItem.refunded =:ref "
                 + "AND TYPE(billItem.item) = Investigation "
                 + "AND (TYPE(bill) != RefundBill AND TYPE(bill) != CancelledBill) ";
 //        String jpql = "SELECT new com.divudi.core.data.ReportTemplateRow(billItem) "
@@ -4768,6 +4770,8 @@ public class ReportsController implements Serializable {
 //                + " AND bill.billTypeAtomic in :bts ";
 
         parameters.put("bts", bts);
+        parameters.put("canceled", false);
+        parameters.put("ref", false);
 
         if (staff != null) {
             jpql += "AND billItem.patientInvestigation.barcodeGeneratedBy.webUserPerson.name = :staff ";


### PR DESCRIPTION
closes #17087
Signed-off-by: DamithDeshan <hkddrajapaksha@gmail.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed external laboratory workload report to exclude cancelled and refunded bills from results, ensuring only active billing items are included in workload data retrieval.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->