### PR TITLE
19207 bug opd bill refund billfeefeevalue not negated causes qb report professional fee overcounting

### DIFF
--- a/src/main/java/com/divudi/bean/common/BillSearch.java
+++ b/src/main/java/com/divudi/bean/common/BillSearch.java
@@ -1672,7 +1672,7 @@ public class BillSearch implements Serializable, ControllerWithMultiplePayments 
 
             double refundingValue = 0;
             for (BillFee refundingBillFees : refundingBillItem.getBillFees()) {
-                refundingValue += refundingBillFees.getFeeValue();
+                refundingValue += Math.abs(refundingBillFees.getFeeValue());
             }
             refundingBillItem.setNetValue(refundingValue);
             refundingBillItem.setGrossValue(refundingValue);
@@ -1719,9 +1719,10 @@ public class BillSearch implements Serializable, ControllerWithMultiplePayments 
             }
 
             for (BillFee bf : bi.getBillFees()) {
-                // Convert all fee values to negative
-                double feeValue = bf.getFeeValue();
-                feeValue = -Math.abs(feeValue);
+                // Always treat user-entered value as positive magnitude, then negate for refund.
+                // Guards against over-enthusiastic users who enter a negative value directly.
+                double feeValue = -Math.abs(bf.getFeeValue());
+                bf.setFeeValue(feeValue);
 
                 if (bf.getInstitution() != null && bf.getInstitution().getInstitutionType() == InstitutionType.CollectingCentre) {
                     billItemCcTotal += feeValue;
@@ -2146,8 +2147,8 @@ public class BillSearch implements Serializable, ControllerWithMultiplePayments 
         if (refundingBill.getBillItems() != null) {
             for (BillItem refundingBillItemTmp : refundingBill.getBillItems()) {
                 for (BillFee refundingBillFeeTmp : refundingBillItemTmp.getBillFees()) {
-                    if (refundingBillFeeTmp.getReferenceBillFee().getFeeValue() < refundingBillFeeTmp.getFeeValue()) {
-                        JsfUtil.addErrorMessage("Pleace Enter Correct Value");
+                    if (Math.abs(refundingBillFeeTmp.getReferenceBillFee().getFeeValue()) < Math.abs(refundingBillFeeTmp.getFeeValue())) {
+                        JsfUtil.addErrorMessage("Refund amount cannot exceed the original fee value. Please enter a correct value.");
                         return "";
                     }
                 }

--- a/src/main/resources/META-INF/persistence.xml
+++ b/src/main/resources/META-INF/persistence.xml
@@ -2,7 +2,7 @@
 <persistence version="2.2" xmlns="http://java.sun.com/xml/ns/persistence" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/persistence http://xmlns.jcp.org/xml/ns/persistence/persistence_2_2.xsd">
     <persistence-unit name="hmisPU" transaction-type="JTA">
         <provider>org.eclipse.persistence.jpa.PersistenceProvider</provider>
-        <jta-data-source>jdbc/ruhunu</jta-data-source>
+        <jta-data-source>${JDBC_DATASOURCE}</jta-data-source>
         <exclude-unlisted-classes>false</exclude-unlisted-classes>
         <properties>
             <property name="eclipselink.logging.level.sql" value="SEVERE"/>
@@ -10,7 +10,7 @@
         </properties>
     </persistence-unit>
     <persistence-unit name="hmisAuditPU" transaction-type="JTA">
-        <jta-data-source>jdbc/ruhunuaudit</jta-data-source>
+        <jta-data-source>${JDBC_AUDIT_DATASOURCE}</jta-data-source>
         <exclude-unlisted-classes>false</exclude-unlisted-classes>
         <properties>
             <property name="eclipselink.logging.level.sql" value="SEVERE"/>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Added comprehensive billing reconciliation guidance for Daily Return and Cashier Summary reports, including discrepancy diagnostics and troubleshooting procedures.

* **Bug Fixes**
  * Improved refund processing logic to correctly handle negative values and ensure accurate refund calculations.

* **New Features**
  * Enhanced bill data management with JSON export functionality and improved navigation utilities for bill viewing and pharmacy adjustment workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->