### PR TITLE
8 args constructor has been to the AmppDto class

### DIFF
--- a/src/main/java/com/divudi/core/data/dto/AmppDto.java
+++ b/src/main/java/com/divudi/core/data/dto/AmppDto.java
@@ -93,20 +93,20 @@ public class AmppDto implements Serializable {
     }
 
     /**
-     * Extended constructor - with AMP relationship for display
-     * Used when AMP information is needed for display purposes
+     * Extended constructor - with pack size and AMP relationship
+     * Used when pack size and AMP information are needed for display purposes
      *
-     * @param id AMPP ID
-     * @param name AMPP name
-     * @param code AMPP code
-     * @param retired Whether AMPP is retired/deleted
-     * @param inactive Whether AMPP is inactive
-     * @param dblValue Pack size value
-     * @param ampId AMP ID
-     * @param ampName AMP name
+     * `@param` id AMPP ID
+     * `@param` name AMPP name
+     * `@param` code AMPP code
+     * `@param` retired Whether AMPP is retired/deleted
+     * `@param` inactive Whether AMPP is inactive
+     * `@param` dblValue Pack size value
+     * `@param` ampId AMP ID
+     * `@param` ampName AMP name
      */
     public AmppDto(Long id, String name, String code, Boolean retired, Boolean inactive,
-               Double dblValue, Long ampId, String ampName) {
+                   Double dblValue, Long ampId, String ampName) {
         this(id, name, code, retired, inactive);
         this.dblValue = dblValue;
         this.ampId = ampId;


### PR DESCRIPTION
#18450 
Added the constructor with javadoc at the dedisred location.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved internal handling of pack-size and AMP relationship data so these values can be initialized together, reducing setup steps and ensuring consistent pack-related information across the app.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->