### PR TITLE
Fix department filter in inpatient pharmacy DTO report and add legacy warning

### DIFF
--- a/src/main/java/com/divudi/bean/inward/InwardReportControllerBht.java
+++ b/src/main/java/com/divudi/bean/inward/InwardReportControllerBht.java
@@ -258,45 +258,18 @@ public class InwardReportControllerBht implements Serializable {
                 + "AND bi.bill.retired = FALSE "
                 + "AND bi.bill.cancelled = FALSE ";
 
-        // Removed department filter to show all pharmacy items for the patient encounter
-        // regardless of which department issued them
-        jpql += "ORDER BY bi.bill.createdAt, bi.id";
-
         Map<String, Object> params = new HashMap<>();
         params.put("billTypeAtomics", billTypes);
         params.put("patientEncounter", patientEncounter);
-        // Removed department parameter since we're not filtering by department anymore
 
-        // Debug query to check what's filtering out records
-        String debugJpql = "SELECT COUNT(bi) FROM BillItem bi WHERE bi.bill.patientEncounter = :patientEncounter";
-        Map<String, Object> debugParams = new HashMap<>();
-        debugParams.put("patientEncounter", patientEncounter);
-        Long debugCount = billItemFacade.countByJpql(debugJpql, debugParams);
+        if (department != null) {
+            jpql += "AND bi.bill.department = :department ";
+            params.put("department", department);
+        }
 
-        String debugJpql2 = "SELECT COUNT(bi) FROM BillItem bi WHERE bi.bill.patientEncounter = :patientEncounter AND bi.bill.billTypeAtomic IN :billTypeAtomics";
-        Map<String, Object> debugParams2 = new HashMap<>();
-        debugParams2.put("patientEncounter", patientEncounter);
-        debugParams2.put("billTypeAtomics", billTypes);
-        Long debugCount2 = billItemFacade.countByJpql(debugJpql2, debugParams2);
-
-        // Test individual fields to find the problematic one
-        String testJpql1 = "SELECT bi.id, bi.item.name, bi.qty, bi.netValue FROM BillItem bi WHERE bi.bill.patientEncounter = :patientEncounter AND bi.bill.billTypeAtomic IN :billTypeAtomics";
-        List<Object[]> testResult1 = billItemFacade.findAggregates(testJpql1, debugParams2);
-
-        String testJpql2 = "SELECT bi.id, bi.item.name, bi.qty, bi.netValue, bi.bill.createdAt FROM BillItem bi WHERE bi.bill.patientEncounter = :patientEncounter AND bi.bill.billTypeAtomic IN :billTypeAtomics";
-        List<Object[]> testResult2 = billItemFacade.findAggregates(testJpql2, debugParams2);
-
-        String testJpql3 = "SELECT bi.id, bi.item.name, bi.qty, bi.netValue, bi.bill.createdAt, bi.bill.billTypeAtomic FROM BillItem bi WHERE bi.bill.patientEncounter = :patientEncounter AND bi.bill.billTypeAtomic IN :billTypeAtomics";
-        List<Object[]> testResult3 = billItemFacade.findAggregates(testJpql3, debugParams2);
-
-        String testJpql4 = "SELECT bi.id, bi.item.name, bi.qty, bi.netValue, bi.bill.createdAt, bi.bill.billTypeAtomic, COALESCE(bi.bill.department.name, 'N/A') FROM BillItem bi WHERE bi.bill.patientEncounter = :patientEncounter AND bi.bill.billTypeAtomic IN :billTypeAtomics";
-        List<Object[]> testResult4 = billItemFacade.findAggregates(testJpql4, debugParams2);
-
-        String testJpql5 = "SELECT bi.id, bi.item.name, bi.qty, bi.netValue, bi.bill.createdAt, bi.bill.billTypeAtomic, COALESCE(bi.bill.department.name, 'N/A'), bi.referanceBillItem.id FROM BillItem bi WHERE bi.bill.patientEncounter = :patientEncounter AND bi.bill.billTypeAtomic IN :billTypeAtomics";
-        List<Object[]> testResult5 = billItemFacade.findAggregates(testJpql5, debugParams2);
+        jpql += "ORDER BY bi.bill.createdAt, bi.id";
 
         List<InpatientPharmacyIssueDTO> result = (List<InpatientPharmacyIssueDTO>) billItemFacade.findLightsByJpql(jpql, params);
-
 
         return result != null ? result : new ArrayList<>();
     }

