### PR TITLE
Fixed - Mark as forigner in Pation Registration & Patient Profile

### DIFF
--- a/src/main/webapp/opd/patient.xhtml
+++ b/src/main/webapp/opd/patient.xhtml
@@ -178,6 +178,16 @@
                                         <div class="card-body">
                                             <div class="row">
                                                 <div class="col-md-6">
+                                                    <h:panelGroup rendered="#{configOptionApplicationController.getBooleanValueByKey('Save the Patient with Patient Status')}" layout="block" styleClass="mb-3">
+                                                        <strong class="text-muted">Residency Status:</strong><br/>
+                                                        <p:badge 
+                                                            value="#{patientController.current.person.foreigner?'Foreigner':'Local'}"
+                                                            severity="#{patientController.current.person.foreigner?'warning':'info'}"
+                                                            size="large"
+                                                            style="width: 8em;">
+                                                        </p:badge>
+                                                    </h:panelGroup>
+
                                                     <h:panelGroup rendered="#{not empty patientController.current.person.nic}" layout="block" styleClass="mb-3">
                                                         <strong class="text-muted">NIC / Passport:</strong><br/>
                                                         <h:outputText value="#{patientController.current.person.nic}" styleClass="fw-bold"/>
@@ -236,11 +246,6 @@
                                                                  severity="#{patientController.current.blacklisted eq true ? 'danger' : 'success'}"/>
                                                     </div>
 
-                                                    <h:panelGroup rendered="#{configOptionApplicationController.getBooleanValueByKey('Save the Patient with Patient Status')}" layout="block" styleClass="mb-3">
-                                                        <strong class="text-muted">Residency Status:</strong><br/>
-                                                        <p:badge value="#{patientController.current.person.foreigner?'Foreigner':'Local'}"
-                                                                 severity="#{patientController.current.person.foreigner?'warning':'info'}"/>
-                                                    </h:panelGroup>
                                                 </div>
                                             </div>
                                         </div>


### PR DESCRIPTION
closes #17316
Signed-off-by: damithdeshan98 <hkddrajapaksha@gmail.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Relocated Residency Status display from the Account & Status panel to the Personal Details section.
  * Enhanced Residency Status visualization with status badges (Foreigner/Local) and color-coded indicators.
  * Removed redundant residency status display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->