### PR TITLE
Fix-In-the-interim-bill-both-Room-and-Bed-Charges-Inward

### DIFF
--- a/src/main/java/com/divudi/bean/inward/BhtSummeryController.java
+++ b/src/main/java/com/divudi/bean/inward/BhtSummeryController.java
@@ -3351,4 +3351,29 @@ public class BhtSummeryController implements Serializable {
         this.childPatientEncouters = childPatientEncouters;
     }
 
+    /**
+     * Calculate total of bed charges (Linen, MO, Nursing, Maintain, Medical Care, Administration)
+     * @param billItems List of bill items to calculate from
+     * @return Total of all bed charges
+     */
+    public double getBedChargesTotal(List<BillItem> billItems) {
+        if (billItems == null) {
+            return 0.0;
+        }
+        
+        double total = 0.0;
+        for (BillItem item : billItems) {
+            if (item.getAdjustedValue() != 0 && 
+                (item.getInwardChargeType() == InwardChargeType.LinenCharges ||
+                 item.getInwardChargeType() == InwardChargeType.MOCharges ||
+                 item.getInwardChargeType() == InwardChargeType.NursingCharges ||
+                 item.getInwardChargeType() == InwardChargeType.MaintainCharges ||
+                 item.getInwardChargeType() == InwardChargeType.MedicalCareICU ||
+                 item.getInwardChargeType() == InwardChargeType.AdministrationCharge)) {
+                total += item.getAdjustedValue();
+            }
+        }
+        return total;
+    }
+
 }

--- a/src/main/webapp/resources/inward/bill/finalBill.xhtml
+++ b/src/main/webapp/resources/inward/bill/finalBill.xhtml
@@ -423,95 +423,116 @@
                                     </h:panelGroup>
                                 </ui:repeat>
 
-                                <!-- Loop through NursingCharges first -->
-                                <ui:repeat value="#{cc.attrs.bill.billItems}" var="bip">
-                                    <h:panelGroup rendered="#{bip.inwardChargeType eq 'NursingCharges' and bip.adjustedValue != 0}" style="font-size: 12px;">
-                                        <tr style="width: 100%; font-weight: 400; line-height: 18px;">
-                                            <td style="text-align: left; font-size: 13px!important; margin-top: -10px;">
-                                                <h:outputLabel value="#{bip.inwardChargeType.name}" />
-                                            </td>
-                                            <td style="margin-top: -10px;">
-                                            </td>
-                                            <td style="width: 30%; text-align: right; font-size: 13px!important;">
-                                                <h:outputLabel value="#{bip.adjustedValue}">
-                                                    <f:convertNumber pattern="#,##0.00" />
-                                                </h:outputLabel>
-                                            </td>
-                                        </tr>
-                                    </h:panelGroup>
-                                </ui:repeat>
+                                <!-- Bed Charges - Display individually if option is off -->
+                                <h:panelGroup rendered="#{!configOptionApplicationController.getBooleanValueByKey('Group Bed Charges in Bills', false)}">
+                                    <!-- Loop through NursingCharges first -->
+                                    <ui:repeat value="#{cc.attrs.bill.billItems}" var="bip">
+                                        <h:panelGroup rendered="#{bip.inwardChargeType eq 'NursingCharges' and bip.adjustedValue != 0}" style="font-size: 12px;">
+                                            <tr style="width: 100%; font-weight: 400; line-height: 18px;">
+                                                <td style="text-align: left; font-size: 13px!important; margin-top: -10px;">
+                                                    <h:outputLabel value="#{bip.inwardChargeType.name}" />
+                                                </td>
+                                                <td style="margin-top: -10px;">
+                                                </td>
+                                                <td style="width: 30%; text-align: right; font-size: 13px!important;">
+                                                    <h:outputLabel value="#{bip.adjustedValue}">
+                                                        <f:convertNumber pattern="#,##0.00" />
+                                                    </h:outputLabel>
+                                                </td>
+                                            </tr>
+                                        </h:panelGroup>
+                                    </ui:repeat>
 
