### PR TITLE
Fix appointment payment not reflected in inward balance

### DIFF
--- a/src/main/java/com/divudi/bean/inward/AdmissionController.java
+++ b/src/main/java/com/divudi/bean/inward/AdmissionController.java
@@ -1941,7 +1941,11 @@ public class AdmissionController implements Serializable, ControllerWithPatient 
         }
 
         if (appointmentFee != 0) {
-            getInwardPaymentController().getCurrent().setPaymentMethod(getCurrent().getPaymentMethod());
+            PaymentMethod appointmentPaymentMethod = getAppointmentBill().getPaymentMethod() != null
+                    ? getAppointmentBill().getPaymentMethod()
+                    : getCurrent().getPaymentMethod();
+            getInwardPaymentController().setPaymentMethod(appointmentPaymentMethod);
+            getInwardPaymentController().getCurrent().setPaymentMethod(appointmentPaymentMethod);
             getInwardPaymentController().getCurrent().setPatientEncounter(current);
             getInwardPaymentController().getCurrent().setTotal(appointmentFee);
             getInwardPaymentController().pay();
@@ -2016,7 +2020,11 @@ public class AdmissionController implements Serializable, ControllerWithPatient 
         }
 
         if (appointmentFee != 0) {
-            getInwardPaymentController().getCurrent().setPaymentMethod(getCurrent().getPaymentMethod());
+            PaymentMethod appointmentPaymentMethod = getAppointmentBill().getPaymentMethod() != null
+                    ? getAppointmentBill().getPaymentMethod()
+                    : getCurrent().getPaymentMethod();
+            getInwardPaymentController().setPaymentMethod(appointmentPaymentMethod);
+            getInwardPaymentController().getCurrent().setPaymentMethod(appointmentPaymentMethod);
             getInwardPaymentController().getCurrent().setPatientEncounter(current);
             getInwardPaymentController().getCurrent().setTotal(appointmentFee);
             getInwardPaymentController().pay();


### PR DESCRIPTION
## Summary
- `InwardPaymentController.pay()` was silently failing when called from `AdmissionController` during appointment-to-admission conversion
- Root cause: `errorCheck()` validates `this.paymentMethod` (the field), but `AdmissionController` only set `getCurrent().setPaymentMethod()` (the bill object) — the field was never set, so `errorCheck()` returned `true` and `pay()` exited early without creating the `InwardPaymentBill`
- Fix: call `getInwardPaymentController().setPaymentMethod(...)` before `pay()`, using the appointment bill's payment method (falling back to the admission's method)
- Applied to both `saveSelected()` and `saveConvertSelected()` in `AdmissionController`

## Test plan
- [ ] Create an inward appointment with a payment (Cash)
- [ ] Convert the appointment to an admission via `appointment_admit.xhtml`
- [ ] Open the interim bill at `inward_bill_intrim.xhtml`
- [ ] Verify the appointment payment amount appears in the Payments tab and is reflected in the "Paid By Patient" balance

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #19293

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved payment method handling for admissions with appointment fees to ensure proper payment method selection when processing patient payments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->