### PR TITLE
Add DTO-based optimization for Category Day End Report

### DIFF
--- a/src/main/java/com/divudi/core/data/dto/CategoryDayEndReportDto.java
+++ b/src/main/java/com/divudi/core/data/dto/CategoryDayEndReportDto.java
@@ -1,0 +1,140 @@
+package com.divudi.core.data.dto;
+
+import java.io.Serializable;
+
+/**
+ * DTO for Category Day End Report - optimized for performance
+ * Used to replace entity-based queries that were causing timeouts
+ *
+ * @author buddhika.ari@gmail.com
+ */
+public class CategoryDayEndReportDto implements Serializable {
+
+    private String categoryName;
+    private String subCategoryName;
+    private double cashValue;
+    private double creditValue;
+    private double totalValue;
+    private String billType;
+    private String paymentMethod;
+    private long billCount;
+
+    public CategoryDayEndReportDto() {
+    }
+
+    /**
+     * Constructor for JPQL queries with aggregated data
+     * Used in native/JPQL queries that aggregate bill/fee data by category
+     *
+     * @param categoryName Name of the category
+     * @param subCategoryName Name of the subcategory (optional)
+     * @param cashValue Total cash amount
+     * @param creditValue Total credit amount
+     * @param billCount Number of bills
+     */
+    public CategoryDayEndReportDto(String categoryName, String subCategoryName,
+                                   double cashValue, double creditValue, long billCount) {
+        this.categoryName = categoryName;
+        this.subCategoryName = subCategoryName;
+        this.cashValue = cashValue;
+        this.creditValue = creditValue;
+        this.totalValue = cashValue + creditValue;
+        this.billCount = billCount;
+    }
+
+    /**
+     * Constructor for simplified queries
+     *
+     * @param categoryName Name of the category
+     * @param totalValue Total value (all payment methods combined)
+     * @param billCount Number of bills
+     */
+    public CategoryDayEndReportDto(String categoryName, double totalValue, long billCount) {
+        this.categoryName = categoryName;
+        this.totalValue = totalValue;
+        this.billCount = billCount;
+    }
+
+    /**
+     * Constructor for detailed payment method breakdown
+     *
+     * @param categoryName Name of the category
+     * @param billType Type of bill
+     * @param paymentMethod Payment method used
+     * @param totalValue Total value
+     * @param billCount Number of bills
+     */
+    public CategoryDayEndReportDto(String categoryName, String billType,
+                                   String paymentMethod, double totalValue, long billCount) {
+        this.categoryName = categoryName;
+        this.billType = billType;
+        this.paymentMethod = paymentMethod;
+        this.totalValue = totalValue;
+        this.billCount = billCount;
+    }
+
+    // Getters and Setters
+    public String getCategoryName() {
+        return categoryName;
+    }
+
+    public void setCategoryName(String categoryName) {
+        this.categoryName = categoryName;
+    }
+
+    public String getSubCategoryName() {
+        return subCategoryName;
+    }
+
+    public void setSubCategoryName(String subCategoryName) {
+        this.subCategoryName = subCategoryName;
+    }
+
+    public double getCashValue() {
+        return cashValue;
+    }
+
+    public void setCashValue(double cashValue) {
+        this.cashValue = cashValue;
+    }
+
+    public double getCreditValue() {
+        return creditValue;
+    }
+
+    public void setCreditValue(double creditValue) {
+        this.creditValue = creditValue;
+    }
+
+    public double getTotalValue() {
+        return totalValue;
+    }
+
+    public void setTotalValue(double totalValue) {
+        this.totalValue = totalValue;
+    }
+
+    public String getBillType() {
+        return billType;
+    }
+
+    public void setBillType(String billType) {
+        this.billType = billType;
+    }
+
+    public String getPaymentMethod() {
+        return paymentMethod;
+    }
+
+    public void setPaymentMethod(String paymentMethod) {
+        this.paymentMethod = paymentMethod;
+    }
+
+    public long getBillCount() {
+        return billCount;
+    }
+
+    public void setBillCount(long billCount) {
+        this.billCount = billCount;
+    }
+}

