### PR TITLE
Fix silent zero quantity on concurrent pharmacy sale

### DIFF
--- a/src/main/java/com/divudi/bean/pharmacy/PharmacyWholeSaleController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacyWholeSaleController.java
@@ -1199,6 +1199,8 @@ public class PharmacyWholeSaleController implements Serializable, ControllerWith
                 tbi.setTmpQty(0);
                 getPharmaceuticalBillItemFacade().edit(tbi.getPharmaceuticalBillItem());
                 getBillItemFacade().edit(tbi);
+                JsfUtil.addErrorMessage(tbi.getItem().getName()
+                        + " - Could not deduct stock. Quantity set to zero. Another user may have already consumed this stock.");
             }
 
             getPreBill().getBillItems().add(tbi);
@@ -1276,6 +1278,29 @@ public class PharmacyWholeSaleController implements Serializable, ControllerWith
 
     }
 
+    private boolean checkAllBillItemStockAvailability() {
+        boolean hasIssue = false;
+        for (BillItem b : getPreBill().getBillItems()) {
+            if (b.getPharmaceuticalBillItem() == null || b.getPharmaceuticalBillItem().getStock() == null) {
+                continue;
+            }
+            Stock freshStock = getStockFacade().findWithoutCache(b.getPharmaceuticalBillItem().getStock().getId());
+            if (freshStock == null) {
+                JsfUtil.addErrorMessage(b.getItem().getName() + " - Stock record not found.");
+                hasIssue = true;
+                continue;
+            }
+            double requiredQty = Math.abs(b.getPharmaceuticalBillItem().getQtyInUnit()) + b.getPharmaceuticalBillItem().getFreeQtyInUnit();
+            if (freshStock.getStock() < requiredQty) {
+                JsfUtil.addErrorMessage(b.getItem().getName() + " - Insufficient stock. Available: "
+                        + (int) freshStock.getStock() + ", Required: " + (int) requiredQty
+                        + ". Another user may have already sold this stock.");
+                hasIssue = true;
+            }
+        }
+        return hasIssue;
+    }
+
     public void settlePreBill() {
         editingQty = null;
 
@@ -1283,10 +1308,9 @@ public class PharmacyWholeSaleController implements Serializable, ControllerWith
             return;
         }
 
-//        if (checkAllBillItem()) {
-//            //   Before Settle Bill Current Bills Item Check Agian There is any otheruser change his qty
-//            return;
-//        }
+        if (checkAllBillItemStockAvailability()) {
+            return;
+        }
         if (errorCheckForPreBill()) {
             return;
         }
@@ -1438,9 +1462,9 @@ public class PharmacyWholeSaleController implements Serializable, ControllerWith
             }
         }
 
-//        if (checkAllBillItem()) {
-//            return;
-//        }
+        if (checkAllBillItemStockAvailability()) {
+            return;
+        }
         if (errorCheckForSaleBill()) {
             return;
         }


### PR DESCRIPTION
## Summary

- Adds pre-settlement stock availability check that re-reads stock from DB and blocks settlement if stock was consumed by another user
- Adds safety-net error message when stock deduction fails during settlement
- Fixes both `settlePreBill()` and `settleBillWithPay()` methods in `PharmacyWholeSaleController`

## Background

The original `checkAllBillItem()` validation was removed as Coop requested performance improvements — the old check used `onEdit()` which had additional overhead (user stock validation, recalculation, etc.) on every settlement. However, removing it introduced a concurrency bug where stock consumed by one user is silently zeroed for another.

The new `checkAllBillItemStockAvailability()` is a lightweight replacement that only does a direct DB stock read via `findWithoutCache` — much faster than the old approach while still preventing the race condition.

## Root Cause

When two pharmacists bill the same stock simultaneously, `deductFromStock()` fails for the second user but the system silently sets qty=0 instead of warning.

## Evidence

Confirmed in Coop production: Bill MP/SALE/112283 (2026-03-14) had Ecosprin 75 with QTY=0 despite 359 units in stock.

## Test plan

- [ ] Two users simultaneously add the same stock item to separate bills
- [ ] First user settles successfully
- [ ] Second user gets error message "Insufficient stock. Another user may have already sold this stock."
- [ ] Settlement is blocked, not silently zeroed
- [ ] Single-user normal billing flow still works without issues

Closes #19263

🤖 Generated with [Claude Code](https://claude.com/claude-code)