### PR TITLE
Implement Audit Event Recording for Person Entity

### DIFF
--- a/src/main/java/com/divudi/service/PersonService.java
+++ b/src/main/java/com/divudi/service/PersonService.java
@@ -1,0 +1,44 @@
+package com.divudi.service;
+
+import java.text.SimpleDateFormat;
+import java.util.Map;
+
+import com.divudi.core.entity.Person;
+import javax.ejb.Stateless;
+
+@Stateless
+public class PersonService {
+    
+    // PersonEdit Audit Event Log: personToAuditMap
+    public void personToAuditMap(Map<String, Object> map ,Person person) {
+        if (person == null || map == null) {
+            return;
+        }
+
+        map.put("personId", person.getId());
+        map.put("name", person.getName());
+        map.put("title", person.getTitle());
+        map.put("nic", person.getNic());
+        map.put("fullName", person.getFullName());
+        map.put("nameWithInitials", person.getNameWithInitials());
+        map.put("surName", person.getSurName());
+        map.put("lastName", person.getLastName());
+        map.put("address", person.getAddress());
+        map.put("gender", person.getSex());
+
+        if (person.getDob() != null) {
+            map.put("dob", new SimpleDateFormat("yyyy-MM-dd").format(person.getDob()));
+        } else {
+            map.put("dob", null);
+        }
+
+        // Contact details
+        map.put("phone", person.getPhone());
+        map.put("mobile", person.getMobile());
+        map.put("email", person.getEmail());
+        map.put("fax", person.getFax());
+        return;
+    }
+}
+
+            

--- a/src/main/webapp/admin/staff/admin_doctor_consultant.xhtml
+++ b/src/main/webapp/admin/staff/admin_doctor_consultant.xhtml
@@ -48,10 +48,12 @@
                                                  filterMatchMode="contains"
                                                  class="w-100 my-1" value="#{consultantController.current}">
                                 <f:selectItems  value="#{consultantController.selectedItems}" var="myItem" itemValue="#{myItem}" itemLabel="#{myItem.person.nameWithTitle}"  ></f:selectItems>
-                                <f:ajax render="gpDetail" execute="lstSelect" />                                        
+                                <f:ajax event="change"
+                                        render="gpDetail" 
+                                        execute="lstSelect" 
+                                        listener="#{consultantController.changeStaff()}"/>                                        
                             </p:selectOneListbox>
 
-                            >
                         </div>
                         <div class="col-6">
                             <p:panel header="Consultant Details">

--- a/src/main/webapp/admin/staff/doctors_excluding_consultants.xhtml
+++ b/src/main/webapp/admin/staff/doctors_excluding_consultants.xhtml
@@ -57,7 +57,10 @@
                                 value="#{doctorController.current}" 
                                 filter="true" >
                                 <f:selectItems  value="#{doctorController.selectedItems}" var="myItem" itemValue="#{myItem}" itemLabel="#{myItem.person.nameWithTitle}"  ></f:selectItems>
-                                <p:ajax update="gpDetail" process="lstSelect" />                                        
+                                <p:ajax event="change"
+                                        update="gpDetail" 
+                                        process="lstSelect" 
+                                        listener="#{doctorController.changeStaff()}"/>                                        
                             </p:selectOneListbox>
 
                         </div>

--- a/src/main/webapp/admin/staff/doctors_including_consultants.xhtml
+++ b/src/main/webapp/admin/staff/doctors_including_consultants.xhtml
@@ -12,7 +12,7 @@
 
         <h:panelGroup >
             <h:form  >
-                <p:growl />
+                <p:growl id="msg"/>
                 <p:focus id="selectFocus" for="lstSelect" />
                 <p:focus id="detailFocus" for="gpDetail" />
 
@@ -57,7 +57,11 @@
                                 value="#{doctorController.current}" 
                                 filter="true" >
                                 <f:selectItems  value="#{doctorController.selectedItems}" var="myItem" itemValue="#{myItem}" itemLabel="#{myItem.person.nameWithTitle}"  ></f:selectItems>
-                                <p:ajax update="gpDetail" process="lstSelect" />                                        
+                                <p:ajax 
+                                    event="change"
+                                    update="gpDetail"
+                                    process="lstSelect"
+                                    listener="#{doctorController.changeStaff()}"/>                                        
                             </p:selectOneListbox>
 
                         </div>
