### PR TITLE
18415 pharmacy retail rate adjustment not updated in f15

### DIFF
--- a/src/main/resources/META-INF/persistence.xml
+++ b/src/main/resources/META-INF/persistence.xml
@@ -2,7 +2,7 @@
 <persistence version="2.2" xmlns="http://java.sun.com/xml/ns/persistence" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/persistence http://xmlns.jcp.org/xml/ns/persistence/persistence_2_2.xsd">
     <persistence-unit name="hmisPU" transaction-type="JTA">
         <provider>org.eclipse.persistence.jpa.PersistenceProvider</provider>
-        <jta-data-source>jdbc/coop</jta-data-source>
+        <jta-data-source>${JDBC_DATASOURCE}</jta-data-source>
         <exclude-unlisted-classes>false</exclude-unlisted-classes>
         <properties>
             <property name="eclipselink.logging.level.sql" value="SEVERE"/>
@@ -10,7 +10,7 @@
         </properties>
     </persistence-unit>
     <persistence-unit name="hmisAuditPU" transaction-type="JTA">
-        <jta-data-source>jdbc/ruhunuAudit</jta-data-source>
+        <jta-data-source>${JDBC_AUDIT_DATASOURCE}</jta-data-source>
         <exclude-unlisted-classes>false</exclude-unlisted-classes>
         <properties>
             <property name="eclipselink.logging.level.sql" value="SEVERE"/>


### PR DESCRIPTION
  Root Cause Analysis:

  The F15 report reads three key values from BillFinanceDetails for retail rate adjustment bills:
  1. b.total → Gross Value
  2. b.netTotal → Net Value
  3. bfd.totalRetailSaleValue → Stock Value (Retail)

  Bug 1 — Missing bill total/netTotal update (in saveRsrAdjustmentBillItems):
  The method never called getDeptAdjustmentPreBill().setTotal() / setNetTotal() — unlike saveCrAdjustmentBillItems which
   correctly does this. This caused Gross Value and Net Value to show 0 in the F15 report.

  Bug 2 — BFD aggregation overwrote instead of accumulated (in saveRsrAdjustmentBillItems):
  When multiple stock batches were adjusted, bfd.setNetTotal(changeVal) / setGrossTotal(...) / setTotalQuantity(...)
  were overwriting the values on each iteration instead of accumulating them. Fixed to use prev + current pattern (like
  totalRetailSaleValue and totalBeforeAdjustmentValue already did correctly).

  Bug 3 — BFD not initialized before bill creation (in saveSaleRateAdjustmentBill):
  Added BillFinanceDetails initialization before the bill is first persisted, matching the pattern in
  saveCostRateAdjustmentBill. Also removed dead debug comments.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced stability during pharmacy bill adjustments with improved null-safety handling
  * Totals now update immediately when adjustment items are added
  * Improved error reporting for adjustment operations to provide clearer feedback

<!-- end of auto-generated comment: release notes by coderabbit.ai -->