### PR TITLE
Add missing calTotal() method to PharmacySaleController

### DIFF
--- a/src/main/java/com/divudi/bean/pharmacy/PharmacySaleController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacySaleController.java
@@ -1727,6 +1727,10 @@ public class PharmacySaleController implements Serializable, ControllerWithPatie
         setNetTotal(getPreBill().getNetTotal());
     }
 
+    public void calTotal() {
+        calculateBillItemsAndBillTotalsOfPreBill();
+    }
+
     public double addBillItemSingleItem() {
         editingQty = null;
         errorMessage = null;


### PR DESCRIPTION
PharmacySaleController was missing the calTotal() public method which is referenced as an AJAX listener in:
- pharmacy/pharmacy_bill_retail_sale.xhtml (3 usages)
- clinical/clinical_pharmacy_sale.xhtml (3 usages)

This caused a MethodNotFoundException on every page render that triggered those listeners, producing SEVERE errors that flooded HTTP threads and contributed to the server becoming unresponsive on 27 Feb 2026.

The numbered variants (PharmacySaleController1/2/3) all have calTotal() implemented directly. In the base controller, calTotal() delegates to the equivalent calculateBillItemsAndBillTotalsOfPreBill() which already performs the same work.

Closes #18879

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added an alternate method entry point in the pharmacy sales module to enable recalculation of bill items and totals.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->