### PR TITLE
#17535 Add float out cancellation feature

### DIFF
--- a/src/main/java/com/divudi/bean/cashTransaction/FinancialTransactionController.java
+++ b/src/main/java/com/divudi/bean/cashTransaction/FinancialTransactionController.java
@@ -15,6 +15,7 @@ import com.divudi.core.data.admin.PrivilegeInfo;
 import javax.annotation.PostConstruct;
 import com.divudi.core.data.*;
 import com.divudi.core.entity.Bill;
+import com.divudi.core.entity.CancelledBill;
 import com.divudi.core.entity.Payment;
 import com.divudi.core.facade.BillFacade;
 import com.divudi.core.facade.PaymentFacade;
@@ -258,6 +259,14 @@ public class FinancialTransactionController implements Serializable {
     private double totalCashFund;
 
     boolean floatTransferStarted = false;
+
+    // Float Out Cancellation Properties
+    private List<Bill> myFundTransferBillsOut;
+    private Bill fundTransferBillToCancel;
+    private Bill fundTransferCancellationBill;
+    private String fundTransferCancellationReason;
+    private Date myFloatOutsFromDate;
+    private Date myFloatOutsToDate;
 
     // </editor-fold>
     // <editor-fold defaultstate="collapsed" desc="Constructors">
@@ -2046,6 +2055,14 @@ public class FinancialTransactionController implements Serializable {
         currentBill.setBillType(BillType.FundTransferBill);
         currentBill.setBillTypeAtomic(BillTypeAtomic.FUND_TRANSFER_BILL);
         currentBill.setBillClassType(BillClassType.Bill);
+    }
+
+    public void ensureFundTransferBillInitialized() {
+        if (currentBill == null || currentBill.getBillType() != BillType.FundTransferBill) {
+            prepareToAddNewFundTransferBill();
+            floatTransferStarted = false;
+            currentBillPayments = new ArrayList<>();
+        }
     }
 
     private void prepareToAddNewFundDepositBill() {
@@ -4981,6 +4998,189 @@ public class FinancialTransactionController implements Serializable {
         return billFacade.findByJpql(jpql.toString(), params, TemporalType.TIMESTAMP);
     }
 
+    // Float Out Cancellation Methods
+    public void fillMyFundTransferBillsOut() {
+        Map<String, Object> params = new HashMap<>();
+        StringBuilder jpql = new StringBuilder(
+                "select s from Bill s "
+                + "where s.retired=:ret "
+                + "and s.billTypeAtomic=:btype "
+                + "and s.fromWebUser=:fromUser "
+                + "and s.createdAt between :fd and :td "
+        );
+        params.put("ret", false);
+        params.put("btype", BillTypeAtomic.FUND_TRANSFER_BILL);
+        params.put("fromUser", sessionController.getLoggedUser());
+        params.put("fd", getMyFloatOutsFromDate());
+        params.put("td", getMyFloatOutsToDate());
+        jpql.append("order by s.createdAt desc");
+        myFundTransferBillsOut = billFacade.findByJpql(jpql.toString(), params, TemporalType.TIMESTAMP);
+    }
+
+    public String navigateToMyFundTransferBillsOut() {
+        myFloatOutsFromDate = CommonFunctions.getStartOfDay(CommonFunctions.getAddedDate(new Date(), -30));
+        myFloatOutsToDate = CommonFunctions.getEndOfDay(new Date());
+        fillMyFundTransferBillsOut();
+        return "/cashier/fund_transfer_bills_my_float_outs?faces-redirect=true";
+    }
+
+    public String navigateToFundTransferBillCancel(Bill bill) {
+        if (bill == null) {
+            JsfUtil.addErrorMessage("No bill selected");
+            return "";
+        }
+        if (bill.getBillTypeAtomic() != BillTypeAtomic.FUND_TRANSFER_BILL) {
+            JsfUtil.addErrorMessage("Invalid bill type");
+            return "";
+        }
+        if (bill.isCancelled()) {
+            JsfUtil.addErrorMessage("This float transfer has already been cancelled");
+            return "";
+        }
+        if (bill.getReferenceBill() != null) {
+            JsfUtil.addErrorMessage("This float transfer has already been accepted and cannot be cancelled");
+            return "";
+        }
+        fundTransferBillToCancel = bill;
+        fundTransferCancellationReason = null;
+        // Load payments for display
+        if (fundTransferBillToCancel.getPayments() == null || fundTransferBillToCancel.getPayments().isEmpty()) {
+            fundTransferBillToCancel.setPayments(findPaymentsForBill(fundTransferBillToCancel));
+        }
+        return "/cashier/fund_transfer_bill_cancel?faces-redirect=true";
+    }
+
+    public String navigateToViewFundTransferBill(Bill bill) {
+        if (bill == null) {
+            JsfUtil.addErrorMessage("No bill selected");
+            return "";
+        }
+        currentBill = bill;
+        if (currentBill.getPayments() == null || currentBill.getPayments().isEmpty()) {
+            currentBill.setPayments(findPaymentsForBill(currentBill));
+        }
+        currentBillPayments = currentBill.getPayments();
+        return "/cashier/fund_transfer_bill_print?faces-redirect=true";
+    }
+
+    public String cancelFundTransferBill() {
+        // Re-validate before executing
+        if (fundTransferBillToCancel == null) {
+            JsfUtil.addErrorMessage("No bill selected for cancellation");
+            return "";
+        }
+        // Refresh from database to check current state
+        Bill freshBill = billFacade.find(fundTransferBillToCancel.getId());
+        if (freshBill.isCancelled()) {
+            JsfUtil.addErrorMessage("This float transfer has already been cancelled");
+            return "";
+        }
+        if (freshBill.getReferenceBill() != null) {
+            JsfUtil.addErrorMessage("This float transfer has been accepted and cannot be cancelled");
+            return "";
+        }
+        if (fundTransferCancellationReason == null || fundTransferCancellationReason.trim().isEmpty()) {
+            JsfUtil.addErrorMessage("Cancellation reason is required");
+            return "";
+        }
+
+        // Create cancellation bill
+        fundTransferCancellationBill = new CancelledBill();
+        fundTransferCancellationBill.setBillType(BillType.FundTransferBill);
+        fundTransferCancellationBill.setBillTypeAtomic(BillTypeAtomic.FUND_TRANSFER_BILL_CANCELLED);
+        fundTransferCancellationBill.setBillClassType(BillClassType.CancelledBill);
+
+        // Copy department info from original
+        fundTransferCancellationBill.setDepartment(fundTransferBillToCancel.getDepartment());
+        fundTransferCancellationBill.setInstitution(fundTransferBillToCancel.getInstitution());
+
+        // Copy from/to info
+        fundTransferCancellationBill.setFromStaff(fundTransferBillToCancel.getFromStaff());
+        fundTransferCancellationBill.setFromWebUser(fundTransferBillToCancel.getFromWebUser());
+        fundTransferCancellationBill.setToStaff(fundTransferBillToCancel.getToStaff());
+        fundTransferCancellationBill.setToWebUser(fundTransferBillToCancel.getToWebUser());
+
+        // Set audit fields
+        fundTransferCancellationBill.setCreater(sessionController.getLoggedUser());
+        fundTransferCancellationBill.setCreatedAt(new Date());
+        fundTransferCancellationBill.setBillDate(new Date());
+        fundTransferCancellationBill.setBillTime(new Date());
+        fundTransferCancellationBill.setStaff(sessionController.getLoggedUser().getStaff());
+
+        // Set comments
+        fundTransferCancellationBill.setComments(fundTransferCancellationReason);
+
+        // Link to original bill
+        fundTransferCancellationBill.setBilledBill(fundTransferBillToCancel);
+        fundTransferCancellationBill.setBackwardReferenceBill(fundTransferBillToCancel);
+
+        // Generate bill number
+        String deptId = billNumberGenerator.departmentBillNumberGeneratorYearly(
+                sessionController.getDepartment(),
+                BillTypeAtomic.FUND_TRANSFER_BILL_CANCELLED
+        );
+        fundTransferCancellationBill.setDeptId(deptId);
+        fundTransferCancellationBill.setInsId(deptId);
+
+        // Save cancellation bill
+        billController.save(fundTransferCancellationBill);
+
+        // Create reversed payments and update drawer
+        List<Payment> cancellationPayments = new ArrayList<>();
+        double totalValue = 0.0;
+
+        // Get original payments
+        List<Payment> originalPayments = findPaymentsForBill(fundTransferBillToCancel);
+
+        for (Payment originalPayment : originalPayments) {
+            Payment cancellationPayment = new Payment();
+            cancellationPayment.setBill(fundTransferCancellationBill);
+            cancellationPayment.setPaymentMethod(originalPayment.getPaymentMethod());
+            cancellationPayment.setCreatedAt(new Date());
+            cancellationPayment.setCreater(sessionController.getLoggedUser());
+
+            // POSITIVE value for cancellation (reverses the negative from original)
+            cancellationPayment.setPaidValue(Math.abs(originalPayment.getPaidValue()));
+            totalValue += cancellationPayment.getPaidValue();
+
+            // Copy other payment details
+            cancellationPayment.setBank(originalPayment.getBank());
+            cancellationPayment.setChequeRefNo(originalPayment.getChequeRefNo());
+            cancellationPayment.setChequeDate(originalPayment.getChequeDate());
+            cancellationPayment.setCreditCardRefNo(originalPayment.getCreditCardRefNo());
+            cancellationPayment.setInstitution(originalPayment.getInstitution());
+
+            paymentController.save(cancellationPayment);
+            cancellationPayments.add(cancellationPayment);
+
+            // Reverse drawer update - add back to sender's drawer
+            drawerController.updateDrawerForIns(cancellationPayment);
+        }
+
+        // Set totals (positive for cancellation)
+        fundTransferCancellationBill.setTotal(totalValue);
+        fundTransferCancellationBill.setNetTotal(totalValue);
+        fundTransferCancellationBill.getPayments().addAll(cancellationPayments);
+        billController.save(fundTransferCancellationBill);
+
+        // Update original bill as cancelled
+        fundTransferBillToCancel.setCancelled(true);
+        fundTransferBillToCancel.setCancelledBill(fundTransferCancellationBill);
+        billController.save(fundTransferBillToCancel);
+
+        currentBill = fundTransferCancellationBill;
+        currentBillPayments = cancellationPayments;
+
+        JsfUtil.addSuccessMessage("Float transfer cancelled successfully");
+
+        return "/cashier/fund_transfer_bill_cancel_print?faces-redirect=true";
+    }
+
+    public String navigateBackToMyFloatOuts() {
+        fillMyFundTransferBillsOut();
+        return "/cashier/fund_transfer_bills_my_float_outs?faces-redirect=true";
+    }
+
     public boolean hasAtLeastOneFundTransferBillToReceive(WebUser fromUser,
             Staff fromStaff,
             WebUser toUser,
@@ -6077,6 +6277,61 @@ public class FinancialTransactionController implements Serializable {
 
     public void setSelectedBill(Bill selectedBill) {
         this.selectedBill = selectedBill;
+    }
+
+    // Float Out Cancellation Getters/Setters
+    public List<Bill> getMyFundTransferBillsOut() {
+        return myFundTransferBillsOut;
+    }
+
+    public void setMyFundTransferBillsOut(List<Bill> myFundTransferBillsOut) {
+        this.myFundTransferBillsOut = myFundTransferBillsOut;
+    }
+
+    public Bill getFundTransferBillToCancel() {
+        return fundTransferBillToCancel;
+    }
+
+    public void setFundTransferBillToCancel(Bill fundTransferBillToCancel) {
+        this.fundTransferBillToCancel = fundTransferBillToCancel;
+    }
+
+    public Bill getFundTransferCancellationBill() {
+        return fundTransferCancellationBill;
+    }
+
+    public void setFundTransferCancellationBill(Bill fundTransferCancellationBill) {
+        this.fundTransferCancellationBill = fundTransferCancellationBill;
+    }
+
+    public String getFundTransferCancellationReason() {
+        return fundTransferCancellationReason;
+    }
+
+    public void setFundTransferCancellationReason(String fundTransferCancellationReason) {
+        this.fundTransferCancellationReason = fundTransferCancellationReason;
+    }
+
+    public Date getMyFloatOutsFromDate() {
+        if (myFloatOutsFromDate == null) {
+            myFloatOutsFromDate = CommonFunctions.getStartOfDay(CommonFunctions.getStartOfMonth());
+        }
+        return myFloatOutsFromDate;
+    }
+
+    public void setMyFloatOutsFromDate(Date myFloatOutsFromDate) {
+        this.myFloatOutsFromDate = myFloatOutsFromDate;
+    }
+
+    public Date getMyFloatOutsToDate() {
+        if (myFloatOutsToDate == null) {
+            myFloatOutsToDate = CommonFunctions.getEndOfDay(new Date());
+        }
+        return myFloatOutsToDate;
+    }
+
+    public void setMyFloatOutsToDate(Date myFloatOutsToDate) {
+        this.myFloatOutsToDate = myFloatOutsToDate;
     }
 
     // </editor-fold>

--- a/src/main/webapp/cashier/fund_transfer_bill.xhtml
+++ b/src/main/webapp/cashier/fund_transfer_bill.xhtml
@@ -12,6 +12,9 @@
         <ui:composition template="./index.xhtml">
 
             <ui:define name="subcontent">
+                <f:metadata>
+                    <f:viewAction action="#{financialTransactionController.ensureFundTransferBillInitialized()}" />
+                </f:metadata>
                 <h:form>
 
 

--- a/src/main/webapp/cashier/fund_transfer_bill_cancel.xhtml
+++ b/src/main/webapp/cashier/fund_transfer_bill_cancel.xhtml
@@ -1,0 +1,122 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
+      xmlns:h="http://xmlns.jcp.org/jsf/html"
+      xmlns:p="http://primefaces.org/ui"
+      xmlns:f="http://xmlns.jcp.org/jsf/core">
+
+    <h:body>
+
+        <ui:composition template="./index.xhtml">
+            <ui:define name="subcontent">
+                <h:form>
+                    <p:panel>
+                        <f:facet name="header">
+                            <h:outputText value="Cancel Float Transfer" style="color: #dc3545; font-weight: bold;" />
+                            <p:commandButton
+                                class="float-end"
+                                value="Back to My Float Outs"
+                                action="#{financialTransactionController.navigateBackToMyFloatOuts()}"
+                                ajax="false"
+                                icon="pi pi-arrow-left" />
+                        </f:facet>
+
+                        <div class="row">
+                            <div class="col-md-6">
+                                <p:panel header="Original Float Transfer Details">
+                                    <p:panelGrid columns="2" class="w-100" columnClasses="fw-bold, text-end">
+                                        <h:outputText value="Bill ID" />
+                                        <h:outputText value="#{financialTransactionController.fundTransferBillToCancel.deptId}" />
+
+                                        <h:outputText value="From User" />
+                                        <h:outputText value="#{financialTransactionController.fundTransferBillToCancel.fromWebUser.webUserPerson.nameWithTitle}" />
+
+                                        <h:outputText value="To User" />
+                                        <h:outputText value="#{financialTransactionController.fundTransferBillToCancel.toWebUser.webUserPerson.nameWithTitle}" />
+
+                                        <h:outputText value="Created At" />
+                                        <h:outputText value="#{financialTransactionController.fundTransferBillToCancel.createdAt}">
+                                            <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateTimeFormat}" />
+                                        </h:outputText>
+
+                                        <h:outputText value="Original Comments" />
+                                        <h:outputText value="#{financialTransactionController.fundTransferBillToCancel.comments}" />
+
+                                        <h:outputText value="Total Amount" />
+                                        <h:outputText value="#{financialTransactionController.fundTransferBillToCancel.absoluteNetTotalTransient}" style="font-weight: bold; font-size: 1.2em;">
+                                            <f:convertNumber pattern="#,##0.00" />
+                                        </h:outputText>
+                                    </p:panelGrid>
+                                </p:panel>
+                            </div>
+
+                            <div class="col-md-6">
+                                <p:panel header="Payment Details">
+                                    <p:dataTable
+                                        value="#{financialTransactionController.fundTransferBillToCancel.payments}"
+                                        var="payment"
+                                        emptyMessage="No payments found">
+
+                                        <p:column headerText="Payment Method">
+                                            <h:outputText value="#{payment.paymentMethod}" />
+                                        </p:column>
+
+                                        <p:column headerText="Details">
+                                            <h:panelGroup rendered="#{payment.paymentMethod eq 'Cheque'}">
+                                                <h:outputText value="#{payment.bank.name} - #{payment.chequeRefNo}" />
+                                            </h:panelGroup>
+                                            <h:panelGroup rendered="#{payment.paymentMethod eq 'Card'}">
+                                                <h:outputText value="Card Ref: #{payment.creditCardRefNo}" />
+                                            </h:panelGroup>
+                                            <h:panelGroup rendered="#{payment.paymentMethod eq 'Slip'}">
+                                                <h:outputText value="Bank: #{payment.bank.name}" />
+                                            </h:panelGroup>
+                                        </p:column>
+
+                                        <p:column headerText="Amount" style="text-align: right;">
+                                            <h:outputText value="#{payment.absolutePaidValueTransient}">
+                                                <f:convertNumber pattern="#,##0.00" />
+                                            </h:outputText>
+                                        </p:column>
+
+                                    </p:dataTable>
+                                </p:panel>
+                            </div>
+                        </div>
+
+                        <div class="row mt-3">
+                            <div class="col-12">
+                                <p:panel header="Cancellation Details" styleClass="ui-panel-danger">
+                                    <div class="p-field">
+                                        <h:outputLabel value="Cancellation Reason *" for="cancellationReason" class="fw-bold" />
+                                        <p:inputTextarea
+                                            id="cancellationReason"
+                                            value="#{financialTransactionController.fundTransferCancellationReason}"
+                                            rows="3"
+                                            class="w-100"
+                                            placeholder="Please provide a reason for cancelling this float transfer..."
+                                            required="true"
+                                            requiredMessage="Cancellation reason is required" />
+                                    </div>
+
+                                    <div class="mt-3 text-center">
+                                        <p:commandButton
+                                            value="Confirm Cancellation"
+                                            icon="pi pi-times-circle"
+                                            action="#{financialTransactionController.cancelFundTransferBill()}"
+                                            ajax="false"
+                                            styleClass="ui-button-danger"
+                                            onclick="if (!confirm('Are you sure you want to cancel this float transfer? This action cannot be undone.')) return false;" />
+                                    </div>
+                                </p:panel>
+                            </div>
+                        </div>
+
+                    </p:panel>
+                </h:form>
+            </ui:define>
+        </ui:composition>
+
+    </h:body>
+</html>

--- a/src/main/webapp/cashier/fund_transfer_bill_cancel_print.xhtml
+++ b/src/main/webapp/cashier/fund_transfer_bill_cancel_print.xhtml
@@ -1,0 +1,151 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
+      xmlns:h="http://xmlns.jcp.org/jsf/html"
+      xmlns:p="http://primefaces.org/ui"
+      xmlns:prints="http://xmlns.jcp.org/jsf/composite/ezcomp/prints"
+      xmlns:f="http://xmlns.jcp.org/jsf/core">
+
+    <h:body>
+
+        <ui:composition template="./index.xhtml">
+            <ui:define name="subcontent">
+
+                <h:form>
+                    <p:panel class="m-1">
+                        <f:facet name="header">
+                            <h:outputText value="Float Transfer Cancellation Note" style="color: #dc3545;" />
+                            <p:commandButton
+                                class="float-end me-2"
+                                value="Back to My Float Outs"
+                                action="#{financialTransactionController.navigateBackToMyFloatOuts()}"
+                                ajax="false"
+                                icon="pi pi-arrow-left" />
+                            <p:commandButton
+                                class="float-end me-2"
+                                value="Cashier Index"
+                                action="#{financialTransactionController.navigateToFinancialTransactionIndex()}"
+                                ajax="false"
+                                icon="pi pi-home" />
+                        </f:facet>
+
+                        <div class="row">
+                            <div class="col-3">
+                                <p:panelGrid
+                                    class="w-100"
+                                    layout="tabular"
+                                    columns="2"
+                                    columnClasses="text-start, text-end">
+                                    <h:outputText class="fw-medium" value="Cancellation Bill ID" />
+                                    <h:outputText value="#{financialTransactionController.currentBill.deptId}" />
+
+                                    <h:outputText class="fw-medium" value="Cancelled At" />
+                                    <h:outputText value="#{financialTransactionController.currentBill.createdAt}">
+                                        <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateTimeFormat}" />
+                                    </h:outputText>
+
+                                    <h:outputText class="fw-medium" value="Cancelled By" />
+                                    <h:outputText value="#{financialTransactionController.currentBill.creater.name}" />
+                                </p:panelGrid>
+                            </div>
+                            <div class="col-3">
+                                <p:panelGrid
+                                    layout="tabular"
+                                    columns="2"
+                                    class="w-100"
+                                    columnClasses="text-start, text-end">
+                                    <h:outputText class="fw-medium" value="Original Bill ID" />
+                                    <h:outputText value="#{financialTransactionController.currentBill.billedBill.deptId}" />
+
+                                    <h:outputText class="fw-medium" value="Original From" />
+                                    <h:outputText value="#{financialTransactionController.currentBill.fromWebUser.webUserPerson.nameWithTitle}" />
+
+                                    <h:outputText class="fw-medium" value="Original To" />
+                                    <h:outputText value="#{financialTransactionController.currentBill.toWebUser.webUserPerson.nameWithTitle}" />
+                                </p:panelGrid>
+                            </div>
+                            <div class="col-6">
+                                <p:dataTable
+                                    class="w-100"
+                                    id="tblPayments"
+                                    value="#{financialTransactionController.currentBillPayments}"
+                                    var="bp">
+                                    <p:column headerText="Payment Method">
+                                        <h:outputText value="#{bp.paymentMethod}" />
+                                        <f:facet name="footer">
+                                            <h:outputLabel value="Total" />
+                                        </f:facet>
+                                    </p:column>
+                                    <p:column
+                                        headerText="Value"
+                                        class="text-end">
+                                        <h:outputText value="#{bp.paidValue}">
+                                            <f:convertNumber pattern="#,##0.00" />
+                                        </h:outputText>
+                                        <f:facet name="footer">
+                                            <h:outputLabel value="#{financialTransactionController.currentBill.netTotal}">
+                                                <f:convertNumber pattern="#,##0.00" />
+                                            </h:outputLabel>
+                                        </f:facet>
+                                    </p:column>
+                                </p:dataTable>
+                            </div>
+                        </div>
+
+                        <div class="row mt-3">
+                            <div class="col-12">
+                                <p:panel header="Cancellation Reason">
+                                    <h:outputText value="#{financialTransactionController.currentBill.comments}" />
+                                </p:panel>
+                            </div>
+                        </div>
+
+                    </p:panel>
+
+                    <h:panelGroup id="panelPrint">
+                        <!-- POS Paper with header -->
+                        <h:panelGroup rendered="#{configOptionController.getBooleanValueByKey('Fund Transfer Bill is POS Paper', false)}">
+                            <prints:float_transfer_cancel_pos bill="#{financialTransactionController.currentBill}"/>
+                        </h:panelGroup>
+
+                        <!-- POS Printed Paper (without header) -->
+                        <h:panelGroup rendered="#{configOptionController.getBooleanValueByKey('Fund Transfer Bill is POS Printed Paper', false)}">
+                            <prints:float_transfer_cancel_pos bill="#{financialTransactionController.currentBill}"/>
+                        </h:panelGroup>
+
+                        <!-- 5x5 Paper with header (default) -->
+                        <h:panelGroup rendered="#{configOptionController.getBooleanValueByKey('Fund Transfer Bill is 5x5 Paper', true)}">
+                            <prints:float_transfer_cancel_five_five bill="#{financialTransactionController.currentBill}"/>
+                        </h:panelGroup>
+
+                        <!-- 5x5 Printed Paper (without header) -->
+                        <h:panelGroup rendered="#{configOptionController.getBooleanValueByKey('Fund Transfer Bill is 5x5 Printed Paper', false)}">
+                            <prints:float_transfer_cancel_five_five bill="#{financialTransactionController.currentBill}"/>
+                        </h:panelGroup>
+
+                        <!-- A4 Paper with header -->
+                        <h:panelGroup rendered="#{configOptionController.getBooleanValueByKey('Fund Transfer Bill is A4 Paper', false)}">
+                            <prints:float_transfer_cancel_a4 bill="#{financialTransactionController.currentBill}"/>
+                        </h:panelGroup>
+
+                        <!-- A4 Printed Paper (without header) -->
+                        <h:panelGroup rendered="#{configOptionController.getBooleanValueByKey('Fund Transfer Bill is A4 Printed Paper', false)}">
+                            <prints:float_transfer_cancel_a4 bill="#{financialTransactionController.currentBill}"/>
+                        </h:panelGroup>
+                    </h:panelGroup>
+
+                    <p:commandButton
+                        value="Print"
+                        ajax="false"
+                        icon="pi pi-print"
+                        style="margin-top: 10px;">
+                        <p:printer target="panelPrint"/>
+                    </p:commandButton>
+
+                </h:form>
+            </ui:define>
+        </ui:composition>
+
+    </h:body>
+</html>

--- a/src/main/webapp/cashier/fund_transfer_bills_my_float_outs.xhtml
+++ b/src/main/webapp/cashier/fund_transfer_bills_my_float_outs.xhtml
@@ -1,0 +1,120 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
+      xmlns:h="http://xmlns.jcp.org/jsf/html"
+      xmlns:p="http://primefaces.org/ui"
+      xmlns:f="http://xmlns.jcp.org/jsf/core">
+
+    <h:body>
+
+        <ui:composition template="./index.xhtml">
+            <ui:define name="subcontent">
+                <h:form>
+                    <p:panel header="My Float Outs">
+                        <div class="row mb-3">
+                            <div class="col-md-3">
+                                <h:outputLabel value="From Date" class="fw-bold" />
+                                <p:datePicker
+                                    id="fromDate"
+                                    value="#{financialTransactionController.myFloatOutsFromDate}"
+                                    pattern="#{sessionController.applicationPreference.shortDateFormat}"
+                                    showIcon="true"
+                                    class="w-100" />
+                            </div>
+                            <div class="col-md-3">
+                                <h:outputLabel value="To Date" class="fw-bold" />
+                                <p:datePicker
+                                    id="toDate"
+                                    value="#{financialTransactionController.myFloatOutsToDate}"
+                                    pattern="#{sessionController.applicationPreference.shortDateFormat}"
+                                    showIcon="true"
+                                    class="w-100" />
+                            </div>
+                            <div class="col-md-2 d-flex align-items-end">
+                                <p:commandButton
+                                    value="Search"
+                                    icon="pi pi-search"
+                                    action="#{financialTransactionController.fillMyFundTransferBillsOut()}"
+                                    update="tblMyFloatOuts"
+                                    class="ui-button-primary" />
+                            </div>
+                        </div>
+
+                        <p:dataTable
+                            id="tblMyFloatOuts"
+                            value="#{financialTransactionController.myFundTransferBillsOut}"
+                            var="bp"
+                            rowKey="#{bp.id}"
+                            emptyMessage="No float transfers found for the selected period"
+                            paginator="true"
+                            rows="20"
+                            paginatorPosition="bottom">
+
+                            <p:column headerText="Bill ID">
+                                <h:outputText value="#{bp.deptId}" />
+                            </p:column>
+
+                            <p:column headerText="Created At">
+                                <h:outputText value="#{bp.createdAt}">
+                                    <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateTimeFormat}" />
+                                </h:outputText>
+                            </p:column>
+
+                            <p:column headerText="To User">
+                                <h:outputText value="#{bp.toWebUser.webUserPerson.nameWithTitle}" />
+                            </p:column>
+
+                            <p:column headerText="Amount" style="text-align: right;">
+                                <h:outputText value="#{bp.absoluteNetTotalTransient}">
+                                    <f:convertNumber pattern="#,##0.00" />
+                                </h:outputText>
+                            </p:column>
+
+                            <p:column headerText="Accepted">
+                                <h:panelGroup rendered="#{bp.referenceBill ne null}">
+                                    <span class="badge bg-success">Yes</span>
+                                </h:panelGroup>
+                                <h:panelGroup rendered="#{bp.referenceBill eq null and not bp.cancelled}">
+                                    <span class="badge bg-warning text-dark">Pending</span>
+                                </h:panelGroup>
+                                <h:panelGroup rendered="#{bp.referenceBill eq null and bp.cancelled}">
+                                    <span class="badge bg-secondary">N/A</span>
+                                </h:panelGroup>
+                            </p:column>
+
+                            <p:column headerText="Cancelled">
+                                <h:panelGroup rendered="#{bp.cancelled}">
+                                    <span class="badge bg-danger">Yes</span>
+                                </h:panelGroup>
+                                <h:panelGroup rendered="#{not bp.cancelled}">
+                                    <span class="badge bg-light text-dark">No</span>
+                                </h:panelGroup>
+                            </p:column>
+
+                            <p:column headerText="Actions" style="width: 200px;">
+                                <p:commandButton
+                                    value="View"
+                                    icon="pi pi-eye"
+                                    action="#{financialTransactionController.navigateToViewFundTransferBill(bp)}"
+                                    ajax="false"
+                                    class="ui-button-info ui-button-sm me-1" />
+
+                                <p:commandButton
+                                    value="Cancel"
+                                    icon="pi pi-times"
+                                    action="#{financialTransactionController.navigateToFundTransferBillCancel(bp)}"
+                                    ajax="false"
+                                    rendered="#{bp.referenceBill eq null and not bp.cancelled}"
+                                    class="ui-button-danger ui-button-sm" />
+                            </p:column>
+
+                        </p:dataTable>
+
+                    </p:panel>
+                </h:form>
+            </ui:define>
+        </ui:composition>
+
+    </h:body>
+</html>

--- a/src/main/webapp/cashier/index.xhtml
+++ b/src/main/webapp/cashier/index.xhtml
@@ -148,29 +148,37 @@
                                 </p:tab>
 
                                 <p:tab title="Float Management">
-                                    <p:commandButton 
-                                        class="my-1 w-100 ui-button-primary" 
+                                    <p:commandButton
+                                        class="my-1 w-100 ui-button-primary"
                                         value="Float Transfer"
-                                        icon="pi pi-directions"  
-                                        ajax="false" 
+                                        icon="pi pi-directions"
+                                        ajax="false"
                                         action="#{financialTransactionController.navigateToFundTransferBill()}" >
                                     </p:commandButton>
 
                                     <p:badge severity="danger" value="#{financialTransactionController.fundTransferBillsToReceiveCount}">
-                                        <p:commandButton 
-                                            class="my-1 w-100 ui-button-warning"  
+                                        <p:commandButton
+                                            class="my-1 w-100 ui-button-warning"
                                             value="Float Transfers for me to Receive"
-                                            icon="pi pi-inbox" 
-                                            ajax="false" 
+                                            icon="pi pi-inbox"
+                                            ajax="false"
                                             action="#{financialTransactionController.navigateToReceiveFundTransferBillsForMe()}" >
                                         </p:commandButton>
                                     </p:badge>
 
-                                    <p:commandButton 
-                                        class="my-1 w-100 ui-button-success"  
+                                    <p:commandButton
+                                        class="my-1 w-100 ui-button-info"
+                                        value="My Float Outs"
+                                        icon="pi pi-sign-out"
+                                        ajax="false"
+                                        action="#{financialTransactionController.navigateToMyFundTransferBillsOut()}" >
+                                    </p:commandButton>
+
+                                    <p:commandButton
+                                        class="my-1 w-100 ui-button-success"
                                         value="Transfer Bill Payment Method"
-                                        icon="pi pi-refresh" 
-                                        ajax="false" 
+                                        icon="pi pi-refresh"
+                                        ajax="false"
                                         action="#{financialTransactionController.navigateToTransferPaymentMethod()}" >
                                     </p:commandButton>
                                 </p:tab>

--- a/src/main/webapp/resources/ezcomp/prints/float_transfer_cancel_a4.xhtml
+++ b/src/main/webapp/resources/ezcomp/prints/float_transfer_cancel_a4.xhtml
@@ -1,0 +1,148 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:cc="http://xmlns.jcp.org/jsf/composite"
+      xmlns:f="http://xmlns.jcp.org/jsf/core"
+      xmlns:h="http://xmlns.jcp.org/jsf/html"
+      xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
+      xmlns:p="http://primefaces.org/ui">
+
+    <cc:interface>
+        <cc:attribute name="bill" type="com.divudi.core.entity.Bill" />
+        <cc:attribute name="duplicate" type="java.lang.Boolean"/>
+    </cc:interface>
+
+    <cc:implementation>
+
+        <div style="width: 210mm; padding: 20mm; font-family: Arial, sans-serif;">
+
+            <div style="text-align: center; font-size: 24px; font-weight: bold; padding: 15px; border-bottom: 3px solid #000;">
+                <h:outputText value="#{configOptionApplicationController.getLongTextValueByKey('Float Transfer Note Header Text')}" escape="false"></h:outputText>
+            </div>
+
+            <div style="text-align: center; font-size: 20px; font-weight: bold; padding: 10px; color: #dc3545;">
+                <h:outputLabel value="Float Transfer Cancellation Note"/>
+                <h:outputLabel value=" - **Duplicate**" rendered="#{cc.attrs.duplicate eq true}" style="color: red;"/>
+            </div>
+
+            <hr style="border-top: 2px solid #dc3545;"/>
+
+            <div style="padding: 15px;">
+                <table style="width: 100%; border-collapse: collapse; font-size: 14px;">
+                    <tr>
+                        <td style="width: 25%; font-weight: bold; padding: 8px;">Cancellation Bill ID:</td>
+                        <td style="width: 25%; padding: 8px;"><h:outputLabel value="#{cc.attrs.bill.deptId}"></h:outputLabel></td>
+                        <td style="width: 25%; font-weight: bold; padding: 8px;">Cancelled At:</td>
+                        <td style="width: 25%; padding: 8px;">
+                            <h:outputLabel value="#{cc.attrs.bill.createdAt}">
+                                <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateTimeFormat}"></f:convertDateTime>
+                            </h:outputLabel>
+                        </td>
+                    </tr>
+                    <tr>
+                        <td style="font-weight: bold; padding: 8px;">Original Bill ID:</td>
+                        <td style="padding: 8px;"><h:outputLabel value="#{cc.attrs.bill.billedBill.deptId}"></h:outputLabel></td>
+                        <td style="font-weight: bold; padding: 8px;">Original Date:</td>
+                        <td style="padding: 8px;">
+                            <h:outputLabel value="#{cc.attrs.bill.billedBill.createdAt}">
+                                <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateTimeFormat}"></f:convertDateTime>
+                            </h:outputLabel>
+                        </td>
+                    </tr>
+                    <tr>
+                        <td style="font-weight: bold; padding: 8px;">From:</td>
+                        <td style="padding: 8px;"><h:outputLabel value="#{cc.attrs.bill.fromWebUser.name}"></h:outputLabel></td>
+                        <td style="font-weight: bold; padding: 8px;">To:</td>
+                        <td style="padding: 8px;"><h:outputLabel value="#{cc.attrs.bill.toWebUser.webUserPerson.nameWithTitle}"></h:outputLabel></td>
+                    </tr>
+                    <tr>
+                        <td style="font-weight: bold; padding: 8px;">Cancelled By:</td>
+                        <td colspan="3" style="padding: 8px;"><h:outputLabel value="#{cc.attrs.bill.creater.name}"></h:outputLabel></td>
+                    </tr>
+                </table>
+            </div>
+
+            <hr style="border-top: 1px solid #000;"/>
+
+            <div style="padding: 15px;">
+                <h3 style="text-align: center; font-weight: bold; margin-bottom: 15px;">Payment Details (Reversed)</h3>
+                <table style="width: 100%; border-collapse: collapse; border: 1px solid #000;">
+                    <tr style="background: #f2f2f2;">
+                        <th style="padding: 12px; text-align: left; border: 1px solid #000;">Payment Method</th>
+                        <th style="padding: 12px; text-align: left; border: 1px solid #000;">Details</th>
+                        <th style="padding: 12px; text-align: right; border: 1px solid #000;">Amount</th>
+                    </tr>
+                    <ui:repeat value="#{cc.attrs.bill.payments}" var="bip">
+                        <tr>
+                            <td style="padding: 10px; border: 1px solid #ccc;"><h:outputLabel value="#{bip.paymentMethod}"></h:outputLabel></td>
+                            <td style="padding: 10px; border: 1px solid #ccc;">
+                                <h:panelGroup rendered="#{bip.paymentMethod eq 'Cash'}">
+                                    <ui:repeat value="#{bip.humanReadableDenominations}" var="denomination">
+                                        <h:outputText value="#{denomination}"/><br/>
+                                    </ui:repeat>
+                                </h:panelGroup>
+                                <h:panelGroup rendered="#{bip.paymentMethod eq 'Cheque'}">
+                                    <h:outputText value="#{bip.bank.name} - #{bip.chequeRefNo} " />
+                                    <h:outputText value="#{bip.chequeDate}">
+                                        <f:convertDateTime pattern="#{sessionController.applicationPreference.shortDateFormat}"></f:convertDateTime>
+                                    </h:outputText>
+                                </h:panelGroup>
+                                <h:panelGroup rendered="#{bip.paymentMethod eq 'Card'}">
+                                    <h:outputText value="Card Ref: #{bip.creditCardRefNo} - #{bip.institution.name} " />
+                                </h:panelGroup>
+                                <h:panelGroup rendered="#{bip.paymentMethod eq 'ewallet'}">
+                                    <h:outputText value="eWallet: #{bip.chequeRefNo} - #{bip.institution.name} " />
+                                </h:panelGroup>
+                                <h:panelGroup rendered="#{bip.paymentMethod eq 'Slip'}">
+                                    <h:outputText value="Bank: #{bip.bank.name} - #{bip.chequeDate}">
+                                        <f:convertDateTime pattern="#{sessionController.applicationPreference.shortDateFormat}"></f:convertDateTime>
+                                    </h:outputText>
+                                </h:panelGroup>
+                            </td>
+                            <td style="padding: 10px; text-align: right; border: 1px solid #ccc;">
+                                <h:outputLabel value="#{bip.paidValue}">
+                                    <f:convertNumber pattern="#,##0.00"/>
+                                </h:outputLabel>
+                            </td>
+                        </tr>
+                    </ui:repeat>
+                    <tr style="background: #f2f2f2; font-weight: bold;">
+                        <td colspan="2" style="padding: 12px; text-align: right; border: 1px solid #000;">Total Amount Reversed:</td>
+                        <td style="padding: 12px; text-align: right; border: 1px solid #000;">
+                            <h:outputLabel value="#{cc.attrs.bill.netTotal}">
+                                <f:convertNumber pattern="#,##0.00"/>
+                            </h:outputLabel>
+                        </td>
+                    </tr>
+                </table>
+            </div>
+
+            <div style="padding: 15px; background-color: #fff3cd; border: 2px solid #ffc107; border-radius: 8px; margin: 15px 0;">
+                <h:outputText value="Cancellation Reason: " style="font-weight: bold; font-size: 16px;"/>
+                <h:outputText value="#{cc.attrs.bill.comments}" style="font-size: 14px;"/>
+            </div>
+
+            <hr style="border-top: 1px solid #000;"/>
+
+            <div style="margin-top: 40px;">
+                <table style="width: 100%;">
+                    <tr>
+                        <td style="width: 50%; text-align: center; padding-top: 30px;">
+                            <div style="border-top: 1px solid #000; width: 200px; margin: 0 auto;"></div>
+                            <div style="margin-top: 5px;">Cancelled By Signature</div>
+                        </td>
+                        <td style="width: 50%; text-align: center; padding-top: 30px;">
+                            <div style="border-top: 1px solid #000; width: 200px; margin: 0 auto;"></div>
+                            <div style="margin-top: 5px;">Authorized Signature</div>
+                        </td>
+                    </tr>
+                </table>
+            </div>
+
+            <div style="text-align: center; font-size: 12px; padding: 15px; color: gray; margin-top: 20px;">
+                <h:outputText value="#{configOptionApplicationController.getLongTextValueByKey('Float Transfer Note Footer Text')}" escape="false"></h:outputText>
+            </div>
+
+        </div>
+    </cc:implementation>
+</html>

