### PR TITLE
Replace raw h4 heading with h:outputText in mf.xhtml

### DIFF
--- a/src/main/webapp/mf.xhtml
+++ b/src/main/webapp/mf.xhtml
@@ -51,7 +51,7 @@
             <h:panelGroup rendered="#{not webUserController.hasPrivilege('Admin')}">
                 <div class="container mt-5">
                     <div class="alert alert-danger text-center" role="alert">
-                        <h4 class="alert-heading">Access Denied</h4>
+                        <h:outputText value="Access Denied" styleClass="alert-heading h4"/>
                         <p>This page is restricted to administrators. No database migration is currently pending.</p>
                     </div>
                 </div>


### PR DESCRIPTION
### Motivation
- Replace the raw HTML `<h4>` heading in `src/main/webapp/mf.xhtml` with a JSF `h:outputText` to comply with the project's XHTML/JSF coding guidelines.

### Description
- Updated `src/main/webapp/mf.xhtml` by replacing `<h4 class="alert-heading">Access Denied</h4>` with `<h:outputText value="Access Denied" styleClass="alert-heading h4"/>`, committed the change, and this PR closes `#18447`.

### Testing
- No build or unit tests were run because this is a JSF/XHTML-only change; a file inspection using `nl -ba src/main/webapp/mf.xhtml | sed -n '48,60p'` confirmed the replacement and an automated Playwright page load attempt failed with `net::ERR_EMPTY_RESPONSE` due to no local web server running.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698bb98a605c832fb57080e2115ceca4)