### PR TITLE
Closes #19063

### DIFF
--- a/src/main/java/com/divudi/bean/common/QuickBookReportController.java
+++ b/src/main/java/com/divudi/bean/common/QuickBookReportController.java
@@ -387,8 +387,22 @@ public class QuickBookReportController implements Serializable {
         }
 
         List<Bill> bills = getBillFacade().findByJpql(billJpql, billParams, TemporalType.TIMESTAMP);
-        if (bills == null) {
+        if (bills == null || bills.isEmpty()) {
             return;
+        }
+
+        // Fetch all BillFees for these bills in one query and group by bill id
+        Map<String, Object> feeParams = new HashMap<>();
+        feeParams.put("bills", bills);
+        List<com.divudi.core.entity.BillFee> allBillFees = getBillFeeFacade().findByJpql(
+                "select bf from BillFee bf where bf.bill in :bills and bf.retired = false",
+                feeParams);
+        Map<Long, List<com.divudi.core.entity.BillFee>> billFeesMap = new HashMap<>();
+        if (allBillFees != null) {
+            for (com.divudi.core.entity.BillFee bf : allBillFees) {
+                Long billId = bf.getBill().getId();
+                billFeesMap.computeIfAbsent(billId, k -> new ArrayList<>()).add(bf);
+            }
         }
 
         for (Bill bill : bills) {
@@ -399,14 +413,7 @@ public class QuickBookReportController implements Serializable {
                 ccName += (cpn != null && !cpn.isEmpty()) ? cpn : bill.getCreditCompany().getName();
             }
 
-            // Fetch BillFees for this bill
-            String feeJpql = "select bf from BillFee bf"
-                    + " where bf.bill = :bill"
-                    + " and bf.retired = false";
-            Map<String, Object> feeParams = new HashMap<>();
-            feeParams.put("bill", bill);
-            List<com.divudi.core.entity.BillFee> billFees = getBillFeeFacade().findByJpql(feeJpql, feeParams);
-
+            List<com.divudi.core.entity.BillFee> billFees = billFeesMap.get(bill.getId());
             if (billFees == null || billFees.isEmpty()) {
                 continue;
             }


### PR DESCRIPTION
  Replaced the old createQBFormatOpdDayCredit() in QuickBookReportController.java with a new per-bill implementation:

  Flow:
  1. Fetches all OPD Credit bills (BilledBill, CancelledBill, RefundBill) in the date range, ordered by credit company then date
  2. For each bill, fetches its BillFee records and separates them into non-Staff fees and Staff fees
  3. Outputs:
    - TRNS row: date=bill.createdAt, accnt=Accounts Receivable:Debtors Control - OPD Credit, name=CREDIT COMPANY:<chequePrintingName|name>, amount=±netTotal, docNum=bill.deptId, memo=Sales
    - SPL rows (one per non-Staff BillFee): accnt=cat.description (or RHD LAB INCOME:RHD OPD Sale for Investigation items), invItem=dept:item.name, amount=±(-feeValue)
    - SPL row (Staff fees, once per bill if sum≠0): accnt=ACCRUED CHARGES:Consultant Advance:Consultant Payment, invItem=Consultant Payment:OPD CONSULTANT CHARGES, amount=±(-staffTotal)
    - ENDTRNS row

  Sign convention: BilledBill → positive TRNS / negative SPLs. CancelledBill/RefundBill → negative TRNS / positive SPLs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Optimized OPD credit bill report generation with batch retrieval and optional filters (date, institution, site, department). Ensures consistent date formatting and sign-aware amounts, splits staff vs. non-staff fee lines, adds null-safety and early-return when no bills are found, and guarantees complete transaction boundaries per bill for more reliable and faster reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->