### PR TITLE
fix the  custom bill print not showing 

### DIFF
--- a/src/main/webapp/opd/view/opd_bill.xhtml
+++ b/src/main/webapp/opd/view/opd_bill.xhtml
@@ -86,6 +86,11 @@
                                                                 <prints:five_five_paper_coustom_1 bill="#{ffb}" duplicate="true"/>                        
                                                             </ui:repeat>
                                                         </h:panelGroup>
+                                                        <h:panelGroup rendered="#{sessionController.departmentPreference.opdBillPaperType eq 'FiveFiveCustom3'}">
+                                                            <ui:repeat value="#{billSearch.viewingBill}" var="ffb">
+                                                                <prints:five_five_custom_3 bill="#{ffb}" duplicate="true"/>
+                                                            </ui:repeat>
+                                                        </h:panelGroup>
                                                     </h:panelGroup>
                                                 </div>
                                                 <div class="col-6">


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new FiveFiveCustom3 paper format option for OPC bill printing, giving users expanded choices for customizing bill output and print formatting based on departmental preferences.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->