### PR TITLE
18322 department vice stock report print outputs only first page due to pagination issue

### DIFF
--- a/src/main/java/com/divudi/bean/pharmacy/ReportsStock.java
+++ b/src/main/java/com/divudi/bean/pharmacy/ReportsStock.java
@@ -2452,6 +2452,8 @@ public class ReportsStock implements Serializable, ControllerWithReportFilters {
             rows = stocks.size();
         } else if (stockDtos != null && !stockDtos.isEmpty()) {
             rows = stockDtos.size();
+        } else if (departmentViceStockDtos != null && !departmentViceStockDtos.isEmpty()) {
+            rows = departmentViceStockDtos.size();
         } else {
             rows = 0;
         }

--- a/src/main/webapp/pharmacy/pharmacy_report_department_vice_stock.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_report_department_vice_stock.xhtml
@@ -51,8 +51,8 @@
 
                             <p:dataTable id="tbl" rowIndexVar="ii"
                                          value="#{reportsStock.departmentViceStockDtos}" var="i"
-                                         rows="20"
-                                         paginator="true"
+                                         rows="#{reportsStock.rows}"
+                                         paginator="#{reportsStock.paginator}"
                                          paginatorPosition="bottom"
                                          paginatorTemplate="{CurrentPageReport}  {FirstPageLink} {PreviousPageLink} {PageLinks}{NextPageLink} {LastPageLink} {RowsPerPageDropdown}"
                                          rowsPerPageTemplate="20, 50, 100">


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced stock report data handling during print preparation with improved null-checking.

* **Improvements**
  * Pagination controls for department pharmacy reports are now dynamically configured instead of using fixed values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->