### PR TITLE
Fix NullPointerException in navigateToAdmissionProfilePage

### DIFF
--- a/src/main/java/com/divudi/bean/inward/AdmissionController.java
+++ b/src/main/java/com/divudi/bean/inward/AdmissionController.java
@@ -968,16 +968,6 @@ public class AdmissionController implements Serializable, ControllerWithPatient 
                 bhtSummeryController.setPatientEncounterHasProvisionalBill(isAddmissionHaveProvisionalBill((Admission) current));
                 return bhtSummeryController.navigateToInpatientProfile();
             } else {
-                if (current.getCurrentPatientRoom().getRoomFacilityCharge().getDepartment() == null) {
-                    JsfUtil.addErrorMessage("Selected Room no has a department.");
-                    return "";
-                }
-
-                if (!current.getCurrentPatientRoom().getRoomFacilityCharge().getDepartment().getId().equals(sessionController.getDepartment().getId())) {
-                    JsfUtil.addErrorMessage("Patient is not in your department. Please transfer to the correct department.");
-                    return "";
-                }
-
                 roomChangeController.setCurrent(current);
                 roomChangeController.setCurrentPatientRoom(current.getCurrentPatientRoom());
                 return "/inward/admit_room?faces-redirect=true";


### PR DESCRIPTION
Remove unsafe getCurrentPatientRoom().getRoomFacilityCharge().getDepartment() chain that throws NPE when currentPatientRoom is null (new admissions not yet assigned to a room). Route directly to room assignment page instead.