### PR TITLE
Escape audit.difference to prevent XSS in department audit events

### DIFF
--- a/src/main/webapp/admin/institutions/department_audit_events.xhtml
+++ b/src/main/webapp/admin/institutions/department_audit_events.xhtml
@@ -98,7 +98,7 @@
 
                             <p:column headerText="Changes" style="width: auto;">
                                 <div class="audit-changes">
-                                    <h:outputText value="#{audit.difference}" />
+                                    <h:outputText value="#{audit.difference}" escape="true" />
                                 </div>
                             </p:column>
 


### PR DESCRIPTION
### Motivation
- Ensure the `Changes` column in the department audit events table does not render raw HTML/JS by explicitly enabling HTML escaping for `audit.difference` to mitigate an XSS risk and satisfy the issue request.

### Description
- Updated `src/main/webapp/admin/institutions/department_audit_events.xhtml` to render `#{audit.difference}` with `escape="true"` (`<h:outputText value="#{audit.difference}" escape="true" />`) to ensure the field is HTML-escaped and included `Closes #18430` for issue tracking.

### Testing
- Verified the modification by searching for the `audit.difference` usage with `rg` and inspecting the updated file contents, and did not run a build or automated tests because this is a JSF/XHTML-only change per repository guidance.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698bc2ae565c832fb4dd596498e00455)