### PR TITLE
resolve EvaluationException when filtering by Net Total in Add to Stock bill search

### DIFF
--- a/src/main/java/com/divudi/bean/common/SearchController.java
+++ b/src/main/java/com/divudi/bean/common/SearchController.java
@@ -3229,8 +3229,14 @@ public class SearchController implements Serializable {
         }
 
         if (getSearchKeyword().getNetTotal() != null && !getSearchKeyword().getNetTotal().trim().equals("")) {
-            sql += " and  ((b.netTotal) = :netTotal )";
-            m.put("netTotal", "%" + getSearchKeyword().getNetTotal().trim().toUpperCase() + "%");
+            try {
+                Double netTotalValue = Double.parseDouble(getSearchKeyword().getNetTotal().trim());
+                sql += " and (b.netTotal = :netTotal)";
+                m.put("netTotal", netTotalValue);
+            } catch (NumberFormatException e) {
+                JsfUtil.addErrorMessage("Invalid Net Total value. Please enter a valid number.");
+                return;
+            }
         }
 
         sql += " order by b.createdAt desc  ";


### PR DESCRIPTION
-  Filtering bills by Net Total on the Add to Stock search page (pharmacy_add_to_stock_search_bill.xhtml) threw a 500 EvaluationException / ConversionException on every search.
- The filter now correctly parses the input to Double and binds it as a typed JPQL parameter.
<img width="1917" height="995" alt="image" src="https://github.com/user-attachments/assets/77761661-a923-4ec5-8339-bbd676ddb503" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Optimized report data loading and retrieval for faster performance across billing and pharmacy modules.
  * Enhanced data fetching mechanisms to reduce system load times.

* **Improvements**
  * Improved error handling during report generation processes.
  * Better navigation state management in reports section.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->