### PR TITLE
Add PATCH bill data correction API for F15-approved fixes

### DIFF
--- a/developer_docs/API_BILL_DATA_CORRECTION.md
+++ b/developer_docs/API_BILL_DATA_CORRECTION.md
@@ -1,0 +1,116 @@
+# Bill Data Correction API
+
+## Overview
+
+This API provides a controlled way to correct already-saved bill-related financial data after human approval.
+
+- **Endpoint**: `PATCH /api/bill_data_correction`
+- **Auth Header**: `Finance: <API_KEY>`
+- **Purpose**: Correct historical data in bill records without direct database access.
+
+## Current Related Endpoints
+
+Before applying corrections, use these read-only endpoints to identify the exact records:
+
+- `GET /api/pharmacy_f15_report`
+- `GET /api/costing_data/bills_by_type`
+- `GET /api/costing_data/by_bill_id/{billId}`
+
+Then apply updates using:
+
+- `PATCH /api/bill_data_correction`
+
+## Request Body
+
+```json
+{
+  "targetType": "BILL_FINANCE_DETAILS",
+  "targetId": 987654,
+  "fields": {
+    "totalRetailSaleValue": -62709.88,
+    "totalCostValue": 0.0
+  },
+  "auditComment": "F15 discrepancy correction — approved by Dr. Smith on 2026-02-20",
+  "approvedBy": "Dr. Smith"
+}
+```
+
+## Supported `targetType`
+
+| targetType | Entity | Editable fields |
+|---|---|---|
+| `BILL` | Bill | `netTotal`, `grossTotal`, `comments` |
+| `BILL_ITEM` | BillItem | `qty`, `rate`, `grossValue`, `netValue`, `discount` |
+| `BILL_FINANCE_DETAILS` | BillFinanceDetails | `totalRetailSaleValue`, `totalCostValue`, `totalPurchaseValue`, `netTotal`, `grossTotal` |
+| `BILL_FEES` | BillFee | `feeValue`, `grossValue`, `netValue` |
+| `BILL_ITEM_FINANCE_DETAILS` | BillItemFinanceDetails | `valueAtRetailRate`, `valueAtCostRate`, `costRate`, `retailSaleRate` |
+| `PHARMACEUTICAL_BILL_ITEM` | PharmaceuticalBillItem | `qty`, `retailRate`, `costRate`, `retailValue`, `costValue` |
+
+## Validation Rules
+
+- `targetType`, `targetId`, and `fields` are mandatory.
+- `auditComment` is mandatory.
+- `approvedBy` is mandatory.
+- Unknown fields for the selected `targetType` are rejected with `400`.
+- API key must be valid and mapped to an active user.
+
+## Response (Success)
+
+```json
+{
+  "status": "success",
+  "code": 200,
+  "data": {
+    "targetType": "BILL_FINANCE_DETAILS",
+    "targetId": 987654,
+    "previousValues": {
+      "totalRetailSaleValue": -62422.21
+    },
+    "newValues": {
+      "totalRetailSaleValue": -62709.88
+    },
+    "auditComment": "F15 discrepancy correction — approved by Dr. Smith on 2026-02-20",
+    "approvedBy": "Dr. Smith",
+    "correctedAt": "2026-02-20 14:35:00",
+    "correctedByApiUser": "admin_user"
+  }
+}
+```
+
+## Error Response
+
+```json
+{
+  "status": "error",
+  "code": 400,
+  "message": "Field 'unknownField' is not allowed for BILL_FINANCE_DETAILS"
+}
+```
+
+## Example cURL
+
+```bash
+curl -s -X PATCH "$BASE_URL/api/bill_data_correction" \
+  -H "Finance: $FINANCE_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "targetType": "BILL_FINANCE_DETAILS",
+    "targetId": 987654,
+    "fields": {
+      "totalRetailSaleValue": -62709.88
+    },
+    "auditComment": "F15 discrepancy correction - approved by Dr. Smith on 2026-02-20",
+    "approvedBy": "Dr. Smith"
+  }'
+```
+
+## Audit Trail
+
+Every correction is appended to the parent bill's `comments` including:
+
+- correction timestamp
+- target type and id
+- API user
+- approver
+- audit comment
+- previous values and new values

