### PR TITLE
Set off the validations for 'back to search' button

### DIFF
--- a/src/main/webapp/patient_deposit/view/bill_cancel.xhtml
+++ b/src/main/webapp/patient_deposit/view/bill_cancel.xhtml
@@ -50,6 +50,7 @@
                                         style="float: right"
                                         value="Back To Search"
                                         icon="fa-solid fa-arrow-left"
+                                        immediate="true"
                                         action="/patient_deposit/patient_deposit_search?faces-redirect=true"
                                         ajax="false">
                                     </p:commandButton>


### PR DESCRIPTION
Issue: #17404 

Files Changed: patient_deposit/view/bill_cancel.xhtml

Used:
- `immediate="true"`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced the back navigation experience when canceling a bill, ensuring users can return to search more reliably without encountering unexpected validation issues.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->