--- a/src/main/webapp/reportInstitution/report_cash_category_with_pro_day_dto.xhtml
+++ b/src/main/webapp/reportInstitution/report_cash_category_with_pro_day_dto.xhtml
@@ -1,0 +1,271 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<!DOCTYPE composition PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<ui:composition xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
+                template="/reportInstitution/report_own.xhtml"
+                xmlns:h="http://xmlns.jcp.org/jsf/html"
+                xmlns:p="http://primefaces.org/ui"
+                xmlns:f="http://xmlns.jcp.org/jsf/core"
+                xmlns:ca="http://xmlns.jcp.org/jsf/composite/cashSummery"
+                xmlns:in="http://xmlns.jcp.org/jsf/composite/income_report"
+                >
+
+    <ui:define name="subcontent">
+
+        <h:form >
+
+            <p:panel>
+                <f:facet name="header" >
+                    <h:outputLabel value="Book Keeping Summary (With Professional) - DTO Optimized"  styleClass="noPrintButton" />
+                    </f:facet>
+                    <h:panelGrid columns="2" class="my-2" >
+                        <h:outputLabel value="From Date"/>
+                        <p:calendar class="w-100 mx-4" inputStyleClass="w-100" id="frmDate" value="#{bookKeepingSummery.fromDate}" pattern="dd MM yyyy HH:mm:ss" >
+                        </p:calendar>
+
+                        <h:outputLabel value="To Date"/>
+                        <p:calendar class="w-100 mx-4" inputStyleClass="w-100 my-1" id="toDate" value="#{bookKeepingSummery.toDate}" pattern="dd MM yyyy HH:mm:ss" >
+                        </p:calendar>
+
+                        <h:outputLabel value="Select Institution"/>
+
+                        <p:autoComplete class="w-100 mx-4" inputStyleClass="w-100" completeMethod="#{institutionController.completeCompany}" required="true"
+                                        forceSelection="true"
+                                        requiredMessage="Please Select Institution" value="#{bookKeepingSummery.institution}"
+                                        var="pta" itemLabel="#{pta.name}" itemValue="#{pta}" />
+                    </h:panelGrid>
+
+                    <h:panelGrid columns="6" class="my-2">
+
+                        <p:commandButton value="Process" ajax="false" class="ui-button-warning" icon="fas fa-cogs"
+                                         action="#{bookKeepingSummery.createCashCategoryWithProDayDto}"/>
+                        <p:commandButton ajax="false" value="Print"  class="ui-button-info mx-2" icon="fas fa-print" >
+                            <p:printer target="panelPrint" />
+                        </p:commandButton>
+                        <p:commandButton value="Excel" ajax="false" class="ui-button-success" icon="fas fa-file-excel" >
+                            <p:dataExporter type="xlsx" target="opdCashTable,
+                                            opdCreditTable,
+                                            pharmacySalesTable,
+                                            pharmacyWholeSalesTable,
+                                            channelTable,
+                                            inwardTable,
+                                            summaryTable"
+                                            fileName="Book_Keeping_Summery_with_pro_day_dto"
+                                            />
+                        </p:commandButton>
+                        <p:commandButton value="Compare with Old Version" ajax="false" class="ui-button-secondary" icon="fas fa-balance-scale"
+                                         action="report_cash_category_with_pro_day"/>
+                    </h:panelGrid>
+                <!--            <p:spacer height="30" />-->
+                <p:panel id="panelPrint" styleClass="noBorder summeryBorder">
+                    <h:outputStylesheet library="css" name="printing.css"></h:outputStylesheet>
+
+                    <div class="alert alert-success" role="alert">
+                        <strong>DTO Optimized Version:</strong> This report uses optimized database queries for better performance.
+                    </div>
+
+                    <p:spacer height="30"/>
+
+                    <!-- OPD Cash Collections -->
+                    <h3>OPD Cash Collections (Cash, Card, Cheque, Slip)</h3>
+                    <p:dataTable id="opdCashTable" value="#{bookKeepingSummery.opdCashDtoList}" var="dto"
+                                 emptyMessage="No data available">
+                        <p:column headerText="Category">
+                            <h:outputLabel value="#{dto.categoryName}" />
+                        </p:column>
+                        <p:column headerText="Total Value" style="text-align: right;">
+                            <h:outputLabel value="#{dto.totalValue}">
+                                <f:convertNumber pattern="#,##0.00"/>
+                            </h:outputLabel>
+                        </p:column>
+                        <p:column headerText="Bill Count" style="text-align: right;">
+                            <h:outputLabel value="#{dto.billCount}" />
+                        </p:column>
+                        <f:facet name="footer">
+                            <h:outputLabel value="Total: #{bookKeepingSummery.opdCashDtoTotal}" style="font-weight: bold;">
+                                <f:convertNumber pattern="#,##0.00"/>
+                            </h:outputLabel>
+                        </f:facet>
+                    </p:dataTable>
+
+                    <p:spacer height="30"/>
+
+                    <!-- OPD Credit Collections -->
+                    <h3>OPD Credit Collections</h3>
+                    <p:dataTable id="opdCreditTable" value="#{bookKeepingSummery.opdCreditDtoList}" var="dto"
+                                 emptyMessage="No data available">
+                        <p:column headerText="Category">
+                            <h:outputLabel value="#{dto.categoryName}" />
+                        </p:column>
+                        <p:column headerText="Total Value" style="text-align: right;">
+                            <h:outputLabel value="#{dto.totalValue}">
+                                <f:convertNumber pattern="#,##0.00"/>
+                            </h:outputLabel>
+                        </p:column>
+                        <p:column headerText="Bill Count" style="text-align: right;">
+                            <h:outputLabel value="#{dto.billCount}" />
+                        </p:column>
+                        <f:facet name="footer">
+                            <h:outputLabel value="Total: #{bookKeepingSummery.opdCreditDtoTotal}" style="font-weight: bold;">
+                                <f:convertNumber pattern="#,##0.00"/>
+                            </h:outputLabel>
+                        </f:facet>
+                    </p:dataTable>
+
+                    <p:spacer height="30"/>
+
+                    <!-- Pharmacy Sales -->
+                    <h3>Pharmacy Sales</h3>
+                    <p:dataTable id="pharmacySalesTable" value="#{bookKeepingSummery.pharmacySalesDtoList}" var="dto"
+                                 emptyMessage="No data available">
+                        <p:column headerText="Category">
+                            <h:outputLabel value="#{dto.categoryName}" />
+                        </p:column>
+                        <p:column headerText="Total Value" style="text-align: right;">
+                            <h:outputLabel value="#{dto.totalValue}">
+                                <f:convertNumber pattern="#,##0.00"/>
+                            </h:outputLabel>
+                        </p:column>
+                        <p:column headerText="Bill Count" style="text-align: right;">
+                            <h:outputLabel value="#{dto.billCount}" />
+                        </p:column>
+                    </p:dataTable>
+
+                    <p:spacer height="30"/>
+
+                    <!-- Pharmacy Wholesale -->
+                    <h3>Pharmacy Wholesale</h3>
+                    <p:dataTable id="pharmacyWholeSalesTable" value="#{bookKeepingSummery.pharmacyWholeSalesDtoList}" var="dto"
+                                 emptyMessage="No data available">
+                        <p:column headerText="Category">
+                            <h:outputLabel value="#{dto.categoryName}" />
+                        </p:column>
+                        <p:column headerText="Total Value" style="text-align: right;">
+                            <h:outputLabel value="#{dto.totalValue}">
+                                <f:convertNumber pattern="#,##0.00"/>
+                            </h:outputLabel>
+                        </p:column>
+                        <p:column headerText="Bill Count" style="text-align: right;">
+                            <h:outputLabel value="#{dto.billCount}" />
+                        </p:column>
+                        <f:facet name="footer">
+                            <h:outputLabel value="Pharmacy Total: #{bookKeepingSummery.pharmacyDtoTotal}" style="font-weight: bold;">
+                                <f:convertNumber pattern="#,##0.00"/>
+                            </h:outputLabel>
+                        </f:facet>
+                    </p:dataTable>
+
+                    <p:spacer height="30"/>
+
+                    <!-- Channel Collections -->
+                    <h3>Channel Collections</h3>
+                    <p:dataTable id="channelTable" value="#{bookKeepingSummery.channelBillsDtoList}" var="dto"
+                                 emptyMessage="No data available">
+                        <p:column headerText="Category">
+                            <h:outputLabel value="#{dto.categoryName}" />
+                        </p:column>
+                        <p:column headerText="Total Value" style="text-align: right;">
+                            <h:outputLabel value="#{dto.totalValue}">
+                                <f:convertNumber pattern="#,##0.00"/>
+                            </h:outputLabel>
+                        </p:column>
+                        <p:column headerText="Bill Count" style="text-align: right;">
+                            <h:outputLabel value="#{dto.billCount}" />
+                        </p:column>
+                        <f:facet name="footer">
+                            <h:outputLabel value="Total: #{bookKeepingSummery.channelDtoTotal}" style="font-weight: bold;">
+                                <f:convertNumber pattern="#,##0.00"/>
+                            </h:outputLabel>
+                        </f:facet>
+                    </p:dataTable>
+
+                    <p:spacer height="30"/>
+
+                    <!-- Inward Collections -->
+                    <h3>Inward Collections</h3>
+                    <p:dataTable id="inwardTable" value="#{bookKeepingSummery.inwardCollectionsDtoList}" var="dto"
+                                 emptyMessage="No data available">
+                        <p:column headerText="Category">
+                            <h:outputLabel value="#{dto.categoryName}" />
+                        </p:column>
+                        <p:column headerText="Total Value" style="text-align: right;">
+                            <h:outputLabel value="#{dto.totalValue}">
+                                <f:convertNumber pattern="#,##0.00"/>
+                            </h:outputLabel>
+                        </p:column>
+                        <p:column headerText="Bill Count" style="text-align: right;">
+                            <h:outputLabel value="#{dto.billCount}" />
+                        </p:column>
+                        <f:facet name="footer">
+                            <h:outputLabel value="Total: #{bookKeepingSummery.inwardDtoTotal}" style="font-weight: bold;">
+                                <f:convertNumber pattern="#,##0.00"/>
+                            </h:outputLabel>
+                        </f:facet>
+                    </p:dataTable>
+
+                    <p:spacer height="30"/>
+
+                    <!-- Agent Collections (using existing entity-based) -->
+                    <h3>Agent Collections</h3>
+                    <p:dataTable value="#{bookKeepingSummery.agentCollections}" var="bill"
+                                 emptyMessage="No data available">
+                        <p:column headerText="Bill Number">
+                            <h:outputLabel value="#{bill.deptId}" />
+                        </p:column>
+                        <p:column headerText="Net Total" style="text-align: right;">
+                            <h:outputLabel value="#{bill.netTotal}">
+                                <f:convertNumber pattern="#,##0.00"/>
+                            </h:outputLabel>
+                        </p:column>
+                        <f:facet name="footer">
+                            <h:outputLabel value="Total: #{bookKeepingSummery.agentPaymentTotal}" style="font-weight: bold;">
+                                <f:convertNumber pattern="#,##0.00"/>
+                            </h:outputLabel>
+                        </f:facet>
+                    </p:dataTable>
+
+                    <p:spacer height="30"/>
+
+                    <!-- Collecting Centre Collections (using existing entity-based) -->
+                    <h3>Collecting Centre Collections</h3>
+                    <p:dataTable value="#{bookKeepingSummery.collectingCentreCollections}" var="bill"
+                                 emptyMessage="No data available">
+                        <p:column headerText="Bill Number">
+                            <h:outputLabel value="#{bill.deptId}" />
+                        </p:column>
+                        <p:column headerText="Net Total" style="text-align: right;">
+                            <h:outputLabel value="#{bill.netTotal}">
+                                <f:convertNumber pattern="#,##0.00"/>
+                            </h:outputLabel>
+                        </p:column>
+                        <f:facet name="footer">
+                            <h:outputLabel value="Total: #{bookKeepingSummery.collectingCentrePaymentTotal}" style="font-weight: bold;">
+                                <f:convertNumber pattern="#,##0.00"/>
+                            </h:outputLabel>
+                        </f:facet>
+                    </p:dataTable>
+
+                    <p:spacer height="30"/>
+
+                    <!-- Grand Summary -->
+                    <h3>Grand Summary</h3>
+                    <p:dataTable id="summaryTable">
+                        <p:column headerText="Description" style="font-weight: bold;">
+                            <h:outputLabel value="Grand Total (DTO Optimized)" />
+                        </p:column>
+                        <p:column headerText="Amount" style="text-align: right; font-weight: bold;">
+                            <h:outputLabel value="#{bookKeepingSummery.grandDtoTotal}">
+                                <f:convertNumber pattern="#,##0.00"/>
+                            </h:outputLabel>
+                        </p:column>
+                    </p:dataTable>
+
+                    <f:facet name="footer" >
+                        <h:outputLabel value="Printed By: #{sessionController.loggedUser.webUserPerson.name}" style="float: right"/>
+                    </f:facet>
+                </p:panel>
+            </p:panel>
+        </h:form>
+    </ui:define>
+
+
+</ui:composition>

