### PR TITLE
  Fix partially visible columns in GRN and Direct Purchase Return approval tables

### DIFF
--- a/src/main/webapp/pharmacy/pharmacy_direct_purchase_return_list_to_approve.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_direct_purchase_return_list_to_approve.xhtml
@@ -155,10 +155,10 @@
                         </p:panel>
                     </div>
                     <div class="col-lg-9 col-md-8">
-                        <p:panel header="Direct Purchase Return Requests for Approval" styleClass="shadow-sm">
-                            <p:dataTable 
-                                id="tbl" 
-                                value="#{directPurchaseReturnWorkflowController.directPurchaseReturnsToApprove}" 
+                        <p:panel header="Direct Purchase Return Requests for Approval" styleClass="shadow-sm" contentStyle="overflow-x: auto; overflow-y: visible;">
+                            <p:dataTable
+                                id="tbl"
+                                value="#{directPurchaseReturnWorkflowController.directPurchaseReturnsToApprove}"
                                 var="b"
                                 rows="#{userSettingsController.pharmacyDirectPurchaseReturnListToApprovePageSize}"
                                 paginator="true"
@@ -169,9 +169,8 @@
                                 emptyMessage="No Direct Purchase return requests found matching your criteria"
                                 filteredValue="#{directPurchaseReturnWorkflowController.filteredDirectPurchaseReturnsToApprove}"
                                 sortMode="multiple"
-                                resizableColumns="true"
-                                reflow="true">
-                                <p:column headerText="Requested At" rendered="#{userSettingsController.pharmacyDirectPurchaseReturnListToApproveRequestedAtVisible}">
+                                tableStyle="width: max-content;">
+                                <p:column headerText="Requested At" rendered="#{userSettingsController.pharmacyDirectPurchaseReturnListToApproveRequestedAtVisible}" style="min-width: 140px;" headerStyle="white-space: nowrap;">
                                 <h:commandLink action="pharmacy_reprint_direct_purchase_return_request">
                                     <h:outputLabel value="#{b.createdAt}">
                                         <f:convertDateTime timeZone="Asia/Colombo" pattern="#{sessionController.applicationPreference.longDateTimeFormat}" />
@@ -188,7 +187,7 @@
                                 </h:panelGroup>                       
                             </p:column> 
 
-                                <p:column headerText="Requested By" rendered="#{userSettingsController.pharmacyDirectPurchaseReturnListToApproveRequestedByVisible}">
+                                <p:column headerText="Requested By" rendered="#{userSettingsController.pharmacyDirectPurchaseReturnListToApproveRequestedByVisible}" style="min-width: 130px;" headerStyle="white-space: nowrap;">
                                 <h:commandLink action="pharmacy_reprint_direct_purchase_return_request">
                                     <h:outputLabel value="#{b.creater.webUserPerson.name}">                                      
                                     </h:outputLabel>
@@ -203,29 +202,29 @@
                                 </h:panelGroup>
                             </p:column>    
 
-                                <p:column headerText="Supplier" rendered="#{userSettingsController.pharmacyDirectPurchaseReturnListToApproveSupplierVisible}">
+                                <p:column headerText="Supplier" rendered="#{userSettingsController.pharmacyDirectPurchaseReturnListToApproveSupplierVisible}" style="min-width: 130px;" headerStyle="white-space: nowrap;">
                                 <h:commandLink action="pharmacy_reprint_direct_purchase_return_request">
                                     #{b.toInstitution.name}
                                     <f:setPropertyActionListener target="#{pharmacyBillSearch.bill}" value="#{b}"/>
                                 </h:commandLink>
                             </p:column>
 
-                                <p:column headerText="Return No" rendered="#{userSettingsController.pharmacyDirectPurchaseReturnListToApproveReturnNoVisible}">
+                                <p:column headerText="Return No" rendered="#{userSettingsController.pharmacyDirectPurchaseReturnListToApproveReturnNoVisible}" style="min-width: 110px;" headerStyle="white-space: nowrap;">
                                 <h:outputText value="#{b.deptId}"></h:outputText>
                             </p:column>
 
