### PR TITLE
use error msg for "Nothing to Delete" in all controller delete() methods

### DIFF
--- a/src/main/java/com/divudi/bean/cashTransaction/DrawerController.java
+++ b/src/main/java/com/divudi/bean/cashTransaction/DrawerController.java
@@ -475,7 +475,7 @@ public class DrawerController implements Serializable {
             getFacade().edit(current);
             JsfUtil.addSuccessMessage("Deleted Successfully");
         } else {
-            JsfUtil.addSuccessMessage("Nothing to Delete");
+            JsfUtil.addErrorMessage("Nothing to Delete");
         }
         recreateModel();
         getItems();

--- a/src/main/java/com/divudi/bean/channel/AgentReferenceBookController.java
+++ b/src/main/java/com/divudi/bean/channel/AgentReferenceBookController.java
@@ -407,11 +407,11 @@ public class AgentReferenceBookController implements Serializable {
 
     public void bulkDeleteChannelBooks() {
         if (selectedList == null) {
-            JsfUtil.addSuccessMessage("Nothing to Delete");
+            JsfUtil.addErrorMessage("Nothing to Delete");
             return;
         }
         if (selectedList.isEmpty()) {
-            JsfUtil.addSuccessMessage("Nothing to Delete(Empty)");
+            JsfUtil.addErrorMessage("Nothing to Delete(Empty)");
             return;
         }
         for (AgentReferenceBook rb : selectedList) {

--- a/src/main/java/com/divudi/bean/channel/ChannelScheduleController.java
+++ b/src/main/java/com/divudi/bean/channel/ChannelScheduleController.java
@@ -960,7 +960,7 @@ public class ChannelScheduleController implements Serializable {
             }
             JsfUtil.addSuccessMessage("Deleted Successfully");
         } else {
-            JsfUtil.addSuccessMessage("Nothing to Delete");
+            JsfUtil.addErrorMessage("Nothing to Delete");
         }
 
         getItems();

--- a/src/main/java/com/divudi/bean/channel/ChannelStaffPaymentBillController.java
+++ b/src/main/java/com/divudi/bean/channel/ChannelStaffPaymentBillController.java
@@ -1404,7 +1404,7 @@ public class ChannelStaffPaymentBillController implements Serializable {
             getFacade().edit(current);
             JsfUtil.addSuccessMessage("Deleted Successfully");
         } else {
-            JsfUtil.addSuccessMessage("Nothing to Delete");
+            JsfUtil.addErrorMessage("Nothing to Delete");
         }
         recreateModel();
 //        getItems();

--- a/src/main/java/com/divudi/bean/channel/ChannellingFeeController.java
+++ b/src/main/java/com/divudi/bean/channel/ChannellingFeeController.java
@@ -308,7 +308,7 @@ public class ChannellingFeeController implements Serializable {
             getItemFeeFacade().edit(removingFee);
             JsfUtil.addSuccessMessage("Deleted Successfull");
         } else {
-            JsfUtil.addSuccessMessage("Nothing To Delete");
+            JsfUtil.addErrorMessage("Nothing To Delete");
         }
         fillFees();
         session.setTotal(calTot());

--- a/src/main/java/com/divudi/bean/channel/OnlineBookingAgentController.java
+++ b/src/main/java/com/divudi/bean/channel/OnlineBookingAgentController.java
@@ -1356,7 +1356,7 @@ public class OnlineBookingAgentController implements Serializable {
             JsfUtil.addSuccessMessage("Deleted Successfully");
         } else {
             current = null;
-            JsfUtil.addSuccessMessage("Nothing to Delete");
+            JsfUtil.addErrorMessage("Nothing to Delete");
         }
     }
 

--- a/src/main/java/com/divudi/bean/channel/PatientSessionInstanceActivityController.java
+++ b/src/main/java/com/divudi/bean/channel/PatientSessionInstanceActivityController.java
@@ -160,7 +160,7 @@ public class PatientSessionInstanceActivityController implements Serializable {
             getFacade().edit(current);
             JsfUtil.addSuccessMessage("Deleted Successfully");
         } else {
-            JsfUtil.addSuccessMessage("Nothing to Delete");
+            JsfUtil.addErrorMessage("Nothing to Delete");
         }
         recreateModel();
         getItems();

--- a/src/main/java/com/divudi/bean/channel/SessionInstanceActivityController.java
+++ b/src/main/java/com/divudi/bean/channel/SessionInstanceActivityController.java
@@ -260,7 +260,7 @@ public class SessionInstanceActivityController implements Serializable {
             getFacade().edit(current);
             JsfUtil.addSuccessMessage("Deleted Successfully");
         } else {
-            JsfUtil.addSuccessMessage("Nothing to Delete");
+            JsfUtil.addErrorMessage("Nothing to Delete");
         }
         recreateModel();
         getItems();

--- a/src/main/java/com/divudi/bean/channel/analytics/ReportTemplateController.java
+++ b/src/main/java/com/divudi/bean/channel/analytics/ReportTemplateController.java
@@ -2900,7 +2900,7 @@ public class ReportTemplateController implements Serializable {
             getFacade().edit(current);
             JsfUtil.addSuccessMessage("Deleted Successfully");
         } else {
-            JsfUtil.addSuccessMessage("Nothing to Delete");
+            JsfUtil.addErrorMessage("Nothing to Delete");
         }
         recreateModel();
         getItems();

--- a/src/main/java/com/divudi/bean/clinic/ClinicScheduleController.java
+++ b/src/main/java/com/divudi/bean/clinic/ClinicScheduleController.java
@@ -878,7 +878,7 @@ public class ClinicScheduleController implements Serializable {
             }
             JsfUtil.addSuccessMessage("Deleted Successfully");
         } else {
-            JsfUtil.addSuccessMessage("Nothing to Delete");
+            JsfUtil.addErrorMessage("Nothing to Delete");
         }
 
         getItems();

--- a/src/main/java/com/divudi/bean/clinical/ClinicalEntityController.java
+++ b/src/main/java/com/divudi/bean/clinical/ClinicalEntityController.java
@@ -201,7 +201,7 @@ public class ClinicalEntityController implements Serializable {
             getFacade().edit(current);
             JsfUtil.addSuccessMessage("Deleted Successfully");
         } else {
-            JsfUtil.addSuccessMessage("Nothing to Delete");
+            JsfUtil.addErrorMessage("Nothing to Delete");
         }
         recreateModel();
         getItems();

--- a/src/main/java/com/divudi/bean/clinical/ClinicalFindingItemController.java
+++ b/src/main/java/com/divudi/bean/clinical/ClinicalFindingItemController.java
@@ -130,7 +130,7 @@ public class ClinicalFindingItemController implements Serializable {
             getFacade().edit(current);
             JsfUtil.addSuccessMessage("Deleted Successfully");
         } else {
-            JsfUtil.addSuccessMessage("Nothing to Delete");
+            JsfUtil.addErrorMessage("Nothing to Delete");
         }
         recreateModel();
         getItems();

--- a/src/main/java/com/divudi/bean/clinical/DiagnosisController.java
+++ b/src/main/java/com/divudi/bean/clinical/DiagnosisController.java
@@ -216,7 +216,7 @@ public class DiagnosisController implements Serializable {
             getFacade().edit(current);
             JsfUtil.addSuccessMessage("Deleted Successfully");
         } else {
-            JsfUtil.addSuccessMessage("Nothing to Delete");
+            JsfUtil.addErrorMessage("Nothing to Delete");
         }
         recreateModel();
         fillItems();

--- a/src/main/java/com/divudi/bean/clinical/DocumentTemplateController.java
+++ b/src/main/java/com/divudi/bean/clinical/DocumentTemplateController.java
@@ -220,7 +220,7 @@ public class DocumentTemplateController implements Serializable {
             getFacade().edit(current);
             JsfUtil.addSuccessMessage("Deleted Successfully");
         } else {
-            JsfUtil.addSuccessMessage("Nothing to Delete");
+            JsfUtil.addErrorMessage("Nothing to Delete");
         }
         items = null;
         current = null;

--- a/src/main/java/com/divudi/bean/clinical/PastPatientEncounterController.java
+++ b/src/main/java/com/divudi/bean/clinical/PastPatientEncounterController.java
@@ -2205,7 +2205,7 @@ public class PastPatientEncounterController implements Serializable {
             getFacade().edit(current);
             JsfUtil.addSuccessMessage("Deleted Successfully");
         } else {
-            JsfUtil.addSuccessMessage("Nothing to Delete");
+            JsfUtil.addErrorMessage("Nothing to Delete");
         }
         recreateModel();
         getItems();

--- a/src/main/java/com/divudi/bean/clinical/PatientEncounterController.java
+++ b/src/main/java/com/divudi/bean/clinical/PatientEncounterController.java
@@ -3047,7 +3047,7 @@ public class PatientEncounterController implements Serializable {
             getFacade().edit(current);
             JsfUtil.addSuccessMessage("Deleted Successfully");
         } else {
-            JsfUtil.addSuccessMessage("Nothing to Delete");
+            JsfUtil.addErrorMessage("Nothing to Delete");
         }
         recreateModel();
         getItems();

--- a/src/main/java/com/divudi/bean/clinical/PlanController.java
+++ b/src/main/java/com/divudi/bean/clinical/PlanController.java
@@ -199,7 +199,7 @@ public class PlanController implements Serializable {
             getFacade().edit(current);
             JsfUtil.addSuccessMessage("Deleted Successfully");
         } else {
-            JsfUtil.addSuccessMessage("Nothing to Delete");
+            JsfUtil.addErrorMessage("Nothing to Delete");
         }
         recreateModel();
         getItems();

--- a/src/main/java/com/divudi/bean/clinical/ProcedureController.java
+++ b/src/main/java/com/divudi/bean/clinical/ProcedureController.java
@@ -197,7 +197,7 @@ public class ProcedureController implements Serializable {
             getFacade().edit(current);
             JsfUtil.addSuccessMessage("Deleted Successfully");
         } else {
-            JsfUtil.addSuccessMessage("Nothing to Delete");
+            JsfUtil.addErrorMessage("Nothing to Delete");
         }
         recreateModel();
         getItems();