-                                <!-- Loop through MOCharges first -->
-                                <ui:repeat value="#{cc.attrs.bill.billItems}" var="bip">
-                                    <h:panelGroup rendered="#{bip.inwardChargeType eq 'MOCharges' and bip.adjustedValue != 0}" style="font-size: 12px;">
-                                        <tr style="width: 100%; font-weight: 400; line-height: 18px;">
-                                            <td style="text-align: left; font-size: 13px!important; margin-top: -10px;">
-                                                <h:outputLabel value="#{bip.inwardChargeType.name}" />
-                                            </td>
-                                            <td style="margin-top: -10px;">
-                                            </td>
-                                            <td style="width: 30%; text-align: right; font-size: 13px!important;">
-                                                <h:outputLabel value="#{bip.adjustedValue}">
-                                                    <f:convertNumber pattern="#,##0.00" />
-                                                </h:outputLabel>
-                                            </td>
-                                        </tr>
-                                    </h:panelGroup>
-                                </ui:repeat>
+                                    <!-- Loop through MOCharges -->
+                                    <ui:repeat value="#{cc.attrs.bill.billItems}" var="bip">
+                                        <h:panelGroup rendered="#{bip.inwardChargeType eq 'MOCharges' and bip.adjustedValue != 0}" style="font-size: 12px;">
+                                            <tr style="width: 100%; font-weight: 400; line-height: 18px;">
+                                                <td style="text-align: left; font-size: 13px!important; margin-top: -10px;">
+                                                    <h:outputLabel value="#{bip.inwardChargeType.name}" />
+                                                </td>
+                                                <td style="margin-top: -10px;">
+                                                </td>
+                                                <td style="width: 30%; text-align: right; font-size: 13px!important;">
+                                                    <h:outputLabel value="#{bip.adjustedValue}">
+                                                        <f:convertNumber pattern="#,##0.00" />
+                                                    </h:outputLabel>
+                                                </td>
+                                            </tr>
+                                        </h:panelGroup>
+                                    </ui:repeat>
 
-                                <!-- Loop through LinenCharges first -->
-                                <ui:repeat value="#{cc.attrs.bill.billItems}" var="bip">
-                                    <h:panelGroup rendered="#{bip.inwardChargeType eq 'LinenCharges' and bip.adjustedValue != 0}" style="font-size: 12px;">
-                                        <tr style="width: 100%; font-weight: 400; line-height: 18px;">
-                                            <td style="text-align: left; font-size: 13px!important; margin-top: -10px;">
-                                                <h:outputLabel value="#{bip.inwardChargeType.name}" />
-                                            </td>
-                                            <td style="margin-top: -10px;">
-                                            </td>
-                                            <td style="width: 30%; text-align: right; font-size: 13px!important;">
-                                                <h:outputLabel value="#{bip.adjustedValue}">
-                                                    <f:convertNumber pattern="#,##0.00" />
-                                                </h:outputLabel>
-                                            </td>
-                                        </tr>
-                                    </h:panelGroup>
-                                </ui:repeat>
+                                    <!-- Loop through LinenCharges -->
+                                    <ui:repeat value="#{cc.attrs.bill.billItems}" var="bip">
+                                        <h:panelGroup rendered="#{bip.inwardChargeType eq 'LinenCharges' and bip.adjustedValue != 0}" style="font-size: 12px;">
+                                            <tr style="width: 100%; font-weight: 400; line-height: 18px;">
+                                                <td style="text-align: left; font-size: 13px!important; margin-top: -10px;">
+                                                    <h:outputLabel value="#{bip.inwardChargeType.name}" />
+                                                </td>
+                                                <td style="margin-top: -10px;">
+                                                </td>
+                                                <td style="width: 30%; text-align: right; font-size: 13px!important;">
+                                                    <h:outputLabel value="#{bip.adjustedValue}">
+                                                        <f:convertNumber pattern="#,##0.00" />
+                                                    </h:outputLabel>
+                                                </td>
+                                            </tr>
+                                        </h:panelGroup>
+                                    </ui:repeat>
 
