### PR TITLE
Cash refunded Bill Show As Cheque Refund

### DIFF
--- a/src/main/java/com/divudi/bean/common/BillReturnController.java
+++ b/src/main/java/com/divudi/bean/common/BillReturnController.java
@@ -411,6 +411,7 @@ public class BillReturnController implements Serializable, ControllerWithMultipl
         // fetch original bill now, checked alteady returned, cancelled, ,
         newlyReturnedBill = new RefundBill();
         newlyReturnedBill.copy(originalBillToReturn);
+        newlyReturnedBill.setPaymentMethod(paymentMethod);
         newlyReturnedBill.setBillTypeAtomic(BillTypeAtomic.OPD_BILL_REFUND);
         newlyReturnedBill.setComments(refundComment);
         newlyReturnedBill.setInstitution(sessionController.getInstitution());


### PR DESCRIPTION
- Problem: OPD bill returns made using Cash were incorrectly recorded as Cheque payments in the reports. This happened because the return bill’s paymentMethod was inherited from the original bill instead of using the method selected by the user.

- Solution: Updated the logic(settleOpdReturnBill()) so that the new return bill’s paymentMethod is explicitly set to the payment option chosen by the user during the return process. This ensures return bills accurately reflect their actual payment method.

- Files changed: BillReturnController.java

This fix also addresses other similar issues where return bills were incorrectly showing the original bill’s payment method instead of the user-selected one.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed payment method assignment during the refund process to ensure the selected payment method is properly applied to returned bills.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->