### PR TITLE
17901 4 momo data format payment mode date suplier

### DIFF
--- a/src/main/java/com/divudi/bean/common/QuickBookReportController.java
+++ b/src/main/java/com/divudi/bean/common/QuickBookReportController.java
@@ -993,12 +993,8 @@ public class QuickBookReportController implements Serializable {
             Date memoDate = b.getInvoiceDate() != null ? b.getInvoiceDate() :
                            (b.getApproveAt() != null ? b.getApproveAt() : b.getCreatedAt());
 
-            String memoText;
-            if (b.getPaymentMethod() == PaymentMethod.Cash && b.getFromInstitution() != null) {
-                memoText = b.getPaymentMethod().toString() + " / " + sdf.format(memoDate) + " / " + b.getFromInstitution().getChequePrintingName();
-            } else {
-                memoText = b.getPaymentMethod().toString() + " / " + sdf.format(memoDate);
-            }
+            String supplierName = b.getFromInstitution() != null ? b.getFromInstitution().getChequePrintingName() : "";
+            String memoText = b.getPaymentMethod().toString() + " / " + sdf.format(memoDate) + " / " + supplierName;
 
             // Determine TRNSTYPE based on transaction type
             String trnsType = isReturnTransaction ? "Bill Refund" : "Bill";

--- a/src/main/resources/META-INF/persistence.xml
+++ b/src/main/resources/META-INF/persistence.xml
@@ -2,15 +2,16 @@
 <persistence version="2.2" xmlns="http://java.sun.com/xml/ns/persistence" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/persistence http://xmlns.jcp.org/xml/ns/persistence/persistence_2_2.xsd">
     <persistence-unit name="hmisPU" transaction-type="JTA">
         <provider>org.eclipse.persistence.jpa.PersistenceProvider</provider>
-        <jta-data-source>jdbc/ruhunu</jta-data-source>
+        <jta-data-source>${JDBC_DATASOURCE}</jta-data-source>
         <exclude-unlisted-classes>false</exclude-unlisted-classes>
         <properties>
             <property name="eclipselink.logging.level.sql" value="SEVERE"/>
             <property name="eclipselink.logging.level" value="SEVERE"/>
         </properties>
     </persistence-unit>
+
     <persistence-unit name="hmisAuditPU" transaction-type="JTA">
-        <jta-data-source>jdbc/ruhunuAudit</jta-data-source>
+        <jta-data-source>${JDBC_AUDIT_DATASOURCE}</jta-data-source>
         <exclude-unlisted-classes>false</exclude-unlisted-classes>
         <properties>
             <property name="eclipselink.logging.level.sql" value="SEVERE"/>


### PR DESCRIPTION
● Done. The memo format is now updated to always show Payment Method / Date / Supplier for all transactions:

  Before:
  - Cash with supplier: Cash / 2023-01-05 / ABC Pharma
  - Credit: Credit / 2023-01-05 (no supplier)

  After:
  - Cash with supplier: Cash / 2023-01-05 / ABC Pharma
  - Credit with supplier: Credit / 2023-01-05 / ABC Pharma
  - Any payment without supplier: Credit / 2023-01-05 /  (empty string if no supplier)

  Let me verify all changes with git diff:

● Bash(cd C:/Development/hmis && git diff src/main/java/com/divudi/bean/common/QuickBookReportController.java)
  ⎿ diff --git a/src/main/java/com/divudi/bean/common/QuickBookReportController.java b/src/main/java/com/divudi/bean/commo
    n/QuickBookReportController.java
    index b89999e1d9..1055216198 100644
    … +21 lines (ctrl+o to expand)

Closes #17901

● All changes are in place:

  1. Memo format fix: Now always shows Payment Method / Date / Supplier for all transactions (with null-safe handling for supplier)
  2. Previous fixes (from earlier session):
    - Return transaction TRNS includes expenses for balance
    - Null-safety for getFromInstitution() (now simplified)

Signed-off-by: Dr M H B Ariyaratne <buddhika.ari@gmail.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced pharmacy billing records with consistent supplier name display. Supplier information is now reliably included in memo fields across all payment methods, improving transaction detail visibility.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->