-                                <!-- Loop through MedicalCareICU first -->
-                                <ui:repeat value="#{cc.attrs.bill.billItems}" var="bip">
-                                    <h:panelGroup rendered="#{bip.inwardChargeType eq 'MedicalCareICU' and bip.adjustedValue != 0}" style="font-size: 12px;">
-                                        <tr style="width: 100%; font-weight: 400; line-height: 18px;">
-                                            <td style="text-align: left; font-size: 13px!important; margin-top: -10px;">
-                                                <h:outputLabel value="#{bip.inwardChargeType.name}" />
-                                            </td>
-                                            <td style="margin-top: -10px;">
-                                            </td>
-                                            <td style="width: 30%; text-align: right; font-size: 13px!important;">
-                                                <h:outputLabel value="#{bip.adjustedValue}">
-                                                    <f:convertNumber pattern="#,##0.00" />
-                                                </h:outputLabel>
-                                            </td>
-                                        </tr>
-                                    </h:panelGroup>
-                                </ui:repeat>
+                                    <!-- Loop through MedicalCareICU -->
+                                    <ui:repeat value="#{cc.attrs.bill.billItems}" var="bip">
+                                        <h:panelGroup rendered="#{bip.inwardChargeType eq 'MedicalCareICU' and bip.adjustedValue != 0}" style="font-size: 12px;">
+                                            <tr style="width: 100%; font-weight: 400; line-height: 18px;">
+                                                <td style="text-align: left; font-size: 13px!important; margin-top: -10px;">
+                                                    <h:outputLabel value="#{bip.inwardChargeType.name}" />
+                                                </td>
+                                                <td style="margin-top: -10px;">
+                                                </td>
+                                                <td style="width: 30%; text-align: right; font-size: 13px!important;">
+                                                    <h:outputLabel value="#{bip.adjustedValue}">
+                                                        <f:convertNumber pattern="#,##0.00" />
+                                                    </h:outputLabel>
+                                                </td>
+                                            </tr>
+                                        </h:panelGroup>
+                                    </ui:repeat>
 
-                                <!-- Loop through AdministrationCharge first -->
-                                <ui:repeat value="#{cc.attrs.bill.billItems}" var="bip">
-                                    <h:panelGroup rendered="#{bip.inwardChargeType eq 'AdministrationCharge' and bip.adjustedValue != 0}" style="font-size: 12px;">
+                                    <!-- Loop through AdministrationCharge -->
+                                    <ui:repeat value="#{cc.attrs.bill.billItems}" var="bip">
+                                        <h:panelGroup rendered="#{bip.inwardChargeType eq 'AdministrationCharge' and bip.adjustedValue != 0}" style="font-size: 12px;">
+                                            <tr style="width: 100%; font-weight: 400; line-height: 18px;">
+                                                <td style="text-align: left; font-size: 13px!important; margin-top: -10px;">
+                                                    <h:outputLabel value="#{bip.inwardChargeType.name}" />
+                                                </td>
+                                                <td style="margin-top: -10px;">
+                                                </td>
+                                                <td style="width: 30%; text-align: right; font-size: 13px!important;">
+                                                    <h:outputLabel value="#{bip.adjustedValue}">
+                                                        <f:convertNumber pattern="#,##0.00" />
+                                                    </h:outputLabel>
+                                                </td>
+                                            </tr>
+                                        </h:panelGroup>
+                                    </ui:repeat>
+                                </h:panelGroup>
+
+                                <!-- Grouped Bed Charges - Display as single line if option is on -->
+                                <h:panelGroup rendered="#{configOptionApplicationController.getBooleanValueByKey('Group Bed Charges in Bills', false)}">
+                                    <h:panelGroup rendered="#{bhtSummeryController.getBedChargesTotal(cc.attrs.bill.billItems) > 0}" style="font-size: 12px;">
                                         <tr style="width: 100%; font-weight: 400; line-height: 18px;">
                                             <td style="text-align: left; font-size: 13px!important; margin-top: -10px;">
-                                                <h:outputLabel value="#{bip.inwardChargeType.name}" />
+                                                <h:outputLabel value="#{configOptionApplicationController.getLongTextValueByKey('Bed Charges Label', 'Bed Charges')}" />
                                             </td>
                                             <td style="margin-top: -10px;">
                                             </td>
                                             <td style="width: 30%; text-align: right; font-size: 13px!important;">
-                                                <h:outputLabel value="#{bip.adjustedValue}">
+                                                <h:outputLabel value="#{bhtSummeryController.getBedChargesTotal(cc.attrs.bill.billItems)}">
                                                     <f:convertNumber pattern="#,##0.00" />
                                                 </h:outputLabel>
                                             </td>
                                         </tr>
                                     </h:panelGroup>