--- a/src/main/java/com/divudi/bean/clinical/SignController.java
+++ b/src/main/java/com/divudi/bean/clinical/SignController.java
@@ -195,7 +195,7 @@ public class SignController implements Serializable {
             getFacade().edit(current);
             JsfUtil.addSuccessMessage("Deleted Successfully");
         } else {
-            JsfUtil.addSuccessMessage("Nothing to Delete");
+            JsfUtil.addErrorMessage("Nothing to Delete");
         }
         recreateModel();
         getItems();

--- a/src/main/java/com/divudi/bean/clinical/SymptomController.java
+++ b/src/main/java/com/divudi/bean/clinical/SymptomController.java
@@ -196,7 +196,7 @@ public class SymptomController implements Serializable {
             getFacade().edit(current);
             JsfUtil.addSuccessMessage("Deleted Successfully");
         } else {
-            JsfUtil.addSuccessMessage("Nothing to Delete");
+            JsfUtil.addErrorMessage("Nothing to Delete");
         }
         recreateModel();
         getItems();

--- a/src/main/java/com/divudi/bean/clinical/TreatementController.java
+++ b/src/main/java/com/divudi/bean/clinical/TreatementController.java
@@ -144,7 +144,7 @@ public class TreatementController implements Serializable {
             getFacade().edit(current);
             JsfUtil.addSuccessMessage("Deleted Successfully");
         } else {
-            JsfUtil.addSuccessMessage("Nothing to Delete");
+            JsfUtil.addErrorMessage("Nothing to Delete");
         }
         recreateModel();
         getItems();

--- a/src/main/java/com/divudi/bean/common/AgencyController.java
+++ b/src/main/java/com/divudi/bean/common/AgencyController.java
@@ -251,7 +251,7 @@ public class AgencyController implements Serializable {
             getFacade().edit(current);
             JsfUtil.addSuccessMessage("Deleted Successfully");
         } else {
-            JsfUtil.addSuccessMessage("Nothing to Delete");
+            JsfUtil.addErrorMessage("Nothing to Delete");
         }
         recreateModel();
         getItems();

--- a/src/main/java/com/divudi/bean/common/ApiKeyController.java
+++ b/src/main/java/com/divudi/bean/common/ApiKeyController.java
@@ -186,7 +186,7 @@ public class ApiKeyController implements Serializable {
             getFacade().edit(removing);
             JsfUtil.addSuccessMessage("Removed Successfully");
         } else {
-            JsfUtil.addSuccessMessage("Nothing to Delete");
+            JsfUtil.addErrorMessage("Nothing to Delete");
         }
         recreateModel();
         listMyApiKeys();

--- a/src/main/java/com/divudi/bean/common/AreaController.java
+++ b/src/main/java/com/divudi/bean/common/AreaController.java
@@ -158,7 +158,7 @@ public class AreaController implements Serializable {
             getFacade().edit(current);
             JsfUtil.addSuccessMessage("Deleted Successfully");
         } else {
-            JsfUtil.addSuccessMessage("Nothing to Delete");
+            JsfUtil.addErrorMessage("Nothing to Delete");
         }
         recreateModel();
         getItems();

--- a/src/main/java/com/divudi/bean/common/BankAccountController.java
+++ b/src/main/java/com/divudi/bean/common/BankAccountController.java
@@ -145,7 +145,7 @@ public class BankAccountController implements Serializable {
             getFacade().edit(current);
             JsfUtil.addSuccessMessage("Deleted Successfully");
         } else {
-            JsfUtil.addSuccessMessage("Nothing to Delete");
+            JsfUtil.addErrorMessage("Nothing to Delete");
         }
         recreateModel();
         getItems();

--- a/src/main/java/com/divudi/bean/common/BankController.java
+++ b/src/main/java/com/divudi/bean/common/BankController.java
@@ -115,7 +115,7 @@ public class BankController implements Serializable {
             getFacade().edit(current);
             JsfUtil.addSuccessMessage("Deleted Successfully");
         } else {
-            JsfUtil.addSuccessMessage("Nothing to Delete");
+            JsfUtil.addErrorMessage("Nothing to Delete");
         }
         recreateModel();
         getItems();

--- a/src/main/java/com/divudi/bean/common/BillExpenseController.java
+++ b/src/main/java/com/divudi/bean/common/BillExpenseController.java
@@ -132,7 +132,7 @@ public class BillExpenseController implements Serializable {
             getFacade().edit(current);
             JsfUtil.addSuccessMessage("Deleted Successfully");
         } else {
-            JsfUtil.addSuccessMessage("Nothing to Delete");
+            JsfUtil.addErrorMessage("Nothing to Delete");
         }
         recreateModel();
         getItems();

--- a/src/main/java/com/divudi/bean/common/BillFeeController.java
+++ b/src/main/java/com/divudi/bean/common/BillFeeController.java
@@ -150,7 +150,7 @@ public class BillFeeController implements Serializable {
             getFacade().edit(current);
             JsfUtil.addSuccessMessage("Deleted Successfully");
         } else {
-            JsfUtil.addSuccessMessage("Nothing to Delete");
+            JsfUtil.addErrorMessage("Nothing to Delete");
         }
         recreateModel();
         getItems();

--- a/src/main/java/com/divudi/bean/common/CategoryController.java
+++ b/src/main/java/com/divudi/bean/common/CategoryController.java
@@ -665,7 +665,7 @@ public class CategoryController implements Serializable {
             getFacade().edit(current);
             JsfUtil.addSuccessMessage("Deleted Successfully");
         } else {
-            JsfUtil.addSuccessMessage("Nothing to Delete");
+            JsfUtil.addErrorMessage("Nothing to Delete");
         }
         recreateModel();
         getItems();

--- a/src/main/java/com/divudi/bean/common/CategoryItemController.java
+++ b/src/main/java/com/divudi/bean/common/CategoryItemController.java
@@ -87,7 +87,7 @@ public class CategoryItemController implements Serializable {
             getFacade().edit(current);
             JsfUtil.addSuccessMessage("Deleted Successfully");
         } else {
-            JsfUtil.addSuccessMessage("Nothing to Delete");
+            JsfUtil.addErrorMessage("Nothing to Delete");
         }
         getItems();
         current = null;

--- a/src/main/java/com/divudi/bean/common/ClinicalFindingValueController.java
+++ b/src/main/java/com/divudi/bean/common/ClinicalFindingValueController.java
@@ -100,7 +100,7 @@ public class ClinicalFindingValueController implements Serializable {
             getFacade().edit(current);
             JsfUtil.addSuccessMessage("Deleted Successfully");
         } else {
-            JsfUtil.addSuccessMessage("Nothing to Delete");
+            JsfUtil.addErrorMessage("Nothing to Delete");
         }
         recreateModel();
         getItems();

--- a/src/main/java/com/divudi/bean/common/ConsultantController.java
+++ b/src/main/java/com/divudi/bean/common/ConsultantController.java
@@ -99,7 +99,7 @@ public class ConsultantController implements Serializable {
             getFacade().edit(current);
             JsfUtil.addSuccessMessage("Deleted Successfully");
         } else {
-            JsfUtil.addSuccessMessage("Nothing to Delete");
+            JsfUtil.addErrorMessage("Nothing to Delete");
         }
         recreateModel();
         //  getItems();

--- a/src/main/java/com/divudi/bean/common/CreditCompanyController.java
+++ b/src/main/java/com/divudi/bean/common/CreditCompanyController.java
@@ -237,7 +237,7 @@ public class CreditCompanyController implements Serializable {
             getFacade().edit(current);
             JsfUtil.addSuccessMessage("Deleted Successfully");
         } else {
-            JsfUtil.addSuccessMessage("Nothing to Delete");
+            JsfUtil.addErrorMessage("Nothing to Delete");
         }
         recreateModel();
         getItems();

--- a/src/main/java/com/divudi/bean/common/DepartmentController.java
+++ b/src/main/java/com/divudi/bean/common/DepartmentController.java
@@ -874,7 +874,7 @@ public class DepartmentController implements Serializable {
             getFacade().edit(current);
             JsfUtil.addSuccessMessage("Deleted Successfully");
         } else {
-            JsfUtil.addSuccessMessage("Nothing to Delete");
+            JsfUtil.addErrorMessage("Nothing to Delete");
         }
         recreateModel();
         getItems();

--- a/src/main/java/com/divudi/bean/common/DepartmentMachineController.java
+++ b/src/main/java/com/divudi/bean/common/DepartmentMachineController.java
@@ -196,7 +196,7 @@ public class DepartmentMachineController implements Serializable {
             getFacade().edit(current);
             JsfUtil.addSuccessMessage("Deleted Successfully");
         } else {
-            JsfUtil.addSuccessMessage("Nothing to Delete");
+            JsfUtil.addErrorMessage("Nothing to Delete");
         }
         getItems();
         current = null;

--- a/src/main/java/com/divudi/bean/common/DoctorController.java
+++ b/src/main/java/com/divudi/bean/common/DoctorController.java
@@ -254,7 +254,7 @@ public class DoctorController implements Serializable {
             getFacade().edit(current);
             JsfUtil.addSuccessMessage("Deleted Successfully");
         } else {
-            JsfUtil.addSuccessMessage("Nothing to Delete");
+            JsfUtil.addErrorMessage("Nothing to Delete");
         }
         recreateModel();
         //  getItems();

--- a/src/main/java/com/divudi/bean/common/DoctorSpecialityController.java
+++ b/src/main/java/com/divudi/bean/common/DoctorSpecialityController.java
@@ -224,7 +224,7 @@ public class DoctorSpecialityController implements Serializable {
             getFacade().edit(current);
             JsfUtil.addSuccessMessage("Deleted Successfully");
         } else {
-            JsfUtil.addSuccessMessage("Nothing to Delete");
+            JsfUtil.addErrorMessage("Nothing to Delete");
         }
         recreateModel();
         getItems();

--- a/src/main/java/com/divudi/bean/common/FeeController.java
+++ b/src/main/java/com/divudi/bean/common/FeeController.java
@@ -141,7 +141,7 @@ public class FeeController implements Serializable {
             getFacade().edit(current);
             JsfUtil.addSuccessMessage("Deleted Successfully");
         } else {
-            JsfUtil.addSuccessMessage("Nothing to Delete");
+            JsfUtil.addErrorMessage("Nothing to Delete");
         }
         recreateModel();
         getItems();

