### PR TITLE
Add config button and configurable item history to PO request page

### DIFF
--- a/src/main/java/com/divudi/bean/pharmacy/PurchaseOrderRequestController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PurchaseOrderRequestController.java
@@ -309,6 +309,7 @@ public class PurchaseOrderRequestController implements Serializable {
         currentBill = billService.reloadBill(currentBill);
         calculateBillTotals();
         currentBillItem = null;
+        itemHistoryVisible = false;
     }
 
     @Inject

--- a/src/main/webapp/pharmacy/pharmacy_purhcase_order_request.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_purhcase_order_request.xhtml
@@ -195,7 +195,7 @@
                                             class="ui-button-danger" 
                                             icon="fas fa-trash"
                                             process="itemList"
-                                            update="itemList :#{p:resolveFirstComponentWithId('tot',view).clientId}"
+                                            update="itemList :#{p:resolveFirstComponentWithId('tot',view).clientId} :form:itemHistoryAboveWrapper :form:itemHistoryBelowWrapper"
                                             tabindex="-1"
                                             style="padding: 0;"
                                             action="#{purchaseOrderRequestController.removeItem(bi)}"/>

--- a/src/main/webapp/resources/pharmacy/history.xhtml
+++ b/src/main/webapp/resources/pharmacy/history.xhtml
@@ -49,6 +49,7 @@
                             icon="pi pi-times"
                             id="btnCloseHistory"
                             title="Close"
+                            aria-label="Close"
                             action="#{cc.attrs.closeActionListener}"
                             update="#{cc.attrs.updateOnClose}"
                             process="@this"


### PR DESCRIPTION
## Summary
- Added **Config button** (Admin-only) to the Purchase Order Request page for managing page configuration options and privileges via the admin interface
- Added **configurable item history position** — new config option `Pharmacy PO - Show Item History Above Items` allows hospitals to choose whether item history displays above or below the items dataTable
- **Item history is now hidden by default** and only shown when a user clicks the search/view details button on an item, with a close button in the history panel header
- Added optional `closeActionListener` and `updateOnClose` attributes to the `ph:history` composite component (fully backward compatible — existing usages unaffected)
- Registered **all 15 config options and 4 privileges** used by this page in `PageMetadataRegistry`
- Set persistence.xml to environment variables for deployment

## Test plan
- [ ] Verify the Config button appears for Admin users in the PO items table header
- [ ] Verify clicking Config navigates to the admin page configuration view
- [ ] Verify item history is hidden by default on page load
- [ ] Verify clicking the search icon on an item row shows the item history panel
- [ ] Verify the close (X) button in the history panel header hides the panel
- [ ] Verify toggling `Pharmacy PO - Show Item History Above Items` config moves the history panel above/below the dataTable
- [ ] Verify all other existing `ph:history` usages across pharmacy pages still work without changes

Closes #19121

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Admins can open page configuration for Pharmacy Purchase Order Request via a new Config button.
  * Item history can be shown above or below the items list, configurable and mutually exclusive.
  * Item history panels include a close button and now refresh when item details are viewed.
  * History component accepts close and update hooks so panels can notify and refresh surrounding UI.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->