### PR TITLE
Fixed - Make Patient Field Validations Configurable in OPD Billing

### DIFF
--- a/src/main/java/com/divudi/bean/opd/OpdBillController.java
+++ b/src/main/java/com/divudi/bean/opd/OpdBillController.java
@@ -685,6 +685,69 @@ public class OpdBillController implements Serializable, ControllerWithPatient, C
                 OptionScope.APPLICATION
         ));
 
+        metadata.addConfigOption(new ConfigOptionInfo(
+                "OPD Billing - Need Patient Title To Save Patient.",
+                "Requires patient title to be selected before settling the OPD bill (default: true)",
+                "OpdBillController.java line 3125: Patient title validation in checkErrors()",
+                OptionScope.APPLICATION
+        ));
+
+        metadata.addConfigOption(new ConfigOptionInfo(
+                "OPD Billing - Need Patient Name To Save Patient.",
+                "Requires patient name to be entered before settling the OPD bill (default: true)",
+                "OpdBillController.java line 3132: Patient name validation in checkErrors()",
+                OptionScope.APPLICATION
+        ));
+
+        metadata.addConfigOption(new ConfigOptionInfo(
+                "OPD Billing - Need Patient Gender To Save Patient.",
+                "Requires patient gender to be selected before settling the OPD bill (default: true)",
+                "OpdBillController.java line 3139: Patient gender validation in checkErrors()",
+                OptionScope.APPLICATION
+        ));
+
+        metadata.addConfigOption(new ConfigOptionInfo(
+                "OPD Billing - Need Patient Age to Save Patient.",
+                "Requires patient date of birth to be entered before settling the OPD bill (default: true)",
+                "OpdBillController.java line 3146: Patient DOB validation in checkErrors()",
+                OptionScope.APPLICATION
+        ));
+
+        metadata.addConfigOption(new ConfigOptionInfo(
+                "OPD Billing - Need Patient Phone Number to save Patient.",
+                "Requires patient phone number to be entered before settling the OPD bill (default: true)",
+                "OpdBillController.java line 3153: Patient phone validation in checkErrors()",
+                OptionScope.APPLICATION
+        ));
+
+        metadata.addConfigOption(new ConfigOptionInfo(
+                "OPD Billing - Need Patient Mail to save Patient.",
+                "Requires a valid patient email address before settling the OPD bill (default: false)",
+                "OpdBillController.java line 3166: Patient email validation in checkErrors()",
+                OptionScope.APPLICATION
+        ));
+
+        metadata.addConfigOption(new ConfigOptionInfo(
+                "OPD Billing - Need Patient NIC to save Patient.",
+                "Requires patient NIC to be entered before settling the OPD bill (default: false)",
+                "OpdBillController.java line 3178: Patient NIC validation in checkErrors()",
+                OptionScope.APPLICATION
+        ));
+
+        metadata.addConfigOption(new ConfigOptionInfo(
+                "OPD Billing - Need Patient Address to save Patient.",
+                "Requires patient address to be entered before settling the OPD bill (default: false)",
+                "OpdBillController.java line 3185: Patient address validation in checkErrors()",
+                OptionScope.APPLICATION
+        ));
+
+        metadata.addConfigOption(new ConfigOptionInfo(
+                "OPD Billing - Need Patient Area to save Patient.",
+                "Requires patient area to be selected before settling the OPD bill, when area registration is required (default: false)",
+                "OpdBillController.java line 3192: Patient area validation in checkErrors()",
+                OptionScope.APPLICATION
+        ));
+
         // Advanced Configuration
         metadata.addConfigOption(new ConfigOptionInfo(
                 "Allow To Change Doctor Speciality And Doctor Added Bill Items in Opd Bill",


### PR DESCRIPTION
## Problem
  OPD billing has hardcoded validation checks for patient fields (name, gender, age,
  phone, area). This prevents flexibility across different hospital configurations where
  certain fields may or may not be required during billing.

  ## Proposed Solution
  Replace hardcoded patient field validations in `OpdBillController` with configurable
  checks via `configOptionApplicationController`, allowing each deployment to
  independently control which patient fields are mandatory before billing.

  ## Changes

  ### `OpdBillController.java`
  - Replaced hardcoded validations in `checkErrors()` with `configOptionApplicationController.getBooleanValueByKey()`
  calls
  - Introduced the following new configuration keys:

  | Config Key | Default | Description |
  |---|---|---|
  | `OPD Billing - Need Patient Title To Save Patient.` | `true` | Require title before billing |
  | `OPD Billing - Need Patient Name To Save Patient.` | `true` | Require Name before billing |
  | `OPD Billing - Need Patient Gender To Save Patient.` | `true` | Require gender before billing |
  | `OPD Billing - Need Patient Age to Save Patient.` | `true` | Require DOB before billing |
  | `OPD Billing - Need Patient Phone Number to save Patient.` | `true` | Require phone before billing |
  | `OPD Billing - Need Patient Mail to save Patient.` | `false` | Require email before billing |
  | `OPD Billing - Need Patient NIC to save Patient.` | `false` | Require NIC before billing |
  | `OPD Billing - Need Patient Address to save Patient.` | `false` | Require address before billing |
  | `OPD Billing - Need Patient Area to save Patient.` | `false` | Require area before billing |

  - Phone validation now checks for empty string in addition to `null`
  - Email validated using `CommonFunctions.isValidEmail()` when the email config is enabled

  ## Test Plan
  - [ ] OPD billing works with default config (title, gender, age, phone required)
  - [ ] Disabling a config key allows billing without that field
  - [ ] Email validation rejects malformed addresses when enabled
  - [ ] Phone validation rejects blank/empty strings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved and expanded patient-info validations (name, title, gender, age, phone, email, NIC, address) with clearer error handling and configurable enforcement.
  * Ensured payment method is validated earlier to prevent incomplete bill saves.

* **Refactor**
  * Reworked multi-payment calculations to consistently sum only selected payment amounts and automatically assign any remaining amount to the final payment entry.
  * Consolidated payment-total logic for more consistent billing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->