### PR TITLE
Fix stock take print page showing wrong bill items when navigating via URL

### DIFF
--- a/src/main/java/com/divudi/bean/pharmacy/PharmacyStockTakeController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacyStockTakeController.java
@@ -3211,7 +3211,7 @@ public class PharmacyStockTakeController implements Serializable {
                 + (snapshotBillDisplay != null ? snapshotBillDisplay.getId() : "null"));
 
         if (snapshotBillDisplay != null && snapshotBillDisplay.getId() != null) {
-            if (snapshotBill == null) {
+            if (snapshotBill == null || !snapshotBillDisplay.getId().equals(snapshotBill.getId())) {
                 snapshotBill = billFacade.getReference(snapshotBillDisplay.getId());
                 System.out.println("[GetLazy] Created proxy billId=" + snapshotBill.getId());
             }


### PR DESCRIPTION
## Summary
- When opening `pharmacy_stock_take_print.xhtml?billId=X` directly via URL (e.g. from the list page View button), the print page loaded bill items from a previously viewed bill instead of the requested one
- Root cause: `getSnapshotItems()` only replaced the internal `snapshotBill` reference when it was `null`, so a stale reference from an earlier navigation was reused
- Fix: replace `snapshotBill` whenever its ID does not match `snapshotBillDisplay.getId()` — a one-line change

## Test plan
- [ ] Open stock take list, click View on a bill → print page shows correct items
- [ ] Click View on a different bill in the same session → items update to the new bill (this was broken before)
- [ ] Navigate directly via URL `?billId=X` without going through the list → correct items shown

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue in the pharmacy stock-taking module where switching between different snapshots could display outdated bill information. Snapshot data now correctly refreshes for each selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->