### PR TITLE
17787 Return Patient Deposit bill header is displayed as “Cancel”

### DIFF
--- a/src/main/webapp/resources/ezcomp/prints/five_five_paper_custom_1_patient_deposit_cancel.xhtml
+++ b/src/main/webapp/resources/ezcomp/prints/five_five_paper_custom_1_patient_deposit_cancel.xhtml
@@ -46,7 +46,7 @@
                     <h:outputLabel value="Deposit Cancel Receipt"/>
                 </div>
                 <div>
-                    <h:outputLabel value="**Duplicate**"  rendered="#{cc.attrs.duplicate eq true}" style="font-size: small"/>
+                    <h:outputLabel value="**Duplicate**"  rendered="#{cc.attrs.duplicate eq true}" style="font-size: medium"/>
                 </div>
             </div>
 

--- a/src/main/webapp/resources/ezcomp/prints/five_five_paper_custom_2_patient_deposit_cancel.xhtml
+++ b/src/main/webapp/resources/ezcomp/prints/five_five_paper_custom_2_patient_deposit_cancel.xhtml
@@ -47,7 +47,7 @@
                         <h:outputLabel value="Deposit Cancel Receipt"/>
                     </div>
                     <div>
-                        <h:outputLabel value="**Duplicate**"  rendered="#{cc.attrs.duplicate eq true}" style="font-size: small"/>
+                        <h:outputLabel value="**Duplicate**"  rendered="#{cc.attrs.duplicate eq true}" style="font-size: medium"/>
                     </div>
                 </div>
             </div>

--- a/src/main/webapp/resources/ezcomp/prints/five_five_paper_patient_deposit.xhtml
+++ b/src/main/webapp/resources/ezcomp/prints/five_five_paper_patient_deposit.xhtml
@@ -46,10 +46,7 @@
                     <h:outputLabel value="Deposit Receive Receipt"/>
                 </div>
                 <div>
-                    <h:outputLabel value="**Duplicate**"  rendered="#{cc.attrs.duplicate eq true}" style="font-size: small"/>
-                </div>
-                <div>
-                    <h:outputLabel value="**Cancelled**"  rendered="#{cc.attrs.bill.cancelled eq true}" style="font-size: small"/>
+                    <h:outputLabel value="**Duplicate**"  rendered="#{cc.attrs.duplicate eq true}" style="font-size: medium"/>
                 </div>
             </div>
 
@@ -250,13 +247,6 @@
                     <h:outputLabel value="#{cc.attrs.bill.cancelledBill.comments}"/>
                 </div>
             </h:panelGroup>
-            <div class="d-flex justify-content-end align-items-center" style="margin-right: 5%;font-size: 9pt">
-                <h:panelGroup rendered="#{cc.attrs.bill.cancelled}">
-                    <div>
-                        <h:outputLabel value="Cancelled Bill No :  #{cc.attrs.bill.cancelledBill.deptId}" />
-                    </div>
-                </h:panelGroup>
-            </div>
 
             <div class="footer" style="text-align: center;">
                 <br/>

--- a/src/main/webapp/resources/ezcomp/prints/five_five_paper_patient_deposit_return.xhtml
+++ b/src/main/webapp/resources/ezcomp/prints/five_five_paper_patient_deposit_return.xhtml
@@ -46,10 +46,10 @@
                     <h:outputLabel value="Deposit Refund Receipt"/>
                 </div>
                 <div>
-                    <h:outputLabel value="**Duplicate**"  rendered="#{cc.attrs.duplicate eq true}" style="font-size: small"/>
+                    <h:outputLabel value="**Duplicate**"  rendered="#{cc.attrs.duplicate eq true}" style="font-size: medium"/>
                 </div>
                 <div>
-                    <h:outputLabel value="**Cancelled**"  rendered="#{cc.attrs.bill.cancelled eq true}" style="font-size: small"/>
+                    <h:outputLabel value="**Cancelled**"  rendered="#{cc.attrs.bill.cancelled eq true}" style="font-size: medium"/>
                 </div>
             </div>
 


### PR DESCRIPTION
Issue: 
- #17787
- #17571 

Files Changed:
- five_five_paper_custom_1_patient_deposit_cancel.xhtml
- five_five_paper_custom_1_patient_deposit_cancel.xhtml
- five_five_paper_patient_deposit.xhtml  
- five_five_paper_patient_deposit_return.xhtml

Removed `cancel` from patient deposit receive bill and changed the font size for `Duplicate` status.
- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated font sizes for Duplicate and Cancelled labels in deposit receipt templates from small to medium.
  * Removed Cancelled label display from Deposit Receive Receipt.
  * Removed Cancelled Bill No section from Deposit Receive Receipt.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->