### PR TITLE
Fix typo and HTTP status for pharmacy adjustment authorization failures

### DIFF
--- a/src/main/java/com/divudi/ws/pharmacy/PharmacyAdjustmentApi.java
+++ b/src/main/java/com/divudi/ws/pharmacy/PharmacyAdjustmentApi.java
@@ -89,7 +89,7 @@ public class PharmacyAdjustmentApi {
             
             String privilege = "PharmacyAdjustmentDepartmentStockQTY";
             if (!webUserService.hasPrivilege(privilege,user, request.getDepartmentId())) {
-                return errorResponse("Not autherized", 401);
+                return errorResponse("Not authorized", 403);
             }
             
 
@@ -133,7 +133,7 @@ public class PharmacyAdjustmentApi {
 
             String privilege = "PharmacyAdjustmentSaleRate";
             if (!webUserService.hasPrivilege(privilege, user, request.getDepartmentId())) {
-                return errorResponse("Not autherized", 401);
+                return errorResponse("Not authorized", 403);
             }
 
             // Process adjustment
@@ -176,7 +176,7 @@ public class PharmacyAdjustmentApi {
 
             String privilege = "PharmacyAdjustmentExpiryDate";
             if (!webUserService.hasPrivilege(privilege, user, request.getDepartmentId())) {
-                return errorResponse("Not autherized", 401);
+                return errorResponse("Not authorized", 403);
             }
 
             // Process adjustment
@@ -219,7 +219,7 @@ public class PharmacyAdjustmentApi {
 
             String privilege = "PharmacyAdjustmentPurchaseRate";
             if (!webUserService.hasPrivilege(privilege, user, request.getDepartmentId())) {
-                return errorResponse("Not autherized", 401);
+                return errorResponse("Not authorized", 403);
             }
 
             // Process adjustment


### PR DESCRIPTION
### Motivation
- The pharmacy adjustment REST endpoints returned a misspelled message ("autherized") and used HTTP 401 for authorization failures, which is semantically incorrect for authenticated users lacking privileges. 
- Update needed across all four adjustment endpoints so clients receive a clear message and correct `403 Forbidden` status on privilege checks.

### Description
- Corrected the error message from "Not autherized" to "Not authorized" in the pharmacy adjustment API. 
- Changed the HTTP response code from `401` to `403` for failed privilege checks in the stock quantity, retail rate, expiry date, and purchase rate endpoints. 
- File modified: `src/main/java/com/divudi/ws/pharmacy/PharmacyAdjustmentApi.java` to apply these fixes and align responses with authorization semantics. 
- This change addresses and will close issue `#18417`.

### Testing
- Performed static verification with search for the old typo and the updated message and status, which confirmed the four locations were updated. 
- Inspected the diff of `PharmacyAdjustmentApi.java` to validate the exact changes and line locations. 
- No Maven build or unit tests were executed because automated Java tests were not requested and repository guidelines advise running them only when explicitly asked.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698bc586272c832fa64dc97cea9a47f4)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected authorization failure responses in pharmacy API endpoints to use proper HTTP 403 status code and fixed error message text for clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->