### PR TITLE
Add null-safe exception message handling in DataAdministrationController

### DIFF
--- a/src/main/java/com/divudi/bean/common/DataAdministrationController.java
+++ b/src/main/java/com/divudi/bean/common/DataAdministrationController.java
@@ -2028,8 +2028,9 @@ public class DataAdministrationController implements Serializable {
             JsfUtil.addSuccessMessage("Found " + billsToCorrect + " bills that need correction. Click 'Execute Correction' to proceed.");
 
         } catch (Exception e) {
+            String exceptionMessage = getExceptionMessage(e);
             String errorMsg = buildBillingFeeCorrectionErrorMessage(
-                    e,
+                    exceptionMessage,
                     "Error checking bills for correction: ",
                     ". This appears to be a database schema issue. Please check if the BILL and BILLITEM tables exist in your database.");
 
@@ -2056,8 +2057,9 @@ public class DataAdministrationController implements Serializable {
             }
 
         } catch (Exception e) {
+            String exceptionMessage = getExceptionMessage(e);
             String errorMsg = buildBillingFeeCorrectionErrorMessage(
-                    e,
+                    exceptionMessage,
                     "Error correcting historical bill fees: ",
                     ". This appears to be a database schema issue. The correction failed due to table name case sensitivity or missing tables.");
 
@@ -2089,8 +2091,9 @@ public class DataAdministrationController implements Serializable {
             }
 
         } catch (Exception e) {
+            String exceptionMessage = getExceptionMessage(e);
             String errorMsg = buildBillingFeeCorrectionErrorMessage(
-                    e,
+                    exceptionMessage,
                     "Error checking bills in custom date range: ",
                     ". Database schema issue detected. Check table names and database connectivity.");
 
@@ -2120,8 +2123,9 @@ public class DataAdministrationController implements Serializable {
             }
 
         } catch (Exception e) {
+            String exceptionMessage = getExceptionMessage(e);
             String errorMsg = buildBillingFeeCorrectionErrorMessage(
-                    e,
+                    exceptionMessage,
                     "Error correcting bills in custom date range: ",
                     ". Database execution failed due to schema issues. Verify table structure and permissions.");
 
@@ -2131,12 +2135,7 @@ public class DataAdministrationController implements Serializable {
         }
     }
 
-    private String buildBillingFeeCorrectionErrorMessage(Exception e, String prefix, String schemaGuidance) {
-        String exceptionMessage = e.getMessage();
-        if (exceptionMessage == null || exceptionMessage.trim().isEmpty()) {
-            exceptionMessage = e.getClass().getName();
-        }
-
+    private String buildBillingFeeCorrectionErrorMessage(String exceptionMessage, String prefix, String schemaGuidance) {
         String errorMsg = prefix + exceptionMessage;
         if (exceptionMessage.contains("doesn't exist") || exceptionMessage.contains("Table") || exceptionMessage.contains("SQLSyntaxErrorException")) {
             errorMsg += schemaGuidance;


### PR DESCRIPTION
### Motivation
- Prevent potential NullPointerExceptions when `e.getMessage()` returns null in OPD billing fee correction error handling.
- Ensure error message assembly is robust and consistent across historical and custom date-range correction flows.

### Description
- Resolve the exception text once per catch block via `String exceptionMessage = getExceptionMessage(e);` and pass that string to the message builder.
- Change `buildBillingFeeCorrectionErrorMessage` to accept the resolved `String exceptionMessage` instead of the `Exception` object.
- Apply the pattern in `correctHistoricalOpdBillingFees()`, `executeHistoricalOpdBillingFeesCorrection()`, `correctCustomDateRangeBillingFees()`, and `executeCustomDateRangeBillingFeesCorrection()` to avoid repeated `e.getMessage()` calls. 
- This change is confined to error handling message assembly and does not alter correction logic; the PR closes `#18135`.

### Testing
- Fetched the issue metadata with `curl -s https://api.github.com/repos/hmislk/hmis/issues/18135` and confirmed the target issue, which succeeded. 
- Performed repository inspections using `rg` to find relevant usages and `sed`/`nl` to view the modified regions, and verified the updated source lines, all of which succeeded. 
- Verified the diff with `git diff` and committed the change with `git commit`, which completed successfully. 
- No Java build or unit tests were run as repository guidelines require explicit request for builds when modifying Java code.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a364cac3a8832fadebc75a0885105a)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Refactored exception handling in billing fee correction operations to pre-process exception messages before error construction, improving consistency and maintainability of error reporting across correction workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->