--- a/src/main/webapp/resources/ezcomp/prints/float_transfer_cancel_five_five.xhtml
+++ b/src/main/webapp/resources/ezcomp/prints/float_transfer_cancel_five_five.xhtml
@@ -1,0 +1,140 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:cc="http://xmlns.jcp.org/jsf/composite"
+      xmlns:f="http://xmlns.jcp.org/jsf/core"
+      xmlns:h="http://xmlns.jcp.org/jsf/html"
+      xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
+      xmlns:p="http://primefaces.org/ui">
+
+    <cc:interface>
+        <cc:attribute name="bill" type="com.divudi.core.entity.Bill" />
+        <cc:attribute name="duplicate" type="java.lang.Boolean"/>
+    </cc:interface>
+
+    <cc:implementation>
+
+        <div style="#{configOptionApplicationController.getLongTextValueByKey('Float Transfer Note CSS')}">
+
+            <div style="text-align: center; font-size: 20px; font-weight: bold; padding: 10px; border-bottom: 2px solid #000;">
+                <h:outputText value="#{configOptionApplicationController.getLongTextValueByKey('Float Transfer Note Header Text')}" escape="false"></h:outputText>
+            </div>
+
+            <div style="text-align: center; font-size: 18px; font-weight: bold; padding: 5px; color: #dc3545;">
+                <h:outputLabel value="Float Transfer Cancellation Note"/>
+                <h:outputLabel value=" - **Duplicate**" rendered="#{cc.attrs.duplicate eq true}" style="color: red;"/>
+            </div>
+
+            <hr style="border-top: 2px solid #dc3545;"/>
+
+            <div style="padding: 10px;">
+                <table style="width: 100%; border-collapse: collapse;">
+                    <tr>
+                        <td style="font-weight: bold;">Cancellation Bill ID:</td>
+                        <td><h:outputLabel value="#{cc.attrs.bill.deptId}"></h:outputLabel></td>
+                        <td style="font-weight: bold;">Cancelled At:</td>
+                        <td>
+                            <h:outputLabel value="#{cc.attrs.bill.createdAt}">
+                                <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateTimeFormat}"></f:convertDateTime>
+                            </h:outputLabel>
+                        </td>
+                    </tr>
+                    <tr>
+                        <td style="font-weight: bold;">Original Bill ID:</td>
+                        <td><h:outputLabel value="#{cc.attrs.bill.billedBill.deptId}"></h:outputLabel></td>
+                        <td style="font-weight: bold;">Original Date:</td>
+                        <td>
+                            <h:outputLabel value="#{cc.attrs.bill.billedBill.createdAt}">
+                                <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateTimeFormat}"></f:convertDateTime>
+                            </h:outputLabel>
+                        </td>
+                    </tr>
+                    <tr>
+                        <td style="font-weight: bold;">From:</td>
+                        <td><h:outputLabel value="#{cc.attrs.bill.fromWebUser.name}"></h:outputLabel></td>
+                        <td style="font-weight: bold;">To:</td>
+                        <td><h:outputLabel value="#{cc.attrs.bill.toWebUser.webUserPerson.nameWithTitle}"></h:outputLabel></td>
+                    </tr>
+                    <tr>
+                        <td style="font-weight: bold;">Cancelled By:</td>
+                        <td colspan="3"><h:outputLabel value="#{cc.attrs.bill.creater.name}"></h:outputLabel></td>
+                    </tr>
+                </table>
+            </div>
+
+            <div style="#{configOptionApplicationController.getLongTextValueByKey('Float Transfer Note Horizontal Line CSS')}">
+                <hr style="border-top: 1px solid #000;"/>
+            </div>
+
+            <div style="padding: 10px;">
+                <h3 style="text-align: center; font-weight: normal">Payment Details (Reversed)</h3>
+                <table style="width: 100%; border-collapse: collapse; border: 1px solid #ccc;">
+                    <tr style="background: #f2f2f2;">
+                        <th style="padding: 8px; text-align: left;">Payment Method</th>
+                        <th style="padding: 8px; text-align: left;">Details</th>
+                        <th style="padding: 8px; text-align: right;">Amount</th>
+                    </tr>
+                    <ui:repeat value="#{cc.attrs.bill.payments}" var="bip">
+                        <tr>
+                            <td style="padding: 8px; border-bottom: 1px solid #ccc;"><h:outputLabel value="#{bip.paymentMethod}"></h:outputLabel></td>
+                            <td style="padding: 8px; border-bottom: 1px solid #ccc;">
+                                <h:panelGroup rendered="#{bip.paymentMethod eq 'Cash'}">
+                                    <h:outputText value="Cash"/>
+                                </h:panelGroup>
+                                <h:panelGroup rendered="#{bip.paymentMethod eq 'Cheque'}">
+                                    <h:outputText value="#{bip.bank.name} - #{bip.chequeRefNo} " />
+                                    <h:outputText value="#{bip.chequeDate}">
+                                        <f:convertDateTime pattern="#{sessionController.applicationPreference.shortDateFormat}"></f:convertDateTime>
+                                    </h:outputText>
+                                </h:panelGroup>
+                                <h:panelGroup rendered="#{bip.paymentMethod eq 'Card'}">
+                                    <h:outputText value="Card Ref: #{bip.creditCardRefNo} - #{bip.institution.name} " />
+                                </h:panelGroup>
+                                <h:panelGroup rendered="#{bip.paymentMethod eq 'ewallet'}">
+                                    <h:outputText value="eWallet: #{bip.chequeRefNo} - #{bip.institution.name} " />
+                                </h:panelGroup>
+                                <h:panelGroup rendered="#{bip.paymentMethod eq 'Slip'}">
+                                    <h:outputText value="Bank: #{bip.bank.name} - #{bip.chequeDate}">
+                                        <f:convertDateTime pattern="#{sessionController.applicationPreference.shortDateFormat}"></f:convertDateTime>
+                                    </h:outputText>
+                                </h:panelGroup>
+                            </td>
+                            <td style="padding: 8px; text-align: right; border-bottom: 1px solid #ccc;">
+                                <h:outputLabel value="#{bip.paidValue}">
+                                    <f:convertNumber pattern="#,##0.00"/>
+                                </h:outputLabel>
+                            </td>
+                        </tr>
+                    </ui:repeat>
+                </table>
+            </div>
+
+            <div style="#{configOptionApplicationController.getLongTextValueByKey('Float Transfer Note Horizontal Line CSS')}">
+                <hr/>
+            </div>
+
+            <div style="text-align: right; font-size: 18px; font-weight: bold; padding: 10px;">
+                <h:panelGroup>
+                    Total Amount Reversed:
+                    <h:outputLabel value="#{cc.attrs.bill.netTotal}">
+                        <f:convertNumber pattern="#,##0.00"/>
+                    </h:outputLabel>
+                </h:panelGroup>
+            </div>
+
+            <div style="#{configOptionApplicationController.getLongTextValueByKey('Float Transfer Note Horizontal Line CSS')}">
+                <hr style="border-top: 1px solid #000;"/>
+            </div>
+
+            <div style="padding: 10px; background-color: #fff3cd; border: 1px solid #ffc107; border-radius: 4px; margin: 10px 0;">
+                <h:outputText value="Cancellation Reason: " style="font-weight: bold;"/>
+                <h:outputText value="#{cc.attrs.bill.comments}"/>
+            </div>
+
+            <div style="text-align: center; font-size: 14px; padding: 10px; color: gray;">
+                <h:outputText value="#{configOptionApplicationController.getLongTextValueByKey('Float Transfer Note Footer Text')}" escape="false"></h:outputText>
+            </div>
+
+        </div>
+    </cc:implementation>
+</html>