--- a/src/main/webapp/inward/admission_profile.xhtml
+++ b/src/main/webapp/inward/admission_profile.xhtml
@@ -497,21 +497,8 @@
                         <p:panel header="Reports" class="m-1">
                             <div class="d-grid gap-3">
                                 <p:commandButton 
-                                    ajax="false"
-                                    value="Pharmacy Issue Summary (Entity)" 
-                                    action="#{inwardReportControllerBht.navigateToInpatientPharmacyItemList}" 
-                                    icon="fa fa-prescription-bottle-alt"
-                                    class="w-100"
-                                    title="Traditional entity-based report">
-                                    <f:setPropertyActionListener 
-                                        value="#{admissionController.current}" 
-                                        target="#{inwardReportControllerBht.patientEncounter}" />
-                                    <f:setPropertyActionListener 
-                                        value="#{null}" 
-                                        target="#{inwardReportControllerBht.department}" />
-                                </p:commandButton>
-                                <p:commandButton 
-                                    value="Pharmacy Issue Summary (DTO - Fast)" 
+                                    id="btnPharmacyIssues"
+                                    value="Pharmacy Issue Summary" 
                                     action="#{inwardReportControllerBht.navigateToInpatientPharmacyItemListDto()}" 
                                     icon="fa fa-rocket"
                                     ajax="false"
@@ -543,6 +530,22 @@
                                     ajax="false"
                                     icon="pi pi-chart-line"
                                     class="ui-button-success mx-1 mb-2">
+                                </p:commandButton>
+                                <p:commandButton
+                                    id="btnLegacy"
+                                    ajax="false"
+                                    value="Pharmacy Issue Summary (Legacy)"
+                                    action="#{inwardReportControllerBht.navigateToInpatientPharmacyItemList}"
+                                    icon="fa fa-prescription-bottle-alt"
+                                    class="w-100 ui-button-secondary"
+                                    title="Traditional entity-based report"
+                                    onclick="return confirm('Warning: This is the legacy report and may be slow to load. Use the Pharmacy Issue Summary button above for better performance. Continue anyway?')">
+                                    <f:setPropertyActionListener 
+                                        value="#{admissionController.current}" 
+                                        target="#{inwardReportControllerBht.patientEncounter}" />
+                                    <f:setPropertyActionListener 
+                                        value="#{null}" 
+                                        target="#{inwardReportControllerBht.department}" />
                                 </p:commandButton>
                             </div>
                         </p:panel>


### PR DESCRIPTION
## Summary
- Restore department filter in `fetchPharmacyIssueDtos()` — it had been removed, causing the department dropdown to have no effect on the DTO-based pharmacy report
- Remove leftover debug/test JPQL queries from `fetchPharmacyIssueDtos()` that were executing unnecessary DB queries on every page load
- Add JS confirmation warning to the legacy button in `admission_profile.xhtml` directing users to the faster DTO-based report instead

## Test plan
- [ ] Open an inpatient admission profile
- [ ] Click "Pharmacy Issue Summary" (green/DTO button) — verify department filter works
- [ ] Click "Pharmacy Issue Summary (Legacy)" — verify confirmation dialog appears warning about performance
- [ ] Confirm → legacy report loads; cancel → navigation aborted
- [ ] On either report page, select a specific department and click Process — verify results filter correctly

Closes #18855

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Pharmacy Issue Summary feature optimized for improved performance and faster response times.
  * Legacy version available as fallback option for users requiring previous functionality.
  * Enhanced filtering and sorting of pharmacy issue data.
  * Internal code cleanup for improved system efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->