### PR TITLE
Harden AMPP audit difference output escaping

### DIFF
--- a/src/main/webapp/pharmacy/admin/ampp_audit_events.xhtml
+++ b/src/main/webapp/pharmacy/admin/ampp_audit_events.xhtml
@@ -95,7 +95,7 @@
 
                             <p:column headerText="Changes" style="width: auto;">
                                 <div class="audit-changes">
-                                    <h:outputText value="#{audit.difference}" />
+                                    <h:outputText value="#{audit.difference}" escape="true" />
                                 </div>
                             </p:column>
 


### PR DESCRIPTION
### Motivation
- Prevent XSS by ensuring audit "difference" data rendered on the AMPP audit events page is HTML-escaped and cannot inject markup or scripts.

### Description
- Set `escape="true"` on the `<h:outputText>` that renders `#{audit.difference}` in `src/main/webapp/pharmacy/admin/ampp_audit_events.xhtml` so the value is rendered as plain text; Closes #18449.

### Testing
- Confirmed the updated line appears via a repository search (`rg`) and inspected the file/diff to verify `escape="true"` is present, and the checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698bb8367eb4832f9f6c05cf93082a35)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced content rendering safety in the audit events display to prevent potential display issues with special characters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->