### PR TITLE
Add confirmation to receive pateint deposit

### DIFF
--- a/src/main/webapp/patient_deposit/receive.xhtml
+++ b/src/main/webapp/patient_deposit/receive.xhtml
@@ -29,6 +29,8 @@
                                                  id="btnSettle"
                                                  value="Settle"
                                                  action="#{patientDepositController.settlePatientDeposit}"
+                                                 onclick="if (!confirm('Are you sure you want to Settle This Bill ?'))
+                                                                return false;"
                                                  ajax="false"
                                                  style="width: 150px; padding: 1px;border: 1px solid ; margin: auto;" >
                                 </p:commandButton>


### PR DESCRIPTION
Issue: #17671 

Add confirmation on `SETTLE` button when receiving patient deposit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The Settle button in patient deposit processing now displays a confirmation prompt. Users must verify their action before the settle operation is submitted, preventing accidental transactions and improving workflow safety.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->