--- a/developer_docs/API_F15_REPORT.md
+++ b/developer_docs/API_F15_REPORT.md
@@ -435,8 +435,25 @@ curl -s -X POST "$BASE_URL/api/pharmacy_adjustments/purchase_rate" \
   }'
 ```
 
-For bill-level data corrections (wrong `BillItemFinanceDetails` values), these require
-developer action — a future correction API will be added once specific root causes are identified.
+For bill-level data corrections, use the bill correction endpoint after explicit human approval:
+
+```bash
+# Set BASE_URL and FINANCE_KEY from user input before running
+curl -s -X PATCH "$BASE_URL/api/bill_data_correction" \
+  -H "Finance: $FINANCE_KEY" \
+  -H "Content-Type: application/json" \
+  -d "{
+    \"targetType\": \"BILL_FINANCE_DETAILS\",
+    \"targetId\": <billFinanceDetailsId>,
+    \"fields\": {
+      \"totalRetailSaleValue\": <corrected_value>
+    },
+    \"auditComment\": \"F15 discrepancy correction - approved by <name> on <date>\",
+    \"approvedBy\": \"<name>\"
+  }"
+```
+
+Supported correction targets are documented in `developer_docs/API_BILL_DATA_CORRECTION.md`.
 
 ---
 

--- a/src/main/java/com/divudi/service/BillDataCorrectionService.java
+++ b/src/main/java/com/divudi/service/BillDataCorrectionService.java
@@ -1,0 +1,403 @@
+package com.divudi.service;
+
+import com.divudi.core.entity.Bill;
+import com.divudi.core.entity.BillFee;
+import com.divudi.core.entity.BillFinanceDetails;
+import com.divudi.core.entity.BillItem;
+import com.divudi.core.entity.BillItemFinanceDetails;
+import com.divudi.core.entity.WebUser;
+import com.divudi.core.entity.pharmacy.PharmaceuticalBillItem;
+import java.math.BigDecimal;
+import java.text.SimpleDateFormat;
+import java.util.Arrays;
+import java.util.Date;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Set;
+import javax.ejb.Stateless;
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+
+@Stateless
+public class BillDataCorrectionService {
+
+    @PersistenceContext
+    private EntityManager em;
+
+    private static final Set<String> BILL_FIELDS = new HashSet<>(Arrays.asList("netTotal", "grossTotal", "comments"));
+    private static final Set<String> BILL_ITEM_FIELDS = new HashSet<>(Arrays.asList("qty", "rate", "grossValue", "netValue", "discount"));
+    private static final Set<String> BILL_FINANCE_FIELDS = new HashSet<>(Arrays.asList("totalRetailSaleValue", "totalCostValue", "totalPurchaseValue", "netTotal", "grossTotal"));
+    private static final Set<String> BILL_FEE_FIELDS = new HashSet<>(Arrays.asList("feeValue", "grossValue", "netValue"));
+    private static final Set<String> BILL_ITEM_FINANCE_FIELDS = new HashSet<>(Arrays.asList("valueAtRetailRate", "valueAtCostRate", "costRate", "retailSaleRate"));
+    private static final Set<String> PHARMACEUTICAL_BILL_ITEM_FIELDS = new HashSet<>(Arrays.asList("qty", "retailRate", "costRate", "retailValue", "costValue"));
+
+    public Map<String, Object> correctData(String targetType,
+            Long targetId,
+            Map<String, Object> fields,
+            String auditComment,
+            String approvedBy,
+            WebUser apiUser) {
+
+        if (targetType == null || targetType.trim().isEmpty()) {
+            throw new IllegalArgumentException("targetType is required");
+        }
+        if (targetId == null) {
+            throw new IllegalArgumentException("targetId is required");
+        }
+        if (fields == null || fields.isEmpty()) {
+            throw new IllegalArgumentException("fields are required");
+        }
+
+        String normalizedType = targetType.trim().toUpperCase();
+
+        Map<String, Object> previousValues = new LinkedHashMap<>();
+        Map<String, Object> newValues = new LinkedHashMap<>();
+        Bill parentBill;
+
+        switch (normalizedType) {
+            case "BILL":
+                parentBill = updateBill(targetId, fields, previousValues, newValues);
+                break;
+            case "BILL_ITEM":
+                parentBill = updateBillItem(targetId, fields, previousValues, newValues);
+                break;
+            case "BILL_FINANCE_DETAILS":
+                parentBill = updateBillFinanceDetails(targetId, fields, previousValues, newValues);
+                break;
+            case "BILL_FEES":
+                parentBill = updateBillFee(targetId, fields, previousValues, newValues);
+                break;
+            case "BILL_ITEM_FINANCE_DETAILS":
+                parentBill = updateBillItemFinanceDetails(targetId, fields, previousValues, newValues);
+                break;
+            case "PHARMACEUTICAL_BILL_ITEM":
+                parentBill = updatePharmaceuticalBillItem(targetId, fields, previousValues, newValues);
+                break;
+            default:
+                throw new IllegalArgumentException("Unsupported targetType: " + targetType);
+        }
+
+        if (parentBill == null) {
+            throw new IllegalStateException("Unable to resolve parent bill for targetType " + targetType + " and targetId " + targetId);
+        }
+
+        appendAuditLog(parentBill, normalizedType, targetId, previousValues, newValues, auditComment, approvedBy, apiUser);
+        em.merge(parentBill);
+        em.flush();
+
+        String correctedBy = apiUser != null ? apiUser.getWebUserName() : null;
+
+        Map<String, Object> result = new LinkedHashMap<>();
+        result.put("targetType", normalizedType);
+        result.put("targetId", targetId);
+        result.put("previousValues", previousValues);
+        result.put("newValues", newValues);
+        result.put("auditComment", auditComment);
+        result.put("approvedBy", approvedBy);
+        result.put("correctedAt", new SimpleDateFormat("yyyy-MM-dd HH:mm:ss").format(new Date()));
+        result.put("correctedByApiUser", correctedBy);
+        return result;
+    }
+
+    private Bill updateBill(Long id, Map<String, Object> fields, Map<String, Object> previousValues, Map<String, Object> newValues) {
+        Bill entity = em.find(Bill.class, id);
+        if (entity == null) {
+            throw new IllegalArgumentException("Bill not found for id " + id);
+        }
+        validateAllowedFields(fields, BILL_FIELDS, "BILL");
+
+        if (fields.containsKey("netTotal")) {
+            previousValues.put("netTotal", entity.getNetTotal());
+            double value = toDouble(fields.get("netTotal"), "netTotal");
+            entity.setNetTotal(value);
+            newValues.put("netTotal", entity.getNetTotal());
+        }
+        if (fields.containsKey("grossTotal")) {
+            previousValues.put("grossTotal", entity.getTotal());
+            double value = toDouble(fields.get("grossTotal"), "grossTotal");
+            entity.setTotal(value);
+            newValues.put("grossTotal", entity.getTotal());
+        }
+        if (fields.containsKey("comments")) {
+            previousValues.put("comments", entity.getComments());
+            String value = toStringValue(fields.get("comments"));
+            entity.setComments(value);
+            newValues.put("comments", entity.getComments());
+        }
+
+        em.merge(entity);
+        return entity;
+    }
+
+    private Bill updateBillItem(Long id, Map<String, Object> fields, Map<String, Object> previousValues, Map<String, Object> newValues) {
+        BillItem entity = em.find(BillItem.class, id);
+        if (entity == null) {
+            throw new IllegalArgumentException("BillItem not found for id " + id);
+        }
+        validateAllowedFields(fields, BILL_ITEM_FIELDS, "BILL_ITEM");
+
+        if (fields.containsKey("qty")) {
+            previousValues.put("qty", entity.getQty());
+            double value = toDouble(fields.get("qty"), "qty");
+            entity.setQty(value);
+            newValues.put("qty", entity.getQty());
+        }
+        if (fields.containsKey("rate")) {
+            previousValues.put("rate", entity.getRate());
+            double value = toDouble(fields.get("rate"), "rate");
+            entity.setRate(value);
+            newValues.put("rate", entity.getRate());
+        }
+        if (fields.containsKey("grossValue")) {
+            previousValues.put("grossValue", entity.getGrossValue());
+            double value = toDouble(fields.get("grossValue"), "grossValue");
+            entity.setGrossValue(value);
+            newValues.put("grossValue", entity.getGrossValue());
+        }
+        if (fields.containsKey("netValue")) {
+            previousValues.put("netValue", entity.getNetValue());
+            double value = toDouble(fields.get("netValue"), "netValue");
+            entity.setNetValue(value);
+            newValues.put("netValue", entity.getNetValue());
+        }
+        if (fields.containsKey("discount")) {
+            previousValues.put("discount", entity.getDiscount());
+            double value = toDouble(fields.get("discount"), "discount");
+            entity.setDiscount(value);
+            newValues.put("discount", entity.getDiscount());
+        }
+
+        em.merge(entity);
+        return entity.getBill();
+    }
+
+    private Bill updateBillFinanceDetails(Long id, Map<String, Object> fields, Map<String, Object> previousValues, Map<String, Object> newValues) {
+        BillFinanceDetails entity = em.find(BillFinanceDetails.class, id);
+        if (entity == null) {
+            throw new IllegalArgumentException("BillFinanceDetails not found for id " + id);
+        }
+        validateAllowedFields(fields, BILL_FINANCE_FIELDS, "BILL_FINANCE_DETAILS");
+
+        if (fields.containsKey("totalRetailSaleValue")) {
+            previousValues.put("totalRetailSaleValue", entity.getTotalRetailSaleValue());
+            BigDecimal value = toBigDecimal(fields.get("totalRetailSaleValue"), "totalRetailSaleValue");
+            entity.setTotalRetailSaleValue(value);
+            newValues.put("totalRetailSaleValue", entity.getTotalRetailSaleValue());
+        }
+        if (fields.containsKey("totalCostValue")) {
+            previousValues.put("totalCostValue", entity.getTotalCostValue());
+            BigDecimal value = toBigDecimal(fields.get("totalCostValue"), "totalCostValue");
+            entity.setTotalCostValue(value);
+            newValues.put("totalCostValue", entity.getTotalCostValue());
+        }
+        if (fields.containsKey("totalPurchaseValue")) {
+            previousValues.put("totalPurchaseValue", entity.getTotalPurchaseValue());
+            BigDecimal value = toBigDecimal(fields.get("totalPurchaseValue"), "totalPurchaseValue");
+            entity.setTotalPurchaseValue(value);
+            newValues.put("totalPurchaseValue", entity.getTotalPurchaseValue());
+        }
+        if (fields.containsKey("netTotal")) {
+            previousValues.put("netTotal", entity.getNetTotal());
+            BigDecimal value = toBigDecimal(fields.get("netTotal"), "netTotal");
+            entity.setNetTotal(value);
+            newValues.put("netTotal", entity.getNetTotal());
+        }
+        if (fields.containsKey("grossTotal")) {
+            previousValues.put("grossTotal", entity.getGrossTotal());
+            BigDecimal value = toBigDecimal(fields.get("grossTotal"), "grossTotal");
+            entity.setGrossTotal(value);
+            newValues.put("grossTotal", entity.getGrossTotal());
+        }
+
+        em.merge(entity);
+        return entity.getBill();
+    }
+
+    private Bill updateBillFee(Long id, Map<String, Object> fields, Map<String, Object> previousValues, Map<String, Object> newValues) {
+        BillFee entity = em.find(BillFee.class, id);
+        if (entity == null) {
+            throw new IllegalArgumentException("BillFee not found for id " + id);
+        }
+        validateAllowedFields(fields, BILL_FEE_FIELDS, "BILL_FEES");
+
+        if (fields.containsKey("feeValue")) {
+            previousValues.put("feeValue", entity.getFeeValue());
+            double value = toDouble(fields.get("feeValue"), "feeValue");
+            entity.setFeeValue(value);
+            newValues.put("feeValue", entity.getFeeValue());
+        }
+        if (fields.containsKey("grossValue")) {
+            previousValues.put("grossValue", entity.getFeeGrossValue());
+            double value = toDouble(fields.get("grossValue"), "grossValue");
+            entity.setFeeGrossValue(value);
+            newValues.put("grossValue", entity.getFeeGrossValue());
+        }
+        if (fields.containsKey("netValue")) {
+            previousValues.put("netValue", entity.getFeeValue());
+            double value = toDouble(fields.get("netValue"), "netValue");
+            entity.setFeeValue(value);
+            newValues.put("netValue", entity.getFeeValue());
+        }
+
+        em.merge(entity);
+        if (entity.getBill() != null) {
+            return entity.getBill();
+        }
+        if (entity.getBillItem() != null) {
+            return entity.getBillItem().getBill();
+        }
+        return null;
+    }
+
+    private Bill updateBillItemFinanceDetails(Long id, Map<String, Object> fields, Map<String, Object> previousValues, Map<String, Object> newValues) {
+        BillItemFinanceDetails entity = em.find(BillItemFinanceDetails.class, id);
+        if (entity == null) {
+            throw new IllegalArgumentException("BillItemFinanceDetails not found for id " + id);
+        }
+        validateAllowedFields(fields, BILL_ITEM_FINANCE_FIELDS, "BILL_ITEM_FINANCE_DETAILS");
+
+        if (fields.containsKey("valueAtRetailRate")) {
+            previousValues.put("valueAtRetailRate", entity.getValueAtRetailRate());
+            BigDecimal value = toBigDecimal(fields.get("valueAtRetailRate"), "valueAtRetailRate");
+            entity.setValueAtRetailRate(value);
+            newValues.put("valueAtRetailRate", entity.getValueAtRetailRate());
+        }
+        if (fields.containsKey("valueAtCostRate")) {
+            previousValues.put("valueAtCostRate", entity.getValueAtCostRate());
+            BigDecimal value = toBigDecimal(fields.get("valueAtCostRate"), "valueAtCostRate");
+            entity.setValueAtCostRate(value);
+            newValues.put("valueAtCostRate", entity.getValueAtCostRate());
+        }
+        if (fields.containsKey("costRate")) {
+            previousValues.put("costRate", entity.getCostRate());
+            BigDecimal value = toBigDecimal(fields.get("costRate"), "costRate");
+            entity.setCostRate(value);
+            newValues.put("costRate", entity.getCostRate());
+        }
+        if (fields.containsKey("retailSaleRate")) {
+            previousValues.put("retailSaleRate", entity.getRetailSaleRate());
+            BigDecimal value = toBigDecimal(fields.get("retailSaleRate"), "retailSaleRate");
+            entity.setRetailSaleRate(value);
+            newValues.put("retailSaleRate", entity.getRetailSaleRate());
+        }
+
+        em.merge(entity);
+        return entity.getBillItem() != null ? entity.getBillItem().getBill() : null;
+    }
+
+    private Bill updatePharmaceuticalBillItem(Long id, Map<String, Object> fields, Map<String, Object> previousValues, Map<String, Object> newValues) {
+        PharmaceuticalBillItem entity = em.find(PharmaceuticalBillItem.class, id);
+        if (entity == null) {
+            throw new IllegalArgumentException("PharmaceuticalBillItem not found for id " + id);
+        }
+        validateAllowedFields(fields, PHARMACEUTICAL_BILL_ITEM_FIELDS, "PHARMACEUTICAL_BILL_ITEM");
+
+        if (fields.containsKey("qty")) {
+            previousValues.put("qty", entity.getQty());
+            double value = toDouble(fields.get("qty"), "qty");
+            entity.setQty(value);
+            newValues.put("qty", entity.getQty());
+        }
+        if (fields.containsKey("retailRate")) {
+            previousValues.put("retailRate", entity.getRetailRate());
+            double value = toDouble(fields.get("retailRate"), "retailRate");
+            entity.setRetailRate(value);
+            newValues.put("retailRate", entity.getRetailRate());
+        }
+        if (fields.containsKey("costRate")) {
+            previousValues.put("costRate", entity.getCostRate());
+            double value = toDouble(fields.get("costRate"), "costRate");
+            entity.setCostRate(value);
+            newValues.put("costRate", entity.getCostRate());
+        }
+        if (fields.containsKey("retailValue")) {
+            previousValues.put("retailValue", entity.getRetailValue());
+            double value = toDouble(fields.get("retailValue"), "retailValue");
+            entity.setRetailValue(value);
+            newValues.put("retailValue", entity.getRetailValue());
+        }
+        if (fields.containsKey("costValue")) {
+            previousValues.put("costValue", entity.getCostValue());
+            double value = toDouble(fields.get("costValue"), "costValue");
+            entity.setCostValue(value);
+            newValues.put("costValue", entity.getCostValue());
+        }
+
+        em.merge(entity);
+        return entity.getBillItem() != null ? entity.getBillItem().getBill() : null;
+    }
+
+    private void validateAllowedFields(Map<String, Object> fields, Set<String> allowedFields, String targetType) {
+        for (String key : fields.keySet()) {
+            if (!allowedFields.contains(key)) {
+                throw new IllegalArgumentException("Field '" + key + "' is not allowed for " + targetType);
+            }
+        }
+    }
+
+    private void appendAuditLog(Bill bill,
+            String targetType,
+            Long targetId,
+            Map<String, Object> previousValues,
+            Map<String, Object> newValues,
+            String auditComment,
+            String approvedBy,
+            WebUser apiUser) {
+
+        String existing = bill.getComments();
+        String correctedBy = apiUser != null ? apiUser.getWebUserName() : "Unknown API User";
+        String now = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss").format(new Date());
+
+        StringBuilder sb = new StringBuilder();
+        if (existing != null && !existing.trim().isEmpty()) {
+            sb.append(existing.trim()).append("\n\n");
+        }
+        sb.append("[Bill Data Correction]")
+                .append("\nTime: ").append(now)
+                .append("\nTargetType: ").append(targetType)
+                .append("\nTargetId: ").append(targetId)
+                .append("\nCorrectedByApiUser: ").append(correctedBy)
+                .append("\nApprovedBy: ").append(approvedBy)
+                .append("\nAuditComment: ").append(auditComment)
+                .append("\nPreviousValues: ").append(previousValues)
+                .append("\nNewValues: ").append(newValues);
+
+        bill.setComments(sb.toString());
+    }
+
+    private BigDecimal toBigDecimal(Object value, String fieldName) {
+        if (value == null) {
+            return null;
+        }
+        if (value instanceof BigDecimal) {
+            return (BigDecimal) value;
+        }
+        if (value instanceof Number) {
+            return BigDecimal.valueOf(((Number) value).doubleValue());
+        }
+        try {
+            return new BigDecimal(value.toString());
+        } catch (NumberFormatException ex) {
+            throw new IllegalArgumentException("Field '" + fieldName + "' must be numeric");
+        }
+    }
+
+    private double toDouble(Object value, String fieldName) {
+        if (value == null) {
+            throw new IllegalArgumentException("Field '" + fieldName + "' can not be null");
+        }
+        if (value instanceof Number) {
+            return ((Number) value).doubleValue();
+        }
+        try {
+            return Double.parseDouble(value.toString());
+        } catch (NumberFormatException ex) {
+            throw new IllegalArgumentException("Field '" + fieldName + "' must be numeric");
+        }
+    }
+
+    private String toStringValue(Object value) {
+        return value == null ? null : value.toString();
+    }
+}

--- a/src/main/java/com/divudi/ws/common/ApplicationConfig.java
+++ b/src/main/java/com/divudi/ws/common/ApplicationConfig.java
@@ -43,6 +43,7 @@ public class ApplicationConfig extends Application {
         resources.add(com.divudi.ws.common.ConfigResource.class);
         resources.add(com.divudi.ws.fhir.Fhir.class);
         resources.add(com.divudi.ws.finance.BalanceHistoryApi.class);
+        resources.add(com.divudi.ws.finance.BillDataCorrectionApi.class);
         resources.add(com.divudi.ws.finance.CostingData.class);
         resources.add(com.divudi.ws.finance.Finance.class);
         resources.add(com.divudi.ws.finance.Qb.class);

--- a/src/main/java/com/divudi/ws/common/PATCH.java
+++ b/src/main/java/com/divudi/ws/common/PATCH.java
@@ -1,0 +1,13 @@
+package com.divudi.ws.common;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import javax.ws.rs.HttpMethod;
+
+@Target({ElementType.METHOD})
+@Retention(RetentionPolicy.RUNTIME)
+@HttpMethod("PATCH")
+public @interface PATCH {
+}

--- a/src/main/java/com/divudi/ws/finance/BillDataCorrectionApi.java
+++ b/src/main/java/com/divudi/ws/finance/BillDataCorrectionApi.java
@@ -1,0 +1,170 @@
+package com.divudi.ws.finance;
+
+import com.divudi.bean.common.ApiKeyController;
+import com.divudi.core.entity.ApiKey;
+import com.divudi.core.entity.WebUser;
+import com.divudi.service.BillDataCorrectionService;
+import com.divudi.ws.common.PATCH;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonSyntaxException;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import javax.ejb.EJB;
+import javax.enterprise.context.RequestScoped;
+import javax.inject.Inject;
+import javax.servlet.http.HttpServletRequest;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+
+@Path("bill_data_correction")
+@RequestScoped
+public class BillDataCorrectionApi {
+
+    @Context
+    private HttpServletRequest requestContext;
+
+    @Inject
+    private ApiKeyController apiKeyController;
+
+    @EJB
+    private BillDataCorrectionService correctionService;
+
+    private static final Gson gson = new GsonBuilder()
+            .setDateFormat("yyyy-MM-dd HH:mm:ss")
+            .create();
+
+    @PATCH
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response correctBillData(String requestBody) {
+        try {
+            String key = requestContext.getHeader("Finance");
+            WebUser user = validateApiKey(key);
+            if (user == null) {
+                return errorResponse("Not a valid key", 401);
+            }
+
+            CorrectionRequest request;
+            try {
+                request = gson.fromJson(requestBody, CorrectionRequest.class);
+            } catch (JsonSyntaxException ex) {
+                return errorResponse("Invalid JSON format: " + ex.getMessage(), 400);
+            }
+
+            if (request == null) {
+                return errorResponse("Request body is required", 400);
+            }
+            if (request.getAuditComment() == null || request.getAuditComment().trim().isEmpty()) {
+                return errorResponse("auditComment is required", 400);
+            }
+            if (request.getApprovedBy() == null || request.getApprovedBy().trim().isEmpty()) {
+                return errorResponse("approvedBy is required", 400);
+            }
+
+            Map<String, Object> result = correctionService.correctData(
+                    request.getTargetType(),
+                    request.getTargetId(),
+                    request.getFields(),
+                    request.getAuditComment().trim(),
+                    request.getApprovedBy().trim(),
+                    user
+            );
+
+            return successResponse(result);
+        } catch (IllegalArgumentException ex) {
+            return errorResponse(ex.getMessage(), 400);
+        } catch (IllegalStateException ex) {
+            return errorResponse(ex.getMessage(), 500);
+        } catch (Exception ex) {
+            return errorResponse("An error occurred: " + ex.getMessage(), 500);
+        }
+    }
+
+    private WebUser validateApiKey(String key) {
+        if (key == null || key.trim().isEmpty()) {
+            return null;
+        }
+
+        ApiKey apiKey = apiKeyController.findApiKey(key);
+        if (apiKey == null || apiKey.getDateOfExpiary() == null || apiKey.getDateOfExpiary().before(new java.util.Date())) {
+            return null;
+        }
+
+        WebUser user = apiKey.getWebUser();
+        if (user == null || user.isRetired() || !user.isActivated()) {
+            return null;
+        }
+
+        return user;
+    }
+
+    private Response successResponse(Object data) {
+        Map<String, Object> response = new LinkedHashMap<>();
+        response.put("status", "success");
+        response.put("code", 200);
+        response.put("data", data);
+        return Response.ok(gson.toJson(response), MediaType.APPLICATION_JSON).build();
+    }
+
+    private Response errorResponse(String message, int code) {
+        Map<String, Object> response = new LinkedHashMap<>();
+        response.put("status", "error");
+        response.put("code", code);
+        response.put("message", message);
+        return Response.status(code).entity(gson.toJson(response)).type(MediaType.APPLICATION_JSON).build();
+    }
+
+    public static class CorrectionRequest {
+
+        private String targetType;
+        private Long targetId;
+        private Map<String, Object> fields;
+        private String auditComment;
+        private String approvedBy;
+
+        public String getTargetType() {
+            return targetType;
+        }
+
+        public void setTargetType(String targetType) {
+            this.targetType = targetType;
+        }
+
+        public Long getTargetId() {
+            return targetId;
+        }
+
+        public void setTargetId(Long targetId) {
+            this.targetId = targetId;
+        }
+
+        public Map<String, Object> getFields() {
+            return fields;
+        }
+
+        public void setFields(Map<String, Object> fields) {
+            this.fields = fields;
+        }
+
+        public String getAuditComment() {
+            return auditComment;
+        }
+
+        public void setAuditComment(String auditComment) {
+            this.auditComment = auditComment;
+        }
+
+        public String getApprovedBy() {
+            return approvedBy;
+        }
+
+        public void setApprovedBy(String approvedBy) {
+            this.approvedBy = approvedBy;
+        }
+    }
+}


### PR DESCRIPTION
### Motivation
- Provide a controlled, auditable write path so human‑approved corrections can be applied to historical bill data (addresses the gap described in issue #18706). 
- Allow AI agents and operators to fix F15/reporting discrepancies (e.g. wrong `BillFinanceDetails.totalRetailSaleValue`) without direct DB access. 
- Enforce safety rules (field whitelists, mandatory approval text) and keep an audit trail appended to the parent bill's `comments`.

### Description
- Add `PATCH /api/bill_data_correction` JAX‑RS endpoint (`BillDataCorrectionApi`) that authenticates via the `Finance` API key and validates `auditComment` and `approvedBy` before applying changes.
- Implement `BillDataCorrectionService` which updates only whitelisted fields for these target types: `BILL`, `BILL_ITEM`, `BILL_FINANCE_DETAILS`, `BILL_FEES`, `BILL_ITEM_FINANCE_DETAILS`, and `PHARMACEUTICAL_BILL_ITEM`, capturing previous/new values and appending an audit block to the parent bill's `comments` before persisting.
- Add a lightweight `@PATCH` JAX‑RS method annotation and register the new resource in `ApplicationConfig` so the endpoint is exposed.
- Add `developer_docs/API_BILL_DATA_CORRECTION.md` documenting the endpoint, request/response format, allowed target types and validation rules, and update `developer_docs/API_F15_REPORT.md` Step 7 to reference the new endpoint.

### Testing
- Verified issue details with `curl` against the GitHub issue and updated the F15 workflow document to reference the new API; these checks succeeded.
- Ran repository searches (`rg`) and inspected `ApplicationConfig` to confirm the new resource and `@PATCH` annotation are registered; these static checks succeeded.
- Per repository guidelines no Maven compile/test was executed; unit/integration tests were not run in this change set.

Closes #18706

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6997b52c6274832f9706023ccf829af3)