### PR TITLE
Hotfix: GRN bill departmentType not set from item at save time

### DIFF
--- a/src/main/java/com/divudi/bean/pharmacy/GrnCostingController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/GrnCostingController.java
@@ -11,6 +11,7 @@ import com.divudi.core.data.BillClassType;
 import com.divudi.core.data.BillNumberSuffix;
 import com.divudi.core.data.BillType;
 import com.divudi.core.data.BillTypeAtomic;
+import com.divudi.core.data.DepartmentType;
 import com.divudi.core.data.PaymentMethod;
 import com.divudi.core.data.dataStructure.SearchKeyword;
 import com.divudi.ejb.BillNumberGenerator;
@@ -2538,9 +2539,10 @@ public class GrnCostingController implements Serializable {
         getCurrentGrnBillPre().setPaymentMethod(getApproveBill().getPaymentMethod());
         getCurrentGrnBillPre().setCreditDuration(getApproveBill().getCreditDuration());
 
-        // Copy discount from the approved purchase order to GRN
+        // Copy discount and departmentType from the approved purchase order to GRN
         if (getApproveBill() != null) {
             getCurrentGrnBillPre().setDiscount(getApproveBill().getDiscount());
+            getCurrentGrnBillPre().setDepartmentType(getApproveBill().getDepartmentType());
         }
 
         // Ensure calculations are done after setup
@@ -2778,6 +2780,23 @@ public class GrnCostingController implements Serializable {
         if (getCurrentGrnBillPre().getPaymentMethod() == null) {
             JsfUtil.addErrorMessage("Please select a payment method");
             return;
+        }
+
+        // Validate department type consistency across all bill items
+        if (!getBillItems().isEmpty()) {
+            DepartmentType billDeptType = getCurrentGrnBillPre().getDepartmentType();
+            if (billDeptType == null && getBillItems().get(0).getItem() != null) {
+                billDeptType = getBillItems().get(0).getItem().getDepartmentType();
+                getCurrentGrnBillPre().setDepartmentType(billDeptType);
+            }
+            for (BillItem bi : getBillItems()) {
+                if (bi.getItem() != null && bi.getItem().getDepartmentType() != null) {
+                    if (!bi.getItem().getDepartmentType().equals(billDeptType)) {
+                        JsfUtil.addErrorMessage("Items belong to more than one department type. GRN cannot be finalized.");
+                        return;
+                    }
+                }
+            }
         }
 
         // Validate batch details and sale prices for finalization

--- a/src/main/webapp/pharmacy/pharmacy_grn_costing_with_save_approve.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_grn_costing_with_save_approve.xhtml
@@ -642,6 +642,11 @@
                                                 <f:convertNumber pattern="#,##0.00" />
                                             </p:outputLabel>
 
+                                            <p:outputLabel value="Department Type"/>
+                                            <p:outputLabel
+                                                value="#{grnCostingController.currentGrnBillPre.departmentType != null ? grnCostingController.currentGrnBillPre.departmentType.label : 'Not Set'}"
+                                                class="w-100 text-end ui-inputfield"/>
+
                                             <p:outputLabel value="Total Bill Value" />
                                             <p:outputLabel
                                                 id="totalBillValue"


### PR DESCRIPTION
## Summary
- Copies `departmentType` from the PO (`approveBill`) to the GRN bill during `navigateToResiveCostingWithSaveApprove()`
- Adds validation in `finalizeGrnWithSaveApprove()` to block finalization if items span multiple department types
- Displays the department type as a read-only label in the Bill Summary panel of `pharmacy_grn_costing_with_save_approve.xhtml`

## Test plan
- [ ] Create a PO with a specific department type and navigate to GRN — verify the GRN bill inherits the department type from the PO
- [ ] Verify the Department Type label appears in the Bill Summary panel on the GRN costing form
- [ ] Attempt to finalize a GRN where items have mixed department types — verify the error message is shown and finalization is blocked
- [ ] Finalize a normal GRN — verify it completes successfully with department type correctly set on the bill

Hotfix for: #18956

🤖 Generated with [Claude Code](https://claude.com/claude-code)