### PR TITLE
closes #17315-need-to-print-width-5-cm-height-25-cm-paper-details-required

### DIFF
--- a/src/main/webapp/opd/patient.xhtml
+++ b/src/main/webapp/opd/patient.xhtml
@@ -237,7 +237,7 @@
                                         </div>
                                     </div> 
 
-                                    <h:panelGroup id="groupPatientCard" style="text-align: center; width: 5cm; border: 1px solid red;" layout="block">
+                                    <h:panelGroup id="groupPatientCard" style="text-align: center; width: 5cm;" layout="block">
                                         <div style="line-height: 0.5; padding: 0; margin: 0;">
                                             <div class="mt-1" style="height: 0.9cm;  overflow-x: hidden; overflow-y: hidden">
                                                 <p:barcode format="svg" hrp="none" width="185" value="#{patientController.current.phn}" type="code128" cache="false" rendered="true" />


### PR DESCRIPTION
Signed-off-by: denuwanhendalage <shashankadenuwanb@gmail.com>
Minor UI adjustments (line-height, font-size, and width) were applied to optimize the output for a 5 cm × 2.5 cm printed patient card while preserving the original layout and data bindings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Optimized patient card layout with refined visual density and spacing.
  * Adjusted typography sizing for a more compact and streamlined display presentation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->