### PR TITLE
Fix All Cashier Summary missing retired filter

### DIFF
--- a/src/main/java/com/divudi/bean/report/CashierReportController.java
+++ b/src/main/java/com/divudi/bean/report/CashierReportController.java
@@ -2400,7 +2400,8 @@ public class CashierReportController implements Serializable {
         List<BillType> btpList = Arrays.asList(btpArr);
         sql = "select DISTINCT(b.creater) from "
                 + " Bill b "
-                + " where b.institution=:ins "
+                + " where b.retired=false "
+                + " and b.institution=:ins "
                 + " and b.billType in :btp "
                 + " and b.createdAt between :fromDate and :toDate";
         temMap.put("toDate", getToDate());
@@ -2567,7 +2568,7 @@ public class CashierReportController implements Serializable {
         String sql;
         Map temMap = new HashMap();
 
-        sql = "select b from Bill b  where type(b)=:bill and b.creater=:web and "
+        sql = "select b from Bill b  where b.retired=false and type(b)=:bill and b.creater=:web and "
                 + "b.paymentMethod= :pm "
                 + " and b.billType= :billTp and b.createdAt between :fromDate and :toDate";
         temMap.put("toDate", getToDate());


### PR DESCRIPTION
## Summary
- `getCashiers()` and `calTot()` in `CashierReportController` were missing the `b.retired=false` JPQL filter
- This caused retired/inactive bills to still appear in the **All Cashier Summary** report totals
- Other variants (`getCashiersCashier`, `getCashiersWithoutPro`, `calTotalValueForLoggedDepartment`) already had this filter — this was an inconsistency

## Context
Discovered while retiring 4 orphan CC Payment bills (Sept 25, 2025) at Ruhunu Hospital that had no payment records due to a system defect. The Daily Return and QB reports correctly exclude retired bills, but the All Cashier Summary did not.

## Test plan
- [ ] Run All Cashier Summary report for a period containing retired bills
- [ ] Verify retired bills are excluded from totals
- [ ] Compare totals with Daily Return for the same period — should now match

🤖 Generated with [Claude Code](https://claude.com/claude-code)