### PR TITLE
Hotfix: Password changes not reflected across application instances

### DIFF
--- a/src/main/java/com/divudi/bean/common/AuthenticateController.java
+++ b/src/main/java/com/divudi/bean/common/AuthenticateController.java
@@ -37,7 +37,7 @@ public class AuthenticateController {
     public boolean userAuthenticated(String inputUserName, String inputPassword) {
         String temSQL;
         temSQL = "SELECT u FROM WebUser u WHERE u.retired = false";
-        List<WebUser> allUsers = getFacede().findByJpql(temSQL);
+        List<WebUser> allUsers = getFacede().findByJpql(temSQL, true);
         for (WebUser u : allUsers) {
             if ((u.getName()).equalsIgnoreCase(inputUserName)) {
                 if (getSecurityController().matchPassword(inputPassword, u.getWebUserPassword())) {

--- a/src/main/java/com/divudi/bean/common/SessionController.java
+++ b/src/main/java/com/divudi/bean/common/SessionController.java
@@ -1153,12 +1153,12 @@ public class SessionController implements Serializable, HttpSessionListener {
             String hashed = getSecurityController().hashAndCheck(password);
             user.setWebUserPassword(hashed);
             user.setNeedToResetPassword(false);
-            uFacade.edit(user);
+            uFacade.editAndCommit(user);
             recordPasswordHistory(user, hashed);
-            
+
             // Purge old password history entries beyond the configured limit
             purgeOldPasswordHistory(user);
-            
+
             passwordRequirementsFulfilled = true;
             JsfUtil.addSuccessMessage("Password changed");
         } else {
@@ -1188,7 +1188,7 @@ public class SessionController implements Serializable, HttpSessionListener {
 
         String hashed = getSecurityController().hashAndCheck(newPassword);
         user.setWebUserPassword(hashed);
-        uFacade.edit(user);
+        uFacade.editAndCommit(user);
         recordPasswordHistory(user, hashed);
         
         // Purge old password history entries beyond the configured limit
@@ -1280,7 +1280,7 @@ public class SessionController implements Serializable, HttpSessionListener {
     private boolean checkUsers() {
         String temSQL;
         temSQL = "SELECT u FROM WebUser u WHERE u.retired = false";
-        List<WebUser> allUsers = getFacede().findByJpql(temSQL);
+        List<WebUser> allUsers = getFacede().findByJpql(temSQL, true);
         for (WebUser u : allUsers) {
             if ((u.getName()).equalsIgnoreCase(userName)) {
                 if (SecurityController.matchPassword(password, u.getWebUserPassword())) {

--- a/src/main/java/com/divudi/bean/common/WebUserController.java
+++ b/src/main/java/com/divudi/bean/common/WebUserController.java
@@ -1312,7 +1312,7 @@ public class WebUserController implements Serializable {
         String hashedPassword;
         hashedPassword = getSecurityController().hashAndCheck(newPassword);
         current.setWebUserPassword(hashedPassword);
-        getFacade().edit(current);
+        getFacade().editAndCommit(current);
         WebUserPasswordHistory wh = new WebUserPasswordHistory();
         wh.setWebUser(current);
         wh.setPassword(hashedPassword);


### PR DESCRIPTION
## Summary
- Use `editAndCommit()` instead of `edit()` for password writes to flush to DB immediately and evict L2 cache
- Use `findByJpql(sql, true)` for login queries to bypass EclipseLink L2 shared cache and read fresh data from DB
- Fixes issue where password changes on one instance are not visible to other instances pointing to the same database

Closes #17224

🤖 Generated with [Claude Code](https://claude.com/claude-code)