### PR TITLE
Fix Department Vice Stock print pagination

### DIFF
--- a/src/main/java/com/divudi/bean/pharmacy/ReportsStock.java
+++ b/src/main/java/com/divudi/bean/pharmacy/ReportsStock.java
@@ -2452,6 +2452,8 @@ public class ReportsStock implements Serializable, ControllerWithReportFilters {
             rows = stocks.size();
         } else if (stockDtos != null && !stockDtos.isEmpty()) {
             rows = stockDtos.size();
+        } else if (departmentViceStockDtos != null && !departmentViceStockDtos.isEmpty()) {
+            rows = departmentViceStockDtos.size();
         } else {
             rows = 0;
         }

--- a/src/main/webapp/pharmacy/pharmacy_report_department_vice_stock.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_report_department_vice_stock.xhtml
@@ -51,8 +51,8 @@
 
                             <p:dataTable id="tbl" rowIndexVar="ii"
                                          value="#{reportsStock.departmentViceStockDtos}" var="i"
-                                         rows="20"
-                                         paginator="true"
+                                         rows="#{reportsStock.rows}"
+                                         paginator="#{reportsStock.paginator}"
                                          paginatorPosition="bottom"
                                          paginatorTemplate="{CurrentPageReport}  {FirstPageLink} {PreviousPageLink} {PageLinks}{NextPageLink} {LastPageLink} {RowsPerPageDropdown}"
                                          rowsPerPageTemplate="20, 50, 100">


### PR DESCRIPTION
### Motivation
- The Department Vice Stock report was printing only the first paginated page because the dataTable used hard-coded pagination and the print preparation method did not consider the `departmentViceStockDtos` dataset.
- Printing should temporarily disable pagination and expose the full dataset so the print output includes all department records.

### Description
- Updated `pharmacy_report_department_vice_stock.xhtml` to bind the dataTable `rows` and `paginator` attributes to the controller via `rows="#{reportsStock.rows}"` and `paginator="#{reportsStock.paginator}"` instead of hard-coded values. (`src/main/webapp/pharmacy/pharmacy_report_department_vice_stock.xhtml`)
- Extended `ReportsStock.prepareForPrint()` to include `departmentViceStockDtos` when determining the print row count by setting `rows = departmentViceStockDtos.size()` if present. (`src/main/java/com/divudi/bean/pharmacy/ReportsStock.java`)
- This change ensures pagination is disabled during print and the full Department Vice Stock result set is shown in print output.

### Testing
- Verified the source changes with `git diff` and inspected the updated files to confirm `rows`/`paginator` binding and the added `departmentViceStockDtos` branch in `prepareForPrint()` (succeeded). 
- Ran `git status` and file listings to ensure the branch and working tree reflected the change (succeeded).
- Attempted an automated Playwright navigation to capture a screenshot of the running app for visual verification, but the application endpoint was not reachable in this environment resulting in `net::ERR_EMPTY_RESPONSE` (not executed successfully). 

Closes #18322

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aba8f6c628832f9b788a3036f6382e)