### PR TITLE
Add auto-focus to qty field after item select in direct purchase

### DIFF
--- a/src/main/webapp/pharmacy/direct_purchase.xhtml
+++ b/src/main/webapp/pharmacy/direct_purchase.xhtml
@@ -103,16 +103,17 @@
                                                 event="itemSelect"
                                                 process="acItem"
                                                 listener="#{pharmacyDirectPurchaseController.onItemSelect}"
-                                                update="txtQty txtFreeQty txtPrate txtLineDiscountRate txtLineDiscountValue 
+                                                update="txtQty txtFreeQty txtPrate txtLineDiscountRate txtLineDiscountValue
                                                 txtRetailRate txtRetailValue txtUnitsPerPack txtPackOrUnit txtCostValue
-                                                txtPurchaseValueMinusLineDiscountValue txtPurchaseValue" />
+                                                txtPurchaseValueMinusLineDiscountValue txtPurchaseValue focusQty" />
 
                                         </p:autoComplete>
                                     </div>
                                     <div class="col-1">
-                                        <h:outputLabel 
+                                        <h:outputLabel
                                             value="Quantity"
                                             class="w-100 m-1"/><br/>
+                                        <p:focus id="focusQty" for="txtQty" />
                                         <p:inputText
                                             id="txtQty"
                                             class="w-100 m-1 text-end"


### PR DESCRIPTION
## Summary
- Added `p:focus` component for `txtQty` and included `focusQty` in the `itemSelect` ajax update list
- Follows the same pattern used in `pharmacy_bill_retail_sale_*.xhtml` and `pharmacy_fast_retail_sale_*.xhtml` pages
- After selecting an item from the autocomplete, focus automatically moves to the quantity field

## Test plan
- [ ] Open Direct Purchase page
- [ ] Select an item from the autocomplete dropdown
- [ ] Verify focus moves to the Quantity field automatically
- [ ] Verify quantity field content is ready for typing

Closes #18583

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced form usability in the pharmacy purchase interface. The Quantity field now automatically receives focus after selecting an item, improving order entry efficiency and streamlining the user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->