### PR TITLE
Fix analyzer creating reports for unrelated tests on same sample

### DIFF
--- a/src/main/java/com/divudi/ws/lims/LimsMiddlewareController.java
+++ b/src/main/java/com/divudi/ws/lims/LimsMiddlewareController.java
@@ -1020,12 +1020,7 @@ public class LimsMiddlewareController {
                 }
                 if (ii.getTest() != null
                         && (ii.getIxItemType() == InvestigationItemType.Value
-                        || ii.getIxItemType() == InvestigationItemType.ReportImage
-                        || ii.getIxItemType() == InvestigationItemType.Calculation
-                        || ii.getIxItemType() == InvestigationItemType.Flag
-                        || ii.getIxItemType() == InvestigationItemType.Template
-                        || ii.getIxItemType() == InvestigationItemType.WarningFlag
-                        || ii.getIxItemType() == InvestigationItemType.DynamicLabel)) {
+                        || ii.getIxItemType() == InvestigationItemType.ReportImage)) {
                     String codeFromDb = ii.getResultCode();
                     if (codeFromDb == null || codeFromDb.trim().isEmpty()) {
                         codeFromDb = ii.getTest().getCode();


### PR DESCRIPTION
## Summary

- When analyzer results (e.g., FBC from HumaCount5D) arrive via middleware, `addResultToReport()` was iterating over **all** `PatientInvestigation` records on the sample and creating reports for each — even for unrelated tests like Blood Picture that share the same sample but have no matching test codes
- Added a pre-check that verifies the incoming test code matches at least one `InvestigationItem` (by result code or test code) in the investigation before creating a `PatientReport`
- Investigations with no matching items are now skipped entirely, preventing empty auto-generated reports and incorrect `REPORT_CREATED` status on manual tests

## Test plan

- [ ] Send FBC results from analyzer for a sample that also has Blood Picture ordered
- [ ] Verify FBC report is created and populated correctly
- [ ] Verify Blood Picture does **not** get an auto-created report
- [ ] Verify Blood Picture investigation status remains unchanged (not marked as performed)
- [ ] Verify manual entry for Blood Picture still works after FBC results arrive
- [ ] Test with samples that have only a single investigation to ensure no regression

Closes #19480

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Lab reports no longer attach results to unrelated investigations that share a sample. The system now verifies test identifiers within each investigation before creating or updating report entries, ensuring results are recorded only for the matching investigation and preventing cross-contamination of report data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->