### PR TITLE
Fix drawer corruption when handover processes fund transfer payments

### DIFF
--- a/src/main/java/com/divudi/bean/cashTransaction/FinancialTransactionController.java
+++ b/src/main/java/com/divudi/bean/cashTransaction/FinancialTransactionController.java
@@ -5216,6 +5216,11 @@ public class FinancialTransactionController implements Serializable {
                     if (p.getPaymentMethod() == null) {
                         continue;
                     }
+                    // Skip fund transfer payments - they have their own drawer lifecycle
+                    // and must not be reprocessed during handover creation
+                    if (isFundTransferPayment(p)) {
+                        continue;
+                    }
                     if (p.getPaymentMethod() != PaymentMethod.Cash && p.isSelectedForHandover() == false) {
                         continue;
                     }
@@ -5669,6 +5674,23 @@ public class FinancialTransactionController implements Serializable {
             WebUser toUser,
             Staff toStaff) {
         return hasAtLeastOneToReceived(BillTypeAtomic.FUND_TRANSFER_BILL, fromUser, fromStaff, toUser, toStaff);
+    }
+
+    /**
+     * Returns true if the payment belongs to a fund transfer bill type.
+     * Such payments must be excluded from handover processing because their
+     * drawer impact is fully handled at the time of transfer creation, receipt,
+     * or cancellation.
+     */
+    private boolean isFundTransferPayment(Payment payment) {
+        if (payment == null || payment.getBill() == null) {
+            return false;
+        }
+        BillTypeAtomic bta = payment.getBill().getBillTypeAtomic();
+        return bta == BillTypeAtomic.FUND_TRANSFER_BILL
+                || bta == BillTypeAtomic.FUND_TRANSFER_RECEIVED_BILL
+                || bta == BillTypeAtomic.FUND_TRANSFER_BILL_CANCELLED
+                || bta == BillTypeAtomic.FUND_TRANSFER_RECEIVED_BILL_CANCELLED;
     }
 
     public boolean hasAtLeastOneHandoverBillToReceive(WebUser fromUser,
@@ -6205,6 +6227,11 @@ public class FinancialTransactionController implements Serializable {
 //                    continue;
 //                }
                 Payment p = row.getPayment();
+                // Skip fund transfer payments - they have their own drawer lifecycle
+                // and must not be reprocessed during handover acceptance
+                if (isFundTransferPayment(p)) {
+                    continue;
+                }
                 p.setCashbook(bundleCb);
                 p.setCashbookEntry(findCashbookEntry(p, cbEntries));
                 p.setCashbookEntryCompleted(true);

--- a/src/main/java/com/divudi/service/DrawerService.java
+++ b/src/main/java/com/divudi/service/DrawerService.java
@@ -189,6 +189,7 @@ public class DrawerService {
         drawerEntry.setBill(payment.getBill());
         drawerEntry.setDrawer(currentDrawer);
         drawerEntry.setWebUser(user);
+        drawerEntry.setTransactionValue(payment.getPaidValue());
         Double beforeInHandValue = 0.0;
 
         if (payment.getPaymentMethod() != null) {


### PR DESCRIPTION
## Summary

- **Root cause of reported drawer balance corruption after float cancellation**: Shift handover creation (`settleHandoverStartBill`) and acceptance (`acceptHandoverBillAndWriteToCashbook`) were iterating all `ReportTemplateRow` payments without filtering out fund transfer bill payments. This caused the handover to apply extra drawer mutations and flag changes to already-settled float transfer payments.
- **Handover creation bug**: Set `HANDINGOVERSTARTED=true` on fund transfer payments, and for non-cash payments applied a second drawer deduction against the current user.
- **Handover acceptance bug (the main corruption source)**: Added the fund transfer payment's raw value (which is negative for sent transfers) to the recipient's drawer, causing a spurious deduction. Also set `CURRENTHOLDER=recipient` and `HANDINGOVERCOMPLETED=true`, making the original transfer look received while `REFERENCEBILL_ID` remained `null`. When the sender later cancelled the transfer, their drawer was correctly restored, but the recipient's erroneous deduction was never reversed — net loss to the system.
- **Audit trail fix**: `DrawerService.drawerEntryUpdate()` never set `TRANSACTIONVALUE` in the payment-based path, leaving it always `NULL` in `DRAWERENTRY`. Now set to `payment.getPaidValue()`.

## Changes

- Added private helper `isFundTransferPayment(Payment)` in `FinancialTransactionController` that returns `true` for `FUND_TRANSFER_BILL`, `FUND_TRANSFER_RECEIVED_BILL`, `FUND_TRANSFER_BILL_CANCELLED`, and `FUND_TRANSFER_RECEIVED_BILL_CANCELLED`.
- Both handover loops now skip payments identified as fund transfer payments.
- `DrawerService.drawerEntryUpdate(Payment, Drawer, WebUser)` now sets `drawerEntry.setTransactionValue(payment.getPaidValue())`.

## Test plan

- [ ] Create a float transfer from User A to User B
- [ ] Without accepting, have User A perform a shift handover to User C — verify User A's drawer is NOT double-deducted and the float transfer payment has `HANDINGOVERSTARTED` unchanged
- [ ] Have User B accept a shift handover from another user — verify fund transfer payments are excluded and User B's drawer is not incorrectly modified
- [ ] Cancel the float transfer from User A — verify User A's drawer is correctly restored with no side effects on other users
- [ ] Accept the float transfer as User B — verify User B's drawer is correctly credited
- [ ] Check `DRAWERENTRY` records after any float operation — `TRANSACTIONVALUE` should now be populated

Closes #17965

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where fund transfer payments could be incorrectly reprocessed during handover creation and acceptance operations.
  * Improved accuracy of payment value recording in drawer transaction entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->