### PR TITLE
Fix stock take variance report counting unapproved uploads (#19340)

### DIFF
--- a/src/main/webapp/pharmacy/pharmacy_stock_take_review.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_stock_take_review.xhtml
@@ -62,7 +62,7 @@
                                                          styleClass="ui-button-warning ui-button-lg"
                                                          ajax="false"
                                                          rendered="#{webUserController.hasPrivilege('PharmacyStockTakeApprove')}"
-                                                         onclick="if(!confirm('Approve this physical count and post stock adjustments?')){return false;} this.disabled=true; this.value='Processing...';"
+                                                         onclick="return confirm('Approve this physical count and post stock adjustments?');"
                                                          action="#{pharmacyStockTakeController.confirmUploadAndApprove}"/>
                                     </p:panelGrid>
 


### PR DESCRIPTION
Fix variance report summing unapproved uploads + revert disable-button pattern.

Closes #19340

🤖 Generated with [Claude Code](https://claude.com/claude-code)