### PR TITLE
18723 need to improve pharmacy income report print pdf excel

### DIFF
--- a/src/main/java/com/divudi/bean/pharmacy/PharmacySummaryReportController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacySummaryReportController.java
@@ -106,6 +106,7 @@ import org.primefaces.model.file.UploadedFile;
 import com.divudi.core.entity.Upload;
 import com.divudi.core.facade.UploadFacade;
 import java.io.ByteArrayInputStream;
+import java.text.SimpleDateFormat;
 import org.primefaces.model.DefaultStreamedContent;
 
 import org.primefaces.model.StreamedContent;
@@ -2563,6 +2564,10 @@ public class PharmacySummaryReportController implements Serializable {
         }
         return fromDate;
     }
+    
+    public String getFromDateFormatted(){
+        return new SimpleDateFormat("dd_MM_yyyy").format(fromDate);
+    }
 
     /**
      * @param fromDate the fromDate to set
@@ -2579,6 +2584,10 @@ public class PharmacySummaryReportController implements Serializable {
             toDate = CommonFunctions.getEndOfDay();
         }
         return toDate;
+    }
+    
+    public String getToDateFormatted(){
+         return new SimpleDateFormat("dd_MM_yyyy").format(toDate);
     }
 
     /**

--- a/src/main/java/com/divudi/bean/pharmacy/PharmacySummaryReportController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacySummaryReportController.java
@@ -1029,6 +1029,15 @@ public class PharmacySummaryReportController implements Serializable {
         }
         bundle.generatePaymentDetailsForBills();
     }
+    public String getReportHeader() {
+        return "Date From: " + getFromDateFormatted() +
+               " To: " + getToDateFormatted() +
+               "   |   Site: " + (site == null ? "All institutions" : site.getName()) +
+               "   |   Department: " + (department == null ? "All departments" : department.getName()) +
+               "   |   Admission Type: " + (admissionType == null ? "All admission types" : admissionType.getName()) +
+               "   |   Discount Scheme: " + (paymentScheme == null ? "All discount schemes" : paymentScheme.getName()) +
+               "   |   Report Type: " + (reportViewType == null ? "" : reportViewType.getLabel());
+    }
 
     public void processMovementOutWithStocksReportByBill() {
         reportTimerController.trackReportExecution(() -> {

--- a/src/main/webapp/pharmacy/reports/summary_reports/pharmacy_income_report.xhtml
+++ b/src/main/webapp/pharmacy/reports/summary_reports/pharmacy_income_report.xhtml
@@ -515,11 +515,11 @@
                             <p:column headerText="Actual Total" width="10em" class="text-end"
                                       style="padding: 0px!important; margin: 0px!important;"
                                       rendered="#{userSettingsController.pharmacyIncomeReportActualTotalVisible}">
-                                <h:outputText value="#{row.netTotal}">
+                                <h:outputText value="#{row.actualTotal}">
                                     <f:convertNumber pattern="#,##0.00"/>
                                 </h:outputText>
                                 <f:facet name="footer">
-                                    <h:outputText value="#{pharmacySummaryReportController.bundle.summaryRow.netTotal}"
+                                    <h:outputText value="#{pharmacySummaryReportController.bundle.summaryRow.actualTotal}"
                                                   style="padding: 0px!important; margin: 0px!important; font-weight: bold">
                                         <f:convertNumber pattern="#,##0.00"/>
                                     </h:outputText>
@@ -951,11 +951,11 @@
                             </p:column>
                             <p:column headerText="Actual Total" width="10em" class="text-end"
                                       style="padding: 0px!important; margin: 0px!important;">
-                                <h:outputText value="#{row.netTotal}">
+                                <h:outputText value="#{row.actualTotal}">
                                     <f:convertNumber pattern="#,##0.00"/>
                                 </h:outputText>
                                 <f:facet name="footer">
-                                    <h:outputText value="#{pharmacySummaryReportController.bundle.summaryRow.netTotal}"
+                                    <h:outputText value="#{pharmacySummaryReportController.bundle.summaryRow.actualTotal}"
                                                   style="padding: 0px!important; margin: 0px!important; font-weight: bold">
                                         <f:convertNumber pattern="#,##0.00"/>
                                     </h:outputText>
@@ -1242,11 +1242,11 @@
                             </p:column>
                             <p:column headerText="Actual Total" width="10em" class="text-end"
                                       style="padding: 0px!important; margin: 0px!important;">
-                                <h:outputText value="#{row.netTotal}">
+                                <h:outputText value="#{row.actualTotal}">
                                     <f:convertNumber pattern="#,##0.00"/>
                                 </h:outputText>
                                 <f:facet name="footer">
-                                    <h:outputText value="#{pharmacySummaryReportController.bundle.summaryRow.netTotal}"
+                                    <h:outputText value="#{pharmacySummaryReportController.bundle.summaryRow.actualTotal}"
                                                   style="padding: 0px!important; margin: 0px!important; font-weight: bold">
                                         <f:convertNumber pattern="#,##0.00"/>
                                     </h:outputText>

--- a/src/main/webapp/pharmacy/reports/summary_reports/pharmacy_income_report.xhtml
+++ b/src/main/webapp/pharmacy/reports/summary_reports/pharmacy_income_report.xhtml
@@ -238,6 +238,10 @@
                                 rows="#{pharmacySummaryReportController.rowsPerPageForScreen}"
                                 rowsPerPageTemplate="#{pharmacySummaryReportController.rowsPerPageForScreen}, 5,10,15,50,100,500,1000,2000,5000,10000"
                                 paginatorPosition="bottom">
+                            <!-- use for the add title for the excel-->
+                            <f:facet name="header" >
+                                     <h:outputText value="#{pharmacySummaryReportController.reportHeader}" style="display:none !important; font-size:15px;" />
+                            </f:facet>
                             <p:column headerText="Bill No" width="16em"
                                       style="padding: 0px!important; margin: 0px!important;">
                                 <h:outputText value="#{row.bill.deptId}"
@@ -708,6 +712,10 @@
                                 rows="#{pharmacySummaryReportController.rowsPerPageForScreen}"
                                 rowsPerPageTemplate="#{pharmacySummaryReportController.rowsPerPageForScreen}, 5,10,15,50,100"
                                 paginatorPosition="bottom">
+                            <!-- use for the add title for the excel-->
+                            <f:facet name="header" >
+                                     <h:outputText value="#{pharmacySummaryReportController.reportHeader}" style="display:none !important; font-size:15px;" />
+                            </f:facet>
                             <p:column headerText="Bill Type" width="18em">
                                 <h:outputText value="#{row.billTypeAtomic}"/>
                             </p:column>
@@ -992,6 +1000,10 @@
                                 rows="#{pharmacySummaryReportController.rowsPerPageForScreen}"
                                 rowsPerPageTemplate="#{pharmacySummaryReportController.rowsPerPageForScreen}, 5,10,15,50,100"
                                 paginatorPosition="bottom">
+                            <!-- use for the add title for the excel-->
+                            <f:facet name="header" >
+                                     <h:outputText value="#{pharmacySummaryReportController.reportHeader}" style="display:none !important; font-size:15px;" />
+                            </f:facet>
                             <p:column headerText="Group" width="24em">
                                 <h:outputText value="#{row.rowType}"/>
                             </p:column>
@@ -1273,6 +1285,10 @@
                                 rows="#{pharmacySummaryReportController.rowsPerPageForScreen}"
                                 rowsPerPageTemplate="#{pharmacySummaryReportController.rowsPerPageForScreen},5,10,15,50,100"
                                 paginatorPosition="bottom">
+                            <!-- use for the add title for the excel-->
+                            <f:facet name="header" >
+                                     <h:outputText value="#{pharmacySummaryReportController.reportHeader}" style="display:none !important; font-size:18px;" />
+                            </f:facet>
                             <p:column headerText="Bill Type + Group" width="32em">
                                 <h:outputText value="#{row.rowType}"/>
                             </p:column>

--- a/src/main/webapp/pharmacy/reports/summary_reports/pharmacy_income_report.xhtml
+++ b/src/main/webapp/pharmacy/reports/summary_reports/pharmacy_income_report.xhtml
@@ -213,7 +213,7 @@
                             <p:dataExporter
                                     type="xlsx"
                                     target="tbl"
-                                    fileName="pharmacy_income_by_bill_#{pharmacySummaryReportController.fromDate}_to_#{pharmacySummaryReportController.toDate}"/>
+                                    fileName="pharmacy_income_by_bill_#{pharmacySummaryReportController.getFromDateFormatted()}_to_#{pharmacySummaryReportController.getToDateFormatted()}"/>
                         </p:commandButton>
                         <p:commandButton
                                 value="To Print"
@@ -683,7 +683,7 @@
                             <p:dataExporter
                                     type="xlsx"
                                     target="tblBillType"
-                                    fileName="pharmacy_income_by_bill_type_#{pharmacySummaryReportController.fromDate}_to_#{pharmacySummaryReportController.toDate}"/>
+                                    fileName="pharmacy_income_by_bill_type_#{pharmacySummaryReportController.getFromDateFormatted()}_to_#{pharmacySummaryReportController.getToDateFormatted()}"/>
                         </p:commandButton>
                         <p:commandButton
                                 value="Print"
@@ -961,7 +961,7 @@
                             <p:dataExporter
                                     type="xlsx"
                                     target="tblGroupedByDiscountAndAdmission"
-                                    fileName="pharmacy_income_by_discount_and_admission_#{pharmacySummaryReportController.fromDate}_to_#{pharmacySummaryReportController.toDate}"/>
+                                    fileName="pharmacy_income_by_discount_and_admission_#{pharmacySummaryReportController.getFromDateFormatted()}_to_#{pharmacySummaryReportController.getToDateFormatted()}"/>
                         </p:commandButton>
                         <p:commandButton
                                 value="Print"
@@ -1236,7 +1236,7 @@
                             <p:dataExporter
                                     type="xlsx"
                                     target="tblGroupedByBillTypeAndDiscountAdmission"
-                                    fileName="pharmacy_income_by_bill_type_and_discount_admission_#{pharmacySummaryReportController.fromDate}_to_#{pharmacySummaryReportController.toDate}"/>
+                                    fileName="pharmacy_income_by_bill_type_and_discount_admission_#{pharmacySummaryReportController.getFromDateFormatted()}_to_#{pharmacySummaryReportController.getToDateFormatted()}"/>
                         </p:commandButton>
                         <p:commandButton
                                 value="Print"

--- a/src/main/webapp/pharmacy/reports/summary_reports/pharmacy_income_report.xhtml
+++ b/src/main/webapp/pharmacy/reports/summary_reports/pharmacy_income_report.xhtml
@@ -228,7 +228,13 @@
                                 icon="pi pi-print">
                             <p:printer target="tbl"/>
                         </p:commandButton>
-
+                        <p:commandButton
+                            value="PDF"
+                            icon="pi pi-file-pdf"
+                            ajax="false"
+                            styleClass="ui-button-danger m-1"
+                            action="#{pharmacySummaryReportController.exportPharmacyIncomeReportByBillToPdf()}" />
+          
                         <p:dataTable
                                 id="tbl"
                                 style="padding: 0px!important; margin: 0px!important; font-size: #{pharmacySummaryReportController.fontSizeForScreen}!important;"
@@ -702,6 +708,12 @@
                                 icon="pi pi-print">
                             <p:printer target="tblBillType"/>
                         </p:commandButton>
+                        <p:commandButton
+                            value="PDF"
+                            icon="pi pi-file-pdf"
+                            ajax="false"
+                            styleClass="ui-button-danger m-1"
+                            action="#{pharmacySummaryReportController.exportPharmacyIncomeReportByBillTypeToPdf()}" />
 
                         <p:dataTable
                                 id="tblBillType"
@@ -990,6 +1002,12 @@
                                 icon="pi pi-print">
                             <p:printer target="tblGroupedByDiscountAndAdmission"/>
                         </p:commandButton>
+                        <p:commandButton
+                            value="PDF"
+                            icon="pi pi-file-pdf"
+                            ajax="false"
+                            styleClass="ui-button-danger m-1"
+                            action="#{pharmacySummaryReportController.exportPharmacyIncomeReportByBillTypeAdmissionDiscountToPdf()}" />
 
                         <p:dataTable
                                 id="tblGroupedByDiscountAndAdmission"
@@ -1275,6 +1293,12 @@
                                 icon="pi pi-print">
                             <p:printer target="tblGroupedByBillTypeAndDiscountAdmission"/>
                         </p:commandButton>
+                       <p:commandButton
+                            value="PDF"
+                            icon="pi pi-file-pdf"
+                            ajax="false"
+                            styleClass="ui-button-danger m-1"
+                            action="#{pharmacySummaryReportController.exportPharmacyIncomeReportByBillTypeAdmissionDiscountToPdf()}" />
 
                         <p:dataTable
                                 id="tblGroupedByBillTypeAndDiscountAdmission"

--- a/src/main/webapp/pharmacy/reports/summary_reports/pharmacy_income_report.xhtml
+++ b/src/main/webapp/pharmacy/reports/summary_reports/pharmacy_income_report.xhtml
@@ -685,9 +685,15 @@
                                     target="tblBillType"
                                     fileName="pharmacy_income_by_bill_type_#{pharmacySummaryReportController.getFromDateFormatted()}_to_#{pharmacySummaryReportController.getToDateFormatted()}"/>
                         </p:commandButton>
+                        <p:commandButton 
+                            value="To Print"
+                            styleClass="ui-button-warning m-1"
+                            icon="pi pi-print"
+                            action="pharmacy_income_report_print_bill_type_view?faces-redirect=true"/>
                         <p:commandButton
                                 value="Print"
                                 ajax="false"
+                                rendered="false"
                                 styleClass="ui-button-warning m-1"
                                 icon="pi pi-print">
                             <p:printer target="tblBillType"/>
@@ -964,8 +970,14 @@
                                     fileName="pharmacy_income_by_discount_and_admission_#{pharmacySummaryReportController.getFromDateFormatted()}_to_#{pharmacySummaryReportController.getToDateFormatted()}"/>
                         </p:commandButton>
                         <p:commandButton
+                            value="To Print"
+                            styleClass="ui-button-warning m-1"
+                            icon="pi pi-print"
+                            action="pharmacy_income_report_print_discount_admission_view?faces-redirect=true"/>
+                        <p:commandButton
                                 value="Print"
                                 ajax="false"
+                                rendered="false"
                                 styleClass="ui-button-warning m-1"
                                 icon="pi pi-print">
                             <p:printer target="tblGroupedByDiscountAndAdmission"/>
@@ -1238,9 +1250,15 @@
                                     target="tblGroupedByBillTypeAndDiscountAdmission"
                                     fileName="pharmacy_income_by_bill_type_and_discount_admission_#{pharmacySummaryReportController.getFromDateFormatted()}_to_#{pharmacySummaryReportController.getToDateFormatted()}"/>
                         </p:commandButton>
+                        <p:commandButton 
+                            value="To Print"
+                            styleClass="ui-button-warning m-1"
+                            icon="pi pi-print"
+                            action="pharmacy_income_report_print_bill_type_discount_admission_view?faces-redirect=true"/>
                         <p:commandButton
                                 value="Print"
                                 ajax="false"
+                                rendered="false"
                                 styleClass="ui-button-warning m-1"
                                 icon="pi pi-print">
                             <p:printer target="tblGroupedByBillTypeAndDiscountAdmission"/>

--- a/src/main/webapp/pharmacy/reports/summary_reports/pharmacy_income_report_print_bill_type_discount_admission_view.xhtml
+++ b/src/main/webapp/pharmacy/reports/summary_reports/pharmacy_income_report_print_bill_type_discount_admission_view.xhtml
@@ -78,6 +78,7 @@
                                         font-family: Arial, sans-serif;
                                         font-size: 10pt;
                                     }
+                                    size: A4 landscape;
                                 }
 
                                 body {
@@ -87,8 +88,6 @@
                                 .paper{
                                     position: static !important;
                                     width: 297mm!important;
-                                    size: A4 landscape!important;
-
                                 }
 
                                 .header{
@@ -278,7 +277,7 @@
                                                         </h:outputText>
                                                     </td>
                                                     <td style="width: 17mm; text-align: right;">
-                                                        <h:outputText value="#{row.netTotal}" style="margin-right: 1mm;">
+                                                        <h:outputText value="#{row.actualTotal}" style="margin-right: 1mm;">
                                                             <f:convertNumber pattern="#,##0.00" />
                                                         </h:outputText>
                                                     </td>

--- a/src/main/webapp/pharmacy/reports/summary_reports/pharmacy_income_report_print_bill_type_discount_admission_view.xhtml
+++ b/src/main/webapp/pharmacy/reports/summary_reports/pharmacy_income_report_print_bill_type_discount_admission_view.xhtml
@@ -181,7 +181,7 @@
                                         <thead>
                                             <tr>
                                                 <th style="width: 25mm;font-weight: 700;">
-                                                    <h:outputText value="Bill Tyoe + Group" style="margin-left: 1mm;"/>
+                                                    <h:outputText value="Bill Type + Group" style="margin-left: 1mm;"/>
                                                 </th>
                                                 <th style="width: 17mm; font-weight: 700; text-align: right;">
                                                     <h:outputText value="Net Total" style="margin-right: 1mm;"/>
@@ -268,7 +268,7 @@
                                                         </h:outputText>
                                                     </td>
                                                     <td style="width: 17mm; text-align: right;">
-                                                        <h:outputText value="#{row.discount}" style="margin-right: 1mm;">
+                                                        <h:outputText value="#{commonFunctionsProxy.reverseSign(row.discount)}" style="margin-right: 1mm;">
                                                             <f:convertNumber pattern="#,##0.00" />
                                                         </h:outputText>
                                                     </td>
@@ -336,7 +336,7 @@
                                                     </h:outputText>
                                                 </td>
                                                 <td style="width: 17mm; text-align: right;">
-                                                    <h:outputText value="#{pharmacySummaryReportController.bundle.summaryRow.discount}" style="padding: 0px!important; margin: 0px!important; font-weight: bold" >
+                                                    <h:outputText value="#{commonFunctionsProxy.reverseSign(pharmacySummaryReportController.bundle.summaryRow.discount)}" style="padding: 0px!important; margin: 0px!important; font-weight: bold" >
                                                         <f:convertNumber pattern="#,##0.00" />
                                                     </h:outputText>
                                                 </td>
@@ -349,12 +349,13 @@
                                                     <h:outputText value="#{pharmacySummaryReportController.bundle.summaryRow.actualTotal}" style="padding: 0px!important; margin: 0px!important; font-weight: bold" >
                                                         <f:convertNumber pattern="#,##0.00" />
                                                     </h:outputText>
-                                                     <td style="width: 17mm; text-align: right;">
+                                                </td>
+                                                <td style="width: 17mm; text-align: right;">
                                                     <h:outputText value="#{pharmacySummaryReportController.bundle.summaryRow.totalCostValue}" style="padding: 0px!important; margin: 0px!important; font-weight: bold" >
                                                         <f:convertNumber pattern="#,##0.00" />
                                                     </h:outputText>
                                                 </td>
-                                                </td>
+                                                
                                             </tr>
                                         </tfoot>
                                     </table>

--- a/src/main/webapp/pharmacy/reports/summary_reports/pharmacy_income_report_print_bill_type_discount_admission_view.xhtml
+++ b/src/main/webapp/pharmacy/reports/summary_reports/pharmacy_income_report_print_bill_type_discount_admission_view.xhtml
@@ -163,7 +163,7 @@
                                         </div>
 
                                         <div class="d-flex gap-2">
-                                            <h:outputText value="Discount Schema" style="font-weight:600;"/>
+                                            <h:outputText value="Discount Scheme" style="font-weight:600;"/>
                                             <h:outputText 
                                                 value="#{empty pharmacySummaryReportController.paymentScheme ? 'All discount schemes' :pharmacySummaryReportController.paymentScheme.name}"/>
                                         </div>
@@ -180,14 +180,8 @@
                                     <table>
                                         <thead>
                                             <tr>
-                                                <th style="width: 7mm; font-weight: 700;">
-                                                    <h:outputText value="No" style="margin-left: 1mm;"/>
-                                                </th>
                                                 <th style="width: 25mm;font-weight: 700;">
-                                                    <h:outputText value="Bill No" style="margin-left: 1mm;"/>
-                                                </th>
-                                                <th style="width: 17mm; font-weight: 700; text-align: left;">
-                                                    <h:outputText value="Date" style="margin-left:  1mm;"/>
+                                                    <h:outputText value="Bill Tyoe + Group" style="margin-left: 1mm;"/>
                                                 </th>
                                                 <th style="width: 17mm; font-weight: 700; text-align: right;">
                                                     <h:outputText value="Net Total" style="margin-right: 1mm;"/>
@@ -222,24 +216,19 @@
                                                 <th style="width: 17mm; font-weight: 700; text-align: center;">
                                                     <h:outputText value="Actual Total" style="margin-right: 1mm;"/>
                                                 </th>
+                                                <th style="width: 17mm; font-weight: 700; text-align: center;">
+                                                    <h:outputText value="Cost" style="margin-right: 1mm;"/>
+                                                </th>
                                             </tr>
                                         </thead>
                                         <tbody>
                                             <ui:repeat value="#{pharmacySummaryReportController.bundle.rows}" var="row" varStatus="i">
                                                 <tr>
-                                                    <td style="width: 8mm;" >
-                                                        <h:outputText value="#{i.index +1}" style="margin-left: 1mm;"/>
-                                                    </td>
                                                     <td style="width: 25mm; text-align: left;">
-                                                        <h:outputText value="#{row.bill.deptId}" style="margin-left: 1mm;"/>
-                                                    </td>
-                                                    <td style="width: 17mm; text-align: left;">
-                                                        <h:outputText value="#{row.bill.createdAt}" style="margin-left: 1mm;">
-                                                            <f:convertDateTime pattern="dd/MM/YY" />
-                                                        </h:outputText>
+                                                        <h:outputText value="#{row.rowType}" style="margin-left: 1mm;"/>
                                                     </td>
                                                     <td style="width: 17mm; text-align: right;">
-                                                        <h:outputText value="#{row.bill.netTotal}" style="margin-right: 1mm;">
+                                                        <h:outputText value="#{row.netTotal}" style="margin-right: 1mm;">
                                                             <f:convertNumber pattern="#,##0.00" />
                                                         </h:outputText>
                                                     </td>
@@ -293,14 +282,19 @@
                                                             <f:convertNumber pattern="#,##0.00" />
                                                         </h:outputText>
                                                     </td>
+                                                    <td style="width: 17mm; text-align: right;">
+                                                        <h:outputText value="#{row.totalCostValue}" style="margin-right: 1mm;">
+                                                            <f:convertNumber pattern="#,##0.00" />
+                                                        </h:outputText>
+                                                    </td>
                                                 </tr>
                                             </ui:repeat>
                                         </tbody>
                                         <tfoot>
                                             <tr>
-                                                <td style="width: 8mm;" />
-                                                <td style="width: 25mm; text-align: left;"/>
-                                                <td style="width: 17mm; text-align: left;"/>
+                                                <td style="width: 25mm; text-align: center;">
+                                                    <h:outputText value="Total" style="padding: 0px!important; margin: 0px!important; font-weight: bold"/>
+                                                </td>
                                                 <td style="width: 17mm; text-align: right;">
                                                     <h:outputText value="#{pharmacySummaryReportController.bundle.summaryRow.netTotal}" style="padding: 0px!important; margin: 0px!important; font-weight: bold" >
                                                         <f:convertNumber pattern="#,##0.00" />
@@ -352,9 +346,14 @@
                                                     </h:outputText>
                                                 </td>
                                                 <td style="width: 17mm; text-align: right;">
-                                                    <h:outputText value="#{pharmacySummaryReportController.bundle.summaryRow.netTotal}" style="padding: 0px!important; margin: 0px!important; font-weight: bold" >
+                                                    <h:outputText value="#{pharmacySummaryReportController.bundle.summaryRow.actualTotal}" style="padding: 0px!important; margin: 0px!important; font-weight: bold" >
                                                         <f:convertNumber pattern="#,##0.00" />
                                                     </h:outputText>
+                                                     <td style="width: 17mm; text-align: right;">
+                                                    <h:outputText value="#{pharmacySummaryReportController.bundle.summaryRow.totalCostValue}" style="padding: 0px!important; margin: 0px!important; font-weight: bold" >
+                                                        <f:convertNumber pattern="#,##0.00" />
+                                                    </h:outputText>
+                                                </td>
                                                 </td>
                                             </tr>
                                         </tfoot>

--- a/src/main/webapp/pharmacy/reports/summary_reports/pharmacy_income_report_print_bill_type_view.xhtml
+++ b/src/main/webapp/pharmacy/reports/summary_reports/pharmacy_income_report_print_bill_type_view.xhtml
@@ -163,7 +163,7 @@
                                         </div>
 
                                         <div class="d-flex gap-2">
-                                            <h:outputText value="Discount Schema" style="font-weight:600;"/>
+                                            <h:outputText value="Discount Scheme" style="font-weight:600;"/>
                                             <h:outputText 
                                                 value="#{empty pharmacySummaryReportController.paymentScheme ? 'All discount schemes' :pharmacySummaryReportController.paymentScheme.name}"/>
                                         </div>
@@ -180,14 +180,8 @@
                                     <table>
                                         <thead>
                                             <tr>
-                                                <th style="width: 7mm; font-weight: 700;">
-                                                    <h:outputText value="No" style="margin-left: 1mm;"/>
-                                                </th>
                                                 <th style="width: 25mm;font-weight: 700;">
-                                                    <h:outputText value="Bill No" style="margin-left: 1mm;"/>
-                                                </th>
-                                                <th style="width: 17mm; font-weight: 700; text-align: left;">
-                                                    <h:outputText value="Date" style="margin-left:  1mm;"/>
+                                                    <h:outputText value="Bill type" style="margin-left: 1mm;"/>
                                                 </th>
                                                 <th style="width: 17mm; font-weight: 700; text-align: right;">
                                                     <h:outputText value="Net Total" style="margin-right: 1mm;"/>
@@ -222,24 +216,19 @@
                                                 <th style="width: 17mm; font-weight: 700; text-align: center;">
                                                     <h:outputText value="Actual Total" style="margin-right: 1mm;"/>
                                                 </th>
+                                                 <th style="width: 17mm; font-weight: 700; text-align: center;">
+                                                    <h:outputText value="Cost" style="margin-right: 1mm;"/>
+                                                </th>
                                             </tr>
                                         </thead>
                                         <tbody>
                                             <ui:repeat value="#{pharmacySummaryReportController.bundle.rows}" var="row" varStatus="i">
                                                 <tr>
-                                                    <td style="width: 8mm;" >
-                                                        <h:outputText value="#{i.index +1}" style="margin-left: 1mm;"/>
-                                                    </td>
                                                     <td style="width: 25mm; text-align: left;">
-                                                        <h:outputText value="#{row.bill.deptId}" style="margin-left: 1mm;"/>
-                                                    </td>
-                                                    <td style="width: 17mm; text-align: left;">
-                                                        <h:outputText value="#{row.bill.createdAt}" style="margin-left: 1mm;">
-                                                            <f:convertDateTime pattern="dd/MM/YY" />
-                                                        </h:outputText>
+                                                        <h:outputText value="#{row.billTypeAtomic}" style="margin-left: 1mm;"/>
                                                     </td>
                                                     <td style="width: 17mm; text-align: right;">
-                                                        <h:outputText value="#{row.bill.netTotal}" style="margin-right: 1mm;">
+                                                        <h:outputText value="#{row.netTotal}" style="margin-right: 1mm;">
                                                             <f:convertNumber pattern="#,##0.00" />
                                                         </h:outputText>
                                                     </td>
@@ -293,14 +282,19 @@
                                                             <f:convertNumber pattern="#,##0.00" />
                                                         </h:outputText>
                                                     </td>
+                                                    <td style="width: 17mm; text-align: right;">
+                                                        <h:outputText value="#{row.totalCostValue}" style="margin-right: 1mm;">
+                                                            <f:convertNumber pattern="#,##0.00" />
+                                                        </h:outputText>
+                                                    </td>
                                                 </tr>
                                             </ui:repeat>
                                         </tbody>
                                         <tfoot>
                                             <tr>
-                                                <td style="width: 8mm;" />
-                                                <td style="width: 25mm; text-align: left;"/>
-                                                <td style="width: 17mm; text-align: left;"/>
+                                                <td style="width: 25mm; text-align: center;">
+                                                    <h:outputText value="Total" style="padding: 0px!important; margin: 0px!important; font-weight: bold"/>
+                                                </td>
                                                 <td style="width: 17mm; text-align: right;">
                                                     <h:outputText value="#{pharmacySummaryReportController.bundle.summaryRow.netTotal}" style="padding: 0px!important; margin: 0px!important; font-weight: bold" >
                                                         <f:convertNumber pattern="#,##0.00" />
@@ -353,6 +347,11 @@
                                                 </td>
                                                 <td style="width: 17mm; text-align: right;">
                                                     <h:outputText value="#{pharmacySummaryReportController.bundle.summaryRow.netTotal}" style="padding: 0px!important; margin: 0px!important; font-weight: bold" >
+                                                        <f:convertNumber pattern="#,##0.00" />
+                                                    </h:outputText>
+                                                </td>
+                                                <td style="width: 17mm; text-align: right;">
+                                                    <h:outputText value="#{pharmacySummaryReportController.bundle.summaryRow.totalCostValue}" style="padding: 0px!important; margin: 0px!important; font-weight: bold" >
                                                         <f:convertNumber pattern="#,##0.00" />
                                                     </h:outputText>
                                                 </td>

--- a/src/main/webapp/pharmacy/reports/summary_reports/pharmacy_income_report_print_bill_type_view.xhtml
+++ b/src/main/webapp/pharmacy/reports/summary_reports/pharmacy_income_report_print_bill_type_view.xhtml
@@ -268,7 +268,7 @@
                                                         </h:outputText>
                                                     </td>
                                                     <td style="width: 17mm; text-align: right;">
-                                                        <h:outputText value="#{row.discount}" style="margin-right: 1mm;">
+                                                        <h:outputText value="#{commonFunctionsProxy.reverseSign(row.discount)}" style="margin-right: 1mm;">
                                                             <f:convertNumber pattern="#,##0.00" />
                                                         </h:outputText>
                                                     </td>
@@ -336,7 +336,7 @@
                                                     </h:outputText>
                                                 </td>
                                                 <td style="width: 17mm; text-align: right;">
-                                                    <h:outputText value="#{pharmacySummaryReportController.bundle.summaryRow.discount}" style="padding: 0px!important; margin: 0px!important; font-weight: bold" >
+                                                    <h:outputText value="#{commonFunctionsProxy.reverseSign(pharmacySummaryReportController.bundle.summaryRow.discount)}" style="padding: 0px!important; margin: 0px!important; font-weight: bold" >
                                                         <f:convertNumber pattern="#,##0.00" />
                                                     </h:outputText>
                                                 </td>

--- a/src/main/webapp/pharmacy/reports/summary_reports/pharmacy_income_report_print_bill_type_view.xhtml
+++ b/src/main/webapp/pharmacy/reports/summary_reports/pharmacy_income_report_print_bill_type_view.xhtml
@@ -78,6 +78,7 @@
                                         font-family: Arial, sans-serif;
                                         font-size: 10pt;
                                     }
+                                    size: A4 landscape;
                                 }
 
                                 body {
@@ -87,8 +88,6 @@
                                 .paper{
                                     position: static !important;
                                     width: 297mm!important;
-                                    size: A4 landscape!important;
-
                                 }
 
                                 .header{
@@ -278,7 +277,7 @@
                                                         </h:outputText>
                                                     </td>
                                                     <td style="width: 17mm; text-align: right;">
-                                                        <h:outputText value="#{row.netTotal}" style="margin-right: 1mm;">
+                                                        <h:outputText value="#{row.actualTotal}" style="margin-right: 1mm;">
                                                             <f:convertNumber pattern="#,##0.00" />
                                                         </h:outputText>
                                                     </td>
@@ -346,7 +345,7 @@
                                                     </h:outputText>
                                                 </td>
                                                 <td style="width: 17mm; text-align: right;">
-                                                    <h:outputText value="#{pharmacySummaryReportController.bundle.summaryRow.netTotal}" style="padding: 0px!important; margin: 0px!important; font-weight: bold" >
+                                                    <h:outputText value="#{pharmacySummaryReportController.bundle.summaryRow.actualTotal}" style="padding: 0px!important; margin: 0px!important; font-weight: bold" >
                                                         <f:convertNumber pattern="#,##0.00" />
                                                     </h:outputText>
                                                 </td>

--- a/src/main/webapp/pharmacy/reports/summary_reports/pharmacy_income_report_print_discount_admission_view.xhtml
+++ b/src/main/webapp/pharmacy/reports/summary_reports/pharmacy_income_report_print_discount_admission_view.xhtml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8' ?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml"
       xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
       xmlns:h="http://xmlns.jcp.org/jsf/html"
@@ -73,6 +73,7 @@
 
                             @media print {
                                 @page {
+                                    size: A4 landscape;
                                     @bottom-right {
                                         content: "Page " counter(page) " of " counter(pages);
                                         font-family: Arial, sans-serif;
@@ -87,7 +88,6 @@
                                 .paper{
                                     position: static !important;
                                     width: 297mm!important;
-                                    size: A4 landscape!important;
 
                                 }
 
@@ -163,7 +163,7 @@
                                         </div>
 
                                         <div class="d-flex gap-2">
-                                            <h:outputText value="Diccount Scheme" style="font-weight:600;"/>
+                                            <h:outputText value="Discount Scheme" style="font-weight:600;"/>
                                             <h:outputText 
                                                 value="#{empty pharmacySummaryReportController.paymentScheme ? 'All discount schemes' :pharmacySummaryReportController.paymentScheme.name}"/>
                                         </div>
@@ -268,7 +268,7 @@
                                                         </h:outputText>
                                                     </td>
                                                     <td style="width: 17mm; text-align: right;">
-                                                        <h:outputText value="#{row.discount}" style="margin-right: 1mm;">
+                                                        <h:outputText value="#{commonFunctionsProxy.reverseSign(row.discount)}" style="margin-right: 1mm;">
                                                             <f:convertNumber pattern="#,##0.00" />
                                                         </h:outputText>
                                                     </td>
@@ -336,7 +336,7 @@
                                                     </h:outputText>
                                                 </td>
                                                 <td style="width: 17mm; text-align: right;">
-                                                    <h:outputText value="#{pharmacySummaryReportController.bundle.summaryRow.discount}" style="padding: 0px!important; margin: 0px!important; font-weight: bold" >
+                                                    <h:outputText value="#{commonFunctionsProxy.reverseSign(pharmacySummaryReportController.bundle.summaryRow.discount)}" style="padding: 0px!important; margin: 0px!important; font-weight: bold" >
                                                         <f:convertNumber pattern="#,##0.00" />
                                                     </h:outputText>
                                                 </td>

--- a/src/main/webapp/pharmacy/reports/summary_reports/pharmacy_income_report_print_discount_admission_view.xhtml
+++ b/src/main/webapp/pharmacy/reports/summary_reports/pharmacy_income_report_print_discount_admission_view.xhtml
@@ -73,12 +73,12 @@
 
                             @media print {
                                 @page {
-                                    size: A4 landscape;
                                     @bottom-right {
                                         content: "Page " counter(page) " of " counter(pages);
                                         font-family: Arial, sans-serif;
                                         font-size: 10pt;
                                     }
+                                    size: A4 landscape;
                                 }
 
                                 body {
@@ -278,7 +278,7 @@
                                                         </h:outputText>
                                                     </td>
                                                     <td style="width: 17mm; text-align: right;">
-                                                        <h:outputText value="#{row.netTotal}" style="margin-right: 1mm;">
+                                                        <h:outputText value="#{row.actualTotal}" style="margin-right: 1mm;">
                                                             <f:convertNumber pattern="#,##0.00" />
                                                         </h:outputText>
                                                     </td>
@@ -346,7 +346,7 @@
                                                     </h:outputText>
                                                 </td>
                                                 <td style="width: 17mm; text-align: right;">
-                                                    <h:outputText value="#{pharmacySummaryReportController.bundle.summaryRow.netTotal}" style="padding: 0px!important; margin: 0px!important; font-weight: bold" >
+                                                    <h:outputText value="#{pharmacySummaryReportController.bundle.summaryRow.actualTotal}" style="padding: 0px!important; margin: 0px!important; font-weight: bold" >
                                                         <f:convertNumber pattern="#,##0.00" />
                                                     </h:outputText>
                                                 </td>

--- a/src/main/webapp/pharmacy/reports/summary_reports/pharmacy_income_report_print_discount_admission_view.xhtml
+++ b/src/main/webapp/pharmacy/reports/summary_reports/pharmacy_income_report_print_discount_admission_view.xhtml
@@ -163,7 +163,7 @@
                                         </div>
 
                                         <div class="d-flex gap-2">
-                                            <h:outputText value="Discount Schema" style="font-weight:600;"/>
+                                            <h:outputText value="Diccount Scheme" style="font-weight:600;"/>
                                             <h:outputText 
                                                 value="#{empty pharmacySummaryReportController.paymentScheme ? 'All discount schemes' :pharmacySummaryReportController.paymentScheme.name}"/>
                                         </div>
@@ -180,14 +180,8 @@
                                     <table>
                                         <thead>
                                             <tr>
-                                                <th style="width: 7mm; font-weight: 700;">
-                                                    <h:outputText value="No" style="margin-left: 1mm;"/>
-                                                </th>
                                                 <th style="width: 25mm;font-weight: 700;">
-                                                    <h:outputText value="Bill No" style="margin-left: 1mm;"/>
-                                                </th>
-                                                <th style="width: 17mm; font-weight: 700; text-align: left;">
-                                                    <h:outputText value="Date" style="margin-left:  1mm;"/>
+                                                    <h:outputText value="Group" style="margin-left: 1mm;"/>
                                                 </th>
                                                 <th style="width: 17mm; font-weight: 700; text-align: right;">
                                                     <h:outputText value="Net Total" style="margin-right: 1mm;"/>
@@ -222,24 +216,19 @@
                                                 <th style="width: 17mm; font-weight: 700; text-align: center;">
                                                     <h:outputText value="Actual Total" style="margin-right: 1mm;"/>
                                                 </th>
+                                                 <th style="width: 17mm; font-weight: 700; text-align: center;">
+                                                    <h:outputText value="Cost" style="margin-right: 1mm;"/>
+                                                </th>
                                             </tr>
                                         </thead>
                                         <tbody>
                                             <ui:repeat value="#{pharmacySummaryReportController.bundle.rows}" var="row" varStatus="i">
                                                 <tr>
-                                                    <td style="width: 8mm;" >
-                                                        <h:outputText value="#{i.index +1}" style="margin-left: 1mm;"/>
-                                                    </td>
                                                     <td style="width: 25mm; text-align: left;">
-                                                        <h:outputText value="#{row.bill.deptId}" style="margin-left: 1mm;"/>
-                                                    </td>
-                                                    <td style="width: 17mm; text-align: left;">
-                                                        <h:outputText value="#{row.bill.createdAt}" style="margin-left: 1mm;">
-                                                            <f:convertDateTime pattern="dd/MM/YY" />
-                                                        </h:outputText>
+                                                        <h:outputText value="#{row.rowType}" style="margin-left: 1mm;"/>
                                                     </td>
                                                     <td style="width: 17mm; text-align: right;">
-                                                        <h:outputText value="#{row.bill.netTotal}" style="margin-right: 1mm;">
+                                                        <h:outputText value="#{row.netTotal}" style="margin-right: 1mm;">
                                                             <f:convertNumber pattern="#,##0.00" />
                                                         </h:outputText>
                                                     </td>
@@ -293,14 +282,19 @@
                                                             <f:convertNumber pattern="#,##0.00" />
                                                         </h:outputText>
                                                     </td>
+                                                    <td style="width: 17mm; text-align: right;">
+                                                        <h:outputText value="#{row.totalCostValue}" style="margin-right: 1mm;">
+                                                            <f:convertNumber pattern="#,##0.00" />
+                                                        </h:outputText>
+                                                    </td>
                                                 </tr>
                                             </ui:repeat>
                                         </tbody>
                                         <tfoot>
                                             <tr>
-                                                <td style="width: 8mm;" />
-                                                <td style="width: 25mm; text-align: left;"/>
-                                                <td style="width: 17mm; text-align: left;"/>
+                                                <td style="width: 25mm; text-align: center;">
+                                                    <h:outputText value="Total" style="padding: 0px!important; margin: 0px!important; font-weight: bold"/>
+                                                </td>
                                                 <td style="width: 17mm; text-align: right;">
                                                     <h:outputText value="#{pharmacySummaryReportController.bundle.summaryRow.netTotal}" style="padding: 0px!important; margin: 0px!important; font-weight: bold" >
                                                         <f:convertNumber pattern="#,##0.00" />
@@ -353,6 +347,11 @@
                                                 </td>
                                                 <td style="width: 17mm; text-align: right;">
                                                     <h:outputText value="#{pharmacySummaryReportController.bundle.summaryRow.netTotal}" style="padding: 0px!important; margin: 0px!important; font-weight: bold" >
+                                                        <f:convertNumber pattern="#,##0.00" />
+                                                    </h:outputText>
+                                                </td>
+                                                <td style="width: 17mm; text-align: right;">
+                                                    <h:outputText value="#{pharmacySummaryReportController.bundle.summaryRow.totalCostValue}" style="padding: 0px!important; margin: 0px!important; font-weight: bold" >
                                                         <f:convertNumber pattern="#,##0.00" />
                                                     </h:outputText>
                                                 </td>

--- a/src/main/webapp/pharmacy/reports/summary_reports/pharmacy_income_report_print_view.xhtml
+++ b/src/main/webapp/pharmacy/reports/summary_reports/pharmacy_income_report_print_view.xhtml
@@ -163,7 +163,7 @@
                                         </div>
 
                                         <div class="d-flex gap-2">
-                                            <h:outputText value="Discount Schema" style="font-weight:600;"/>
+                                            <h:outputText value="Discount Scheme" style="font-weight:600;"/>
                                             <h:outputText 
                                                 value="#{empty pharmacySummaryReportController.paymentScheme ? 'All discount schemes' :pharmacySummaryReportController.paymentScheme.name}"/>
                                         </div>

--- a/src/main/webapp/pharmacy/reports/summary_reports/pharmacy_income_report_print_view.xhtml
+++ b/src/main/webapp/pharmacy/reports/summary_reports/pharmacy_income_report_print_view.xhtml
@@ -78,6 +78,7 @@
                                         font-family: Arial, sans-serif;
                                         font-size: 10pt;
                                     }
+                                    size: A4 landscape;
                                 }
 
                                 body {
@@ -87,7 +88,6 @@
                                 .paper{
                                     position: static !important;
                                     width: 297mm!important;
-                                    size: A4 landscape!important;
 
                                 }
 
@@ -289,7 +289,7 @@
                                                         </h:outputText>
                                                     </td>
                                                     <td style="width: 17mm; text-align: right;">
-                                                        <h:outputText value="#{row.netTotal}" style="margin-right: 1mm;">
+                                                        <h:outputText value="#{row.actualTotal}" style="margin-right: 1mm;">
                                                             <f:convertNumber pattern="#,##0.00" />
                                                         </h:outputText>
                                                     </td>
@@ -352,7 +352,7 @@
                                                     </h:outputText>
                                                 </td>
                                                 <td style="width: 17mm; text-align: right;">
-                                                    <h:outputText value="#{pharmacySummaryReportController.bundle.summaryRow.netTotal}" style="padding: 0px!important; margin: 0px!important; font-weight: bold" >
+                                                    <h:outputText value="#{pharmacySummaryReportController.bundle.summaryRow.actualTotal}" style="padding: 0px!important; margin: 0px!important; font-weight: bold" >
                                                         <f:convertNumber pattern="#,##0.00" />
                                                     </h:outputText>
                                                 </td>


### PR DESCRIPTION
I done the improvement on the file generation of the pharmacy income report. There are already have excel and print functions, and I improved that function. I added a PDF button to download the PDF and created the backend function for the generation process.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Multi-format PDF export for pharmacy income reports (by bill, bill type, discount/admission combinations) with formatted filenames and consistent headers.
  * Print-optimized report views (A4 landscape) with page numbering and improved layout.
  * New on-page export controls ("Download", "To Print") and hidden title headers for exported files.
  * Consistent numeric/date formatting and updated displayed totals to reflect actual totals.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->