### PR TITLE
Add missing categoty in pharmacy administration

### DIFF
--- a/src/main/webapp/pharmacy/admin/amp.xhtml
+++ b/src/main/webapp/pharmacy/admin/amp.xhtml
@@ -225,7 +225,7 @@
                                         <h6 class="section-header">Essential Information</h6>
                                         <div class="row g-3 mb-3">
                                             <div class="col-md-6">
-                                                <p:outputLabel for="ampName" value="AMP Name "/>
+                                                <p:outputLabel for="ampName" value="AMP Name"/>
                                                 <p:inputText id="ampName"
                                                              value="#{ampController.current.name}"
                                                              class="form-control"
@@ -324,7 +324,7 @@
                                                     </p:outputLabel>
                                                     <p:inputText
                                                         value="#{ampController.current.numberOfDaysToMarkAsShortExpiary}"
-                                                        class="form-control-plaintext"
+                                                        class="form-control"
                                                         disabled="#{not ampController.editable}"/>
                                                 </h:panelGroup>
                                             </div>

--- a/src/main/webapp/pharmacy/admin/lab_amp.xhtml
+++ b/src/main/webapp/pharmacy/admin/lab_amp.xhtml
@@ -324,7 +324,7 @@
                                                     </p:outputLabel>
                                                     <p:inputText
                                                         value="#{labAmpController.current.numberOfDaysToMarkAsShortExpiary}"
-                                                        class="form-control-plaintext"
+                                                        class="form-control"
                                                         disabled="#{not labAmpController.editable}"/>
                                                 </h:panelGroup>
                                             </div>

--- a/src/main/webapp/pharmacy/admin/store_amp.xhtml
+++ b/src/main/webapp/pharmacy/admin/store_amp.xhtml
@@ -324,7 +324,7 @@
                                                     </p:outputLabel>
                                                     <p:inputText
                                                         value="#{storeAmpController.current.numberOfDaysToMarkAsShortExpiary}"
-                                                        class="form-control-plaintext"
+                                                        class="form-control"
                                                         disabled="#{not storeAmpController.editable}"/>
                                                 </h:panelGroup>
                                             </div>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Category autocomplete across pharmacy admin forms (required, respects edit state).
  * Added Days of Short Expiry read-only field with tooltip and editable-state binding.

* **UI/Style**
  * Removed required-field asterisks from AMP Name and VMP labels for cleaner presentation.
  * Adjusted form layouts to integrate the new fields into the Product/Essential Information sections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->