### PR TITLE
Fixed Opd bill print with items and Name of the professional

### DIFF
--- a/src/main/webapp/resources/ezcomp/prints/five_five_paper_with_headings.xhtml
+++ b/src/main/webapp/resources/ezcomp/prints/five_five_paper_with_headings.xhtml
@@ -252,14 +252,26 @@
                             <hr/>
                         </td>
                     </tr>
-                    <tr>
-                        <td style="width:55%!important;">
-                            <h:outputLabel value="ITEM" styleClass="itemHeadingsFiveFive" ></h:outputLabel>
-                        </td>
-                        <td  style="width:10%!important;text-align: right; padding-right: 30px!important">
-                            <h:outputLabel value="VALUE"  styleClass="itemHeadingsFiveFive" ></h:outputLabel>
-                        </td>
-                    </tr>
+                    <h:panelGroup rendered="#{not configOptionApplicationController.getBooleanValueByKey('OPD Bill Display Fee Breakdown', true)}">
+                        <tr>
+                            <td style="width:55%!important;">
+                                <h:outputLabel value="ITEM" styleClass="itemHeadingsFiveFive" />
+                            </td>
+                            <td style="width:10%!important; text-align: right; padding-right: 30px!important">
+                                <h:outputLabel value="VALUE" styleClass="itemHeadingsFiveFive" />
+                            </td>
+                        </tr>
+                    </h:panelGroup>
+                    <h:panelGroup rendered="#{configOptionApplicationController.getBooleanValueByKey('OPD Bill Display Fee Breakdown', true)}">
+                        <tr>
+                            <td style="width:70%!important;">
+                                <h:outputLabel value="ITEM" styleClass="itemHeadingsFiveFive" />
+                            </td>
+                            <td style="width:30%!important; text-align: right; padding-right: 30px!important;">
+                                <h:outputLabel value="VALUE" styleClass="itemHeadingsFiveFive" />
+                            </td>
+                        </tr>
+                    </h:panelGroup>
                     <tr>
                         <td colspan="2" style="text-align: center;" class="billline">
                             <hr/>
@@ -267,32 +279,75 @@
                     </tr>
 
                     <h:panelGroup rendered="#{cc.attrs.bill.margin > 0? 'false':'true'}">
-                        <ui:repeat value="#{cc.attrs.bill.billItems}" var="billItem"   >
-                            <tr>
-                                <td  style="overflow: visible;">
-                                    <h:outputLabel class="itemsBlockRightFiveFive" value="#{billItem.item.printName}"  style="text-transform: capitalize!important;"  >
-                                    </h:outputLabel>
-                                </td>
-                                <td style="text-align: right;" >
-                                    <h:outputLabel class="itemsBlockRightFiveFive"   value="#{billItem.grossValue}"    >
-                                        <f:convertNumber pattern="#,##0.00" />
-                                    </h:outputLabel>
-                                </td>
-                            </tr>
-                            <h:panelGroup rendered="#{billItem.item.printSessionNumber}" >
-                                <h:panelGroup rendered="#{configOptionApplicationController.getBooleanValueByKey('Print Individual Bill Item Session Number in OPD Bills')}" >
+                        <ui:repeat value="#{cc.attrs.bill.billItems}" var="billItem">
+                            <!-- Default item row: item name + total only -->
+                            <h:panelGroup rendered="#{not configOptionApplicationController.getBooleanValueByKey('OPD Bill Display Fee Breakdown', true)}">
+                                <tr>
+                                    <td style="overflow: visible;">
+                                        <h:outputLabel class="itemsBlockRightFiveFive" value="#{billItem.item.printName}" style="text-transform: capitalize!important;"/>
+                                    </td>
+                                    <td style="text-align: right;">
+                                        <h:outputLabel class="itemsBlockRightFiveFive" value="#{billItem.grossValue}">
+                                            <f:convertNumber pattern="#,##0.00" />
+                                        </h:outputLabel>
+                                    </td>
+                                </tr>
+                            </h:panelGroup>
+                            <!-- Fee breakdown item row: item name + total, then sub-rows per fee -->
+                            <h:panelGroup rendered="#{configOptionApplicationController.getBooleanValueByKey('OPD Bill Display Fee Breakdown', true)}">
+                                <tr>
+                                    <td style="overflow: visible;">
+                                        <h:outputLabel class="itemsBlockRightFiveFive" value="#{billItem.item.printName}" style="text-transform: capitalize!important; font-weight: bold;"/>
+                                    </td>
+                                    <td style="text-align: right; padding-right: 30px;">
+                                        <h:outputLabel class="itemsBlockRightFiveFive" value="#{billItem.grossValue}">
+                                            <f:convertNumber pattern="#,##0.00" />
+                                        </h:outputLabel>
+                                    </td>
+                                </tr>
+                                <ui:repeat value="#{billItem.billFees}" var="bf">
+                                    <!-- Hospital / non-staff fee sub-row -->
+                                    <h:panelGroup rendered="#{not bf.retired and bf.fee ne null and bf.fee.feeType ne null and bf.fee.feeType ne 'Staff'}">
+                                        <tr>
+                                            <td style="padding-left: 12px;">
+                                                <h:outputLabel class="itemsBlockRightFiveFive" value="  #{bf.fee.name}" style="font-style: italic;"/>
+                                            </td>
+                                            <td style="text-align: right; padding-right: 30px;">
+                                                <h:outputLabel class="itemsBlockRightFiveFive" value="#{bf.feeGrossValue}">
+                                                    <f:convertNumber pattern="#,##0.00" />
+                                                </h:outputLabel>
+                                            </td>
+                                        </tr>
+                                    </h:panelGroup>
+                                    <!-- Professional (staff) fee sub-row with doctor/technician name -->
+                                    <h:panelGroup rendered="#{not bf.retired and bf.fee ne null and bf.fee.feeType ne null and bf.fee.feeType eq 'Staff'}">
+                                        <tr>
+                                            <td style="padding-left: 12px;">
+                                                <h:outputLabel class="itemsBlockRightFiveFive"
+                                                    value="  #{bf.staff ne null and bf.staff.person ne null ? bf.staff.person.nameWithTitle : bf.fee.name}"
+                                                    style="font-style: italic;"/>
+                                            </td>
+                                            <td style="text-align: right; padding-right: 30px;">
+                                                <h:outputLabel class="itemsBlockRightFiveFive" value="#{bf.feeGrossValue}">
+                                                    <f:convertNumber pattern="#,##0.00" />
+                                                </h:outputLabel>
+                                            </td>
+                                        </tr>
+                                    </h:panelGroup>
+                                </ui:repeat>
+                            </h:panelGroup>
+                            <!-- Session number sub-row (unchanged) -->
+                            <h:panelGroup rendered="#{billItem.item.printSessionNumber}">
+                                <h:panelGroup rendered="#{configOptionApplicationController.getBooleanValueByKey('Print Individual Bill Item Session Number in OPD Bills')}">
                                     <tr>
