### PR TITLE
Fix Doctor Name Show

### DIFF
--- a/src/main/java/com/divudi/core/data/dto/OpdSaleSummaryDTO.java
+++ b/src/main/java/com/divudi/core/data/dto/OpdSaleSummaryDTO.java
@@ -17,6 +17,9 @@ public class OpdSaleSummaryDTO implements Serializable {
     private Long categoryId;
     private Long itemId;
 
+    // Doctor/staff assigned to this item
+    private String staffName;
+
     public OpdSaleSummaryDTO() {
     }
 
@@ -52,6 +55,19 @@ public class OpdSaleSummaryDTO implements Serializable {
         this.grossAmount = grossAmount;
         this.discountAmount = discountAmount;
         this.netTotal = netTotal;
+    }
+
+    // NEW: Constructor with staff name for doctor display in reports
+    public OpdSaleSummaryDTO(Long categoryId, String categoryName,
+                              Long itemId, String itemName,
+                              Long itemCount,
+                              Double hospitalFee, Double professionalFee,
+                              Double grossAmount, Double discountAmount,
+                              Double netTotal,
+                              String staffName) {
+        this(categoryId, categoryName, itemId, itemName, itemCount,
+             hospitalFee, professionalFee, grossAmount, discountAmount, netTotal);
+        this.staffName = staffName;
     }
 
     public String getCategoryName() {
@@ -132,5 +148,13 @@ public class OpdSaleSummaryDTO implements Serializable {
 
     public void setItemId(Long itemId) {
         this.itemId = itemId;
+    }
+
+    public String getStaffName() {
+        return staffName;
+    }
+
+    public void setStaffName(String staffName) {
+        this.staffName = staffName;
     }
 }

--- a/src/main/webapp/opd/analytics/itemized_sale_summary_dto.xhtml
+++ b/src/main/webapp/opd/analytics/itemized_sale_summary_dto.xhtml
@@ -152,7 +152,7 @@
                                              rows="10"
                                              paginatorTemplate="{CurrentPageReport}  {FirstPageLink} {PreviousPageLink} {PageLinks} {NextPageLink} {LastPageLink} {RowsPerPageDropdown}"
                                              rowsPerPageTemplate="5,10,20"
-                                             rowKey="#{row.itemId}">
+                                             rowKey="#{row.itemId}_#{row.staffName}">
                                     <f:facet name="header" >
                                         <h:outputText value="Itemized Sales Summary (DTO - Optimized)" ></h:outputText>
                                     </f:facet>
@@ -187,6 +187,12 @@
                                             action="#{searchController.navigateToOpdBillItemListFromDto(row)}">
                                             <h:outputText title="View Item Details" value="&#xf0f6;" styleClass="fa mr-2" />
                                         </p:commandLink>
+                                    </p:column>
+                                    <p:column>
+                                        <f:facet name="header">
+                                            <h:outputText value="Doctor / Technician" />
+                                        </f:facet>
+                                        <h:outputText value="#{row.staffName}" />
                                     </p:column>
                                     <p:column>
                                         <f:facet name="header">


### PR DESCRIPTION
<img width="1919" height="1000" alt="image" src="https://github.com/user-attachments/assets/a5ad2922-3899-40af-a13e-05c6105d4ee7" />



**The issue was caused by the query filtering with bf.fee.feeType = Staff.
Some BillFee records had fee as null, and in some cases scanning doctor fees were not saved as Staff fee type. Because of that, valid doctor-assigned fees were not coming in the result.
I removed the feeType filter. Since we already use an inner join with bf.staff, it automatically returns only BillFees that have a doctor/technician assigned. So the extra filter was unnecessary and was blocking the correct data**