### PR TITLE
● ✅ Hotfix Applied Successfully!

### DIFF
--- a/src/main/webapp/inward/pharmacy_bill_issue_bht.xhtml
+++ b/src/main/webapp/inward/pharmacy_bill_issue_bht.xhtml
@@ -207,8 +207,11 @@
                                         </div>
 
                                         <p:commandButton
+                                            id="btnSettleInpatientDirectIssue"
                                             value="Settle"
                                             ajax="false"
+                                            onclick="return confirm('Are you sure you want to settle this pharmacy bill issue?')"
+                                            ondblclick="return false;"
                                             action="#{pharmacySaleBhtController.settlePharmacyBhtIssue()}"
                                             class="ui-button-success mx-2"
                                             style="width: 250px"


### PR DESCRIPTION
  I've applied the same hotfix to the Settle button in its new location. The
  button now includes:

  Added to the Settle button in the Item Requests panel header:
  1. Button ID: id="btnSettleInpatientDirectIssue" for proper identification
  2. Confirmation dialog: onclick="return confirm('Are you sure you want to settle this pharmacy bill issue?')"
  3. Double-click prevention: ondblclick="return false;"

  The hotfix is now consistently applied to the Settle button, providing:
  - ✅ User confirmation before settling the pharmacy bill issue
  - ✅ Prevention of accidental double-clicks that could cause duplicate submissions
  - ✅ Proper button identification for testing and maintenance

  Your hotfix for the BHT pharmacy issue settle button is now complete with both
   safety measures implemented!