### PR TITLE
Fix inconsistent query trimming in VmpController.completeVmpDto

### DIFF
--- a/src/main/java/com/divudi/bean/pharmacy/VmpController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/VmpController.java
@@ -820,7 +820,12 @@ public class VmpController implements Serializable {
     }
 
     public List<VmpDto> completeVmpDto(String query) {
-        if (query == null || query.trim().length() < 2) {
+        if (query == null) {
+            return new ArrayList<>();
+        }
+
+        String trimmedQuery = query.trim();
+        if (trimmedQuery.length() < 2) {
             return new ArrayList<>();
         }
 
@@ -830,7 +835,7 @@ public class VmpController implements Serializable {
                 + "AND v.departmentType=:dep AND v.retired=:retired ";
 
         Map<String, Object> params = new HashMap<>();
-        params.put("query", "%" + query.toLowerCase() + "%");
+        params.put("query", "%" + trimmedQuery.toLowerCase() + "%");
         params.put("dep", DepartmentType.Pharmacy);
         params.put("retired", false); // Only show non-deleted items
 


### PR DESCRIPTION
### Motivation
- Avoid inconsistent behavior where `query.trim().length()` is used for validation but the untrimmed `query` is used in the JPQL `LIKE`, which causes queries with leading/trailing spaces to search incorrectly.

### Description
- Trim the incoming `query` once into `trimmedQuery`, return early on `null`, use `trimmedQuery` for the minimum-length check and for the JPQL parameter (`params.put("query", "%" + trimmedQuery.toLowerCase() + "%")`) in `VmpController.completeVmpDto`, and preserve existing department/status filtering; changed file: `src/main/java/com/divudi/bean/pharmacy/VmpController.java` (Closes #18406).

### Testing
- No automated tests were executed for this change (no test run was requested for this small Java fix).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699bd9f6e1e8832f98dd926cf75229d0)