### PR TITLE
Hide retired snapshot bills from stock take list and ongoing check

### DIFF
--- a/src/main/java/com/divudi/bean/pharmacy/PharmacyStockTakeController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacyStockTakeController.java
@@ -2378,7 +2378,7 @@ public class PharmacyStockTakeController implements Serializable {
         jpql.append("select new com.divudi.core.light.common.PharmacySnapshotBillLight( ");
         jpql.append(" b.id, b.deptId, b.createdAt, ins.name, dept.name, ");
         jpql.append(" (select count(bi) from BillItem bi where bi.bill = b), b.netTotal, b.completed ) ");
-        jpql.append(" from Bill b left join b.institution ins left join b.department dept where b.billType=:bt");
+        jpql.append(" from Bill b left join b.institution ins left join b.department dept where b.billType=:bt and b.retired=false");
         params.put("bt", BillType.PharmacySnapshotBill);
         if (fromDate != null) {
             jpql.append(" and b.createdAt>=:fd");
@@ -3660,7 +3660,7 @@ public class PharmacyStockTakeController implements Serializable {
         if (dept == null || dept.getId() == null) {
             return false;
         }
-        String jpql = "select count(b) from Bill b where b.billType=:bt and b.department.id=:deptId and (b.completed is null or b.completed=false)";
+        String jpql = "select count(b) from Bill b where b.billType=:bt and b.department.id=:deptId and b.retired=false and (b.completed is null or b.completed=false)";
         HashMap<String, Object> params = new HashMap<>();
         params.put("bt", BillType.PharmacySnapshotBill);
         params.put("deptId", dept.getId());


### PR DESCRIPTION
## Summary
- `listSnapshotBillRows()`: add `b.retired=false` so cancelled/retired snapshot bills no longer appear in the Manage Stock Takings list
- `hasOngoingStockTaking()`: add `b.retired=false` so retired bills do not block creation of a new stock take session

## Context
During RH staging stock take cleanup, 4 corrupted snapshot bills were retired in the DB. Without this fix they still showed in the UI list and blocked new snapshot creation.

Closes #19433

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved accuracy of pharmacy stock taking by ensuring retired bills are properly excluded from snapshot queries and ongoing stock taking status verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->