### PR TITLE
Add department type filter to Stock Ledger Report

### DIFF
--- a/src/main/java/com/divudi/bean/report/PharmacyReportController.java
+++ b/src/main/java/com/divudi/bean/report/PharmacyReportController.java
@@ -4854,6 +4854,10 @@ public class PharmacyReportController implements Serializable {
                 jpql += "and s.item=:itm ";
                 m.put("itm", item);
             }
+            if (selectedDepartmentTypes != null && !selectedDepartmentTypes.isEmpty()) {
+                jpql += " and s.pbItem.billItem.bill.departmentType in :departmentTypes ";
+                m.put("departmentTypes", selectedDepartmentTypes);
+            }
 //            if ("transferReceiveDoc".equals(documentType) || "transferIssueDoc".equals(documentType) || documentType == null) {
 //                jpql += " and s.department IS NOT NULL ";
 //            }

--- a/src/main/webapp/reports/inventoryReports/stock_ledger.xhtml
+++ b/src/main/webapp/reports/inventoryReports/stock_ledger.xhtml
@@ -229,6 +229,30 @@
                                 <f:selectItem itemLabel="By Batch" itemValue="byBatch"/>
                                 <f:selectItem itemLabel="By Item" itemValue="byItem"/>
                             </p:selectOneMenu>
+
+                            <h:panelGroup layout="block" styleClass="form-group">
+                                <h:outputText styleClass="fa fa-building mr-2"/>
+                                <p:outputLabel value="Department Type" for="departmentTypeFilter" class="m-3"/>
+                            </h:panelGroup>
+                            <h:panelGroup layout="block" styleClass="form-group">
+                                <p:selectCheckboxMenu
+                                    id="departmentTypeFilter"
+                                    value="#{pharmacyReportController.selectedDepartmentTypes}"
+                                    label="Select Department Types"
+                                    class="w-100"
+                                    filter="true"
+                                    filterMatchMode="contains"
+                                    showHeader="true"
+                                    scrollHeight="200"
+                                    title="Select one or more department types to filter results. Leave empty to include all.">
+                                    <f:selectItems
+                                        value="#{pharmacyReportController.availableDepartmentTypes}"
+                                        var="depType"
+                                        itemLabel="#{depType.label}"
+                                        itemValue="#{depType}"/>
+                                </p:selectCheckboxMenu>
+                                <p:tooltip for="departmentTypeFilter" value="Select one or more department types to filter results. Leave empty to include all." position="top"/>
+                            </h:panelGroup>
                         </h:panelGrid>
 
                         <div class="d-flex align-items-center mt-5">


### PR DESCRIPTION
## Summary
- Added a multi-select department type filter (Pharmacy, Store, Lab, Kitchen) to the Stock Ledger Report
- Filter uses `bill.departmentType` for consistency with other inventory reports
- Leaving the filter empty includes all department types

## Changes
- **stock_ledger.xhtml**: Added `p:selectCheckboxMenu` UI component for department type selection
- **PharmacyReportController.java**: Added filter logic to `processStockLedgerReport` method using `s.pbItem.billItem.bill.departmentType`

## Test plan
- [ ] Open Stock Ledger Report page
- [ ] Verify the Department Type filter appears after the Report Type selector
- [ ] Test with no selection (should show all department types)
- [ ] Test with single department type selected (e.g., Pharmacy only)
- [ ] Test with multiple department types selected
- [ ] Verify filter works correctly for both report types: By Batch and By Item

Closes #18361

🤖 Generated with [Claude Code](https://claude.com/claude-code)