### PR TITLE
# 17119-Cash refunded Bill Show As Credit Card Refund

### DIFF
--- a/src/main/java/com/divudi/bean/common/BillReturnController.java
+++ b/src/main/java/com/divudi/bean/common/BillReturnController.java
@@ -412,6 +412,7 @@ public class BillReturnController implements Serializable, ControllerWithMultipl
         newlyReturnedBill = new RefundBill();
         newlyReturnedBill.copy(originalBillToReturn);
         newlyReturnedBill.setBillTypeAtomic(BillTypeAtomic.OPD_BILL_REFUND);
+        newlyReturnedBill.setPaymentMethod(paymentMethod);
         newlyReturnedBill.setComments(refundComment);
         newlyReturnedBill.setInstitution(sessionController.getInstitution());
         newlyReturnedBill.setDepartment(sessionController.getDepartment());


### PR DESCRIPTION
Expected Behavior:
Cash refunds should be displayed under Cash Refund, not under credit card refund.

Actual Behavior:
All cash-refunded bills are shown as Credit Card Refund in the system.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed payment method tracking in OPD refunds to ensure the original payment method is properly carried over to newly created refund bills, maintaining payment consistency across refund transactions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->