### PR TITLE
#18274 Need to download excel Import Items without stock

### DIFF
--- a/src/main/java/com/divudi/bean/emr/DataUploadController.java
+++ b/src/main/java/com/divudi/bean/emr/DataUploadController.java
@@ -8755,7 +8755,7 @@ public class DataUploadController implements Serializable {
 
         // Set the downloading filetemplateForPharmacyItemImport
         templateForPharmacyItemImportWithoutStock = DefaultStreamedContent.builder()
-                .name("template_for_pharmacy_item_import_with_stock.xlsx")
+                .name("template_for_pharmacy_item_import_without_stock.xlsx")
                 .contentType("application/vnd.openxmlformats-officedocument.spreadsheetml.sheet")
                 .stream(() -> inputStream)
                 .build();

--- a/src/main/webapp/pharmacy/pharmacy_item_import_without_stock.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_item_import_without_stock.xhtml
@@ -45,8 +45,8 @@
                     <p:commandButton 
                         value="Download Template" 
                         ajax="false" 
+                        styleClass="ui-button-success mb-3"
                         style="float: right;"
-                        class="ui-button-success mb-3"
                         icon="fa fa-download">
                         <p:fileDownload value="#{dataUploadController.templateForPharmacyItemImportWithoutStock}" />
                     </p:commandButton>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added pharmacy item import option that omits stock tracking.
  * Added a downloadable Excel template for pharmacy item import.
  * Consolidated the import UI into a single panel combining the template download and a detailed Excel column reference.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->