### PR TITLE
Remove debug startup println from ApplicationStartupTimeService

### DIFF
--- a/src/main/java/com/divudi/service/ApplicationStartupTimeService.java
+++ b/src/main/java/com/divudi/service/ApplicationStartupTimeService.java
@@ -22,7 +22,6 @@ public class ApplicationStartupTimeService {
     public void init() {
         // Capture the startup time immediately when the application starts
         startupTime = ZonedDateTime.now();
-        System.out.println("Application started at: " + startupTime);
     }
 
     /**


### PR DESCRIPTION
### Motivation
- Remove the temporary debug `System.out.println` in `ApplicationStartupTimeService.init()` to eliminate unwanted stdout noise during application startup while retaining the startup time tracking.

### Description
- Deleted the `System.out.println("Application started at: " + startupTime);` line and kept `startupTime = ZonedDateTime.now();` so the recorded startup time behavior is unchanged.

### Testing
- Verified the change by inspecting `src/main/java/com/divudi/service/ApplicationStartupTimeService.java` and confirming the `System.out.println` line was removed; no automated unit tests were run per repository guidance for this small Java change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a35cd574c8832f92ef829f05e72798)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed console logging output displayed during application startup. Startup time measurement functionality remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->