### PR TITLE
Filter retired bill items from snapshot export query

### DIFF
--- a/src/main/java/com/divudi/bean/pharmacy/PharmacyStockTakeController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacyStockTakeController.java
@@ -3122,7 +3122,7 @@ public class PharmacyStockTakeController implements Serializable {
                     + "pbi.doe, pbi.stringValue, pbi.description "
                     + "FROM BillItem bi "
                     + "LEFT JOIN bi.pharmaceuticalBillItem pbi "
-                    + "WHERE bi.bill.id = :billId "
+                    + "WHERE bi.bill.id = :billId AND bi.retired = false "
                     + "ORDER BY bi.catId, bi.descreption";
 
             HashMap<String, Object> params = new HashMap<>();


### PR DESCRIPTION
## Summary
`loadSnapshotBillItemsLazily()` was missing `AND bi.retired=false`, so manually retired duplicate items still appeared in the stock take export/download.

## Context
After retiring duplicate bill items directly in the DB to clean up a corrupted snapshot bill, the export still showed all items including retired ones — making the download look doubled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Retired items are now properly excluded from pharmacy stock take operations, ensuring they do not appear in upload, variance, or review processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->