--- a/src/main/java/com/divudi/bean/common/FormFormatController.java
+++ b/src/main/java/com/divudi/bean/common/FormFormatController.java
@@ -197,7 +197,7 @@ public class FormFormatController implements Serializable {
             getFacade().edit(current);
             JsfUtil.addSuccessMessage("Deleted Successfully");
         } else {
-            JsfUtil.addSuccessMessage("Nothing to Delete");
+            JsfUtil.addErrorMessage("Nothing to Delete");
         }
         recreateModel();
         getItems();

--- a/src/main/java/com/divudi/bean/common/InstitutionBranchController.java
+++ b/src/main/java/com/divudi/bean/common/InstitutionBranchController.java
@@ -162,7 +162,7 @@ public class InstitutionBranchController implements Serializable {
             getFacade().edit(getCurrent());
             JsfUtil.addSuccessMessage("Deleted Successfully");
         } else {
-            JsfUtil.addSuccessMessage("Nothing to Delete");
+            JsfUtil.addErrorMessage("Nothing to Delete");
         }
         recreateModel();
         current = null;

--- a/src/main/java/com/divudi/bean/common/InstitutionController.java
+++ b/src/main/java/com/divudi/bean/common/InstitutionController.java
@@ -821,7 +821,7 @@ public class InstitutionController implements Serializable {
             getFacade().edit(getCurrent());
             JsfUtil.addSuccessMessage("Deleted Successfully");
         } else {
-            JsfUtil.addSuccessMessage("Nothing to Delete");
+            JsfUtil.addErrorMessage("Nothing to Delete");
         }
         recreateModel();
         getItems();
@@ -839,7 +839,7 @@ public class InstitutionController implements Serializable {
             getFacade().edit(getCurrent());
             JsfUtil.addSuccessMessage("Deleted Successfully");
         } else {
-            JsfUtil.addSuccessMessage("Nothing to Delete");
+            JsfUtil.addErrorMessage("Nothing to Delete");
         }
 
         current = null;
@@ -857,7 +857,7 @@ public class InstitutionController implements Serializable {
             getFacade().edit(getAgency());
             JsfUtil.addSuccessMessage("Deleted Successfully");
         } else {
-            JsfUtil.addSuccessMessage("Nothing to Delete");
+            JsfUtil.addErrorMessage("Nothing to Delete");
         }
         fetchSelectedAgencys();
         prepareAddAgency();

--- a/src/main/java/com/divudi/bean/common/ItemController.java
+++ b/src/main/java/com/divudi/bean/common/ItemController.java
@@ -3721,7 +3721,7 @@ public class ItemController implements Serializable {
             getFacade().edit(getCurrent());
             JsfUtil.addSuccessMessage("Deleted Successfully");
         } else {
-            JsfUtil.addSuccessMessage("Nothing to Delete");
+            JsfUtil.addErrorMessage("Nothing to Delete");
         }
         recreateModel();
         getAllItems();

--- a/src/main/java/com/divudi/bean/common/ItemFeeController.java
+++ b/src/main/java/com/divudi/bean/common/ItemFeeController.java
@@ -228,7 +228,7 @@ public class ItemFeeController implements Serializable {
             getFacade().edit(currentIx);
             JsfUtil.addSuccessMessage("Deleted Successfully");
         } else {
-            JsfUtil.addSuccessMessage("Nothing to Delete");
+            JsfUtil.addErrorMessage("Nothing to Delete");
         }
 
         currentIx = null;

--- a/src/main/java/com/divudi/bean/common/ItemForItemController.java
+++ b/src/main/java/com/divudi/bean/common/ItemForItemController.java
@@ -222,7 +222,7 @@ public class ItemForItemController implements Serializable {
             getFacade().edit(current);
             JsfUtil.addSuccessMessage("Deleted Successfully");
         } else {
-            JsfUtil.addSuccessMessage("Nothing to Delete");
+            JsfUtil.addErrorMessage("Nothing to Delete");
         }
         recreateModel();
         getItems();

--- a/src/main/java/com/divudi/bean/common/KitchenController.java
+++ b/src/main/java/com/divudi/bean/common/KitchenController.java
@@ -120,7 +120,7 @@ public class KitchenController implements Serializable {
             getFacade().edit(current);
             JsfUtil.addSuccessMessage("Deleted Successfully");
         } else {
-            JsfUtil.addSuccessMessage("Nothing to Delete");
+            JsfUtil.addErrorMessage("Nothing to Delete");
         }
         recreateModel();
         getItems();

--- a/src/main/java/com/divudi/bean/common/MedicalPackageItemController.java
+++ b/src/main/java/com/divudi/bean/common/MedicalPackageItemController.java
@@ -333,7 +333,7 @@ public class MedicalPackageItemController implements Serializable {
             getFacade().edit(current);
             JsfUtil.addSuccessMessage("Deleted Successfully");
         } else {
-            JsfUtil.addSuccessMessage("Nothing to Delete");
+            JsfUtil.addErrorMessage("Nothing to Delete");
         }
         recreateModel();
         getItems();

--- a/src/main/java/com/divudi/bean/common/MedicalPackageItemFeeController.java
+++ b/src/main/java/com/divudi/bean/common/MedicalPackageItemFeeController.java
@@ -224,7 +224,7 @@ public class MedicalPackageItemFeeController implements Serializable {
             getFacade().edit(currentIx);
             JsfUtil.addSuccessMessage("Deleted Successfully");
         } else {
-            JsfUtil.addSuccessMessage("Nothing to Delete");
+            JsfUtil.addErrorMessage("Nothing to Delete");
         }
 
         currentIx = null;

--- a/src/main/java/com/divudi/bean/common/MedicalPackageNameController.java
+++ b/src/main/java/com/divudi/bean/common/MedicalPackageNameController.java
@@ -203,7 +203,7 @@ public  class MedicalPackageNameController implements Serializable {
             getFacade().edit(current);
             JsfUtil.addSuccessMessage("Deleted Successfully");
         } else {
-            JsfUtil.addSuccessMessage("Nothing to Delete");
+            JsfUtil.addErrorMessage("Nothing to Delete");
         }
         recreateModel();
         getItems();

--- a/src/main/java/com/divudi/bean/common/MetadataSuperCategoryController.java
+++ b/src/main/java/com/divudi/bean/common/MetadataSuperCategoryController.java
@@ -157,7 +157,7 @@ public class MetadataSuperCategoryController implements Serializable {
             getFacade().edit(current);
             JsfUtil.addSuccessMessage("Deleted Successfully");
         } else {
-            JsfUtil.addSuccessMessage("Nothing to Delete");
+            JsfUtil.addErrorMessage("Nothing to Delete");
         }
         recreateModel();
         getItems();

--- a/src/main/java/com/divudi/bean/common/NotificationController.java
+++ b/src/main/java/com/divudi/bean/common/NotificationController.java
@@ -443,7 +443,7 @@ public class NotificationController implements Serializable {
             getFacade().edit(current);
             JsfUtil.addSuccessMessage("Deleted Successfully");
         } else {
-            JsfUtil.addSuccessMessage("Nothing to Delete");
+            JsfUtil.addErrorMessage("Nothing to Delete");
         }
         recreateModel();
         getItems();

--- a/src/main/java/com/divudi/bean/common/PackageFeeController.java
+++ b/src/main/java/com/divudi/bean/common/PackageFeeController.java
@@ -116,7 +116,7 @@ public  class PackageFeeController implements Serializable {
             getFacade().edit(current);
             JsfUtil.addSuccessMessage("Deleted Successfully");
         } else {
-            JsfUtil.addSuccessMessage("Nothing to Delete");
+            JsfUtil.addErrorMessage("Nothing to Delete");
         }
         recreateModel();
         getItems();

--- a/src/main/java/com/divudi/bean/common/PackageItemController.java
+++ b/src/main/java/com/divudi/bean/common/PackageItemController.java
@@ -374,7 +374,7 @@ public class PackageItemController implements Serializable {
             getFacade().edit(current);
             JsfUtil.addSuccessMessage("Deleted Successfully");
         } else {
-            JsfUtil.addSuccessMessage("Nothing to Delete");
+            JsfUtil.addErrorMessage("Nothing to Delete");
         }
         recreateModel();
         getItems();

--- a/src/main/java/com/divudi/bean/common/PackageItemFeeController.java
+++ b/src/main/java/com/divudi/bean/common/PackageItemFeeController.java
@@ -223,7 +223,7 @@ public class PackageItemFeeController implements Serializable {
             getFacade().edit(currentIx);
             JsfUtil.addSuccessMessage("Deleted Successfully");
         } else {
-            JsfUtil.addSuccessMessage("Nothing to Delete");
+            JsfUtil.addErrorMessage("Nothing to Delete");
         }
 
         currentIx = null;

--- a/src/main/java/com/divudi/bean/common/PackageNameController.java
+++ b/src/main/java/com/divudi/bean/common/PackageNameController.java
@@ -197,7 +197,7 @@ public  class PackageNameController implements Serializable {
             getFacade().edit(current);
             JsfUtil.addSuccessMessage("Deleted Successfully");
         } else {
-            JsfUtil.addSuccessMessage("Nothing to Delete");
+            JsfUtil.addErrorMessage("Nothing to Delete");
         }
         recreateModel();
         getItems();

--- a/src/main/java/com/divudi/bean/common/PatientController.java
+++ b/src/main/java/com/divudi/bean/common/PatientController.java
@@ -3160,7 +3160,7 @@ public class PatientController implements Serializable, ControllerWithPatient {
             getFacade().edit(current);
             JsfUtil.addSuccessMessage("Deleted Successfull");
         } else {
-            JsfUtil.addSuccessMessage("Nothing to Delete");
+            JsfUtil.addErrorMessage("Nothing to Delete");
         }
         recreateModel();
         getItems();
@@ -3178,7 +3178,7 @@ public class PatientController implements Serializable, ControllerWithPatient {
             getFacade().edit(current);
             JsfUtil.addSuccessMessage("Deleted Successfull");
         } else {
-            JsfUtil.addSuccessMessage("Nothing to Delete");
+            JsfUtil.addErrorMessage("Nothing to Delete");
         }
         recreateModel();
         getItems();

--- a/src/main/java/com/divudi/bean/common/PaymentItemController.java
+++ b/src/main/java/com/divudi/bean/common/PaymentItemController.java
@@ -132,7 +132,7 @@ public class PaymentItemController implements Serializable {
             getFacade().edit(current);
             JsfUtil.addSuccessMessage("Deleted Successfully");
         } else {
-            JsfUtil.addSuccessMessage("Nothing to Delete");
+            JsfUtil.addErrorMessage("Nothing to Delete");
         }
         recreateModel();
         getItems();