-                                        <td  style="overflow: visible;">
-                                            <p:spacer height="1" width="10" ></p:spacer>
-                                            <h:outputLabel class="itemsBlockRightFiveFive" value="Session No. : " >
-                                            </h:outputLabel>
-                                            <h:outputLabel class="itemsBlockRightFiveFive"   value="#{billItem.billSession.serialNo}"    >
-                                            </h:outputLabel>
+                                        <td style="overflow: visible;">
+                                            <p:spacer height="1" width="10"/>
+                                            <h:outputLabel class="itemsBlockRightFiveFive" value="Session No. : "/>
+                                            <h:outputLabel class="itemsBlockRightFiveFive" value="#{billItem.billSession.serialNo}"/>
                                         </td>
                                     </tr>
                                 </h:panelGroup>
                             </h:panelGroup>
-
                         </ui:repeat>
                     </h:panelGroup>
 
@@ -342,6 +397,28 @@
                 <table style="width: 100%;">
 
                     <h:panelGroup rendered="#{cc.attrs.bill.margin > 0? 'false':'true'}">
+                        <h:panelGroup rendered="#{configOptionApplicationController.getBooleanValueByKey('OPD Bill Display Fee Breakdown', true)}">
+                            <tr>
+                                <td class="totalsBlock" style="text-align: left; width: 60%;">
+                                    <h:outputLabel value="Hospital Fee" />
+                                </td>
+                                <td class="totalsBlock" style="text-align: right!important; width: 40%; padding-right: 30px;">
+                                    <h:outputLabel value="#{cc.attrs.bill.hospitalFee}">
+                                        <f:convertNumber pattern="#,##0.00" />
+                                    </h:outputLabel>
+                                </td>
+                            </tr>
+                            <tr>
+                                <td class="totalsBlock" style="text-align: left; width: 60%;">
+                                    <h:outputLabel value="Professional Fee" />
+                                </td>
+                                <td class="totalsBlock" style="text-align: right!important; width: 40%; padding-right: 30px;">
+                                    <h:outputLabel value="#{cc.attrs.bill.staffFee}">
+                                        <f:convertNumber pattern="#,##0.00" />
+                                    </h:outputLabel>
+                                </td>
+                            </tr>
+                        </h:panelGroup>
                         <tr>
                             <td class="totalsBlock" style="text-align: left; width: 60%;">
                                 <h:outputLabel value="Total" />


### PR DESCRIPTION
<img width="1066" height="605" alt="image" src="https://github.com/user-attachments/assets/4c2f402a-4335-4329-b30a-5683f3822b32" />


**The totals section at the bottom still shows separate Hospital Fee and Professional Fee totals for the whole bill. The config key 'OPD Bill Display Fee Breakdown' defaults to true now, so no configuration change is needed.**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced dual display modes for OPD bills: compact view (default) showing item totals, and detailed breakdown mode displaying itemized hospital and professional fees with associated staff information.

* **UI Updates**
  * Enhanced bill layout with improved formatting and spacing across both display modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->