### PR TITLE
Add "Medicines and Surgical Supplies" to be displayed on intrim bill. 

### DIFF
--- a/src/main/java/com/divudi/core/data/inward/InwardChargeType.java
+++ b/src/main/java/com/divudi/core/data/inward/InwardChargeType.java
@@ -22,6 +22,7 @@ public enum InwardChargeType {
     MedicalCareICU("Medical Care"),//Goes With Room
     MedicalServices("Medical Services"),
     Medicine("Medicine"),//For BHT ISSUE
+    MedicinesAndSurgicalSupplies("Medicines and Surgical Supplies"),//For Surgery Bill Medicines
     MOCharges("MO Charges"),//GOES WITH PATIENT ROOM
     MaintainCharges("Maintain Charges"),//GOES WITH PATIENT ROOM
     DoctorAndNurses("Assisting Charge"),//Set Doctor && Nurse Fees

--- a/src/main/webapp/inward/inward_bill_intrim.xhtml
+++ b/src/main/webapp/inward/inward_bill_intrim.xhtml
@@ -532,7 +532,7 @@
 
                                 <p:tab title="Medicine Issue">
                                     <p:dataTable 
-                                        value="#{bhtSummeryController.pharmacyIssues}" 
+                                        value="#{bhtSummeryController.medicineOnlyIssues}" 
                                         var="iss" 
                                         scrollable="true"
                                         scrollHeight="300"
@@ -697,6 +697,75 @@
                                                 rendered="#{iss.billClass eq 'class com.divudi.core.entity.RefundBill'}"
                                                 value="View Return"  >
                                                 <f:setPropertyActionListener value="#{iss}" target="#{storeBillSearch.bill}"/>
+                                            </p:commandButton>
+                                        </p:column>
+                                    </p:dataTable>
+                                </p:tab>
+
+                                <p:tab title="Medicines and Surgical Supplies" rendered="#{configOptionApplicationController.getBooleanValueByKey('Separate Medicines and Surgical Supplies Tab', false)}">
+                                    <p:dataTable 
+                                        value="#{bhtSummeryController.medicinesAndSurgicalSupplies}" 
+                                        var="iss" 
+                                        scrollable="true"
+                                        scrollHeight="300"
+                                        rowStyleClass="#{((iss.billClass eq 'class com.divudi.core.entity.PreBill')
+                                                         or
+                                                         (iss.billedBill ne null
+                                                         and iss.billClass eq 'class com.divudi.core.entity.RefundBill'))? '':'noDisplayRow'}">
+                                        <p:column headerText="Bill No">
+                                            <h:outputLabel  value="#{iss.deptId}"></h:outputLabel>
+                                        </p:column>
+
+                                        <p:column headerText="Billed At">
+                                            <h:outputLabel value="#{iss.createdAt}">
+                                                <f:convertDateTime  timeZone="Asia/Colombo" pattern="#{sessionController.applicationPreference.shortDateTimeFormat}" />
+                                            </h:outputLabel>
+                                            <br/>
+                                            <h:panelGroup rendered="#{iss.cancelled}" >
+                                                <h:outputLabel style="color: red;" value="Cancelled at " />
+                                                <h:outputLabel style="color: red;" rendered="#{iss.cancelled}"
+                                                               value="#{iss.cancelledBill.createdAt}" >
+                                                    <f:convertDateTime pattern="#{sessionController.applicationPreference.shortDateTimeFormat}"/>
+                                                </h:outputLabel>
+                                            </h:panelGroup>
+                                        </p:column>
+                                        <p:column headerText="Bill Total" class="text-end">
+                                            <h:outputLabel  value="#{iss.netTotal}">
+                                                <f:convertNumber pattern="#,##0.00"/>
+                                            </h:outputLabel>
+                                        </p:column>
+                                        <p:column headerText="Billed By">
+                                            <h:outputLabel value="#{iss.creater.webUserPerson.name}"/>
+                                            <br/>
+                                            <h:panelGroup rendered="#{iss.cancelled}" >
+                                                <h:outputLabel style="color: red;" value="Cancelled By " />
+                                                <h:outputLabel style="color: red;" rendered="#{iss.cancelled}"
+                                                               value="#{iss.cancelledBill.creater.webUserPerson.name}" >
+                                                </h:outputLabel>
+                                            </h:panelGroup>
+                                        </p:column>
+                                        <p:column headerText="Checked By">
+                                            <h:outputLabel value="#{iss.checkedBy.webUserPerson.name}"/>
+                                        </p:column>
+                                        <p:column headerText="Checked At">
+                                            <h:outputLabel value="#{iss.checkeAt}">
+                                                <f:convertDateTime  timeZone="Asia/Colombo" pattern="#{sessionController.applicationPreference.longDateTimeFormat}" />
+                                            </h:outputLabel>
+                                        </p:column>
+                                        <p:column>
+                                            <p:commandButton 
+                                                ajax="false" 
+                                                action="pharmacy_reprint_bill_sale_bht?faces-redirect=true"
+                                                rendered="#{iss.billClass eq 'class com.divudi.core.entity.PreBill'}" 
+                                                value="View Issue"  >
+                                                <f:setPropertyActionListener value="#{iss}" target="#{pharmacyBillSearch.bill}"/>
+                                            </p:commandButton>
+                                            <p:commandButton 
+                                                ajax="false" 
+                                                action="pharmacy_reprint_bill_return_bht?faces-redirect=true"
+                                                rendered="#{iss.billClass eq 'class com.divudi.core.entity.RefundBill'}"
+                                                value="View Return"  >
+                                                <f:setPropertyActionListener value="#{iss}" target="#{pharmacyBillSearch.bill}"/>
                                             </p:commandButton>
                                         </p:column>
                                     </p:dataTable>

