### PR TITLE
Record stock history for all departments affected by ItemBatch rate changes

### DIFF
--- a/src/main/java/com/divudi/bean/pharmacy/PharmacyAdjustmentController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacyAdjustmentController.java
@@ -1914,8 +1914,20 @@ public class PharmacyAdjustmentController implements Serializable {
             s.getItemBatch().setPurcahseRate(newPurchaseRate);
             itemBatchFacade.edit(s.getItemBatch());
 
-            // Add to stock history so adjustment appears in stock ledger report
+            // Record stock history for the adjusted department's stock
             pharmacyBean.addToStockHistory(ph, s, getSessionController().getDepartment());
+
+            // Record stock history for every OTHER department that holds stock of the
+            // same ItemBatch — their stock values also change because the rate is shared
+            for (com.divudi.core.entity.pharmacy.Stock otherStock : pharmacyBean.getStocksForItemBatch(s.getItemBatch())) {
+                if (otherStock.getId().equals(s.getId())) {
+                    continue; // already recorded above
+                }
+                if (otherStock.getDepartment() == null) {
+                    continue;
+                }
+                pharmacyBean.addToStockHistory(ph, otherStock, otherStock.getDepartment());
+            }
         }
 
         if (!any) {
@@ -2027,8 +2039,20 @@ public class PharmacyAdjustmentController implements Serializable {
             s.getItemBatch().setRetailsaleRate(newRetailRate);
             itemBatchFacade.edit(s.getItemBatch());
 
-            // Add to stock history so adjustment appears in stock ledger report
+            // Record stock history for the adjusted department's stock
             pharmacyBean.addToStockHistory(ph, s, getSessionController().getDepartment());
+
+            // Record stock history for every OTHER department that holds stock of the
+            // same ItemBatch — their stock values also change because the rate is shared
+            for (com.divudi.core.entity.pharmacy.Stock otherStock : pharmacyBean.getStocksForItemBatch(s.getItemBatch())) {
+                if (otherStock.getId().equals(s.getId())) {
+                    continue; // already recorded above
+                }
+                if (otherStock.getDepartment() == null) {
+                    continue;
+                }
+                pharmacyBean.addToStockHistory(ph, otherStock, otherStock.getDepartment());
+            }
         }
 
         if (!any) {

--- a/src/main/java/com/divudi/ejb/PharmacyBean.java
+++ b/src/main/java/com/divudi/ejb/PharmacyBean.java
@@ -1403,6 +1403,22 @@ public class PharmacyBean {
     }
 
     /**
+     * Returns all Stock records across every department for a given ItemBatch.
+     * Used by rate-adjustment workflows to record stock history in every
+     * department affected by the shared ItemBatch rate change.
+     */
+    public List<Stock> getStocksForItemBatch(ItemBatch itemBatch) {
+        if (itemBatch == null || itemBatch.getId() == null) {
+            return java.util.Collections.emptyList();
+        }
+        String jpql = "select s from Stock s where s.itemBatch.id = :batchId and s.stock > 0";
+        java.util.Map<String, Object> params = new java.util.HashMap<>();
+        params.put("batchId", itemBatch.getId());
+        List<Stock> result = getStockFacade().findByJpql(jpql, params);
+        return result != null ? result : java.util.Collections.emptyList();
+    }
+
+    /**
      * 🏥 CRITICAL AUDIT TRAIL METHOD - HANDLE WITH EXTREME CARE 🏥
      *
      * 🚨 WARNING TO ALL DEVELOPERS AND AI AGENTS: 🚨 This method creates


### PR DESCRIPTION
## Summary

- When a retail rate or purchase rate adjustment is saved, the `ItemBatch` rate is updated globally (shared across all departments). Previously `addToStockHistory` was only called for the logged-in department's `Stock` record — all other departments holding stock of the same batch received no history entry, even though their stock values changed.
- Added `PharmacyBean.getStocksForItemBatch()` to fetch every `Stock` record with positive quantity for a given `ItemBatch` across all departments.
- In `adjustRetailRates()` and `adjustPurchaseRates()`, after recording the primary stock history entry, now iterates over all other `Stock` records for the same `ItemBatch` and calls `addToStockHistory` for each affected department.

Closes #18752

## Test plan

- [ ] Perform a retail rate adjustment for an item batch that exists in more than one department
- [ ] Verify that a `StockHistory` record is created for every department holding that batch, not just the adjusting department
- [ ] Repeat for a purchase rate adjustment
- [ ] Confirm existing single-department adjustments continue to work correctly
- [ ] Check the F15 report opening/closing stock values are correct for all affected departments after the adjustment

🤖 Generated with [Claude Code](https://claude.com/claude-code)