### PR TITLE
Fix pharmacy batch expiry validation and improve date parsing

### DIFF
--- a/src/main/java/com/divudi/service/pharmacy/PharmacyBatchApiService.java
+++ b/src/main/java/com/divudi/service/pharmacy/PharmacyBatchApiService.java
@@ -201,10 +201,23 @@ public class PharmacyBatchApiService implements Serializable {
             throw new Exception("Wholesale rate must be positive when provided");
         }
 
-        // Future date validation
-        if (request.getExpiryDate().before(new Date())) {
-            throw new Exception("Expiry date must be in the future");
+        // Expiry date validation (DATE-ONLY, ignores time component)
+        Date today = truncateToDate(new Date());
+        Date expiry = truncateToDate(request.getExpiryDate());
+
+        if (expiry.before(today)) {
+            throw new Exception("Expiry date must be today or a future date");
         }
+    }
+
+    private Date truncateToDate(Date date) {
+        Calendar cal = Calendar.getInstance();
+        cal.setTime(date);
+        cal.set(Calendar.HOUR_OF_DAY, 0);
+        cal.set(Calendar.MINUTE, 0);
+        cal.set(Calendar.SECOND, 0);
+        cal.set(Calendar.MILLISECOND, 0);
+        return cal.getTime();
     }
 
     private Amp loadAndValidateAmp(Long itemId) throws Exception {


### PR DESCRIPTION
Problem:
Batch creation API was validating expiryDate using timestamp comparison.
This caused same-day expiry dates (00:00:00) to be rejected as "past dates".

Root Cause:
Date.before(new Date()) compares full timestamp, not just the calendar date.

Fix:
• Changed expiry validation to compare DATE ONLY (ignores time component)
• Allow expiryDate >= today
• Updated validation message to "Expiry date must be today or a future date"

API Improvement:
• Added custom Gson Date deserializer
• API now accepts multiple date formats:
  - yyyy-MM-dd
  - yyyy-MM-dd HH:mm:ss
  - yyyy-MM-dd'T'HH:mm:ss

Impact:
Prevents false rejection of valid pharmacy batches and improves API usability.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Relaxed batch expiry date validation to accept today's date in addition to future dates.
* Improved error handling for invalid date format inputs with clearer validation messages.

## New Features
* Added support for multiple date format patterns when creating pharmacy batches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->