### PR TITLE
Patient Deposit Return comment is not updated #17674

### DIFF
--- a/src/main/java/com/divudi/bean/common/BillBeanController.java
+++ b/src/main/java/com/divudi/bean/common/BillBeanController.java
@@ -2868,7 +2868,7 @@ public class BillBeanController implements Serializable {
         if (paymentMethod.equals(PaymentMethod.Card)) {
             b.setCreditCardRefNo(paymentMethodData.getCreditCard().getNo());
             b.setBank(paymentMethodData.getCreditCard().getInstitution());
-            b.setComments(paymentMethodData.getSlip().getComment());
+            b.setComments(paymentMethodData.getCreditCard().getComment());
         }
 
         if (paymentMethod.equals(PaymentMethod.OnlineSettlement)) {
@@ -2879,7 +2879,12 @@ public class BillBeanController implements Serializable {
         if (paymentMethod.getPaymentType() == PaymentType.CREDIT) {
             b.setCreditBill(true);
         }
-
+        
+        if (paymentMethod.equals(PaymentMethod.ewallet)) {
+            b.setCreditCardRefNo(paymentMethodData.getEwallet().getNo());
+            b.setBank(paymentMethodData.getEwallet().getInstitution());
+            b.setComments(paymentMethodData.getEwallet().getComment());
+        }
     }
 
     public List<Payment> createPaymentsForNonCreditIns(

--- a/src/main/webapp/patient_deposit/patient_deposit_return_search.xhtml
+++ b/src/main/webapp/patient_deposit/patient_deposit_return_search.xhtml
@@ -115,7 +115,7 @@
                                 </p:column>
 
                                 <p:column headerText="Comments" >
-                                    <h:outputLabel  rendered="#{bill.cancelledBill ne null}" value="#{bill.cancelledBill.comments}" ></h:outputLabel>
+                                    <h:outputLabel value="#{bill.comments}" ></h:outputLabel>
                                 </p:column>
 
                             </p:dataTable>


### PR DESCRIPTION
Issue: #17674 

Files Changed:
- BillBeanController
- patient_deposit_return_search

Modified the binding of the comment value to the output.

 BillBeancontroller was changed because wrong value was set as comments in card paymentmethoddata and ewallet payment method was not included.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected payment comment handling for card and electronic wallet payments to display accurate information.
  * Fixed the source of comments displayed in patient deposit return search results.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->