### PR TITLE
Cheque component modified

### DIFF
--- a/src/main/webapp/resources/paymentMethod/cheque.xhtml
+++ b/src/main/webapp/resources/paymentMethod/cheque.xhtml
@@ -16,7 +16,7 @@
     <!-- IMPLEMENTATION -->
     <cc:implementation>
         <div class="d-flex flex-wrap align-items-end gap-2 mt-2">
-            <div class="flex-fill">
+            <div class="col-auto">
                 <p:outputLabel for="txtVal" value="Total Value:" />
                 <p:inputText id="txtVal" value="#{cc.attrs.paymentMethodData.cheque.totalValue}" style="width: auto; max-width: 200px;" class="form-control" autocomplete="off"
                              required="true"
@@ -27,7 +27,7 @@
                 </p:inputText>
             </div>
 
-            <div class="flex-fill">
+            <div class="col-auto">
                 <p:outputLabel for="chequeNo" value="Cheque Number:"/>
                 <p:inputText id="chequeNo" placeholder="Cheque No" value="#{cc.attrs.paymentMethodData.cheque.no}" style="width: auto; max-width: 200px;" class="form-control" autocomplete="off"
                              required="true"
@@ -37,9 +37,9 @@
                 </p:inputText>
             </div>
 
-            <div class="flex-fill">
+            <div class="col-auto">
                 <p:outputLabel for="bankSelect" value="Bank:"/>
-                <p:selectOneMenu id="bankSelect" value="#{cc.attrs.paymentMethodData.cheque.institution}" style="width: auto; max-width: 200px;" class="form-control"
+                <p:selectOneMenu id="bankSelect" value="#{cc.attrs.paymentMethodData.cheque.institution}" style="width: 200px;" class="form-control"
                                  required="true"
                                  requiredMessage="Bank is required">
                     <f:selectItem itemLabel="Select Bank" noSelectionOption="true"/>
@@ -49,7 +49,7 @@
                 </p:selectOneMenu>
             </div>
 
-            <div class="flex-fill">
+            <div class="col-auto">
                 <!--                <p:outputLabel for="ChequeDate" value="Cheque Date:"/>-->
                 <p:calendar id="ChequeDate" placeholder="Cheque Date" value="#{cc.attrs.paymentMethodData.cheque.date}" pattern="#{sessionController.applicationPreference.longDateFormat}"
                             required="true"
@@ -59,7 +59,7 @@
                 </p:calendar>
             </div>
 
-            <div class="flex-fill">
+            <div class="col-auto">
                 <!--                <p:outputLabel for="chequeComment" value="Comments:"/>-->
                 <p:inputText id="chequeComment" value="#{cc.attrs.paymentMethodData.cheque.comment}" placeholder="Enter Cheque Comments" style="width: auto; max-width: 200px;" class="form-control"
                              required="true"


### PR DESCRIPTION
Issue: #17788 

Files Changed: cheque.xhtml

Replaced flex-fill with col-auto and removed the auto width style from the bank selection menu to ensure a consistent width and prevent layout shifts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refined the cheque payment form layout with improved spacing and standardized input field widths for enhanced visual consistency and better alignment across responsive layouts.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->