### PR TITLE
revert-17153-17130-when-billing-opd-bill-as-e-wallet-payment-e-wallet-amout-should-be-get-automatically

### DIFF
--- a/src/main/java/com/divudi/bean/opd/OpdBillController.java
+++ b/src/main/java/com/divudi/bean/opd/OpdBillController.java
@@ -3509,9 +3509,7 @@ public class OpdBillController implements Serializable, ControllerWithPatient, C
         setNetTotal(billNet);
         setVat(billVat);
         setNetPlusVat(getVat() + getNetTotal());
-        if (getPaymentMethod() == PaymentMethod.ewallet) {
-            getPaymentMethodData().getEwallet().setTotalValue(getNetTotal());
-        }
+
         if (getSessionController() != null) {
             if (getSessionController().getApplicationPreference() != null) {
 
@@ -4255,8 +4253,6 @@ public class OpdBillController implements Serializable, ControllerWithPatient, C
             }
         } else if (paymentMethod == PaymentMethod.Card) {
             getPaymentMethodData().getCreditCard().setTotalValue(netTotal);
-//        } else if (paymentMethod == PaymentMethod.ewallet){
-//            getPaymentMethodData().getEwallet().setTotalValue(netTotal);
         } else if (paymentMethod == PaymentMethod.MultiplePaymentMethods) {
             getPaymentMethodData().getPatient_deposit().setPatient(patient);
             getPaymentMethodData().getPatient_deposit().setTotalValue(calculatRemainForMultiplePaymentTotal());


### PR DESCRIPTION
Reverts hmislk/hmis#17153

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated e-wallet payment handling to prevent automatic total value updates when e-wallet is selected as the payment method.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->