### PR TITLE
17482 original card bill details not auto displayed during bill cancellation

### DIFF
--- a/src/main/java/com/divudi/bean/common/PatientController.java
+++ b/src/main/java/com/divudi/bean/common/PatientController.java
@@ -1030,14 +1030,12 @@ public class PatientController implements Serializable, ControllerWithPatient {
 
         if (originalBillPayments != null && !originalBillPayments.isEmpty()) {
             initializePaymentDataFromOriginalPayments(originalBillPayments);
-        }
-        if (pm == PaymentMethod.MultiplePaymentMethods) {
+        } else if (pm == PaymentMethod.MultiplePaymentMethods){
             cancelBill.setPaymentMethod(PaymentMethod.Cash);
-            return;
+        } else {
+            cancelBill.setPaymentMethod(pm);
         }
-        cancelBill.setPaymentMethod(pm);
-
-
+        
     }
 
     public void clearDataForPatientRefund() {
@@ -4716,9 +4714,8 @@ public class PatientController implements Serializable, ControllerWithPatient {
         // For single payment method
         if (originalPayments.size() == 1) {
             Payment originalPayment = originalPayments.get(0);
-            paymentMethod = originalPayment.getPaymentMethod();
-
-
+            cancelBill.setPaymentMethod(originalPayment.getPaymentMethod());
+            
             // Initialize paymentMethodData based on payment method (using absolute values for UI display)
             // Note: Total value will be updated later when user selects items to refund
             switch (originalPayment.getPaymentMethod()) {
@@ -4761,7 +4758,7 @@ public class PatientController implements Serializable, ControllerWithPatient {
             }
         } else {
             // Multiple payments - set to MultiplePaymentMethods
-            paymentMethod = PaymentMethod.MultiplePaymentMethods;
+            cancelBill.setPaymentMethod(PaymentMethod.Cash);
             // Note: For multiple payments, the user would need to manually configure them
             // This is a complex scenario that may require additional UI handling
         }

--- a/src/main/java/com/divudi/bean/common/PatientDepositController.java
+++ b/src/main/java/com/divudi/bean/common/PatientDepositController.java
@@ -143,6 +143,10 @@ public class PatientDepositController implements Serializable, ControllerWithPat
     }
 
     public String navigateToNewPatientDepositCancel() {
+        if (patientController.getBill() == null) {
+            JsfUtil.addErrorMessage("A Bill is not selected");
+            return "";
+        }
         if (patientController.getBill().isCancelled()) {
             JsfUtil.addErrorMessage("Already Canceled Bill");
             return "";
@@ -370,7 +374,7 @@ public class PatientDepositController implements Serializable, ControllerWithPat
         List<Payment> p = billBeanController.createPayment(patientController.getCancelBill(),
                 patientController.getCancelBill().getPaymentMethod(),
                 patientController.getPaymentMethodData());
-        drawerController.updateDrawerForOuts(p);
+        drawerController.updateDrawerForOuts(p);        
     }
 
     public void settlePatientDepositReturn() {


### PR DESCRIPTION
Issues:
- #17482 
- #17483 
- #17484 
- #17486 

Files Changed:
- PatientController
- PatientDepositController


initializePaymentDataFromOriginalPayments() method to set the paymentMethoData value using the original payment method details

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The patient deposit cancellation process now includes proper validation logic to ensure that a bill is correctly selected before the cancellation workflow proceeds forward.

* **Improvements**
  * Enhanced payment method data handling during deposit cancellation to better preserve, retrieve, and properly manage original payment information from prior transactions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->