### PR TITLE
Filter inactive departments from pharmacy issue page

### DIFF
--- a/src/main/java/com/divudi/bean/common/DepartmentController.java
+++ b/src/main/java/com/divudi/bean/common/DepartmentController.java
@@ -624,6 +624,7 @@ public class DepartmentController implements Serializable {
         HashMap hm = new HashMap();
         sql = "select c from Department c "
                 + " where c.retired=false "
+                + " and c.inactive=false "
                 + " and (c.name) like :q"
                 + " order by c.name";
         hm.put("q", "%" + qry.toUpperCase() + "%");

--- a/src/main/java/com/divudi/bean/pharmacy/PharmacyIssueController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacyIssueController.java
@@ -2389,6 +2389,8 @@ public class PharmacyIssueController implements Serializable {
                     + " where b.retired=false "
                     + " and b.billTypeAtomic=:bt "
                     + " and b.fromDepartment=:fd "
+                    + " and b.toDepartment.retired=false "
+                    + " and b.toDepartment.inactive=false "
                     + " order by b.id desc";
             Map<String, Object> m = new HashMap<>();
             m.put("bt", BillTypeAtomic.PHARMACY_DISPOSAL_ISSUE);

--- a/src/main/java/com/divudi/core/entity/Department.java
+++ b/src/main/java/com/divudi/core/entity/Department.java
@@ -88,6 +88,9 @@ public class Department implements Serializable {
     String retireComments;
     private Boolean active;
 
+    //Inactive Status
+    private boolean inactive;
+
     double margin;
     double pharmacyMarginFromPurchaseRate;
 
@@ -359,6 +362,14 @@ public class Department implements Serializable {
 
     public void setActive(Boolean active) {
         this.active = active;
+    }
+
+    public boolean isInactive() {
+        return inactive;
+    }
+
+    public void setInactive(boolean inactive) {
+        this.inactive = inactive;
     }
 
     public Institution getSite() {


### PR DESCRIPTION
## Summary
- Adds `boolean inactive` field to `Department` entity (same pattern as `Item` and `Institution`)
- Adds `inactive=false` filter to `DepartmentController.completeDept()` so autocomplete excludes inactive departments
- Adds `toDepartment.retired=false` and `toDepartment.inactive=false` filters to `PharmacyIssueController.getRecentToDepartments()` so "Departments with Recent Issues" buttons exclude retired/inactive departments

## Context
`retired` = soft delete (permanent, kept for historical reports)
`inactive` = temporary status toggle (can be reactivated)

The autocomplete already filtered `retired=false` but not `inactive`. The "Recent Issues" buttons had no department status filtering at all.

## Files Changed
- `src/main/java/com/divudi/core/entity/Department.java` - Added `inactive` field
- `src/main/java/com/divudi/bean/common/DepartmentController.java` - Updated `completeDept()` query
- `src/main/java/com/divudi/bean/pharmacy/PharmacyIssueController.java` - Updated `getRecentToDepartments()` query

## Test plan
- [ ] Verify active departments appear in autocomplete on pharmacy issue page
- [ ] Verify inactive departments do NOT appear in autocomplete
- [ ] Verify inactive departments do NOT appear in "Departments with Recent Issues" buttons
- [ ] Verify pharmacy issue transactions still work normally with active departments

Closes #18428

🤖 Generated with [Claude Code](https://claude.com/claude-code)