### PR TITLE
18647 create wireframe for income summary category

### DIFF
--- a/src/main/webapp/pharmacy/reports/summary_reports/pharmacy_income_summary_category.xhtml
+++ b/src/main/webapp/pharmacy/reports/summary_reports/pharmacy_income_summary_category.xhtml
@@ -30,8 +30,7 @@
                         }
                         
                         .col-space1,
-                        .col-space2,
-                        .col-space3 {
+                        .col-space2 {
                             width: 2%; 
                         }
                     </style>


### PR DESCRIPTION
Issue: #18647 

File Changed:
- pharmacy_income_summary_category.xhtml
<hr/>

- From Date/ To Date/Institution/ site/department -Time Field Not Displayed Properly – Increase Text Box Width
- Discount Should Be Displayed After Net Sales
- X ray should be X-ray
- Report header was wrong ( Pharmacy Income Report should be Income summary category 

<img width="1919" height="931" alt="image" src="https://github.com/user-attachments/assets/299c52f5-aeb9-4af2-87be-bd19e34aa239" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Updated pharmacy income summary headings to use "Report" suffix and clarified column labels (e.g., "Cancel" replacing "Cancellation"); corrected "X-ray".
  * Minor spacing and inline style refinements for consistent gaps and responsive behavior.

* **Refactor**
  * Replaced fixed grid/table layout with responsive flex-based grouping for form controls, date pickers, and institution/site fields.
  * Reordered panels and table columns for improved logical flow and usability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->