### PR TITLE
Remove debug println calls from VtmController DTO selection and audit loading

### DIFF
--- a/src/main/java/com/divudi/bean/pharmacy/VtmController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/VtmController.java
@@ -715,21 +715,15 @@ public class VtmController implements Serializable {
     }
 
     public void setSelectedVtmDto(VtmDto selectedVtmDto) {
-        System.out.println("setSelectedVtmDto called");
-        System.out.println("selectedVtmDto = " + selectedVtmDto);
         this.selectedVtmDto = selectedVtmDto;
 
         // Sync with entity if DTO is selected
         if (selectedVtmDto != null && selectedVtmDto.getId() != null) {
-            System.out.println("selectedVtmDto.getId() = " + selectedVtmDto.getId());
             this.current = getFacade().find(selectedVtmDto.getId());
-            System.out.println("Loaded entity: " + (this.current != null ? this.current.getName() : "null"));
         } else {
             // Clear current entity when no DTO is selected
-            System.out.println("Clearing current entity (selectedVtmDto is null or has null ID)");
             this.current = null;
         }
-        System.out.println("current = " + current);
     }
 
     // Audit Events Methods
@@ -764,7 +758,6 @@ public class VtmController implements Serializable {
                 ae.calculateDifference();
             }
 
-            System.out.println("VTM Audit Events loaded: " + vtmAuditEvents.size() + " events for VTM ID: " + current.getId());
         }
     }
 


### PR DESCRIPTION
### Motivation
- Remove development `System.out.println` debug statements that clutter server logs and were left in DTO selection and audit-related flows.

### Description
- Removed `System.out.println` calls from `setSelectedVtmDto(VtmDto selectedVtmDto)` while preserving DTO-to-entity sync and null-handling logic.
- Removed the audit-summary debug print from `fillVtmAuditEvents()` and left query, parameter setup, and `ae.calculateDifference()` logic unchanged.
- Kept all method behavior and exception handling intact and ensured formatting remains consistent after edits.

### Testing
- Ran `rg -n "System\.out\.println" src/main/java/com/divudi/bean/pharmacy/VtmController.java` to verify removal from the targeted methods, which confirmed the prints in `setSelectedVtmDto` and the audit-count line were removed.
- The search shows there are remaining debug prints elsewhere in the file (notably in the `VtmDtoConverter`), so the `rg` check indicates a partial cleanup rather than a full sweep of all debug prints.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699bda3139a8832fbb3c165b734b48df)