### PR TITLE
Fix GRN cancellation bills not marked as completed

### DIFF
--- a/src/main/java/com/divudi/bean/pharmacy/PharmacyBillSearch.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacyBillSearch.java
@@ -1644,6 +1644,7 @@ public class PharmacyBillSearch implements Serializable {
 
         cb.setComments(getComment());
         cb.setBillTypeAtomic(BillTypeAtomic.PHARMACY_RETAIL_SALE_CANCELLED);
+        cb.setCompleted(true);
 
         return cb;
     }

--- a/src/main/java/com/divudi/bean/store/StoreBillSearch.java
+++ b/src/main/java/com/divudi/bean/store/StoreBillSearch.java
@@ -748,6 +748,7 @@ public class StoreBillSearch implements Serializable {
         cb.setInstitution(getSessionController().getInstitution());
 
         cb.setComments(getBill().getComments());
+        cb.setCompleted(true);
 
         return cb;
     }


### PR DESCRIPTION
## Summary
- Fixed GRN cancellation bills (PHARMACY_GRN_CANCELLED, etc.) not being marked as `completed = true`
- Added `cb.setCompleted(true)` to `pharmacyCreateCancelBill()` methods in both `PharmacyBillSearch.java` and `StoreBillSearch.java`
- This ensures cancellation bills are included in the optimized daily stock report purchase value calculation

## Test plan
- [ ] Create a GRN bill
- [ ] Cancel the GRN bill
- [ ] Verify the cancellation bill has `completed = true` in the database
- [ ] Verify the optimized daily stock report now correctly shows net purchase values (original GRN minus cancellation)

Closes #18355

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed cancelled bill processing to ensure completion status is properly recorded when bills are cancelled, improving data integrity and status tracking consistency across pharmacy and store billing operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->