### PR TITLE
Unable to return deposit using card, cheque, slip, ewallet – error validation displayed

### DIFF
--- a/src/main/java/com/divudi/bean/common/PatientDepositController.java
+++ b/src/main/java/com/divudi/bean/common/PatientDepositController.java
@@ -382,10 +382,6 @@ public class PatientDepositController implements Serializable, ControllerWithPat
             JsfUtil.addErrorMessage("Please Select a Patient");
             return;
         }
-        if (validatePaymentMethodDataForPatientDepositReturn()) {
-            return;
-        }
-
         if (current == null) {
             JsfUtil.addErrorMessage("No current. please start from beginning");
             return;
@@ -397,7 +393,12 @@ public class PatientDepositController implements Serializable, ControllerWithPat
             JsfUtil.addErrorMessage("No Bill in patient controller. please start from beginning");
             return;
         }
+        
         patientController.setBillNetTotal();
+        
+        if (validatePaymentMethodDataForPatientDepositReturn()) {
+            return;
+        }
         if (current.getBalance() < patientController.getBill().getNetTotal()) {
             JsfUtil.addErrorMessage("Can't Refund a Total More that Deposit");
             return;

--- a/src/main/webapp/patient_deposit/pay.xhtml
+++ b/src/main/webapp/patient_deposit/pay.xhtml
@@ -168,7 +168,7 @@
                                                                 requiredMessage="Please enter a title"
                                                                 value="#{patientDepositController.patient.person.title}">
                                                                 <f:selectItem itemLabel="Select Title" />
-                                                                <f:selectItems value="#{patientDepositController.title}" var="i"
+                                                                <f:selectItems value="#{opdBillController.title}" var="i"
                                                                                itemLabel="#{i.label}" itemValue="#{i}"/>
                                                                 <p:ajax event="change" process="cmbTitle" update="cmbSex" ></p:ajax>
                                                             </p:selectOneMenu>
@@ -200,7 +200,7 @@
                                                                 value="#{patientDepositController.patient.person.sex}"
                                                                 class="form-control w-100">
                                                                 <f:selectItem itemLabel="Select Gender"/>
-                                                                <f:selectItems value="#{patientDepositController.sex}"/>
+                                                                <f:selectItems value="#{opdBillController.sex}"/>
                                                             </p:selectOneMenu>
                                                         </div>
                                                         <div class="col-md-9 p-1">


### PR DESCRIPTION
Issues:
- #17572 
- #17573 
- #17574 
- #17575 

Files Changed:
- patientDepositController
- pay.xhtml

Changed the order of the validation steps in the `settlePatientDepositReturn()` method.
Before: bill.netTotal was checked before setting the value

Changed how `title` and `sex` values retrieved in the `pay.xhtml`.
Used `opdBillController`. Referred `receive,xhtml`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved validation logic in patient deposit settlement processing to ensure bill calculations are completed before payment method validation
  * Corrected dropdown data sources for patient information fields to display accurate options

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->