### PR TITLE
17080-add-null-safety-guards-for-diagnosismedicinelist-in-addfavouritediagnosis

### DIFF
--- a/src/main/java/com/divudi/bean/clinical/PatientEncounterController.java
+++ b/src/main/java/com/divudi/bean/clinical/PatientEncounterController.java
@@ -1442,13 +1442,13 @@ public class PatientEncounterController implements Serializable {
                     null
             );
             System.out.println("DEBUG: Weight-based lookup found " + (diagnosisMedicineList != null ? diagnosisMedicineList.size() : "null") + " medicine recommendations");
-            if (!diagnosisMedicineList.isEmpty()) {
+            if (diagnosisMedicineList != null && !diagnosisMedicineList.isEmpty()) {
                 lookupMethod = "weight group (" + patientWeight + " kg)";
             }
         }
 
         // Method 2: By Patient Age Group (fallback when weight is not available or no weight-based favourites found)
-        if (diagnosisMedicineList.isEmpty() && patientAgeInDays != null && patientAgeInDays > 0) {
+        if (diagnosisMedicineList == null || diagnosisMedicineList.isEmpty() && patientAgeInDays != null && patientAgeInDays > 0) {
             System.out.println("DEBUG: Step 1 - Finding medicine list by age group: " + patientAgeInDays + " days");
             diagnosisMedicineList = favouriteController.listFavouriteItems(
                     selectedDiagnosis,
@@ -1457,7 +1457,7 @@ public class PatientEncounterController implements Serializable {
                     patientAgeInDays
             );
             System.out.println("DEBUG: Age-based lookup found " + (diagnosisMedicineList != null ? diagnosisMedicineList.size() : "null") + " medicine recommendations");
-            if (!diagnosisMedicineList.isEmpty()) {
+            if (diagnosisMedicineList!=null && !diagnosisMedicineList.isEmpty()) {
                 lookupMethod = "age group (" + (patientAgeInDays / 365) + " years)";
             }
         }


### PR DESCRIPTION
Added null-safety checks for diagnosisMedicineList in the addFavouriteDiagnosis() method to prevent potential NullPointerException. The conditions were updated to safely handle cases where favouriteController.listFavouriteItems(...) may return null, ensuring isEmpty() is only called when the list is non-null.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stability of the diagnosis lookup functionality to prevent potential crashes when processing diagnosis data across different lookup scenarios.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->