### PR TITLE
Fix Brithdate Selection Year Range

### DIFF
--- a/src/main/webapp/admin/staff/staff.xhtml
+++ b/src/main/webapp/admin/staff/staff.xhtml
@@ -60,7 +60,7 @@
                                     <p:inputText  class="form-control" value="#{staffController.current.person.lastName}"></p:inputText>
 
                                     <p:outputLabel value="Date of Birth"></p:outputLabel>
-                                    <p:calendar navigator="true"  class="w-100" inputStyleClass="w-100" value="#{staffController.current.person.dob}" pattern="#{sessionController.applicationPreference.longDateFormat}" ></p:calendar>
+                                    <p:calendar navigator="true" yearRange="c-100:c" class="w-100" inputStyleClass="w-100" value="#{staffController.current.person.dob}" pattern="#{sessionController.applicationPreference.longDateFormat}" ></p:calendar>
 
                                     <p:outputLabel value="Details"></p:outputLabel>
                                     <p:inputTextarea  class="form-control" value="#{staffController.current.person.description}"></p:inputTextarea>


### PR DESCRIPTION
<img width="1919" height="933" alt="image" src="https://github.com/user-attachments/assets/d3592859-00cc-4cb7-b490-3ace2cece644" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Extended the Date of Birth calendar picker to allow selection of dates up to 100 years in the past, expanding the available year range for user input.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->