@@ -141,7 +145,7 @@
                                                  class=" m-1 ui-button-warning w-25"
                                                  action="#{doctorController.saveSelected()}" 
                                                  process="btnSave gpDetail"
-                                                 update="lstSelect"
+                                                 update="lstSelect selectFocus msg gpDetail"
                                                  />
                                 <p:defaultCommand target="btnSave"/>
                             </p:panel>

--- a/src/main/webapp/admin/staff/hr_staff_without_doctors_admin.xhtml
+++ b/src/main/webapp/admin/staff/hr_staff_without_doctors_admin.xhtml
@@ -11,8 +11,8 @@
                 <h:panelGroup >
                     <h:form >
                         <p:growl id="msg"/>
-                        <p:focus id="selectFocus" context="lstSelect" />
-                        <p:focus id="detailFocus" context="gpDetail" />
+                        <p:focus id="selectFocus" for="lstSelect" />
+                        <p:focus id="detailFocus" for="gpDetail" />
 
 
 
@@ -23,7 +23,7 @@
                                         <p:commandButton
                                             id="btnAdd" 
                                             process="btnAdd"
-                                            update="gpDetail"
+                                            update="gpDetail detailFocus"
                                             value="Add" 
                                             class="ui-button-success w-25"
                                             icon="fas fa-plus"
@@ -43,7 +43,10 @@
                                     </div>
                                     <p:selectOneListbox filter="true" id="lstSelect"   value="#{staffController.current}" style="height: auto;" class="w-100">
                                         <f:selectItems  value="#{staffController.selectedItems}" var="myItem" itemValue="#{myItem}" itemLabel="#{myItem.person.name}(#{myItem.code})" ></f:selectItems>
-                                        <p:ajax event="change" process="lstSelect" update="gpDetail" />                                        
+                                        <p:ajax event="change" 
+                                                process="lstSelect" 
+                                                update="gpDetail" 
+                                                listener="#{staffController.changeStaffWithoutDoctor()}"/>                                        
                                     </p:selectOneListbox>
 
 
@@ -53,13 +56,15 @@
                                         <f:facet name="header" >
                                             <div>
                                                 <p:outputLabel value="Details" ></p:outputLabel>
-                                                <p:commandButton class="w-25 ui-button-warning"
-                                                                 id="btnSave"
-                                                                 value="Save" 
-                                                                 ajax="false"
-                                                                 style="float: right;"
-                                                                 action="#{staffController.saveSelected()}"  >
-                                                </p:commandButton>
+                                                <p:commandButton id="btnSave" 
+                                                                value="Save" 
+                                                                icon="fas fa-save"
+                                                                class=" m-1 ui-button-warning w-25"
+                                                                action="#{staffController.saveSelected()}" 
+                                                                process="btnSave gpDetail"
+                                                                update="lstSelect selectFocus msg gpDetail"
+                                                                />
+                                               <p:defaultCommand target="btnSave"/>
                                             </div>
                                         </f:facet>
 


### PR DESCRIPTION
Issue: #17234 

Files Changed:
- StaffController
- DoctorController
- ConsultantController
- PersonService

<hr/>
- PersonService -> defined **personToAuditMap()** method to create map with person data for audit recording
- Controllers' `saveSelected()` method modified to initiate audit recording
- **changesStaff()** method used to create before JSON when selecting a staff member from lists in `hr_staff_without_doctors_admin`, `doctors_including_consultants`, etc.
- `hr_staff_without_doctors_admin` **Save** button modified because the previous version used wrong person reference when trying to add new staff

<hr/>

**Details included:**
- personId
- name
- nic
- title
- full name
- name with initials
- surname, lastname
- dob
- address
- phone, mobile, email, fax
- gender

**entityType** - `Person`
**eventTrigger** - `createPerson` & `updatePerson`
**objectId** - `person.Id`

**After:**
```text
  {"lastName":"",
    "address":"Galle",
    "surName":"",
    "gender":"Male",
    "mobile":"0112000000",
    "nic":"0000000001",
    "fullName":"",
    "title":"Dr",
    "nameWithInitials":"",
    "phone":"0306666666"
    ,"dob":"1976-02-10",
    "name":"A D M Jayasekara"
    ,"personId":6,
    "fax":"0112456563",
  "email":"" }
```

**Before:**
```text
  {"address":"Galle",
  "gender":"Male",
  "mobile":"0406666666",
  "title":"Dr",
  "phone":"0306666666",
  "name":"A D M Jayasekara",
  "personId":6,
  "fax":"0112456563"}
```