### PR TITLE
Hotfix: Fix OPD bill settling FK violation and reduce log bloat

### DIFF
--- a/src/main/java/com/divudi/bean/collectingCentre/CollectingCentreBillController.java
+++ b/src/main/java/com/divudi/bean/collectingCentre/CollectingCentreBillController.java
@@ -1815,15 +1815,7 @@ public class CollectingCentreBillController implements Serializable, ControllerW
     }
 
     public void setBillFeePaymentAndPayment(double amount, BillFee bf, Payment p) {
-        BillFeePayment bfp = new BillFeePayment();
-        bfp.setBillFee(bf);
-        bfp.setAmount(amount);
-        bfp.setInstitution(bf.getBillItem().getItem().getInstitution());
-        bfp.setDepartment(bf.getBillItem().getItem().getDepartment());
-        bfp.setCreater(getSessionController().getLoggedUser());
-        bfp.setCreatedAt(new Date());
-        bfp.setPayment(p);
-        getBillFeePaymentFacade().create(bfp);
+        // BillFeePayment is deprecated and no longer used
     }
 
     public double calBillPaidValue(Bill b) {

--- a/src/main/java/com/divudi/bean/common/BillBeanController.java
+++ b/src/main/java/com/divudi/bean/common/BillBeanController.java
@@ -5554,15 +5554,7 @@ public class BillBeanController implements Serializable {
     }
 
     public void createBillFeePaymentAndPayment(BillFee bf, Payment p) {
-        BillFeePayment bfp = new BillFeePayment();
-        bfp.setBillFee(bf);
-        bfp.setAmount(bf.getSettleValue());
-        bfp.setInstitution(bf.getBillItem().getItem().getInstitution());
-        bfp.setDepartment(bf.getBillItem().getItem().getDepartment());
-        bfp.setCreater(sessionController.getLoggedUser());
-        bfp.setCreatedAt(new Date());
-        bfp.setPayment(p);
-        getBillFeePaymentFacade().create(bfp);
+        // BillFeePayment is deprecated and no longer used
     }
 
     public ItemFacade getItemFacade() {

--- a/src/main/java/com/divudi/bean/common/BillController.java
+++ b/src/main/java/com/divudi/bean/common/BillController.java
@@ -4922,15 +4922,7 @@ public class BillController implements Serializable, ControllerWithMultiplePayme
     }
 
     public void setBillFeePaymentAndPayment(double amount, BillFee bf, Payment p) {
-        BillFeePayment bfp = new BillFeePayment();
-        bfp.setBillFee(bf);
-        bfp.setAmount(amount);
-        bfp.setInstitution(bf.getBillItem().getItem().getInstitution());
-        bfp.setDepartment(bf.getBillItem().getItem().getDepartment());
-        bfp.setCreater(getSessionController().getLoggedUser());
-        bfp.setCreatedAt(new Date());
-        bfp.setPayment(p);
-        getBillFeePaymentFacade().create(bfp);
+        // BillFeePayment is deprecated and no longer used
     }
 
     public double calBillPaidValue(Bill b) {

--- a/src/main/java/com/divudi/bean/common/BillPackageController.java
+++ b/src/main/java/com/divudi/bean/common/BillPackageController.java
@@ -1963,15 +1963,7 @@ public class BillPackageController implements Serializable, ControllerWithPatien
     }
 
     public void setBillFeePaymentAndPayment(double amount, BillFee bf, Payment p) {
-        BillFeePayment bfp = new BillFeePayment();
-        bfp.setBillFee(bf);
-        bfp.setAmount(amount);
-        bfp.setInstitution(bf.getBillItem().getItem().getTransInstitution());
-        bfp.setDepartment(bf.getBillItem().getItem().getTransDepartment());
-        bfp.setCreater(getSessionController().getLoggedUser());
-        bfp.setCreatedAt(new Date());
-        bfp.setPayment(p);
-        billFeePaymentFacade.create(bfp);
+        // BillFeePayment is deprecated and no longer used
     }
 
     @Override

--- a/src/main/java/com/divudi/bean/common/OpdBatchBillCancellationController.java
+++ b/src/main/java/com/divudi/bean/common/OpdBatchBillCancellationController.java
@@ -5020,15 +5020,7 @@ public class OpdBatchBillCancellationController implements Serializable, Control
     }
 
     public void setBillFeePaymentAndPayment(double amount, BillFee bf, Payment p) {
-        BillFeePayment bfp = new BillFeePayment();
-        bfp.setBillFee(bf);
-        bfp.setAmount(amount);
-        bfp.setInstitution(bf.getBillItem().getItem().getInstitution());
-        bfp.setDepartment(bf.getBillItem().getItem().getDepartment());
-        bfp.setCreater(getSessionController().getLoggedUser());
-        bfp.setCreatedAt(new Date());
-        bfp.setPayment(p);
-        getBillFeePaymentFacade().create(bfp);
+        // BillFeePayment is deprecated and no longer used
     }
 
     public double calBillPaidValue(Bill b) {

--- a/src/main/java/com/divudi/bean/common/OpdPreSettleController.java
+++ b/src/main/java/com/divudi/bean/common/OpdPreSettleController.java
@@ -1654,15 +1654,7 @@ public class OpdPreSettleController implements Serializable, ControllerWithMulti
     }
 
     public void setBillFeePaymentAndPayment(double amount, BillFee bf, Payment p) {
-        BillFeePayment bfp = new BillFeePayment();
-        bfp.setBillFee(bf);
-        bfp.setAmount(amount);
-        bfp.setInstitution(bf.getBillItem().getItem().getInstitution());
-        bfp.setDepartment(bf.getBillItem().getItem().getDepartment());
-        bfp.setCreater(getSessionController().getLoggedUser());
-        bfp.setCreatedAt(new Date());
-        bfp.setPayment(p);
-        getBillFeePaymentFacade().create(bfp);
+        // BillFeePayment is deprecated and no longer used
     }
 
 //    public void setBillFeePaymentAndPayment(BillFee bf, Payment p) {

