### PR TITLE
Prevent duplicate user department/route assignments

### DIFF
--- a/src/main/java/com/divudi/bean/common/UserDepartmentController.java
+++ b/src/main/java/com/divudi/bean/common/UserDepartmentController.java
@@ -154,6 +154,10 @@ public class UserDepartmentController implements Serializable {
             JsfUtil.addSuccessMessage("Select a Department");
             return;
         }
+        if (isDepartmentAlreadyAddedForUser(selectedUser, currentDepartment)) {
+            JsfUtil.addErrorMessage("Selected department is already added for this user");
+            return;
+        }
         WebUserDepartment d = new WebUserDepartment();
         d.setCreatedAt(Calendar.getInstance().getTime());
         ///other properties
@@ -165,6 +169,18 @@ public class UserDepartmentController implements Serializable {
 
     }
 
+    private boolean isDepartmentAlreadyAddedForUser(WebUser user, Department department) {
+        String jpql = "select ud from WebUserDepartment ud "
+                + "where ud.retired=:retired "
+                + "and ud.webUser=:user "
+                + "and ud.department=:department";
+        Map<String, Object> params = new HashMap<>();
+        params.put("retired", false);
+        params.put("user", user);
+        params.put("department", department);
+        return getEjbFacade().findFirstByJpql(jpql, params) != null;
+    }
+
 
     public void addRouteForUser() {
         if (selectedUser == null) {
@@ -173,6 +189,10 @@ public class UserDepartmentController implements Serializable {
         }
         if (currentDepartment == null) {
             JsfUtil.addSuccessMessage("Select a Route");
+            return;
+        }
+        if (isDepartmentAlreadyAddedForUser(selectedUser, currentDepartment)) {
+            JsfUtil.addErrorMessage("Selected route is already added for this user");
             return;
         }
         WebUserDepartment d = new WebUserDepartment();


### PR DESCRIPTION
### Motivation
- Fix a bug where the same department (or route) could be added multiple times for a user from the user department UI, causing duplicate active `WebUserDepartment` rows; prevent duplicate assignments at the backend.

### Description
- Added a pre-insert validation in `UserDepartmentController#addDepartmentForUser()` to block creating a duplicate active `WebUserDepartment` for the same user and department and display an error via `JsfUtil.addErrorMessage(...)`.
- Introduced `isDepartmentAlreadyAddedForUser(WebUser, Department)` that queries non-retired mappings using JPQL and `WebUserDepartmentFacade.findFirstByJpql(...)`.
- Applied the same duplicate check in `addRouteForUser()` so route assignment behavior is consistent.
- Modified file: `src/main/java/com/divudi/bean/common/UserDepartmentController.java`.

### Testing
- No automated tests were executed for this change (no Maven test run was performed per repository guidance).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a7ce5ff4a0832f8cc7d6a892a2aee6)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented duplicate department associations from being added for users
  * Added validation to block route additions if the associated department is already linked to the user

<!-- end of auto-generated comment: release notes by coderabbit.ai -->