### PR TITLE
Remove "Total Value" field for OPD bill Cheque payment method

### DIFF
--- a/src/main/webapp/opd/opd_bill_ac.xhtml
+++ b/src/main/webapp/opd/opd_bill_ac.xhtml
@@ -1235,7 +1235,7 @@
                                                 class="row my-1"
                                                 layout="block" 
                                                 id="cheque"  rendered="#{opdBillController.paymentMethod eq 'Cheque'}" >
-                                                <pa:cheque paymentMethodData="#{opdBillController.paymentMethodData}"/>
+                                                <pa:chequeDetailsAsOnlyPayment paymentMethodData="#{opdBillController.paymentMethodData}"/>
                                             </h:panelGroup>
                                             <h:panelGroup
                                                 class="row my-1"


### PR DESCRIPTION
- The Total Value field is not required when the user selects the Cheque payment method for OPD bills.
- The field was previously displayed but the value was not automatically populated.
- Removing it improves UI clarity and prevents incorrect data entry.
- No business logic has been changed—only the form layout and visibility rules were updated.

<img width="1915" height="1020" alt="image" src="https://github.com/user-attachments/assets/a40533bd-2df6-4f7a-81e4-c39ac79d9ec6" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Updated the cheque payment method interface in the OPD Bill screen to improve the payment details presentation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->