-                                </ui:repeat>
+                                </h:panelGroup>
 
                                 <!-- Loop through all other items excluding RoomCharges and ProfessionalCharge -->
                                 <ui:repeat value="#{cc.attrs.bill.billItems}" var="bip">

--- a/src/main/webapp/resources/inward/bill/intrimBill.xhtml
+++ b/src/main/webapp/resources/inward/bill/intrimBill.xhtml
@@ -167,22 +167,53 @@
 
 
                         <table class="tbl"  >
-                            <ui:repeat value="#{cc.attrs.bill.billItems}" var="bip">
-                                <h:panelGroup rendered="#{bip.adjustedValue !=0}">
-                                    <tr>
+                            <h:panelGroup rendered="#{!configOptionApplicationController.getBooleanValueByKey('Group Bed Charges in Bills', false)}">
+                                <ui:repeat value="#{cc.attrs.bill.billItems}" var="bip">
+                                    <h:panelGroup rendered="#{bip.adjustedValue !=0}">
+                                        <tr>
+                                            <td style="text-align: left;" >
+                                                <h:outputLabel  value="#{bip.inwardChargeType.name}" />
+                                            </td>                                   
+                                            <td style="text-align: right;" >
+                                                <h:outputLabel value="#{bip.adjustedValue}">
+                                                    <f:convertNumber pattern="#,##0.00" />
+                                                </h:outputLabel>  
+                                            </td>
+                                        </tr>
+                                    </h:panelGroup>
+                                </ui:repeat>
+                            </h:panelGroup>
 
+                            <h:panelGroup rendered="#{configOptionApplicationController.getBooleanValueByKey('Group Bed Charges in Bills', false)}">
+                                <ui:repeat value="#{cc.attrs.bill.billItems}" var="bip">
+                                    <h:panelGroup rendered="#{bip.adjustedValue != 0 and bip.inwardChargeType ne 'LinenCharges' and bip.inwardChargeType ne 'MOCharges' and bip.inwardChargeType ne 'NursingCharges' and bip.inwardChargeType ne 'MaintainCharges' and bip.inwardChargeType ne 'MedicalCareICU' and bip.inwardChargeType ne 'AdministrationCharge'}">
+                                        <tr>
+                                            <td style="text-align: left;" >
+                                                <h:outputLabel  value="#{bip.inwardChargeType.name}" />
+                                            </td>                                   
+                                            <td style="text-align: right;" >
+                                                <h:outputLabel value="#{bip.adjustedValue}">
+                                                    <f:convertNumber pattern="#,##0.00" />
+                                                </h:outputLabel>  
+                                            </td>
+                                        </tr>
+                                    </h:panelGroup>
+                                </ui:repeat>
+
+                                <!-- Grouped Bed Charges -->
+                                <h:panelGroup rendered="#{bhtSummeryController.getBedChargesTotal(cc.attrs.bill.billItems) > 0}">
+                                    <tr>
                                         <td style="text-align: left;" >
-                                            <h:outputLabel  value="#{bip.inwardChargeType.name}" />
+                                            <h:outputLabel value="#{configOptionApplicationController.getLongTextValueByKey('Bed Charges Label', 'Bed Charges')}" />
                                         </td>                                   
                                         <td style="text-align: right;" >
-                                            <h:outputLabel value="#{bip.adjustedValue}">
+                                            <h:outputLabel value="#{bhtSummeryController.getBedChargesTotal(cc.attrs.bill.billItems)}">
                                                 <f:convertNumber pattern="#,##0.00" />
-                                            </h:outputLabel>  
+                                            </h:outputLabel>
                                         </td>
-
                                     </tr>
                                 </h:panelGroup>
-                            </ui:repeat>
+                            </h:panelGroup>
 
                             <h:panelGroup>
                                 <tr>   


### PR DESCRIPTION
Signed-off-by: damithdeshan98 <hkddrajapaksha@gmail.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable grouping for bed charges on bills. When enabled via "Group Bed Charges in Bills" setting, multiple charge types (nursing, linens, maintenance, medical care, administration) are consolidated into a single aggregated line item with a customizable label. When disabled, charges display as individual line items.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->