### PR TITLE
Fix JPA cascade double-insert causing 2x bill items in stock count snapshot

### DIFF
--- a/src/main/java/com/divudi/service/pharmacy/StockTakePersistService.java
+++ b/src/main/java/com/divudi/service/pharmacy/StockTakePersistService.java
@@ -77,7 +77,11 @@ public class StockTakePersistService {
         System.out.println("[StockTakePersist] Step1 Bill header persisted. ID=" + billId
                 + "  ms=" + (System.currentTimeMillis() - t0));
 
-        // Restore the list for callers
+        // Detach snapshotBill immediately so JPA cascade does NOT fire when we
+        // restore the billItems list below. Native SQL handles all child inserts.
+        em.clear();
+
+        // Restore the list onto the now-detached bill so callers can still reference it.
         snapshotBill.setBillItems(items);
 
         // -----------------------------------------------------------------------
@@ -93,10 +97,6 @@ public class StockTakePersistService {
         for (int i = 0; i < items.size(); i++) {
             items.get(i).setId(billItemIds[i]);
         }
-
-        // Detach all managed entities before the next allocateIds flush.
-        // EclipseLink would otherwise reject the ID writes above as "primary key updates".
-        em.clear();
 
         // -----------------------------------------------------------------------
         // Step 3: Allocate IDs for PharmaceuticalBillItems, then bulk-insert


### PR DESCRIPTION
## Summary

- Fixes the root cause of 2× bill item duplication in pharmacy stock count snapshots
- Adds missing department boundary check to `generateStockCountBill()`
- Fixes CodeRabbit review comment from PR #19464

## Root Cause

`StockTakePersistService.persistSnapshotBill()` was calling `em.clear()` **after** `snapshotBill.setBillItems(items)` on a still-managed `Bill` entity. EclipseLink's change tracking detected the restored collection as new children and cascade-inserted all BillItems a second time — while native SQL had already inserted them — producing exactly 2× items.

**Fix:** move `em.clear()` to immediately after the Bill header flush, before restoring the list, so `setBillItems()` operates on a detached entity and no JPA cascade fires.

## Changes

- `StockTakePersistService.java` — move `em.clear()` before `setBillItems(items)` to prevent JPA cascade double-insert
- `PharmacyStockTakeController.java` — add department boundary check (`sessionController.getDepartment()` guard) to `generateStockCountBill()`, matching the guard in the async variant

## Test plan

- [ ] Generate snapshot for Matara - General Stores — confirm item count = `SELECT COUNT(*) FROM stock WHERE department_ID = 3692779 AND stock > 0` + zero-stock batches (expect ~147, not 294)
- [ ] Confirm no duplicate `(name, batch)` combinations in the downloaded guided sheet
- [ ] Settle the snapshot — confirm no duplicate BillItems in DB

Closes #19463

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed entity lifecycle handling in stock take bill persistence to prevent unintended cascading updates during bill item restoration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->