### PR TITLE
Closes #19063

### DIFF
--- a/src/main/java/com/divudi/bean/cashTransaction/DrawerAdjustmentController.java
+++ b/src/main/java/com/divudi/bean/cashTransaction/DrawerAdjustmentController.java
@@ -192,6 +192,43 @@ public class DrawerAdjustmentController implements Serializable {
         reason = null;
     }
 
+    public Double getCurrentBalance() {
+        WebUser user = targetDrawerUser != null ? targetDrawerUser : sessionController.getLoggedUser();
+        if (user == null || paymentMethod == null) {
+            return null;
+        }
+        Drawer drawer = drawerService.findUsersDrawerWithoutCreate(user);
+        if (drawer == null) {
+            return null;
+        }
+        switch (paymentMethod) {
+            case Cash: return drawer.getCashInHandValue();
+            case Card: return drawer.getCardInHandValue();
+            case Cheque: return drawer.getChequeInHandValue();
+            case Slip: return drawer.getSlipInHandValue();
+            case ewallet: return drawer.getEwalletInHandValue();
+            case Credit: return drawer.getCreditInHandValue();
+            case Staff: return drawer.getStaffInHandValue();
+            case Staff_Welfare: return drawer.getStaffWelfareInHandValue();
+            case Voucher: return drawer.getVoucherInHandValue();
+            case IOU: return drawer.getIouInHandValue();
+            case Agent: return drawer.getAgentInHandValue();
+            case PatientDeposit: return drawer.getPatientDepositInHandValue();
+            case PatientPoints: return drawer.getPatientPointsInHandValue();
+            case OnlineSettlement: return drawer.getOnlineSettlementInHandValue();
+            case None: return drawer.getNoneInHandValue();
+            default: return null;
+        }
+    }
+
+    public Double getBalanceAfterAdjustment() {
+        Double current = getCurrentBalance();
+        if (current == null || adjustmentDelta == null) {
+            return null;
+        }
+        return current + adjustmentDelta;
+    }
+
     // <editor-fold defaultstate="collapsed" desc="Getters & Setters">
     public WebUser getTargetDrawerUser() {
         return targetDrawerUser;

--- a/src/main/java/com/divudi/bean/common/DataAdministrationController.java
+++ b/src/main/java/com/divudi/bean/common/DataAdministrationController.java
@@ -2284,9 +2284,10 @@ public class DataAdministrationController implements Serializable {
     }
 
     public String fetchWikiDdlVersion() {
+        java.net.HttpURLConnection conn = null;
         try {
             java.net.URL url = new java.net.URL(WIKI_DDL_URL);
-            java.net.HttpURLConnection conn = (java.net.HttpURLConnection) url.openConnection();
+            conn = (java.net.HttpURLConnection) url.openConnection();
             conn.setRequestMethod("GET");
             conn.setConnectTimeout(5000);
             conn.setReadTimeout(10000);
@@ -2307,6 +2308,10 @@ public class DataAdministrationController implements Serializable {
             }
         } catch (Exception e) {
             // Network or parse failure — return null so caller falls back to legacy
+        } finally {
+            if (conn != null) {
+                conn.disconnect();
+            }
         }
         return null;
     }
@@ -2350,6 +2355,22 @@ public class DataAdministrationController implements Serializable {
         configOptionApplicationController.saveShortTextOption(CONFIG_KEY_DDL_VERSION, wikiDdlVersion);
         databaseMigrationService.markMigrationComplete();
         JsfUtil.addSuccessMessage("Schema version " + wikiDdlVersion + " saved. Migration banner cleared.");
+    }
+
+    private void markSchemaAsCurrentSilently(boolean executionPerformed) {
+        if (!executionPerformed) {
+            return;
+        }
+        try {
+            String version = fetchWikiDdlVersion();
+            if (version != null) {
+                configOptionApplicationController.saveShortTextOption(CONFIG_KEY_DDL_VERSION, version);
+                databaseMigrationService.markMigrationComplete();
+                wikiDdlVersion = version;
+            }
+        } catch (Exception e) {
+            // Schema operations succeeded; version tracking is secondary — swallow silently
+        }
     }
 
     public String getStoredDdlVersion() {
@@ -2606,13 +2627,16 @@ public class DataAdministrationController implements Serializable {
         auditDatabaseExecutionFeedback = "";
 
         // Run on both databases if enabled
+        boolean executionPerformed = false;
         if (runOnMainDatabase) {
             createTablesOnDatabase(itemFacade, "Main Database");
+            executionPerformed = true;
         }
         if (runOnAuditDatabase) {
             createTablesOnDatabase(auditDatabaseFacade, "Audit Database");
+            executionPerformed = true;
         }
-        markSchemaAsCurrent();
+        markSchemaAsCurrentSilently(executionPerformed);
     }
 
     private void createTablesOnDatabase(AbstractFacade<?> facade, String databaseName) {
@@ -2709,13 +2733,16 @@ public class DataAdministrationController implements Serializable {
         auditDatabaseExecutionFeedback = "";
 
         // Run on both databases if enabled
+        boolean executionPerformed = false;
         if (runOnMainDatabase) {
             runSqlOnDatabase(itemFacade, suggestedSql, "Main Database");
+            executionPerformed = true;
         }
         if (runOnAuditDatabase) {
             runSqlOnDatabase(auditDatabaseFacade, suggestedSql, "Audit Database");
+            executionPerformed = true;
         }
-        markSchemaAsCurrent();
+        markSchemaAsCurrentSilently(executionPerformed);
     }
 
     private void runSqlOnDatabase(AbstractFacade<?> facade, String sql, String databaseName) {

--- a/src/main/java/com/divudi/bean/common/SearchController.java
+++ b/src/main/java/com/divudi/bean/common/SearchController.java
@@ -3842,6 +3842,11 @@ public class SearchController implements Serializable {
             jpql.append(" and b.deptId like :billNo");
             m.put("billNo", "%" + getSearchKeyword().getBillNo().trim().toUpperCase() + "%");
         }
+        
+        if (getSearchKeyword().getRequestNo()!= null && !getSearchKeyword().getRequestNo().trim().equals("")) {
+            jpql.append(" and b.invoiceNumber like :requestNo");
+            m.put("requestNo", "%" + getSearchKeyword().getRequestNo().trim().toUpperCase() + "%");
+        }
 
         if (getSearchKeyword().getDepartment() != null && !getSearchKeyword().getDepartment().trim().equals("")) {
             jpql.append(" and b.department.name like :fromDep");

--- a/src/main/java/com/divudi/service/DatabaseMigrationService.java
+++ b/src/main/java/com/divudi/service/DatabaseMigrationService.java
@@ -76,9 +76,10 @@ public class DatabaseMigrationService {
     }
 
     private String fetchWikiDdlVersion() {
+        HttpURLConnection conn = null;
         try {
             URL url = new URL(WIKI_DDL_URL);
-            HttpURLConnection conn = (HttpURLConnection) url.openConnection();
+            conn = (HttpURLConnection) url.openConnection();
             conn.setRequestMethod("GET");
             conn.setConnectTimeout(5000);
             conn.setReadTimeout(10000);
@@ -97,6 +98,10 @@ public class DatabaseMigrationService {
             }
         } catch (Exception e) {
             LOGGER.log(Level.WARNING, "DatabaseMigrationService: Could not fetch wiki DDL version.", e);
+        } finally {
+            if (conn != null) {
+                conn.disconnect();
+            }
         }
         return null;
     }

--- a/src/main/java/com/divudi/service/DrawerService.java
+++ b/src/main/java/com/divudi/service/DrawerService.java
@@ -573,6 +573,18 @@ public class DrawerService {
         return drawer;
     }
 
+    public Drawer findUsersDrawerWithoutCreate(WebUser webUser) {
+        if (webUser == null) {
+            return null;
+        }
+        HashMap m = new HashMap();
+        String jpql = "select d from Drawer d "
+                + " where d.retired=false "
+                + " and d.drawerUser=:user";
+        m.put("user", webUser);
+        return drawerFacade.findFirstByJpql(jpql, m);
+    }
+
     /**
      * Applies a drawer adjustment by creating a DrawerEntry and updating the
      * appropriate balance fields on the drawer for the given payment method.

--- a/src/main/webapp/cashier/drawer_adjustment_request.xhtml
+++ b/src/main/webapp/cashier/drawer_adjustment_request.xhtml
@@ -44,6 +44,7 @@
                                             required="true"
                                             requiredMessage="Please select a payment method."
                                             class="w-100">
+                                            <p:ajax update="currentBalance balanceAfter" />
                                             <f:selectItem itemLabel="-- Select Payment Method --" itemValue="#{null}" noSelectionOption="true"/>
                                             <f:selectItem itemLabel="Cash" itemValue="Cash"/>
                                             <f:selectItem itemLabel="Card" itemValue="Card"/>
@@ -62,6 +63,13 @@
                                             <f:selectItem itemLabel="None" itemValue="None"/>
                                         </p:selectOneMenu>
 
+                                        <h:outputLabel value="Current Balance" />
+                                        <p:outputPanel id="currentBalance">
+                                            <h:outputText value="#{drawerAdjustmentController.currentBalance}">
+                                                <f:convertNumber minFractionDigits="2" maxFractionDigits="2"/>
+                                            </h:outputText>
+                                        </p:outputPanel>
+
                                         <h:outputLabel for="adjustmentDelta" value="Adjustment Amount *" />
                                         <p:inputText
                                             id="adjustmentDelta"
@@ -70,8 +78,16 @@
                                             requiredMessage="Please enter an adjustment amount."
                                             placeholder="Positive to add, negative to deduct"
                                             class="w-100">
+                                            <p:ajax update="balanceAfter" />
                                             <f:convertNumber/>
                                         </p:inputText>
+
+                                        <h:outputLabel value="Balance After Adjustment" />
+                                        <p:outputPanel id="balanceAfter">
+                                            <h:outputText value="#{drawerAdjustmentController.balanceAfterAdjustment}">
+                                                <f:convertNumber minFractionDigits="2" maxFractionDigits="2"/>
+                                            </h:outputText>
+                                        </p:outputPanel>
 
                                         <h:outputLabel for="reason" value="Reason *" />
                                         <p:inputTextarea

--- a/src/main/webapp/pharmacy/pharmacy_search_issue_bill.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_search_issue_bill.xhtml
@@ -56,6 +56,16 @@
                                         value="#{searchController.searchKeyword.billNo}"
                                         title="Enter bill number to search"/>
                                 </div>
+                                
+                                <div class="mb-3">
+                                    <p:outputLabel for="requestNo" value="Request No"/>
+                                    <p:inputText
+                                        id="requestNo"
+                                        autocomplete="off"
+                                        styleClass="w-100"
+                                        value="#{searchController.searchKeyword.requestNo}"
+                                        title="Enter request number to search"/>
+                                </div>
 
                                 <div class="mb-3">
                                     <p:outputLabel for="patientName" value="Patient Name"/>


### PR DESCRIPTION
  Replaced the old createQBFormatOpdDayCredit() in QuickBookReportController.java with a new per-bill implementation:

  Flow:
  1. Fetches all OPD Credit bills (BilledBill, CancelledBill, RefundBill) in the date range, ordered by credit company then date
  2. For each bill, fetches its BillFee records and separates them into non-Staff fees and Staff fees
  3. Outputs:
    - TRNS row: date=bill.createdAt, accnt=Accounts Receivable:Debtors Control - OPD Credit, name=CREDIT COMPANY:<chequePrintingName|name>, amount=±netTotal, docNum=bill.deptId, memo=Sales
    - SPL rows (one per non-Staff BillFee): accnt=cat.description (or RHD LAB INCOME:RHD OPD Sale for Investigation items), invItem=dept:item.name, amount=±(-feeValue)
    - SPL row (Staff fees, once per bill if sum≠0): accnt=ACCRUED CHARGES:Consultant Advance:Consultant Payment, invItem=Consultant Payment:OPD CONSULTANT CHARGES, amount=±(-staffTotal)
    - ENDTRNS row

  Sign convention: BilledBill → positive TRNS / negative SPLs. CancelledBill/RefundBill → negative TRNS / positive SPLs.