### PR TITLE
17653 float out prevent accepting cancelled fund transfers exclude in receive flows defensive guard

### DIFF
--- a/src/main/java/com/divudi/bean/cashTransaction/FinancialTransactionController.java
+++ b/src/main/java/com/divudi/bean/cashTransaction/FinancialTransactionController.java
@@ -1732,6 +1732,10 @@ public class FinancialTransactionController implements Serializable {
             JsfUtil.addErrorMessage("Wrong Bill Type");
             return "";
         }
+        if (bill.isCancelled()) {
+            JsfUtil.addErrorMessage("This float transfer has been cancelled and cannot be received");
+            return "";
+        }
         floatTransferStarted = false;
         setSelectedBill(bill);
         resetClassVariablesWithoutSelectedBill();
@@ -5022,6 +5026,7 @@ public class FinancialTransactionController implements Serializable {
         StringBuilder jpql = new StringBuilder(
                 "select s from Bill s "
                 + "where s.retired=:ret "
+                + "and (s.cancelled = false or s.cancelled is null) "
                 + "and s.billTypeAtomic=:btype "
                 + "and s.referenceBill is null "
         );
@@ -5277,6 +5282,7 @@ public class FinancialTransactionController implements Serializable {
                 break;
             case FUND_TRANSFER_BILL:
                 jpql.append("and s.referenceBill is null ");
+                jpql.append("and (s.cancelled = false or s.cancelled is null) ");
                 break;
 
         }
@@ -5430,6 +5436,12 @@ public class FinancialTransactionController implements Serializable {
         if (currentBill.getReferenceBill().getBillType() != BillType.FundTransferBill) {
             floatTransferStarted = false;
             JsfUtil.addErrorMessage("Error - Reference bill type");
+            return "";
+        }
+
+        if (currentBill.getReferenceBill().isCancelled()) {
+            floatTransferStarted = false;
+            JsfUtil.addErrorMessage("This float transfer has been cancelled and cannot be accepted");
             return "";
         }
 


### PR DESCRIPTION
Closes #17653

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced validation to prevent processing of cancelled fund transfers and float transfers.
  * Cancelled transactions are now properly filtered from fund transfer lists.
  * Improved error messaging when attempting to receive or settle invalid or cancelled transactions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->