### PR TITLE
OPD Billing - Clear Referring Doctor on New Bill

### DIFF
--- a/developer_docs/configuration/application-options.md
+++ b/developer_docs/configuration/application-options.md
@@ -32,6 +32,12 @@ This document lists the configuration options used in the application and their 
 | `Pharmacy Transfer Issue Bill Footer CSS`                        | String    | `''`    | CSS for the footer of the transfer issue bill.                                                            |
 | `Pharmacy Transfer Issue Bill Footer Text`                       | String    | `''`    | Text for the footer of the transfer issue bill.                                                             |
 
+## OPD Billing
+
+| Key                                                              | Type      | Default | Description                                                                                             |
+| ---------------------------------------------------------------- | --------- | ------- | ------------------------------------------------------------------------------------------------------- |
+| `OPD Billing - Clear Referring Doctor on New Bill`              | Boolean   | `true`  | When true, clears the referring doctor and referring institution when starting a new OPD bill. When false, the values are preserved across consecutive bills. |
+
 ## Inventory Reports
 
 | Key                                                              | Type      | Default | Description                                                                                             |

--- a/src/main/java/com/divudi/bean/opd/OpdBillController.java
+++ b/src/main/java/com/divudi/bean/opd/OpdBillController.java
@@ -3891,6 +3891,10 @@ public class OpdBillController implements Serializable, ControllerWithPatient, C
                 currentPatientMembershipScheme = null;
                 chiefHouseHolder = null;
                 currentPatientFamily = null;
+                if (configOptionApplicationController.getBooleanValueByKey("OPD Billing - Clear Referring Doctor on New Bill", true)) {
+                    referredBy = null;
+                    referredByInstitution = null;
+                }
                 collectingCentreBillController.setCollectingCentre(null);
                 if (sessionController.getOpdBillItemSearchByAutocomplete()) {
                     return "/opd/opd_bill_ac?faces-redirect=true";
@@ -3908,7 +3912,10 @@ public class OpdBillController implements Serializable, ControllerWithPatient, C
             paymentScheme = null;
             paymentMethod = PaymentMethod.Cash;
             patientEncounter = null;
-            referredBy = null;
+            if (configOptionApplicationController.getBooleanValueByKey("OPD Billing - Clear Referring Doctor on New Bill", true)) {
+                referredBy = null;
+                referredByInstitution = null;
+            }
             collectingCentreBillController.setCollectingCentre(null);
             if (sessionController.getOpdBillItemSearchByAutocomplete()) {
                 return "/opd/opd_bill_ac?faces-redirect=true";


### PR DESCRIPTION
## Summary

- The referring doctor and referring institution fields were not being cleared when clicking **New** in OPD billing
- The two code paths in `navigateToNewOpdBill()` (shift-start and non-shift-start) behaved inconsistently — shift-start never cleared `referredBy`, while non-shift-start only cleared `referredBy` (not `referredByInstitution`)
- Added a boolean config option `OPD Billing - Clear Referring Doctor on New Bill` (default `true`) so both paths behave identically and the behaviour is configurable

## Changes

- `OpdBillController.java` — both branches of `navigateToNewOpdBill()` now check the config and clear `referredBy` and `referredByInstitution` consistently
- `developer_docs/configuration/application-options.md` — new OPD Billing section documenting the config key

## Test plan

- [ ] Start a new OPD bill, set a referring doctor and institution, save the bill, click **New** — verify both fields clear
- [ ] Set `OPD Billing - Clear Referring Doctor on New Bill` to `false` in configuration — verify referring doctor and institution carry over after clicking **New**
- [ ] Verify both shift-start and non-shift-start modes behave the same

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added configuration option for OPD Billing to manage whether referring doctor information is retained when creating new bills.

* **Documentation**
  * Updated configuration documentation to include new OPD Billing options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->