### PR TITLE
Accumulate BillFinanceDetails totals for pharmacy rate adjustments

### DIFF
--- a/src/main/java/com/divudi/bean/pharmacy/PharmacyAdjustmentController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacyAdjustmentController.java
@@ -1063,7 +1063,8 @@ public class PharmacyAdjustmentController implements Serializable {
         java.math.BigDecimal beforeVal = java.math.BigDecimal.valueOf(oldPurchaseRate * getStock().getStock());
         java.math.BigDecimal afterVal = java.math.BigDecimal.valueOf(newPurchaseRate * getStock().getStock());
 
-        bfd.setTotalPurchaseValue(changeVal);
+        java.math.BigDecimal prevPurchaseValue = bfd.getTotalPurchaseValue() == null ? java.math.BigDecimal.ZERO : bfd.getTotalPurchaseValue();
+        bfd.setTotalPurchaseValue(prevPurchaseValue.add(changeVal));
         bfd.setNetTotal(changeVal);
         bfd.setGrossTotal(java.math.BigDecimal.valueOf(Math.abs(changeValue)));
         bfd.setTotalQuantity(java.math.BigDecimal.valueOf(getStock().getStock()));
@@ -1353,7 +1354,8 @@ public class PharmacyAdjustmentController implements Serializable {
             java.math.BigDecimal beforeVal = java.math.BigDecimal.valueOf(oldRetailRate * dto.getStockQty());
             java.math.BigDecimal afterVal = java.math.BigDecimal.valueOf(newRetailRate * dto.getStockQty());
 
-            bfd.setTotalRetailSaleValue(changeVal);
+            java.math.BigDecimal prevRetailValue = bfd.getTotalRetailSaleValue() == null ? java.math.BigDecimal.ZERO : bfd.getTotalRetailSaleValue();
+            bfd.setTotalRetailSaleValue(prevRetailValue.add(changeVal));
             bfd.setNetTotal(changeVal);
             bfd.setGrossTotal(java.math.BigDecimal.valueOf(Math.abs(changeValue)));
             bfd.setTotalQuantity(java.math.BigDecimal.valueOf(dto.getStockQty()));


### PR DESCRIPTION
### Motivation
- A bug caused `BillFinanceDetails.totalRetailSaleValue` and `totalPurchaseValue` to be overwritten for each stock item during retail/purchase rate adjustments, losing earlier items' contributions. 
- This produced incorrect adjustment totals and led to F15 report discrepancies when a single adjustment bill covered multiple batches.

### Description
- Changed `savePrAdjustmentBillItems()` to add the current `changeVal` to `BillFinanceDetails.totalPurchaseValue` instead of overwriting it in `PharmacyAdjustmentController.java`.
- Changed `saveRsrAdjustmentBillItems()` to add the current `changeVal` to `BillFinanceDetails.totalRetailSaleValue` instead of overwriting it in `PharmacyAdjustmentController.java`.
- These edits ensure multi-item rate adjustment bills record cumulative finance totals and restore expected F15 adjustment behavior.
- Closes #18705.

### Testing
- No automated Java tests were run for this change (per repository guidance, run Java tests only on request); run `./detect-maven.sh test` to execute the test suite if desired.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6997afa7fb94832faeea7f14bd45c617)