### PR TITLE
17544 staff welfare not calculated in cashier shift end summary

### DIFF
--- a/src/main/java/com/divudi/core/entity/UserPreference.java
+++ b/src/main/java/com/divudi/core/entity/UserPreference.java
@@ -146,9 +146,6 @@ public class UserPreference implements Serializable {
     @Enumerated(EnumType.STRING)
     private PaperType inwardDepositPaymentBillPaper;
 
-    @Enumerated(EnumType.STRING)
-    private PaperType fundTransferBillPaperType;
-
     private boolean partialPaymentOfPharmacyBillsAllowed;
 
     @Deprecated
@@ -1243,17 +1240,6 @@ public class UserPreference implements Serializable {
 
     public void setInwardDepositPaymentBillPaper(PaperType inwardDepositPaymentBillPaper) {
         this.inwardDepositPaymentBillPaper = inwardDepositPaymentBillPaper;
-    }
-
-    public PaperType getFundTransferBillPaperType() {
-        if (fundTransferBillPaperType == null) {
-            fundTransferBillPaperType = PaperType.FiveFivePaper;
-        }
-        return fundTransferBillPaperType;
-    }
-
-    public void setFundTransferBillPaperType(PaperType fundTransferBillPaperType) {
-        this.fundTransferBillPaperType = fundTransferBillPaperType;
     }
 
     public String getLengthOfOTPIndexes() {

--- a/src/main/webapp/cashier/fund_transfer_bill_print.xhtml
+++ b/src/main/webapp/cashier/fund_transfer_bill_print.xhtml
@@ -97,47 +97,34 @@
 
                     </p:panel>
 
-                    <div class="row mb-2 mt-2">
-                        <div class="d-flex justify-content-end gap-2">
-                            <p:outputLabel value="Paper Type" class="mt-2"/>
-                            <p:selectOneMenu
-                                value="#{sessionController.departmentPreference.fundTransferBillPaperType}"
-                                style="width: 13em;">
-                                <f:selectItem itemLabel="Please Select Paper Type" />
-                                <f:selectItems value="#{enumController.paperTypes}" />
-                            </p:selectOneMenu>
-                            <p:commandButton ajax="false" icon="fa fa-sync-alt" class="ui-button" title="Redraw Bill"/>
-                        </div>
-                    </div>
-
                     <h:panelGroup id="panelPrint">
                         <!-- POS Paper with header -->
-                        <h:panelGroup rendered="#{sessionController.departmentPreference.fundTransferBillPaperType eq 'PosPaper'}">
+                        <h:panelGroup rendered="#{configOptionController.getBooleanValueByKey('Fund Transfer Bill is POS Paper', false)}">
                             <prints:float_transfer_pos bill="#{financialTransactionController.currentBill}"/>
                         </h:panelGroup>
 
                         <!-- POS Printed Paper (without header) -->
-                        <h:panelGroup rendered="#{sessionController.departmentPreference.fundTransferBillPaperType eq 'PosPrintedPaper'}">
+                        <h:panelGroup rendered="#{configOptionController.getBooleanValueByKey('Fund Transfer Bill is POS Printed Paper', false)}">
                             <prints:float_transfer_pos_printed bill="#{financialTransactionController.currentBill}"/>
                         </h:panelGroup>
 
                         <!-- 5x5 Paper with header (default) -->
-                        <h:panelGroup rendered="#{sessionController.departmentPreference.fundTransferBillPaperType eq 'FiveFivePaper' or sessionController.departmentPreference.fundTransferBillPaperType eq null}">
+                        <h:panelGroup rendered="#{configOptionController.getBooleanValueByKey('Fund Transfer Bill is 5x5 Paper', true)}">
                             <prints:float_transfer_five_five bill="#{financialTransactionController.currentBill}"/>
                         </h:panelGroup>
 
                         <!-- 5x5 Printed Paper (without header) -->
-                        <h:panelGroup rendered="#{sessionController.departmentPreference.fundTransferBillPaperType eq 'FiveFivePrintedPaper'}">
+                        <h:panelGroup rendered="#{configOptionController.getBooleanValueByKey('Fund Transfer Bill is 5x5 Printed Paper', false)}">
                             <prints:float_transfer_five_five_printed bill="#{financialTransactionController.currentBill}"/>
                         </h:panelGroup>
 
                         <!-- A4 Paper with header -->
-                        <h:panelGroup rendered="#{sessionController.departmentPreference.fundTransferBillPaperType eq 'A4Paper'}">
+                        <h:panelGroup rendered="#{configOptionController.getBooleanValueByKey('Fund Transfer Bill is A4 Paper', false)}">
                             <prints:float_transfer_a4 bill="#{financialTransactionController.currentBill}"/>
                         </h:panelGroup>
 
                         <!-- A4 Printed Paper (without header) -->
-                        <h:panelGroup rendered="#{sessionController.departmentPreference.fundTransferBillPaperType eq 'A4PrintedPaper'}">
+                        <h:panelGroup rendered="#{configOptionController.getBooleanValueByKey('Fund Transfer Bill is A4 Printed Paper', false)}">
                             <prints:float_transfer_a4_printed bill="#{financialTransactionController.currentBill}"/>
                         </h:panelGroup>
                     </h:panelGroup>

--- a/src/main/webapp/cashier/fund_transfer_receive_bill_print.xhtml
+++ b/src/main/webapp/cashier/fund_transfer_receive_bill_print.xhtml
@@ -101,19 +101,6 @@
                             </div>
                         </div>
 
-                        <div class="row mb-2 mt-2">
-                            <div class="d-flex justify-content-end gap-2">
-                                <p:outputLabel value="Paper Type" class="mt-2"/>
-                                <p:selectOneMenu
-                                    value="#{sessionController.departmentPreference.fundTransferBillPaperType}"
-                                    style="width: 13em;">
-                                    <f:selectItem itemLabel="Please Select Paper Type" />
-                                    <f:selectItems value="#{enumController.paperTypes}" />
-                                </p:selectOneMenu>
-                                <p:commandButton ajax="false" icon="fa fa-sync-alt" class="ui-button" title="Redraw Bill"/>
-                            </div>
-                        </div>
-
                         <p:commandButton
                             value="Print"
                             ajax="false" >
@@ -122,32 +109,32 @@
 
                         <h:panelGroup id="panelPrint">
                             <!-- POS Paper with header -->
-                            <h:panelGroup rendered="#{sessionController.departmentPreference.fundTransferBillPaperType eq 'PosPaper'}">
+                            <h:panelGroup rendered="#{configOptionController.getBooleanValueByKey('Fund Transfer Bill is POS Paper', false)}">
                                 <prints:float_transfer_receive_pos bill="#{financialTransactionController.currentBill}"/>
                             </h:panelGroup>
 
                             <!-- POS Printed Paper (without header) -->
-                            <h:panelGroup rendered="#{sessionController.departmentPreference.fundTransferBillPaperType eq 'PosPrintedPaper'}">
+                            <h:panelGroup rendered="#{configOptionController.getBooleanValueByKey('Fund Transfer Bill is POS Printed Paper', false)}">
                                 <prints:float_transfer_receive_pos_printed bill="#{financialTransactionController.currentBill}"/>
                             </h:panelGroup>
 
                             <!-- 5x5 Paper with header (default) -->
-                            <h:panelGroup rendered="#{sessionController.departmentPreference.fundTransferBillPaperType eq 'FiveFivePaper' or sessionController.departmentPreference.fundTransferBillPaperType eq null}">
+                            <h:panelGroup rendered="#{configOptionController.getBooleanValueByKey('Fund Transfer Bill is 5x5 Paper', true)}">
                                 <prints:float_transfer_receive_five_five bill="#{financialTransactionController.currentBill}"/>
                             </h:panelGroup>
 
                             <!-- 5x5 Printed Paper (without header) -->
-                            <h:panelGroup rendered="#{sessionController.departmentPreference.fundTransferBillPaperType eq 'FiveFivePrintedPaper'}">
+                            <h:panelGroup rendered="#{configOptionController.getBooleanValueByKey('Fund Transfer Bill is 5x5 Printed Paper', false)}">
                                 <prints:float_transfer_receive_five_five_printed bill="#{financialTransactionController.currentBill}"/>
                             </h:panelGroup>
 
                             <!-- A4 Paper with header -->
-                            <h:panelGroup rendered="#{sessionController.departmentPreference.fundTransferBillPaperType eq 'A4Paper'}">
+                            <h:panelGroup rendered="#{configOptionController.getBooleanValueByKey('Fund Transfer Bill is A4 Paper', false)}">
                                 <prints:float_transfer_receive_a4 bill="#{financialTransactionController.currentBill}"/>
                             </h:panelGroup>
 
                             <!-- A4 Printed Paper (without header) -->
-                            <h:panelGroup rendered="#{sessionController.departmentPreference.fundTransferBillPaperType eq 'A4PrintedPaper'}">
+                            <h:panelGroup rendered="#{configOptionController.getBooleanValueByKey('Fund Transfer Bill is A4 Printed Paper', false)}">
                                 <prints:float_transfer_receive_a4_printed bill="#{financialTransactionController.currentBill}"/>
                             </h:panelGroup>
                         </h:panelGroup>

--- a/src/main/webapp/resources/ezcomp/prints/float_transfer_a4.xhtml
+++ b/src/main/webapp/resources/ezcomp/prints/float_transfer_a4.xhtml
@@ -145,16 +145,14 @@
             <!-- Total -->
             <div style="padding: 15px;">
                 <table style="width: 100%; font-size: 14pt;">
-                    <h:panelGroup rendered="#{cc.attrs.bill.margin > 0? 'false':'true'}">
-                        <tr>
-                            <td style="text-align: right; font-weight: bold; width: 70%;">Total Amount:</td>
-                            <td style="text-align: right; font-weight: bold; width: 30%; padding-right: 30px;">
-                                <h:outputLabel value="#{cc.attrs.bill.absoluteNetTotalTransient}">
-                                    <f:convertNumber pattern="#,##0.00"/>
-                                </h:outputLabel>
-                            </td>
-                        </tr>
-                    </h:panelGroup>
+                    <tr>
+                        <td style="text-align: right; font-weight: bold; width: 70%;">Total Amount:</td>
+                        <td style="text-align: right; font-weight: bold; width: 30%; padding-right: 30px;">
+                            <h:outputLabel value="#{cc.attrs.bill.absoluteNetTotalTransient}">
+                                <f:convertNumber pattern="#,##0.00"/>
+                            </h:outputLabel>
+                        </td>
+                    </tr>
                 </table>
             </div>
 

--- a/src/main/webapp/resources/ezcomp/prints/float_transfer_a4_printed.xhtml
+++ b/src/main/webapp/resources/ezcomp/prints/float_transfer_a4_printed.xhtml
@@ -128,16 +128,14 @@
             <!-- Total -->
             <div style="padding: 15px;">
                 <table style="width: 100%; font-size: 14pt;">
-                    <h:panelGroup rendered="#{cc.attrs.bill.margin > 0? 'false':'true'}">
-                        <tr>
-                            <td style="text-align: right; font-weight: bold; width: 70%;">Total Amount:</td>
-                            <td style="text-align: right; font-weight: bold; width: 30%; padding-right: 30px;">
-                                <h:outputLabel value="#{cc.attrs.bill.absoluteNetTotalTransient}">
-                                    <f:convertNumber pattern="#,##0.00"/>
-                                </h:outputLabel>
-                            </td>
-                        </tr>
-                    </h:panelGroup>
+                    <tr>
+                        <td style="text-align: right; font-weight: bold; width: 70%;">Total Amount:</td>
+                        <td style="text-align: right; font-weight: bold; width: 30%; padding-right: 30px;">
+                            <h:outputLabel value="#{cc.attrs.bill.absoluteNetTotalTransient}">
+                                <f:convertNumber pattern="#,##0.00"/>
+                            </h:outputLabel>
+                        </td>
+                    </tr>
                 </table>
             </div>
 

--- a/src/main/webapp/resources/ezcomp/prints/float_transfer_five_five_printed.xhtml
+++ b/src/main/webapp/resources/ezcomp/prints/float_transfer_five_five_printed.xhtml
@@ -101,12 +101,10 @@
             </div>
 
             <div style="text-align: right; font-size: 18px; font-weight: bold; padding: 10px;">
-                <h:panelGroup rendered="#{cc.attrs.bill.margin > 0? 'false':'true'}">
-                    Total Amount:
-                    <h:outputLabel value="#{cc.attrs.bill.absoluteNetTotalTransient}">
-                        <f:convertNumber pattern="#,##0.00"/>
-                    </h:outputLabel>
-                </h:panelGroup>
+                Total Amount:
+                <h:outputLabel value="#{cc.attrs.bill.absoluteNetTotalTransient}">
+                    <f:convertNumber pattern="#,##0.00"/>
+                </h:outputLabel>
             </div>
 
             <div style="#{configOptionApplicationController.getLongTextValueByKey('Float Transfer Note Horizontal Line CSS')}">

--- a/src/main/webapp/resources/ezcomp/prints/float_transfer_pos.xhtml
+++ b/src/main/webapp/resources/ezcomp/prints/float_transfer_pos.xhtml
@@ -164,12 +164,10 @@
 
             <!-- Total -->
             <div style="text-align: right; font-size: 14px; font-weight: bold; padding: 5px;">
-                <h:panelGroup rendered="#{cc.attrs.bill.margin > 0? 'false':'true'}">
-                    Total Amount:
-                    <h:outputLabel value="#{cc.attrs.bill.absoluteNetTotalTransient}">
-                        <f:convertNumber pattern="#,##0.00"/>
-                    </h:outputLabel>
-                </h:panelGroup>
+                Total Amount:
+                <h:outputLabel value="#{cc.attrs.bill.absoluteNetTotalTransient}">
+                    <f:convertNumber pattern="#,##0.00"/>
+                </h:outputLabel>
             </div>
 
             <div class="billline" style="text-align: center;">

--- a/src/main/webapp/resources/ezcomp/prints/float_transfer_pos_printed.xhtml
+++ b/src/main/webapp/resources/ezcomp/prints/float_transfer_pos_printed.xhtml
@@ -152,12 +152,10 @@
 
             <!-- Total -->
             <div style="text-align: right; font-size: 14px; font-weight: bold; padding: 5px;">
-                <h:panelGroup rendered="#{cc.attrs.bill.margin > 0? 'false':'true'}">
-                    Total Amount:
-                    <h:outputLabel value="#{cc.attrs.bill.absoluteNetTotalTransient}">
-                        <f:convertNumber pattern="#,##0.00"/>
-                    </h:outputLabel>
-                </h:panelGroup>
+                Total Amount:
+                <h:outputLabel value="#{cc.attrs.bill.absoluteNetTotalTransient}">
+                    <f:convertNumber pattern="#,##0.00"/>
+                </h:outputLabel>
             </div>
 
             <div class="billline" style="text-align: center;">

--- a/src/main/webapp/resources/ezcomp/prints/float_transfer_receive_a4.xhtml
+++ b/src/main/webapp/resources/ezcomp/prints/float_transfer_receive_a4.xhtml
@@ -137,16 +137,14 @@
             <!-- Total -->
             <div style="padding: 15px;">
                 <table style="width: 100%; font-size: 14pt;">
-                    <h:panelGroup rendered="#{cc.attrs.bill.margin > 0? 'false':'true'}">
-                        <tr>
-                            <td style="text-align: right; font-weight: bold; width: 70%;">Total Amount:</td>
-                            <td style="text-align: right; font-weight: bold; width: 30%; padding-right: 30px;">
-                                <h:outputLabel value="#{cc.attrs.bill.total}">
-                                    <f:convertNumber pattern="#,##0.00"/>
-                                </h:outputLabel>
-                            </td>
-                        </tr>
-                    </h:panelGroup>
+                    <tr>
+                        <td style="text-align: right; font-weight: bold; width: 70%;">Total Amount:</td>
+                        <td style="text-align: right; font-weight: bold; width: 30%; padding-right: 30px;">
+                            <h:outputLabel value="#{cc.attrs.bill.total}">
+                                <f:convertNumber pattern="#,##0.00"/>
+                            </h:outputLabel>
+                        </td>
+                    </tr>
                 </table>
             </div>
 

--- a/src/main/webapp/resources/ezcomp/prints/float_transfer_receive_a4_printed.xhtml
+++ b/src/main/webapp/resources/ezcomp/prints/float_transfer_receive_a4_printed.xhtml
@@ -120,16 +120,14 @@
             <!-- Total -->
             <div style="padding: 15px;">
                 <table style="width: 100%; font-size: 14pt;">
-                    <h:panelGroup rendered="#{cc.attrs.bill.margin > 0? 'false':'true'}">
-                        <tr>
-                            <td style="text-align: right; font-weight: bold; width: 70%;">Total Amount:</td>
-                            <td style="text-align: right; font-weight: bold; width: 30%; padding-right: 30px;">
-                                <h:outputLabel value="#{cc.attrs.bill.total}">
-                                    <f:convertNumber pattern="#,##0.00"/>
-                                </h:outputLabel>
-                            </td>
-                        </tr>
-                    </h:panelGroup>
+                    <tr>
+                        <td style="text-align: right; font-weight: bold; width: 70%;">Total Amount:</td>
+                        <td style="text-align: right; font-weight: bold; width: 30%; padding-right: 30px;">
+                            <h:outputLabel value="#{cc.attrs.bill.total}">
+                                <f:convertNumber pattern="#,##0.00"/>
+                            </h:outputLabel>
+                        </td>
+                    </tr>
                 </table>
             </div>
 

--- a/src/main/webapp/resources/ezcomp/prints/float_transfer_receive_five_five_printed.xhtml
+++ b/src/main/webapp/resources/ezcomp/prints/float_transfer_receive_five_five_printed.xhtml
@@ -135,18 +135,16 @@
 
             <div>
                 <table style="width: 100%;">
-                    <h:panelGroup rendered="#{cc.attrs.bill.margin > 0? 'false':'true'}">
-                        <tr>
-                            <td  >
-                                <h:outputLabel value="Total"/>
-                            </td>
-                            <td >
-                                <h:outputLabel value="#{cc.attrs.bill.total}">
-                                    <f:convertNumber pattern="#,##0.00"/>
-                                </h:outputLabel>
-                            </td>
-                        </tr>
-                    </h:panelGroup>
+                    <tr>
+                        <td>
+                            <h:outputLabel value="Total"/>
+                        </td>
+                        <td>
+                            <h:outputLabel value="#{cc.attrs.bill.total}">
+                                <f:convertNumber pattern="#,##0.00"/>
+                            </h:outputLabel>
+                        </td>
+                    </tr>
                 </table>
             </div>
 

--- a/src/main/webapp/resources/ezcomp/prints/float_transfer_receive_pos.xhtml
+++ b/src/main/webapp/resources/ezcomp/prints/float_transfer_receive_pos.xhtml
@@ -150,18 +150,16 @@
             <!-- Total -->
             <div style="padding: 5px;">
                 <table style="width: 100%; font-size: 12px; font-weight: bold;">
-                    <h:panelGroup rendered="#{cc.attrs.bill.margin > 0? 'false':'true'}">
-                        <tr>
-                            <td style="text-align: left;">
-                                <h:outputLabel value="Total"/>
-                            </td>
-                            <td style="text-align: right;">
-                                <h:outputLabel value="#{cc.attrs.bill.total}">
-                                    <f:convertNumber pattern="#,##0.00"/>
-                                </h:outputLabel>
-                            </td>
-                        </tr>
-                    </h:panelGroup>
+                    <tr>
+                        <td style="text-align: left;">
+                            <h:outputLabel value="Total"/>
+                        </td>
+                        <td style="text-align: right;">
+                            <h:outputLabel value="#{cc.attrs.bill.total}">
+                                <f:convertNumber pattern="#,##0.00"/>
+                            </h:outputLabel>
+                        </td>
+                    </tr>
                 </table>
             </div>
 

--- a/src/main/webapp/resources/ezcomp/prints/float_transfer_receive_pos_printed.xhtml
+++ b/src/main/webapp/resources/ezcomp/prints/float_transfer_receive_pos_printed.xhtml
@@ -138,18 +138,16 @@
             <!-- Total -->
             <div style="padding: 5px;">
                 <table style="width: 100%; font-size: 12px; font-weight: bold;">
-                    <h:panelGroup rendered="#{cc.attrs.bill.margin > 0? 'false':'true'}">
-                        <tr>
-                            <td style="text-align: left;">
-                                <h:outputLabel value="Total"/>
-                            </td>
-                            <td style="text-align: right;">
-                                <h:outputLabel value="#{cc.attrs.bill.total}">
-                                    <f:convertNumber pattern="#,##0.00"/>
-                                </h:outputLabel>
-                            </td>
-                        </tr>
-                    </h:panelGroup>
+                    <tr>
+                        <td style="text-align: left;">
+                            <h:outputLabel value="Total"/>
+                        </td>
+                        <td style="text-align: right;">
+                            <h:outputLabel value="#{cc.attrs.bill.total}">
+                                <f:convertNumber pattern="#,##0.00"/>
+                            </h:outputLabel>
+                        </td>
+                    </tr>
                 </table>
             </div>
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for multiple receipt format options for float transfer and receive operations, including POS, 5x5, and A4 paper sizes
  * Each format now supports variants with and without institutional headers
  * Added pre-printed version options for professional printing workflows

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->