### PR TITLE
update qa3 cicd to trigger manual

### DIFF
--- a/.github/workflows/hims_qa3_ci_cd.yml
+++ b/.github/workflows/hims_qa3_ci_cd.yml
@@ -1,9 +1,7 @@
 name: HIMS QA-3 Environment CI-CD Workflow
 
 on:
-  push:
-    branches:
-      - hims-qa3
+  workflow_dispatch:
 
 jobs:
   build:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Modified deployment workflow to require manual trigger instead of automatic initiation on code push.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->