### PR TITLE
Filter inactive departments from login department selection

### DIFF
--- a/src/main/java/com/divudi/bean/common/SessionController.java
+++ b/src/main/java/com/divudi/bean/common/SessionController.java
@@ -1634,6 +1634,11 @@ public class SessionController implements Serializable, HttpSessionListener {
             return "";
         }
 
+        if (department != null && department.isInactive()) {
+            JsfUtil.addErrorMessage("Cannot log into an inactive department");
+            return "";
+        }
+
         // Clear cached department types to ensure they are refreshed for the new department
         availableDepartmentTypesForPharmacyTransactions = null;
 
@@ -1984,6 +1989,7 @@ public class SessionController implements Serializable, HttpSessionListener {
                 + " from WebUserDepartment wd "
                 + " where wd.retired=false "
                 + " and wd.department.retired=false "
+                + " and wd.department.inactive=false "
                 + " and wd.webUser=:wu "
                 + " order by wd.department.name";
         return departmentFacade.findByJpql(sql, m);
@@ -2001,6 +2007,7 @@ public class SessionController implements Serializable, HttpSessionListener {
                 + " from WebUserDepartment wd "
                 + " where wd.retired=false "
                 + " and wd.department.retired=false "
+                + " and wd.department.inactive=false "
                 + " and wd.webUser=:wu "
                 + " order by wd.department.name";
         return departmentFacade.findByJpql(sql, m);

--- a/src/main/java/com/divudi/core/entity/Department.java
+++ b/src/main/java/com/divudi/core/entity/Department.java
@@ -88,6 +88,9 @@ public class Department implements Serializable {
     String retireComments;
     private Boolean active;
 
+    //Inactive Status
+    private boolean inactive;
+
     double margin;
     double pharmacyMarginFromPurchaseRate;
 
@@ -359,6 +362,14 @@ public class Department implements Serializable {
 
     public void setActive(Boolean active) {
         this.active = active;
+    }
+
+    public boolean isInactive() {
+        return inactive;
+    }
+
+    public void setInactive(boolean inactive) {
+        this.inactive = inactive;
     }
 
     public Institution getSite() {


### PR DESCRIPTION
## Summary
- Adds `boolean inactive` field to `Department` entity (following the same pattern as `Item` and `Institution` entities)
- Filters inactive departments from the login department selection dropdown via `listLoggableDepts()` and `fillLoggableDepts()` in `SessionController`
- Adds server-side validation guard in `selectDepartment()` to reject inactive departments

## Context
`retired` = soft delete (permanent, kept for historical reports)
`inactive` = temporary status toggle (can be reactivated)

Existing queries already filter `retired=false`. This PR adds the new `inactive=false` filter so temporarily deactivated departments cannot be selected during login.

## Files Changed
- `src/main/java/com/divudi/core/entity/Department.java` - Added `inactive` field with getter/setter
- `src/main/java/com/divudi/bean/common/SessionController.java` - Updated JPQL queries + validation guard

## Test plan
- [ ] Verify active departments still appear in login department selection
- [ ] Mark a department as inactive and verify it no longer appears in login selection
- [ ] Verify inactive departments still appear in historical reports

Closes #18425

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the ability to mark departments as inactive in the system.
  * Inactive departments are now excluded from user login attempts, preventing access.
  * Inactive departments no longer appear in the list of available departments for selection during the login process.
  * The system properly handles the new inactive status throughout the authentication and session management workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->