### PR TITLE
16890-add-defensive-null-handling-for-departmenttype-labels-in-autocomplete

### DIFF
--- a/src/main/java/com/divudi/bean/common/DataAdministrationController.java
+++ b/src/main/java/com/divudi/bean/common/DataAdministrationController.java
@@ -3403,8 +3403,10 @@ public class DataAdministrationController implements Serializable {
 
         String query = qry.toLowerCase().trim();
         for (DepartmentType type : DepartmentType.values()) {
-            if (type.getLabel().toLowerCase().contains(query) ||
-                type.name().toLowerCase().contains(query)) {
+            String label = type.getLabel();
+            boolean labelMatches = label != null && label.toLowerCase().contains(query);
+            boolean nameMatches = type.name().toLowerCase().contains(query);
+            if (labelMatches || nameMatches) {
                 filteredTypes.add(type);
             }
         }


### PR DESCRIPTION
I added a null check for DepartmentType labels in the completeDepartmentType() method by storing the label in a local variable and verifying it's not null before calling .toLowerCase(). This prevents a NullPointerException that could occur if any enum constant has a null label, while maintaining the original filtering logic where types match if either their label (when available) or name contains the query.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the robustness of department type filtering and search functionality to better handle edge cases and provide more reliable matching results when selecting department types in the application.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->