### PR TITLE
Fix zero stock item report print view

### DIFF
--- a/src/main/webapp/pharmacy/pharmacy_report_department_stock_by_zero_item.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_report_department_stock_by_zero_item.xhtml
@@ -28,12 +28,8 @@
                             <p:commandButton class="ui-button-success mx-2" icon="fas fa-file-excel" value="Download Excel" ajax="false">
                                 <p:dataExporter type="xlsx" target="tbl" fileName="zero_stock_items" />
                             </p:commandButton>
-                            <p:commandButton class="ui-button-info" icon="fas fa-print" value="Print" actionListener="#{reportsStock.prepareForPrint()}"
-                                             oncomplete="$('#frm\\:print').click()" update=":frm:tbl"/>
-                            <p:commandButton id="print" value="Actual print" style="display: none">
-                                <p:ajax event="click" listener="#{reportsStock.prepareForView()}" update=":frm:tbl"/>
-                                <p:printer target=":frm:tbl" />
-                            </p:commandButton>
+                            <p:commandButton class="ui-button-info" icon="fas fa-print" value="Print" ajax="false"
+                                             action="pharmacy_report_department_stock_by_zero_item_print?faces-redirect=true"/>
                         </h:panelGrid>
 
                         <h:panelGroup id="gpBillPreview"  styleClass="noBorder summeryBorder" class="w-100">

--- a/src/main/webapp/pharmacy/pharmacy_report_department_stock_by_zero_item_print.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_report_department_stock_by_zero_item_print.xhtml
@@ -1,0 +1,158 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
+      xmlns:h="http://xmlns.jcp.org/jsf/html"
+      xmlns:p="http://primefaces.org/ui"
+      xmlns:f="http://xmlns.jcp.org/jsf/core">
+
+    <h:body>
+        <ui:composition template="/resources/template/template.xhtml">
+            <ui:define name="content">
+
+                <h:form>
+                    <p:panel styleClass="w-100">
+                        <f:facet name="header">
+                            <div class="d-flex justify-content-between">
+                                <h:outputText value="Zero Stock Item Report - Print View" class="mt-2"/>
+                                <div class="d-flex gap-2">
+                                    <p:commandButton
+                                        icon="fa-solid fa-print"
+                                        class="ui-button-info"
+                                        style="width: 150px"
+                                        ajax="false"
+                                        value="Print">
+                                        <p:printer target="reportView" />
+                                    </p:commandButton>
+                                    <p:commandButton
+                                        ajax="false"
+                                        value="Back to Report"
+                                        style="width: 200px"
+                                        icon="fa fa-arrow-left"
+                                        class="ui-button-warning"
+                                        action="pharmacy_report_department_stock_by_zero_item?faces-redirect=true">
+                                    </p:commandButton>
+                                </div>
+                            </div>
+                        </f:facet>
+
+                        <style>
+                            @media screen {
+                                .paper {
+                                    position: static !important;
+                                    width: 210mm !important;
+                                    zoom: 2.0;
+                                }
+                                table {
+                                    border-collapse: collapse;
+                                    width: 100%;
+                                    font-size: 12px !important;
+                                    margin-top: 1mm !important;
+                                }
+                                th, td {
+                                    border: 1px solid #000;
+                                    padding: 2px 4px !important;
+                                    text-align: left;
+                                }
+                                .header {
+                                    font-size: 16px !important;
+                                }
+                            }
+
+                            @media print {
+                                @page {
+                                    @bottom-right {
+                                        content: "Page " counter(page) " of " counter(pages);
+                                        font-family: Arial, sans-serif;
+                                        font-size: 10pt;
+                                    }
+                                    size: A4 portrait !important;
+                                    margin: 10mm;
+                                }
+                                body {
+                                    counter-reset: page;
+                                }
+                                .paper {
+                                    position: static !important;
+                                    width: 190mm !important;
+                                }
+                                .header {
+                                    line-height: 1.1;
+                                    margin: 0mm !important;
+                                    font-size: 13px !important;
+                                }
+                                table {
+                                    border-collapse: collapse;
+                                    width: 99.9%;
+                                    font-size: 12px !important;
+                                    margin-top: 1mm !important;
+                                }
+                                th, td {
+                                    border: 1px solid #000;
+                                    padding: 2px 4px !important;
+                                    text-align: left;
+                                }
+                            }
+                        </style>
+
+                        <h:panelGroup id="reportView" class="d-flex justify-content-center">
+                            <div class="paper">
+                                <div class="header">
+                                    <div class="d-flex justify-content-center" style="font-weight: 700; font-size: 22px; margin-bottom: 5px;">
+                                        <h:outputText value="#{sessionController.institution.name}"/>
+                                    </div>
+                                    <div class="d-flex justify-content-center" style="font-weight: 400; font-size: 20px; margin-bottom: 5px;">
+                                        <h:outputText value="Zero Stock Item Report"/>
+                                    </div>
+                                    <div class="d-flex justify-content-center" style="font-weight: 600; font-size: 15px; margin-bottom: 5px;">
+                                        <h:outputLabel value="#{reportsStock.department.name}" rendered="#{reportsStock.department ne null}"/>
+                                        <h:outputLabel value="All Departments" rendered="#{reportsStock.department eq null}"/>
+                                    </div>
+                                    <div class="d-flex justify-content-center" style="font-size: 12px; margin-bottom: 5px;">
+                                        <h:outputLabel value="Total Items: #{reportsStock.pharmacyStockRows.size()}"/>
+                                    </div>
+                                </div>
+
+                                <div>
+                                    <table style="width: 100%; border-collapse: collapse;">
+                                        <thead>
+                                            <tr>
+                                                <th style="width: 15mm; text-align: center;">No</th>
+                                                <th style="width: 50mm;">Code</th>
+                                                <th>Item</th>
+                                            </tr>
+                                        </thead>
+                                        <tbody>
+                                            <ui:repeat value="#{reportsStock.pharmacyStockRows}" var="i" varStatus="status">
+                                                <tr>
+                                                    <td style="text-align: center;">
+                                                        <h:outputText value="#{status.index + 1}"/>
+                                                    </td>
+                                                    <td>
+                                                        <h:outputText value="#{i.code}"/>
+                                                    </td>
+                                                    <td>
+                                                        <h:outputText value="#{i.name}"/>
+                                                    </td>
+                                                </tr>
+                                            </ui:repeat>
+                                        </tbody>
+                                        <tfoot>
+                                            <tr>
+                                                <td colspan="3" style="text-align: left; font-weight: 700;">
+                                                    <h:outputText value="Total Items: #{reportsStock.pharmacyStockRows.size()}"/>
+                                                </td>
+                                            </tr>
+                                        </tfoot>
+                                    </table>
+                                </div>
+                            </div>
+                        </h:panelGroup>
+
+                    </p:panel>
+                </h:form>
+            </ui:define>
+        </ui:composition>
+
+    </h:body>
+</html>


### PR DESCRIPTION
## Summary
- Replaced PrimeFaces `p:printer` paginated table print with a dedicated HTML print page for clean, properly formatted printing
- New print page uses plain HTML table with `ui:repeat` for consistent print output

## Test plan
- [ ] Generate zero stock item report for a department
- [ ] Click Print button and verify it navigates to the print page
- [ ] Verify print page shows institution name, report title, and department name
- [ ] Click Print on the print page and verify clean formatting in browser print dialog
- [ ] Click "Back to Report" and verify it returns to the report page with data intact

Closes #19250

🤖 Generated with [Claude Code](https://claude.com/claude-code)