### PR TITLE
Fix wrong null check in removePatientAllergy

### DIFF
--- a/src/main/java/com/divudi/bean/inward/AdmissionController.java
+++ b/src/main/java/com/divudi/bean/inward/AdmissionController.java
@@ -185,12 +185,18 @@ public class AdmissionController implements Serializable, ControllerWithPatient 
     }
 
     public void removePatientAllergy(ClinicalFindingValue pa) {
-        if (currentPatientAllergy == null) {
+        if (pa == null) {
+            JsfUtil.addErrorMessage("Invalid allergy selection");
             return;
         }
-        pa.setRetired(true);
-        clinicalFindingValueFacade.edit(pa);
-        patientAllergies.remove(pa);
+        try {
+            pa.setRetired(true);
+            clinicalFindingValueFacade.edit(pa);
+            patientAllergies.remove(pa);
+            JsfUtil.addSuccessMessage("Allergy removed successfully");
+        } catch (Exception e) {
+            JsfUtil.addErrorMessage("Failed to remove allergy: " + e.getMessage());
+        }
     }
 
     public void savePatientAllergies() {


### PR DESCRIPTION
This PR fixes a critical logic error in `AdmissionController.removePatientAllergy` where the wrong variable was checked for null.

Changes:
- Checked `pa` (parameter) for null instead of `currentPatientAllergy`.
- Added JsfUtil messages for feedback.
- Added try-catch block.
- Note: Did not add `setRetirer` and `setRetiredAt` as requested in the issue because those properties do not exist on the `ClinicalFindingValue` entity.

Closes #18174.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened patient allergy removal with enhanced input validation and comprehensive error handling. Users now receive clear feedback including success confirmations when allergies are removed and specific error messages when operations fail or invalid selections occur.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->