--- a/src/main/webapp/resources/ezcomp/prints/float_transfer_cancel_pos.xhtml
+++ b/src/main/webapp/resources/ezcomp/prints/float_transfer_cancel_pos.xhtml
@@ -1,0 +1,101 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:cc="http://xmlns.jcp.org/jsf/composite"
+      xmlns:f="http://xmlns.jcp.org/jsf/core"
+      xmlns:h="http://xmlns.jcp.org/jsf/html"
+      xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
+      xmlns:p="http://primefaces.org/ui">
+
+    <cc:interface>
+        <cc:attribute name="bill" type="com.divudi.core.entity.Bill" />
+        <cc:attribute name="duplicate" type="java.lang.Boolean"/>
+    </cc:interface>
+
+    <cc:implementation>
+
+        <div style="width: 80mm; font-family: monospace; font-size: 12px; padding: 5px;">
+
+            <div style="text-align: center; font-weight: bold; padding: 5px;">
+                <h:outputText value="#{configOptionApplicationController.getLongTextValueByKey('Float Transfer Note Header Text')}" escape="false"></h:outputText>
+            </div>
+
+            <div style="text-align: center; font-weight: bold; padding: 3px; color: #dc3545;">
+                <h:outputLabel value="FLOAT TRANSFER CANCELLATION"/>
+                <h:outputLabel value=" **DUPLICATE**" rendered="#{cc.attrs.duplicate eq true}"/>
+            </div>
+
+            <div style="border-top: 1px dashed #000; margin: 5px 0;"></div>
+
+            <div style="padding: 3px;">
+                <table style="width: 100%; font-size: 11px;">
+                    <tr>
+                        <td>Cancel Bill:</td>
+                        <td style="text-align: right;"><h:outputLabel value="#{cc.attrs.bill.deptId}"/></td>
+                    </tr>
+                    <tr>
+                        <td>Cancelled:</td>
+                        <td style="text-align: right;">
+                            <h:outputLabel value="#{cc.attrs.bill.createdAt}">
+                                <f:convertDateTime pattern="dd/MM/yy HH:mm"/>
+                            </h:outputLabel>
+                        </td>
+                    </tr>
+                    <tr>
+                        <td>Original Bill:</td>
+                        <td style="text-align: right;"><h:outputLabel value="#{cc.attrs.bill.billedBill.deptId}"/></td>
+                    </tr>
+                    <tr>
+                        <td>From:</td>
+                        <td style="text-align: right;"><h:outputLabel value="#{cc.attrs.bill.fromWebUser.name}"/></td>
+                    </tr>
+                    <tr>
+                        <td>To:</td>
+                        <td style="text-align: right;"><h:outputLabel value="#{cc.attrs.bill.toWebUser.name}"/></td>
+                    </tr>
+                </table>
+            </div>
+
+            <div style="border-top: 1px dashed #000; margin: 5px 0;"></div>
+
+            <div style="padding: 3px;">
+                <table style="width: 100%; font-size: 11px;">
+                    <tr style="font-weight: bold;">
+                        <td>Method</td>
+                        <td style="text-align: right;">Amount</td>
+                    </tr>
+                    <ui:repeat value="#{cc.attrs.bill.payments}" var="bip">
+                        <tr>
+                            <td><h:outputLabel value="#{bip.paymentMethod}"/></td>
+                            <td style="text-align: right;">
+                                <h:outputLabel value="#{bip.paidValue}">
+                                    <f:convertNumber pattern="#,##0.00"/>
+                                </h:outputLabel>
+                            </td>
+                        </tr>
+                    </ui:repeat>
+                </table>
+            </div>
+
+            <div style="border-top: 1px dashed #000; margin: 5px 0;"></div>
+
+            <div style="text-align: right; font-weight: bold; padding: 3px;">
+                TOTAL: <h:outputLabel value="#{cc.attrs.bill.netTotal}">
+                    <f:convertNumber pattern="#,##0.00"/>
+                </h:outputLabel>
+            </div>
+
+            <div style="border-top: 1px dashed #000; margin: 5px 0;"></div>
+
+            <div style="padding: 3px; font-size: 10px;">
+                <span style="font-weight: bold;">Reason:</span>
+                <h:outputText value="#{cc.attrs.bill.comments}"/>
+            </div>
+
+            <div style="text-align: center; font-size: 10px; padding: 5px; color: gray;">
+                <h:outputText value="#{configOptionApplicationController.getLongTextValueByKey('Float Transfer Note Footer Text')}" escape="false"/>
+            </div>
+
+        </div>
+    </cc:implementation>
+</html>


### PR DESCRIPTION
- Add fund transfer bill cancellation page and print preview
- Add my float outs list view for cashiers
- Add print templates for cancelled float transfers (A4, 5.5, POS)
- Update cashier index with new menu items

Closes #17535

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added ability to cancel float transfer bills with reason documentation
  * Introduced "My Float Outs" view to display and manage outgoing float transfers with date filtering
  * Added cancellation print functionality supporting multiple document formats
  * Enhanced Float Management section with new navigation options

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->