### PR TITLE
change visit type filter in phamacy sale report

### DIFF
--- a/src/main/webapp/reports/financialReports/pharmacy_sale_report.xhtml
+++ b/src/main/webapp/reports/financialReports/pharmacy_sale_report.xhtml
@@ -92,9 +92,9 @@
                                 <h:outputLabel value="Visit Type" for="type" class="m-3"/>
                             </h:panelGroup>
                             <p:selectOneMenu id="type" class="w-100 " >
-                                <f:selectItem itemLabel="Select Type" ></f:selectItem>
-                                <f:selectItem itemLabel="OP" itemValue="op"/>
-                                <f:selectItem itemLabel="IP" itemValue="Ip"/>
+                                <f:selectItem itemValue="Any" itemLabel="Any" ></f:selectItem>
+                                <f:selectItem itemValue="OP" itemLabel="Out Patients (OP)" />
+                                <f:selectItem itemValue="IP" itemLabel="In Patients (IP)" />
                             </p:selectOneMenu>
 
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Visit Type dropdown menu in the Pharmacy Sales Report with corrected option labels and values for consistency. Added an explicit "Any" option to allow users more flexibility when filtering visit types.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->