### PR TITLE
18687 GRN report PDF, Excel, Print preview improvements

### DIFF
--- a/src/main/java/com/divudi/bean/pharmacy/PharmacyController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacyController.java
@@ -2450,7 +2450,7 @@ public class PharmacyController implements Serializable {
         filters.put("Department Type", getSelectedDepartmentTypesString());
         filters.put("Institution", institution != null ? institution.getName() : "All");
         filters.put("Site", site != null ? site.getName() : "All");
-        filters.put("Department", department != null ? department.getName() : "All");
+        filters.put("Department", dept != null ? dept.getName() : "All");
         
         filters.put("Payment Method", paymentMethod != null ? paymentMethod.getLabel() : "All");
         filters.put("Supplier", fromInstitution != null ? fromInstitution.getName() : "All");

--- a/src/main/java/com/divudi/bean/pharmacy/PharmacyController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacyController.java
@@ -2440,29 +2440,53 @@ public class PharmacyController implements Serializable {
         SimpleDateFormat sdf = new SimpleDateFormat(pattern);
         return sdf.format(date);
     }
+    
+    public Map<String,Object> getFiltersForGRNDetailReport(){
+        SimpleDateFormat sdf = new SimpleDateFormat(sessionController.getApplicationPreference().getLongDateTimeFormat());
+        Map<String, Object> filters = new LinkedHashMap<>();
+
+        filters.put("From Date", fromDate != null ? sdf.format(fromDate) : "None");
+        filters.put("To Date", toDate != null ? sdf.format(toDate) : "None");
+        filters.put("Department Type", getSelectedDepartmentTypesString());
+        filters.put("Institution", institution != null ? institution.getName() : "All");
+        filters.put("Site", site != null ? site.getName() : "All");
+        filters.put("Department", department != null ? department.getName() : "All");
+        
+        filters.put("Payment Method", paymentMethod != null ? paymentMethod.getLabel() : "All");
+        filters.put("Supplier", fromInstitution != null ? fromInstitution.getName() : "All");
+        filters.put("report type", reportType != null ? reportType : "All");
+       
+
+        return filters;
+    }
 
     public void exportGrnDetailReportToPdf() {
         boolean hasCosting = configOptionApplicationController.getBooleanValueByKey("Manage Costing", true);
 
         FacesContext context = FacesContext.getCurrentInstance();
         HttpServletResponse response = (HttpServletResponse) context.getExternalContext().getResponse();
-
+        String dates = CommonFunctions.dateRangeForFileName(fromDate, toDate, sessionController.getApplicationPreference().getLongDateFormat());
         response.setContentType("application/pdf");
-        response.setHeader("Content-Disposition", "attachment; filename=GRN_Detail_Report.pdf");
-
+        response.setHeader("Content-Disposition", "attachment; filename=GRN_Detail_Report_"+ dates + ".pdf");
+        SimpleDateFormat sdf = new SimpleDateFormat("dd MM yyyy hh:mm:ss a");
         try (OutputStream out = response.getOutputStream()) {
             Document document = new Document(PageSize.A4.rotate());
             PdfWriter.getInstance(document, out);
 
             document.open();
 
-            com.itextpdf.text.Font boldFont = FontFactory.getFont(FontFactory.HELVETICA_BOLD, 10);
-            com.itextpdf.text.Font normalFont = FontFactory.getFont(FontFactory.HELVETICA, 10);
-
-            Paragraph title = new Paragraph("GRN Report", FontFactory.getFont(FontFactory.HELVETICA_BOLD, 18));
-            title.setAlignment(Element.ALIGN_CENTER);
-            document.add(title);
-
+            com.itextpdf.text.Font boldFont = FontFactory.getFont(FontFactory.HELVETICA_BOLD, 7);
+            com.itextpdf.text.Font normalFont = FontFactory.getFont(FontFactory.HELVETICA, 6);
+            
+            document.add(new Paragraph("GRN Detialed Report", FontFactory.getFont(FontFactory.HELVETICA_BOLD, 18)));
+            document.add(new Paragraph("Date: " + sdf.format(new Date()), FontFactory.getFont(FontFactory.HELVETICA, 12)));
+            document.add(new Paragraph(" "));
+            
+            Map<String, Object> filters = getFiltersForGRNDetailReport();
+            PdfPTable infoTable =createInfoTablePdfExport(sdf, filters);
+            if (infoTable != null) {
+                document.add(infoTable);
+            }
             PdfPTable mainTable = new PdfPTable(hasCosting ? 17 : 15);
             mainTable.setWidthPercentage(100);
             if (hasCosting) {
@@ -2486,8 +2510,7 @@ public class PharmacyController implements Serializable {
             }
 
             for (Bill b : getBills()) {
-                SimpleDateFormat sdf = new SimpleDateFormat("dd-MM-yyyy hh:mm a");
-
+                
                 mainTable.addCell(new Phrase(b.getDeptId(), normalFont));
                 mainTable.addCell(new Phrase(b.getInvoiceNumber() != null ? b.getInvoiceNumber() : b.getReferenceBill().getInvoiceNumber(), normalFont));
                 mainTable.addCell(new Phrase(sdf.format(b.getCreatedAt()), normalFont));
@@ -2611,26 +2634,26 @@ public class PharmacyController implements Serializable {
 
         FacesContext context = FacesContext.getCurrentInstance();
         HttpServletResponse response = (HttpServletResponse) context.getExternalContext().getResponse();
+        String dates = CommonFunctions.dateRangeForFileName(fromDate, toDate, sessionController.getApplicationPreference().getLongDateFormat());
 
         response.setContentType("application/vnd.openxmlformats-officedocument.spreadsheetml.sheet");
-        response.setHeader("Content-Disposition", "attachment; filename=GRN_Detail_Report.xlsx");
-
+        response.setHeader("Content-Disposition", "attachment; filename=GRN_Detail_Report_"+ dates + ".xlsx");
+        Map<String, Object> filters = getFiltersForGRNDetailReport();
+       
         SimpleDateFormat sdf = new SimpleDateFormat("dd-MM-yyyy hh:mm a");
 
         try (XSSFWorkbook workbook = new XSSFWorkbook(); OutputStream out = response.getOutputStream()) {
             XSSFSheet sheet = workbook.createSheet("GRN Detail Report");
             int rowIndex = 0;
 
+            if (filters != null && !filters.isEmpty()) {
+                rowIndex = addMetaDataToExcelSheet(workbook, sheet, rowIndex, "GRN Detial Report", filters);
+            }
             XSSFFont boldFont = workbook.createFont();
             boldFont.setBold(true);
             CellStyle boldStyle = workbook.createCellStyle();
             boldStyle.setFont(boldFont);
 
-            Row titleRow = sheet.createRow(rowIndex++);
-            Cell titleCell = titleRow.createCell(0);
-            titleCell.setCellValue("GRN Report");
-            titleCell.setCellStyle(boldStyle);
-            sheet.addMergedRegion(new CellRangeAddress(0, 0, 0, hasCosting ? 16 : 14));
 
             String[] headers = {"GRN No", "Invoice No", "Created Date", "Approved Date", "Supplier Name", "Institution",
                 "Site", "Department", "Po No", "Purchase Cash", "Purchase Credit", "Sale Cash", "Sale Credit", "Remark", "Purchase Details"};
@@ -2790,10 +2813,12 @@ public class PharmacyController implements Serializable {
 
         FacesContext context = FacesContext.getCurrentInstance();
         HttpServletResponse response = (HttpServletResponse) context.getExternalContext().getResponse();
+        String dates = CommonFunctions.dateRangeForFileName(fromDate, toDate, sessionController.getApplicationPreference().getLongDateFormat());
 
         response.setContentType("application/pdf");
-        response.setHeader("Content-Disposition", "attachment; filename=GRN_Return_Report.pdf");
-
+        response.setHeader("Content-Disposition", "attachment; filename=GRN_Return_Report_"+dates+".pdf");
+        
+        SimpleDateFormat sdf = new SimpleDateFormat("dd MM yyyy hh:mm:ss a");
         try (OutputStream out = response.getOutputStream()) {
             Document document = new Document(PageSize.A4.rotate());
             PdfWriter.getInstance(document, out);
@@ -2802,10 +2827,15 @@ public class PharmacyController implements Serializable {
             com.itextpdf.text.Font boldFont = FontFactory.getFont(FontFactory.HELVETICA_BOLD, 10);
             com.itextpdf.text.Font normalFont = FontFactory.getFont(FontFactory.HELVETICA, 10);
 
-            Paragraph title = new Paragraph("GRN Return Report", FontFactory.getFont(FontFactory.HELVETICA_BOLD, 18));
-            title.setAlignment(Element.ALIGN_CENTER);
-            document.add(title);
+            document.add(new Paragraph("GRN Return Report", FontFactory.getFont(FontFactory.HELVETICA_BOLD, 18)));
+            document.add(new Paragraph("Date: " + sdf.format(new Date()), FontFactory.getFont(FontFactory.HELVETICA, 12)));
+            document.add(new Paragraph(" "));
 
+            Map<String, Object> filters = getFiltersForGRNDetailReport();
+            PdfPTable infoTable = createInfoTablePdfExport(sdf, filters);
+            if (infoTable != null) {
+                document.add(infoTable);
+            }
             PdfPTable mainTable = new PdfPTable(hasCosting ? 12 : 11);
             mainTable.setWidthPercentage(100);
 
@@ -2831,7 +2861,6 @@ public class PharmacyController implements Serializable {
             double totalCost = 0;
 
             for (Bill r : getBills()) {
-                SimpleDateFormat sdf = new SimpleDateFormat("dd-MM-yyyy hh:mm a");
 
                 mainTable.addCell(new Phrase(r.getDeptId(), normalFont));
                 mainTable.addCell(new Phrase(r.getReferenceBill() != null ? r.getReferenceBill().getDeptId() : "", normalFont));
@@ -2923,27 +2952,26 @@ public class PharmacyController implements Serializable {
 
         FacesContext context = FacesContext.getCurrentInstance();
         HttpServletResponse response = (HttpServletResponse) context.getExternalContext().getResponse();
+        String dates = CommonFunctions.dateRangeForFileName(fromDate, toDate, sessionController.getApplicationPreference().getLongDateFormat());
 
         response.setContentType("application/vnd.openxmlformats-officedocument.spreadsheetml.sheet");
-        response.setHeader("Content-Disposition", "attachment; filename=GRN_Return_Report.xlsx");
+        response.setHeader("Content-Disposition", "attachment; filename=GRN_Return_Report_"+dates+".xlsx");
 
         SimpleDateFormat sdf = new SimpleDateFormat("dd-MM-yyyy hh:mm a");
-
+        Map<String, Object> filters = getFiltersForGRNDetailReport();
+        
         try (XSSFWorkbook workbook = new XSSFWorkbook(); OutputStream out = response.getOutputStream()) {
             XSSFSheet sheet = workbook.createSheet("GRN Return Report");
             int rowIndex = 0;
-
+            if (filters != null && !filters.isEmpty()) {
+                rowIndex = addMetaDataToExcelSheet(workbook, sheet, rowIndex, "GRN Return Report", filters);
+            }
             XSSFFont boldFont = workbook.createFont();
             boldFont.setBold(true);
 
             CellStyle boldStyle = workbook.createCellStyle();
             boldStyle.setFont(boldFont);
 
-            Row mainHeader = sheet.createRow(rowIndex++);
-            Cell titleCell = mainHeader.createCell(0);
-            titleCell.setCellValue("GRN Return Report");
-            titleCell.setCellStyle(boldStyle);
-            sheet.addMergedRegion(new CellRangeAddress(0, 0, 0, hasCosting ? 11 : 10));
 
             String[] headers = {"Return No", "GRN No", "GRN Invoice No", "GRN Date", "Reference Institution", "Created At", "Approved At", "Supplier", "Purchase Value", "Sale Value", "Purchase Details"};
 
@@ -3065,9 +3093,11 @@ public class PharmacyController implements Serializable {
 
         FacesContext context = FacesContext.getCurrentInstance();
         HttpServletResponse response = (HttpServletResponse) context.getExternalContext().getResponse();
+        String dates = CommonFunctions.dateRangeForFileName(fromDate, toDate, sessionController.getApplicationPreference().getLongDateFormat());
 
         response.setContentType("application/pdf");
-        response.setHeader("Content-Disposition", "attachment; filename=GRN_Cancellation_Report.pdf");
+        response.setHeader("Content-Disposition", "attachment; filename=GRN_Cancellation_Report_"+dates+".pdf");
+        SimpleDateFormat sdf = new SimpleDateFormat("dd MM yyyy hh:mm:ss a");
 
         try (OutputStream out = response.getOutputStream()) {
             Document document = new Document(PageSize.A4.rotate());
@@ -3077,10 +3107,15 @@ public class PharmacyController implements Serializable {
             com.itextpdf.text.Font boldFont = FontFactory.getFont(FontFactory.HELVETICA_BOLD, 10);
             com.itextpdf.text.Font normalFont = FontFactory.getFont(FontFactory.HELVETICA, 10);
 
-            Paragraph title = new Paragraph("GRN Cancellation Report", FontFactory.getFont(FontFactory.HELVETICA_BOLD, 18));
-            title.setAlignment(Element.ALIGN_CENTER);
-            document.add(title);
+            document.add(new Paragraph("GRN Cancellation Report", FontFactory.getFont(FontFactory.HELVETICA_BOLD, 18)));
+            document.add(new Paragraph("Date: " + sdf.format(new Date()), FontFactory.getFont(FontFactory.HELVETICA, 12)));
+            document.add(new Paragraph(" "));
 
+            Map<String, Object> filters = getFiltersForGRNDetailReport();
+            PdfPTable infoTable = createInfoTablePdfExport(sdf, filters);
+            if (infoTable != null) {
+                document.add(infoTable);
+            }
             PdfPTable mainTable = new PdfPTable(hasCosting ? 12 : 11);
             mainTable.setWidthPercentage(100);
             if (hasCosting) {
@@ -3104,7 +3139,6 @@ public class PharmacyController implements Serializable {
             double totalCost = 0;
 
             for (Bill cb : getBills()) {
-                SimpleDateFormat sdf = new SimpleDateFormat("dd-MM-yyyy hh:mm a");
 
                 mainTable.addCell(new Phrase(cb.getDeptId() != null ? cb.getDeptId() : "", normalFont));
                 mainTable.addCell(new Phrase(cb.getReferenceBill() != null && cb.getReferenceBill().getDeptId() != null ? cb.getReferenceBill().getDeptId() : "", normalFont));
@@ -3204,15 +3238,21 @@ public class PharmacyController implements Serializable {
 
         FacesContext context = FacesContext.getCurrentInstance();
         HttpServletResponse response = (HttpServletResponse) context.getExternalContext().getResponse();
-
+        String dates = CommonFunctions.dateRangeForFileName(fromDate, toDate, sessionController.getApplicationPreference().getLongDateFormat());
+        
         response.setContentType("application/vnd.openxmlformats-officedocument.spreadsheetml.sheet");
-        response.setHeader("Content-Disposition", "attachment; filename=GRN_Cancellation_Report.xlsx");
+        response.setHeader("Content-Disposition", "attachment; filename=GRN_Cancellation_Report_"+dates+".xlsx");
 
         SimpleDateFormat sdf = new SimpleDateFormat("dd-MM-yyyy hh:mm a");
-
+        Map<String, Object> filters = getFiltersForGRNDetailReport();
+        
         try (XSSFWorkbook workbook = new XSSFWorkbook(); OutputStream out = response.getOutputStream()) {
             XSSFSheet sheet = workbook.createSheet("GRN Cancellation Report");
             int rowIndex = 0;
+            
+            if (filters != null && !filters.isEmpty()) {
+                rowIndex = addMetaDataToExcelSheet(workbook, sheet, rowIndex, "GRN Cancellation Report", filters);
+            }
 
             XSSFFont boldFont = workbook.createFont();
             boldFont.setBold(true);
@@ -3220,11 +3260,6 @@ public class PharmacyController implements Serializable {
             CellStyle boldStyle = workbook.createCellStyle();
             boldStyle.setFont(boldFont);
 
-            Row titleRow = sheet.createRow(rowIndex++);
-            Cell titleCell = titleRow.createCell(0);
-            titleCell.setCellValue("GRN Cancellation Report");
-            titleCell.setCellStyle(boldStyle);
-            sheet.addMergedRegion(new CellRangeAddress(0, 0, 0, hasCosting ? 11 : 10));
 
             Row headerRow = sheet.createRow(rowIndex++);
             String[] headers = {"Cancelled No", "GRN No", "GRN Invoice No", "GRN Date", "Reference Institution", "Created At", "Approved At", "Supplier", "Purchase Value", "Sale Value", "Purchase Details"};
@@ -3338,6 +3373,292 @@ public class PharmacyController implements Serializable {
 
             workbook.write(out);
             context.responseComplete();
+        } catch (Exception e) {
+            Logger.getLogger(PharmacyController.class.getName()).log(Level.SEVERE, e.getMessage());
+        }
+    }
+    
+    public void exportSummaryReportToPdf() {
+        boolean hasCosting = configOptionApplicationController.getBooleanValueByKey("Manage Costing", true);
+
+        FacesContext context = FacesContext.getCurrentInstance();
+        HttpServletResponse response = (HttpServletResponse) context.getExternalContext().getResponse();
+        String dates = CommonFunctions.dateRangeForFileName(fromDate, toDate, sessionController.getApplicationPreference().getLongDateFormat());
+
+        response.setContentType("application/pdf");
+        response.setHeader("Content-Disposition", "attachment; filename=GRN_Summary_Report_" + dates + ".pdf");
+        SimpleDateFormat sdf = new SimpleDateFormat("dd MM yyyy hh:mm:ss a");
+
+        try (OutputStream out = response.getOutputStream()) {
+            Document document = new Document(PageSize.A4.rotate());
+            PdfWriter.getInstance(document, out);
+            document.open();
+
+            com.itextpdf.text.Font boldFont = FontFactory.getFont(FontFactory.HELVETICA_BOLD, 10);
+            com.itextpdf.text.Font normalFont = FontFactory.getFont(FontFactory.HELVETICA, 10);
+
+            // ── Title & timestamp ──────────────────────────────────────────
+            document.add(new Paragraph("GRN Summary Report",
+                    FontFactory.getFont(FontFactory.HELVETICA_BOLD, 18)));
+            document.add(new Paragraph("Date: " + sdf.format(new Date()),
+                    FontFactory.getFont(FontFactory.HELVETICA, 12)));
+            document.add(new Paragraph(" "));
+
+            // ── Optional filter info table (same pattern as reference) ─────
+            Map<String, Object> filters = getFiltersForGRNDetailReport();
+            PdfPTable infoTable = createInfoTablePdfExport(sdf, filters);
+            if (infoTable != null) {
+                document.add(infoTable);
+            }
+
+            // ── Decide column count based on costing flag ──────────────────
+            //    Columns: Label | Purchase Value | Sale Value | [Cost Value] | Net Total
+            int colCount = hasCosting ? 5 : 4;
+            PdfPTable mainTable = new PdfPTable(colCount);
+            mainTable.setWidthPercentage(100);
+
+            if (hasCosting) {
+                mainTable.setWidths(new float[]{6f, 3f, 3f, 3f, 3f});
+            } else {
+                mainTable.setWidths(new float[]{6f, 3f, 3f, 3f});
+            }
+
+            // ── Header row ─────────────────────────────────────────────────
+            String[] headers = hasCosting
+                    ? new String[]{"", "Purchase Value", "Sale Value", "Cost Value", "Net Total"}
+                    : new String[]{"", "Purchase Value", "Sale Value", "Net Total"};
+
+            for (String header : headers) {
+                PdfPCell cell = new PdfPCell(new Phrase(header, boldFont));
+                cell.setHorizontalAlignment(Element.ALIGN_CENTER);
+                cell.setBackgroundColor(BaseColor.LIGHT_GRAY);
+                mainTable.addCell(cell);
+            }
+
+            // ── Running totals ─────────────────────────────────────────────
+            double grandTotalPurchase = 0;
+            double grandTotalSale     = 0;
+            double grandTotalCost     = 0;
+            double grandTotalNet      = 0;
+
+            // ── Data rows — driven by the same getData() list the table uses ─
+            for (String1Value1 s : getData()) {
+
+                // Label column (s.string)
+                PdfPCell labelCell = new PdfPCell(new Phrase(
+                        s.getString() != null ? s.getString() : "", normalFont));
+                labelCell.setHorizontalAlignment(Element.ALIGN_LEFT);
+                mainTable.addCell(labelCell);
+
+                // Purchase Value (s.value)
+                PdfPCell purchaseCell = new PdfPCell(new Phrase(
+                        String.format("%,.2f", s.getValue()), normalFont));
+                purchaseCell.setHorizontalAlignment(Element.ALIGN_RIGHT);
+                mainTable.addCell(purchaseCell);
+
+                // Sale Value (s.value2)
+                PdfPCell saleCell = new PdfPCell(new Phrase(
+                        String.format("%,.2f", s.getValue2()), normalFont));
+                saleCell.setHorizontalAlignment(Element.ALIGN_RIGHT);
+                mainTable.addCell(saleCell);
+
+                // Cost Value (s.value3) — only when costing is enabled
+                double cost = 0.0;
+                if (hasCosting) {
+                    cost = s.getValue3();
+                    PdfPCell costCell = new PdfPCell(new Phrase(
+                            String.format("%,.2f", cost), normalFont));
+                    costCell.setHorizontalAlignment(Element.ALIGN_RIGHT);
+                    mainTable.addCell(costCell);
+                }
+
+                // Net Total (s.value4)
+                PdfPCell netCell = new PdfPCell(new Phrase(
+                        String.format("%,.2f", s.getValue4()), normalFont));
+                netCell.setHorizontalAlignment(Element.ALIGN_RIGHT);
+                mainTable.addCell(netCell);
+
+                // Accumulate totals
+                grandTotalPurchase += s.getValue();
+                grandTotalSale     += s.getValue2();
+                grandTotalCost     += hasCosting ? s.getValue3() : 0.0;
+                grandTotalNet      += s.getValue4();
+                            }
+
+            // ── Footer / totals row ────────────────────────────────────────
+            PdfPCell footerLabel = new PdfPCell(new Phrase("Total", boldFont));
+            footerLabel.setHorizontalAlignment(Element.ALIGN_RIGHT);
+            footerLabel.setBackgroundColor(BaseColor.LIGHT_GRAY);
+            mainTable.addCell(footerLabel);
+
+            PdfPCell totalPurchaseCell = new PdfPCell(new Phrase(
+                    String.format("%,.2f", grandTotalPurchase), boldFont));
+            totalPurchaseCell.setHorizontalAlignment(Element.ALIGN_RIGHT);
+            totalPurchaseCell.setBackgroundColor(BaseColor.LIGHT_GRAY);
+            mainTable.addCell(totalPurchaseCell);
+
+            PdfPCell totalSaleCell = new PdfPCell(new Phrase(
+                    String.format("%,.2f", grandTotalSale), boldFont));
+            totalSaleCell.setHorizontalAlignment(Element.ALIGN_RIGHT);
+            totalSaleCell.setBackgroundColor(BaseColor.LIGHT_GRAY);
+            mainTable.addCell(totalSaleCell);
+
+            if (hasCosting) {
+                PdfPCell totalCostCell = new PdfPCell(new Phrase(
+                        String.format("%,.2f", grandTotalCost), boldFont));
+                totalCostCell.setHorizontalAlignment(Element.ALIGN_RIGHT);
+                totalCostCell.setBackgroundColor(BaseColor.LIGHT_GRAY);
+                mainTable.addCell(totalCostCell);
+            }
+
+            PdfPCell totalNetCell = new PdfPCell(new Phrase(
+                    String.format("%,.2f", grandTotalNet), boldFont));
+            totalNetCell.setHorizontalAlignment(Element.ALIGN_RIGHT);
+            totalNetCell.setBackgroundColor(BaseColor.LIGHT_GRAY);
+            mainTable.addCell(totalNetCell);
+
+            document.add(mainTable);
+            document.close();
+            context.responseComplete();
+
+        } catch (Exception e) {
+            Logger.getLogger(PharmacyController.class.getName())
+                  .log(Level.SEVERE, e.getMessage());
+        }
+    }
+    
+    
+    public void exportSummaryReportToExcel() {
+        boolean hasCosting = configOptionApplicationController.getBooleanValueByKey("Manage Costing", true);
+
+        FacesContext context = FacesContext.getCurrentInstance();
+        HttpServletResponse response = (HttpServletResponse) context.getExternalContext().getResponse();
+        String dates = CommonFunctions.dateRangeForFileName(fromDate, toDate, sessionController.getApplicationPreference().getLongDateFormat());
+
+        response.setContentType("application/vnd.openxmlformats-officedocument.spreadsheetml.sheet");
+        response.setHeader("Content-Disposition", "attachment; filename=Summary_Report_" + dates + ".xlsx");
+
+        SimpleDateFormat sdf = new SimpleDateFormat("dd-MM-yyyy hh:mm a");
+        Map<String, Object> filters = getFiltersForGRNDetailReport();
+
+        try (XSSFWorkbook workbook = new XSSFWorkbook(); OutputStream out = response.getOutputStream()) {
+            XSSFSheet sheet = workbook.createSheet("Summary Report");
+            int rowIndex = 0;
+
+            // ── Meta / filter info block (same as reference) ───────────────
+            if (filters != null && !filters.isEmpty()) {
+                rowIndex = addMetaDataToExcelSheet(workbook, sheet, rowIndex, "Summary Report", filters);
+            }
+
+            // ── Font & cell styles ─────────────────────────────────────────
+            XSSFFont boldFont = workbook.createFont();
+            boldFont.setBold(true);
+
+            CellStyle boldStyle = workbook.createCellStyle();
+            boldStyle.setFont(boldFont);
+
+            CellStyle boldRightStyle = workbook.createCellStyle();
+            boldRightStyle.setFont(boldFont);
+            boldRightStyle.setAlignment(HorizontalAlignment.RIGHT);
+
+            CellStyle numberStyle = workbook.createCellStyle();
+            DataFormat format = workbook.createDataFormat();
+            numberStyle.setDataFormat(format.getFormat("#,##0.00"));
+            numberStyle.setAlignment(HorizontalAlignment.RIGHT);
+
+            CellStyle boldNumberStyle = workbook.createCellStyle();
+            boldNumberStyle.setFont(boldFont);
+            boldNumberStyle.setDataFormat(format.getFormat("#,##0.00"));
+            boldNumberStyle.setAlignment(HorizontalAlignment.RIGHT);
+
+            // ── Header row ─────────────────────────────────────────────────
+            Row headerRow = sheet.createRow(rowIndex++);
+            String[] headers = hasCosting
+                    ? new String[]{"", "Purchase Value", "Sale Value", "Cost Value", "Net Total"}
+                    : new String[]{"", "Purchase Value", "Sale Value", "Net Total"};
+
+            for (int i = 0; i < headers.length; i++) {
+                Cell cell = headerRow.createCell(i);
+                cell.setCellValue(headers[i]);
+                cell.setCellStyle(boldStyle);
+            }
+
+            // ── Running totals ─────────────────────────────────────────────
+            double grandTotalPurchase = 0;
+            double grandTotalSale     = 0;
+            double grandTotalCost     = 0;
+            double grandTotalNet      = 0;
+
+            // ── Data rows ──────────────────────────────────────────────────
+            for (String1Value1 s : getData()) {  // replace getData() with your actual getter
+                Row row = sheet.createRow(rowIndex++);
+
+                // Column 0 — Label
+                row.createCell(0).setCellValue(s.getString() != null ? s.getString() : "");
+
+                // Column 1 — Purchase Value
+                Cell purchaseCell = row.createCell(1);
+                purchaseCell.setCellValue(s.getValue());
+                purchaseCell.setCellStyle(numberStyle);
+
+                // Column 2 — Sale Value
+                Cell saleCell = row.createCell(2);
+                saleCell.setCellValue(s.getValue2());
+                saleCell.setCellStyle(numberStyle);
+
+                // Column 3 — Cost Value (only when costing enabled)
+                if (hasCosting) {
+                    Cell costCell = row.createCell(3);
+                    costCell.setCellValue(s.getValue3());
+                    costCell.setCellStyle(numberStyle);
+                }
+
+                // Column 3 or 4 — Net Total
+                Cell netCell = row.createCell(hasCosting ? 4 : 3);
+                netCell.setCellValue(s.getValue4());
+                netCell.setCellStyle(numberStyle);
+
+                // Accumulate totals
+                grandTotalPurchase += s.getValue();
+                grandTotalSale     += s.getValue2();
+                grandTotalCost     += hasCosting ? s.getValue3() : 0.0;
+                grandTotalNet      += s.getValue4();
+            }
+
+            // ── Footer / totals row ────────────────────────────────────────
+            Row footerRow = sheet.createRow(rowIndex++);
+
+            Cell footerLabel = footerRow.createCell(0);
+            footerLabel.setCellValue("Total");
+            footerLabel.setCellStyle(boldStyle);
+
+            Cell totalPurchaseCell = footerRow.createCell(1);
+            totalPurchaseCell.setCellValue(grandTotalPurchase);
+            totalPurchaseCell.setCellStyle(boldNumberStyle);
+
+            Cell totalSaleCell = footerRow.createCell(2);
+            totalSaleCell.setCellValue(grandTotalSale);
+            totalSaleCell.setCellStyle(boldNumberStyle);
+
+            if (hasCosting) {
+                Cell totalCostCell = footerRow.createCell(3);
+                totalCostCell.setCellValue(grandTotalCost);
+                totalCostCell.setCellStyle(boldNumberStyle);
+            }
+
+            Cell totalNetCell = footerRow.createCell(hasCosting ? 4 : 3);
+            totalNetCell.setCellValue(grandTotalNet);
+            totalNetCell.setCellStyle(boldNumberStyle);
+
+            // ── Auto-size all columns for clean layout ─────────────────────
+            int totalCols = hasCosting ? 5 : 4;
+            for (int i = 0; i < totalCols; i++) {
+                sheet.autoSizeColumn(i);
+            }
+
+            workbook.write(out);
+            context.responseComplete();
+
         } catch (Exception e) {
             Logger.getLogger(PharmacyController.class.getName()).log(Level.SEVERE, e.getMessage());
         }

--- a/src/main/webapp/reports/inventoryReports/grn_report.xhtml
+++ b/src/main/webapp/reports/inventoryReports/grn_report.xhtml
@@ -168,49 +168,42 @@
                                              value="Process"
                                              action="#{pharmacyController.generateGrnReportTable()}">
                             </p:commandButton>
-                            <p:commandButton class="ui-button- mx-1" icon="fas fa-print" ajax="false" value="Print All"
-                                             rendered="#{pharmacyController.reportType eq 'detailReport'}">
-                                <p:printer target="tbl1"/>
-                            </p:commandButton>
-                            <p:commandButton class="ui-button- mx-1" icon="fas fa-print" ajax="false" value="Print All"
-                                             rendered="#{pharmacyController.reportType eq 'returnReport'}">
-                                <p:printer target="tbl2"/>
-                            </p:commandButton>
-                            <p:commandButton class="ui-button- mx-1" icon="fas fa-print" ajax="false" value="Print All"
-                                             rendered="#{pharmacyController.reportType eq 'summeryReport'}">
-                                <p:printer target="tbl3"/>
-                            </p:commandButton>
-                            <p:commandButton class="ui-button- mx-1" icon="fas fa-print" ajax="false" value="Print All"
-                                             rendered="#{pharmacyController.reportType eq 'cancellationReport'}">
-                                <p:printer target="tbl4"/>
+                            <p:commandButton
+                                class="ui-button-primary mx-1"
+                                icon="fas fa-print"
+                                ajax="false"
+                                value="To Print"
+                                action="grn_report_print?faces-redirect=true">
                             </p:commandButton>
 
                             <p:commandButton
                                 class="ui-button-success mx-1"
                                 icon="fas fa-file-excel"
                                 ajax="false"
-                                value="Export to Excel"
+                                value="Excel"
                                 action="#{pharmacyController.exportGrnDetailReportToExcel()}"
                                 rendered="#{pharmacyController.reportType eq 'detailReport'}"/>
                             <p:commandButton
                                 class="ui-button-success mx-1"
                                 icon="fas fa-file-excel"
                                 ajax="false"
-                                value="Export to Excel"
+                                value="Excel"
                                 action="#{pharmacyController.exportGrnReturnReportToExcel()}"
                                 rendered="#{pharmacyController.reportType eq 'returnReport'}"/>
                             <p:commandButton
                                 class="ui-button-success mx-1"
                                 icon="fas fa-file-excel"
                                 ajax="false"
-                                value="Export to Excel"
+                                value="Excel"
                                 rendered="#{pharmacyController.reportType eq 'cancellationReport'}"
                                 action="#{pharmacyController.exportGrnCancellationReportToExcel()}"/>
-                            <p:commandButton class="ui-button-success mx-1" icon="fas fa-file-excel" ajax="false"
-                                             value="Download"
-                                             rendered="#{pharmacyController.reportType eq 'summeryReport'}">
-                                <p:dataExporter type="xlsx" target="tbl3" fileName="grn_summery_report"/>
-                            </p:commandButton>
+                            <p:commandButton 
+                                class="ui-button-success mx-1" 
+                                icon="fas fa-file-excel" ajax="false"
+                                value="Excel"
+                                rendered="#{pharmacyController.reportType eq 'summeryReport'}"
+                                action="#{pharmacyController.exportSummaryReportToExcel()}"
+                                />
 
                             <p:commandButton class="ui-button-danger mx-1" icon="fas fa-file-pdf" ajax="false" value="PDF"
                                              rendered="#{pharmacyController.reportType eq 'detailReport'}"
@@ -219,9 +212,8 @@
                                              rendered="#{pharmacyController.reportType eq 'returnReport'}"
                                              action="#{pharmacyController.exportGrnReturnReportToPdf}"/>
                             <p:commandButton class="ui-button-danger mx-1" icon="fas fa-file-pdf" ajax="false" value="PDF"
-                                             rendered="#{pharmacyController.reportType eq 'summeryReport'}">
-                                <p:dataExporter type="pdf" target="tbl3" fileName="grn_summery_report"/>
-                            </p:commandButton>
+                                             rendered="#{pharmacyController.reportType eq 'summeryReport'}"
+                                             action="#{pharmacyController.exportSummaryReportToPdf()}"/>
                             <p:commandButton class="ui-button-danger mx-1" icon="fas fa-file-pdf" ajax="false" value="PDF"
                                              rendered="#{pharmacyController.reportType eq 'cancellationReport'}"
                                              action="#{pharmacyController.exportGrnCancellationReportToPdf}"/>

--- a/src/main/webapp/reports/inventoryReports/grn_report_includes/summary_report_table.xhtml
+++ b/src/main/webapp/reports/inventoryReports/grn_report_includes/summary_report_table.xhtml
@@ -17,9 +17,9 @@
                              currentPageReportTemplate="Showing {startRecord} to {endRecord} of {totalRecords}"
                              rowsPerPageTemplate="5,10,15,25,50,100,500,1000">
 
-                    <f:facet name="header">
+<!--                    <f:facet name="header">
                         Summary
-                    </f:facet>
+                    </f:facet>-->
 
                     <p:column width="10em">
                         <h:outputLabel value="#{s.string}"/>

--- a/src/main/webapp/reports/inventoryReports/grn_report_print.xhtml
+++ b/src/main/webapp/reports/inventoryReports/grn_report_print.xhtml
@@ -1,0 +1,1109 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
+      xmlns:h="http://xmlns.jcp.org/jsf/html"
+      xmlns:p="http://primefaces.org/ui"
+      xmlns:f="http://xmlns.jcp.org/jsf/core">
+    <h:body>
+        <ui:composition template="/resources/template/template.xhtml">
+            <ui:define name="content">
+                <h:form>
+                    <style>
+                        @media screen {
+                            .paper {
+                                position: static !important;
+                                width: 297mm !important;
+                                zoom: 2.0;
+                            }
+                        }
+
+                        @media print {
+                            @page {
+                                size: A4 landscape !important;
+                                @bottom-right {
+                                    content: "Page " counter(page) " of " counter(pages);
+                                    font-family: Arial, sans-serif;
+                                    font-size: 8pt;
+                                }
+                            }
+
+                            body {
+                                counter-reset: page;
+                            }
+
+                            .paper {
+                                position: static !important;
+                                width: 297mm !important;
+                            }
+                        }
+
+                        @media screen, print {
+
+                            .header {
+                                line-height: 1.1;
+                                margin: 0mm !important;
+                            }
+
+                            .table-detail {
+                                width: 99%;
+                                font-size: 6pt !important;
+                                margin-top: 3mm !important;
+                                border-collapse: collapse !important;
+                                table-layout: fixed;
+                            }
+
+                            .table-summary {
+                                width: 60%;
+                                font-size: 8pt !important;
+                                margin-top: 3mm !important;
+                                border-collapse: collapse !important;
+                                table-layout: fixed;
+                            }
+
+                            th, td {
+                                border: 1pt solid #000000 !important;
+                                padding: 1pt !important;
+                                text-align: left;
+                                overflow-wrap: break-word;
+                                white-space: normal;
+                            }
+
+                            .report-header-table {
+                                border-collapse: collapse;
+                            }
+
+                            .report-header-table .label {
+                                font-weight: 600;
+                                padding-right: 5px;
+                                white-space: nowrap;
+                            }
+
+                            .report-header-table td {
+                                padding: 3px 8px;
+                                vertical-align: top;
+                            }
+
+                            .nested-table {
+                                width: 100%;
+                                font-size: 6pt !important;
+                                border-collapse: collapse !important;
+                                table-layout: fixed;
+                                margin: 0 !important;
+                            }
+                        }
+                    </style>
+
+                    <!-- ═══════════════════════════════════════════════════════════ -->
+                    <!--  1. DETAIL REPORT                                          -->
+                    <!-- ═══════════════════════════════════════════════════════════ -->
+                    <h:panelGroup rendered="#{pharmacyController.reportType eq 'detailReport'}">
+                        <p:panel styleClass="my-2">
+                            <f:facet name="header">
+                                <div class="d-flex justify-content-between">
+                                    <h:outputText value="GRN Detail Report" class="mt-2"/>
+                                    <div class="d-flex gap-2">
+                                        <p:commandButton
+                                            icon="fa-solid fa-print"
+                                            class="ui-button-info"
+                                            style="width: 150px"
+                                            ajax="false"
+                                            value="Print">
+                                            <p:printer target="detailRp"/>
+                                        </p:commandButton>
+                                        <p:commandButton
+                                            ajax="false"
+                                            value="Back to Report"
+                                            style="width: 200px"
+                                            icon="fa fa-arrow-left"
+                                            class="ui-button-warning"
+                                            action="/reports/inventoryReports/grn_report?faces-redirect=true">
+                                        </p:commandButton>
+                                    </div>
+                                </div>
+                            </f:facet>
+                        </p:panel>
+
+                        <h:panelGroup id="detailRp" class="d-flex justify-content-center">
+                            <div class="paper">
+                                <div class="header">
+                                    <div class="d-flex justify-content-center" style="font-weight: 700; font-size: 18px;">
+                                        <h:outputText value="#{sessionController.institution.name}"/>
+                                    </div>
+                                    <div class="d-flex justify-content-center" style="font-weight: 700; font-size: 16px;">
+                                        <h:outputText value="GRN Report (Detail)"/>
+                                    </div>
+                                    <div class="d-flex justify-content-center m-3">
+                                        <h:panelGrid columns="6" styleClass="report-header-table"
+                                                     style="font-size:10px; width:80%;"
+                                                     columnClasses="label,value,label,value,label,value">
+
+                                            <!-- Row 1 -->
+                                            <h:outputText value="From Date:" styleClass="label"/>
+                                            <h:outputText value="#{pharmacyController.fromDate}">
+                                                <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateTimeFormat}"/>
+                                            </h:outputText>
+
+                                            <h:outputText value="To Date:" styleClass="label"/>
+                                            <h:outputText value="#{pharmacyController.toDate}">
+                                                <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateTimeFormat}"/>
+                                            </h:outputText>
+
+                                            <h:outputText value="Report Type:" styleClass="label"/>
+                                            <h:outputText value="Detail"/>
+
+                                            <!-- Row 2 -->
+                                            <h:outputText value="Institution:" styleClass="label"/>
+                                            <h:outputText value="#{pharmacyController.institution != null ? pharmacyController.institution.name : 'All'}"/>
+
+                                            <h:outputText value="Site:" styleClass="label"/>
+                                            <h:outputText value="#{pharmacyController.site != null ? pharmacyController.site.name : 'All'}"/>
+
+                                            <h:outputText value="Department:" styleClass="label"/>
+                                            <h:outputText value="#{pharmacyController.dept != null ? pharmacyController.dept.name : 'All'}"/>
+
+                                            <!-- Row 3 -->
+                                            <h:outputText value="Department Type:" styleClass="label"/>
+                                            <h:outputText value="#{pharmacyController.getSelectedDepartmentTypesString()}"/>
+
+                                            <h:outputText value="Payment Mode:" styleClass="label"/>
+                                            <h:outputText value="#{pharmacyController.paymentMethod != null ? pharmacyController.paymentMethod : 'All'}"/>
+
+                                            <h:outputText value="Supplier:" styleClass="label"/>
+                                            <h:outputText value="#{pharmacyController.fromInstitution != null ? pharmacyController.fromInstitution.name : 'All'}"/>
+
+                                        </h:panelGrid>
+                                    </div>
+                                </div>
+
+                                <!-- Detail Data Table -->
+                                 <div class="d-flex justify-content-center">
+                                     <div style="width:99%;">
+                                         <p:dataTable
+                                            id="printDetailTbl"
+                                            value="#{pharmacyController.bills}"
+                                            var="b"
+                                            rowIndexVar="n"
+                                            styleClass="table-detail">
+
+                                            <p:columnGroup type="header">
+                                                <p:row>
+                                                    <p:column headerText="Bill No"             style="width:5%;"/>
+                                                    <p:column headerText="Bill Type"           style="width:5%;"/>
+                                                    <p:column headerText="Invoice No"          style="width:4%;"/>
+                                                    <p:column headerText="Created Date"        style="width:7%;"/>
+                                                    <p:column headerText="Approved Date"       style="width:7%;"/>
+                                                    <p:column headerText="Supplier"            style="width:7%;"/>
+                                                    <p:column headerText="Institution"         style="width:7%;"/>
+                                                    <p:column headerText="Site"                style="width:6%;"/>
+                                                    <p:column headerText="Department"          style="width:6%;"/>
+                                                    <p:column headerText="PO No"               style="width:4%;"/>
+                                                    <p:column headerText="Purchase Value Cash"  style="width:5%;"/>
+                                                    <p:column headerText="Purchase Value Credit" style="width:5%;"/>
+                                                    <p:column headerText="Cost Value Cash"     style="width:5%;"/>
+                                                    <p:column headerText="Cost Value Credit"   style="width:5%;"/>
+                                                    <p:column headerText="Sale Value Cash"     style="width:5%;"/>
+                                                    <p:column headerText="Sale Value Credit"   style="width:5%;"/>
+                                                    <p:column headerText="Net Total"           style="width:5%;"/>
+                                                    <p:column headerText="Remark"              style="width:7%;"/>
+                                                </p:row>
+                                            </p:columnGroup>
+
+                                            <!-- Bill No -->
+                                            <p:column>
+                                                <h:outputText value="#{b.deptId}"/>
+                                                <f:facet name="footer">
+                                                    <h:outputText value="Net Purchase Value"/>
+                                                    <br/>
+                                                    <h:outputText value="Net Cost Value"/>
+                                                    <br/>
+                                                    <h:outputText value="Net Sale Value"/>
+                                                </f:facet>
+                                            </p:column>
+
+                                            <!-- Bill Type -->
+                                            <p:column>
+                                                <h:outputText value="#{b.billTypeAtomic}"/>
+                                            </p:column>
+
+                                            <!-- Invoice No -->
+                                            <p:column>
+                                                <h:outputText value="#{b.invoiceNumber}"/>
+                                                <h:outputText value="#{b.referenceBill.invoiceNumber}"/>
+                                            </p:column>
+
+                                            <!-- Created Date -->
+                                            <p:column>
+                                                <h:outputText value="#{b.createdAt}">
+                                                    <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateTimeFormat}"/>
+                                                </h:outputText>
+                                                <f:facet name="footer">
+                                                    <h:outputText value="#{pharmacyController.totalPurchase}">
+                                                        <f:convertNumber pattern="#,##0.00"/>
+                                                    </h:outputText>
+                                                    <br/>
+                                                    <h:outputText value="#{pharmacyController.totalCostValue}">
+                                                        <f:convertNumber pattern="#,##0.00"/>
+                                                    </h:outputText>
+                                                    <br/>
+                                                    <h:outputText value="#{pharmacyController.totalSaleValue}">
+                                                        <f:convertNumber pattern="#,##0.00"/>
+                                                    </h:outputText>
+                                                </f:facet>
+                                            </p:column>
+
+                                            <!-- Approved Date -->
+                                            <p:column>
+                                                <h:outputText value="#{b.referenceBill.createdAt}">
+                                                    <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateTimeFormat}"/>
+                                                </h:outputText>
+                                            </p:column>
+
+                                            <!-- Supplier -->
+                                            <p:column>
+                                                <h:outputText value="#{b.fromInstitution.name ne null ? b.fromInstitution.name : b.toInstitution.name}"/>
+                                            </p:column>
+
+                                            <!-- Institution -->
+                                            <p:column>
+                                                <h:outputText value="#{b.institution.name}"/>
+                                            </p:column>
+
+                                            <!-- Site -->
+                                            <p:column>
+                                                <h:outputText value="#{b.department.site.name}"/>
+                                            </p:column>
+
+                                            <!-- Department -->
+                                            <p:column>
+                                                <h:outputText value="#{b.department.name}"/>
+                                            </p:column>
+
+                                            <!-- PO No -->
+                                            <p:column>
+                                                <h:outputText value="#{(b.billTypeAtomic eq 'PHARMACY_GRN_RETURN' or b.billTypeAtomic eq 'PHARMACY_DIRECT_PURCHASE_REFUND')
+                                                                       ? (b.referenceBill.referenceBill ne null ? b.referenceBill.referenceBill.deptId : '')
+                                                                       : (b.referenceBill ne null ? b.referenceBill.deptId : '')}"/>
+                                            </p:column>
+
+                                            <!-- Purchase Value Cash -->
+                                            <p:column style="text-align: right;">
+                                                <h:outputLabel
+                                                    value="#{b.billFinanceDetails.totalPurchaseValue}"
+                                                    rendered="#{b.paymentMethod ne 'Credit'}">
+                                                    <f:convertNumber pattern="#,##0.00"/>
+                                                </h:outputLabel>
+                                                <f:facet name="footer">
+                                                    <h:outputText value="#{pharmacyController.totalCashPurchaseValue}">
+                                                        <f:convertNumber pattern="#,##0.00"/>
+                                                    </h:outputText>
+                                                </f:facet>
+                                            </p:column>
+
+                                            <!-- Purchase Value Credit -->
+                                            <p:column style="text-align: right;">
+                                                <h:outputLabel
+                                                    value="#{b.billFinanceDetails.totalPurchaseValue}"
+                                                    rendered="#{b.paymentMethod eq 'Credit'}">
+                                                    <f:convertNumber pattern="#,##0.00"/>
+                                                </h:outputLabel>
+                                                <f:facet name="footer">
+                                                    <h:outputText value="#{pharmacyController.totalCreditPurchaseValue}">
+                                                        <f:convertNumber pattern="#,##0.00"/>
+                                                    </h:outputText>
+                                                </f:facet>
+                                            </p:column>
+
+                                            <!-- Cost Value Cash -->
+                                            <p:column style="text-align: right;">
+                                                <h:outputLabel
+                                                    value="#{b.billFinanceDetails.totalCostValue}"
+                                                    rendered="#{b.paymentMethod ne 'Credit'}">
+                                                    <f:convertNumber pattern="#,##0.00"/>
+                                                </h:outputLabel>
+                                                <f:facet name="footer">
+                                                    <h:outputText value="#{pharmacyController.totalCashCostValue}">
+                                                        <f:convertNumber pattern="#,##0.00"/>
+                                                    </h:outputText>
+                                                </f:facet>
+                                            </p:column>
+
+                                            <!-- Cost Value Credit -->
+                                            <p:column style="text-align: right;">
+                                                <h:outputLabel
+                                                    value="#{b.billFinanceDetails.totalCostValue}"
+                                                    rendered="#{b.paymentMethod eq 'Credit'}">
+                                                    <f:convertNumber pattern="#,##0.00"/>
+                                                </h:outputLabel>
+                                                <f:facet name="footer">
+                                                    <h:outputText value="#{pharmacyController.totalCreditCostValue}">
+                                                        <f:convertNumber pattern="#,##0.00"/>
+                                                    </h:outputText>
+                                                </f:facet>
+                                            </p:column>
+
+                                            <!-- Sale Value Cash -->
+                                            <p:column style="text-align: right;">
+                                                <h:outputLabel
+                                                    value="#{b.billFinanceDetails.totalRetailSaleValue}"
+                                                    rendered="#{b.paymentMethod ne 'Credit'}">
+                                                    <f:convertNumber pattern="#,##0.00"/>
+                                                </h:outputLabel>
+                                                <f:facet name="footer">
+                                                    <h:outputText value="#{pharmacyController.totalCashSaleValue}">
+                                                        <f:convertNumber pattern="#,##0.00"/>
+                                                    </h:outputText>
+                                                </f:facet>
+                                            </p:column>
+
+                                            <!-- Sale Value Credit -->
+                                            <p:column style="text-align: right;">
+                                                <h:outputLabel
+                                                    value="#{b.billFinanceDetails.totalRetailSaleValue}"
+                                                    rendered="#{b.paymentMethod eq 'Credit'}">
+                                                    <f:convertNumber pattern="#,##0.00"/>
+                                                </h:outputLabel>
+                                                <f:facet name="footer">
+                                                    <h:outputText value="#{pharmacyController.totalCreditSaleValue}">
+                                                        <f:convertNumber pattern="#,##0.00"/>
+                                                    </h:outputText>
+                                                </f:facet>
+                                            </p:column>
+
+                                            <!-- Net Total -->
+                                            <p:column style="text-align: right;">
+                                                <h:outputLabel value="#{b.netTotal}">
+                                                    <f:convertNumber pattern="#,##0.00"/>
+                                                </h:outputLabel>
+                                                <f:facet name="footer">
+                                                    <h:outputText value="#{pharmacyController.totalNetTotal}">
+                                                        <f:convertNumber pattern="#,##0.00"/>
+                                                    </h:outputText>
+                                                </f:facet>
+                                            </p:column>
+
+                                            <!-- Remark -->
+                                            <p:column>
+                                                <h:outputLabel value="#{b.comments}"/>
+                                            </p:column>
+
+                                        </p:dataTable>
+                                    
+                                
+
+                                <!-- Bill Items Sub-Table per Bill -->
+                                <ui:repeat value="#{pharmacyController.bills}" var="b">
+                                    <div style="margin-top:4pt; font-size:6pt; font-weight:bold;">
+                                        <h:outputText value="Bill No: #{b.deptId} — Item Details"/>
+                                    </div>
+                                    <p:dataTable
+                                        value="#{b.billItems}"
+                                        var="bi"
+                                        rowKey="#{bi.id}"
+                                        styleClass="nested-table">
+                                        <p:column headerText="Item Name"      style="width:20%;">
+                                            <h:outputText value="#{bi.item.name}"/>
+                                        </p:column>
+                                        <p:column headerText="Qty"            style="width:6%; text-align:right;">
+                                            <h:outputText value="#{bi.billItemFinanceDetails.quantity}">
+                                                <f:convertNumber pattern="#,##0.00"/>
+                                            </h:outputText>
+                                        </p:column>
+                                        <p:column headerText="Free Qty"       style="width:6%; text-align:right;">
+                                            <h:outputText value="#{bi.billItemFinanceDetails.freeQuantity}">
+                                                <f:convertNumber pattern="#,##0.00"/>
+                                            </h:outputText>
+                                        </p:column>
+                                        <p:column headerText="Purchase Rate"  style="width:8%; text-align:right;">
+                                            <h:outputText value="#{bi.billItemFinanceDetails.lineGrossRate}">
+                                                <f:convertNumber pattern="#,##0.00"/>
+                                            </h:outputText>
+                                        </p:column>
+                                        <p:column headerText="Discount Rate"  style="width:8%; text-align:right;">
+                                            <h:outputText value="#{bi.billItemFinanceDetails.lineDiscountRate}">
+                                                <f:convertNumber pattern="#,##0.00"/>
+                                            </h:outputText>
+                                        </p:column>
+                                        <p:column headerText="Cost Rate"      style="width:8%; text-align:right;">
+                                            <h:outputText value="#{bi.billItemFinanceDetails.costRate}">
+                                                <f:convertNumber pattern="#,##0.00"/>
+                                            </h:outputText>
+                                        </p:column>
+                                        <p:column headerText="Item MRP"       style="width:8%; text-align:right;">
+                                            <h:outputText value="#{bi.pharmaceuticalBillItem.retailRate}">
+                                                <f:convertNumber pattern="#,##0.00"/>
+                                            </h:outputText>
+                                        </p:column>
+                                        <p:column headerText="Batch Code"     style="width:10%;">
+                                            <h:outputText value="#{bi.pharmaceuticalBillItem.itemBatch.batchNo}"/>
+                                        </p:column>
+<!--                                        <p:column headerText="Expiry Date"    style="width:10%;">
+                                            <h:outputText value="#{bi.pharmaceuticalBillItem.itemBatch.expiryDate}">
+                                                <f:convertDateTime pattern="#{sessionController.applicationPreference.shortDateFormat}"/>
+                                            </h:outputText>
+                                        </p:column>-->
+                                        <p:column headerText="UOM"            style="width:6%;">
+                                            <h:outputText value="#{bi.item.measurementUnit.name}"/>
+                                        </p:column>
+                                    </p:dataTable>
+                                </ui:repeat>
+                                 </div>
+                                 </div>
+
+                            </div>
+                        </h:panelGroup>
+                    </h:panelGroup>
+
+                    <!-- ═══════════════════════════════════════════════════════════ -->
+                    <!--  2. RETURN REPORT                                          -->
+                    <!-- ═══════════════════════════════════════════════════════════ -->
+                    <h:panelGroup rendered="#{pharmacyController.reportType eq 'returnReport'}">
+                        <p:panel styleClass="my-2">
+                            <f:facet name="header">
+                                <div class="d-flex justify-content-between">
+                                    <h:outputText value="GRN Return Report" class="mt-2"/>
+                                    <div class="d-flex gap-2">
+                                        <p:commandButton
+                                            icon="fa-solid fa-print"
+                                            class="ui-button-info"
+                                            style="width: 150px"
+                                            ajax="false"
+                                            value="Print">
+                                            <p:printer target="returnRp"/>
+                                        </p:commandButton>
+                                        <p:commandButton
+                                            ajax="false"
+                                            value="Back to Report"
+                                            style="width: 200px"
+                                            icon="fa fa-arrow-left"
+                                            class="ui-button-warning"
+                                            action="/reports/inventoryReports/grn_report?faces-redirect=true">
+                                        </p:commandButton>
+                                    </div>
+                                </div>
+                            </f:facet>
+                        </p:panel>
+
+                        <h:panelGroup id="returnRp" class="d-flex justify-content-center">
+                            <div class="paper">
+                                <div class="header">
+                                    <div class="d-flex justify-content-center" style="font-weight: 700; font-size: 18px;">
+                                        <h:outputText value="#{sessionController.institution.name}"/>
+                                    </div>
+                                    <div class="d-flex justify-content-center" style="font-weight: 700; font-size: 16px;">
+                                        <h:outputText value="GRN Report (Return)"/>
+                                    </div>
+                                    <div class="d-flex justify-content-center m-3">
+                                        <h:panelGrid columns="6" styleClass="report-header-table"
+                                                     style="font-size:10px; width:80%;"
+                                                     columnClasses="label,value,label,value,label,value">
+
+                                            <!-- Row 1 -->
+                                            <h:outputText value="From Date:" styleClass="label"/>
+                                            <h:outputText value="#{pharmacyController.fromDate}">
+                                                <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateTimeFormat}"/>
+                                            </h:outputText>
+
+                                            <h:outputText value="To Date:" styleClass="label"/>
+                                            <h:outputText value="#{pharmacyController.toDate}">
+                                                <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateTimeFormat}"/>
+                                            </h:outputText>
+
+                                            <h:outputText value="Report Type:" styleClass="label"/>
+                                            <h:outputText value="Return"/>
+
+                                            <!-- Row 2 -->
+                                            <h:outputText value="Institution:" styleClass="label"/>
+                                            <h:outputText value="#{pharmacyController.institution != null ? pharmacyController.institution.name : 'All'}"/>
+
+                                            <h:outputText value="Site:" styleClass="label"/>
+                                            <h:outputText value="#{pharmacyController.site != null ? pharmacyController.site.name : 'All'}"/>
+
+                                            <h:outputText value="Department:" styleClass="label"/>
+                                            <h:outputText value="#{pharmacyController.dept != null ? pharmacyController.dept.name : 'All'}"/>
+
+                                            <!-- Row 3 -->
+                                            <h:outputText value="Department Type:" styleClass="label"/>
+                                            <h:outputText value="#{pharmacyController.getSelectedDepartmentTypesString()}"/>
+
+                                            <h:outputText value="Payment Mode:" styleClass="label"/>
+                                            <h:outputText value="#{pharmacyController.paymentMethod != null ? pharmacyController.paymentMethod : 'All'}"/>
+
+                                            <h:outputText value="Supplier:" styleClass="label"/>
+                                            <h:outputText value="#{pharmacyController.fromInstitution != null ? pharmacyController.fromInstitution.name : 'All'}"/>
+
+                                        </h:panelGrid>
+                                    </div>
+                                </div>
+
+                                <!-- Return Data Table -->
+                                <div class="d-flex justify-content-center">
+                                    <div style="width:99%;">
+                                         <p:dataTable
+                                            id="printReturnTbl"
+                                            value="#{pharmacyController.bills}"
+                                            var="r"
+                                            rowIndexVar="n"
+                                            styleClass="table-detail">
+
+                                            <p:columnGroup type="header">
+                                                <p:row>
+                                                    <p:column headerText="Purchase Return No"    style="width:7%;"/>
+                                                    <p:column headerText="GRN No"               style="width:6%;"/>
+                                                    <p:column headerText="GRN Invoice No"       style="width:6%;"/>
+                                                    <p:column headerText="GRN Date"             style="width:9%;"/>
+                                                    <p:column headerText="Reference Institution" style="width:9%;"/>
+                                                    <p:column headerText="Created At"           style="width:9%;"/>
+                                                    <p:column headerText="Approved At"          style="width:9%;"/>
+                                                    <p:column headerText="Supplier"             style="width:8%;"/>
+                                                    <p:column headerText="Purchase Value"       style="width:7%;"/>
+                                                    <p:column headerText="Cost Value"           style="width:7%;"/>
+                                                    <p:column headerText="Sale Value"           style="width:7%;"/>
+                                                </p:row>
+                                            </p:columnGroup>
+
+                                            <!-- Purchase Return No -->
+                                            <p:column>
+                                                <h:outputText value="#{r.deptId}"/>
+                                                <f:facet name="footer">
+                                                    <h:outputText value="Total"/>
+                                                </f:facet>
+                                            </p:column>
+
+                                            <!-- GRN No -->
+                                            <p:column>
+                                                <h:outputText value="#{r.referenceBill.deptId}"/>
+                                            </p:column>
+
+                                            <!-- GRN Invoice No -->
+                                            <p:column style="text-align: right;">
+                                                <h:outputText value="#{r.referenceBill.invoiceNumber}"/>
+                                            </p:column>
+
+                                            <!-- GRN Date -->
+                                            <p:column>
+                                                <h:outputText value="#{r.referenceBill.createdAt}">
+                                                    <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateTimeFormat}"/>
+                                                </h:outputText>
+                                            </p:column>
+
+                                            <!-- Reference Institution -->
+                                            <p:column>
+                                                <h:outputText value="#{r.referenceBill.referenceInstitution.name}"/>
+                                            </p:column>
+
+                                            <!-- Created At -->
+                                            <p:column>
+                                                <h:outputText value="#{r.createdAt}">
+                                                    <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateTimeFormat}"/>
+                                                </h:outputText>
+                                            </p:column>
+
+                                            <!-- Approved At -->
+                                            <p:column>
+                                                <h:outputText value="#{r.referenceBill.createdAt}">
+                                                    <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateTimeFormat}"/>
+                                                </h:outputText>
+                                            </p:column>
+
+                                            <!-- Supplier -->
+                                            <p:column>
+                                                <h:outputText value="#{r.toInstitution.name}"/>
+                                            </p:column>
+
+                                            <!-- Purchase Value -->
+                                            <p:column style="text-align: right;">
+                                                <h:outputText value="#{r.billFinanceDetails.totalPurchaseValue}">
+                                                    <f:convertNumber pattern="#,##0.00"/>
+                                                </h:outputText>
+                                                <f:facet name="footer">
+                                                    <h:outputText value="#{pharmacyController.totalPurchase}">
+                                                        <f:convertNumber pattern="#,##0.00"/>
+                                                    </h:outputText>
+                                                </f:facet>
+                                            </p:column>
+
+                                            <!-- Cost Value -->
+                                            <p:column style="text-align: right;">
+                                                <h:outputText value="#{r.billFinanceDetails.totalCostValue}">
+                                                    <f:convertNumber pattern="#,##0.00"/>
+                                                </h:outputText>
+                                                <f:facet name="footer">
+                                                    <h:outputText value="#{pharmacyController.totalCostValue}">
+                                                        <f:convertNumber pattern="#,##0.00"/>
+                                                    </h:outputText>
+                                                </f:facet>
+                                            </p:column>
+
+                                            <!-- Sale Value -->
+                                            <p:column style="text-align: right;">
+                                                <h:outputText value="#{r.billFinanceDetails.totalRetailSaleValue}">
+                                                    <f:convertNumber pattern="#,##0.00"/>
+                                                </h:outputText>
+                                                <f:facet name="footer">
+                                                    <h:outputText value="#{pharmacyController.totalSaleValue}">
+                                                        <f:convertNumber pattern="#,##0.00"/>
+                                                    </h:outputText>
+                                                </f:facet>
+                                            </p:column>
+
+                                        </p:dataTable>
+
+                                        <!-- Return Bill Items Sub-Table per Bill -->
+                                        <ui:repeat value="#{pharmacyController.bills}" var="r">
+                                            <div style="margin-top:4pt; font-size:6pt; font-weight:bold;">
+                                                <h:outputText value="Return No: #{r.deptId} — Item Details"/>
+                                            </div>
+                                            <p:dataTable
+                                                value="#{r.billItems}"
+                                                var="bi"
+                                                rowKey="#{bi.id}"
+                                                styleClass="nested-table">
+                                                <p:column headerText="Item Name"      style="width:22%;"/>
+                                                <p:column headerText="Qty"            style="width:6%; text-align:right;">
+                                                    <h:outputText value="#{bi.pharmaceuticalBillItem.qty}"/>
+                                                </p:column>
+                                                <p:column headerText="Free Qty"       style="width:6%; text-align:right;">
+                                                    <h:outputText value="#{bi.pharmaceuticalBillItem.freeQty}"/>
+                                                </p:column>
+                                                <p:column headerText="Purchase Rate"  style="width:9%; text-align:right;">
+                                                    <h:outputText value="#{bi.pharmaceuticalBillItem.purchaseRate}">
+                                                        <f:convertNumber pattern="#,##0.00"/>
+                                                    </h:outputText>
+                                                </p:column>
+                                                <p:column headerText="Cost Rate"      style="width:9%; text-align:right;">
+                                                    <h:outputText value="#{bi.billItemFinanceDetails.lineCostRate}">
+                                                        <f:convertNumber pattern="#,##0.00"/>
+                                                    </h:outputText>
+                                                </p:column>
+                                                <p:column headerText="Discount Rate"  style="width:9%; text-align:right;">
+                                                    <h:outputText value="#{bi.billItemFinanceDetails.lineDiscountRate ne null ?
+                                                                            bi.billItemFinanceDetails.lineDiscountRate :
+                                                                            bi.referanceBillItem.billItemFinanceDetails.lineDiscountRate}">
+                                                        <f:convertNumber pattern="#,##0.00"/>
+                                                    </h:outputText>
+                                                </p:column>
+                                                <p:column headerText="Item MRP"       style="width:9%; text-align:right;">
+                                                    <h:outputText value="#{bi.pharmaceuticalBillItem.retailRate}">
+                                                        <f:convertNumber pattern="#,##0.00"/>
+                                                    </h:outputText>
+                                                </p:column>
+                                                <p:column headerText="Batch Code"     style="width:12%;">
+                                                    <h:outputText value="#{bi.pharmaceuticalBillItem.itemBatch.batchNo}"/>
+                                                </p:column>
+                                                <p:column headerText="UOM"            style="width:8%;">
+                                                    <h:outputText value="#{bi.item.measurementUnit.name}"/>
+                                                </p:column>
+                                            </p:dataTable>
+                                        </ui:repeat>
+                                    </div>
+                                </div>
+                               
+
+                            </div>
+                        </h:panelGroup>
+                    </h:panelGroup>
+
+                    <!-- ═══════════════════════════════════════════════════════════ -->
+                    <!--  3. SUMMARY REPORT                                         -->
+                    <!-- ═══════════════════════════════════════════════════════════ -->
+                    <h:panelGroup rendered="#{pharmacyController.reportType eq 'summeryReport'}">
+                        <p:panel styleClass="my-2">
+                            <f:facet name="header">
+                                <div class="d-flex justify-content-between">
+                                    <h:outputText value="GRN Summary Report" class="mt-2"/>
+                                    <div class="d-flex gap-2">
+                                        <p:commandButton
+                                            icon="fa-solid fa-print"
+                                            class="ui-button-info"
+                                            style="width: 150px"
+                                            ajax="false"
+                                            value="Print">
+                                            <p:printer target="summaryRp"/>
+                                        </p:commandButton>
+                                        <p:commandButton
+                                            ajax="false"
+                                            value="Back to Report"
+                                            style="width: 200px"
+                                            icon="fa fa-arrow-left"
+                                            class="ui-button-warning"
+                                            action="/reports/inventoryReports/grn_report?faces-redirect=true">
+                                        </p:commandButton>
+                                    </div>
+                                </div>
+                            </f:facet>
+                        </p:panel>
+
+                        <h:panelGroup id="summaryRp" class="d-flex justify-content-center">
+                            <div class="paper">
+                                <div class="header">
+                                    <div class="d-flex justify-content-center" style="font-weight: 700; font-size: 18px;">
+                                        <h:outputText value="#{sessionController.institution.name}"/>
+                                    </div>
+                                    <div class="d-flex justify-content-center" style="font-weight: 700; font-size: 16px;">
+                                        <h:outputText value="GRN Report (Summary)"/>
+                                    </div>
+                                    <div class="d-flex justify-content-center m-3">
+                                        <h:panelGrid columns="6" styleClass="report-header-table"
+                                                     style="font-size:10px; width:80%;"
+                                                     columnClasses="label,value,label,value,label,value">
+
+                                            <!-- Row 1 -->
+                                            <h:outputText value="From Date:" styleClass="label"/>
+                                            <h:outputText value="#{pharmacyController.fromDate}">
+                                                <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateTimeFormat}"/>
+                                            </h:outputText>
+
+                                            <h:outputText value="To Date:" styleClass="label"/>
+                                            <h:outputText value="#{pharmacyController.toDate}">
+                                                <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateTimeFormat}"/>
+                                            </h:outputText>
+
+                                            <h:outputText value="Report Type:" styleClass="label"/>
+                                            <h:outputText value="Summary"/>
+
+                                            <!-- Row 2 -->
+                                            <h:outputText value="Institution:" styleClass="label"/>
+                                            <h:outputText value="#{pharmacyController.institution != null ? pharmacyController.institution.name : 'All'}"/>
+
+                                            <h:outputText value="Site:" styleClass="label"/>
+                                            <h:outputText value="#{pharmacyController.site != null ? pharmacyController.site.name : 'All'}"/>
+
+                                            <h:outputText value="Department:" styleClass="label"/>
+                                            <h:outputText value="#{pharmacyController.dept != null ? pharmacyController.dept.name : 'All'}"/>
+
+                                            <!-- Row 3 -->
+                                            <h:outputText value="Department Type:" styleClass="label"/>
+                                            <h:outputText value="#{pharmacyController.getSelectedDepartmentTypesString()}"/>
+
+                                            <h:outputText value="Payment Mode:" styleClass="label"/>
+                                            <h:outputText value="#{pharmacyController.paymentMethod != null ? pharmacyController.paymentMethod : 'All'}"/>
+
+                                            <h:outputText value="Supplier:" styleClass="label"/>
+                                            <h:outputText value="#{pharmacyController.fromInstitution != null ? pharmacyController.fromInstitution.name : 'All'}"/>
+
+                                        </h:panelGrid>
+                                    </div>
+                                </div>
+
+                                <!-- Summary Data Table -->
+                                <div class="d-flex justify-content-center">
+                                    <div style="width:99%;">
+                                        <p:dataTable
+                                    id="printSummaryTbl"
+                                    value="#{pharmacyController.data}"
+                                    var="s"
+                                    rowIndexVar="n"
+                                    style="width: 100%"
+                                    styleClass="table-summary">
+
+                                    <p:column width="12em">
+                                        <h:outputLabel value="#{s.string}"/>
+                                    </p:column>
+
+                                    <p:column style="font-weight: bold; text-align: right;">
+                                        <f:facet name="header">
+                                            <h:outputLabel value="Purchase Value"/>
+                                        </f:facet>
+                                        <h:outputLabel value="#{s.value}">
+                                            <f:convertNumber pattern="#,##0.00"/>
+                                        </h:outputLabel>
+                                    </p:column>
+
+                                    <p:column style="font-weight: bold; text-align: right;">
+                                        <f:facet name="header">
+                                            <h:outputLabel value="Sale Value"/>
+                                        </f:facet>
+                                        <h:outputLabel value="#{s.value2}">
+                                            <f:convertNumber pattern="#,##0.00"/>
+                                        </h:outputLabel>
+                                    </p:column>
+
+                                    <p:column style="font-weight: bold; text-align: right;">
+                                        <f:facet name="header">
+                                            <h:outputLabel value="Cost Value"/>
+                                        </f:facet>
+                                        <h:outputLabel value="#{s.value3}">
+                                            <f:convertNumber pattern="#,##0.00"/>
+                                        </h:outputLabel>
+                                    </p:column>
+
+                                    <p:column style="font-weight: bold; text-align: right;">
+                                        <f:facet name="header">
+                                            <h:outputLabel value="Net Total"/>
+                                        </f:facet>
+                                        <h:outputLabel value="#{s.value4}">
+                                            <f:convertNumber pattern="#,##0.00"/>
+                                        </h:outputLabel>
+                                    </p:column>
+
+                                </p:dataTable>
+                                    </div>
+                                </div>
+                                
+
+                            </div>
+                        </h:panelGroup>
+                    </h:panelGroup>
+
+                    <!-- ═══════════════════════════════════════════════════════════ -->
+                    <!--  4. CANCELLATION REPORT                                    -->
+                    <!-- ═══════════════════════════════════════════════════════════ -->
+                    <h:panelGroup rendered="#{pharmacyController.reportType eq 'cancellationReport'}">
+                        <p:panel styleClass="my-2">
+                            <f:facet name="header">
+                                <div class="d-flex justify-content-between">
+                                    <h:outputText value="GRN Cancellation Report" class="mt-2"/>
+                                    <div class="d-flex gap-2">
+                                        <p:commandButton
+                                            icon="fa-solid fa-print"
+                                            class="ui-button-info"
+                                            style="width: 150px"
+                                            ajax="false"
+                                            value="Print">
+                                            <p:printer target="cancellationRp"/>
+                                        </p:commandButton>
+                                        <p:commandButton
+                                            ajax="false"
+                                            value="Back to Report"
+                                            style="width: 200px"
+                                            icon="fa fa-arrow-left"
+                                            class="ui-button-warning"
+                                            action="/reports/inventoryReports/grn_report?faces-redirect=true">
+                                        </p:commandButton>
+                                    </div>
+                                </div>
+                            </f:facet>
+                        </p:panel>
+
+                        <h:panelGroup id="cancellationRp" class="d-flex justify-content-center">
+                            <div class="paper">
+                                <div class="header">
+                                    <div class="d-flex justify-content-center" style="font-weight: 700; font-size: 18px;">
+                                        <h:outputText value="#{sessionController.institution.name}"/>
+                                    </div>
+                                    <div class="d-flex justify-content-center" style="font-weight: 700; font-size: 16px;">
+                                        <h:outputText value="GRN Report (Cancellation)"/>
+                                    </div>
+                                    <div class="d-flex justify-content-center m-3">
+                                        <h:panelGrid columns="6" styleClass="report-header-table"
+                                                     style="font-size:10px; width:80%;"
+                                                     columnClasses="label,value,label,value,label,value">
+
+                                            <!-- Row 1 -->
+                                            <h:outputText value="From Date:" styleClass="label"/>
+                                            <h:outputText value="#{pharmacyController.fromDate}">
+                                                <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateTimeFormat}"/>
+                                            </h:outputText>
+
+                                            <h:outputText value="To Date:" styleClass="label"/>
+                                            <h:outputText value="#{pharmacyController.toDate}">
+                                                <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateTimeFormat}"/>
+                                            </h:outputText>
+
+                                            <h:outputText value="Report Type:" styleClass="label"/>
+                                            <h:outputText value="Cancellation"/>
+
+                                            <!-- Row 2 -->
+                                            <h:outputText value="Institution:" styleClass="label"/>
+                                            <h:outputText value="#{pharmacyController.institution != null ? pharmacyController.institution.name : 'All'}"/>
+
+                                            <h:outputText value="Site:" styleClass="label"/>
+                                            <h:outputText value="#{pharmacyController.site != null ? pharmacyController.site.name : 'All'}"/>
+
+                                            <h:outputText value="Department:" styleClass="label"/>
+                                            <h:outputText value="#{pharmacyController.dept != null ? pharmacyController.dept.name : 'All'}"/>
+
+                                            <!-- Row 3 -->
+                                            <h:outputText value="Department Type:" styleClass="label"/>
+                                            <h:outputText value="#{pharmacyController.getSelectedDepartmentTypesString()}"/>
+
+                                            <h:outputText value="Payment Mode:" styleClass="label"/>
+                                            <h:outputText value="#{pharmacyController.paymentMethod != null ? pharmacyController.paymentMethod : 'All'}"/>
+
+                                            <h:outputText value="Supplier:" styleClass="label"/>
+                                            <h:outputText value="#{pharmacyController.fromInstitution != null ? pharmacyController.fromInstitution.name : 'All'}"/>
+
+                                        </h:panelGrid>
+                                    </div>
+                                </div>
+
+                                <!-- Cancellation Data Table (with inline item sub-table) -->
+                                <div class="d-flex justify-content-center">
+                                    <div style="width:99%;">
+                                        <p:dataTable
+                                            id="printCancellationTbl"
+                                            value="#{pharmacyController.bills}"
+                                            var="cb"
+                                            rowIndexVar="n"
+                                            styleClass="table-detail">
+
+                                            <p:columnGroup type="header">
+                                                <p:row>
+                                                    <p:column headerText="GRN Cancelled No"    style="width:7%;"/>
+                                                    <p:column headerText="GRN No"             style="width:6%;"/>
+                                                    <p:column headerText="GRN Invoice No"     style="width:6%;"/>
+                                                    <p:column headerText="GRN Date"           style="width:9%;"/>
+                                                    <p:column headerText="Reference Institution" style="width:9%;"/>
+                                                    <p:column headerText="Created At"         style="width:9%;"/>
+                                                    <p:column headerText="Approved At"        style="width:9%;"/>
+                                                    <p:column headerText="Supplier"           style="width:8%;"/>
+                                                    <p:column headerText="Purchase Value"     style="width:7%;"/>
+                                                    <p:column headerText="Cost Value"         style="width:7%;"/>
+                                                    <p:column headerText="Sale Value"         style="width:7%;"/>
+                                                </p:row>
+                                            </p:columnGroup>
+
+                                            <!-- GRN Cancelled No -->
+                                            <p:column>
+                                                <h:outputText value="#{cb.deptId}"/>
+                                                <f:facet name="footer">
+                                                    <h:outputText value="Total"/>
+                                                </f:facet>
+                                            </p:column>
+
+                                            <!-- GRN No -->
+                                            <p:column>
+                                                <h:outputText value="#{cb.referenceBill.deptId}"/>
+                                            </p:column>
+
+                                            <!-- GRN Invoice No -->
+                                            <p:column style="text-align: right;">
+                                                <h:outputText value="#{cb.invoiceNumber}"/>
+                                            </p:column>
+
+                                            <!-- GRN Date -->
+                                            <p:column>
+                                                <h:outputText value="#{cb.referenceBill.createdAt}">
+                                                    <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateTimeFormat}"/>
+                                                </h:outputText>
+                                            </p:column>
+
+                                            <!-- Reference Institution -->
+                                            <p:column>
+                                                <h:outputText value="#{cb.referenceInstitution.name}"/>
+                                            </p:column>
+
+                                            <!-- Created At -->
+                                            <p:column>
+                                                <h:outputText value="#{cb.createdAt}">
+                                                    <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateTimeFormat}"/>
+                                                </h:outputText>
+                                            </p:column>
+
+                                            <!-- Approved At -->
+                                            <p:column>
+                                                <h:outputText value="#{cb.referenceBill.createdAt}">
+                                                    <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateTimeFormat}"/>
+                                                </h:outputText>
+                                            </p:column>
+
+                                            <!-- Supplier -->
+                                            <p:column>
+                                                <h:outputText value="#{cb.fromInstitution.name}"/>
+                                            </p:column>
+
+                                            <!-- Purchase Value -->
+                                            <p:column style="text-align: right;">
+                                                <h:outputText value="#{cb.billFinanceDetails.lineNetTotal gt 0
+                                                                       ? -1 * cb.billFinanceDetails.lineNetTotal
+                                                                       : cb.billFinanceDetails.lineNetTotal}">
+                                                    <f:convertNumber pattern="#,##0.00"/>
+                                                </h:outputText>
+                                                <f:facet name="footer">
+                                                    <h:outputText value="#{pharmacyController.totalPurchase}">
+                                                        <f:convertNumber pattern="#,##0.00"/>
+                                                    </h:outputText>
+                                                </f:facet>
+                                            </p:column>
+
+                                            <!-- Cost Value -->
+                                            <p:column style="text-align: right;">
+                                                <h:outputText value="#{cb.billFinanceDetails.totalCostValue gt 0
+                                                                       ? -1 * cb.billFinanceDetails.totalCostValue
+                                                                       : cb.billFinanceDetails.totalCostValue}">
+                                                    <f:convertNumber pattern="#,##0.00"/>
+                                                </h:outputText>
+                                                <f:facet name="footer">
+                                                    <h:outputText value="#{pharmacyController.totalCostValue}">
+                                                        <f:convertNumber pattern="#,##0.00"/>
+                                                    </h:outputText>
+                                                </f:facet>
+                                            </p:column>
+
+                                            <!-- Sale Value -->
+                                            <p:column style="text-align: right;">
+                                                <h:outputText value="#{cb.billFinanceDetails.totalRetailSaleValue gt 0
+                                                                       ? -1 * cb.billFinanceDetails.totalRetailSaleValue
+                                                                       : cb.billFinanceDetails.totalRetailSaleValue}">
+                                                    <f:convertNumber pattern="#,##0.00"/>
+                                                </h:outputText>
+                                                <f:facet name="footer">
+                                                    <h:outputText value="#{pharmacyController.totalSaleValue}">
+                                                        <f:convertNumber pattern="#,##0.00"/>
+                                                    </h:outputText>
+                                                </f:facet>
+                                            </p:column>
+
+                                        </p:dataTable>
+
+                                        <!-- Cancellation Bill Items Sub-Table per Bill -->
+                                        <ui:repeat value="#{pharmacyController.bills}" var="cb">
+                                            <div style="margin-top:4pt; font-size:6pt; font-weight:bold;">
+                                                <h:outputText value="Cancelled GRN No: #{cb.deptId} — Item Details"/>
+                                            </div>
+                                            <p:dataTable
+                                                value="#{cb.billItems}"
+                                                var="cbi"
+                                                rowKey="#{cbi.id}"
+                                                styleClass="nested-table">
+                                                <p:column headerText="Item Name"      style="width:22%;"/>
+                                                <p:column headerText="Qty"            style="width:6%; text-align:right;">
+                                                    <h:outputText value="#{cbi.pharmaceuticalBillItem.qty}"/>
+                                                </p:column>
+                                                <p:column headerText="Free Qty"       style="width:6%; text-align:right;">
+                                                    <h:outputText value="#{cbi.pharmaceuticalBillItem.freeQty}"/>
+                                                </p:column>
+                                                <p:column headerText="Purchase Rate"  style="width:9%; text-align:right;">
+                                                    <h:outputText value="#{cbi.pharmaceuticalBillItem.purchaseRate}">
+                                                        <f:convertNumber pattern="#,##0.00"/>
+                                                    </h:outputText>
+                                                </p:column>
+                                                <p:column headerText="Cost Rate"      style="width:9%; text-align:right;">
+                                                    <h:outputText value="#{cbi.billItemFinanceDetails.lineCostRate}">
+                                                        <f:convertNumber pattern="#,##0.00"/>
+                                                    </h:outputText>
+                                                </p:column>
+                                                <p:column headerText="Discount Rate"  style="width:9%; text-align:right;">
+                                                    <h:outputText value="#{cbi.billItemFinanceDetails.lineDiscountRate ne null ?
+                                                                            cbi.billItemFinanceDetails.lineDiscountRate :
+                                                                            cbi.referanceBillItem.billItemFinanceDetails.lineDiscountRate}">
+                                                        <f:convertNumber pattern="#,##0.00"/>
+                                                    </h:outputText>
+                                                </p:column>
+                                                <p:column headerText="Item MRP"       style="width:9%; text-align:right;">
+                                                    <h:outputText value="#{cbi.pharmaceuticalBillItem.retailRate}">
+                                                        <f:convertNumber pattern="#,##0.00"/>
+                                                    </h:outputText>
+                                                </p:column>
+                                                <p:column headerText="Batch Code"     style="width:12%;">
+                                                    <h:outputText value="#{cbi.pharmaceuticalBillItem.itemBatch.batchNo}"/>
+                                                </p:column>
+                                                <p:column headerText="UOM"            style="width:8%;">
+                                                    <h:outputText value="#{cbi.item.measurementUnit.name}"/>
+                                                </p:column>
+                                            </p:dataTable>
+                                        </ui:repeat>
+                                    </div>
+                                </div>
+                                
+
+                            </div>
+                        </h:panelGroup>
+                    </h:panelGroup>
+
+                </h:form>
+            </ui:define>
+        </ui:composition>
+    </h:body>
+</html>

--- a/src/main/webapp/reports/inventoryReports/grn_report_print.xhtml
+++ b/src/main/webapp/reports/inventoryReports/grn_report_print.xhtml
@@ -659,7 +659,9 @@
                                                 var="bi"
                                                 rowKey="#{bi.id}"
                                                 styleClass="nested-table">
-                                                <p:column headerText="Item Name"      style="width:22%;"/>
+                                                <p:column headerText="Item Name"      style="width:22%;">
+                                                    <h:outputText value="#{bi.item.name}"/>
+                                                </p:column>
                                                 <p:column headerText="Qty"            style="width:6%; text-align:right;">
                                                     <h:outputText value="#{bi.pharmaceuticalBillItem.qty}"/>
                                                 </p:column>
@@ -1057,7 +1059,9 @@
                                                 var="cbi"
                                                 rowKey="#{cbi.id}"
                                                 styleClass="nested-table">
-                                                <p:column headerText="Item Name"      style="width:22%;"/>
+                                                <p:column headerText="Item Name"      style="width:22%;">
+                                                    <h:outputText value="#{cbi.item.name}"/>
+                                                </p:column>
                                                 <p:column headerText="Qty"            style="width:6%; text-align:right;">
                                                     <h:outputText value="#{cbi.pharmaceuticalBillItem.qty}"/>
                                                 </p:column>


### PR DESCRIPTION
I improved PDF, Excel, and Print preview on the inventory Reports -> GRN report.
Changed files
1) PharmacyController.java (create method for generating PDF, Excel)
2) grn_report.xhtml (dataExport changed into generation methods)
3) grn_report_print.xhtml (newly created file for showing print preview)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * GRN Summary Report export added (PDF & Excel) with totals and date-range filenames
  * Unified print view and a single "To Print" action with simplified Excel/PDF export buttons
  * Exports for Detail/Return/Cancellation now include embedded filter metadata and date-range filenames

* **Refactor**
  * Standardized report layout, metadata presentation, and export flows across all GRN report types
<!-- end of auto-generated comment: release notes by coderabbit.ai -->