### PR TITLE
#17121- Staff not Loading For Staff welfare Bill Return

### DIFF
--- a/src/main/java/com/divudi/bean/common/BillReturnController.java
+++ b/src/main/java/com/divudi/bean/common/BillReturnController.java
@@ -124,6 +124,9 @@ public class BillReturnController implements Serializable, ControllerWithMultipl
         originalBillItemsAvailableToReturn = billBeanController.fetchBillItems(originalBillToReturn);
         returningStarted.set(false);
         paymentMethod = originalBillToReturn.getPaymentMethod();
+        if(paymentMethod == PaymentMethod.Staff_Welfare){
+            toStaff = originalBillToReturn.getToStaff();
+        }
         paymentMethods = paymentService.fetchAvailablePaymentMethodsForRefundsAndCancellations(originalBillToReturn);
         return "/opd/bill_return?faces-redirect=true";
     }


### PR DESCRIPTION
Expected Behavior:
When opening the Staff Welfare Bill Return page, the staff list should load automatically.

Actual Behavior:
The staff list remains empty

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of staff welfare bill returns to properly maintain staff context during the payment method selection process.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->