### PR TITLE
Add item department type filter to consumption report

### DIFF
--- a/src/main/java/com/divudi/bean/pharmacy/PharmacyController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacyController.java
@@ -3460,6 +3460,11 @@ public class PharmacyController implements Serializable {
                 tmp.put("toDept", toDepartment);
             }
 
+            if (selectedDepartmentTypes != null && !selectedDepartmentTypes.isEmpty()) {
+                jpql += " AND b.departmentType IN :departmentTypes";
+                tmp.put("departmentTypes", selectedDepartmentTypes);
+            }
+
             jpql += " order by b.createdAt asc";
 
             bills = getBillFacade().findByJpql(jpql, tmp, TemporalType.TIMESTAMP);
@@ -3615,6 +3620,11 @@ public class PharmacyController implements Serializable {
             if (toDepartment != null) {
                 jpql.append("AND bi.bill.toDepartment = :toDepartment ");
                 parameters.put("toDepartment", toDepartment);
+            }
+
+            if (selectedDepartmentTypes != null && !selectedDepartmentTypes.isEmpty()) {
+                jpql.append("AND bi.bill.departmentType IN :departmentTypes ");
+                parameters.put("departmentTypes", selectedDepartmentTypes);
             }
 
             jpql.append("ORDER BY bi.bill.createdAt ASC");
@@ -4029,6 +4039,11 @@ public class PharmacyController implements Serializable {
             if (toDepartment != null) {
                 jpql += "AND bi.bill.toDepartment = :toDepartment ";
                 parameters.put("toDepartment", toDepartment);
+            }
+
+            if (selectedDepartmentTypes != null && !selectedDepartmentTypes.isEmpty()) {
+                jpql += "AND bi.bill.departmentType IN :departmentTypes ";
+                parameters.put("departmentTypes", selectedDepartmentTypes);
             }
 
             // Group by clause - removed rates since we're aggregating values
@@ -7612,6 +7627,7 @@ public class PharmacyController implements Serializable {
     }
 
     private Institution institution;
+    private List<DepartmentType> selectedDepartmentTypes;
     private List<StockAverage> stockAverages;
 
     @Inject
@@ -10575,6 +10591,26 @@ public class PharmacyController implements Serializable {
 
     public void setPharmacyHistoryIndex(int pharmacyHistoryIndex) {
         this.pharmacyHistoryIndex = pharmacyHistoryIndex;
+    }
+
+    public List<DepartmentType> getSelectedDepartmentTypes() {
+        if (selectedDepartmentTypes == null) {
+            selectedDepartmentTypes = new ArrayList<>();
+        }
+        return selectedDepartmentTypes;
+    }
+
+    public void setSelectedDepartmentTypes(List<DepartmentType> selectedDepartmentTypes) {
+        this.selectedDepartmentTypes = selectedDepartmentTypes;
+    }
+
+    public List<DepartmentType> getAvailableDepartmentTypes() {
+        return Arrays.asList(
+            DepartmentType.Pharmacy,
+            DepartmentType.Store,
+            DepartmentType.Lab,
+            DepartmentType.Kitchen
+        );
     }
 
     public static class TransferBreakdownGroup implements Serializable {

--- a/src/main/webapp/reports/inventoryReports/consumption.xhtml
+++ b/src/main/webapp/reports/inventoryReports/consumption.xhtml
@@ -112,6 +112,30 @@
                                                itemValue="#{category}"/>
                             </p:selectOneMenu>
 
+                            <h:panelGroup layout="block" styleClass="form-group">
+                                <h:outputText styleClass="fa fa-building ml-5"/>
+                                <p:outputLabel value="Item Department Type" for="departmentTypeFilter" class="mx-3"/>
+                            </h:panelGroup>
+                            <h:panelGroup layout="block" styleClass="form-group">
+                                <p:selectCheckboxMenu
+                                    id="departmentTypeFilter"
+                                    value="#{pharmacyController.selectedDepartmentTypes}"
+                                    label="Select Department Types"
+                                    class="w-100"
+                                    filter="true"
+                                    filterMatchMode="contains"
+                                    showHeader="true"
+                                    scrollHeight="200"
+                                    title="Select one or more department types to filter results. Leave empty to include all.">
+                                    <f:selectItems
+                                        value="#{pharmacyController.availableDepartmentTypes}"
+                                        var="depType"
+                                        itemLabel="#{depType.label}"
+                                        itemValue="#{depType}"/>
+                                </p:selectCheckboxMenu>
+                                <p:tooltip for="departmentTypeFilter" value="Select one or more department types to filter results. Leave empty to include all." position="top"/>
+                            </h:panelGroup>
+
                             <p:spacer width="20"/>
 
                             <h:panelGroup layout="block" styleClass="form-group">


### PR DESCRIPTION
## Summary
- Added item department type filter (multi-select checkbox menu) to the consumption report
- Filter allows selecting Pharmacy, Store, Lab, and Kitchen department types
- Updated all consumption report query methods (byBill, byBillItem, summery/categoryWise) to filter by item's department type

Closes #18357

## Test plan
- [ ] Navigate to consumption report page
- [ ] Verify the new "Item Department Type" filter appears after the Category filter
- [ ] Select one or more department types and click Process
- [ ] Verify only items with the selected department types are shown in the report
- [ ] Leave the filter empty and verify all items are shown (no filtering)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added department-type filtering to consumption and inventory reports. Users can now select one or more department types (Pharmacy, Store, Lab, Kitchen) via a new checkbox menu to restrict report results at runtime, enabling more targeted reporting and analysis with tooltip guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->