### PR TITLE
17299 original opd payment details are required for batch bill cancellation

### DIFF
--- a/src/main/java/com/divudi/bean/common/BillController.java
+++ b/src/main/java/com/divudi/bean/common/BillController.java
@@ -2316,7 +2316,7 @@ public class BillController implements Serializable, ControllerWithMultiplePayme
         applyRefundSignToPaymentData();
 
         // Create payments using PaymentService
-        List<Payment> cancelPayments = paymentService.createPayment(cancellationBatchBill, paymentMethod, paymentMethodData, sessionController.getDepartment(), sessionController.getLoggedUser());
+        List<Payment> cancelPayments = paymentService.createPayment(cancellationBatchBill, paymentMethodData);
 
         if (cancellationBatchBill.getPaymentMethod() == PaymentMethod.MultiplePaymentMethods) {
             paymentService.updateBalances(cancelPayments);

--- a/src/main/java/com/divudi/bean/common/BillSearch.java
+++ b/src/main/java/com/divudi/bean/common/BillSearch.java
@@ -2573,7 +2573,7 @@ public class BillSearch implements Serializable, ControllerWithMultiplePayments 
         applyRefundSignToPaymentData();
 
         // Create payments using PaymentService
-        List<Payment> ps = paymentService.createPayment(cancellationBill, paymentMethod, paymentMethodData, sessionController.getDepartment(), sessionController.getLoggedUser());
+        List<Payment> ps = paymentService.createPayment(cancellationBill, paymentMethodData);
         List<BillItem> list = cancelBillItems(getBill(), cancellationBill, ps);
 
         try {


### PR DESCRIPTION
 I've successfully completed all the changes for both OPD individual bill cancellations and OPD batch bill cancellations. Here's a summary of what was done:

  Changes Implemented

  BillSearch.java (Individual OPD Bill Cancellation)

  1. ✅ Added initializePaymentDataFromOriginalPayments() method at BillSearch.java:3475
  2. ✅ Added applyRefundSignToPaymentData() method at BillSearch.java:3571
  3. ✅ Updated navigateToCancelOpdBill() to initialize payment data from original payments at BillSearch.java:3453
  4. ✅ Updated cancelOpdBill() to use paymentService.createPayment() at BillSearch.java:2573-2576

  BillController.java (Batch OPD Bill Cancellation)

  1. ✅ Added initializePaymentDataFromOriginalPayments() method at BillController.java:2043
  2. ✅ Added applyRefundSignToPaymentData() method at BillController.java:2139
  3. ✅ Updated navigateToCancelOpdBatchBill() to initialize payment data in both code paths:
    - When request is approved: BillController.java:2018-2021
    - When no mandatory permission: BillController.java:2039-2042
  4. ✅ Updated cancelOpdBatchBill() to use paymentService.createPayment() at BillController.java:2315-2319

  How It Works

  When canceling bills:
  1. The system fetches the original bill's payment records
  2. Initializes the payment method data with the original payment details (card numbers, reference numbers, etc.)
  3. Displays this data on the cancellation page for user review/modification
  4. When the user confirms cancellation, applies negative signs to all payment values
  5. Creates the refund payment records using the centralized paymentService.createPayment() method

  This ensures consistency across all OPD cancellation workflows and allows users to see and modify payment methods during the cancellation process.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved accuracy in refund calculations for bill cancellations involving multiple payment methods
  * Enhanced tracking and preservation of original payment method information during batch bill cancellations
  * Better consistency in payment data handling across all payment types
  * Refined refund amount processing for accurate ledger entries during bill cancellation workflows

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->