### PR TITLE
Fix typo in fund transfer bills receive header (#17908)

### DIFF
--- a/src/main/webapp/cashier/fund_transfer_bills_for_me_to_receive.xhtml
+++ b/src/main/webapp/cashier/fund_transfer_bills_for_me_to_receive.xhtml
@@ -28,7 +28,7 @@
                     <p:panel rendered="#{financialTransactionController.nonClosedShiftStartFundBill ne null}" >
                         <p:panel>
                             <f:facet name="header">
-                                <h:outputLabel value="Floats for me to Received" class="mx-2" />
+                                <h:outputLabel value="Floats for me to Receive" class="mx-2" />
                                 <h:panelGroup rendered="#{webUserController.hasPrivilege('Admin')}">
                                     <p:commandButton
                                         value="Config"


### PR DESCRIPTION
**Description:**
Fixes a grammatical error in the header label on the fund transfer bills receive page.

**Change:**
Updated the header text from “Floats for me to Received” to “Floats for me to Receive”.

**Location:**
`src/main/webapp/cashier/fund_transfer_bills_for_me_to_receive.xhtml` (~line 31)

**Related:**
Identified during review of PR #17907 (requested by @buddhika75)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected grammar in the fund transfer header text from "Floats for me to Received" to "Floats for me to Receive".

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->