-                                <p:column headerText="Original Purchase" rendered="#{userSettingsController.pharmacyDirectPurchaseReturnListToApproveOriginalPurchaseVisible}">
+                                <p:column headerText="Original Purchase" rendered="#{userSettingsController.pharmacyDirectPurchaseReturnListToApproveOriginalPurchaseVisible}" style="min-width: 130px;" headerStyle="white-space: nowrap;">
                                 <h:outputText value="#{b.referenceBill.deptId}"></h:outputText>
                             </p:column>
 
-                                <p:column headerText="Requested Department" rendered="#{userSettingsController.pharmacyDirectPurchaseReturnListToApproveRequestedDepartmentVisible}">
+                                <p:column headerText="Requested Department" rendered="#{userSettingsController.pharmacyDirectPurchaseReturnListToApproveRequestedDepartmentVisible}" style="min-width: 160px;" headerStyle="white-space: nowrap;">
                                 <h:commandLink action="pharmacy_reprint_direct_purchase_return_request">
                                     #{b.department.name}
                                     <f:setPropertyActionListener target="#{pharmacyBillSearch.bill}" value="#{b}"/>
                                 </h:commandLink>
                             </p:column> 
 
-                                <p:column headerText="Requested Value" sortBy="#{b.netTotal}" styleClass="text-end" rendered="#{userSettingsController.pharmacyDirectPurchaseReturnListToApproveRequestedValueVisible}">
+                                <p:column headerText="Requested Value" sortBy="#{b.netTotal}" styleClass="text-end" rendered="#{userSettingsController.pharmacyDirectPurchaseReturnListToApproveRequestedValueVisible}" style="min-width: 140px;" headerStyle="white-space: nowrap;">
                                 <div class="d-flex align-items-center justify-content-end">
                                     <i class="fas fa-coins text-success me-2"></i>
                                     <span class="fw-bold text-success fs-6">
@@ -236,7 +235,7 @@
                                 </div>
                             </p:column>
 
-                                <p:column headerText="Approved Person" rendered="#{userSettingsController.pharmacyDirectPurchaseReturnListToApproveApprovedPersonVisible}">
+                                <p:column headerText="Approved Person" rendered="#{userSettingsController.pharmacyDirectPurchaseReturnListToApproveApprovedPersonVisible}" style="min-width: 140px;" headerStyle="white-space: nowrap;">
                                 <h:commandLink 
                                     action="pharmacy_reprint_direct_purchase_return_request" 
                                     value="#{b.completedBy.webUserPerson.nameWithTitle}"
@@ -245,7 +244,7 @@
                                 </h:commandLink>
                             </p:column> 
 
-                                <p:column headerText="Approved Value" sortBy="#{b.netTotal}" styleClass="text-end" rendered="#{userSettingsController.pharmacyDirectPurchaseReturnListToApproveApprovedValueVisible}">
+                                <p:column headerText="Approved Value" sortBy="#{b.netTotal}" styleClass="text-end" rendered="#{userSettingsController.pharmacyDirectPurchaseReturnListToApproveApprovedValueVisible}" style="min-width: 130px;" headerStyle="white-space: nowrap;">
                                 <div class="d-flex align-items-center justify-content-end" rendered="#{b.completed eq true}">
                                     <i class="fas fa-coins text-info me-2"></i>
                                     <span class="fw-bold text-info fs-6">
@@ -256,7 +255,7 @@
                                 </div>
                             </p:column>
 
-                                <p:column headerText="Status" width="8em" rendered="#{userSettingsController.pharmacyDirectPurchaseReturnListToApproveStatusVisible}">
+                                <p:column headerText="Status" rendered="#{userSettingsController.pharmacyDirectPurchaseReturnListToApproveStatusVisible}" style="min-width: 110px;" headerStyle="white-space: nowrap;">
                                 <h:panelGroup rendered="#{b.checkedBy ne null and (b.completed eq false or b.completed eq null)}">
                                     <span class="badge bg-warning text-dark">Pending Approval</span>
                                 </h:panelGroup>
@@ -268,7 +267,7 @@
                                 </h:panelGroup>
                             </p:column>
 