--- a/src/main/java/com/divudi/bean/common/StaffPaymentBillController.java
+++ b/src/main/java/com/divudi/bean/common/StaffPaymentBillController.java
@@ -898,15 +898,7 @@ public class StaffPaymentBillController implements Serializable {
     }
 
     public void createBillFeePaymentAndPayment(BillFee bf, Payment p) {
-        BillFeePayment bfp = new BillFeePayment();
-        bfp.setBillFee(bf);
-        bfp.setAmount(bf.getSettleValue());
-        bfp.setInstitution(getSessionController().getInstitution());
-        bfp.setDepartment(getSessionController().getDepartment());
-        bfp.setCreater(getSessionController().getLoggedUser());
-        bfp.setCreatedAt(new Date());
-        bfp.setPayment(p);
-        getBillFeePaymentFacade().create(bfp);
+        // BillFeePayment is deprecated and no longer used
     }
 
     public BillFee saveBillFee(BillItem bi, Payment p) {

--- a/src/main/java/com/divudi/bean/hr/WorkingTimeController.java
+++ b/src/main/java/com/divudi/bean/hr/WorkingTimeController.java
@@ -399,15 +399,7 @@ public class WorkingTimeController implements Serializable {
     }
 
     public void createBillFeePaymentAndPayment(BillFee bf, Payment p) {
-        BillFeePayment bfp = new BillFeePayment();
-        bfp.setBillFee(bf);
-        bfp.setAmount(bf.getSettleValue());
-        bfp.setInstitution(getSessionController().getInstitution());
-        bfp.setDepartment(getSessionController().getDepartment());
-        bfp.setCreater(getSessionController().getLoggedUser());
-        bfp.setCreatedAt(new Date());
-        bfp.setPayment(p);
-        billFeePaymentFacade.create(bfp);
+        // BillFeePayment is deprecated and no longer used
     }
 
     public void calculateStaffPayments() {

--- a/src/main/java/com/divudi/bean/inward/InwardStaffPaymentBillController.java
+++ b/src/main/java/com/divudi/bean/inward/InwardStaffPaymentBillController.java
@@ -485,15 +485,7 @@ public class InwardStaffPaymentBillController implements Serializable {
     }
 
     public void createBillFeePaymentAndPayment(BillFee bf, Payment p) {
-        BillFeePayment bfp = new BillFeePayment();
-        bfp.setBillFee(bf);
-        bfp.setAmount(bf.getSettleValue());
-        bfp.setInstitution(getSessionController().getInstitution());
-        bfp.setDepartment(getSessionController().getDepartment());
-        bfp.setCreater(getSessionController().getLoggedUser());
-        bfp.setCreatedAt(new Date());
-        bfp.setPayment(p);
-        getBillFeePaymentFacade().create(bfp);
+        // BillFeePayment is deprecated and no longer used
     }
 
     public void fillDocPayingBillByCreatedDate() {

--- a/src/main/java/com/divudi/bean/inward/InwardSurgeryPaymentBillController.java
+++ b/src/main/java/com/divudi/bean/inward/InwardSurgeryPaymentBillController.java
@@ -460,15 +460,7 @@ public class InwardSurgeryPaymentBillController implements Serializable {
     }
 
     public void createBillFeePaymentAndPayment(BillFee bf, Payment p) {
-        BillFeePayment bfp = new BillFeePayment();
-        bfp.setBillFee(bf);
-        bfp.setAmount(bf.getSettleValue());
-        bfp.setInstitution(getSessionController().getInstitution());
-        bfp.setDepartment(getSessionController().getDepartment());
-        bfp.setCreater(getSessionController().getLoggedUser());
-        bfp.setCreatedAt(new Date());
-        bfp.setPayment(p);
-        getBillFeePaymentFacade().create(bfp);
+        // BillFeePayment is deprecated and no longer used
     }
 
     private void fetchWithholdingDetailConfiguration() {

--- a/src/main/java/com/divudi/bean/lab/PatientReportController.java
+++ b/src/main/java/com/divudi/bean/lab/PatientReportController.java
@@ -801,16 +801,9 @@ public class PatientReportController implements Serializable {
             JsfUtil.addErrorMessage("Report Items values is empty");
             return 0;
         }
-        System.out.println("currentPatientReport = " + currentPatientReport);
-        System.out.println("currentPatientReport.getPatientReportItemValues() = " + currentPatientReport.getPatientReportItemValues());
-
         for (PatientReportItemValue priv : currentPatientReport.getPatientReportItemValues()) {
             if (priv != null) {
-                System.out.println("priv = " + priv);
-                System.out.println("priv in finding val is " + priv.getInvestigationItem().getName());
-                System.out.println("compairing are " + priv.getInvestigationItem().getId() + "  vs " + nameOfIxItem);
                 if (Objects.equals(priv.getInvestigationItem().getName(), nameOfIxItem)) {
-                    System.out.println("double val is " + priv.getDoubleValue());
                     if (priv.getDoubleValue() == null) {
                         return 0.0;
                     }
@@ -822,7 +815,6 @@ public class PatientReportController implements Serializable {
     }
 
     public void calculate() {
-        System.out.println("calculate");
         Date startTime = new Date();
         if (currentPatientReport == null) {
             JsfUtil.addErrorMessage("No Report to calculate");
@@ -927,11 +919,8 @@ public class PatientReportController implements Serializable {
                         calString = calString + currentPatientReport.getPatientInvestigation().getPatient().getAgeYears();
                     }
                 }
-                System.out.println("calString = " + calString);
-                System.out.println("baseJs = " + baseJs);
                 if (baseJs != null) {
                     calString = generateModifiedJavascriptFromBaseJavaScript(currentPatientReport, baseJs);
-                    System.out.println("calString = " + calString);
                 }
 
                 ScriptEngineManager mgr = new ScriptEngineManager();
@@ -940,23 +929,17 @@ public class PatientReportController implements Serializable {
                 try {
                     resultObj = engine.eval(calString);
                     if (resultObj == null) {
-                        System.out.println("resultObj Null = ");
                         result = 0.0;
                         resultStr = "";
                     } else if (resultObj instanceof String) {
                         resultStr = (String) resultObj;
-                        System.out.println("resultStr = " + resultObj);
                     } else if (resultObj instanceof Double) {
                         result = (double) resultObj;
                         resultStr = result + "";
-                        System.out.println("result = " + result);
                     } else {
-                        System.out.println("Else = ");
                         result = 0.0;
                         resultStr = "";
                     }
-                    System.out.println("resultStr = " + resultStr);
-                    System.out.println("result = " + result);
 
                 } catch (Exception ex) {
                     Logger.getLogger(PatientReportController.class
@@ -984,37 +967,29 @@ public class PatientReportController implements Serializable {
     private String generateModifiedJavascriptFromBaseJavaScript(PatientReport pr, String baseJs) {
         String modifiedJs = "";
         if (pr == null) {
-            System.out.println("Debug: PatientReport is null");
             return modifiedJs;
         }
         if (baseJs == null || baseJs.isEmpty()) {
-            System.out.println("Debug: Base JavaScript is null or empty");
             return modifiedJs;
         } else {
             modifiedJs = baseJs;
         }
 
         if (pr.getPatientInvestigation() == null) {
-            System.out.println("Debug: PatientInvestigation is null");
             return modifiedJs;
         }
         if (pr.getPatientInvestigation().getBillItem() == null) {
-            System.out.println("Debug: BillItem is null");
             return modifiedJs;
         }
         if (pr.getPatientInvestigation().getBillItem().getBill() == null) {
-            System.out.println("Debug: Bill is null");
             return modifiedJs;
         }
         if (pr.getPatientInvestigation().getBillItem().getBill().getPatient() == null) {
-            System.out.println("Debug: Patient is null");
             return modifiedJs;
         }
 
         String sex = pr.getPatientInvestigation().getBillItem().getBill().getPatient().getPerson().getSex() == Sex.Male ? "male" : "female";
         int ageInYears = pr.getPatientInvestigation().getBillItem().getBill().getPatient().getPerson().getAgeYearsComponent();
-
-        System.out.println("Debug: Sex is " + sex + ", Age is " + ageInYears);
 
         Pattern pattern = Pattern.compile("\\{\\{[^}]+\\}\\}");
         Matcher matcher = pattern.matcher(modifiedJs);
@@ -1023,18 +998,13 @@ public class PatientReportController implements Serializable {
             String placeholder = matcher.group();
             String placeholderWithoutBraces = placeholder.substring(2, placeholder.length() - 2); // Remove double braces for matching
 
-            System.out.println("Debug: Found placeholder " + placeholder);
-
             if ("sex".equalsIgnoreCase(placeholderWithoutBraces)) {
                 modifiedJs = modifiedJs.replace(placeholder, sex);
-                System.out.println("Debug: Replaced " + placeholder + " with " + sex);
             } else if ("age".equalsIgnoreCase(placeholderWithoutBraces)) {
                 modifiedJs = modifiedJs.replace(placeholder, String.valueOf(ageInYears));
-                System.out.println("Debug: Replaced " + placeholder + " with " + ageInYears);
             } else {
                 double reportItemValue = findPtReportItemVal(placeholderWithoutBraces);
                 modifiedJs = modifiedJs.replace(placeholder, String.valueOf(reportItemValue));
-                System.out.println("Debug: Replaced " + placeholder + " with " + reportItemValue);
             }
         }
 
@@ -1243,7 +1213,6 @@ public class PatientReportController implements Serializable {
                 currentReportUpload.setRetirer(sessionController.getLoggedUser());
                 uploadFacade.create(currentReportUpload);
             }
-            System.out.println("Report Removed");
         }
 
         if (configOptionApplicationController.getBooleanValueByKey("Lab Test History Enabled", false)) {
@@ -1306,9 +1275,7 @@ public class PatientReportController implements Serializable {
                             String suffix = priv.getInvestigationItem().getFormatSuffix() != null ? priv.getInvestigationItem().getFormatSuffix() : "";
                             String prefix = priv.getInvestigationItem().getFormatPrefix() != null ? priv.getInvestigationItem().getFormatPrefix() : "";
                             valueToReplacePlaceholder = prefix + String.format(formatString, dbl) + suffix;
-                            System.out.println("dbl = " + dbl + ", formatted value = " + valueToReplacePlaceholder);
                         } else {
-                            System.out.println("Double value is null for: " + itemName);
                         }
                         break;
                     case Memo:
@@ -1316,15 +1283,11 @@ public class PatientReportController implements Serializable {
                         break;
                     default:
                         valueToReplacePlaceholder = ""; // Handle other types if necessary
-                        System.out.println("No matching value for: " + itemName);
                         break;
                 }
 
                 if (valueToReplacePlaceholder != null && !valueToReplacePlaceholder.isEmpty()) {
                     replacementMap.put(itemName, valueToReplacePlaceholder);
-                    System.out.println("Mapping placeholder: " + itemName + " to value: " + valueToReplacePlaceholder);
-                } else {
-                    System.out.println("Value for placeholder " + itemName + " is null or empty.");
                 }
             }
         }
@@ -1335,42 +1298,25 @@ public class PatientReportController implements Serializable {
             String replacementValue = replacementMap.get(placeholder);
             if (replacementValue != null && !replacementValue.isEmpty()) {
                 updatedHtmlText = updatedHtmlText.replace("{" + placeholder + "}", replacementValue);
-                System.out.println("Replaced {" + placeholder + "} with " + replacementValue);
             } else {
                 // Replace with an empty string if no replacement value is found
                 updatedHtmlText = updatedHtmlText.replace("{" + placeholder + "}", "");
-                System.out.println("Replaced {" + placeholder + "} with an empty string.");
             }
         }
 
 // Save the updated HTML text back to the patient-specific report item
         for (PatientReportItemValue privHtml : currentPatientReport.getPatientReportItemValues()) {
-            System.out.println("privHtml = " + privHtml);
-
             if (privHtml == null) {
-                System.out.println("Skipping null privHtml.");
                 continue; // Skip null PatientReportItemValue
             }
 
             if (privHtml.getInvestigationItem() == null) {
-                System.out.println("Skipping privHtml with null InvestigationItem.");
                 continue; // Skip if InvestigationItem is null
             }
 
-            System.out.println("privHtml.getInvestigationItem() = " + privHtml.getInvestigationItem());
-            System.out.println("templateItem = " + templateItem);
-
             if (privHtml.getInvestigationItem().equals(templateItem)) {
-                System.out.println("InvestigationItem matches the templateItem.");
-
                 // Set the updated HTML content
                 privHtml.setLobValue(updatedHtmlText);
-
-                System.out.println("Set updated HTML content for PatientReportItemValue: "
-                        + "ID: " + privHtml.getId() + ", Name: "
-                        + privHtml.getInvestigationItem().getName());
-            } else {
-                System.out.println("InvestigationItem does not match the templateItem.");
             }
         }
 
@@ -1901,7 +1847,6 @@ public class PatientReportController implements Serializable {
 
             params.put("pi", patientInvestigation);
             params.put("ret", false);
-            System.out.println("jpql = " + jpql);
 
             pr = getFacade().findFirstByJpql(jpql, params);
 
@@ -1933,7 +1878,6 @@ public class PatientReportController implements Serializable {
             params.put("pi", patientInvestigation);
             params.put("ret", false);
             params.put("app", true);
-            System.out.println("jpql = " + jpql);
 
             pr = getFacade().findFirstByJpql(jpql, params);
 
@@ -1961,7 +1905,6 @@ public class PatientReportController implements Serializable {
         int groupCount = currentPatientReport.getPatientReportGroups().size();
 
         if (groupCount == 1) {
-            System.out.println("first group");
             for (PatientReportItemValue pvm : currentPatientReport.getPatientReportItemValues()) {
                 if (pvm.getInvestigationItem() != null
                         && pvm.getInvestigationItem().getIxItemType() != null
@@ -1970,9 +1913,7 @@ public class PatientReportController implements Serializable {
                 }
             }
         } else {
-            System.out.println("more than one group");
             PatientReportGroup firstGroup = currentPatientReport.getPatientReportGroups().get(0);
-            System.out.println("firstGroup = " + firstGroup.getGroupName());
             // Step 1: Filter the base items first
             List<PatientReportItemValue> baseAntibioticItems = new ArrayList<>();
             for (PatientReportItemValue basePvm : currentPatientReport.getPatientReportItemValues()) {
@@ -2269,7 +2210,6 @@ public class PatientReportController implements Serializable {
     }
 
     public void sendEmailForPatientReport() {
-        System.out.println("sendEmailForPatientReport");
         if (currentPatientReport == null) {
             JsfUtil.addErrorMessage("No patient report selected");
             return;
@@ -2311,8 +2251,6 @@ public class PatientReportController implements Serializable {
             return;
         }
 
-        System.out.println("all checks ok");
-
         AppEmail email = new AppEmail();
         email.setCreatedAt(new Date());
         email.setCreater(sessionController.getLoggedUser());
@@ -2328,8 +2266,6 @@ public class PatientReportController implements Serializable {
         email.setSentSuccessfully(false);
         email.setPending(true);
         getEmailFacade().create(email);
-
-        System.out.println("email = " + email);
 
         if (configOptionApplicationController.getBooleanValueByKey("Lab Test History Enabled", false)) {
             labTestHistoryController.addReportSentEmailHistory(currentPtIx, currentPatientReport, email);
@@ -2708,7 +2644,6 @@ public class PatientReportController implements Serializable {
     }
 
     public PatientReport createNewPatientReport(PatientInvestigation pi, Investigation ix, String sampleIds) {
-        System.out.println("createNewPatientReport");
         PatientReport r = null;
         if (pi != null && pi.getId() != null && ix != null) {
             r = new PatientReport();
@@ -2762,7 +2697,6 @@ public class PatientReportController implements Serializable {
     }
 
     public PatientReport createNewPatientReportForUpload(PatientInvestigation pi, Investigation ix, String sampleIds) {
-        System.out.println("createNewPatientReport");
         PatientReport r = null;
         if (pi != null && pi.getId() != null && ix != null) {
             r = new PatientReport();
@@ -2813,8 +2747,6 @@ public class PatientReportController implements Serializable {
     }
 
     public PatientReport createNewPatientTemplateReport(PatientInvestigation pi, Investigation ix) {
-        System.out.println("createNewPatientTemplateReport");
-
         //System.err.println("creating a new patient report");
         PatientReport r = null;
         if (pi != null && pi.getId() != null && ix != null) {
@@ -3024,11 +2956,7 @@ public class PatientReportController implements Serializable {
         }
         currentPatientReport = newlyCreatedReport;
 
-        System.out.println("New Report = " + currentPatientReport);
-
         getCommonReportItemController().setCategory(ix.getReportFormat());
-
-        System.out.println("currentPtIx = " + currentPtIx);
 
         patientReportUploadController.setReportUpload(null);
         patientReportUploadController.setPatientInvestigation(pi);
@@ -3113,30 +3041,23 @@ public class PatientReportController implements Serializable {
     }
 
     public void createNewReport(PatientInvestigation pi) {
-        System.out.println("createNewReport");
-        System.out.println("pi = " + pi);
         if (pi == null) {
             JsfUtil.addErrorMessage("No Patient Report");
             return;
         }
         Investigation ix = null;
-        System.out.println("pi.getInvestigation() = " + pi.getInvestigation());
         if (pi.getInvestigation() == null) {
             JsfUtil.addErrorMessage("No Investigation for Patient Report");
             return;
         } else {
             ix = (Investigation) pi.getInvestigation();
-            System.out.println("ix = " + ix);
         }
-        System.out.println("ix.getReportedAs() = " + ix.getReportedAs());
         if (ix.getReportedAs() != null) {
             ix = (Investigation) pi.getInvestigation().getReportedAs();
-            System.out.println("ix = " + ix);
         }
 
         currentReportInvestigation = ix;
         currentPtIx = pi;
-        System.out.println("ix.getReportType()  = " + ix.getReportType());
         if (ix.getReportType() == InvestigationReportType.Microbiology) {
             createNewMicrobiologyReport(pi, ix);
         } else if (ix.getReportType() == InvestigationReportType.HtmlTemplate) {

--- a/src/main/java/com/divudi/bean/opd/OpdBillController.java
+++ b/src/main/java/com/divudi/bean/opd/OpdBillController.java
@@ -4442,17 +4442,7 @@ public class OpdBillController implements Serializable, ControllerWithPatient, C
     }
 
     public void setBillFeePaymentAndPayment(double amount, BillFee bf, Payment p) {
-        if (bf.getId() != null) {
-            BillFeePayment bfp = new BillFeePayment();
-            bfp.setBillFee(bf);
-            bfp.setAmount(amount);
-            bfp.setInstitution(bf.getBillItem().getItem().getInstitution());
-            bfp.setDepartment(bf.getBillItem().getItem().getDepartment());
-            bfp.setCreater(getSessionController().getLoggedUser());
-            bfp.setCreatedAt(new Date());
-            bfp.setPayment(p);
-            billFeePaymentFacade.create(bfp);
-        }
+        // BillFeePayment is deprecated and no longer used
     }
 
     public double calBillPaidValue(Bill b) {

--- a/src/main/java/com/divudi/bean/opd/OpdOrderController.java
+++ b/src/main/java/com/divudi/bean/opd/OpdOrderController.java
@@ -3737,17 +3737,7 @@ public class OpdOrderController implements Serializable, ControllerWithPatient, 
     }
 
     public void setBillFeePaymentAndPayment(double amount, BillFee bf, Payment p) {
-        if (bf.getId() != null) {
-            BillFeePayment bfp = new BillFeePayment();
-            bfp.setBillFee(bf);
-            bfp.setAmount(amount);
-            bfp.setInstitution(bf.getBillItem().getItem().getInstitution());
-            bfp.setDepartment(bf.getBillItem().getItem().getDepartment());
-            bfp.setCreater(getSessionController().getLoggedUser());
-            bfp.setCreatedAt(new Date());
-            bfp.setPayment(p);
-            billFeePaymentFacade.create(bfp);
-        }
+        // BillFeePayment is deprecated and no longer used
     }
 
     public double calBillPaidValue(Bill b) {

--- a/src/main/java/com/divudi/bean/optician/OpticianPurchaseController.java
+++ b/src/main/java/com/divudi/bean/optician/OpticianPurchaseController.java
@@ -607,15 +607,7 @@ public class OpticianPurchaseController implements Serializable {
     }
 
     public void createBillFeePaymentAndPayment(BillFee bf, Payment p) {
-        BillFeePayment bfp = new BillFeePayment();
-        bfp.setBillFee(bf);
-        bfp.setAmount(bf.getSettleValue());
-        bfp.setInstitution(getSessionController().getInstitution());
-        bfp.setDepartment(getSessionController().getDepartment());
-        bfp.setCreater(getSessionController().getLoggedUser());
-        bfp.setCreatedAt(new Date());
-        bfp.setPayment(p);
-        getBillFeePaymentFacade().create(bfp);
+        // BillFeePayment is deprecated and no longer used
     }
 //
 //    public void recreate() {

--- a/src/main/java/com/divudi/bean/optician/OpticianRepairBillController.java
+++ b/src/main/java/com/divudi/bean/optician/OpticianRepairBillController.java
@@ -3022,15 +3022,7 @@ public class OpticianRepairBillController implements Serializable, ControllerWit
     }
 
     public void setBillFeePaymentAndPayment(double amount, BillFee bf, Payment p) {
-        BillFeePayment bfp = new BillFeePayment();
-        bfp.setBillFee(bf);
-        bfp.setAmount(amount);
-        bfp.setInstitution(bf.getBillItem().getItem().getInstitution());
-        bfp.setDepartment(bf.getBillItem().getItem().getDepartment());
-        bfp.setCreater(getSessionController().getLoggedUser());
-        bfp.setCreatedAt(new Date());
-        bfp.setPayment(p);
-        billFeePaymentFacade.create(bfp);
+        // BillFeePayment is deprecated and no longer used
     }
 
     public double calBillPaidValue(Bill b) {

--- a/src/main/java/com/divudi/bean/optician/OpticianSaleController.java
+++ b/src/main/java/com/divudi/bean/optician/OpticianSaleController.java
@@ -2473,15 +2473,7 @@ public class OpticianSaleController implements Serializable, ControllerWithPatie
     }
 
     public void createBillFeePaymentAndPayment(BillFee bf, Payment p) {
-        BillFeePayment bfp = new BillFeePayment();
-        bfp.setBillFee(bf);
-        bfp.setAmount(bf.getSettleValue());
-        bfp.setInstitution(getSessionController().getInstitution());
-        bfp.setDepartment(getSessionController().getDepartment());
-        bfp.setCreater(getSessionController().getLoggedUser());
-        bfp.setCreatedAt(new Date());
-        bfp.setPayment(p);
-        getBillFeePaymentFacade().create(bfp);
+        // BillFeePayment is deprecated and no longer used
     }
 
     private void clearBill() {

--- a/src/main/java/com/divudi/bean/pharmacy/GoodsReturnController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/GoodsReturnController.java
@@ -506,15 +506,7 @@ public class GoodsReturnController implements Serializable {
     }
 
     public void createBillFeePaymentAndPayment(BillFee bf, Payment p) {
-        BillFeePayment bfp = new BillFeePayment();
-        bfp.setBillFee(bf);
-        bfp.setAmount(bf.getSettleValue());
-        bfp.setInstitution(getSessionController().getInstitution());
-        bfp.setDepartment(getSessionController().getDepartment());
-        bfp.setCreater(getSessionController().getLoggedUser());
-        bfp.setCreatedAt(new Date());
-        bfp.setPayment(p);
-        getBillFeePaymentFacade().create(bfp);
+        // BillFeePayment is deprecated and no longer used
     }
 
 //    public void onEditItem(BillItem tmp) {

--- a/src/main/java/com/divudi/bean/pharmacy/GrnController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/GrnController.java
@@ -1524,15 +1524,7 @@ public class GrnController implements Serializable {
     }
 
     public void createBillFeePaymentAndPayment(BillFee bf, Payment p) {
-        BillFeePayment bfp = new BillFeePayment();
-        bfp.setBillFee(bf);
-        bfp.setAmount(bf.getSettleValue());
-        bfp.setInstitution(getSessionController().getInstitution());
-        bfp.setDepartment(getSessionController().getDepartment());
-        bfp.setCreater(getSessionController().getLoggedUser());
-        bfp.setCreatedAt(new Date());
-        bfp.setPayment(p);
-        getBillFeePaymentFacade().create(bfp);
+        // BillFeePayment is deprecated and no longer used
     }
 
     public BillItem getCurrentExpense() {

--- a/src/main/java/com/divudi/bean/pharmacy/GrnCostingController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/GrnCostingController.java
@@ -1977,15 +1977,7 @@ public class GrnCostingController implements Serializable {
 
     @Deprecated // THis is NO longer Needed
     public void createBillFeePaymentAndPayment(BillFee bf, Payment p) {
-        BillFeePayment bfp = new BillFeePayment();
-        bfp.setBillFee(bf);
-        bfp.setAmount(bf.getSettleValue());
-        bfp.setInstitution(getSessionController().getInstitution());
-        bfp.setDepartment(getSessionController().getDepartment());
-        bfp.setCreater(getSessionController().getLoggedUser());
-        bfp.setCreatedAt(new Date());
-        bfp.setPayment(p);
-        getBillFeePaymentFacade().create(bfp);
+        // BillFeePayment is deprecated and no longer used
     }
 
     public BillItem getCurrentExpense() {

--- a/src/main/java/com/divudi/bean/pharmacy/PharmacyPurchaseController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacyPurchaseController.java
@@ -877,15 +877,7 @@ public class PharmacyPurchaseController implements Serializable {
 
     @Deprecated
     public void createBillFeePaymentAndPayment(BillFee bf, Payment p) {
-        BillFeePayment bfp = new BillFeePayment();
-        bfp.setBillFee(bf);
-        bfp.setAmount(bf.getSettleValue());
-        bfp.setInstitution(getSessionController().getInstitution());
-        bfp.setDepartment(getSessionController().getDepartment());
-        bfp.setCreater(getSessionController().getLoggedUser());
-        bfp.setCreatedAt(new Date());
-        bfp.setPayment(p);
-        getBillFeePaymentFacade().create(bfp);
+        // BillFeePayment is deprecated and no longer used
     }
 //
 //    public void recreate() {

--- a/src/main/java/com/divudi/bean/pharmacy/PharmacySaleController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacySaleController.java
@@ -1575,37 +1575,17 @@ public class PharmacySaleController implements Serializable, ControllerWithPatie
     }
 
     public void handleSelectAction() {
-        long startTime = System.currentTimeMillis();
-        System.out.println("=== REGULAR SALE handleSelectAction START at " + startTime);
-
         if (stock == null) {
-            System.out.println("=== REGULAR SALE handleSelectAction - stock is null, returning");
             return;
         }
 
-        long beforeSetStock = System.currentTimeMillis();
-        System.out.println("=== REGULAR SALE Before setStock: " + (beforeSetStock - startTime) + "ms");
         getBillItem().getPharmaceuticalBillItem().setStock(stock);
-
-        long beforeCalculateRates = System.currentTimeMillis();
-        System.out.println("=== REGULAR SALE Before calculateRates: " + (beforeCalculateRates - beforeSetStock) + "ms");
         calculateRatesOfSelectedBillItemBeforeAddingToTheList(billItem);
-
-        long beforeAddInstructions = System.currentTimeMillis();
-        System.out.println("=== REGULAR SALE Before addInstructions: " + (beforeAddInstructions - beforeCalculateRates) + "ms");
         pharmacyService.addBillItemInstructions(billItem);
-
-        long endTime = System.currentTimeMillis();
-        System.out.println("=== REGULAR SALE After addInstructions: " + (endTime - beforeAddInstructions) + "ms");
-        System.out.println("=== REGULAR SALE handleSelectAction TOTAL TIME: " + (endTime - startTime) + "ms");
     }
 
     public void handleSelect(SelectEvent event) {
-        long startTime = System.currentTimeMillis();
-        System.out.println("=== REGULAR SALE handleSelect EVENT START at " + startTime);
         handleSelectAction();
-        long endTime = System.currentTimeMillis();
-        System.out.println("=== REGULAR SALE handleSelect EVENT END - Total: " + (endTime - startTime) + "ms");
     }
 
     //    public void calculateRatesOfSelectedBillItemBeforeAddingToTheList(BillItem bi) {
@@ -1707,9 +1687,6 @@ public class PharmacySaleController implements Serializable, ControllerWithPatie
     }
 
     public void calculateRatesOfSelectedBillItemBeforeAddingToTheList(BillItem bi) {
-        long startTime = System.currentTimeMillis();
-        System.out.println("    === REGULAR SALE calculateRatesOfSelectedBillItemBeforeAddingToTheList START");
-
         PharmaceuticalBillItem pharmBillItem = bi.getPharmaceuticalBillItem();
         if (pharmBillItem != null && pharmBillItem.getStock() != null) {
             ItemBatch itemBatch = pharmBillItem.getStock().getItemBatch();
@@ -1717,12 +1694,7 @@ public class PharmacySaleController implements Serializable, ControllerWithPatie
                 bi.setRate(itemBatch.getRetailsaleRate());
             }
 
-            long beforeDiscount = System.currentTimeMillis();
-            System.out.println("    === REGULAR SALE Before calculateBillItemDiscountRate: " + (beforeDiscount - startTime) + "ms");
             bi.setDiscountRate(calculateBillItemDiscountRate(bi));
-
-            long afterDiscount = System.currentTimeMillis();
-            System.out.println("    === REGULAR SALE After calculateBillItemDiscountRate: " + (afterDiscount - beforeDiscount) + "ms");
 
             bi.setNetRate(bi.getRate() - bi.getDiscountRate());
 
@@ -1731,9 +1703,6 @@ public class PharmacySaleController implements Serializable, ControllerWithPatie
             bi.setNetValue(bi.getGrossValue() - bi.getDiscount());
 
         }
-
-        long endTime = System.currentTimeMillis();
-        System.out.println("    === REGULAR SALE calculateRatesOfSelectedBillItemBeforeAddingToTheList TOTAL: " + (endTime - startTime) + "ms");
     }
 
     public void calculatePreBillTotals() {
@@ -3687,8 +3656,6 @@ public class PharmacySaleController implements Serializable, ControllerWithPatie
      * with simplified retail-only calculations and proper cost rate handling.
      */
     public void updateRetailSaleFinanceDetails(Bill bill) {
-        System.out.println("=== Starting updateRetailSaleFinanceDetails ===");
-
         if (bill == null || bill.getBillItems() == null || bill.getBillItems().isEmpty()) {
             return;
         }
@@ -3701,21 +3668,13 @@ public class PharmacySaleController implements Serializable, ControllerWithPatie
         BigDecimal totalFreeQuantity = BigDecimal.ZERO;
 
         // Process each bill item
-        int itemIndex = 0;
         for (BillItem billItem : bill.getBillItems()) {
-            itemIndex++;
-            System.out.println("--- Processing Bill Item " + itemIndex + " ---");
-            System.out.println("BillItem ID: " + (billItem != null ? billItem.getId() : "null"));
-            System.out.println("BillItem retired: " + (billItem != null ? billItem.isRetired() : "null"));
-            System.out.println("BillItem qty: " + (billItem != null ? billItem.getQty() : "null"));
-
             if (billItem == null || billItem.isRetired()) {
                 continue;
             }
 
             // Get pharmaceutical bill item for rate information
             PharmaceuticalBillItem pharmaItem = billItem.getPharmaceuticalBillItem();
-            System.out.println("PharmaceuticalBillItem: " + (pharmaItem != null ? "exists" : "null"));
             if (pharmaItem == null) {
                 continue;
             }
@@ -3724,14 +3683,11 @@ public class PharmacySaleController implements Serializable, ControllerWithPatie
             BigDecimal qty = BigDecimal.valueOf(billItem.getQty());
             BigDecimal freeQty = BigDecimal.valueOf(pharmaItem.getFreeQty());
             BigDecimal totalQty = qty.add(freeQty);
-            System.out.println("Quantities - qty: " + qty + ", freeQty: " + freeQty + ", totalQty: " + totalQty);
 
             // Get rates from pharmaceutical bill item
             BigDecimal retailRate = BigDecimal.valueOf(pharmaItem.getRetailRate());
             BigDecimal purchaseRate = BigDecimal.valueOf(pharmaItem.getPurchaseRate());
             BigDecimal wholesaleRate = BigDecimal.valueOf(pharmaItem.getWholesaleRate());
-
-            System.out.println("Pharma rates - retail: " + retailRate + ", purchase: " + purchaseRate + ", wholesale: " + wholesaleRate);
 
             // Get cost rate from item batch (correct approach) with fallback to purchase rate
             BigDecimal costRate = purchaseRate; // default fallback
@@ -3739,14 +3695,11 @@ public class PharmacySaleController implements Serializable, ControllerWithPatie
                 Double batchCostRate = pharmaItem.getItemBatch().getCostRate();
                 if (batchCostRate != null && batchCostRate > 0) {
                     costRate = BigDecimal.valueOf(batchCostRate);
-                } else {
                 }
-            } else {
             }
 
             // Get BillItemFinanceDetails (note: getBillItemFinanceDetails() auto-creates if null)
             BillItemFinanceDetails bifd = billItem.getBillItemFinanceDetails();
-            System.out.println("BillItemFinanceDetails for item - ID: " + bifd.getId() + " (will be null if newly created)");
 
             // Calculate absolute quantity for calculations
             BigDecimal absQty = qty.abs();
@@ -3762,8 +3715,6 @@ public class PharmacySaleController implements Serializable, ControllerWithPatie
             bifd.setPurchaseRate(purchaseRate);
             bifd.setRetailSaleRate(retailRate);
 
-            System.out.println("Set rates - costRate: " + costRate.doubleValue() + ", purchaseRate: " + purchaseRate.doubleValue() + ", retailSaleRate: " + retailRate.doubleValue());
-
             // UPDATE TOTAL FIELDS in BillItemFinanceDetails
             bifd.setLineGrossTotal(BigDecimal.valueOf(billItem.getGrossValue()));
             bifd.setGrossTotal(BigDecimal.valueOf(billItem.getGrossValue()));
@@ -3778,16 +3729,10 @@ public class PharmacySaleController implements Serializable, ControllerWithPatie
             bifd.setBillCost(BigDecimal.ZERO); // Set to 0 as per user requirement
             bifd.setTotalCost(itemCostValue);
 
-            System.out.println("Cost values: lineCost: " + bifd.getLineCost() + ", totalCost: " + bifd.getTotalCost());
-
             // UPDATE VALUE FIELDS in BillItemFinanceDetails (negative for retail sales - stock goes out)
             bifd.setValueAtCostRate(costRate.multiply(totalQty).negate());
             bifd.setValueAtPurchaseRate(purchaseRate.multiply(totalQty).negate());
             bifd.setValueAtRetailRate(retailRate.multiply(totalQty).negate());
-
-            System.out.println("BIFD values: valueAtCostRate: " + bifd.getValueAtCostRate()
-                    + ", valueAtPurchaseRate: " + bifd.getValueAtPurchaseRate()
-                    + ", valueAtRetailRate: " + bifd.getValueAtRetailRate());
 
             // UPDATE QUANTITIES in BillItemFinanceDetails (negative for retail sales - stock goes out)
             bifd.setQuantity(qty.negate());
@@ -3798,10 +3743,6 @@ public class PharmacySaleController implements Serializable, ControllerWithPatie
             pharmaItem.setCostValue(itemCostValue.doubleValue());
             pharmaItem.setRetailValue(itemRetailValue.doubleValue());
             pharmaItem.setPurchaseValue(itemPurchaseValue.doubleValue());
-
-            System.out.println("PBI values: costValue: " + pharmaItem.getCostValue()
-                    + ", retailValue: " + pharmaItem.getRetailValue()
-                    + ", purchaseValue: " + pharmaItem.getPurchaseValue());
 
             // Accumulate bill-level totals
             totalCostValue = totalCostValue.add(itemCostValue);
@@ -3815,11 +3756,9 @@ public class PharmacySaleController implements Serializable, ControllerWithPatie
         // UPDATE BILL-LEVEL FINANCE DETAILS (check if auto-creation happens here too)
         BillFinanceDetails bfd = bill.getBillFinanceDetails();
         if (bfd == null) {
-            System.out.println("WARNING: BillFinanceDetails missing for bill ID " + bill.getId() + " - creating new one");
             bfd = new BillFinanceDetails();
             bfd.setBill(bill);
             bill.setBillFinanceDetails(bfd);
-        } else {
         }
 
         // Set basic totals from bill
@@ -3833,33 +3772,9 @@ public class PharmacySaleController implements Serializable, ControllerWithPatie
         bfd.setTotalQuantity(totalQuantity.negate());
         bfd.setTotalFreeQuantity(totalFreeQuantity.negate());
 
-        System.out.println("=== PRECISION DEBUG ===");
-        System.out.println("Before saving - totalCostValue BigDecimal: " + totalCostValue);
-        System.out.println("Before saving - totalCostValue scale: " + totalCostValue.scale());
-        System.out.println("Before saving - totalCostValue precision: " + totalCostValue.precision());
-        System.out.println("Before saving - totalCostValue toString: " + totalCostValue.toString());
-        System.out.println("Before saving - totalCostValue doubleValue: " + totalCostValue.doubleValue());
-
-        System.out.println("Bill totals - netTotal: " + bfd.getNetTotal()
-                + ", grossTotal: " + bfd.getGrossTotal()
-                + ", totalCostValue: " + bfd.getTotalCostValue()
-                + ", totalPurchaseValue: " + bfd.getTotalPurchaseValue()
-                + ", totalRetailSaleValue: " + bfd.getTotalRetailSaleValue()
-                + ", totalQuantity: " + bfd.getTotalQuantity()
-                + ", totalFreeQuantity: " + bfd.getTotalFreeQuantity());
-
-        System.out.println("After setting - BFD.totalCostValue BigDecimal: " + bfd.getTotalCostValue());
-        System.out.println("After setting - BFD.totalCostValue scale: " + (bfd.getTotalCostValue() != null ? bfd.getTotalCostValue().scale() : "null"));
-        System.out.println("After setting - BFD.totalCostValue toString: " + (bfd.getTotalCostValue() != null ? bfd.getTotalCostValue().toString() : "null"));
-        System.out.println("=== END PRECISION DEBUG ===");
-
     }
 
     private void updateAll() {
-        System.out.println("=== updateAll() - Before saving to database ===");
-        if (saleBill.getBillFinanceDetails() != null) {
-        }
-
         for (BillItem pbi : preBill.getBillItems()) {
             billItemFacade.edit(pbi);
         }
@@ -3868,12 +3783,6 @@ public class PharmacySaleController implements Serializable, ControllerWithPatie
             billItemFacade.edit(sbi);
         }
         billFacade.edit(saleBill);
-
-        if (saleBill.getBillFinanceDetails() != null) {
-            System.out.println("SaleBill BFD totalCostValue after DB save: " + saleBill.getBillFinanceDetails().getTotalCostValue());
-            System.out.println("*** DATABASE SCHEMA ISSUE CONFIRMED ***");
-            System.out.println("Expected: DECIMAL(18,4) but database has DECIMAL(38,0)");
-        }
     }
 
     public String newPharmacyRetailSale() {
@@ -4093,9 +4002,6 @@ public class PharmacySaleController implements Serializable, ControllerWithPatie
 
     //    TO check the functionality
     public double calculateBillItemDiscountRate(BillItem bi) {
-        long startTime = System.currentTimeMillis();
-        System.out.println("        === REGULAR SALE calculateBillItemDiscountRate START");
-
         if (bi == null) {
             return 0.0;
         }
@@ -4112,7 +4018,6 @@ public class PharmacySaleController implements Serializable, ControllerWithPatie
         double retailRate = bi.getPharmaceuticalBillItem().getStock().getItemBatch().getRetailsaleRate();
         double discountRate = 0;
         boolean discountAllowed = bi.getItem().isDiscountAllowed();
-        System.out.println("        === REGULAR SALE Initial setup: " + (System.currentTimeMillis() - startTime) + "ms");
 //        MembershipScheme membershipScheme = membershipSchemeController.fetchPatientMembershipScheme(getPatient(), getSessionController().getApplicationPreference().isMembershipExpires());
         //MEMBERSHIPSCHEME DISCOUNT
 //        if (membershipScheme != null && discountAllowed) {
@@ -4149,11 +4054,7 @@ public class PharmacySaleController implements Serializable, ControllerWithPatie
         //PAYMENTSCHEME DISCOUNT
 
         if (getPaymentScheme() != null && discountAllowed) {
-            long beforePriceMatrix = System.currentTimeMillis();
-            System.out.println("        === REGULAR SALE Before getPaymentSchemeDiscount (PaymentScheme): " + (beforePriceMatrix - startTime) + "ms");
             PriceMatrix priceMatrix = getPriceMatrixController().getPaymentSchemeDiscount(getPaymentMethod(), getPaymentScheme(), getSessionController().getDepartment(), bi.getItem());
-            long afterPriceMatrix = System.currentTimeMillis();
-            System.out.println("        === REGULAR SALE After getPaymentSchemeDiscount (PaymentScheme): " + (afterPriceMatrix - beforePriceMatrix) + "ms");
 
             if (priceMatrix != null) {
                 bi.setPriceMatrix(priceMatrix);
@@ -4162,18 +4063,13 @@ public class PharmacySaleController implements Serializable, ControllerWithPatie
 
             double dr;
             dr = (retailRate * discountRate) / 100;
-            System.out.println("        === REGULAR SALE calculateBillItemDiscountRate TOTAL: " + (System.currentTimeMillis() - startTime) + "ms");
             return dr;
 
         }
 
         //PAYMENTMETHOD DISCOUNT
         if (getPaymentMethod() != null && discountAllowed) {
-            long beforePriceMatrix = System.currentTimeMillis();
-            System.out.println("        === REGULAR SALE Before getPaymentSchemeDiscount (PaymentMethod): " + (beforePriceMatrix - startTime) + "ms");
             PriceMatrix priceMatrix = getPriceMatrixController().getPaymentSchemeDiscount(getPaymentMethod(), getSessionController().getDepartment(), bi.getItem());
-            long afterPriceMatrix = System.currentTimeMillis();
-            System.out.println("        === REGULAR SALE After getPaymentSchemeDiscount (PaymentMethod): " + (afterPriceMatrix - beforePriceMatrix) + "ms");
 
             if (priceMatrix != null) {
                 bi.setPriceMatrix(priceMatrix);
@@ -4182,7 +4078,6 @@ public class PharmacySaleController implements Serializable, ControllerWithPatie
 
             double dr;
             dr = (retailRate * discountRate) / 100;
-            System.out.println("        === REGULAR SALE calculateBillItemDiscountRate TOTAL: " + (System.currentTimeMillis() - startTime) + "ms");
             return dr;
 
         }
@@ -4193,10 +4088,8 @@ public class PharmacySaleController implements Serializable, ControllerWithPatie
 
             double dr;
             dr = (retailRate * discountRate) / 100;
-            System.out.println("        === REGULAR SALE calculateBillItemDiscountRate TOTAL: " + (System.currentTimeMillis() - startTime) + "ms");
             return dr;
         }
-        System.out.println("        === REGULAR SALE calculateBillItemDiscountRate TOTAL (No discount): " + (System.currentTimeMillis() - startTime) + "ms");
         return 0;
 
     }

--- a/src/main/java/com/divudi/bean/pharmacy/PharmacySaleController1.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacySaleController1.java
@@ -3650,15 +3650,7 @@ public class PharmacySaleController1 implements Serializable, ControllerWithPati
     }
 
     public void createBillFeePaymentAndPayment(BillFee bf, Payment p) {
-        BillFeePayment bfp = new BillFeePayment();
-        bfp.setBillFee(bf);
-        bfp.setAmount(bf.getSettleValue());
-        bfp.setInstitution(getSessionController().getInstitution());
-        bfp.setDepartment(getSessionController().getDepartment());
-        bfp.setCreater(getSessionController().getLoggedUser());
-        bfp.setCreatedAt(new Date());
-        bfp.setPayment(p);
-        getBillFeePaymentFacade().create(bfp);
+        // BillFeePayment is deprecated and no longer used
     }
 
     private void clearBill() {

--- a/src/main/java/com/divudi/bean/pharmacy/PharmacySaleController2.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacySaleController2.java
@@ -3650,15 +3650,7 @@ public class PharmacySaleController2 implements Serializable, ControllerWithPati
     }
 
     public void createBillFeePaymentAndPayment(BillFee bf, Payment p) {
-        BillFeePayment bfp = new BillFeePayment();
-        bfp.setBillFee(bf);
-        bfp.setAmount(bf.getSettleValue());
-        bfp.setInstitution(getSessionController().getInstitution());
-        bfp.setDepartment(getSessionController().getDepartment());
-        bfp.setCreater(getSessionController().getLoggedUser());
-        bfp.setCreatedAt(new Date());
-        bfp.setPayment(p);
-        getBillFeePaymentFacade().create(bfp);
+        // BillFeePayment is deprecated and no longer used
     }
 
     private void clearBill() {

--- a/src/main/java/com/divudi/bean/pharmacy/PharmacySaleController3.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacySaleController3.java
@@ -3650,15 +3650,7 @@ public class PharmacySaleController3 implements Serializable, ControllerWithPati
     }
 
     public void createBillFeePaymentAndPayment(BillFee bf, Payment p) {
-        BillFeePayment bfp = new BillFeePayment();
-        bfp.setBillFee(bf);
-        bfp.setAmount(bf.getSettleValue());
-        bfp.setInstitution(getSessionController().getInstitution());
-        bfp.setDepartment(getSessionController().getDepartment());
-        bfp.setCreater(getSessionController().getLoggedUser());
-        bfp.setCreatedAt(new Date());
-        bfp.setPayment(p);
-        getBillFeePaymentFacade().create(bfp);
+        // BillFeePayment is deprecated and no longer used
     }
 
     private void clearBill() {

--- a/src/main/java/com/divudi/bean/pharmacy/PharmacySaleWithoutStockController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacySaleWithoutStockController.java
@@ -1708,15 +1708,7 @@ public class PharmacySaleWithoutStockController implements Serializable, Control
     }
 
     public void createBillFeePaymentAndPayment(BillFee bf, Payment p) {
-        BillFeePayment bfp = new BillFeePayment();
-        bfp.setBillFee(bf);
-        bfp.setAmount(bf.getSettleValue());
-        bfp.setInstitution(getSessionController().getInstitution());
-        bfp.setDepartment(getSessionController().getDepartment());
-        bfp.setCreater(getSessionController().getLoggedUser());
-        bfp.setCreatedAt(new Date());
-        bfp.setPayment(p);
-        getBillFeePaymentFacade().create(bfp);
+        // BillFeePayment is deprecated and no longer used
     }
 
     private void clearBill() {

--- a/src/main/java/com/divudi/bean/pharmacy/PharmacySimpleRetailSaleController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacySimpleRetailSaleController.java
@@ -2602,15 +2602,7 @@ public class PharmacySimpleRetailSaleController implements Serializable, Control
     }
 
     public void createBillFeePaymentAndPayment(BillFee bf, Payment p) {
-        BillFeePayment bfp = new BillFeePayment();
-        bfp.setBillFee(bf);
-        bfp.setAmount(bf.getSettleValue());
-        bfp.setInstitution(getSessionController().getInstitution());
-        bfp.setDepartment(getSessionController().getDepartment());
-        bfp.setCreater(getSessionController().getLoggedUser());
-        bfp.setCreatedAt(new Date());
-        bfp.setPayment(p);
-        getBillFeePaymentFacade().create(bfp);
+        // BillFeePayment is deprecated and no longer used
     }
 
     private void clearBill() {

--- a/src/main/java/com/divudi/bean/pharmacy/PurchaseReturnController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PurchaseReturnController.java
@@ -417,15 +417,7 @@ public class PurchaseReturnController implements Serializable {
     }
 
     public void createBillFeePaymentAndPayment(BillFee bf, Payment p) {
-        BillFeePayment bfp = new BillFeePayment();
-        bfp.setBillFee(bf);
-        bfp.setAmount(bf.getSettleValue());
-        bfp.setInstitution(getSessionController().getInstitution());
-        bfp.setDepartment(getSessionController().getDepartment());
-        bfp.setCreater(getSessionController().getLoggedUser());
-        bfp.setCreatedAt(new Date());
-        bfp.setPayment(p);
-        getBillFeePaymentFacade().create(bfp);
+        // BillFeePayment is deprecated and no longer used
     }
 
     public PharmaceuticalBillItemFacade getPharmaceuticalBillItemFacade() {

--- a/src/main/java/com/divudi/bean/pharmacy/SupplierPaymentController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/SupplierPaymentController.java
@@ -2978,15 +2978,7 @@ public class SupplierPaymentController implements Serializable {
     }
 
     public void createBillFeePaymentAndPayment(BillFee bf, Payment p) {
-        BillFeePayment bfp = new BillFeePayment();
-        bfp.setBillFee(bf);
-        bfp.setAmount(bf.getSettleValue());
-        bfp.setInstitution(getSessionController().getInstitution());
-        bfp.setDepartment(getSessionController().getDepartment());
-        bfp.setCreater(getSessionController().getLoggedUser());
-        bfp.setCreatedAt(new Date());
-        bfp.setPayment(p);
-        getBillFeePaymentFacade().create(bfp);
+        // BillFeePayment is deprecated and no longer used
     }
 
     private void setValues(Institution inst, String1Value5 dataTable5Value, List<BillType> billTypesBilled, List<BillType> billTypesReturned) {

--- a/src/main/java/com/divudi/bean/store/StorePurchaseController.java
+++ b/src/main/java/com/divudi/bean/store/StorePurchaseController.java
@@ -427,15 +427,7 @@ public class StorePurchaseController implements Serializable {
     }
 
     public void createBillFeePaymentAndPayment(BillFee bf, Payment p) {
-        BillFeePayment bfp = new BillFeePayment();
-        bfp.setBillFee(bf);
-        bfp.setAmount(bf.getSettleValue());
-        bfp.setInstitution(getSessionController().getInstitution());
-        bfp.setDepartment(getSessionController().getDepartment());
-        bfp.setCreater(getSessionController().getLoggedUser());
-        bfp.setCreatedAt(new Date());
-        bfp.setPayment(p);
-        getBillFeePaymentFacade().create(bfp);
+        // BillFeePayment is deprecated and no longer used
     }
 
     private List<BillItem> billItems;

--- a/src/main/java/com/divudi/core/entity/lab/PatientReportItemValue.java
+++ b/src/main/java/com/divudi/core/entity/lab/PatientReportItemValue.java
@@ -193,47 +193,35 @@ public class PatientReportItemValue implements Serializable, RetirableEntity {
 
     public String getValue() {
         if (this.investigationItem == null || this.investigationItem.ixItemValueType == null) {
-            System.out.println("Investigation item or item value type is null");
             return "";
         }
 
         String value = "";
         String formatString = this.investigationItem.formatString;
-        System.out.println("Format string: " + formatString);
-
-        System.out.println("this.investigationItem.ixItemValueType = " + this.investigationItem.ixItemValueType);
 
         switch (this.investigationItem.ixItemValueType) {
             case Double:
             case Long:
                 if (this.doubleValue != null) {
-                    System.out.println("Double value before formatting: " + this.doubleValue);
                     if (formatString != null) {
                         DecimalFormat decimalFormat = new DecimalFormat(formatString);
                         value = decimalFormat.format(this.doubleValue);
                     } else {
                         value = Double.toString(this.doubleValue);
                     }
-                    System.out.println("Double value after formatting: " + value);
-                } else {
-                    System.out.println("Double value is null");
                 }
                 break;
             case Varchar:
                 value = this.strValue;
-                System.out.println("Varchar value: " + value);
                 break;
             case Memo:
                 value = this.lobValue;
-                System.out.println("Memo value: " + value);
                 break;
             default:
                 value = this.investigationItem.ixItemValueType.toString();
-                System.out.println("Default value: " + value);
                 break;
         }
 
-        System.out.println("Final value: " + value);
         return value;
     }
 

--- a/src/main/java/com/divudi/service/BillService.java
+++ b/src/main/java/com/divudi/service/BillService.java
@@ -958,9 +958,7 @@ public class BillService {
             bi.setCollectingCentreFee(collectingCentreFeesCalculatedByBillFees);
             bi.setStaffFee(staffFeesCalculatedByBillFees);
             bi.setHospitalFee(hospitalFeeCalculatedByBillFees);
-            billItemFacade.editAndCommit(bi);
-            // Log the values set to the BillItem
-            // Log the values set to the BillItem
+            billItemFacade.edit(bi);
 
             // Accumulate the fees to the Bill totals
             billCollectingCentreFee += collectingCentreFeesCalculatedByBillFees;
@@ -983,7 +981,7 @@ public class BillService {
         // Log the final bill totals
 
         // Persist the updated Bill
-        billFacade.editAndCommit(bill);
+        billFacade.edit(bill);
     }
 
     public void calculateBillBreakdownAsHospitalCcAndStaffTotalsByBillFees(List<Bill> bills) {

--- a/src/main/java/com/divudi/ws/lims/LimsMiddlewareController.java
+++ b/src/main/java/com/divudi/ws/lims/LimsMiddlewareController.java
@@ -973,9 +973,6 @@ public class LimsMiddlewareController {
     }
 
     public boolean addResultToReport(String sampleId, String testCodeFromUploadedDataBundle, String result, String unit, String error) {
-        System.out.println("addResultToReport");
-        System.out.println("testStr = " + testCodeFromUploadedDataBundle);
-        System.out.println("result = " + result);
         boolean temFlag = false;
         Long sid;
         try {
@@ -1025,27 +1022,16 @@ public class LimsMiddlewareController {
                 boolean valueToSave = false;
                 // // System.out.println("Patient Report = " + rtpr);
                 for (PatientReportItemValue priv : rtpr.getPatientReportItemValues()) {
-                    System.out.println("Patient Report Item Value = " + priv);
-                    System.out.println("priv.getInvestigationItem()  = " + priv.getInvestigationItem());
-
                     if (priv.getInvestigationItem() != null && priv.getInvestigationItem().getTest() != null
                             && priv.getInvestigationItem().getIxItemType() == InvestigationItemType.ReportImage) {
 
-                        System.out.println("image found");
-
-                        System.out.println("priv.getInvestigationItem().getTest() = " + priv.getInvestigationItem().getTest());
                         String testCodeFromDatabase;
                         testCodeFromDatabase = priv.getInvestigationItem().getResultCode();
-                        System.out.println("Test Result Code from LIMS = " + testCodeFromDatabase);
                         if (testCodeFromDatabase == null || testCodeFromDatabase.trim().equals("")) {
                             testCodeFromDatabase = priv.getInvestigationItem().getTest().getCode().toUpperCase();
-                            System.out.println("Test Code from Test = " + testCodeFromDatabase);
                         }
-                        System.out.println("Test Name from Data Bundle = " + testCodeFromUploadedDataBundle);
                         if (testCodeFromDatabase.equalsIgnoreCase(testCodeFromUploadedDataBundle)) {
-                            System.out.println("data bundle and componant are the same");
-                            System.out.println("ps.getInvestigationComponant() = " + ps.getInvestigationComponant());
-                            System.out.println("priv.getInvestigationItem().getSampleComponent() = " + priv.getInvestigationItem().getSampleComponent());
+
                             for (PatientSampleComponant patientSampleComponant : pscs) {
                                 Item investigationComponentFromPatientSampleComponant = patientSampleComponant.getInvestigationComponant();
                                 Item investigationComponentFromPatientReportItem = priv.getInvestigationItem().getSampleComponent();
@@ -1053,12 +1039,10 @@ public class LimsMiddlewareController {
                                         && investigationComponentFromPatientReportItem != null
                                         && investigationComponentFromPatientSampleComponant.equals(investigationComponentFromPatientReportItem)) {
 
-                                    System.out.println("0 result = " + result);
                                     priv.setLobValue(result);
                                     priv.setBaImage(base64TextToByteArray(result));
 
                                     String fileType = extractImageTypeFromResult(result);
-                                    System.out.println("fileType = " + fileType);
                                     priv.setFileType(fileType);
 
                                     String fileName = testCodeFromDatabase + sid;
@@ -1425,19 +1409,14 @@ public class LimsMiddlewareController {
     }
 
     private String extractImageTypeFromResult(String result) {
-        System.out.println("Received result = " + result);
         if (result == null || result.isEmpty()) {
-            System.out.println("Result is null or empty. Defaulting to BMP.");
             return "BMP";
         }
         Pattern pattern = Pattern.compile("^\\^Image\\^([A-Z]+)\\^Base64\\^");
         Matcher matcher = pattern.matcher(result);
         if (matcher.find()) {
             String type = matcher.group(1);
-            System.out.println("Extracted image type = " + type);
             return type;
-        } else {
-            System.out.println("No image type pattern matched. Defaulting to BMP.");
         }
         return "BMP";
     }
@@ -1941,19 +1920,13 @@ public class LimsMiddlewareController {
     }
 
     public List<String> generateTestCodesForAnalyzer(String sampleId, String sendingAnalyzerName) {
-        System.out.println("sendingAnalyzerName = " + sendingAnalyzerName);
-        System.out.println("generateTestCodesForAnalyzer");
         PatientSample ps = patientSampleFromId(sampleId);
-        System.out.println("ps = " + ps);
         if (ps == null) {
-            System.out.println("No PS");
             return null;
         }
 
         List<PatientSampleComponant> pscs = getPatientSampleComponents(ps);
-        System.out.println("pscs = " + pscs);
         if (pscs == null || pscs.isEmpty()) {
-            System.out.println("PSCS NULL OR EMPTY");
             return null;
         }
 
@@ -1974,14 +1947,11 @@ public class LimsMiddlewareController {
             }
 
             for (InvestigationItem tii : myIx.getReportItems()) {
-                System.out.println("tii = " + tii.getName());
                 if (tii.getIxItemType() == InvestigationItemType.Value) {
-                    System.out.println("value");
                     String sampleTypeName;
                     String samplePriority;
 
                     if (tii.getItem() == null) {
-                        System.out.println("tii is NULL " + tii);
                         continue;
                     }
 
@@ -1998,35 +1968,21 @@ public class LimsMiddlewareController {
                     MySpeciman ms = new MySpeciman();
                     ms.setSpecimanName(sampleTypeName);
                     if (tii.getItem().isHasMoreThanOneComponant()) {
-                        System.out.println("more than one componant");
-                        System.out.println("tii = " + tii.getName());
-                        System.out.println("tii.getTest() = " + tii.getTest());
                         if (tii.getTest() != null && !tii.getTest().getName().trim().equals("")) {
-                            System.out.println("tii.getSampleComponent() = " + tii.getSampleComponent());
-                            System.out.println("c.getInvestigationComponant() = " + c.getInvestigationComponant());
                             if (tii.getSampleComponent().equals(c.getInvestigationComponant())) {
-                                System.out.println("going to check analyzer equal");
                                 if (tii.getMachine().getName().equalsIgnoreCase(sendingAnalyzerName)) {
-                                    System.out.println("tii.getTest().getCode() = " + tii.getTest().getCode());
-                                    System.out.println("c.getInvestigationComponant().getName() = " + c.getInvestigationComponant().getName());
                                     tests.add(tii.getTest().getCode());
                                     updateStatusToPeformed(c);
-                                    System.out.println("1. tii.getTest().getCode() = " + tii.getTest().getCode());
                                 }
 //                                tests.add(tii.getTest().getName());
 
                             }
                         }
                     } else {
-                        System.out.println("one componant");
-                        System.out.println("tti = " + tii.getName());
-                        System.out.println("tii.getTest() = " + tii.getTest());
                         if (tii.getTest() != null && !tii.getTest().getName().trim().equals("")) {
-                            System.out.println("going to check analyzer equal");
                             if (tii.getMachine().getName().equalsIgnoreCase(sendingAnalyzerName)) {
                                 tests.add(tii.getTest().getCode());
                                 updateStatusToPeformed(c);
-                                System.out.println("1. tii.getTest().getCode() = " + tii.getTest().getCode());
                             }
 
                         }
@@ -2034,7 +1990,6 @@ public class LimsMiddlewareController {
                 }
             }
         }
-        System.out.println("tests = " + tests);
         Set<String> uniqueTests = new HashSet<>(tests);
         List<String> uniqueTestList = new ArrayList<>(uniqueTests);
         return uniqueTestList;


### PR DESCRIPTION
## Summary
- **Fix BillFee FK constraint violation** in `settleOpdBill` — replaced `editAndCommit()` with `edit()` in `calculateBillBreakdownAsHospitalCcAndStaffTotalsByBillFees` to prevent `em.clear()` from destabilizing the persistence context, which was triggering orphan BillFee deletions blocked by the `billfeepayment` FK constraint. This caused OPD and pharmacy bill settling failures, transaction rollbacks, and likely double bills on retry.
- **Remove deprecated BillFeePayment creation** across 27 controllers — all `setBillFeePaymentAndPayment` / `createBillFeePaymentAndPayment` method bodies emptied (signatures kept). The `BillFeePayment` entity was already marked `@Deprecated` and is no longer needed.
- **Remove ~460 lines of `System.out.println`** from 4 high-traffic files (`PatientReportItemValue`, `LimsMiddlewareController`, `PharmacySaleController`, `PatientReportController`) that were causing **1.9GB / 7,661 log files** on the coop production server.

## Test plan
- [ ] Verify OPD bill settling works without errors
- [ ] Verify pharmacy retail sale settling works without errors
- [ ] Verify lab results display correctly (no regression from removed logging in `PatientReportItemValue`)
- [ ] Verify LIMS middleware still receives analyzer results correctly
- [ ] Monitor server log volume after deployment — should drop dramatically

🤖 Generated with [Claude Code](https://claude.com/claude-code)