### PR TITLE
18106 add confirmation dialog and double click prevention to bht pharmacy issue settle button stg hotfix

### DIFF
--- a/src/main/webapp/inward/pharmacy_bill_issue_bht.xhtml
+++ b/src/main/webapp/inward/pharmacy_bill_issue_bht.xhtml
@@ -207,8 +207,11 @@
                                         </div>
 
                                         <p:commandButton
+                                            id="btnSettleInpatientDirectIssue"
                                             value="Settle"
                                             ajax="false"
+                                            onclick="return confirm('Are you sure you want to settle this pharmacy bill issue?')"
+                                            ondblclick="return false;"
                                             action="#{pharmacySaleBhtController.settlePharmacyBhtIssue()}"
                                             class="ui-button-success mx-2"
                                             style="width: 250px"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a new "Settle" button in the Item Requests section that enables users to settle inpatient direct issue pharmacy bills with a built-in confirmation prompt and double-click prevention for improved safety.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->