### PR TITLE
Replace System.out.println in createPoTablePharmacyDto with logger calls

### DIFF
--- a/src/main/java/com/divudi/bean/common/SearchController.java
+++ b/src/main/java/com/divudi/bean/common/SearchController.java
@@ -6939,7 +6939,7 @@ public class SearchController implements Serializable {
      * Does NOT include GRN details (nested table) for maximum performance.
      */
     public void createPoTablePharmacyDto() {
-        System.out.println("createPoTablePharmacyDto: START");
+        logger.info("createPoTablePharmacyDto: START");
         pharmacyPurchaseOrderDtos = null;
         String jpql;
         Map<String, Object> params = new HashMap<>();
@@ -6960,15 +6960,15 @@ public class SearchController implements Serializable {
         countParams.put("dept", sessionController.getDepartment());
         countParams.put("bta", BillTypeAtomic.PHARMACY_ORDER_APPROVAL);
 
-        System.out.println("createPoTablePharmacyDto: Count JPQL = " + countJpql);
-        System.out.println("createPoTablePharmacyDto: fromDate = " + getFromDate());
-        System.out.println("createPoTablePharmacyDto: toDate = " + getToDate());
-        System.out.println("createPoTablePharmacyDto: institution = " + getSessionController().getInstitution());
-        System.out.println("createPoTablePharmacyDto: department = " + sessionController.getDepartment());
-        System.out.println("createPoTablePharmacyDto: billTypeAtomic = " + BillTypeAtomic.PHARMACY_ORDER_APPROVAL);
+        logger.debug("createPoTablePharmacyDto: Count JPQL = {}", countJpql);
+        logger.debug("createPoTablePharmacyDto: fromDate = {}", getFromDate());
+        logger.debug("createPoTablePharmacyDto: toDate = {}", getToDate());
+        logger.debug("createPoTablePharmacyDto: institution = {}", getSessionController().getInstitution());
+        logger.debug("createPoTablePharmacyDto: department = {}", sessionController.getDepartment());
+        logger.debug("createPoTablePharmacyDto: billTypeAtomic = {}", BillTypeAtomic.PHARMACY_ORDER_APPROVAL);
 
         Long count = getBillFacade().countByJpql(countJpql, countParams, TemporalType.TIMESTAMP);
-        System.out.println("createPoTablePharmacyDto: COUNT = " + count);
+        logger.info("createPoTablePharmacyDto: COUNT = {}", count);
 
         // First test with a simple query to check exact types returned by JPQL
         String testJpql = "SELECT b.id, b.deptId, b.createdAt, b.netTotal, b.consignment, b.cancelled, b.billClosed, b.fullyIssued FROM Bill b "
@@ -6979,17 +6979,17 @@ public class SearchController implements Serializable {
                 + "AND b.createdAt BETWEEN :fromDate AND :toDate ";
 
         List testResult = getBillFacade().findByJpql(testJpql, countParams, TemporalType.TIMESTAMP);
-        System.out.println("createPoTablePharmacyDto: TEST QUERY Result size = " + (testResult != null ? testResult.size() : "null"));
+        logger.debug("createPoTablePharmacyDto: TEST QUERY Result size = {}", (testResult != null ? testResult.size() : "null"));
         if (testResult != null && !testResult.isEmpty()) {
             Object[] firstRow = (Object[]) testResult.get(0);
-            System.out.println("createPoTablePharmacyDto: TEST Row - id type: " + (firstRow[0] != null ? firstRow[0].getClass().getName() : "null"));
-            System.out.println("createPoTablePharmacyDto: TEST Row - deptId type: " + (firstRow[1] != null ? firstRow[1].getClass().getName() : "null"));
-            System.out.println("createPoTablePharmacyDto: TEST Row - createdAt type: " + (firstRow[2] != null ? firstRow[2].getClass().getName() : "null"));
-            System.out.println("createPoTablePharmacyDto: TEST Row - netTotal type: " + (firstRow[3] != null ? firstRow[3].getClass().getName() : "null"));
-            System.out.println("createPoTablePharmacyDto: TEST Row - consignment type: " + (firstRow[4] != null ? firstRow[4].getClass().getName() : "null") + " value: " + firstRow[4]);
-            System.out.println("createPoTablePharmacyDto: TEST Row - cancelled type: " + (firstRow[5] != null ? firstRow[5].getClass().getName() : "null") + " value: " + firstRow[5]);
-            System.out.println("createPoTablePharmacyDto: TEST Row - billClosed type: " + (firstRow[6] != null ? firstRow[6].getClass().getName() : "null") + " value: " + firstRow[6]);
-            System.out.println("createPoTablePharmacyDto: TEST Row - fullyIssued type: " + (firstRow[7] != null ? firstRow[7].getClass().getName() : "null") + " value: " + firstRow[7]);
+            logger.debug("createPoTablePharmacyDto: TEST Row - id type: {}", (firstRow[0] != null ? firstRow[0].getClass().getName() : "null"));
+            logger.debug("createPoTablePharmacyDto: TEST Row - deptId type: {}", (firstRow[1] != null ? firstRow[1].getClass().getName() : "null"));
+            logger.debug("createPoTablePharmacyDto: TEST Row - createdAt type: {}", (firstRow[2] != null ? firstRow[2].getClass().getName() : "null"));
+            logger.debug("createPoTablePharmacyDto: TEST Row - netTotal type: {}", (firstRow[3] != null ? firstRow[3].getClass().getName() : "null"));
+            logger.debug("createPoTablePharmacyDto: TEST Row - consignment type: {} value: {}", (firstRow[4] != null ? firstRow[4].getClass().getName() : "null"), firstRow[4]);
+            logger.debug("createPoTablePharmacyDto: TEST Row - cancelled type: {} value: {}", (firstRow[5] != null ? firstRow[5].getClass().getName() : "null"), firstRow[5]);
+            logger.debug("createPoTablePharmacyDto: TEST Row - billClosed type: {} value: {}", (firstRow[6] != null ? firstRow[6].getClass().getName() : "null"), firstRow[6]);
+            logger.debug("createPoTablePharmacyDto: TEST Row - fullyIssued type: {} value: {}", (firstRow[7] != null ? firstRow[7].getClass().getName() : "null"), firstRow[7]);
         }
 
         // Use the working minimal DTO approach - just use the minimal constructor and set rest to null
@@ -7012,7 +7012,7 @@ public class SearchController implements Serializable {
                 + "AND b.department = :dept "
                 + "AND b.createdAt BETWEEN :fromDate AND :toDate ";
 
-        System.out.println("createPoTablePharmacyDto: DTO JPQL = " + jpql);
+        logger.debug("createPoTablePharmacyDto: DTO JPQL = {}", jpql);
 
         if (getSearchKeyword() != null) {
             if (getSearchKeyword().getBillNo() != null && !getSearchKeyword().getBillNo().trim().isEmpty()) {
@@ -7052,7 +7052,7 @@ public class SearchController implements Serializable {
         params.put("dept", sessionController.getDepartment());
         params.put("bta", BillTypeAtomic.PHARMACY_ORDER_APPROVAL);
 
-        System.out.println("createPoTablePharmacyDto: Executing DTO query...");
+        logger.info("createPoTablePharmacyDto: Executing DTO query...");
         try {
             if (getReportKeyWord() != null && getReportKeyWord().isAdditionalDetails()) {
                 pharmacyPurchaseOrderDtos = (List<PharmacyPurchaseOrderDTO>) getBillFacade()
@@ -7061,16 +7061,15 @@ public class SearchController implements Serializable {
                 pharmacyPurchaseOrderDtos = (List<PharmacyPurchaseOrderDTO>) getBillFacade()
                         .findLightsByJpql(jpql, params, TemporalType.TIMESTAMP, 50);
             }
-            System.out.println("createPoTablePharmacyDto: Query executed successfully");
-            System.out.println("createPoTablePharmacyDto: Result size = " + (pharmacyPurchaseOrderDtos != null ? pharmacyPurchaseOrderDtos.size() : "null"));
+            logger.info("createPoTablePharmacyDto: Query executed successfully");
+            logger.info("createPoTablePharmacyDto: Result size = {}", (pharmacyPurchaseOrderDtos != null ? pharmacyPurchaseOrderDtos.size() : "null"));
             if (pharmacyPurchaseOrderDtos != null && !pharmacyPurchaseOrderDtos.isEmpty()) {
-                System.out.println("createPoTablePharmacyDto: First DTO = " + pharmacyPurchaseOrderDtos.get(0));
+                logger.debug("createPoTablePharmacyDto: First DTO = {}", pharmacyPurchaseOrderDtos.get(0));
             }
         } catch (Exception e) {
-            System.out.println("createPoTablePharmacyDto: ERROR = " + e.getMessage());
-            e.printStackTrace();
+            logger.error("createPoTablePharmacyDto: ERROR while executing DTO query", e);
         }
-        System.out.println("createPoTablePharmacyDto: END");
+        logger.info("createPoTablePharmacyDto: END");
     }
 
     public void createPoTableStore() {


### PR DESCRIPTION
### Motivation

- Remove ad-hoc `System.out.println` debugging from the DTO-based pharmacy PO search to keep logging consistent with the project's logging framework. 
- Use appropriate log levels to make debugging and operational logs actionable and to avoid noisy stdout in production.

### Description

- Replaced all `System.out.println` calls in `createPoTablePharmacyDto()` with `logger` calls using `debug` for query/type diagnostics, `info` for start/finish and milestones, and `error` for exceptions. 
- Replaced `e.printStackTrace()` with `logger.error(..., e)` to ensure exceptions are logged with stack traces through the logging framework. 
- File updated: `src/main/java/com/divudi/bean/common/SearchController.java` (method `createPoTablePharmacyDto`). 
- The change focuses only on replacing debugging prints and does not alter business logic or query construction.

### Testing

- Verified the replacements by running `rg -n "createPoTablePharmacyDto|System\.out\.println" src/main/java/com/divudi/bean/common/SearchController.java` to confirm `System.out.println` usage was removed from the method. 
- No unit or integration tests were executed as part of this change, and no build was run; recommend running `./detect-maven.sh test` or a full `mvn -DskipTests=false test` if you want compilation/test validation before merge.
- This PR closes `#17473` and `#17477`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a368e7fe20832f8c35ef1bcf4a5059)