### PR TITLE
Handle null/invalid report date ranges in ReportTimerController

### DIFF
--- a/src/main/java/com/divudi/bean/common/ReportTimerController.java
+++ b/src/main/java/com/divudi/bean/common/ReportTimerController.java
@@ -41,9 +41,15 @@ public class ReportTimerController implements Serializable {
         } catch (IllegalArgumentException e) {
             LOGGER.log(Level.WARNING, "Skipping report generation due to invalid date range or missing date values", e);
         } catch (EJBTransactionRolledbackException e) {
-            Throwable rootCause = e.getCause();
-            if (rootCause instanceof IllegalArgumentException) {
-                LOGGER.log(Level.WARNING, "Skipping report generation due to invalid date range or missing date values", rootCause);
+            IllegalArgumentException foundCause = null;
+            for (Throwable cause = e; cause != null; cause = cause.getCause()) {
+                if (cause instanceof IllegalArgumentException) {
+                    foundCause = (IllegalArgumentException) cause;
+                    break;
+                }
+            }
+            if (foundCause != null) {
+                LOGGER.log(Level.WARNING, "Skipping report generation due to invalid date range or missing date values", foundCause);
             } else {
                 LOGGER.log(Level.SEVERE, "Error occurred while generating the report", e);
             }


### PR DESCRIPTION
### Motivation
- Scheduled report jobs sometimes invoked report generation with `fromDate`/`toDate` unset which caused `IllegalArgumentException` to bubble up and produce EJB transaction rollbacks and SEVERE log spam. 

### Description
- Add explicit handling in `ReportTimerController.trackReportExecution(...)`: catch `IllegalArgumentException` and log a warning to skip the run, catch `EJBTransactionRolledbackException` and downgrade to a warning when its root cause is an `IllegalArgumentException`, and add the `EJBTransactionRolledbackException` import; modified file `src/main/java/com/divudi/bean/common/ReportTimerController.java`, and this change closes `#18880`. 

### Testing
- No automated unit tests were executed; changes were validated via repository checks and file inspection using `git status`, `git show --stat`, and viewing `src/main/java/com/divudi/bean/common/ReportTimerController.java` to confirm the new exception handling was applied successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a23191085c832f991b72876c36b0c0)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling and logging for report generation, providing clearer diagnostic messages when invalid date ranges are provided or system failures occur during report execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->