### PR TITLE
Fix stock take print page missing items and upload button regression

### DIFF
--- a/src/main/java/com/divudi/bean/pharmacy/PharmacyStockTakeController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacyStockTakeController.java
@@ -3056,7 +3056,7 @@ public class PharmacyStockTakeController implements Serializable {
                     + "FROM BillItem bi "
                     + "LEFT JOIN bi.pharmaceuticalBillItem pbi "
                     + "LEFT JOIN bi.item i "
-                    + "WHERE bi.bill.id = :billId AND bi.retired = false "
+                    + "WHERE bi.bill.id = :billId AND (bi.retired IS NULL OR bi.retired = false) "
                     + "ORDER BY bi.catId, bi.descreption";
 
             HashMap<String, Object> params = new HashMap<>();

--- a/src/main/webapp/pharmacy/pharmacy_stock_take_upload.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_stock_take_upload.xhtml
@@ -149,13 +149,11 @@
 
 
                                 <h:form id="frmUpload" enctype="multipart/form-data" rendered="#{not pharmacyStockTakeController.snapshotBillDisplay.completed}">
-                                    <p:blockUI block="frmUpload" trigger="btnProcessUpload">
-                                        <div style="text-align:center; padding: 20px; color: white;">
-                                            <i class="fa fa-spinner fa-spin fa-3x" style="margin-bottom: 12px;"></i>
-                                            <div style="font-size: 1.1em; font-weight: bold;">Processing upload, please wait...</div>
-                                            <div style="font-size: 0.9em; margin-top: 6px;">This may take several minutes for large files.</div>
-                                        </div>
-                                    </p:blockUI>
+                                    <div id="uploadOverlay" style="display:none; position:fixed; top:0; left:0; width:100%; height:100%; background:rgba(0,0,0,0.6); z-index:9999; text-align:center; padding-top:20%;">
+                                        <i class="fa fa-spinner fa-spin fa-3x" style="color:white; margin-bottom: 12px;"></i>
+                                        <div style="color:white; font-size: 1.1em; font-weight: bold;">Processing upload, please wait...</div>
+                                        <div style="color:white; font-size: 0.9em; margin-top: 6px;">This may take several minutes for large files.</div>
+                                    </div>
                                     <div class="card">
                                         <div class="card-header bg-secondary text-white">
                                             <i class="fa fa-upload" style="margin-right: 8px;"></i>
@@ -192,7 +190,8 @@
                                                                icon="fa fa-upload"
                                                                styleClass="ui-button-success ui-button-lg"
                                                                action="#{pharmacyStockTakeController.parseAndPersistNavigate}"
-                                                               timeout="600000"/>
+                                                               ajax="false"
+                                                               onclick="document.getElementById('uploadOverlay').style.display='block';"/>
                                             </div>
                                         </div>
                                     </div>


### PR DESCRIPTION
## Summary

- **Missing items on print page**: The snapshot items JPQL query used `AND bi.retired = false` which silently excludes rows where `retired IS NULL` (standard SQL null comparison behaviour). Items persisted without an explicit `retired = false` appeared on the settle page (loads via JPA collection) but were dropped on the print/download page.
- **Upload button regression**: PR #19504 changed the upload button to AJAX mode to add a timeout, but `p:fileUpload mode="simple"` requires a full form POST — AJAX mode never submits the file, causing a null file in the controller and the blockUI spinner hanging forever. Reverted to `ajax="false"` with a plain JS overlay instead of `p:blockUI`.

## Changes

- `PharmacyStockTakeController.java` — fix `loadSnapshotBillItemsLazily()` query: `retired = false` → `(retired IS NULL OR retired = false)`
- `pharmacy_stock_take_upload.xhtml` — restore `ajax="false"` on upload button; replace `p:blockUI` with a plain `<div>` overlay shown via `onclick`

## Test plan

- [ ] Record a stock count snapshot with multiple items
- [ ] Navigate to the print page via `?billId=` — confirm all items appear and totals match the settle page
- [ ] Upload a stock count Excel file — confirm the spinner appears and navigation to review page works after processing

Closes #19507

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced inventory record filtering in pharmacy stock take operations to correctly include all active items in snapshots.

* **UI Improvements**
  * Redesigned upload processing experience with a new full-screen overlay indicator.
  * Optimized form submission behavior for improved upload reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->