--- a/src/main/webapp/resources/inward/bill/finalBill.xhtml
+++ b/src/main/webapp/resources/inward/bill/finalBill.xhtml
@@ -572,6 +572,24 @@
                                     </h:panelGroup>
                                 </ui:repeat>
 
+                                <!-- Loop through Medicines and Surgical Supplies -->
+                                <ui:repeat value="#{cc.attrs.bill.billItems}" var="bip">
+                                    <h:panelGroup rendered="#{configOptionApplicationController.getBooleanValueByKey('Separate Medicines and Surgical Supplies Tab', false) and bip.inwardChargeType eq 'MedicinesAndSurgicalSupplies' and bip.adjustedValue != 0}" style="font-size: 12px;">
+                                        <tr style="width: 100%; font-weight: 400; line-height: 18px;">
+                                            <td style="text-align: left; font-size: 13px!important; margin-top: -10px;">
+                                                <h:outputLabel value="#{bip.inwardChargeType.name}" />
+                                            </td>
+                                            <td style="margin-top: -10px;">
+                                            </td>
+                                            <td style="width: 30%; text-align: right; font-size: 13px!important;">
+                                                <h:outputLabel value="#{bip.adjustedValue}">
+                                                    <f:convertNumber pattern="#,##0.00" />
+                                                </h:outputLabel>
+                                            </td>
+                                        </tr>
+                                    </h:panelGroup>
+                                </ui:repeat>
+
                                 <!-- Loop through Laboratory first -->
                                 <ui:repeat value="#{cc.attrs.bill.billItems}" var="bip">
                                     <h:panelGroup rendered="#{bip.inwardChargeType eq 'Laboratory' and bip.adjustedValue != 0}" style="font-size: 12px;">


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configuration option to separate medicines and surgical supplies in billing displays with dedicated tabs and line item sections for respective medicine categories.

* **Enhancements**
  * Updated bill item categorization to distinguish medicine-only charges from medicines-with-surgical-supplies charges in summaries and detailed bill views when the separation feature is enabled.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->