### PR TITLE
Replace heading wrappers with styled `h:outputText` in report print view

### DIFF
--- a/src/main/webapp/opd/analytics/summary_reports/hospital_doctor_fee_report_print.xhtml
+++ b/src/main/webapp/opd/analytics/summary_reports/hospital_doctor_fee_report_print.xhtml
@@ -64,6 +64,21 @@
                                     font-size: 16px!important;
                                 }
 
+                                .report-title,
+                                .report-subtitle {
+                                    display: block;
+                                    text-align: center;
+                                    font-weight: 700;
+                                }
+
+                                .report-title {
+                                    font-size: 22px;
+                                }
+
+                                .report-subtitle {
+                                    font-size: 16px;
+                                }
+
                                 tfoot{
                                     font-weight: 700!important;
                                     font-size: 10px!important;
@@ -94,6 +109,21 @@
                                     line-height: 1.2;
                                     margin: 0mm!important;
                                     font-size: 10px!important;
+                                }
+
+                                .report-title,
+                                .report-subtitle {
+                                    display: block;
+                                    text-align: center;
+                                    font-weight: 700;
+                                }
+
+                                .report-title {
+                                    font-size: 22px;
+                                }
+
+                                .report-subtitle {
+                                    font-size: 16px;
                                 }
 
                                 table {
@@ -137,12 +167,8 @@
                         <h:panelGroup id="reportView" class="d-flex justify-content-center">
                             <div class="paper">
                                 <div class="header" >
-                                    <div class="d-flex justify-content-center text-5 gap-2" style="font-weight: 700; font-size: 22px;">
-                                        <h:outputText value="#{sessionController.institution.name}"/>
-                                    </div>
-                                    <div class="d-flex justify-content-center text-5 gap-2" style="font-weight: 700; font-size: 16px;">
-                                        <h:outputText value="Hospital Fee &amp; Doctor Fee Report"/>
-                                    </div>
+                                    <h:outputText value="#{sessionController.institution.name}" styleClass="report-title"/>
+                                    <h:outputText value="Hospital Fee &amp; Doctor Fee Report" styleClass="report-subtitle"/>
                                     <div class="d-flex justify-content-center mt-2" style=" font-size: 12px;">
                                         <div class="d-flex gap-3">
                                             <h:outputText value="From Date" style="width: 5em!important; font-weight: 600;"/>


### PR DESCRIPTION
### Motivation
- Conform to project XHTML guidelines by replacing raw heading wrappers with JSF `h:outputText` components for report headings. 
- Ensure heading styles are class-driven so the print and screen styling is consistent and not tied to raw HTML tags.

### Description
- Updated `src/main/webapp/opd/analytics/summary_reports/hospital_doctor_fee_report_print.xhtml` to replace the heading wrapper blocks with `h:outputText` elements using `styleClass` values `report-title` and `report-subtitle`.
- Added `.report-title` and `.report-subtitle` CSS rules to both `@media screen` and `@media print` blocks to preserve the previous typography and alignment while using class selectors.
- Kept visual layout and print-friendly rules unchanged aside from moving heading styling to the new classes.

### Testing
- Verified the source with a file inspection and `git diff` to confirm the intended edits to `hospital_doctor_fee_report_print.xhtml` were applied. 
- Attempted an automated UI capture with Playwright, but the local app endpoint at `http://localhost:8080` returned `ERR_EMPTY_RESPONSE` so a screenshot could not be obtained. 
- This is a UI-only XHTML/CSS change and no Java compilation or server-side tests were required per repository testing guidelines.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a35ce37fa4832f943615bb9e6fe971)