### PR TITLE
Fixed - After canceling the bill, do not allow the sample to be sent to the external laboratory.

### DIFF
--- a/src/main/java/com/divudi/bean/common/ReportsController.java
+++ b/src/main/java/com/divudi/bean/common/ReportsController.java
@@ -4861,10 +4861,14 @@ public class ReportsController implements Serializable {
                 + "LEFT JOIN PatientInvestigation pi ON pi.billItem = billItem "
                 + "WHERE bill.billTypeAtomic IN :bts "
                 + "AND billItem.item is not null "
+                + "AND billItem.bill.cancelled =:canceled "
+                + "AND billItem.refunded =:ref "
                 + "AND TYPE(billItem.item) = Investigation "
                 + "AND (TYPE(bill) = RefundBill OR TYPE(bill) = CancelledBill) ";
 
         cancelledParameters.put("bts", bts);
+        cancelledParameters.put("canceled", false);
+        cancelledParameters.put("ref", false);
 
         if (staff != null) {
             cancelledJpql += "AND billItem.patientInvestigation.barcodeGeneratedBy.webUserPerson.name = :staff ";
@@ -5054,8 +5058,13 @@ public class ReportsController implements Serializable {
                 + "LEFT JOIN PatientInvestigation pi ON pi.billItem = billItem "
                 + "WHERE bill.billTypeAtomic IN :bts "
                 + "AND bill.createdAt BETWEEN :fd AND :td "
+                + "AND bill.cancelled =:canceled "
+                + "AND billItem.refunded =:ref "
                 + "AND TYPE(billItem.item) = Investigation "
                 + "AND (TYPE(bill) != RefundBill AND TYPE(bill) != CancelledBill) ";
+        
+        parameters.put("canceled", false);
+        parameters.put("ref", false);
 
         if (staff != null) {
             jpql += "AND billItem.patientInvestigation.barcodeGeneratedBy.webUserPerson.name = :staff ";
@@ -5149,8 +5158,13 @@ public class ReportsController implements Serializable {
                 + "LEFT JOIN PatientInvestigation pi ON pi.billItem = billItem "
                 + "WHERE bill.billTypeAtomic IN :bts "
                 + "AND bill.createdAt BETWEEN :fd AND :td "
+                + "AND billItem.bill.cancelled =:canceled "
+                + "AND billItem.refunded =:ref "
                 + "AND TYPE(billItem.item) = Investigation "
                 + "AND (TYPE(bill) = RefundBill OR TYPE(bill) = CancelledBill) ";
+        
+        cancelledParameters.put("canceled", false);
+        cancelledParameters.put("ref", false);
 
         if (staff != null) {
             cancelledJpql += "AND billItem.patientInvestigation.barcodeGeneratedBy.webUserPerson.name = :staff ";


### PR DESCRIPTION
After canceling the bill, do not allow the sample to be sent to the external laboratory.

closes #17115
Signed-off-by: DamithDeshan <hkddrajapaksha@gmail.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * External laboratory reports now exclude cancelled and refunded transactions from workload summaries and detailed breakdowns.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->