### PR TITLE
Closes #18893 : All three bin card views now have matching totals

### DIFF
--- a/src/main/java/com/divudi/bean/pharmacy/PharmacyErrorChecking.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacyErrorChecking.java
@@ -68,6 +68,8 @@ public class PharmacyErrorChecking implements Serializable {
     double currentStock;
     double currentSaleValue;
     double currentPurchaseValue;
+    private double binCardTotalIn;
+    private double binCardTotalOut;
     @Named
     @Inject
     private SessionController sessionController;
@@ -147,7 +149,24 @@ public class PharmacyErrorChecking implements Serializable {
                 }
             }
 
+            calculateBinCardTotals();
+
         }, PharmacyReports.PHARMACY_BIN_CARD, sessionController.getLoggedUser());
+    }
+
+    private void calculateBinCardTotals() {
+        binCardTotalIn = 0;
+        binCardTotalOut = 0;
+        if (binCardEntries != null) {
+            for (PharmacyBinCardDTO dto : binCardEntries) {
+                double qtyPlusFree = dto.getTransQtyPlusFreeQty();
+                if (qtyPlusFree > 0) {
+                    binCardTotalIn += qtyPlusFree;
+                } else if (qtyPlusFree < 0) {
+                    binCardTotalOut += Math.abs(qtyPlusFree);
+                }
+            }
+        }
     }
 
     /**
@@ -603,6 +622,18 @@ public class PharmacyErrorChecking implements Serializable {
         int colorIndex = hash % 10; // Use 10 different colors
         
         return "batch-color-" + colorIndex;
+    }
+
+    public double getBinCardTotalIn() {
+        return binCardTotalIn;
+    }
+
+    public double getBinCardTotalOut() {
+        return binCardTotalOut;
+    }
+
+    public double getBinCardNetTotal() {
+        return binCardTotalIn - binCardTotalOut;
     }
 
 }

--- a/src/main/webapp/pharmacy/bin_card_batch.xhtml
+++ b/src/main/webapp/pharmacy/bin_card_batch.xhtml
@@ -140,6 +140,9 @@
                         <h:outputText value="#{sh.createdAt}">
                             <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateTimeFormat}" />
                         </h:outputText>
+                        <f:facet name="footer">
+                            <h:outputText value="Total" styleClass="fw-bold"/>
+                        </f:facet>
                     </p:column>
 
                     <p:column headerText="Transaction Type" width="15rem">
@@ -166,6 +169,11 @@
                                       styleClass="#{sh.qty gt 0 ? 'text-success' : ''}">
                             <f:convertNumber pattern="#.#"/>
                         </h:outputText>
+                        <f:facet name="footer">
+                            <h:outputText value="#{pharmacyErrorChecking.binCardTotalIn}" styleClass="text-success fw-bold">
+                                <f:convertNumber pattern="#,##0.#"/>
+                            </h:outputText>
+                        </f:facet>
                     </p:column>
 
                     <p:column headerText="Quantity Out" class="text-end">
@@ -174,12 +182,24 @@
                                       styleClass="#{sh.qty lt 0 ? 'text-danger' : ''}">
                             <f:convertNumber pattern="#.#"/>
                         </h:outputText>
+                        <f:facet name="footer">
+                            <h:outputText value="#{pharmacyErrorChecking.binCardTotalOut}" styleClass="text-danger fw-bold">
+                                <f:convertNumber pattern="#,##0.#"/>
+                            </h:outputText>
+                        </f:facet>
                     </p:column>
 
                     <p:column headerText="Stock Before (Batch)" class="text-end">
                         <h:outputText value="#{sh.transThisIsStockIn ? sh.stockQty - sh.transAbsoluteQtyPlusFreeQty : sh.stockQty + sh.transAbsoluteQtyPlusFreeQty}">
                             <f:convertNumber pattern="#.#"/>
                         </h:outputText>
+                        <f:facet name="footer">
+                            <h:outputText value="Net: " styleClass="fw-bold"/>
+                            <h:outputText value="#{pharmacyErrorChecking.binCardNetTotal}"
+                                          styleClass="fw-bold #{pharmacyErrorChecking.binCardNetTotal ge 0 ? 'text-success' : 'text-danger'}">
+                                <f:convertNumber pattern="#,##0.#"/>
+                            </h:outputText>
+                        </f:facet>
                     </p:column>
 
                     <p:column headerText="Stock After (Batch)" class="text-end">

--- a/src/main/webapp/pharmacy/bin_card_dto.xhtml
+++ b/src/main/webapp/pharmacy/bin_card_dto.xhtml
@@ -114,6 +114,9 @@
                         <h:outputText value="#{sh.createdAt}">
                             <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateTimeFormat}" />
                         </h:outputText>
+                        <f:facet name="footer">
+                            <h:outputText value="Total" styleClass="fw-bold"/>
+                        </f:facet>
                     </p:column>
 
                     <!-- Transaction Type -->
@@ -138,21 +141,31 @@
 
                     <!-- Quantity In -->
                     <p:column headerText="Quantity In" class="text-end">
-                        <h:outputText value="#{sh.transAbsoluteQtyPlusFreeQty}" 
+                        <h:outputText value="#{sh.transAbsoluteQtyPlusFreeQty}"
                                       rendered="#{sh.transThisIsStockIn}"
                                       styleClass="#{sh.qty gt 0 ? 'text-success' : ''}">
                             <f:convertNumber pattern="#.#"/>
                         </h:outputText>
+                        <f:facet name="footer">
+                            <h:outputText value="#{pharmacyErrorChecking.binCardTotalIn}" styleClass="text-success fw-bold">
+                                <f:convertNumber pattern="#,##0.#"/>
+                            </h:outputText>
+                        </f:facet>
                     </p:column>
 
                     <!-- Quantity Out -->
                     <p:column headerText="Quantity Out" class="text-end">
-                        <h:outputText 
-                            value="#{sh.transAbsoluteQtyPlusFreeQty}" 
+                        <h:outputText
+                            value="#{sh.transAbsoluteQtyPlusFreeQty}"
                             rendered="#{sh.transThisIsStockOut}"
                             styleClass="#{sh.qty lt 0 ? 'text-danger' : ''}">
                             <f:convertNumber pattern="#.#"/>
                         </h:outputText>
+                        <f:facet name="footer">
+                            <h:outputText value="#{pharmacyErrorChecking.binCardTotalOut}" styleClass="text-danger fw-bold">
+                                <f:convertNumber pattern="#,##0.#"/>
+                            </h:outputText>
+                        </f:facet>
                     </p:column>
 
                     <!-- Stock Before Transaction (Item) -->
@@ -160,6 +173,13 @@
                         <h:outputText value="#{sh.transThisIsStockIn ? sh.itemStock - sh.transAbsoluteQtyPlusFreeQty : sh.itemStock + sh.transAbsoluteQtyPlusFreeQty}">
                             <f:convertNumber pattern="#.#"/>
                         </h:outputText>
+                        <f:facet name="footer">
+                            <h:outputText value="Net: " styleClass="fw-bold"/>
+                            <h:outputText value="#{pharmacyErrorChecking.binCardNetTotal}"
+                                          styleClass="fw-bold #{pharmacyErrorChecking.binCardNetTotal ge 0 ? 'text-success' : 'text-danger'}">
+                                <f:convertNumber pattern="#,##0.#"/>
+                            </h:outputText>
+                        </f:facet>
                     </p:column>
 
                     <!-- Stock After Transaction (Item) -->

--- a/src/main/webapp/pharmacy/bin_card_item.xhtml
+++ b/src/main/webapp/pharmacy/bin_card_item.xhtml
@@ -106,6 +106,9 @@
                         <h:outputText value="#{sh.createdAt}">
                             <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateTimeFormat}" />
                         </h:outputText>
+                        <f:facet name="footer">
+                            <h:outputText value="Total" styleClass="fw-bold"/>
+                        </f:facet>
                     </p:column>
 
                     <p:column headerText="Transaction Type" width="15rem">
@@ -128,6 +131,11 @@
                                       styleClass="#{sh.qty gt 0 ? 'text-success' : ''}">
                             <f:convertNumber pattern="#.#"/>
                         </h:outputText>
+                        <f:facet name="footer">
+                            <h:outputText value="#{pharmacyErrorChecking.binCardTotalIn}" styleClass="text-success fw-bold">
+                                <f:convertNumber pattern="#,##0.#"/>
+                            </h:outputText>
+                        </f:facet>
                     </p:column>
 
                     <p:column headerText="Quantity Out" class="text-end">
@@ -136,12 +144,24 @@
                                       styleClass="#{sh.qty lt 0 ? 'text-danger' : ''}">
                             <f:convertNumber pattern="#.#"/>
                         </h:outputText>
+                        <f:facet name="footer">
+                            <h:outputText value="#{pharmacyErrorChecking.binCardTotalOut}" styleClass="text-danger fw-bold">
+                                <f:convertNumber pattern="#,##0.#"/>
+                            </h:outputText>
+                        </f:facet>
                     </p:column>
 
                     <p:column headerText="Stock Before (Item)" class="text-end">
                         <h:outputText value="#{sh.transThisIsStockIn ? sh.itemStock - sh.transAbsoluteQtyPlusFreeQty : sh.itemStock + sh.transAbsoluteQtyPlusFreeQty}">
                             <f:convertNumber pattern="#.#"/>
                         </h:outputText>
+                        <f:facet name="footer">
+                            <h:outputText value="Net: " styleClass="fw-bold"/>
+                            <h:outputText value="#{pharmacyErrorChecking.binCardNetTotal}"
+                                          styleClass="fw-bold #{pharmacyErrorChecking.binCardNetTotal ge 0 ? 'text-success' : 'text-danger'}">
+                                <f:convertNumber pattern="#,##0.#"/>
+                            </h:outputText>
+                        </f:facet>
                     </p:column>
 
                     <p:column headerText="Stock After (Item)" class="text-end">


### PR DESCRIPTION
Closes #18893 : All three bin card views now have matching total footer rows. 

Here's a summary:                                             

  Files updated:                                                                
  - bin_card_item.xhtml - Item Bin Card
  - bin_card_batch.xhtml - Batch Bin Card                                       
                                                            
  Footer rows added to each (same pattern as bin_card_dto.xhtml):
  - Date & Time column: "Total" label
  - Quantity In column: Total in (green, bold)
  - Quantity Out column: Total out (red, bold)
  - Stock Before column: "Net: X" (green if positive, red if negative)

  No Java changes needed — both processItemBinCardWithDTO() and
  processBatchBinCardWithDTO() delegate to processBinCardWithDTO() which already
   calls calculateBinCardTotals().



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Bin card tables now display footer rows with aggregate totals for Quantity In (green), Quantity Out (red), and calculated Net Total with conditional color-coding based on value.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->