### PR TITLE
Filter inactive departments from pharmacy transfer request page

### DIFF
--- a/src/main/java/com/divudi/bean/pharmacy/TransferRequestController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/TransferRequestController.java
@@ -1460,6 +1460,8 @@ public class TransferRequestController implements Serializable {
                     + " where b.retired=false "
                     + " and b.billTypeAtomic=:bt "
                     + " and b.fromDepartment=:fd "
+                    + " and b.toDepartment.retired=false "
+                    + " and b.toDepartment.inactive=false "
                     + " order by b.id desc";
             Map<String, Object> m = new HashMap<>();
             m.put("bt", BillTypeAtomic.PHARMACY_TRANSFER_REQUEST);

--- a/src/main/java/com/divudi/core/entity/Department.java
+++ b/src/main/java/com/divudi/core/entity/Department.java
@@ -88,6 +88,9 @@ public class Department implements Serializable {
     String retireComments;
     private Boolean active;
 
+    //Inactive Status
+    private boolean inactive;
+
     double margin;
     double pharmacyMarginFromPurchaseRate;
 
@@ -359,6 +362,14 @@ public class Department implements Serializable {
 
     public void setActive(Boolean active) {
         this.active = active;
+    }
+
+    public boolean isInactive() {
+        return inactive;
+    }
+
+    public void setInactive(boolean inactive) {
+        this.inactive = inactive;
     }
 
     public Institution getSite() {


### PR DESCRIPTION
## Summary
- Adds `boolean inactive` field to `Department` entity (same pattern as `Item` and `Institution`)
- Adds `toDepartment.retired=false` and `toDepartment.inactive=false` filters to `TransferRequestController.getRecentToDepartments()` so "Departments with Recent Requests Sent To" buttons exclude retired/inactive departments

## Context
`retired` = soft delete (permanent, kept for historical reports)
`inactive` = temporary status toggle (can be reactivated)

The autocomplete (`completeDept`) already filtered `retired=false`. The "Recent Requests" buttons had no department status filtering at all. The `completeDept()` inactive filter is covered in PR #18432.

## Files Changed
- `src/main/java/com/divudi/core/entity/Department.java` - Added `inactive` field
- `src/main/java/com/divudi/bean/pharmacy/TransferRequestController.java` - Updated `getRecentToDepartments()` query

## Test plan
- [ ] Verify active departments appear in "Recent Requests Sent To" buttons
- [ ] Verify inactive departments do NOT appear in recent request buttons
- [ ] Verify pharmacy transfer request transactions still work normally

Closes #18429

🤖 Generated with [Claude Code](https://claude.com/claude-code)