### PR TITLE
Fix variance report ghost rows for un-uploaded snapshot items (#19340)

### DIFF
--- a/src/main/java/com/divudi/bean/pharmacy/PharmacyStockTakeController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacyStockTakeController.java
@@ -2825,6 +2825,12 @@ public class PharmacyStockTakeController implements Serializable {
             vr.setSumVariance(vr.getSumVariance() + (adjustedValue != null ? adjustedValue : 0.0));
             vr.setLastPhysicalQty(physQty);
         }
+
+        // Remove snapshot rows that were never uploaded (no physical count match) — these
+        // have sumVariance still at 0.0 and lastPhysicalQty null. Keeping them causes items
+        // with multiple batches to appear twice: once with the real variance, once as a
+        // zero-variance ghost row from the un-uploaded batch.
+        varianceRows.removeIf(vr -> vr.getLastPhysicalQty() == null);
     }
 
     /**


### PR DESCRIPTION
## Summary
- Items with multiple batches in the snapshot appeared twice in the variance report: once with the real variance (uploaded batch) and once as a zero-variance ghost row (un-uploaded batch)
- Fix: remove snapshot rows where `lastPhysicalQty` is still `null` after aggregation — meaning no physical count bill item ever referenced that snapshot row
- Items uploaded with genuine zero variance (physical qty matches system qty) are preserved since `lastPhysicalQty` is set even when `adjustedValue` is 0

Closes #19340

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Improved stock variance reporting accuracy by eliminating phantom zero-variance entries that previously appeared for inventory items without corresponding physical count matches. This ensures pharmacy inventory reconciliation reports are cleaner, more meaningful, and easier to analyze, reducing confusion during stock take operations while enhancing data quality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->