### PR TITLE
Change made:

### DIFF
--- a/src/main/java/com/divudi/bean/common/SearchController.java
+++ b/src/main/java/com/divudi/bean/common/SearchController.java
@@ -19103,6 +19103,8 @@ public class SearchController implements Serializable {
 
         String jpql = "select b "
                 + " from Bill b "
+                + " left join fetch b.patient patient "
+                + " left join fetch patient.person "
                 + " where b.retired = :br "
                 + " and b.createdAt between :fd and :td "
                 + " and b.billTypeAtomic in :btas ";


### PR DESCRIPTION
  String jpql = "select b "
          + " from Bill b "
          + " left join fetch b.patient patient "
          + " left join fetch patient.person "
          + " where b.retired = :br "
          + " and b.createdAt between :fd and :td "
          + " and b.billTypeAtomic in :btas ";

  This ensures Patient and Person entities are eagerly loaded in the same UnitOfWork/persistence context, preventing the EclipseLink-6004 error when the daily return report renders row.bill.patient.person.nameWithTitle.

  You can now compile and test the fix by:
  1. Creating an OPD or pharmacy bill with patient deposit payment
  2. Opening the daily return report
  3. Verifying no error occurs and patient names display correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced financial reporting capabilities including cashier summaries, income analysis, and departmental breakdowns.
  * Data export to PDF and Excel formats for reports and financial records.
  * Improved bill and payment transaction processing with comprehensive validation.

* **Performance Improvements**
  * Optimized database queries for faster report generation and data retrieval.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->