### PR TITLE
17995 pharmacy retail sale cancelled   stock value cost stock value retail should displayed as positive value

### DIFF
--- a/src/main/resources/META-INF/persistence.xml
+++ b/src/main/resources/META-INF/persistence.xml
@@ -2,7 +2,7 @@
 <persistence version="2.2" xmlns="http://java.sun.com/xml/ns/persistence" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/persistence http://xmlns.jcp.org/xml/ns/persistence/persistence_2_2.xsd">
     <persistence-unit name="hmisPU" transaction-type="JTA">
         <provider>org.eclipse.persistence.jpa.PersistenceProvider</provider>
-        <jta-data-source>jdbc/rhDS</jta-data-source>
+        <jta-data-source>${JDBC_DATASOURCE}</jta-data-source>
         <exclude-unlisted-classes>false</exclude-unlisted-classes>
         <properties>
             <property name="eclipselink.logging.level.sql" value="SEVERE"/>
@@ -11,7 +11,7 @@
     </persistence-unit>
 
     <persistence-unit name="hmisAuditPU" transaction-type="JTA">
-        <jta-data-source>jdbc/rhAuditDS</jta-data-source>
+        <jta-data-source>${JDBC_AUDIT_DATASOURCE}</jta-data-source>
         <exclude-unlisted-classes>false</exclude-unlisted-classes>
         <properties>
             <property name="eclipselink.logging.level.sql" value="SEVERE"/>

--- a/src/main/webapp/pharmacy/pharmacy_analytics.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_analytics.xhtml
@@ -47,7 +47,7 @@
                                                 value="Pharmacy Income and Cost"
                                                 action="#{pharmacySummaryReportController.navigateToPharmacyIncomeAndCostReport()}"/>
                                             <p:commandButton 
-                                                rendered="#{configOptionApplicationController.getBooleanValueByKey('Pharmacy Analytics - Show Daily Stock Values')}"
+                                                rendered="false"
                                                 class="w-100"
                                                 ajax="false"
                                                 style="text-align: left"

--- a/src/main/webapp/resources/pharmacy/sale_cancelltion_bill_five_five_custom_3.xhtml
+++ b/src/main/webapp/resources/pharmacy/sale_cancelltion_bill_five_five_custom_3.xhtml
@@ -148,7 +148,7 @@
                                     </h:outputLabel>
                                 </td>
                                 <td style="text-align: right">
-                                    <h:outputLabel value="#{item.grossValue}">
+                                    <h:outputLabel value="#{commonFunctionsProxy.abs(item.grossValue)}">
                                         <f:convertNumber pattern="#,##0.00" />
                                     </h:outputLabel>
                                 </td>
@@ -165,7 +165,7 @@
                     <tr>
                         <td >Total:</td>
                         <td  style="text-align: right;">
-                            <h:outputLabel value="#{cc.attrs.bill.total}" >
+                            <h:outputLabel value="#{commonFunctionsProxy.abs(cc.attrs.bill.total)}" >
                                 <f:convertNumber pattern="#,##0.00" />
                             </h:outputLabel>
                         </td>
@@ -175,7 +175,7 @@
                         <tr>
                             <td >Discount:</td>
                             <td  style="text-align: right;">
-                                <h:outputLabel  value="#{-cc.attrs.bill.discount}">
+                                <h:outputLabel  value="#{commonFunctionsProxy.abs(cc.attrs.bill.discount)}">
                                     <f:convertNumber pattern="#,##0.00" />
                                 </h:outputLabel>
                             </td>
@@ -183,7 +183,7 @@
                         <tr>
                             <td >Net Total:</td>
                             <td style="text-align: right;">
-                                <h:outputLabel value="#{cc.attrs.bill.netTotal}">
+                                <h:outputLabel value="#{commonFunctionsProxy.abs(cc.attrs.bill.netTotal)}">
                                     <f:convertNumber pattern="#,##0.00" />
                                 </h:outputLabel>
                             </td>
@@ -217,7 +217,7 @@
                                             <h:outputText style="font-size: 8pt; width: 2cm;"  value=" (#{ps.creditCardRefNo})" rendered="#{ps.paymentMethod eq 'Card'}"/>
                                         </td>
                                         <td style="width: 2cm; text-align: end">
-                                            <h:outputText style="font-size: 8pt; width: 2cm;"  value="#{ps.paidValue}">
+                                            <h:outputText style="font-size: 8pt; width: 2cm;"  value="#{commonFunctionsProxy.abs(ps.paidValue)}">
                                                 <f:convertNumber pattern="#,##0.00" />
                                             </h:outputText>
                                         </td>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed the "Daily Stock Values" button from the Pharmacy Analytics page
  * Updated bill displays to consistently show financial amounts as positive values across gross values, totals, discounts, net totals, and payment records

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->