### PR TITLE
personService and auditService used to log updatePerson

### DIFF
--- a/src/main/java/com/divudi/bean/common/ConsultantController.java
+++ b/src/main/java/com/divudi/bean/common/ConsultantController.java
@@ -14,6 +14,7 @@ import com.divudi.core.entity.Person;
 import com.divudi.core.entity.Speciality;
 import com.divudi.core.facade.ConsultantFacade;
 import com.divudi.core.facade.PersonFacade;
+import com.divudi.service.PersonService;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Date;
@@ -50,9 +51,13 @@ public class ConsultantController implements Serializable {
     private ConsultantFacade ejbFacade;
     @EJB
     private PersonFacade personFacade;
+    @EJB
+    PersonService personService;
+    
     List<Consultant> selectedItems;
 
     private Consultant current;
+    private Person originalPerson;
     private List<Consultant> items = null;
     String selectText = "";
     private Speciality speciality;
@@ -208,7 +213,7 @@ public class ConsultantController implements Serializable {
         if (current.getPerson().getId() == null || current.getPerson().getId() == 0) {
             getPersonFacade().create(current.getPerson());
         } else {
-            getPersonFacade().edit(current.getPerson());
+            personService.editPerson(getOriginalPerson(), current.getPerson());
         }
         if (getCurrent().getId() != null && getCurrent().getId() > 0) {
             getFacade().edit(current);
@@ -386,7 +391,24 @@ public class ConsultantController implements Serializable {
     public void setSpeciality(Speciality speciality) {
         this.speciality = speciality;
     }
+    
+    public Person getOriginalPerson() {
+        return originalPerson;
+    }
 
+    public void setOriginalPerson(Person originalPerson) {
+        this.originalPerson = originalPerson;
+    }
+    
+    // lsitener to set the originalPerson values
+    public void changeStaff() {
+        // for Audit Event Recording for Person Entity Update
+        if (current.getPerson() != null) {
+            setOriginalPerson(current.getPerson().cloneAuditPerson());
+        }
+       
+    }
+    
     /**
      *
      */

--- a/src/main/java/com/divudi/bean/hr/StaffController.java
+++ b/src/main/java/com/divudi/bean/hr/StaffController.java
@@ -41,6 +41,7 @@ import com.divudi.core.facade.StaffEmploymentFacade;
 import com.divudi.core.facade.StaffFacade;
 import com.divudi.core.facade.StaffSalaryFacade;
 import com.divudi.core.util.JsfUtil;
+import com.divudi.service.PersonService;
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 import java.io.Serializable;
@@ -89,6 +90,8 @@ public class StaffController implements Serializable {
     private CommonReportItemFacade criFacade;
     @EJB
     FormItemValueFacade fivFacade;
+    @EJB
+    PersonService personService;
 
     // </editor-fold>
     // <editor-fold defaultstate="collapsed" desc="Controllers">
@@ -111,6 +114,7 @@ public class StaffController implements Serializable {
     private Staff selectedStaff;
     private Staff current;
     private Person currentPerson;
+    private Person originalPerson;
     private List<Staff> staffWithCode;
     private List<Staff> items = null;
     private String selectText = "";
@@ -1270,7 +1274,8 @@ public class StaffController implements Serializable {
             getPersonFacade().createAndFlush(current.getPerson());
             JsfUtil.addSuccessMessage("New Person Created");
         } else {
-            getPersonFacade().editAndFlush(current.getPerson());
+            personService.editAndFlushPerson(getOriginalPerson(), current.getPerson());
+//            getPersonFacade().editAndFlush(current.getPerson());
             JsfUtil.addSuccessMessage("Person Updated");
         }
 
@@ -1484,6 +1489,11 @@ public class StaffController implements Serializable {
     }
 
     public void changeStaff() {
+        // for Audit Event Recording for Person Entity Update
+        if (current.getPerson() != null) {
+            setOriginalPerson(current.getPerson().cloneAuditPerson());
+        }
+        
         formItems = null;
         tempRetireDate = null;
         removeResign = false;
@@ -1703,6 +1713,14 @@ public class StaffController implements Serializable {
 
     public void setCurrentPerson(Person currentPerson) {
         this.currentPerson = currentPerson;
+    }
+
+    public Person getOriginalPerson() {
+        return originalPerson;
+    }
+
+    public void setOriginalPerson(Person originalPerson) {
+        this.originalPerson = originalPerson;
     }
 
     public String getSignatureUrl() {

--- a/src/main/java/com/divudi/core/entity/Person.java
+++ b/src/main/java/com/divudi/core/entity/Person.java
@@ -718,4 +718,27 @@ public class Person implements Serializable, RetirableEntity  {
     public void setSmsNumber(String smsNumber) {
         this.smsNumber = smsNumber;
     }
+
+    public Person cloneAuditPerson() {
+        // only the data recorded in the audit event is cloned.
+        Person p = new Person();
+        p.setName(this.getName());
+        p.setAddress(this.getAddress());
+        p.setDob(this.getDob());
+        p.setEmail(this.getEmail());
+        p.setFax(this.getFax());
+        p.setSex(this.getSex());
+        p.setMobile(this.getMobile());
+        p.setNic(this.getNic());
+        p.setPhone(this.getPhone());
+        p.setTitle(this.getTitle());
+        p.setId(this.getId());
+        p.setSurName(this.getSurName());
+        p.setPhone(this.getPhone());
+        p.setInitials(this.getInitials());
+        p.setFullName(this.getFullName());
+        p.setLastName(this.getLastName());
+        p.setArea(this.getArea());
+        return p;
+    }
 }

--- a/src/main/java/com/divudi/service/AuditService.java
+++ b/src/main/java/com/divudi/service/AuditService.java
@@ -7,6 +7,8 @@ import com.google.gson.Gson;
 import java.util.Date;
 import javax.ejb.EJB;
 import javax.ejb.Stateless;
+import javax.ejb.TransactionAttribute;
+import javax.ejb.TransactionAttributeType;
 
 /**
  *
@@ -30,6 +32,23 @@ public class AuditService {
             audit.setEventTrigger(eventTrigger);
             audit.setBeforeJson(before != null ? gson.toJson(before) : null);
             audit.setAfterJson(after != null ? gson.toJson(after) : null);
+            auditEventFacade.create(audit);
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+
+    @TransactionAttribute(TransactionAttributeType.REQUIRES_NEW)
+    public void logAudit(String before, String after, WebUser user, String entityType, String eventTrigger, Long objectId) {
+        try {
+            AuditEvent audit = new AuditEvent();
+            audit.setEventDataTime(new Date());
+            audit.setWebUserId(user.getId());
+            audit.setEntityType(entityType);
+            audit.setEventTrigger(eventTrigger);
+            audit.setBeforeJson(before != null ? before : null);
+            audit.setAfterJson(after != null ? after : null);
+            audit.setObjectId(objectId);
             auditEventFacade.create(audit);
         } catch (Exception e) {
             e.printStackTrace();

--- a/src/main/java/com/divudi/service/PersonService.java
+++ b/src/main/java/com/divudi/service/PersonService.java
@@ -1,0 +1,87 @@
+package com.divudi.service;
+
+import javax.ejb.EJB;
+import javax.ejb.Stateless;
+import javax.inject.Inject;
+
+import com.divudi.bean.common.AuditEventController;
+import com.divudi.bean.common.SessionController;
+import com.divudi.core.entity.Person;
+import com.divudi.core.facade.PersonFacade;
+import java.text.SimpleDateFormat;
+import org.json.JSONObject;
+
+@Stateless
+public class PersonService {
+    
+    @EJB
+    private PersonFacade personFacade;
+    @EJB
+    private AuditService auditService;
+
+    @Inject
+    private SessionController sessionController;
+
+    public void editPerson(Person original, Person current) {
+        getPersonFacade().edit(current);
+        
+        String BEFOREJSON = personToJsonForEditAuditLog(original);
+        String AFTERJSON = personToJsonForEditAuditLog(current);
+        
+        getAuditService().logAudit(BEFOREJSON, AFTERJSON, sessionController.getLoggedUser(), "Person", "updatePerson", current.getId());   
+    } 
+    
+    public void editAndFlushPerson(Person original, Person current) {
+        getPersonFacade().editAndFlush(current);
+        
+        String BEFOREJSON = personToJsonForEditAuditLog(original);
+        String AFTERJSON = personToJsonForEditAuditLog(current);
+        
+        getAuditService().logAudit(BEFOREJSON, AFTERJSON, sessionController.getLoggedUser(), "Person", "updatePerson", current.getId()); 
+    }
+
+    public AuditService getAuditService() {
+        return auditService;
+    }
+
+    public PersonFacade getPersonFacade() {
+        return personFacade;
+    }
+    
+    public String personToJsonForEditAuditLog(Person p) {
+
+        if (p == null) {
+            return "{}";
+        }
+
+        JSONObject json = new JSONObject();
+
+        json.put("personId", p.getId());
+        json.put("name", p.getName());
+        json.put("title", p.getTitle());
+        json.put("surname", p.getSurName());
+
+        json.put("dob",
+            p.getDob() == null ? null :
+            new SimpleDateFormat("yyyy-MM-dd").format(p.getDob())
+        );
+
+        json.put("sex", p.getSex());
+        json.put("nic", p.getNic());
+        json.put("address", p.getAddress());
+        json.put("mobile", p.getMobile());
+        json.put("email", p.getEmail());
+        json.put("phone", p.getPhone());
+        json.put("initials", p.getInitials());
+        json.put("fullName", p.getFullName());
+        json.put("lastName", p.getLastName());
+
+        json.put("area",
+            p.getArea() == null ? null : p.getArea().getId()
+        );
+
+        return json.toString();
+    }
+
+
+}

--- a/src/main/webapp/admin/staff/admin_doctor_consultant.xhtml
+++ b/src/main/webapp/admin/staff/admin_doctor_consultant.xhtml
@@ -48,7 +48,7 @@
                                                  filterMatchMode="contains"
                                                  class="w-100 my-1" value="#{consultantController.current}">
                                 <f:selectItems  value="#{consultantController.selectedItems}" var="myItem" itemValue="#{myItem}" itemLabel="#{myItem.person.nameWithTitle}"  ></f:selectItems>
-                                <f:ajax render="gpDetail" execute="lstSelect" />                                        
+                                <f:ajax render="gpDetail" execute="lstSelect" listener="#{consultantController.changeStaff()}"/>                                        
                             </p:selectOneListbox>
 
                             >


### PR DESCRIPTION
### Not Ready for Merge – Feedback Required

- Introduced PersonService to create an audit log before updating edited person data in the database.
- Added the originalPerson attribute to PatientController, StaffController, and ConsultantController to store the original version of a Person instance.
- Added auditLog() method to AuditService
- saveSelected() method is modified in each controller to call the PersonService method
- ajax listeners and navigate methods are used to set the originalPerson 

Note: Currently, only edits made through certain paths and flows are supported.
 