### PR TITLE
Collection Centre Balance Update Issue Fixed

### DIFF
--- a/src/main/java/com/divudi/bean/common/AgentAndCcApplicationController.java
+++ b/src/main/java/com/divudi/bean/common/AgentAndCcApplicationController.java
@@ -191,7 +191,7 @@ public class AgentAndCcApplicationController {
                     CommonFunctions.roundToTwoDecimalsBigDecimal(balanceAfterTx)
             );
 
-            agentHistoryFacade.create(agentHistory);
+            agentHistoryFacade.createAndFlush(agentHistory);
 
             collectingCentre.setBallance(balanceAfterTx);
             institutionFacade.editAndCommit(collectingCentre);
@@ -215,7 +215,7 @@ public class AgentAndCcApplicationController {
             agentHistory.setDepartment(bill.getDepartment());
             agentHistory.setAgency(collectingCentre);
             agentHistory.setReferenceNumber(bill.getAgentRefNo());
-            agentHistory.setHistoryType(HistoryType.RepaymentToCollectingCentreCancel);
+            agentHistory.setHistoryType(HistoryType.CollectingCentreBillingCancel);
             agentHistory.setCompanyTransactionValue(0 - Math.abs(hospitalFee));
             agentHistory.setAgentTransactionValue(0 - Math.abs(collectingCentreFee));
             agentHistory.setStaffTrasnactionValue(0 - Math.abs(staffFee));
@@ -233,7 +233,7 @@ public class AgentAndCcApplicationController {
                     CommonFunctions.roundToTwoDecimalsBigDecimal(balanceAfterTx)
             );
 
-            agentHistoryFacade.create(agentHistory);
+            agentHistoryFacade.createAndFlush(agentHistory);
 
             collectingCentre.setBallance(balanceAfterTx);
             institutionFacade.editAndCommit(collectingCentre);
@@ -257,7 +257,7 @@ public class AgentAndCcApplicationController {
             agentHistory.setDepartment(bill.getDepartment());
             agentHistory.setAgency(collectingCentre);
             agentHistory.setReferenceNumber(bill.getAgentRefNo());
-            agentHistory.setHistoryType(HistoryType.CollectingCentreBillingCancel);
+            agentHistory.setHistoryType(HistoryType.CollectingCentreBillingRefund);
             agentHistory.setCompanyTransactionValue(0 - Math.abs(hospitalFee));
             agentHistory.setAgentTransactionValue(0 - Math.abs(collectingCentreFee));
             agentHistory.setStaffTrasnactionValue(0 - Math.abs(staffFee));
@@ -275,7 +275,7 @@ public class AgentAndCcApplicationController {
                     CommonFunctions.roundToTwoDecimalsBigDecimal(balanceAfterTx)
             );
 
-            agentHistoryFacade.create(agentHistory);
+            agentHistoryFacade.createAndFlush(agentHistory);
 
             collectingCentre.setBallance(balanceAfterTx);
             institutionFacade.editAndCommit(collectingCentre);
@@ -318,7 +318,7 @@ public class AgentAndCcApplicationController {
                     CommonFunctions.roundToTwoDecimalsBigDecimal(balanceAfterTx)
             );
 
-            agentHistoryFacade.create(agentHistory);
+            agentHistoryFacade.createAndFlush(agentHistory);
 
             collectingCentre.setBallance(balanceAfterTx);
             institutionFacade.editAndCommit(collectingCentre);
@@ -342,7 +342,7 @@ public class AgentAndCcApplicationController {
             agentHistory.setDepartment(bill.getDepartment());
             agentHistory.setAgency(collectingCentre);
             agentHistory.setReferenceNumber(bill.getAgentRefNo());
-            agentHistory.setHistoryType(HistoryType.CollectingCentreCreditNote);
+            agentHistory.setHistoryType(HistoryType.CollectingentrePaymentMadeBill);
             agentHistory.setCompanyTransactionValue(0);
             agentHistory.setAgentTransactionValue(0);
             agentHistory.setStaffTrasnactionValue(0);
@@ -359,7 +359,7 @@ public class AgentAndCcApplicationController {
                     CommonFunctions.roundToTwoDecimalsBigDecimal(balanceAfterTx)
             );
 
-            agentHistoryFacade.create(agentHistory);
+            agentHistoryFacade.createAndFlush(agentHistory);
 
             collectingCentre.setBallance(balanceAfterTx);
             institutionFacade.editAndCommit(collectingCentre);
@@ -402,7 +402,7 @@ public class AgentAndCcApplicationController {
                     CommonFunctions.roundToTwoDecimalsBigDecimal(balanceAfterTx)
             );
 
-            agentHistoryFacade.create(agentHistory);
+            agentHistoryFacade.createAndFlush(agentHistory);
 
             collectingCentre.setBallance(balanceAfterTx);
             institutionFacade.editAndCommit(collectingCentre);
@@ -445,7 +445,7 @@ public class AgentAndCcApplicationController {
                     CommonFunctions.roundToTwoDecimalsBigDecimal(balanceAfterTx)
             );
 
-            agentHistoryFacade.create(agentHistory);
+            agentHistoryFacade.createAndFlush(agentHistory);
 
             collectingCentre.setBallance(balanceAfterTx);
             institutionFacade.editAndCommit(collectingCentre);
@@ -487,7 +487,7 @@ public class AgentAndCcApplicationController {
                     CommonFunctions.roundToTwoDecimalsBigDecimal(balanceAfterTx)
             );
 
-            agentHistoryFacade.create(agentHistory);
+            agentHistoryFacade.createAndFlush(agentHistory);
 
             collectingCentre.setBallance(balanceAfterTx);
             institutionFacade.editAndCommit(collectingCentre);
@@ -496,7 +496,7 @@ public class AgentAndCcApplicationController {
             lock.unlock();
         }
     }
-    
+
     private void handleCcDeposit(Institution collectingCentre, double hospitalFee, double collectingCentreFee, double staffFee, double transactionValue, Bill bill) {
         Long collectingCentreId = collectingCentre.getId(); // Assuming each Institution has a unique ID
         Lock lock = lockMap.computeIfAbsent(collectingCentreId, id -> new ReentrantLock());
@@ -662,7 +662,7 @@ public class AgentAndCcApplicationController {
                     CommonFunctions.roundToTwoDecimalsBigDecimal(balanceAfterTx)
             );
 
-            agentHistoryFacade.create(agentHistory);
+            agentHistoryFacade.createAndFlush(agentHistory);
 
             collectingCentre.setBallance(balanceAfterTx);
             institutionFacade.editAndCommit(collectingCentre);
@@ -709,7 +709,7 @@ public class AgentAndCcApplicationController {
                     CommonFunctions.roundToTwoDecimalsBigDecimal(balanceAfterTx)
             );
 
-            agentHistoryFacade.create(agentHistory);
+            agentHistoryFacade.createAndFlush(agentHistory);
 
             collectingCentre.setBallance(balanceAfterTx);
             institutionFacade.editAndCommit(collectingCentre);

--- a/src/main/java/com/divudi/bean/lab/CollectingCentreController.java
+++ b/src/main/java/com/divudi/bean/lab/CollectingCentreController.java
@@ -300,7 +300,7 @@ public class CollectingCentreController implements Serializable {
         String jpql = "SELECT ah FROM AgentHistory ah "
                 + "WHERE ah.retired = :ret "
                 + "AND ah.agency = :agency "
-                + "ORDER BY ah.id DESC";
+                + "ORDER BY ah.createdAt DESC, ah.id DESC";
 
         Map<String, Object> params = new HashMap<>();
         params.put("ret", false);


### PR DESCRIPTION
  Changes Made
  1. CollectingCentreController.java:303 — Fixed query ordering                                                                                                    - Before: ORDER BY ah.id DESC
  - After: ORDER BY ah.createdAt DESC, ah.id DESC
  - This is the primary fix for the reported discrepancy. The deposit for RCC131 (id=3640694, time=12:49:21) had a lower auto-increment ID than billing records
  (id=3640704/3640718, time=12:42-12:43) that happened earlier. Ordering by createdAt ensures the chronologically last record is returned.

  2. AgentAndCcApplicationController.java — Changed all create() to createAndFlush() (11 handlers fixed)
  - Handlers already using createAndFlush: handleCcDeposit, handleCcRePayment, handleCcRePaymentCancel
  - Handlers fixed: handleCcBalanceUpdateBill, handleCcBillingCancel, handleCcBillingRefund, handleCcCollectingCentreCreditNote, handleCcCollectingCentrePaymentMade, handleCcCreditNoteCancel, handleCcDebitNoteCancel, handleCcDebitNote, handleCcDepositCancel, handleCollectingCentreBilling
  - This prevents future ID ordering issues by ensuring auto-increment IDs are assigned immediately upon creation.

  3. AgentAndCcApplicationController.java — Fixed three wrong HistoryType labels
  - handleCcBillingCancel (line 218): RepaymentToCollectingCentreCancel → CollectingCentreBillingCancel
  - handleCcBillingRefund (line 260): CollectingCentreBillingCancel → CollectingCentreBillingRefund
  - handleCcCollectingCentrePaymentMade (line 345): CollectingCentreCreditNote → CollectingentrePaymentMadeBill

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected classification of collecting centre billing transactions (refunds, cancellations, and credit notes).
  * Improved data consistency in agent history tracking and record ordering by prioritizing creation date.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->