### PR TITLE
Fix Request from Department isn’t updated in Store Transfer Request

### DIFF
--- a/src/main/java/com/divudi/bean/store/StoreTransferRequestController.java
+++ b/src/main/java/com/divudi/bean/store/StoreTransferRequestController.java
@@ -150,7 +150,8 @@ public class StoreTransferRequestController implements Serializable {
 
             getBill().setInstitution(getSessionController().getInstitution());
             getBill().setDepartment(getSessionController().getDepartment());
-
+            getBill().setFromDepartment(getSessionController().getDepartment());
+            getBill().setFromInstitution(getSessionController().getInstitution());
             getBill().setToInstitution(getBill().getToDepartment().getInstitution());
 
             getBillFacade().create(getBill());


### PR DESCRIPTION
 fix sets fromDepartment and fromInstitution on the request bill (matching how the pharmacy TransferRequestController already does it), so the downstream issue process works correctly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed store transfer requests to properly record the source department and institution information alongside the destination details, ensuring complete and accurate transfer tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->