--- a/src/main/java/com/divudi/bean/common/PersonController.java
+++ b/src/main/java/com/divudi/bean/common/PersonController.java
@@ -142,7 +142,7 @@ public class PersonController implements Serializable {
             getFacade().edit(current);
             JsfUtil.addSuccessMessage("Deleted Successfully");
         } else {
-            JsfUtil.addSuccessMessage("Nothing to Delete");
+            JsfUtil.addErrorMessage("Nothing to Delete");
         }
         recreateModel();
         getItems();

--- a/src/main/java/com/divudi/bean/common/RelationController.java
+++ b/src/main/java/com/divudi/bean/common/RelationController.java
@@ -131,7 +131,7 @@ public class RelationController implements Serializable {
             getFacade().edit(current);
             JsfUtil.addSuccessMessage("Deleted Successfully");
         } else {
-            JsfUtil.addSuccessMessage("Nothing to Delete");
+            JsfUtil.addErrorMessage("Nothing to Delete");
         }
         recreateModel();
         fillItems();

--- a/src/main/java/com/divudi/bean/common/RouteController.java
+++ b/src/main/java/com/divudi/bean/common/RouteController.java
@@ -223,7 +223,7 @@ public class RouteController implements Serializable {
             getFacade().edit(current);
             JsfUtil.addSuccessMessage("Deleted Successfully");
         } else {
-            JsfUtil.addSuccessMessage("Nothing to Delete");
+            JsfUtil.addErrorMessage("Nothing to Delete");
         }
         recreateModel();
         getItems();

--- a/src/main/java/com/divudi/bean/common/ServiceCategoryController.java
+++ b/src/main/java/com/divudi/bean/common/ServiceCategoryController.java
@@ -121,7 +121,7 @@ public class ServiceCategoryController implements Serializable {
             getFacade().edit(current);
             JsfUtil.addSuccessMessage("Deleted Successfully");
         } else {
-            JsfUtil.addSuccessMessage("Nothing to Delete");
+            JsfUtil.addErrorMessage("Nothing to Delete");
         }
         recreateModel();
         getItems();

--- a/src/main/java/com/divudi/bean/common/ServiceController.java
+++ b/src/main/java/com/divudi/bean/common/ServiceController.java
@@ -729,7 +729,7 @@ public class ServiceController implements Serializable {
             getFacade().edit(current);
             JsfUtil.addSuccessMessage("Deleted Successfull");
         } else {
-            JsfUtil.addSuccessMessage("Nothing to Delete");
+            JsfUtil.addErrorMessage("Nothing to Delete");
         }
         recreateModel();
         getItems();
@@ -754,7 +754,7 @@ public class ServiceController implements Serializable {
             getFacade().edit(currentInactiveService);
             JsfUtil.addSuccessMessage("Deleted Successfull");
         } else {
-            JsfUtil.addSuccessMessage("Nothing to Delete");
+            JsfUtil.addErrorMessage("Nothing to Delete");
         }
         recreateModel();
         getSelectedRetiredItems();

--- a/src/main/java/com/divudi/bean/common/ServiceFeeController.java
+++ b/src/main/java/com/divudi/bean/common/ServiceFeeController.java
@@ -238,7 +238,7 @@ public class ServiceFeeController implements Serializable {
             getFacade().edit(currentIx);
             JsfUtil.addSuccessMessage("Deleted Successfully");
         } else {
-            JsfUtil.addSuccessMessage("Nothing to Delete");
+            JsfUtil.addErrorMessage("Nothing to Delete");
         }
 
         currentIx = null;

--- a/src/main/java/com/divudi/bean/common/ServiceSessionController.java
+++ b/src/main/java/com/divudi/bean/common/ServiceSessionController.java
@@ -142,7 +142,7 @@ public class ServiceSessionController implements Serializable {
             getFacade().edit(current);
             JsfUtil.addSuccessMessage("Deleted Successfully");
         } else {
-            JsfUtil.addSuccessMessage("Nothing to Delete");
+            JsfUtil.addErrorMessage("Nothing to Delete");
         }
         recreateModel();
         getItems();

--- a/src/main/java/com/divudi/bean/common/ServiceSubCategoryController.java
+++ b/src/main/java/com/divudi/bean/common/ServiceSubCategoryController.java
@@ -130,7 +130,7 @@ public class ServiceSubCategoryController implements Serializable {
             getFacade().edit(current);
             JsfUtil.addSuccessMessage("Deleted Successfully");
         } else {
-            JsfUtil.addSuccessMessage("Nothing to Delete");
+            JsfUtil.addErrorMessage("Nothing to Delete");
         }
         recreateModel();
         getItems();

--- a/src/main/java/com/divudi/bean/common/SpecialityController.java
+++ b/src/main/java/com/divudi/bean/common/SpecialityController.java
@@ -333,7 +333,7 @@ public class SpecialityController implements Serializable {
             getFacade().edit(current);
             JsfUtil.addSuccessMessage("Deleted Successfully");
         } else {
-            JsfUtil.addSuccessMessage("Nothing to Delete");
+            JsfUtil.addErrorMessage("Nothing to Delete");
         }
         recreateModel();
         getItems();

--- a/src/main/java/com/divudi/bean/common/StaffPaymentBillController.java
+++ b/src/main/java/com/divudi/bean/common/StaffPaymentBillController.java
@@ -793,7 +793,7 @@ public class StaffPaymentBillController implements Serializable {
             getFacade().edit(current);
             JsfUtil.addSuccessMessage("Deleted Successfully");
         } else {
-            JsfUtil.addSuccessMessage("Nothing to Delete");
+            JsfUtil.addErrorMessage("Nothing to Delete");
         }
         recreateModel();
 //        getItems();

--- a/src/main/java/com/divudi/bean/common/StoreController.java
+++ b/src/main/java/com/divudi/bean/common/StoreController.java
@@ -207,7 +207,7 @@ public class StoreController implements Serializable {
             getFacade().edit(current);
             JsfUtil.addSuccessMessage("Deleted Successfully");
         } else {
-            JsfUtil.addSuccessMessage("Nothing to Delete");
+            JsfUtil.addErrorMessage("Nothing to Delete");
         }
         recreateModel();
         getItems();

--- a/src/main/java/com/divudi/bean/common/TheatreController.java
+++ b/src/main/java/com/divudi/bean/common/TheatreController.java
@@ -120,7 +120,7 @@ public class TheatreController implements Serializable {
             getFacade().edit(current);
             JsfUtil.addSuccessMessage("Deleted Successfully");
         } else {
-            JsfUtil.addSuccessMessage("Nothing to Delete");
+            JsfUtil.addErrorMessage("Nothing to Delete");
         }
         recreateModel();
         getItems();

--- a/src/main/java/com/divudi/bean/common/UserDepartmentController.java
+++ b/src/main/java/com/divudi/bean/common/UserDepartmentController.java
@@ -137,7 +137,7 @@ public class UserDepartmentController implements Serializable {
             getEjbFacade().edit(current);
             JsfUtil.addSuccessMessage("Deleted Successfully");
         } else {
-            JsfUtil.addSuccessMessage("Nothing to Delete");
+            JsfUtil.addErrorMessage("Nothing to Delete");
         }
         recreateModel();
         getItems();

--- a/src/main/java/com/divudi/bean/common/UserNotificationController.java
+++ b/src/main/java/com/divudi/bean/common/UserNotificationController.java
@@ -567,7 +567,7 @@ public class UserNotificationController implements Serializable {
             getFacade().edit(current);
             JsfUtil.addSuccessMessage("Deleted Successfully");
         } else {
-            JsfUtil.addSuccessMessage("Nothing to Delete");
+            JsfUtil.addErrorMessage("Nothing to Delete");
         }
         recreateModel();
         getItems();

--- a/src/main/java/com/divudi/bean/common/UserPaymentSchemeController.java
+++ b/src/main/java/com/divudi/bean/common/UserPaymentSchemeController.java
@@ -131,7 +131,7 @@ public  class UserPaymentSchemeController implements Serializable {
             getEjbFacade().edit(current);
             JsfUtil.addSuccessMessage("Deleted Successfully");
         } else {
-            JsfUtil.addSuccessMessage("Nothing to Delete");
+            JsfUtil.addErrorMessage("Nothing to Delete");
         }
         recreateModel();
         getItems();

--- a/src/main/java/com/divudi/bean/common/UserRouteController.java
+++ b/src/main/java/com/divudi/bean/common/UserRouteController.java
@@ -136,7 +136,7 @@ public class UserRouteController implements Serializable {
             getEjbFacade().edit(current);
             JsfUtil.addSuccessMessage("Deleted Successfully");
         } else {
-            JsfUtil.addSuccessMessage("Nothing to Delete");
+            JsfUtil.addErrorMessage("Nothing to Delete");
         }
         recreateModel();
         getItems();

--- a/src/main/java/com/divudi/bean/common/VocabularyController.java
+++ b/src/main/java/com/divudi/bean/common/VocabularyController.java
@@ -177,7 +177,7 @@ public class VocabularyController implements Serializable {
             getFacade().edit(current);
             JsfUtil.addSuccessMessage("Deleted Successfully");
         } else {
-            JsfUtil.addSuccessMessage("Nothing to Delete");
+            JsfUtil.addErrorMessage("Nothing to Delete");
         }
         recreateModel();
         getItems();

--- a/src/main/java/com/divudi/bean/common/WebContentController.java
+++ b/src/main/java/com/divudi/bean/common/WebContentController.java
@@ -314,7 +314,7 @@ public class WebContentController implements Serializable {
             getFacade().edit(selected);
             JsfUtil.addSuccessMessage("Deleted Successfully");
         } else {
-            JsfUtil.addSuccessMessage("Nothing to Delete");
+            JsfUtil.addErrorMessage("Nothing to Delete");
         }
         recreateModel();
         getItems();

--- a/src/main/java/com/divudi/bean/common/WebLanguageController.java
+++ b/src/main/java/com/divudi/bean/common/WebLanguageController.java
@@ -199,7 +199,7 @@ public class WebLanguageController implements Serializable {
             getFacade().edit(selected);
             JsfUtil.addSuccessMessage("Deleted Successfully");
         } else {
-            JsfUtil.addSuccessMessage("Nothing to Delete");
+            JsfUtil.addErrorMessage("Nothing to Delete");
         }
         recreateModel();
         getItems();

