### PR TITLE
19425 service name error in service category wise bill detail report

### DIFF
--- a/src/main/webapp/reports/financialReports/service_category_wise_bill_detail.xhtml
+++ b/src/main/webapp/reports/financialReports/service_category_wise_bill_detail.xhtml
@@ -160,10 +160,11 @@
                                 </p:outputLabel>
                             </h:panelGroup>
                             <h:panelGroup id="gpItem" layout="block" styleClass="form-group">
-                                <p:autoComplete 
+                                <p:autoComplete
                                     class="w-100"
                                     inputStyleClass="w-100"
                                     rendered="#{searchController.category eq null}"
+                                    value="#{searchController.item}"
                                     completeMethod="#{itemController.completeServicesPlusInvestigationsAll}"
                                     var="acitem"
                                     itemLabel="#{acitem.name}"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Service Name autocomplete selection binding in the financial reports feature to ensure selected values are properly captured and retained when users interact with the dropdown.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->