### PR TITLE
19187 need improvements for expiring stock report

### DIFF
--- a/src/main/java/com/divudi/bean/pharmacy/ReportsStock.java
+++ b/src/main/java/com/divudi/bean/pharmacy/ReportsStock.java
@@ -1498,6 +1498,82 @@ public class ReportsStock implements Serializable, ControllerWithReportFilters {
 
     private Date date;
 
+    public void fillDepartmentExpiaryStockDtos() {
+        reportTimerController.trackReportExecution(() -> {
+            Map<String, Object> m = new HashMap<>();
+            StringBuilder jpql = new StringBuilder("select new com.divudi.core.data.dto.StockDTO(");
+            jpql.append("s.id, ");
+            jpql.append("cat.name, ");
+            jpql.append("s.itemBatch.item.name, ");
+            jpql.append("s.itemBatch.item.departmentType, ");
+            jpql.append("s.itemBatch.item.code, ");
+            jpql.append("s.itemBatch.dateOfExpire, ");
+            jpql.append("s.itemBatch.batchNo, ");
+            jpql.append("s.stock, ");
+            jpql.append("s.itemBatch.purcahseRate, ");
+            jpql.append("s.itemBatch.costRate, ");
+            jpql.append("s.itemBatch.retailsaleRate, ");
+            jpql.append("df.name) ");
+            jpql.append("from Stock s ");
+            jpql.append("left join s.itemBatch.item.category cat ");
+            jpql.append("left join s.itemBatch.item.dosageForm df ");
+            jpql.append("where s.stock > 0");
+            jpql.append(" and s.itemBatch.dateOfExpire between :fd and :td");
+            m.put("fd", getFromDate());
+            m.put("td", getToDate());
+
+            if (department != null) {
+                jpql.append(" and s.department=:d");
+                m.put("d", department);
+            }
+            if (site != null) {
+                jpql.append(" and s.department.site=:site");
+                m.put("site", site);
+            }
+            if (institution != null) {
+                jpql.append(" and s.department.institution=:ins");
+                m.put("ins", institution);
+            }
+            if (selectedDepartmentTypes != null && !selectedDepartmentTypes.isEmpty()) {
+                jpql.append(" and s.itemBatch.item.departmentType IN :departmentTypes");
+                m.put("departmentTypes", selectedDepartmentTypes);
+            }
+            if (category != null) {
+                jpql.append(" and s.itemBatch.item.category=:cat");
+                m.put("cat", category);
+            }
+            if (dosageForm != null) {
+                jpql.append(" and s.itemBatch.item.dosageForm=:df");
+                m.put("df", dosageForm);
+            }
+            jpql.append(" order by s.itemBatch.dateOfExpire");
+
+            stockDtos = (List<StockDTO>) stockFacade.findLightsByJpql(jpql.toString(), m);
+
+            stockPurchaseValue = stockDtos.stream()
+                    .mapToDouble(s -> {
+                        Double pr = s.getPurchaseRate();
+                        Double qty = s.getStockQty();
+                        return (pr == null ? 0.0 : pr) * (qty == null ? 0.0 : qty);
+                    })
+                    .sum();
+            stockSaleValue = stockDtos.stream()
+                    .mapToDouble(s -> {
+                        Double rr = s.getRetailRate();
+                        Double qty = s.getStockQty();
+                        return (rr == null ? 0.0 : rr) * (qty == null ? 0.0 : qty);
+                    })
+                    .sum();
+            stockCostValue = stockDtos.stream()
+                    .mapToDouble(s -> {
+                        Double cr = s.getCostRate();
+                        Double qty = s.getStockQty();
+                        return (cr == null ? 0.0 : cr) * (qty == null ? 0.0 : qty);
+                    })
+                    .sum();
+        }, PharmacyReports.STOCK_REPORT_BY_EXPIRY, sessionController.getLoggedUser());
+    }
+
     public void fillDepartmentExpiaryStocks() {
         reportTimerController.trackReportExecution(() -> {
             if (department == null) {
@@ -2243,7 +2319,7 @@ public class ReportsStock implements Serializable, ControllerWithReportFilters {
         Calendar c = Calendar.getInstance();
         c.set(Calendar.MONTH, c.get(Calendar.MONTH) + 3);
         toDate = c.getTime();
-        fillDepartmentExpiaryStocks();;
+        fillDepartmentExpiaryStockDtos();
     }
 
     public void fillSixMonthsExpiary() {
@@ -2251,7 +2327,7 @@ public class ReportsStock implements Serializable, ControllerWithReportFilters {
         Calendar c = Calendar.getInstance();
         c.set(Calendar.MONTH, c.get(Calendar.MONTH) + 6);
         toDate = c.getTime();
-        fillDepartmentExpiaryStocks();;
+        fillDepartmentExpiaryStockDtos();
     }
 
     public void fillOneYearExpiary() {
@@ -2259,7 +2335,7 @@ public class ReportsStock implements Serializable, ControllerWithReportFilters {
         Calendar c = Calendar.getInstance();
         c.set(Calendar.YEAR, c.get(Calendar.YEAR) + 1);
         toDate = c.getTime();
-        fillDepartmentExpiaryStocks();;
+        fillDepartmentExpiaryStockDtos();
     }
 
     public void fillThreeMonthsExpiaryOfSupplier() {

--- a/src/main/resources/META-INF/persistence.xml
+++ b/src/main/resources/META-INF/persistence.xml
@@ -2,7 +2,7 @@
 <persistence version="2.2" xmlns="http://java.sun.com/xml/ns/persistence" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/persistence http://xmlns.jcp.org/xml/ns/persistence/persistence_2_2.xsd">
     <persistence-unit name="hmisPU" transaction-type="JTA">
         <provider>org.eclipse.persistence.jpa.PersistenceProvider</provider>
-        <jta-data-source>jdbc/coop</jta-data-source>
+        <jta-data-source>${JDBC_DATASOURCE}</jta-data-source>
         <exclude-unlisted-classes>false</exclude-unlisted-classes>
         <properties>
             <property name="eclipselink.logging.level.sql" value="SEVERE"/>
@@ -10,7 +10,7 @@
         </properties>
     </persistence-unit>
     <persistence-unit name="hmisAuditPU" transaction-type="JTA">
-        <jta-data-source>jdbc/ruhunuaudit</jta-data-source>
+        <jta-data-source>${JDBC_AUDIT_DATASOURCE}</jta-data-source>
         <exclude-unlisted-classes>false</exclude-unlisted-classes>
         <properties>
             <property name="eclipselink.logging.level.sql" value="SEVERE"/>

--- a/src/main/webapp/pharmacy/pharmacy_report_department_stock_by_batch_expiary.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_report_department_stock_by_batch_expiary.xhtml
@@ -5,255 +5,402 @@
       xmlns:p="http://primefaces.org/ui"
       xmlns:h="http://xmlns.jcp.org/jsf/html"
       xmlns:f="http://xmlns.jcp.org/jsf/core"
-      >
+      xmlns:common="http://xmlns.jcp.org/jsf/composite/ezcomp/common">
 
     <h:body>
 
         <ui:composition template="/pharmacy/pharmacy_analytics.xhtml">
 
             <ui:define name="subcontent">
-                <h:form>
+                <h:form id="frm">
 
+                    <p:panel header="Stock Report by Expiry">
 
-                    <p:panel header="Stock Report by Expiry" >
-                        <h:panelGrid columns="2" class="my-2" >
-                            <h:outputLabel value="Department" ></h:outputLabel>
-                            <p:autoComplete class="w-100 mx-4" inputStyleClass="w-100" completeMethod="#{departmentController.completeDept}" var="dept" itemLabel="#{dept.name}" itemValue="#{dept}" forceSelection="true" value="#{reportsStock.department}"  >
-                            </p:autoComplete>
-                            <h:outputLabel value="From" ></h:outputLabel>
-                            <p:calendar class="w-100 mx-4" inputStyleClass="w-100" value="#{reportsStock.fromDate}" pattern="#{sessionController.applicationPreference.longDateFormat}" ></p:calendar>
-                            <h:outputLabel value="To" ></h:outputLabel>
-                            <p:calendar class="w-100 mx-4" inputStyleClass="w-100" value="#{reportsStock.toDate}" pattern="#{sessionController.applicationPreference.longDateFormat}" ></p:calendar>
-                        </h:panelGrid>
-                        <h:panelGrid columns="6" class="my-2">
-                            <p:commandButton class="ui-button-outlined" ajax="false" value="List Three Months Expiry" actionListener="#{reportsStock.fillThreeMonthsExpiary()}" ></p:commandButton>
-                            <p:commandButton class="ui-button-outlined mx-2" ajax="false" value="List Six Months Expiry" actionListener="#{reportsStock.fillSixMonthsExpiary()}" ></p:commandButton>
-                            <p:commandButton class="ui-button-outlined " ajax="false" value="List One Year Expiry" actionListener="#{reportsStock.fillOneYearExpiary()}" ></p:commandButton>
+                        <common:institution_site_department_filter controller="#{reportsStock}"/>
 
-                            <p:commandButton class="ui-button-warning mx-2" icon="fas fa-cogs" ajax="false" value="Process" actionListener="#{reportsStock.fillDepartmentExpiaryStocks()}" ></p:commandButton>
-                            <p:commandButton class="ui-button-info " icon="fas fa-print" value="Print" ajax="false" >
-                                <p:printer target="gpBillPreview" ></p:printer>
-                            </p:commandButton>
-                            <p:commandButton class="ui-button-success mx-2" icon="fas fa-file-excel" value="Excel" ajax="false">
-                                <p:dataExporter type="xlsx" target="tbl" fileName="Total Stock" />
-                            </p:commandButton>
-                        </h:panelGrid>
+                        <h:panelGroup id="panelDeptType" layout="block" styleClass="container-fluid my-2">
+                            <h:panelGroup layout="block" styleClass="row">
+                                <!-- Category Filter -->
+                                <h:panelGroup layout="block" styleClass="col-lg-4 col-md-6 col-sm-12 mb-3">
+                                    <h:panelGroup layout="block" styleClass="form-group">
+                                        <h:panelGroup layout="block" styleClass="d-flex align-items-center mb-2">
+                                            <h:outputText styleClass="fa fa-tags mr-2" />
+                                            <h:outputLabel value="Category" for="categoryFilter" styleClass="mb-0"/>
+                                        </h:panelGroup>
+                                        <p:selectOneMenu
+                                            id="categoryFilter"
+                                            value="#{reportsStock.category}"
+                                            styleClass="w-100"
+                                            filter="true"
+                                            filterMatchMode="contains">
+                                            <f:selectItem itemLabel="All Categories"/>
+                                            <f:selectItems value="#{pharmaceuticalItemCategoryController.items}" var="cat" itemLabel="#{cat.name}" itemValue="#{cat}"/>
+                                        </p:selectOneMenu>
+                                    </h:panelGroup>
+                                </h:panelGroup>
+                                <!-- Dosage Form Filter -->
+                                <h:panelGroup layout="block" styleClass="col-lg-4 col-md-6 col-sm-12 mb-3">
+                                    <h:panelGroup layout="block" styleClass="form-group">
+                                        <h:panelGroup layout="block" styleClass="d-flex align-items-center mb-2">
+                                            <h:outputText styleClass="fa fa-capsules mr-2" />
+                                            <h:outputLabel value="Dosage Form" for="dosageFormFilter" styleClass="mb-0"/>
+                                        </h:panelGroup>
+                                        <p:selectOneMenu
+                                            id="dosageFormFilter"
+                                            value="#{reportsStock.dosageForm}"
+                                            styleClass="w-100"
+                                            filter="true"
+                                            filterMatchMode="contains">
+                                            <f:selectItem itemLabel="All Dosage Forms"/>
+                                            <f:selectItems value="#{dosageFormController.items}" var="df" itemLabel="#{df.name}" itemValue="#{df}"/>
+                                        </p:selectOneMenu>
+                                    </h:panelGroup>
+                                </h:panelGroup>
+                                <!-- Department Type Filter -->
+                                <h:panelGroup layout="block" styleClass="col-lg-4 col-md-6 col-sm-12 mb-3">
+                                    <h:panelGroup layout="block" styleClass="form-group">
+                                        <h:panelGroup layout="block" styleClass="d-flex align-items-center mb-2">
+                                            <h:outputText value="&#xf0e8;" styleClass="fa mr-2" />
+                                            <h:outputLabel value="Department Types" for="departmentTypeFilter" styleClass="mb-0"/>
+                                        </h:panelGroup>
+                                        <p:selectCheckboxMenu
+                                            id="departmentTypeFilter"
+                                            value="#{reportsStock.selectedDepartmentTypes}"
+                                            label="Select Department Types"
+                                            styleClass="w-100"
+                                            filter="true"
+                                            filterMatchMode="contains"
+                                            showHeader="true"
+                                            scrollHeight="200"
+                                            title="Select one or more department types to filter results. Leave empty to include all departments.">
+                                            <f:selectItems
+                                                value="#{reportsStock.availableDepartmentTypes}"
+                                                var="depType"
+                                                itemLabel="#{depType.label}"
+                                                itemValue="#{depType}"/>
+                                        </p:selectCheckboxMenu>
+                                    </h:panelGroup>
+                                </h:panelGroup>
+                            </h:panelGroup>
+                        </h:panelGroup>
 
-                        <h:panelGroup id="gpBillPreview"  styleClass="noBorder summeryBorder" style="min-width: 100%!important;">
-                            <p:dataTable id="tbl" value="#{reportsStock.stocks}" var="i"  
-                                         rows="20"
-                                         paginator="true"
-                                         paginatorTemplate="{CurrentPageReport}  {FirstPageLink} {PreviousPageLink} {PageLinks} {NextPageLink} {LastPageLink} {RowsPerPageDropdown}"
-                                         rowsPerPageTemplate="10, 20, 50" >
+                        <h:panelGroup layout="block" styleClass="container-fluid my-2">
+                            <h:panelGroup layout="block" styleClass="row">
+                                <!-- From Date -->
+                                <h:panelGroup layout="block" styleClass="col-lg-3 col-md-6 col-sm-12 mb-3">
+                                    <h:panelGroup layout="block" styleClass="form-group">
+                                        <h:panelGroup layout="block" styleClass="d-flex align-items-center mb-2">
+                                            <h:outputText styleClass="fa fa-calendar mr-2" />
+                                            <h:outputLabel value="From" for="fromDateFilter" styleClass="mb-0"/>
+                                        </h:panelGroup>
+                                        <p:calendar id="fromDateFilter" styleClass="w-100" inputStyleClass="w-100"
+                                                    value="#{reportsStock.fromDate}"
+                                                    pattern="#{sessionController.applicationPreference.longDateFormat}" />
+                                    </h:panelGroup>
+                                </h:panelGroup>
+                                <!-- To Date -->
+                                <h:panelGroup layout="block" styleClass="col-lg-3 col-md-6 col-sm-12 mb-3">
+                                    <h:panelGroup layout="block" styleClass="form-group">
+                                        <h:panelGroup layout="block" styleClass="d-flex align-items-center mb-2">
+                                            <h:outputText styleClass="fa fa-calendar mr-2" />
+                                            <h:outputLabel value="To" for="toDateFilter" styleClass="mb-0"/>
+                                        </h:panelGroup>
+                                        <p:calendar id="toDateFilter" styleClass="w-100" inputStyleClass="w-100"
+                                                    value="#{reportsStock.toDate}"
+                                                    pattern="#{sessionController.applicationPreference.longDateFormat}" />
+                                    </h:panelGroup>
+                                </h:panelGroup>
+                                <!-- Action Buttons -->
+                                <h:panelGroup layout="block" styleClass="col-lg-6 col-md-12 col-sm-12 mb-3">
+                                    <h:panelGroup layout="block" styleClass="d-flex align-items-center mb-2">
+                                        <h:outputLabel value="&#160;" styleClass="mb-0"/>
+                                    </h:panelGroup>
+                                    <p:commandButton class="ui-button-outlined mr-1" ajax="false"
+                                                     value="3 Months" icon="fas fa-calendar"
+                                                     actionListener="#{reportsStock.fillThreeMonthsExpiary()}" />
+                                    <p:commandButton class="ui-button-outlined mr-1" ajax="false"
+                                                     value="6 Months" icon="fas fa-calendar"
+                                                     actionListener="#{reportsStock.fillSixMonthsExpiary()}" />
+                                    <p:commandButton class="ui-button-outlined mr-1" ajax="false"
+                                                     value="1 Year" icon="fas fa-calendar"
+                                                     actionListener="#{reportsStock.fillOneYearExpiary()}" />
+                                    <p:commandButton class="ui-button-warning mr-1" icon="fas fa-cogs"
+                                                     ajax="false" value="Process"
+                                                     actionListener="#{reportsStock.fillDepartmentExpiaryStockDtos()}" />
+                                    <p:commandButton class="ui-button-info mr-1" icon="fas fa-print"
+                                                     value="Print" ajax="false">
+                                        <p:printer target="gpBillPreview" />
+                                    </p:commandButton>
+                                    <p:commandButton icon="fas fa-file-excel" class="ui-button-success"
+                                                     value="Excel" ajax="false">
+                                        <p:dataExporter type="xlsx" target="tbl" fileName="Expiry Stock" />
+                                    </p:commandButton>
+                                </h:panelGroup>
+                            </h:panelGroup>
+                        </h:panelGroup>
+
+                        <h:panelGroup id="gpBillPreview" styleClass="noBorder summeryBorder" style="min-width: 100%!important;">
+
+                            <p:dataTable id="tbl" rowIndexVar="ii"
+                                         value="#{reportsStock.stockDtos}" var="i"
+                                         rows="#{reportsStock.rows}"
+                                         paginator="#{reportsStock.paginator}"
+                                         paginatorPosition="bottom"
+                                         paginatorTemplate="{CurrentPageReport}  {FirstPageLink} {PreviousPageLink} {PageLinks}{NextPageLink} {LastPageLink} {RowsPerPageDropdown}"
+                                         rowsPerPageTemplate="20, 50, 100">
+
                                 <f:facet name="header">
-                                    <h:outputLabel value="#{reportsStock.department.name} Stock"/>                                     
+                                    <h:outputLabel value="Expiry Stock Report" />
                                 </f:facet>
 
-                                <p:column headerText="Item"
-                                          sortBy="#{i.itemBatch.item.name}"
-                                          filterBy="#{i.itemBatch.item.name}"
+                                <p:column headerText="Category" style="text-align: left;"
+                                          sortBy="#{i.categoryName}"
+                                          filterBy="#{i.categoryName}"
+                                          filterMatchMode="contains"
+                                          rendered="#{userSettingsController.pharmacyDepartmentStockByBatchCategoryVisible}">
+                                    <f:facet name="header">
+                                        <h:outputLabel value="Category" />
+                                    </f:facet>
+                                    <h:outputLabel value="#{i.categoryName}" />
+                                </p:column>
+
+                                <p:column headerText="Dosage Form" style="text-align: left;"
+                                          sortBy="#{i.dosageFormName}"
+                                          filterBy="#{i.dosageFormName}"
                                           filterMatchMode="contains">
                                     <f:facet name="header">
-                                        <h:outputLabel value="Item"/>                                     
+                                        <h:outputLabel value="Dosage Form" />
                                     </f:facet>
-                                    <h:outputLabel value="#{i.itemBatch.item.name}" style="width: 100px!important;" ></h:outputLabel>
+                                    <h:outputLabel value="#{i.dosageFormName}" />
                                 </p:column>
 
-                                <p:column headerText="Code"
-                                          sortBy="#{i.itemBatch.item.code}"
-                                          filterBy="#{i.itemBatch.item.code}"
+                                <p:column headerText="Item"
+                                          sortBy="#{i.itemName}"
+                                          filterBy="#{i.itemName}"
+                                          filterMatchMode="contains">
+                                    <f:facet name="header">
+                                        <h:outputLabel value="Item" />
+                                    </f:facet>
+                                    <h:outputLabel value="#{i.itemName}" />
+                                </p:column>
+
+                                <p:column headerText="Type"
+                                          sortBy="#{i.departmentType}"
+                                          filterBy="#{i.departmentType}"
                                           filterMatchMode="contains"
-                                          styleClass="averageNumericColumn"
-                                          >
+                                          rendered="#{userSettingsController.pharmacyDepartmentStockByBatchTypeVisible}">
                                     <f:facet name="header">
-                                        <h:outputLabel value="Code"/>
+                                        <h:outputLabel value="Type" />
                                     </f:facet>
-                                    <h:outputLabel value="#{i.itemBatch.item.code}" style="width: 100px!important;" ></h:outputLabel>
+                                    <h:outputLabel value="#{i.departmentType}" />
                                 </p:column>
 
-                                <p:column headerText="Quantity" 
-                                          style="text-align: right;"
-                                          sortBy="#{i.stock}" styleClass="averageNumericColumn">
+                                <p:column headerText="Code" styleClass="averageNumericColumn"
+                                          sortBy="#{i.code}"
+                                          filterBy="#{i.code}"
+                                          filterMatchMode="contains"
+                                          rendered="#{userSettingsController.pharmacyDepartmentStockByBatchCodeVisible}">
                                     <f:facet name="header">
-                                        <h:outputLabel value="Quantity"/>                                     
+                                        <h:outputLabel value="Code" />
                                     </f:facet>
-                                    <h:outputLabel value="#{i.stock}" styleClass="averateNumericText" >
-                                        <f:convertNumber pattern="#,###" ></f:convertNumber>
-                                    </h:outputLabel>                                 
+                                    <h:outputLabel value="#{i.code}" />
                                 </p:column>
 
-                                <p:column headerText="Expiry"
-                                          sortBy="#{i.itemBatch.dateOfExpire}"
-                                          styleClass="averageNumericColumn">
+                                <p:column headerText="Expiry" sortBy="#{i.dateOfExpire}">
                                     <f:facet name="header">
-                                        <h:outputLabel value="Expiry"/>                                     
+                                        <h:outputLabel value="Expiry" />
                                     </f:facet>
-                                    <h:outputLabel value="#{i.itemBatch.dateOfExpire}"  >
-                                        <f:convertDateTime  timeZone="Asia/Colombo" pattern="#{sessionController.applicationPreference.longDateFormat}" ></f:convertDateTime>
+                                    <h:outputLabel value="#{i.dateOfExpire}">
+                                        <f:convertDateTime timeZone="Asia/Colombo" pattern="#{sessionController.applicationPreference.longDateFormat}" />
                                     </h:outputLabel>
                                 </p:column>
-                                
-                                <p:column headerText="Supplier">
+
+                                <p:column headerText="Batch No"
+                                          sortBy="#{i.batchNo}"
+                                          filterBy="#{i.batchNo}"
+                                          filterMatchMode="contains"
+                                          rendered="#{userSettingsController.pharmacyDepartmentStockByBatchBatchNoVisible}">
                                     <f:facet name="header">
-                                        <h:outputLabel value="Supplier"/>
+                                        <h:outputLabel value="Batch No" />
                                     </f:facet>
-                                    <h:outputLabel value="#{i.itemBatch.lastPurchaseBillItem.bill.fromInstitution.name}" style="width: 100px!important;" ></h:outputLabel>
+                                    <h:outputLabel value="#{i.batchNo}" />
                                 </p:column>
 
-                                <p:column headerText="Purchase Rate" 
-                                          style="text-align: right;"
-                                          styleClass="averageNumericColumn"
-                                          sortBy="#{i.itemBatch.purcahseRate}">
+                                <p:column headerText="Stock" style="text-align: right;" styleClass="averageNumericColumn"
+                                          sortBy="#{i.stockQty}">
                                     <f:facet name="header">
-                                        <h:outputLabel value="Purchase Rate"/>                                     
+                                        <h:outputLabel value="Stock" />
                                     </f:facet>
-                                    <h:outputLabel value="#{i.itemBatch.purcahseRate}"  >
-                                        <f:convertNumber pattern="#,##0.00" ></f:convertNumber>
+                                    <f:facet name="footer">
+                                        <h:outputLabel value="Total" style="font-weight: bold;" />
+                                    </f:facet>
+                                    <h:outputLabel value="#{i.stockQty}">
+                                        <f:convertNumber pattern="#,##0.00" />
                                     </h:outputLabel>
-
-                                    <f:facet name="footer" >
-                                        <h:outputLabel value="Total"/>                                       
-                                    </f:facet>
                                 </p:column>
 
-                                <p:column headerText="Purchase Value" 
-                                          styleClass="averageNumericColumn"
-                                          style="text-align: right;"
-                                          sortBy="#{i.itemBatch.purcahseRate * i.stock}">
+                                <p:column headerText="Purchase Rate" style="text-align: right;" styleClass="averageNumericColumn"
+                                          sortBy="#{i.purchaseRate}"
+                                          rendered="#{userSettingsController.pharmacyDepartmentStockByBatchPurchaseRateVisible}">
                                     <f:facet name="header">
-                                        <h:outputLabel value="Purchase Value"/>                                     
+                                        <h:outputLabel value="Purchase Rate" />
                                     </f:facet>
-                                    <h:outputLabel value="#{i.itemBatch.purcahseRate * i.stock}"  >
-                                        <f:convertNumber pattern="#,##0.00" ></f:convertNumber>
+                                    <h:outputLabel value="#{i.purchaseRate}">
+                                        <f:convertNumber pattern="#,##0.00" />
                                     </h:outputLabel>
-                                    <f:facet name="footer" >
-                                        <h:outputLabel value="#{reportsStock.stockPurchaseValue}" >
-                                            <f:convertNumber parent="#,##0.00" ></f:convertNumber>
+                                </p:column>
+
+                                <p:column headerText="Purchase Value" style="text-align: right;" styleClass="averageNumericColumn"
+                                          sortBy="#{i.purchaseRate * i.stockQty}"
+                                          rendered="#{userSettingsController.pharmacyDepartmentStockByBatchPurchaseValueVisible}">
+                                    <f:facet name="header">
+                                        <h:outputLabel value="Purchase Value" />
+                                    </f:facet>
+                                    <f:facet name="footer">
+                                        <h:outputLabel value="#{reportsStock.stockPurchaseValue}" style="font-weight: bold;">
+                                            <f:convertNumber pattern="#,##0.00" />
                                         </h:outputLabel>
                                     </f:facet>
-                                </p:column>
-
-                                <p:column headerText="Retail Rate" 
-                                          style="text-align: right;"
-                                          styleClass="averageNumericColumn"
-                                          sortBy="#{i.itemBatch.retailsaleRate}">
-                                    <f:facet name="header">
-                                        <h:outputLabel value="Retail Rate"/>                                     
-                                    </f:facet>
-                                    <h:outputLabel value="#{i.itemBatch.retailsaleRate}"  >
-                                        <f:convertNumber pattern="#,##0.00" ></f:convertNumber>
+                                    <h:outputLabel value="#{i.purchaseRate * i.stockQty}">
+                                        <f:convertNumber pattern="#,##0.00" />
                                     </h:outputLabel>
                                 </p:column>
 
-                                <p:column headerText="Cost Rate"
-                                          style="text-align: right;"
-                                          styleClass="averageNumericColumn"
-                                          sortBy="#{i.itemBatch.costRate}">
+                                <p:column headerText="Cost Rate" style="text-align: right;" styleClass="averageNumericColumn"
+                                          sortBy="#{i.costRate}"
+                                          rendered="#{userSettingsController.pharmacyDepartmentStockByBatchCostRateVisible}">
                                     <f:facet name="header">
-                                        <h:outputLabel value="Cost Rate"/>
+                                        <h:outputLabel value="Cost Rate" />
                                     </f:facet>
-                                    <h:outputLabel value="#{i.itemBatch.costRate}"  >
-                                        <f:convertNumber pattern="#,##0.00" ></f:convertNumber>
+                                    <h:outputLabel value="#{i.costRate}">
+                                        <f:convertNumber pattern="#,##0.00" />
                                     </h:outputLabel>
                                 </p:column>
 
-                                <p:column headerText="Cost Value"
-                                          style="text-align: right;"
-                                          styleClass="averageNumericColumn"
-                                          sortBy="#{i.itemBatch.costRate * i.stock}">
+                                <p:column headerText="Cost Value" style="text-align: right;" styleClass="averageNumericColumn"
+                                          sortBy="#{i.costRate * i.stockQty}"
+                                          rendered="#{userSettingsController.pharmacyDepartmentStockByBatchCostValueVisible}">
                                     <f:facet name="header">
-                                        <h:outputLabel value="Cost Value"/>
+                                        <h:outputLabel value="Cost Value" />
                                     </f:facet>
-                                    <h:outputLabel value="#{i.itemBatch.costRate * i.stock}"  >
-                                        <f:convertNumber pattern="#,##0.00" ></f:convertNumber>
-                                    </h:outputLabel>
-                                    <f:facet name="footer" >
-                                        <h:outputLabel value="#{reportsStock.stockCostValue}" >
-                                            <f:convertNumber parent="#,##0.00" ></f:convertNumber>
+                                    <f:facet name="footer">
+                                        <h:outputLabel value="#{reportsStock.stockCostValue}" style="font-weight: bold;">
+                                            <f:convertNumber pattern="#,##0.00" />
                                         </h:outputLabel>
                                     </f:facet>
+                                    <h:outputLabel value="#{i.costRate * i.stockQty}">
+                                        <f:convertNumber pattern="#,##0.00" />
+                                    </h:outputLabel>
                                 </p:column>
 
-                                <p:column headerText="Retail Sale Value" 
-                                          style="text-align: right;"
-                                          styleClass="averageNumericColumn"
-                                          sortBy="#{i.itemBatch.retailsaleRate * i.stock}">
+                                <p:column headerText="Retail Rate" style="text-align: right;" styleClass="averageNumericColumn"
+                                          sortBy="#{i.retailRate}"
+                                          rendered="#{userSettingsController.pharmacyDepartmentStockByBatchRetailRateVisible}">
                                     <f:facet name="header">
-                                        <h:outputLabel value="Retail Sale Value"/>                                     
+                                        <h:outputLabel value="Retail Rate" />
                                     </f:facet>
-                                    <h:outputLabel value="#{i.itemBatch.retailsaleRate * i.stock}"  >
-                                        <f:convertNumber pattern="#,##0.00" ></f:convertNumber>
+                                    <h:outputLabel value="#{i.retailRate}">
+                                        <f:convertNumber pattern="#,##0.00" />
                                     </h:outputLabel>
-                                    <f:facet name="footer" >
-                                        <h:outputLabel value="#{reportsStock.stockSaleValue}" >
-                                            <f:convertNumber parent="#,##0.00" ></f:convertNumber>
+                                </p:column>
+
+                                <p:column headerText="Retail Value" style="text-align: right;" styleClass="averageNumericColumn"
+                                          sortBy="#{i.retailRate * i.stockQty}"
+                                          rendered="#{userSettingsController.pharmacyDepartmentStockByBatchRetailValueVisible}">
+                                    <f:facet name="header">
+                                        <h:outputLabel value="Retail Value" />
+                                    </f:facet>
+                                    <f:facet name="footer">
+                                        <h:outputLabel value="#{reportsStock.stockSaleValue}" style="font-weight: bold;">
+                                            <f:convertNumber pattern="#,##0.00" />
                                         </h:outputLabel>
                                     </f:facet>
-
+                                    <h:outputLabel value="#{i.retailRate * i.stockQty}">
+                                        <f:convertNumber pattern="#,##0.00" />
+                                    </h:outputLabel>
                                 </p:column>
-                                <p:column headerText="Comments" 
-                                          style="text-align: right;">
-                                    <f:facet name="header">
-                                        <h:outputLabel value="Comments"/>                                     
-                                    </f:facet>
-                                    <p:inputText value="#{i.code}" maxlength="254">
-                                        <f:ajax event="blur" execute="@this" listener="#{reportsStock.addComment(i)}"></f:ajax>
-                                    </p:inputText>
-                                </p:column>
-
-
-                                <p:columnGroup type="footer">
-                                    <p:row>
-                                        <p:column colspan="5" footerText="Total">
-                                            <f:facet name="footer">
-                                                <h:outputLabel value="Total" />
-                                            </f:facet>
-                                        </p:column>
-                                        <p:column style="text-align: right;" footerText="#{reportsStock.stockPurchaseValue}">
-                                            <f:facet name="footer" >
-                                                <h:outputLabel value="#{reportsStock.stockPurchaseValue}" >
-                                                    <f:convertNumber parent="#,##0.00" />
-                                                </h:outputLabel>
-                                            </f:facet>
-                                        </p:column>
-                                        <p:column></p:column>
-                                        <p:column style="text-align: right;" footerText="#{reportsStock.stockCostValue}">
-                                            <f:facet name="footer" >
-                                                <h:outputLabel value="#{reportsStock.stockCostValue}" >
-                                                    <f:convertNumber parent="#,##0.00" />
-                                                </h:outputLabel>
-                                            </f:facet>
-                                        </p:column>
-                                        <p:column style="text-align: right;" footerText="#{reportsStock.stockSaleValue}">
-                                            <f:facet name="footer" >
-                                                <h:outputLabel value="#{reportsStock.stockSaleValue}" >
-                                                    <f:convertNumber parent="#,##0.00" />
-                                                </h:outputLabel>
-                                            </f:facet>
-                                        </p:column>
-                                    </p:row>
-                                    <p:row>
-                                        <p:column colspan="11" >
-                                            <f:facet name="footer" >
-                                                <h:outputLabel value="Printed At " ></h:outputLabel>
-                                                <h:outputLabel value="#{sessionController.currentDate}" >
-                                                    <f:convertDateTime pattern="dd MMMM yyyy - hh:mm a" ></f:convertDateTime>
-                                                </h:outputLabel>
-                                            </f:facet>
-                                        </p:column>
-                                    </p:row>
-                                </p:columnGroup>
 
                             </p:dataTable>
-
-
                         </h:panelGroup>
+
+                        <!-- Column Visibility Controls -->
+                        <div class="mt-3 pt-2" style="border-top: 1px solid #e9ecef;">
+                            <p:panel toggleable="true" collapsed="true" styleClass="ui-panel-sm">
+                                <f:facet name="header">
+                                    <span style="font-size: 0.85rem; color: #6c757d;">
+                                        <i class="fas fa-eye me-1" style="font-size: 0.75rem;"></i>
+                                        Customize Columns
+                                    </span>
+                                </f:facet>
+                                <div class="d-flex flex-wrap gap-2" style="font-size: 0.8rem;">
+                                    <div class="d-flex align-items-center me-3 mb-2">
+                                        <h:selectBooleanCheckbox id="chkCategory" value="#{userSettingsController.pharmacyDepartmentStockByBatchCategoryVisible}">
+                                            <f:ajax render="tbl" />
+                                        </h:selectBooleanCheckbox>
+                                        <h:outputLabel for="chkCategory" value="Category" styleClass="ms-1" />
+                                    </div>
+                                    <div class="d-flex align-items-center me-3 mb-2">
+                                        <h:selectBooleanCheckbox id="chkType" value="#{userSettingsController.pharmacyDepartmentStockByBatchTypeVisible}">
+                                            <f:ajax render="tbl" />
+                                        </h:selectBooleanCheckbox>
+                                        <h:outputLabel for="chkType" value="Type" styleClass="ms-1" />
+                                    </div>
+                                    <div class="d-flex align-items-center me-3 mb-2">
+                                        <h:selectBooleanCheckbox id="chkCode" value="#{userSettingsController.pharmacyDepartmentStockByBatchCodeVisible}">
+                                            <f:ajax render="tbl" />
+                                        </h:selectBooleanCheckbox>
+                                        <h:outputLabel for="chkCode" value="Code" styleClass="ms-1" />
+                                    </div>
+                                    <div class="d-flex align-items-center me-3 mb-2">
+                                        <h:selectBooleanCheckbox id="chkBatchNo" value="#{userSettingsController.pharmacyDepartmentStockByBatchBatchNoVisible}">
+                                            <f:ajax render="tbl" />
+                                        </h:selectBooleanCheckbox>
+                                        <h:outputLabel for="chkBatchNo" value="Batch No" styleClass="ms-1" />
+                                    </div>
+                                    <div class="d-flex align-items-center me-3 mb-2">
+                                        <h:selectBooleanCheckbox id="chkPurchaseRate" value="#{userSettingsController.pharmacyDepartmentStockByBatchPurchaseRateVisible}">
+                                            <f:ajax render="tbl" />
+                                        </h:selectBooleanCheckbox>
+                                        <h:outputLabel for="chkPurchaseRate" value="Purchase Rate" styleClass="ms-1" />
+                                    </div>
+                                    <div class="d-flex align-items-center me-3 mb-2">
+                                        <h:selectBooleanCheckbox id="chkPurchaseValue" value="#{userSettingsController.pharmacyDepartmentStockByBatchPurchaseValueVisible}">
+                                            <f:ajax render="tbl" />
+                                        </h:selectBooleanCheckbox>
+                                        <h:outputLabel for="chkPurchaseValue" value="Purchase Value" styleClass="ms-1" />
+                                    </div>
+                                    <div class="d-flex align-items-center me-3 mb-2">
+                                        <h:selectBooleanCheckbox id="chkCostRate" value="#{userSettingsController.pharmacyDepartmentStockByBatchCostRateVisible}">
+                                            <f:ajax render="tbl" />
+                                        </h:selectBooleanCheckbox>
+                                        <h:outputLabel for="chkCostRate" value="Cost Rate" styleClass="ms-1" />
+                                    </div>
+                                    <div class="d-flex align-items-center me-3 mb-2">
+                                        <h:selectBooleanCheckbox id="chkCostValue" value="#{userSettingsController.pharmacyDepartmentStockByBatchCostValueVisible}">
+                                            <f:ajax render="tbl" />
+                                        </h:selectBooleanCheckbox>
+                                        <h:outputLabel for="chkCostValue" value="Cost Value" styleClass="ms-1" />
+                                    </div>
+                                    <div class="d-flex align-items-center me-3 mb-2">
+                                        <h:selectBooleanCheckbox id="chkRetailRate" value="#{userSettingsController.pharmacyDepartmentStockByBatchRetailRateVisible}">
+                                            <f:ajax render="tbl" />
+                                        </h:selectBooleanCheckbox>
+                                        <h:outputLabel for="chkRetailRate" value="Retail Rate" styleClass="ms-1" />
+                                    </div>
+                                    <div class="d-flex align-items-center me-3 mb-2">
+                                        <h:selectBooleanCheckbox id="chkRetailValue" value="#{userSettingsController.pharmacyDepartmentStockByBatchRetailValueVisible}">
+                                            <f:ajax render="tbl" />
+                                        </h:selectBooleanCheckbox>
+                                        <h:outputLabel for="chkRetailValue" value="Retail Value" styleClass="ms-1" />
+                                    </div>
+                                </div>
+                            </p:panel>
+                        </div>
+
                     </p:panel>
                 </h:form>
 
-
             </ui:define>
-
 
         </ui:composition>
 


### PR DESCRIPTION
  ReportsStock.java:
  - Added fillDepartmentExpiaryStockDtos() — DTO-based expiry query using the same JPQL pattern as
  fillDepartmentStockDtos(), with an added dateOfExpire between :fd and :td filter, always stock > 0 (no zero-stock
  toggle for expiry), and all filters: department/site/institution, department types, category, dosage form. Results
  ordered by expiry date.
  - Updated fillThreeMonthsExpiary(), fillSixMonthsExpiary(), fillOneYearExpiary() to call
  fillDepartmentExpiaryStockDtos() instead of the old entity-based fillDepartmentExpiaryStocks().
  - The old fillDepartmentExpiaryStocks() is kept (not removed) since it may be used elsewhere.

  pharmacy_report_department_stock_by_batch_expiary.xhtml:
  - Replaced old panelGrid-based layout with the same modern Bootstrap grid layout as the batch DTO report
  - Added institution_site_department_filter composite component (institution/site/department selector)
  - Added Category, Dosage Form, and Department Types filters (same as batch report)
  - Added From/To date pickers inline with action buttons
  - Quick buttons renamed to shorter "3 Months", "6 Months", "1 Year" labels
  - Data table now bound to stockDtos (DTO-based) instead of stocks (entity-based) — eliminates lazy-loading and N+1
  queries that caused column misalignment
  - All columns use DTO fields directly (i.itemName, i.purchaseRate, etc.) — no more deep entity navigation like
  i.itemBatch.item.name
  - Column visibility toggles reuse existing userSettingsController.pharmacyDepartmentStockBy* settings (shared with
  batch report, so user preferences persist)
  - "Customize Columns" panel at the bottom matches the batch report