--- a/src/main/java/com/divudi/bean/hr/DesignationController.java
+++ b/src/main/java/com/divudi/bean/hr/DesignationController.java
@@ -134,7 +134,7 @@ public class DesignationController implements Serializable {
             getFacade().edit(current);
             JsfUtil.addSuccessMessage("Deleted Successfully");
         } else {
-            JsfUtil.addSuccessMessage("Nothing to Delete");
+            JsfUtil.addErrorMessage("Nothing to Delete");
         }
         recreateModel();
         getItems();

--- a/src/main/java/com/divudi/bean/hr/FingerPrintRecordController.java
+++ b/src/main/java/com/divudi/bean/hr/FingerPrintRecordController.java
@@ -246,7 +246,7 @@ public class FingerPrintRecordController implements Serializable {
             getFacade().edit(current);
             JsfUtil.addSuccessMessage("Deleted Successfully");
         } else {
-            JsfUtil.addSuccessMessage("Nothing to Delete");
+            JsfUtil.addErrorMessage("Nothing to Delete");
         }
         recreateModel();
         getItems();

--- a/src/main/java/com/divudi/bean/hr/GradeController.java
+++ b/src/main/java/com/divudi/bean/hr/GradeController.java
@@ -131,7 +131,7 @@ public class GradeController implements Serializable {
             getFacade().edit(current);
             JsfUtil.addSuccessMessage("Deleted Successfully");
         } else {
-            JsfUtil.addSuccessMessage("Nothing to Delete");
+            JsfUtil.addErrorMessage("Nothing to Delete");
         }
         recreateModel();
         getItems();

--- a/src/main/java/com/divudi/bean/hr/HrmVariablesController.java
+++ b/src/main/java/com/divudi/bean/hr/HrmVariablesController.java
@@ -119,7 +119,7 @@ public class HrmVariablesController implements Serializable {
             getFacade().edit(current);
             JsfUtil.addSuccessMessage("Deleted Successfully");
         } else {
-            JsfUtil.addSuccessMessage("Nothing to Delete");
+            JsfUtil.addErrorMessage("Nothing to Delete");
         }
 
         current = null;

--- a/src/main/java/com/divudi/bean/hr/LoanController.java
+++ b/src/main/java/com/divudi/bean/hr/LoanController.java
@@ -138,7 +138,7 @@ public class LoanController implements Serializable {
             getFacade().edit(current);
             JsfUtil.addSuccessMessage("Deleted Successfully");
         } else {
-            JsfUtil.addSuccessMessage("Nothing to Delete");
+            JsfUtil.addErrorMessage("Nothing to Delete");
         }
         recreateModel();
         getItems();

--- a/src/main/java/com/divudi/bean/hr/PaysheetComponentController.java
+++ b/src/main/java/com/divudi/bean/hr/PaysheetComponentController.java
@@ -174,7 +174,7 @@ public class PaysheetComponentController implements Serializable {
             getFacade().edit(current);
             JsfUtil.addSuccessMessage("Deleted Successfully");
         } else {
-            JsfUtil.addSuccessMessage("Nothing to Delete");
+            JsfUtil.addErrorMessage("Nothing to Delete");
         }
         recreateModel();
         getItems();

--- a/src/main/java/com/divudi/bean/hr/PaysheetComponentSystemController.java
+++ b/src/main/java/com/divudi/bean/hr/PaysheetComponentSystemController.java
@@ -168,7 +168,7 @@ public class PaysheetComponentSystemController implements Serializable {
             getFacade().edit(current);
             JsfUtil.addSuccessMessage("Deleted Successfully");
         } else {
-            JsfUtil.addSuccessMessage("Nothing to Delete");
+            JsfUtil.addErrorMessage("Nothing to Delete");
         }
         recreateModel();
         getItems();

--- a/src/main/java/com/divudi/bean/hr/PhDateController.java
+++ b/src/main/java/com/divudi/bean/hr/PhDateController.java
@@ -178,7 +178,7 @@ public class PhDateController implements Serializable {
             getFacade().edit(current);
             JsfUtil.addSuccessMessage("Deleted Successfully");
         } else {
-            JsfUtil.addSuccessMessage("Nothing to Delete");
+            JsfUtil.addErrorMessage("Nothing to Delete");
         }
         recreateModel();
         getItems();

--- a/src/main/java/com/divudi/bean/hr/RosterController.java
+++ b/src/main/java/com/divudi/bean/hr/RosterController.java
@@ -133,7 +133,7 @@ public class RosterController implements Serializable {
             getFacade().edit(current);
             JsfUtil.addSuccessMessage("Deleted Successfully");
         } else {
-            JsfUtil.addSuccessMessage("Nothing to Delete");
+            JsfUtil.addErrorMessage("Nothing to Delete");
         }
         recreateModel();
         getItems();

--- a/src/main/java/com/divudi/bean/hr/SalaryCycleController.java
+++ b/src/main/java/com/divudi/bean/hr/SalaryCycleController.java
@@ -311,7 +311,7 @@ public class SalaryCycleController implements Serializable {
 //            getRosterFacade().edit(getCurrentRoster());
             JsfUtil.addSuccessMessage("Deleted Successfully");
         } else {
-            JsfUtil.addSuccessMessage("Nothing to Delete");
+            JsfUtil.addErrorMessage("Nothing to Delete");
         }
         //   recreateModel();
 

--- a/src/main/java/com/divudi/bean/hr/StaffCategoryController.java
+++ b/src/main/java/com/divudi/bean/hr/StaffCategoryController.java
@@ -135,7 +135,7 @@ public class StaffCategoryController implements Serializable {
             getFacade().edit(current);
             JsfUtil.addSuccessMessage("Deleted Successfully");
         } else {
-            JsfUtil.addSuccessMessage("Nothing to Delete");
+            JsfUtil.addErrorMessage("Nothing to Delete");
         }
         recreateModel();
         getItems();

