### PR TITLE
Summary of Changes

### DIFF
--- a/src/main/java/com/divudi/bean/pharmacy/PharmacyConfigController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacyConfigController.java
@@ -164,6 +164,14 @@ public class PharmacyConfigController implements Serializable {
     private boolean pettyCashA4Paper;
     private boolean pettyCashCustomPaper;
 
+    // Fund Transfer Receive Bill Settings
+    private boolean fundTransferReceivePosPaper;
+    private boolean fundTransferReceivePosPrintedPaper;
+    private boolean fundTransferReceiveFiveFivePaper;
+    private boolean fundTransferReceiveFiveFivePrintedPaper;
+    private boolean fundTransferReceiveA4Paper;
+    private boolean fundTransferReceiveA4PrintedPaper;
+
     public PharmacyConfigController() {
     }
     
@@ -311,6 +319,14 @@ public class PharmacyConfigController implements Serializable {
         pettyCashA4Paper = configOptionController.getBooleanValueByKey("Petty Cash Receipt A4 Paper", false);
         pettyCashCustomPaper = configOptionController.getBooleanValueByKey("Petty Cash Receipt Custom Paper", false);
 
+        // Fund Transfer Receive Bill Settings
+        fundTransferReceivePosPaper = configOptionController.getBooleanValueByKey("Fund Transfer Bill is POS Paper", false);
+        fundTransferReceivePosPrintedPaper = configOptionController.getBooleanValueByKey("Fund Transfer Bill is POS Printed Paper", false);
+        fundTransferReceiveFiveFivePaper = configOptionController.getBooleanValueByKey("Fund Transfer Bill is 5x5 Paper", true);
+        fundTransferReceiveFiveFivePrintedPaper = configOptionController.getBooleanValueByKey("Fund Transfer Bill is 5x5 Printed Paper", false);
+        fundTransferReceiveA4Paper = configOptionController.getBooleanValueByKey("Fund Transfer Bill is A4 Paper", false);
+        fundTransferReceiveA4PrintedPaper = configOptionController.getBooleanValueByKey("Fund Transfer Bill is A4 Printed Paper", false);
+
     }
 
     /**
@@ -442,6 +458,14 @@ public class PharmacyConfigController implements Serializable {
             configOptionController.setBooleanValueByKey("Petty Cash Receipt POS Paper", pettyCashPosPaper);
             configOptionController.setBooleanValueByKey("Petty Cash Receipt A4 Paper", pettyCashA4Paper);
             configOptionController.setBooleanValueByKey("Petty Cash Receipt Custom Paper", pettyCashCustomPaper);
+
+            // Fund Transfer Receive Bill Settings
+            configOptionController.setBooleanValueByKey("Fund Transfer Bill is POS Paper", fundTransferReceivePosPaper);
+            configOptionController.setBooleanValueByKey("Fund Transfer Bill is POS Printed Paper", fundTransferReceivePosPrintedPaper);
+            configOptionController.setBooleanValueByKey("Fund Transfer Bill is 5x5 Paper", fundTransferReceiveFiveFivePaper);
+            configOptionController.setBooleanValueByKey("Fund Transfer Bill is 5x5 Printed Paper", fundTransferReceiveFiveFivePrintedPaper);
+            configOptionController.setBooleanValueByKey("Fund Transfer Bill is A4 Paper", fundTransferReceiveA4Paper);
+            configOptionController.setBooleanValueByKey("Fund Transfer Bill is A4 Printed Paper", fundTransferReceiveA4PrintedPaper);
 
             JsfUtil.addSuccessMessage("Configuration saved successfully");
 
@@ -707,6 +731,29 @@ public class PharmacyConfigController implements Serializable {
 
         } catch (Exception e) {
             JsfUtil.addErrorMessage("Error saving Petty Cash configuration: " + e.getMessage());
+        }
+    }
+
+    /**
+     * Save Fund Transfer Receive Bill configuration changes specifically
+     */
+    public void saveFundTransferReceiveConfig() {
+        try {
+            // Fund Transfer Receive Bill Settings
+            configOptionController.setBooleanValueByKey("Fund Transfer Bill is POS Paper", fundTransferReceivePosPaper);
+            configOptionController.setBooleanValueByKey("Fund Transfer Bill is POS Printed Paper", fundTransferReceivePosPrintedPaper);
+            configOptionController.setBooleanValueByKey("Fund Transfer Bill is 5x5 Paper", fundTransferReceiveFiveFivePaper);
+            configOptionController.setBooleanValueByKey("Fund Transfer Bill is 5x5 Printed Paper", fundTransferReceiveFiveFivePrintedPaper);
+            configOptionController.setBooleanValueByKey("Fund Transfer Bill is A4 Paper", fundTransferReceiveA4Paper);
+            configOptionController.setBooleanValueByKey("Fund Transfer Bill is A4 Printed Paper", fundTransferReceiveA4PrintedPaper);
+
+            JsfUtil.addSuccessMessage("Fund Transfer Receive configuration saved successfully");
+
+            // Reload current values to ensure consistency
+            loadCurrentConfig();
+
+        } catch (Exception e) {
+            JsfUtil.addErrorMessage("Error saving Fund Transfer Receive configuration: " + e.getMessage());
         }
     }
 
@@ -1465,6 +1512,55 @@ public class PharmacyConfigController implements Serializable {
 
     public void setPettyCashCustomPaper(boolean pettyCashCustomPaper) {
         this.pettyCashCustomPaper = pettyCashCustomPaper;
+    }
+
+    // Fund Transfer Receive Bill Getters and Setters
+    public boolean isFundTransferReceivePosPaper() {
+        return fundTransferReceivePosPaper;
+    }
+
+    public void setFundTransferReceivePosPaper(boolean fundTransferReceivePosPaper) {
+        this.fundTransferReceivePosPaper = fundTransferReceivePosPaper;
+    }
+
+    public boolean isFundTransferReceivePosPrintedPaper() {
+        return fundTransferReceivePosPrintedPaper;
+    }
+
+    public void setFundTransferReceivePosPrintedPaper(boolean fundTransferReceivePosPrintedPaper) {
+        this.fundTransferReceivePosPrintedPaper = fundTransferReceivePosPrintedPaper;
+    }
+
+    public boolean isFundTransferReceiveFiveFivePaper() {
+        return fundTransferReceiveFiveFivePaper;
+    }
+
+    public void setFundTransferReceiveFiveFivePaper(boolean fundTransferReceiveFiveFivePaper) {
+        this.fundTransferReceiveFiveFivePaper = fundTransferReceiveFiveFivePaper;
+    }
+
+    public boolean isFundTransferReceiveFiveFivePrintedPaper() {
+        return fundTransferReceiveFiveFivePrintedPaper;
+    }
+
+    public void setFundTransferReceiveFiveFivePrintedPaper(boolean fundTransferReceiveFiveFivePrintedPaper) {
+        this.fundTransferReceiveFiveFivePrintedPaper = fundTransferReceiveFiveFivePrintedPaper;
+    }
+
+    public boolean isFundTransferReceiveA4Paper() {
+        return fundTransferReceiveA4Paper;
+    }
+
+    public void setFundTransferReceiveA4Paper(boolean fundTransferReceiveA4Paper) {
+        this.fundTransferReceiveA4Paper = fundTransferReceiveA4Paper;
+    }
+
+    public boolean isFundTransferReceiveA4PrintedPaper() {
+        return fundTransferReceiveA4PrintedPaper;
+    }
+
+    public void setFundTransferReceiveA4PrintedPaper(boolean fundTransferReceiveA4PrintedPaper) {
+        this.fundTransferReceiveA4PrintedPaper = fundTransferReceiveA4PrintedPaper;
     }
 
 }

--- a/src/main/webapp/cashier/fund_transfer_bill_print.xhtml
+++ b/src/main/webapp/cashier/fund_transfer_bill_print.xhtml
@@ -18,6 +18,13 @@
                             <h:outputText value="Float Transfer Note" >
                             </h:outputText>
                             <p:commandButton
+                                rendered="#{webUserController.hasPrivilege('ChangeReceiptPrintingPaperTypes')}"
+                                value="Settings"
+                                icon="fas fa-cog"
+                                class="float-end m-1 ui-button-secondary"
+                                type="button"
+                                onclick="PF('fundTransferConfigDialog').show();" />
+                            <p:commandButton
                                 class="float-end"
                                 value="Back to Fund Transfer List"
                                 action="#{financialTransactionController.navigateToFinancialTransactionIndex()}"
@@ -137,7 +144,110 @@
                         <p:printer target="panelPrint"/>
                     </p:commandButton>
 
+                    <!-- Fund Transfer Bill Configuration Dialog -->
+                    <p:dialog id="fundTransferConfigDialog"
+                              header="Fund Transfer Bill Printer Configuration"
+                              widgetVar="fundTransferConfigDialog"
+                              modal="true"
+                              width="600"
+                              height="500"
+                              resizable="true"
+                              maximizable="true"
+                              closeOnEscape="true">
 
+                        <p:ajax event="open" listener="#{pharmacyConfigController.loadCurrentConfig}" update=":#{p:resolveFirstComponentWithId('fundTransferCheckboxes',view).clientId}" process="@this" />
+
+                        <h:form id="fundTransferConfigForm">
+
+                            <div class="row">
+                                <div class="col-12">
+                                    <div class="card config-section">
+                                        <div class="card-header">
+                                            <h6><i class="fas fa-file-alt"></i> Fund Transfer Bill Paper Settings</h6>
+                                        </div>
+                                        <div class="card-body">
+                                            <h:panelGroup id="fundTransferCheckboxes">
+                                                <div class="mb-3">
+                                                    <h:selectBooleanCheckbox
+                                                        id="fundTransferPosPaper"
+                                                        value="#{pharmacyConfigController.fundTransferReceivePosPaper}" />
+                                                    <h:outputLabel for="fundTransferPosPaper" value="POS Paper (with header)" class="ms-2" />
+                                                    <small class="form-text text-muted d-block">POS thermal paper format with institutional header</small>
+                                                </div>
+
+                                                <div class="mb-3">
+                                                    <h:selectBooleanCheckbox
+                                                        id="fundTransferPosPrintedPaper"
+                                                        value="#{pharmacyConfigController.fundTransferReceivePosPrintedPaper}" />
+                                                    <h:outputLabel for="fundTransferPosPrintedPaper" value="POS Printed Paper (without header)" class="ms-2" />
+                                                    <small class="form-text text-muted d-block">POS format for pre-printed paper without header</small>
+                                                </div>
+
+                                                <div class="mb-3">
+                                                    <h:selectBooleanCheckbox
+                                                        id="fundTransferFiveFivePaper"
+                                                        value="#{pharmacyConfigController.fundTransferReceiveFiveFivePaper}" />
+                                                    <h:outputLabel for="fundTransferFiveFivePaper" value="5x5 Paper (with header)" class="ms-2" />
+                                                    <small class="form-text text-muted d-block">5x5 inch paper format with institutional header (Default)</small>
+                                                </div>
+
+                                                <div class="mb-3">
+                                                    <h:selectBooleanCheckbox
+                                                        id="fundTransferFiveFivePrintedPaper"
+                                                        value="#{pharmacyConfigController.fundTransferReceiveFiveFivePrintedPaper}" />
+                                                    <h:outputLabel for="fundTransferFiveFivePrintedPaper" value="5x5 Printed Paper (without header)" class="ms-2" />
+                                                    <small class="form-text text-muted d-block">5x5 inch format for pre-printed paper without header</small>
+                                                </div>
+
+                                                <div class="mb-3">
+                                                    <h:selectBooleanCheckbox
+                                                        id="fundTransferA4Paper"
+                                                        value="#{pharmacyConfigController.fundTransferReceiveA4Paper}" />
+                                                    <h:outputLabel for="fundTransferA4Paper" value="A4 Paper (with header)" class="ms-2" />
+                                                    <small class="form-text text-muted d-block">Standard A4 size paper format with institutional header</small>
+                                                </div>
+
+                                                <div class="mb-3">
+                                                    <h:selectBooleanCheckbox
+                                                        id="fundTransferA4PrintedPaper"
+                                                        value="#{pharmacyConfigController.fundTransferReceiveA4PrintedPaper}" />
+                                                    <h:outputLabel for="fundTransferA4PrintedPaper" value="A4 Printed Paper (without header)" class="ms-2" />
+                                                    <small class="form-text text-muted d-block">A4 format for pre-printed paper without header</small>
+                                                </div>
+                                            </h:panelGroup>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+
+                            <div class="row mt-4">
+                                <div class="col-12">
+                                    <div class="card">
+                                        <div class="card-body">
+                                            <p:messages id="fundTransferConfigMessages" showDetail="true" closable="true" />
+                                            <div class="d-flex justify-content-between align-items-center">
+                                                <div class="d-flex gap-2">
+                                                    <p:commandButton
+                                                        value="Apply &amp; Close"
+                                                        icon="fas fa-save"
+                                                        class="ui-button-success"
+                                                        ajax="false"
+                                                        action="#{pharmacyConfigController.saveFundTransferReceiveConfig}" />
+                                                    <p:commandButton
+                                                        value="Cancel"
+                                                        icon="fas fa-times"
+                                                        class="ui-button-secondary"
+                                                        onclick="PF('fundTransferConfigDialog').hide(); return false;"
+                                                        type="button" />
+                                                </div>
+                                            </div>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+
+                        </h:form>
+                    </p:dialog>
 
                 </h:form>
             </ui:define>

--- a/src/main/webapp/cashier/fund_transfer_receive_bill_print.xhtml
+++ b/src/main/webapp/cashier/fund_transfer_receive_bill_print.xhtml
@@ -15,21 +15,28 @@
                 <h:form >
 
 
-                    <p:panel 
+                    <p:panel
                         header="Fund Transfer Received Bill"
                         class="w-100 m-1"     >
                         <f:facet name="header" >
                             <h:outputLabel value="Float Transfer Receive Note" ></h:outputLabel>
-                            <p:commandButton 
-                                value="Cashier Index" 
-                                ajax="false" 
+                            <p:commandButton
+                                rendered="#{webUserController.hasPrivilege('ChangeReceiptPrintingPaperTypes')}"
+                                value="Settings"
+                                icon="fas fa-cog"
+                                class="float-end m-1 ui-button-secondary"
+                                type="button"
+                                onclick="PF('fundTransferReceiveConfigDialog').show();" />
+                            <p:commandButton
+                                value="Cashier Index"
+                                ajax="false"
                                 class="float-end m-1"
                                 action="#{financialTransactionController.navigateToFinancialTransactionIndex()}" >
                             </p:commandButton>
-                            <p:commandButton 
+                            <p:commandButton
                                 value="To List Fund Transfers for me to Receive"
                                 icon=""
-                                ajax="false" 
+                                ajax="false"
                                 class="float-end m-1"
                                 action="#{financialTransactionController.navigateToReceiveFundTransferBillsForMe()}" >
                             </p:commandButton>
@@ -143,6 +150,110 @@
 
                     </p:panel>
 
+                    <!-- Fund Transfer Receive Bill Configuration Dialog -->
+                    <p:dialog id="fundTransferReceiveConfigDialog"
+                              header="Fund Transfer Receive Bill Printer Configuration"
+                              widgetVar="fundTransferReceiveConfigDialog"
+                              modal="true"
+                              width="600"
+                              height="500"
+                              resizable="true"
+                              maximizable="true"
+                              closeOnEscape="true">
+
+                        <p:ajax event="open" listener="#{pharmacyConfigController.loadCurrentConfig}" update=":#{p:resolveFirstComponentWithId('fundTransferReceiveCheckboxes',view).clientId}" process="@this" />
+
+                        <h:form id="fundTransferReceiveConfigForm">
+
+                            <div class="row">
+                                <div class="col-12">
+                                    <div class="card config-section">
+                                        <div class="card-header">
+                                            <h6><i class="fas fa-file-alt"></i> Fund Transfer Receive Bill Paper Settings</h6>
+                                        </div>
+                                        <div class="card-body">
+                                            <h:panelGroup id="fundTransferReceiveCheckboxes">
+                                                <div class="mb-3">
+                                                    <h:selectBooleanCheckbox
+                                                        id="fundTransferReceivePosPaper"
+                                                        value="#{pharmacyConfigController.fundTransferReceivePosPaper}" />
+                                                    <h:outputLabel for="fundTransferReceivePosPaper" value="POS Paper (with header)" class="ms-2" />
+                                                    <small class="form-text text-muted d-block">POS thermal paper format with institutional header</small>
+                                                </div>
+
+                                                <div class="mb-3">
+                                                    <h:selectBooleanCheckbox
+                                                        id="fundTransferReceivePosPrintedPaper"
+                                                        value="#{pharmacyConfigController.fundTransferReceivePosPrintedPaper}" />
+                                                    <h:outputLabel for="fundTransferReceivePosPrintedPaper" value="POS Printed Paper (without header)" class="ms-2" />
+                                                    <small class="form-text text-muted d-block">POS format for pre-printed paper without header</small>
+                                                </div>
+
+                                                <div class="mb-3">
+                                                    <h:selectBooleanCheckbox
+                                                        id="fundTransferReceiveFiveFivePaper"
+                                                        value="#{pharmacyConfigController.fundTransferReceiveFiveFivePaper}" />
+                                                    <h:outputLabel for="fundTransferReceiveFiveFivePaper" value="5x5 Paper (with header)" class="ms-2" />
+                                                    <small class="form-text text-muted d-block">5x5 inch paper format with institutional header (Default)</small>
+                                                </div>
+
+                                                <div class="mb-3">
+                                                    <h:selectBooleanCheckbox
+                                                        id="fundTransferReceiveFiveFivePrintedPaper"
+                                                        value="#{pharmacyConfigController.fundTransferReceiveFiveFivePrintedPaper}" />
+                                                    <h:outputLabel for="fundTransferReceiveFiveFivePrintedPaper" value="5x5 Printed Paper (without header)" class="ms-2" />
+                                                    <small class="form-text text-muted d-block">5x5 inch format for pre-printed paper without header</small>
+                                                </div>
+
+                                                <div class="mb-3">
+                                                    <h:selectBooleanCheckbox
+                                                        id="fundTransferReceiveA4Paper"
+                                                        value="#{pharmacyConfigController.fundTransferReceiveA4Paper}" />
+                                                    <h:outputLabel for="fundTransferReceiveA4Paper" value="A4 Paper (with header)" class="ms-2" />
+                                                    <small class="form-text text-muted d-block">Standard A4 size paper format with institutional header</small>
+                                                </div>
+
+                                                <div class="mb-3">
+                                                    <h:selectBooleanCheckbox
+                                                        id="fundTransferReceiveA4PrintedPaper"
+                                                        value="#{pharmacyConfigController.fundTransferReceiveA4PrintedPaper}" />
+                                                    <h:outputLabel for="fundTransferReceiveA4PrintedPaper" value="A4 Printed Paper (without header)" class="ms-2" />
+                                                    <small class="form-text text-muted d-block">A4 format for pre-printed paper without header</small>
+                                                </div>
+                                            </h:panelGroup>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+
+                            <div class="row mt-4">
+                                <div class="col-12">
+                                    <div class="card">
+                                        <div class="card-body">
+                                            <p:messages id="fundTransferReceiveConfigMessages" showDetail="true" closable="true" />
+                                            <div class="d-flex justify-content-between align-items-center">
+                                                <div class="d-flex gap-2">
+                                                    <p:commandButton
+                                                        value="Apply &amp; Close"
+                                                        icon="fas fa-save"
+                                                        class="ui-button-success"
+                                                        ajax="false"
+                                                        action="#{pharmacyConfigController.saveFundTransferReceiveConfig}" />
+                                                    <p:commandButton
+                                                        value="Cancel"
+                                                        icon="fas fa-times"
+                                                        class="ui-button-secondary"
+                                                        onclick="PF('fundTransferReceiveConfigDialog').hide(); return false;"
+                                                        type="button" />
+                                                </div>
+                                            </div>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+
+                        </h:form>
+                    </p:dialog>
 
                 </h:form>
             </ui:define>


### PR DESCRIPTION
  I've implemented multiple report formats (A4, POS, Five Five) with printer configuration for the fund transfer receive bill print page.

  Files Modified:

  1. src/main/java/com/divudi/bean/pharmacy/PharmacyConfigController.java:
    - Added 6 new boolean properties for Fund Transfer Receive Bill configuration: - fundTransferReceivePosPaper
      - fundTransferReceivePosPrintedPaper
      - fundTransferReceiveFiveFivePaper - fundTransferReceiveFiveFivePrintedPaper - fundTransferReceiveA4Paper - fundTransferReceiveA4PrintedPaper
    - Added loading logic in loadCurrentConfig() method
    - Added saving logic in saveConfig() method
    - Added new saveFundTransferReceiveConfig() method for saving specifically this configuration
    - Added all getters and setters for the new properties
  2. src/main/webapp/cashier/fund_transfer_receive_bill_print.xhtml:
    - Added Settings button (visible to users with ChangeReceiptPrintingPaperTypes privilege)
    - Added configuration dialog fundTransferReceiveConfigDialog with checkboxes for:
        - POS Paper (with header)
      - POS Printed Paper (without header) - 5x5 Paper (with header) - Default - 5x5 Printed Paper (without header) - A4 Paper (with header) - A4 Printed Paper (without header)
    - Print formats reference existing composite components that were already created
  3. src/main/webapp/cashier/fund_transfer_bill_print.xhtml:
    - Added the same Settings button and configuration dialog for the fund transfer initiation page

  Print Components (Already Existed):

  - float_transfer_receive_pos.xhtml - POS with header
  - float_transfer_receive_pos_printed.xhtml - POS without header
  - float_transfer_receive_five_five.xhtml - 5x5 with header
  - float_transfer_receive_five_five_printed.xhtml - 5x5 without header
  - float_transfer_receive_a4.xhtml - A4 with header
  - float_transfer_receive_a4_printed.xhtml - A4 without header

  The page now supports hospital-specific customization through the Settings button, allowing users with appropriate privileges to select which paper format(s) to use for printing fund transfer receive bills.

Closes #17537