### PR TITLE
Remove "Total Value" field for OPD bill Slip payment method

### DIFF
--- a/src/main/webapp/opd/opd_bill_ac.xhtml
+++ b/src/main/webapp/opd/opd_bill_ac.xhtml
@@ -1241,7 +1241,7 @@
                                                 class="row my-1"
                                                 layout="block"
                                                 id="slip"  rendered="#{opdBillController.paymentMethod eq 'Slip'}" >
-                                                <pa:slip paymentMethodData="#{opdBillController.paymentMethodData}"/>
+                                                <pa:slipDetailsAsOnlyPayment paymentMethodData="#{opdBillController.paymentMethodData}"/>
                                             </h:panelGroup>
                                             <h:panelGroup
                                                 class="row my-1"


### PR DESCRIPTION
- The Total Value field is not required when the user selects the Slip payment method for OPD bills.
- The field was previously displayed but was not automatically populated.
- Removing it improves UI clarity.
- No business logic has been changed—only the form layout and visibility rules were updated.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the Slip payment method interface in the OPD Billing module for enhanced display and user experience while maintaining all payment functionality.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->