### PR TITLE
17071-add-user-feedback-for-failed-settings-operations-in-usersettingscontroller

### DIFF
--- a/src/main/java/com/divudi/bean/common/UserSettingsController.java
+++ b/src/main/java/com/divudi/bean/common/UserSettingsController.java
@@ -76,7 +76,7 @@ public class UserSettingsController implements Serializable {
             });
         } catch (Exception e) {
             // Graceful degradation - if settings can't be loaded, continue with defaults
-
+            JsfUtil.addErrorMessage("Failed to load your settings. Using defaults.");
         }
     }
 
@@ -197,6 +197,7 @@ public class UserSettingsController implements Serializable {
             settingsCache.put(key, option);
 
         } catch (Exception e) {
+            JsfUtil.addErrorMessage("Failed to save your settings.");
         }
     }
 
@@ -228,6 +229,7 @@ public class UserSettingsController implements Serializable {
             String jsonString = serializeToJson(value);
             saveUserSetting(key, jsonString, OptionValueType.LONG_TEXT);
         } catch (Exception e) {
+            JsfUtil.addErrorMessage("Failed to save your settings.");
         }
     }
 


### PR DESCRIPTION
I added error messages to three places where settings operations were failing silently. Now users will see "Failed to load your settings" or "Failed to save your settings" messages when these operations fail, similar to how other parts of the application already show error feedback.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced error handling in user settings. Users now receive clearer notifications when settings fail to load (with default values applied) or when save operations fail.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->