### PR TITLE
Fix stock take snapshot: duplicate billitems and missing batches in export

### DIFF
--- a/src/main/java/com/divudi/bean/pharmacy/PharmacyStockTakeController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacyStockTakeController.java
@@ -623,19 +623,11 @@ public class PharmacyStockTakeController implements Serializable {
                 System.out.println("[settleStockCount] Batch persist complete. ms=" + (System.currentTimeMillis() - tSettle0));
             } catch (Exception e) {
                 LOGGER.log(Level.SEVERE, "[settleStockCount] Batch persist failed", e);
-                // If the bill header was already persisted (snapshotBill.getId() != null),
-                // do NOT fall back to billFacade.create() — that would cascade-insert all
-                // BillItems into the already-existing bill, producing duplicate rows.
-                // Surface the error so the user can retry with a clean snapshot.
-                if (snapshotBill.getId() != null) {
-                    JsfUtil.addErrorMessage("Stock count save failed after bill header was created (ID="
-                            + snapshotBill.getId() + "). Please contact support.");
-                    return null;
-                }
-                // Bill header was never persisted — safe to fall back to JPA cascade.
-                LOGGER.log(Level.WARNING, "[settleStockCount] Falling back to JPA cascade (header not yet persisted)");
-                billFacade.create(snapshotBill);
-                System.out.println("[settleStockCount] JPA cascade complete. ms=" + (System.currentTimeMillis() - tSettle0));
+                // Never fall back to billFacade.create() — if the bill header was already
+                // persisted (even partially), a JPA cascade would insert all BillItems again
+                // into the same bill, producing duplicate rows in the database.
+                JsfUtil.addErrorMessage("Stock count save failed. Please generate a new snapshot and try again.");
+                return null;
             }
         } else {
             // Existing bill: update only
@@ -3153,13 +3145,17 @@ public class PharmacyStockTakeController implements Serializable {
                 ));
             }
 
-            // Deduplicate by (itemName, batchNo) — keep the row with the lowest billItemId.
+            // Deduplicate by (itemName, batchNo, expiryDate) — keep the row with the lowest billItemId.
             // This guards against snapshot bills that were accidentally persisted twice
             // (bill header created once, but BillItems inserted in two separate passes),
             // which results in duplicate rows per batch in the database.
+            // Expiry date is included in the key so that two legitimate batches with the same
+            // batch number but different expiry dates are NOT collapsed into one.
             java.util.LinkedHashMap<String, com.divudi.core.data.dto.SnapshotBillItemDTO> seen = new java.util.LinkedHashMap<>();
             for (com.divudi.core.data.dto.SnapshotBillItemDTO dto : dtos) {
-                String key = (dto.getItemName() != null ? dto.getItemName() : "") + "||" + (dto.getBatchNo() != null ? dto.getBatchNo() : "");
+                String expiryStr = dto.getExpiryDate() != null
+                        ? new java.text.SimpleDateFormat("yyyy-MM-dd").format(dto.getExpiryDate()) : "";
+                String key = (dto.getItemName() != null ? dto.getItemName() : "") + "||" + (dto.getBatchNo() != null ? dto.getBatchNo() : "") + "||" + expiryStr;
                 com.divudi.core.data.dto.SnapshotBillItemDTO existing = seen.get(key);
                 if (existing == null || (dto.getBillItemId() != null && existing.getBillItemId() != null && dto.getBillItemId() < existing.getBillItemId())) {
                     seen.put(key, dto);


### PR DESCRIPTION
## Summary

- **Bug 1**: Removes the JPA fallback in `settleStockCount()` that caused every billitem to be inserted twice. When `persistSnapshotBill()` threw after the bill header was already persisted, the catch block re-inserted all items via `billFacade.create()`, doubling rows in the DB
- **Bug 2**: Adds expiry date to the deduplication key in `loadSnapshotBillItemsLazily()` so two legitimate batches with the same `batchNo` but different expiry dates are not silently collapsed into one row in the Excel export

Closes #19287

## Test plan

- [ ] Generate a new stock take snapshot for a department with stock
- [ ] Click **Record Stock Counts** — verify the saved bill has exactly N billitems (one per batch), not 2×N
- [ ] Download the guided Excel sheet — verify all rows are present, including items that have two batches with the same batch number but different expiry dates
- [ ] Verify system quantities in the Excel match the `stock` table totals per batch

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling in stock count operations to provide clear error messages when batch processing fails, preventing silent data inconsistencies.
  * Fixed an issue where inventory items with identical names and batch numbers but different expiry dates were being incorrectly consolidated, ensuring separate entries are now preserved during inventory reconciliation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->