-                            <p:column headerText="Actions" styleClass="text-center" exportable="false" width="230">
+                            <p:column headerText="Actions" styleClass="text-center" exportable="false" style="min-width: 230px;" headerStyle="white-space: nowrap;">
                                 <div class="d-flex justify-content-center align-items-center gap-1">
                                     <p:commandButton
                                         id="approve"
@@ -312,7 +311,7 @@
                                 </div>
                             </p:column>
                         </p:dataTable>
-                            
+
                             <!-- Column Visibility Settings -->
                             <div class="mt-3 pt-2" style="border-top: 1px solid #e9ecef;">
                                 <p:panel id="panelColumnToggler" toggleable="true" collapsed="true" styleClass="ui-panel-sm">

--- a/src/main/webapp/pharmacy/pharmacy_grn_return_list_to_approve.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_grn_return_list_to_approve.xhtml
@@ -155,7 +155,7 @@
                         </p:panel>
                     </div>
                     <div class="col-lg-9 col-md-8">
-                        <p:panel styleClass="shadow-sm">
+                        <p:panel styleClass="shadow-sm" contentStyle="overflow-x: auto; overflow-y: visible;">
                             <f:facet name="header">
                                 <div class="d-flex justify-content-between align-items-center">
                                     <span>GRN Return Requests for Approval</span>
@@ -188,10 +188,8 @@
                                 emptyMessage="No GRN return requests found matching your criteria"
                                 filteredValue="#{grnReturnWorkflowController.filteredGrnReturnsToApprove}"
                                 sortMode="multiple"
-                                scrollable="true"
-                                scrollWidth="100%"
-                                tableStyle="min-width: 1500px;">
-                            <p:column id="colRequestedAt" headerText="Requested At" toggleable="true" style="min-width: 140px;">
+                                tableStyle="width: max-content;">
+                            <p:column id="colRequestedAt" headerText="Requested At" toggleable="true" style="min-width: 140px;" headerStyle="white-space: nowrap;">
                                 <h:commandLink action="pharmacy_reprint_grn_return_request">
                                     <h:outputLabel value="#{b.createdAt}">
                                         <f:convertDateTime timeZone="Asia/Colombo" pattern="#{sessionController.applicationPreference.longDateTimeFormat}" />
@@ -208,7 +206,7 @@
                                 </h:panelGroup>                       
                             </p:column> 
 
-                            <p:column id="colRequestedBy" headerText="Requested By" toggleable="true" style="min-width: 130px;">
+                            <p:column id="colRequestedBy" headerText="Requested By" toggleable="true" style="min-width: 130px;" headerStyle="white-space: nowrap;">
                                 <h:commandLink action="pharmacy_reprint_grn_return_request">
                                     <h:outputLabel value="#{b.creater.webUserPerson.name}">                                      
                                     </h:outputLabel>
@@ -223,29 +221,29 @@
                                 </h:panelGroup>
                             </p:column>    
 
-                            <p:column id="colSupplier" headerText="Supplier" toggleable="true" style="min-width: 130px;">
+                            <p:column id="colSupplier" headerText="Supplier" toggleable="true" style="min-width: 130px;" headerStyle="white-space: nowrap;">
                                 <h:commandLink action="pharmacy_reprint_grn_return_request">
                                     #{b.toInstitution.name}
                                     <f:setPropertyActionListener target="#{pharmacyBillSearch.bill}" value="#{b}"/>
                                 </h:commandLink>
                             </p:column>
 
-                            <p:column id="colReturnNo" headerText="Return No" toggleable="true" style="min-width: 110px;">
+                            <p:column id="colReturnNo" headerText="Return No" toggleable="true" style="min-width: 110px;" headerStyle="white-space: nowrap;">
                                 <h:outputText value="#{b.deptId}"></h:outputText>
                             </p:column>
 
-                            <p:column id="colOriginalGrn" headerText="Original GRN" toggleable="true" style="min-width: 120px;">
+                            <p:column id="colOriginalGrn" headerText="Original GRN" toggleable="true" style="min-width: 120px;" headerStyle="white-space: nowrap;">
                                 <h:outputText value="#{b.referenceBill.deptId}"></h:outputText>
                             </p:column>
 
