### PR TITLE
Add EclipseLink concurrency manager tuning to prevent login timeout

### DIFF
--- a/src/main/resources/META-INF/persistence.xml
+++ b/src/main/resources/META-INF/persistence.xml
@@ -7,6 +7,13 @@
         <properties>
             <property name="eclipselink.logging.level.sql" value="SEVERE"/>
             <property name="eclipselink.logging.level" value="SEVERE"/>
+            <!-- EclipseLink concurrency manager tuning (issue #19397) -->
+            <!-- Reduce cache lock wait from default 900s to 10s to fail fast -->
+            <property name="eclipselink.concurrency.manager.waittime" value="10000"/>
+            <!-- Throw exception instead of silently waiting on cache lock contention -->
+            <property name="eclipselink.concurrency.manager.allow.concurrencyexception" value="true"/>
+            <!-- Log cache contention warnings for early detection -->
+            <property name="eclipselink.concurrency.manager.maxfrequencytodumptinymessage" value="5000"/>
         </properties>
     </persistence-unit>
     <persistence-unit name="hmisAuditPU" transaction-type="JTA">


### PR DESCRIPTION
## Summary
- Add EclipseLink concurrency manager properties to `persistence.xml` to prevent 15-minute login timeouts caused by shared cache lock contention
- Reduces cache lock wait from default 900s to 10s (fail fast)
- Enables concurrency exceptions and contention logging for early detection

## Root Cause
On coop (hmis08), a DB deadlock on `patientsample` triggered EclipseLink shared cache lock contention. With no concurrency tuning, every thread (including login's `listLoggableDepts()`) silently waited the full 15-minute default timeout, making the app completely unusable. Affected all clients on hmis08.

## Test plan
- [ ] Deploy to QA and verify login works under concurrent access
- [ ] Verify no regression in normal query performance
- [ ] Monitor server logs for `ConcurrencyException` entries (these now surface instead of silent 15-min waits)

Closes #19397

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized concurrency and database cache management settings to improve application performance under high-load conditions. Implemented faster timeout handling for cache lock waits, enabled exception-based signaling for contention issues to improve visibility and debugging, and adjusted logging frequency for better performance monitoring and diagnostics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->