--- a/src/main/java/com/divudi/bean/hr/StaffController.java
+++ b/src/main/java/com/divudi/bean/hr/StaffController.java
@@ -1170,7 +1170,7 @@ public class StaffController implements Serializable {
     public void delete() {
         if (current != null) {
             if (current.getId() == null) {
-                JsfUtil.addSuccessMessage("Nothing To Delete");
+                JsfUtil.addErrorMessage("Nothing To Delete");
             } else {
 
                 current.setRetired(true);
@@ -1180,7 +1180,7 @@ public class StaffController implements Serializable {
                 JsfUtil.addSuccessMessage("Deleted Successfully");
             }
         } else {
-            JsfUtil.addSuccessMessage("Nothing to Delete");
+            JsfUtil.addErrorMessage("Nothing to Delete");
         }
         recreateModel();
         getItems();

--- a/src/main/java/com/divudi/bean/hr/StaffGroupController.java
+++ b/src/main/java/com/divudi/bean/hr/StaffGroupController.java
@@ -109,7 +109,7 @@ public class StaffGroupController implements Serializable {
 //            getFacade().edit(current);
 //            JsfUtil.addSuccessMessage("Deleted Successfully");
 //        } else {
-//            JsfUtil.addSuccessMessage("Nothing to Delete");
+//            JsfUtil.addErrorMessage("Nothing to Delete");
 //        }
 //        recreateModel();
 //        getItems();

--- a/src/main/java/com/divudi/bean/hr/StaffLeaveEntitleController.java
+++ b/src/main/java/com/divudi/bean/hr/StaffLeaveEntitleController.java
@@ -193,7 +193,7 @@ public class StaffLeaveEntitleController implements Serializable {
             getFacade().edit(current);
             JsfUtil.addSuccessMessage("Deleted Successfully");
         } else {
-            JsfUtil.addSuccessMessage("Nothing to Delete");
+            JsfUtil.addErrorMessage("Nothing to Delete");
         }
         recreateModel();
         getItems();

--- a/src/main/java/com/divudi/bean/hr/WorkingTimeController.java
+++ b/src/main/java/com/divudi/bean/hr/WorkingTimeController.java
@@ -682,7 +682,7 @@ public class WorkingTimeController implements Serializable {
             getFacade().edit(current);
             JsfUtil.addSuccessMessage("Deleted Successfully");
         } else {
-            JsfUtil.addSuccessMessage("Nothing to Delete");
+            JsfUtil.addErrorMessage("Nothing to Delete");
         }
         recreateModel();
         getItems();

--- a/src/main/java/com/divudi/bean/inward/AdmissionController.java
+++ b/src/main/java/com/divudi/bean/inward/AdmissionController.java
@@ -1145,7 +1145,7 @@ public class AdmissionController implements Serializable, ControllerWithPatient 
             getFacade().edit(getCurrent());
             JsfUtil.addSuccessMessage("Deleted Successfully");
         } else {
-            JsfUtil.addSuccessMessage("Nothing to Delete");
+            JsfUtil.addErrorMessage("Nothing to Delete");
         }
         prepereToAdmitNewPatient();
 //        getItems();

--- a/src/main/java/com/divudi/bean/inward/AdmissionTypeController.java
+++ b/src/main/java/com/divudi/bean/inward/AdmissionTypeController.java
@@ -164,7 +164,7 @@ public class AdmissionTypeController implements Serializable {
             getFacade().edit(getCurrent());
             JsfUtil.addSuccessMessage("Deleted Successfully");
         } else {
-            JsfUtil.addSuccessMessage("Nothing to Delete");
+            JsfUtil.addErrorMessage("Nothing to Delete");
         }
         recreateModel();
         getItems();

--- a/src/main/java/com/divudi/bean/inward/BhtEditController.java
+++ b/src/main/java/com/divudi/bean/inward/BhtEditController.java
@@ -386,7 +386,7 @@ public class BhtEditController implements Serializable, ControllerWithPatient {
             getFacade().edit(getCurrent());
             JsfUtil.addSuccessMessage("Deleted Successfully");
         } else {
-            JsfUtil.addSuccessMessage("Nothing to Delete");
+            JsfUtil.addErrorMessage("Nothing to Delete");
         }
         prepereForNew();
         getItems();

--- a/src/main/java/com/divudi/bean/inward/DischargeController.java
+++ b/src/main/java/com/divudi/bean/inward/DischargeController.java
@@ -84,7 +84,7 @@ public class DischargeController implements Serializable {
             getFacade().edit(getCurrent());
             JsfUtil.addSuccessMessage("Deleted Successfully");
         } else {
-            JsfUtil.addSuccessMessage("Nothing to Delete");
+            JsfUtil.addErrorMessage("Nothing to Delete");
         }
         makeNull();
         getItems();

--- a/src/main/java/com/divudi/bean/inward/InpatientClinicalDataController.java
+++ b/src/main/java/com/divudi/bean/inward/InpatientClinicalDataController.java
@@ -2408,7 +2408,7 @@ public class InpatientClinicalDataController implements Serializable {
             getFacade().edit(current);
             JsfUtil.addSuccessMessage("Deleted Successfully");
         } else {
-            JsfUtil.addSuccessMessage("Nothing to Delete");
+            JsfUtil.addErrorMessage("Nothing to Delete");
         }
         recreateModel();
         getItems();

--- a/src/main/java/com/divudi/bean/inward/InwardPriceAdjustmntController.java
+++ b/src/main/java/com/divudi/bean/inward/InwardPriceAdjustmntController.java
@@ -304,7 +304,7 @@ public class InwardPriceAdjustmntController implements Serializable {
             getFacade().edit(current);
             JsfUtil.addSuccessMessage("Deleted Successfully");
         } else {
-            JsfUtil.addSuccessMessage("Nothing to Delete");
+            JsfUtil.addErrorMessage("Nothing to Delete");
         }
         //    recreateModel();
         getItems();

--- a/src/main/java/com/divudi/bean/inward/InwardServiceController.java
+++ b/src/main/java/com/divudi/bean/inward/InwardServiceController.java
@@ -316,7 +316,7 @@ public class InwardServiceController implements Serializable {
             getFacade().edit(current);
             JsfUtil.addSuccessMessage("Deleted Successfully");
         } else {
-            JsfUtil.addSuccessMessage("Nothing to Delete");
+            JsfUtil.addErrorMessage("Nothing to Delete");
         }
         recreateModel();
         getItems();

--- a/src/main/java/com/divudi/bean/inward/InwardStaffPaymentBillController.java
+++ b/src/main/java/com/divudi/bean/inward/InwardStaffPaymentBillController.java
@@ -1592,7 +1592,7 @@ public class InwardStaffPaymentBillController implements Serializable {
             getFacade().edit(current);
             JsfUtil.addSuccessMessage("Deleted Successfully");
         } else {
-            JsfUtil.addSuccessMessage("Nothing to Delete");
+            JsfUtil.addErrorMessage("Nothing to Delete");
         }
         recreateModel();
         getItems();

--- a/src/main/java/com/divudi/bean/inward/PatientRoomController.java
+++ b/src/main/java/com/divudi/bean/inward/PatientRoomController.java
@@ -126,7 +126,7 @@ public class PatientRoomController implements Serializable {
             getFacade().edit(current);
             JsfUtil.addSuccessMessage("Deleted Successfully");
         } else {
-            JsfUtil.addSuccessMessage("Nothing to Delete");
+            JsfUtil.addErrorMessage("Nothing to Delete");
         }
         recreateModel();
         current = null;

--- a/src/main/java/com/divudi/bean/inward/RoomCategoryController.java
+++ b/src/main/java/com/divudi/bean/inward/RoomCategoryController.java
@@ -122,7 +122,7 @@ public class RoomCategoryController implements Serializable {
             getFacade().edit(current);
             JsfUtil.addSuccessMessage("Deleted Successfully");
         } else {
-            JsfUtil.addSuccessMessage("Nothing to Delete");
+            JsfUtil.addErrorMessage("Nothing to Delete");
         }
         recreateModel();
         getItems();

--- a/src/main/java/com/divudi/bean/inward/RoomChangeController.java
+++ b/src/main/java/com/divudi/bean/inward/RoomChangeController.java
@@ -504,7 +504,7 @@ public class RoomChangeController implements Serializable {
             getFacade().edit(getCurrent());
             JsfUtil.addSuccessMessage("Deleted Successfully");
         } else {
-            JsfUtil.addSuccessMessage("Nothing to Delete");
+            JsfUtil.addErrorMessage("Nothing to Delete");
         }
         recreateModel();
         getItems();

--- a/src/main/java/com/divudi/bean/inward/RoomController.java
+++ b/src/main/java/com/divudi/bean/inward/RoomController.java
@@ -122,7 +122,7 @@ public class RoomController implements Serializable {
             getFacade().edit(current);
             JsfUtil.addSuccessMessage("Deleted Successfully");
         } else {
-            JsfUtil.addSuccessMessage("Nothing to Delete");
+            JsfUtil.addErrorMessage("Nothing to Delete");
         }
         recreateModel();
         getItems();

--- a/src/main/java/com/divudi/bean/inward/RoomFacilityChargeController.java
+++ b/src/main/java/com/divudi/bean/inward/RoomFacilityChargeController.java
@@ -280,7 +280,7 @@ public class RoomFacilityChargeController implements Serializable {
             getFacade().edit(current);
             JsfUtil.addSuccessMessage("Deleted Successfully");
         } else {
-            JsfUtil.addSuccessMessage("Nothing to Delete");
+            JsfUtil.addErrorMessage("Nothing to Delete");
         }
         recreateModel();
         getItems();

--- a/src/main/java/com/divudi/bean/inward/TheatreServiceController.java
+++ b/src/main/java/com/divudi/bean/inward/TheatreServiceController.java
@@ -309,7 +309,7 @@ public class TheatreServiceController implements Serializable {
             getTheatreServiceFacade().edit(current);
             JsfUtil.addSuccessMessage("Deleted Successfully");
         } else {
-            JsfUtil.addSuccessMessage("Nothing to Delete");
+            JsfUtil.addErrorMessage("Nothing to Delete");
         }
         recreateModel();
         getItems();

--- a/src/main/java/com/divudi/bean/inward/TimedItemCategoryController.java
+++ b/src/main/java/com/divudi/bean/inward/TimedItemCategoryController.java
@@ -116,7 +116,7 @@ public  class TimedItemCategoryController implements Serializable {
             getFacade().edit(current);
             JsfUtil.addSuccessMessage("Deleted Successfully");
         } else {
-            JsfUtil.addSuccessMessage("Nothing to Delete");
+            JsfUtil.addErrorMessage("Nothing to Delete");
         }
         recreateModel();
         getItems();

--- a/src/main/java/com/divudi/bean/inward/TimedItemController.java
+++ b/src/main/java/com/divudi/bean/inward/TimedItemController.java
@@ -357,7 +357,7 @@ public class TimedItemController implements Serializable {
             getFacade().edit(current);
             JsfUtil.addSuccessMessage("Deleted Successfully");
         } else {
-            JsfUtil.addSuccessMessage("Nothing to Delete");
+            JsfUtil.addErrorMessage("Nothing to Delete");
         }
         recreateModel();
         getItems();

--- a/src/main/java/com/divudi/bean/inward/TimedItemFeeController.java
+++ b/src/main/java/com/divudi/bean/inward/TimedItemFeeController.java
@@ -187,7 +187,7 @@ public class TimedItemFeeController implements Serializable {
             getFacade().edit(currentIx);
             JsfUtil.addSuccessMessage("Deleted Successfully");
         } else {
-            JsfUtil.addSuccessMessage("Nothing to Delete");
+            JsfUtil.addErrorMessage("Nothing to Delete");
         }
 
         currentIx = null;

--- a/src/main/java/com/divudi/bean/lab/AntibioticController.java
+++ b/src/main/java/com/divudi/bean/lab/AntibioticController.java
@@ -235,7 +235,7 @@ public class AntibioticController implements Serializable {
             getFacade().edit(current);
             JsfUtil.addSuccessMessage("Deleted Successfully");
         } else {
-            JsfUtil.addSuccessMessage("Nothing to Delete");
+            JsfUtil.addErrorMessage("Nothing to Delete");
         }
         recreateModel();
         getItems();

--- a/src/main/java/com/divudi/bean/lab/CollectingCentreController.java
+++ b/src/main/java/com/divudi/bean/lab/CollectingCentreController.java
@@ -591,7 +591,7 @@ public class CollectingCentreController implements Serializable {
             getFacade().edit(current);
             JsfUtil.addSuccessMessage("Deleted Successfully");
         } else {
-            JsfUtil.addSuccessMessage("Nothing to Delete");
+            JsfUtil.addErrorMessage("Nothing to Delete");
         }
         recreateModel();
         getItems();

--- a/src/main/java/com/divudi/bean/lab/InvestigationCategoryController.java
+++ b/src/main/java/com/divudi/bean/lab/InvestigationCategoryController.java
@@ -149,7 +149,7 @@ public class InvestigationCategoryController implements Serializable {
             getFacade().edit(current);
             JsfUtil.addSuccessMessage("Deleted Successfully");
         } else {
-            JsfUtil.addSuccessMessage("Nothing to Delete");
+            JsfUtil.addErrorMessage("Nothing to Delete");
         }
         recreateModel();
         getItems();

--- a/src/main/java/com/divudi/bean/lab/InvestigationController.java
+++ b/src/main/java/com/divudi/bean/lab/InvestigationController.java
@@ -1861,7 +1861,7 @@ public class InvestigationController implements Serializable {
             getFacade().edit(current);
             JsfUtil.addSuccessMessage("Deleted Successfully");
         } else {
-            JsfUtil.addSuccessMessage("Nothing to Delete");
+            JsfUtil.addErrorMessage("Nothing to Delete");
         }
         recreateModel();
         getItems();

--- a/src/main/java/com/divudi/bean/lab/InvestigationItemDynamicLabelController.java
+++ b/src/main/java/com/divudi/bean/lab/InvestigationItemDynamicLabelController.java
@@ -339,7 +339,7 @@ public class InvestigationItemDynamicLabelController implements Serializable {
             getFacade().edit(current);
             JsfUtil.addSuccessMessage("Deleted Successfully");
         } else {
-            JsfUtil.addSuccessMessage("Nothing to Delete");
+            JsfUtil.addErrorMessage("Nothing to Delete");
         }
         recreateModel();
         getItems();

--- a/src/main/java/com/divudi/bean/lab/InvestigationItemValueController.java
+++ b/src/main/java/com/divudi/bean/lab/InvestigationItemValueController.java
@@ -161,7 +161,7 @@ public class InvestigationItemValueController implements Serializable {
             getFacade().edit(current);
             JsfUtil.addSuccessMessage("Deleted Successfully");
         } else {
-            JsfUtil.addSuccessMessage("Nothing to Delete");
+            JsfUtil.addErrorMessage("Nothing to Delete");
         }
         recreateModel();
         current = null;

--- a/src/main/java/com/divudi/bean/lab/InvestigationTubeController.java
+++ b/src/main/java/com/divudi/bean/lab/InvestigationTubeController.java
@@ -152,7 +152,7 @@ public class InvestigationTubeController implements Serializable {
             getFacade().edit(current);
             JsfUtil.addSuccessMessage("Deleted Successfully");
         } else {
-            JsfUtil.addSuccessMessage("Nothing to Delete");
+            JsfUtil.addErrorMessage("Nothing to Delete");
         }
         recreateModel();
         getItems();

--- a/src/main/java/com/divudi/bean/lab/LabAmpController.java
+++ b/src/main/java/com/divudi/bean/lab/LabAmpController.java
@@ -151,7 +151,7 @@ public class LabAmpController implements Serializable {
             getFacade().edit(current);
             JsfUtil.addSuccessMessage("Deleted Successfully");
         } else {
-            JsfUtil.addSuccessMessage("Nothing to Delete");
+            JsfUtil.addErrorMessage("Nothing to Delete");
         }
         recreateModel();
         getItems();

--- a/src/main/java/com/divudi/bean/lab/MachineController.java
+++ b/src/main/java/com/divudi/bean/lab/MachineController.java
@@ -64,7 +64,7 @@ public class MachineController implements Serializable {
             getEjbFacade().edit(current);
             JsfUtil.addSuccessMessage("Deleted Successfully");
         } else {
-            JsfUtil.addSuccessMessage("Nothing to Delete");
+            JsfUtil.addErrorMessage("Nothing to Delete");
         }
         recreateModel();
         getItems();

--- a/src/main/java/com/divudi/bean/lab/PatientInvestigationController.java
+++ b/src/main/java/com/divudi/bean/lab/PatientInvestigationController.java
@@ -5360,7 +5360,7 @@ public class PatientInvestigationController implements Serializable {
             getFacade().edit(current);
             JsfUtil.addSuccessMessage("Deleted Successfully");
         } else {
-            JsfUtil.addSuccessMessage("Nothing to Delete");
+            JsfUtil.addErrorMessage("Nothing to Delete");
         }
         recreateModel();
         getItems();

--- a/src/main/java/com/divudi/bean/lab/PatientSampleController.java
+++ b/src/main/java/com/divudi/bean/lab/PatientSampleController.java
@@ -180,7 +180,7 @@ public class PatientSampleController implements Serializable {
             getFacade().edit(current);
             JsfUtil.addSuccessMessage("Deleted Successfully");
         } else {
-            JsfUtil.addSuccessMessage("Nothing to Delete");
+            JsfUtil.addErrorMessage("Nothing to Delete");
         }
         recreateModel();
         getItems();

--- a/src/main/java/com/divudi/bean/lab/ReportFormatController.java
+++ b/src/main/java/com/divudi/bean/lab/ReportFormatController.java
@@ -243,7 +243,7 @@ public class ReportFormatController implements Serializable {
             getFacade().edit(current);
             JsfUtil.addSuccessMessage("Deleted Successfully");
         } else {
-            JsfUtil.addSuccessMessage("Nothing to Delete");
+            JsfUtil.addErrorMessage("Nothing to Delete");
         }
         recreateModel();
         getItems();

--- a/src/main/java/com/divudi/bean/lab/SampleController.java
+++ b/src/main/java/com/divudi/bean/lab/SampleController.java
@@ -130,7 +130,7 @@ public class SampleController implements Serializable {
             getFacade().edit(current);
             JsfUtil.addSuccessMessage("Deleted Successfully");
         } else {
-            JsfUtil.addSuccessMessage("Nothing to Delete");
+            JsfUtil.addErrorMessage("Nothing to Delete");
         }
         recreateModel();
         getItems();

--- a/src/main/java/com/divudi/bean/lab/TestFlagController.java
+++ b/src/main/java/com/divudi/bean/lab/TestFlagController.java
@@ -371,7 +371,7 @@ public class TestFlagController implements Serializable {
             getFacade().edit(current);
             JsfUtil.addSuccessMessage("Deleted Successfully");
         } else {
-            JsfUtil.addSuccessMessage("Nothing to Delete");
+            JsfUtil.addErrorMessage("Nothing to Delete");
         }
         recreateModel();
         getItems();

--- a/src/main/java/com/divudi/bean/membership/MembershipSchemeController.java
+++ b/src/main/java/com/divudi/bean/membership/MembershipSchemeController.java
@@ -185,7 +185,7 @@ public class MembershipSchemeController implements Serializable {
             getFacade().edit(current);
             JsfUtil.addSuccessMessage("Deleted Successfully");
         } else {
-            JsfUtil.addSuccessMessage("Nothing to Delete");
+            JsfUtil.addErrorMessage("Nothing to Delete");
         }
         recreateModel();
         fillItems();

--- a/src/main/java/com/divudi/bean/membership/OpdMemberShipDiscountController.java
+++ b/src/main/java/com/divudi/bean/membership/OpdMemberShipDiscountController.java
@@ -723,7 +723,7 @@ public class OpdMemberShipDiscountController implements Serializable {
             getFacade().edit(current);
             JsfUtil.addSuccessMessage("Deleted Successfully");
         } else {
-            JsfUtil.addSuccessMessage("Nothing to Delete");
+            JsfUtil.addErrorMessage("Nothing to Delete");
         }
         //    recreateModel();
 
@@ -741,7 +741,7 @@ public class OpdMemberShipDiscountController implements Serializable {
             getFacade().edit(current);
             JsfUtil.addSuccessMessage("Deleted Successfully");
         } else {
-            JsfUtil.addSuccessMessage("Nothing to Delete");
+            JsfUtil.addErrorMessage("Nothing to Delete");
         }
         //    recreateModel();
 
@@ -798,7 +798,7 @@ public class OpdMemberShipDiscountController implements Serializable {
             getFacade().edit(current);
             JsfUtil.addSuccessMessage("Deleted Successfully");
         } else {
-            JsfUtil.addSuccessMessage("Nothing to Delete");
+            JsfUtil.addErrorMessage("Nothing to Delete");
         }
         //    recreateModel();
 

--- a/src/main/java/com/divudi/bean/membership/PaymentSchemeController.java
+++ b/src/main/java/com/divudi/bean/membership/PaymentSchemeController.java
@@ -315,7 +315,7 @@ public class PaymentSchemeController implements Serializable {
             getFacade().edit(paymentScheme);
             JsfUtil.addSuccessMessage("Deleted Successfully");
         } else {
-            JsfUtil.addSuccessMessage("Nothing to Delete");
+            JsfUtil.addErrorMessage("Nothing to Delete");
         }
         recreateModel();
         getItems();

--- a/src/main/java/com/divudi/bean/pharmacy/AdjustmentCategoryController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/AdjustmentCategoryController.java
@@ -116,7 +116,7 @@ public class AdjustmentCategoryController implements Serializable {
             getFacade().edit(current);
             JsfUtil.addSuccessMessage("Deleted Successfully");
         } else {
-            JsfUtil.addSuccessMessage("Nothing to Delete");
+            JsfUtil.addErrorMessage("Nothing to Delete");
         }
         recreateModel();
         getItems();

--- a/src/main/java/com/divudi/bean/pharmacy/AmpController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/AmpController.java
@@ -1001,7 +1001,7 @@ public class AmpController implements Serializable {
             getFacade().edit(current);
             JsfUtil.addSuccessMessage("Deleted Successfully");
         } else {
-            JsfUtil.addSuccessMessage("Nothing to Delete");
+            JsfUtil.addErrorMessage("Nothing to Delete");
         }
         recreateModel();
         getItems();

--- a/src/main/java/com/divudi/bean/pharmacy/AmppController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/AmppController.java
@@ -194,7 +194,7 @@ public class AmppController implements Serializable {
             getFacade().edit(current);
             JsfUtil.addSuccessMessage("Deleted Successfully");
         } else {
-            JsfUtil.addSuccessMessage("Nothing to Delete");
+            JsfUtil.addErrorMessage("Nothing to Delete");
         }
         recreateModel();
         getItems();

--- a/src/main/java/com/divudi/bean/pharmacy/AtmController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/AtmController.java
@@ -254,7 +254,7 @@ public class AtmController implements Serializable {
             getFacade().edit(current);
             JsfUtil.addSuccessMessage("Deleted Successfully");
         } else {
-            JsfUtil.addSuccessMessage("Nothing to Delete");
+            JsfUtil.addErrorMessage("Nothing to Delete");
         }
         recreateModel();
         getItems();

--- a/src/main/java/com/divudi/bean/pharmacy/DealerController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/DealerController.java
@@ -219,7 +219,7 @@ public class DealerController implements Serializable {
             getFacade().edit(current);
             JsfUtil.addSuccessMessage("Deleted Successfully");
         } else {
-            JsfUtil.addSuccessMessage("Nothing to Delete");
+            JsfUtil.addErrorMessage("Nothing to Delete");
         }
         recreateModel();
         //      getItems();

--- a/src/main/java/com/divudi/bean/pharmacy/DiscardCategoryController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/DiscardCategoryController.java
@@ -119,7 +119,7 @@ public class DiscardCategoryController implements Serializable {
             getFacade().edit(current);
             JsfUtil.addSuccessMessage("Deleted Successfully");
         } else {
-            JsfUtil.addSuccessMessage("Nothing to Delete");
+            JsfUtil.addErrorMessage("Nothing to Delete");
         }
         recreateModel();
         getItems();

--- a/src/main/java/com/divudi/bean/pharmacy/DosageFormController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/DosageFormController.java
@@ -198,7 +198,7 @@ public class DosageFormController implements Serializable {
             getFacade().edit(current);
             JsfUtil.addSuccessMessage("Deleted Successfully");
         } else {
-            JsfUtil.addSuccessMessage("Nothing to Delete");
+            JsfUtil.addErrorMessage("Nothing to Delete");
         }
         recreateModel();
         getItems();

--- a/src/main/java/com/divudi/bean/pharmacy/FrequencyUnitController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/FrequencyUnitController.java
@@ -119,7 +119,7 @@ public  class FrequencyUnitController implements Serializable {
             getFacade().edit(current);
             JsfUtil.addSuccessMessage("Deleted Successfully");
         } else {
-            JsfUtil.addSuccessMessage("Nothing to Delete");
+            JsfUtil.addErrorMessage("Nothing to Delete");
         }
         recreateModel();
         getItems();

--- a/src/main/java/com/divudi/bean/pharmacy/ImporterController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/ImporterController.java
@@ -112,7 +112,7 @@ public class ImporterController implements Serializable {
             getFacade().edit(current);
             JsfUtil.addSuccessMessage("Deleted Successfully");
         } else {
-            JsfUtil.addSuccessMessage("Nothing to Delete");
+            JsfUtil.addErrorMessage("Nothing to Delete");
         }
         recreateModel();
         getItems();

--- a/src/main/java/com/divudi/bean/pharmacy/ItemsDistributorsController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/ItemsDistributorsController.java
@@ -342,7 +342,7 @@ public class ItemsDistributorsController implements Serializable {
             getFacade().edit(current);
             JsfUtil.addSuccessMessage("Deleted Successfully");
         } else {
-            JsfUtil.addSuccessMessage("Nothing to Delete");
+            JsfUtil.addErrorMessage("Nothing to Delete");
         }
         recreateModel();
         getItems();

--- a/src/main/java/com/divudi/bean/pharmacy/ManufacturerController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/ManufacturerController.java
@@ -128,7 +128,7 @@ public class ManufacturerController implements Serializable {
             getFacade().edit(current);
             JsfUtil.addSuccessMessage("Deleted Successfully");
         } else {
-            JsfUtil.addSuccessMessage("Nothing to Delete");
+            JsfUtil.addErrorMessage("Nothing to Delete");
         }
         recreateModel();
         getItems();

--- a/src/main/java/com/divudi/bean/pharmacy/MeasurementUnitController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/MeasurementUnitController.java
@@ -230,7 +230,7 @@ public class MeasurementUnitController implements Serializable {
             getFacade().edit(current);
             JsfUtil.addSuccessMessage("Deleted Successfully");
         } else {
-            JsfUtil.addSuccessMessage("Nothing to Delete");
+            JsfUtil.addErrorMessage("Nothing to Delete");
         }
         recreateModel();
         getItems();

--- a/src/main/java/com/divudi/bean/pharmacy/PharmaceuticalItemCategoryController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmaceuticalItemCategoryController.java
@@ -198,7 +198,7 @@ public class PharmaceuticalItemCategoryController implements Serializable {
             getFacade().edit(current);
             JsfUtil.addSuccessMessage("Deleted Successfully");
         } else {
-            JsfUtil.addSuccessMessage("Nothing to Delete");
+            JsfUtil.addErrorMessage("Nothing to Delete");
         }
         recreateModel();
         getItems();

--- a/src/main/java/com/divudi/bean/pharmacy/PharmaceuticalItemTypeController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmaceuticalItemTypeController.java
@@ -120,7 +120,7 @@ public class PharmaceuticalItemTypeController implements Serializable {
             getFacade().edit(current);
             JsfUtil.addSuccessMessage("Deleted Successfully");
         } else {
-            JsfUtil.addSuccessMessage("Nothing to Delete");
+            JsfUtil.addErrorMessage("Nothing to Delete");
         }
         recreateModel();
         getItems();

--- a/src/main/java/com/divudi/bean/pharmacy/StockController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/StockController.java
@@ -1045,7 +1045,7 @@ public class StockController implements Serializable {
             getFacade().remove(current);
             JsfUtil.addSuccessMessage("Deleted Successfully");
         } else {
-            JsfUtil.addSuccessMessage("Nothing to Delete");
+            JsfUtil.addErrorMessage("Nothing to Delete");
         }
         recreateModel();
         getItems();

--- a/src/main/java/com/divudi/bean/pharmacy/VmpController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/VmpController.java
@@ -657,7 +657,7 @@ public class VmpController implements Serializable {
 
             JsfUtil.addSuccessMessage("Deleted Successfully");
         } else {
-            JsfUtil.addSuccessMessage("Nothing to Delete");
+            JsfUtil.addErrorMessage("Nothing to Delete");
         }
         recreateModel();
         getItems();

--- a/src/main/java/com/divudi/bean/pharmacy/VmppController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/VmppController.java
@@ -163,7 +163,7 @@ public class VmppController implements Serializable {
 
             JsfUtil.addSuccessMessage("Deleted Successfully");
         } else {
-            JsfUtil.addSuccessMessage("Nothing to Delete");
+            JsfUtil.addErrorMessage("Nothing to Delete");
         }
         recreateModel();
         current = null;

--- a/src/main/java/com/divudi/bean/pharmacy/VtmController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/VtmController.java
@@ -379,7 +379,7 @@ public class VtmController implements Serializable {
             getFacade().edit(current);
             JsfUtil.addSuccessMessage("Deleted Successfully");
         } else {
-            JsfUtil.addSuccessMessage("Nothing to Delete");
+            JsfUtil.addErrorMessage("Nothing to Delete");
         }
         current = null;
         items = null;

--- a/src/main/java/com/divudi/bean/pharmacy/VtmInVmpController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/VtmInVmpController.java
@@ -117,7 +117,7 @@ public class VtmInVmpController implements Serializable {
             getFacade().edit(current);
             JsfUtil.addSuccessMessage("Deleted Successfully");
         } else {
-            JsfUtil.addSuccessMessage("Nothing to Delete");
+            JsfUtil.addErrorMessage("Nothing to Delete");
         }
         recreateModel();
         getItems();

--- a/src/main/java/com/divudi/bean/store/StoreAmpController.java
+++ b/src/main/java/com/divudi/bean/store/StoreAmpController.java
@@ -151,7 +151,7 @@ public class StoreAmpController implements Serializable {
             getFacade().edit(current);
             JsfUtil.addSuccessMessage("Deleted Successfully");
         } else {
-            JsfUtil.addSuccessMessage("Nothing to Delete");
+            JsfUtil.addErrorMessage("Nothing to Delete");
         }
         recreateModel();
         getItems();

--- a/src/main/java/com/divudi/bean/store/StoreDealorController.java
+++ b/src/main/java/com/divudi/bean/store/StoreDealorController.java
@@ -126,7 +126,7 @@ public class StoreDealorController implements Serializable {
             getFacade().edit(current);
             JsfUtil.addSuccessMessage("Deleted Successfully");
         } else {
-            JsfUtil.addSuccessMessage("Nothing to Delete");
+            JsfUtil.addErrorMessage("Nothing to Delete");
         }
         recreateModel();
         //      getItems();

--- a/src/main/java/com/divudi/bean/store/StoreFrequencyUnitController.java
+++ b/src/main/java/com/divudi/bean/store/StoreFrequencyUnitController.java
@@ -114,7 +114,7 @@ public  class StoreFrequencyUnitController implements Serializable {
             getFacade().edit(current);
             JsfUtil.addSuccessMessage("Deleted Successfully");
         } else {
-            JsfUtil.addSuccessMessage("Nothing to Delete");
+            JsfUtil.addErrorMessage("Nothing to Delete");
         }
         recreateModel();
         getItems();

--- a/src/main/java/com/divudi/bean/store/StoreInventryAmpController.java
+++ b/src/main/java/com/divudi/bean/store/StoreInventryAmpController.java
@@ -115,7 +115,7 @@ public class StoreInventryAmpController implements Serializable {
             getFacade().edit(current);
             JsfUtil.addSuccessMessage("Deleted Successfully");
         } else {
-            JsfUtil.addSuccessMessage("Nothing to Delete");
+            JsfUtil.addErrorMessage("Nothing to Delete");
         }
         recreateModel();
         getItems();

--- a/src/main/java/com/divudi/bean/store/StoreItemCategoryController.java
+++ b/src/main/java/com/divudi/bean/store/StoreItemCategoryController.java
@@ -150,7 +150,7 @@ public class StoreItemCategoryController implements Serializable {
             getFacade().edit(current);
             JsfUtil.addSuccessMessage("Deleted Successfully");
         } else {
-            JsfUtil.addSuccessMessage("Nothing to Delete");
+            JsfUtil.addErrorMessage("Nothing to Delete");
         }
         recreateModel();
         getItems();

--- a/src/main/java/com/divudi/bean/store/StoreItemsDistributorsController.java
+++ b/src/main/java/com/divudi/bean/store/StoreItemsDistributorsController.java
@@ -323,7 +323,7 @@ public class StoreItemsDistributorsController implements Serializable {
             getFacade().edit(current);
             JsfUtil.addSuccessMessage("Deleted Successfully");
         } else {
-            JsfUtil.addSuccessMessage("Nothing to Delete");
+            JsfUtil.addErrorMessage("Nothing to Delete");
         }
         recreateModel();
         getItems();

--- a/src/main/java/com/divudi/bean/store/StoreMeasurementUnitController.java
+++ b/src/main/java/com/divudi/bean/store/StoreMeasurementUnitController.java
@@ -114,7 +114,7 @@ public  class StoreMeasurementUnitController implements Serializable {
             getFacade().edit(current);
             JsfUtil.addSuccessMessage("Deleted Successfully");
         } else {
-            JsfUtil.addSuccessMessage("Nothing to Delete");
+            JsfUtil.addErrorMessage("Nothing to Delete");
         }
         recreateModel();
         getItems();


### PR DESCRIPTION
## Summary
This PR fixes a UX inconsistency across the codebase:  
When a user attempts to delete an item but **nothing is selected or available to delete**, the application currently shows a **success message** (`JsfUtil.addSuccessMessage("Nothing to Delete")`), which is misleading.

## What changed?
- Replaced `JsfUtil.addSuccessMessage("Nothing to Delete")` with `JsfUtil.addErrorMessage("Nothing to Delete")` in **all controller classes** that had this pattern.
- The change aligns with the existing correct implementation in `SurgeryTypeController.java`.
- Affected ～150 controller files — all changes are mechanical and consistent.

## Why?
- **Success messages should indicate successful actions**, not no-ops.
- Showing "Nothing to Delete" as a success confuses users and violates common UI/UX principles.
- Consistency improves maintainability and reduces cognitive load for developers.

## Notes
- This is my first contribution! I carefully reviewed the pattern and ensured all changes follow the same logic.
- Happy to adjust if you prefer a different message type (e.g., warning) or wording.

Thanks for your guidance! 🌱

Closes #18208