-                            <p:column id="colRequestedDept" headerText="Requested Department" toggleable="true" style="min-width: 160px;">
+                            <p:column id="colRequestedDept" headerText="Requested Department" toggleable="true" style="min-width: 160px;" headerStyle="white-space: nowrap;">
                                 <h:commandLink action="pharmacy_reprint_grn_return_request">
                                     #{b.department.name}
                                     <f:setPropertyActionListener target="#{pharmacyBillSearch.bill}" value="#{b}"/>
                                 </h:commandLink>
                             </p:column> 
 
-                            <p:column id="colRequestedValue" headerText="Requested Value" sortBy="#{b.netTotal}" styleClass="text-end" toggleable="true" style="min-width: 140px;">
+                            <p:column id="colRequestedValue" headerText="Requested Value" sortBy="#{b.netTotal}" styleClass="text-end" toggleable="true" style="min-width: 140px;" headerStyle="white-space: nowrap;">
                                 <div class="d-flex align-items-center justify-content-end">
                                     <i class="fas fa-coins text-success me-2"></i>
                                     <span class="fw-bold text-success fs-6">
@@ -256,7 +254,7 @@
                                 </div>
                             </p:column>
 
-                            <p:column id="colApprovedPerson" headerText="Approved Person" toggleable="true" style="min-width: 140px;">
+                            <p:column id="colApprovedPerson" headerText="Approved Person" toggleable="true" style="min-width: 140px;" headerStyle="white-space: nowrap;">
                                 <h:commandLink 
                                     action="pharmacy_reprint_grn_return_request" 
                                     value="#{b.completedBy.webUserPerson.nameWithTitle}"
@@ -265,7 +263,7 @@
                                 </h:commandLink>
                             </p:column> 
 
-                            <p:column id="colApprovedValue" headerText="Approved Value" sortBy="#{b.netTotal}" styleClass="text-end" toggleable="true" style="min-width: 130px;">
+                            <p:column id="colApprovedValue" headerText="Approved Value" sortBy="#{b.netTotal}" styleClass="text-end" toggleable="true" style="min-width: 130px;" headerStyle="white-space: nowrap;">
                                 <div class="d-flex align-items-center justify-content-end" rendered="#{b.completed eq true}">
                                     <i class="fas fa-coins text-info me-2"></i>
                                     <span class="fw-bold text-info fs-6">
@@ -276,7 +274,7 @@
                                 </div>
                             </p:column>
 
-                            <p:column id="colStatus" headerText="Status" width="8em" toggleable="true">
+                            <p:column id="colStatus" headerText="Status" toggleable="true" style="min-width: 100px;" headerStyle="white-space: nowrap;">
                                 <h:panelGroup rendered="#{b.checkedBy ne null and (b.completed eq false or b.completed eq null)}">
                                     <span class="badge bg-warning text-dark">Pending Approval</span>
                                 </h:panelGroup>
@@ -288,7 +286,7 @@
                                 </h:panelGroup>
                             </p:column>
 
-                            <p:column headerText="Actions" styleClass="text-center" exportable="false" width="150">
+                            <p:column headerText="Actions" styleClass="text-center" exportable="false" style="min-width: 150px;" headerStyle="white-space: nowrap;">
                                 <div class="d-flex justify-content-center align-items-center gap-1">
                                     <p:commandButton
                                         id="approve"


### PR DESCRIPTION

**Approve Direct Purchase Return Requests**

<img width="1919" height="973" alt="image" src="https://github.com/user-attachments/assets/7418f6f0-f711-424d-9c93-519a6ed7451e" />


**Approve GRN Return Requests**

<img width="1919" height="965" alt="image" src="https://github.com/user-attachments/assets/896dc107-8e66-46a3-a154-a75a58e0b005" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved table layout and horizontal scrolling on pharmacy return approval pages (Direct Purchase Returns and GRN Returns) to ensure consistent column widths and prevent header text wrapping, enhancing overall visibility and usability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->