### PR TITLE
update 5x5 Custom 3 Bill

### DIFF
--- a/src/main/webapp/resources/ezcomp/prints/five_five_custom_3.xhtml
+++ b/src/main/webapp/resources/ezcomp/prints/five_five_custom_3.xhtml
@@ -260,7 +260,16 @@
                             <tr>
                                 <!-- Display the item number across all items -->
                                 <td>#{s.index +1}</td> <!-- status.index starts from 0, so add 1 for a human-readable count -->
-                                <td>#{item.item.name}</td>
+                                <td>
+                                    <h:outputLabel 
+                                        value="#{item.item.name}" 
+                                        rendered="#{!configOptionApplicationController.getBooleanValueByKey('Show the print name of the items on the 5x5 Custum 3 bill.',false)}">
+                                    </h:outputLabel>
+                                    <h:outputLabel 
+                                        value="#{item.item.printName}" 
+                                        rendered="#{configOptionApplicationController.getBooleanValueByKey('Show the print name of the items on the 5x5 Custum 3 bill.',false)}">
+                                    </h:outputLabel>  
+                                </td>
                                 <td style="text-align: right">
                                     <h:outputLabel value="#{item.grossValue}">
                                         <f:convertNumber pattern="#,##0.00" />


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a new configuration option for the 5x5 Custom 3 bill that enables customization of how item names are displayed. Users can now toggle between showing standard item names or specialized print-specific names, providing increased flexibility in bill presentation and accommodating different formatting preferences.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->