### PR TITLE
Harden VMP audit events change rendering against XSS

### DIFF
--- a/src/main/webapp/pharmacy/admin/vmp_audit_events.xhtml
+++ b/src/main/webapp/pharmacy/admin/vmp_audit_events.xhtml
@@ -90,7 +90,7 @@
 
                             <p:column headerText="Changes" style="width: auto;">
                                 <div class="audit-changes">
-                                    <h:outputText value="#{audit.difference}" />
+                                    <h:outputText value="#{audit.difference}" escape="true" />
                                 </div>
                             </p:column>
 


### PR DESCRIPTION
### Motivation
- Prevent possible XSS by ensuring the audit "Changes" field does not render unescaped HTML when `audit.difference` contains user-controlled content.

### Description
- Updated `src/main/webapp/pharmacy/admin/vmp_audit_events.xhtml` to render `#{audit.difference}` with `escape="true"` so HTML/script payloads are escaped and shown as text (Closes #18408).

### Testing
- Verified the update with a code search that shows the `h:outputText` now contains `escape="true"` and noted this is a JSF-only change so no Java build was required.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699bd9b8bc30832fba15ad2f62620df5)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the audit events display to properly escape HTML characters in the changes column, ensuring special characters render as plain text rather than formatted code.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->