### PR TITLE
 prevent empty bill creation when no bill selected in Add to Stock

### DIFF
--- a/src/main/java/com/divudi/bean/common/SearchController.java
+++ b/src/main/java/com/divudi/bean/common/SearchController.java
@@ -9399,6 +9399,10 @@ public class SearchController implements Serializable {
     }
 
     public void addToStock() {
+        if (getSelectedBills().isEmpty()) {
+            JsfUtil.addErrorMessage("Please select a bill from the list to proceed.");
+            return;
+        }
         bill = new Bill();
         bill.setBillDate(new Date());
         bill.setBillTime(new Date());

--- a/src/main/webapp/pharmacy/pharmacy_search_pre_bill_not_paid.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_search_pre_bill_not_paid.xhtml
@@ -54,13 +54,14 @@
                                             actionListener="#{searchController.createPreBillsNotPaid()}">
                                         </p:commandButton>
                                         
-                                        <p:commandButton 
-                                            ajax="false" 
-                                            value="Add To Stock" 
-                                            action="#{searchController.addToStock}" 
-                                            icon="fas fa-plus" 
+                                        <p:commandButton
+                                            id="btnAddToStock"
+                                            ajax="false"
+                                            value="Add To Stock"
+                                            action="#{searchController.addToStock}"
+                                            icon="fas fa-plus"
                                             styleClass="ui-button-success"
-                                            disabled="#{!webUserController.hasPrivilege('PharmacyAddToStock')}">
+                                            disabled="#{!webUserController.hasPrivilege('PharmacyAddToStock') or empty searchController.selectedBills}">
                                         </p:commandButton>
                                         
                                         <p:commandButton 
@@ -76,10 +77,10 @@
                             </div>
                         </div>
 
-                        <p:dataTable 
-                            id="tblBills" 
-                            value="#{searchController.bills}"                             
-                            var="bill" 
+                        <p:dataTable
+                            id="tblBills"
+                            value="#{searchController.bills}"
+                            var="bill"
                             rowKey="#{bill.id}"
                             selection="#{searchController.selectedBills}"
                             paginator="true"
@@ -91,6 +92,9 @@
                             selectionRowMode="add"
                             selectionMode="multiple"
                             styleClass="table-striped">
+                            <p:ajax event="rowSelectCheckbox"   update=":#{p:resolveFirstComponentWithId('btnAddToStock', view).clientId}" />
+                            <p:ajax event="rowUnselectCheckbox" update=":#{p:resolveFirstComponentWithId('btnAddToStock', view).clientId}" />
+                            <p:ajax event="toggleSelect"        update=":#{p:resolveFirstComponentWithId('btnAddToStock', view).clientId}" />
                             <p:column selectionBox="true" width="3em" styleClass="text-center"></p:column>
 
                             <p:column headerText="Pre Bill No">


### PR DESCRIPTION
Clicking "Add to Stock" with no bill selected silently consumed a bill number, persisted an empty Bill to the database, and displayed a blank print preview.The button is now disabled until at least one bill is selected, and a server-side guard prevents any database write if the selection is somehow empty.

**Button Disable State**
<img width="1919" height="1028" alt="Screenshot 2026-02-23 145611" src="https://github.com/user-attachments/assets/4f213632-bc26-4a63-851a-d0c743fbafda" />

**Active Button State**
<img width="1919" height="1027" alt="Screenshot 2026-02-23 145650" src="https://github.com/user-attachments/assets/1ceb72ab-ab10-4014-8085-97db1366e393" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added input validation to prevent the Add To Stock action from executing when no bills are selected, displaying an error message if attempted.
  * Improved UI responsiveness by dynamically enabling/disabling the Add To Stock button based on bill selection state in real-time.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->