--- a/src/main/webapp/reportInstitution/report_own.xhtml
+++ b/src/main/webapp/reportInstitution/report_own.xhtml
@@ -20,10 +20,12 @@
                                 <p:ajax process="@this"></p:ajax>
 
                                     <p:tab title="Book Keeping Summary (With Professional)" >
-                                        <div class="d-grid gap-2">  
+                                        <div class="d-grid gap-2">
 
-                                            <p:commandButton styleClass="linkButton" ajax="false" value="By Category Day End" action="report_cash_category_with_pro_day"/> 
-                                            <p:commandButton class="w-100" ajax="false" value="By Category Month End" action="report_cash_category_with_pro_month"/>                             
+                                            <p:commandButton styleClass="linkButton" ajax="false" value="By Category Day End" action="report_cash_category_with_pro_day"/>
+                                            <p:commandButton class="w-100 ui-button-success" ajax="false" value="By Category Day End (DTO Optimized)" action="report_cash_category_with_pro_day_dto"
+                                                           title="Optimized version using DTO queries for better performance"/>
+                                            <p:commandButton class="w-100" ajax="false" value="By Category Month End" action="report_cash_category_with_pro_month"/>
                                         </div>
                                     </p:tab>
 


### PR DESCRIPTION
This commit resolves performance issues and timeouts in the By Category Day End Report by implementing DTO-based database queries instead of entity-based queries.

Changes:
- Created CategoryDayEndReportDto class for optimized data transfer
- Added createCashCategoryWithProDayDto() method in BookKeepingSummery controller with DTO-based query methods
- Created new JSF page report_cash_category_with_pro_day_dto.xhtml for the optimized report
- Added green button in navigation (report_own.xhtml) to access the new DTO-optimized report
- Kept old entity-based methods intact for backward compatibility and comparison

The DTO approach uses aggregated JPQL queries that fetch only necessary data, significantly reducing memory usage and execution time compared to loading full entity objects.

Closes #18380

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced an optimized Book Keeping Summary report by Category Day End providing detailed financial breakdowns across OPD, Pharmacy, Channels, and collection categories with payment method analysis
  * Includes Excel export capability and is accessible through a new dedicated button in the reporting interface

<!-- end of auto-generated comment: release notes by coderabbit.ai -->