### PR TITLE
Closes #19570

### DIFF
--- a/src/main/java/com/divudi/bean/inward/BhtSummeryController.java
+++ b/src/main/java/com/divudi/bean/inward/BhtSummeryController.java
@@ -59,6 +59,7 @@ import com.divudi.core.facade.ServiceFacade;
 import com.divudi.core.facade.TimedItemFeeFacade;
 import com.divudi.core.util.JsfUtil;
 import com.divudi.core.data.BillTypeAtomic;
+import com.divudi.core.data.dataStructure.CreditCompanyAllocation;
 import com.divudi.core.entity.EncounterCreditCompany;
 import com.divudi.core.entity.Staff;
 import com.divudi.core.facade.EncounterCreditCompanyFacade;
@@ -147,6 +148,7 @@ public class BhtSummeryController implements Serializable {
     List<PatientItem> patientItems;
     private List<ChargeItemTotal> chargeItemTotals;
     List<PatientRoom> patientRooms;
+    private List<CreditCompanyAllocation> creditCompanyAllocations;
     //////////////////////////
     private double grantTotal = 0.0;
     private double discount;
@@ -1326,7 +1328,11 @@ public class BhtSummeryController implements Serializable {
 
         if (getPatientEncounter().getPaymentMethod() == PaymentMethod.Credit) {
             getInwardBean().updateCreditDetail(getPatientEncounter(), getCurrent().getNetTotal());
-            createCreditBillForCreditCompany(getPatientEncounter(), getCurrent().getNetTotal());
+            for (CreditCompanyAllocation alloc : creditCompanyAllocations) {
+                if (alloc.getAllocatedAmount() > 0) {
+                    saveCCBillForAllocation(getPatientEncounter(), alloc);
+                }
+            }
         }
 
         getPatientEncounter().setFinalBill(getCurrent());
@@ -1452,6 +1458,52 @@ public class BhtSummeryController implements Serializable {
 
     public void saveCreditBillForCreditCompany(PatientEncounter pe, EncounterCreditCompany ecc, Double value) {
         saveCCBill(pe, ecc, value);
+    }
+
+    private void populateCreditCompanyAllocations() {
+        creditCompanyAllocations = new ArrayList<>();
+        double remaining = (grantTotal - discount) - paidByPatient - paidByCompany;
+        List<EncounterCreditCompany> eccs = fillCreditCompaniesByPatient(patientEncounter);
+        if (eccs != null && !eccs.isEmpty()) {
+            for (EncounterCreditCompany ecc : eccs) {
+                if (remaining <= 0) {
+                    break;
+                }
+                double alloc = Math.min(remaining, ecc.getCreditLimit());
+                creditCompanyAllocations.add(new CreditCompanyAllocation(ecc, alloc));
+                remaining -= alloc;
+            }
+        } else if (patientEncounter.getCreditCompany() != null) {
+            creditCompanyAllocations.add(new CreditCompanyAllocation(patientEncounter.getCreditCompany(), remaining));
+        }
+    }
+
+    private boolean checkCreditAllocationTotal() {
+        if (getPatientEncounter() == null
+                || getPatientEncounter().getPaymentMethod() != PaymentMethod.Credit
+                || creditCompanyAllocations == null
+                || creditCompanyAllocations.isEmpty()) {
+            return false;
+        }
+        double totalAllocated = 0.0;
+        for (CreditCompanyAllocation alloc : creditCompanyAllocations) {
+            totalAllocated += alloc.getAllocatedAmount();
+        }
+        double expected = (grantTotal - discount) - paidByPatient - paidByCompany;
+        if (Math.abs(totalAllocated - expected) > 0.01) {
+            JsfUtil.addErrorMessage("Credit allocation total (" + String.format("%.2f", totalAllocated)
+                    + ") does not match the net due amount (" + String.format("%.2f", expected) + ")");
+            return true;
+        }
+        return false;
+    }
+
+    private void saveCCBillForAllocation(PatientEncounter pe, CreditCompanyAllocation alloc) {
+        if (alloc.getEncounterCreditCompany() != null) {
+            saveCCBill(pe, alloc.getEncounterCreditCompany(), alloc.getAllocatedAmount());
+        } else {
+            saveCCBillByInstitution(pe, alloc.getCreditCompany(), alloc.getAllocatedAmount());
+        }
     }
 
     private boolean checkRoomIsDischarged() {
@@ -1588,6 +1640,10 @@ public class BhtSummeryController implements Serializable {
         }
 
         if (checkCatTotal()) {
+            return true;
+        }
+
+        if (checkCreditAllocationTotal()) {
             return true;
         }
 
@@ -1885,6 +1941,38 @@ public class BhtSummeryController implements Serializable {
         creditCompanyBill.setPatientEncounter(patientEncounter);
         creditCompanyBill.setPatient(patientEncounter.getPatient());
 //        getCurrent().setMembershipScheme(membershipSchemeController.fetchPatientMembershipScheme(patientEncounter.getPatient(), getSessionController().getApplicationPreference().isMembershipExpires()));
+        creditCompanyBill.setCreatedAt(new Date());
+        creditCompanyBill.setCreater(getSessionController().getLoggedUser());
+        creditCompanyBill.setReferenceBill(getCurrent());
+
+        if (creditCompanyBill.getId() == null) {
+            getBillFacade().create(creditCompanyBill);
+        } else {
+            getBillFacade().edit(creditCompanyBill);
+        }
+    }
+
+    private void saveCCBillByInstitution(PatientEncounter pe, Institution company, Double value) {
+
+        Bill creditCompanyBill = new BilledBill();
+
+        creditCompanyBill.setGrantTotal(value);
+        creditCompanyBill.setTotal(value);
+        creditCompanyBill.setNetTotal(value);
+        creditCompanyBill.setInstitution(getSessionController().getInstitution());
+        creditCompanyBill.setCreditCompany(company);
+        creditCompanyBill.setPaymentMethod(PaymentMethod.Credit);
+
+        creditCompanyBill.setDeptId(getBillNumberBean().departmentBillNumberGenerator(getSessionController().getDepartment(), BillType.InwardFinalBillCCPayment, BillClassType.BilledBill, BillNumberSuffix.INWFINALCCPAY));
+        creditCompanyBill.setInsId(getBillNumberBean().institutionBillNumberGenerator(getSessionController().getInstitution(), BillType.InwardFinalBillCCPayment, BillClassType.BilledBill, BillNumberSuffix.INWFINALCCPAY));
+
+        creditCompanyBill.setBillType(BillType.InwardFinalBillCCPayment);
+        creditCompanyBill.setBillTypeAtomic(BillTypeAtomic.INWARD_FINAL_BILL_PAYMENT_BY_CREDIT_COMPANY);
+
+        creditCompanyBill.setBillDate(new Date());
+        creditCompanyBill.setBillTime(new Date());
+        creditCompanyBill.setPatientEncounter(patientEncounter);
+        creditCompanyBill.setPatient(patientEncounter.getPatient());
         creditCompanyBill.setCreatedAt(new Date());
         creditCompanyBill.setCreater(getSessionController().getLoggedUser());
         creditCompanyBill.setReferenceBill(getCurrent());
@@ -2808,6 +2896,9 @@ public class BhtSummeryController implements Serializable {
 //        }
         changed = false;
 
+        if (getPatientEncounter() != null && getPatientEncounter().getPaymentMethod() == PaymentMethod.Credit) {
+            populateCreditCompanyAllocations();
+        }
     }
 
     public void changeIsMade() {
@@ -2837,6 +2928,14 @@ public class BhtSummeryController implements Serializable {
     }
 
     public void onEdit(RowEditEvent event) {
+    }
+
+    public List<CreditCompanyAllocation> getCreditCompanyAllocations() {
+        return creditCompanyAllocations;
+    }
+
+    public void setCreditCompanyAllocations(List<CreditCompanyAllocation> creditCompanyAllocations) {
+        this.creditCompanyAllocations = creditCompanyAllocations;
     }
 
     private List<Bill> additionalChargeBill;

--- a/src/main/java/com/divudi/core/data/dataStructure/CreditCompanyAllocation.java
+++ b/src/main/java/com/divudi/core/data/dataStructure/CreditCompanyAllocation.java
@@ -1,0 +1,74 @@
+/*
+ * Open Hospital Management Information System
+ *
+ * Dr M H B Ariyaratne
+ */
+package com.divudi.core.data.dataStructure;
+
+import com.divudi.core.entity.EncounterCreditCompany;
+import com.divudi.core.entity.Institution;
+
+/**
+ * Transient (in-memory) allocation of the inward final bill net due across
+ * credit companies. Populated when Process is clicked; consumed by Settle.
+ *
+ * @author Dr M H B Ariyaratne
+ */
+public class CreditCompanyAllocation {
+
+    /** Source record; null for the single-company fallback row. */
+    private EncounterCreditCompany encounterCreditCompany;
+
+    /** The credit company institution. */
+    private Institution creditCompany;
+
+    /** Amount allocated to this company; editable by the cashier. */
+    private double allocatedAmount;
+
+    /**
+     * Constructor for normal rows built from an {@link EncounterCreditCompany}.
+     */
+    public CreditCompanyAllocation(EncounterCreditCompany ecc, double allocatedAmount) {
+        this.encounterCreditCompany = ecc;
+        this.creditCompany = ecc.getInstitution();
+        this.allocatedAmount = allocatedAmount;
+    }
+
+    /**
+     * Constructor for the fallback row when no {@link EncounterCreditCompany}
+     * records exist but {@code PatientEncounter.creditCompany} is set.
+     */
+    public CreditCompanyAllocation(Institution creditCompany, double allocatedAmount) {
+        this.creditCompany = creditCompany;
+        this.allocatedAmount = allocatedAmount;
+    }
+
+    /** Display name derived from the institution. */
+    public String getCompanyName() {
+        return creditCompany != null ? creditCompany.getName() : "";
+    }
+
+    public EncounterCreditCompany getEncounterCreditCompany() {
+        return encounterCreditCompany;
+    }
+
+    public void setEncounterCreditCompany(EncounterCreditCompany encounterCreditCompany) {
+        this.encounterCreditCompany = encounterCreditCompany;
+    }
+
+    public Institution getCreditCompany() {
+        return creditCompany;
+    }
+
+    public void setCreditCompany(Institution creditCompany) {
+        this.creditCompany = creditCompany;
+    }
+
+    public double getAllocatedAmount() {
+        return allocatedAmount;
+    }
+
+    public void setAllocatedAmount(double allocatedAmount) {
+        this.allocatedAmount = allocatedAmount;
+    }
+}

--- a/src/main/webapp/inward/inward_bill_final.xhtml
+++ b/src/main/webapp/inward/inward_bill_final.xhtml
@@ -145,16 +145,7 @@
                                     <f:facet name="header">
                                         <h:outputLabel value="Credit Company Details"/>
                                     </f:facet>
-
-<!--                                    <ui:repeat value="#{bhtSummeryController.encounterCreditCompanies}" var="ec">
-                                        <h:panelGrid columns="3" class="w-100">
-                                            <h:outputLabel value="#{ec.institution.name}"/>
-                                            <h:outputLabel value=":"/>
-                                            <p:inputText value="#{ec.creditLimit}"> 
-                                            </p:inputText>
-                                        </h:panelGrid>
-                                    </ui:repeat>-->
-
+                                    <h:outputLabel value="Click Process to view the credit company allocation." />
                                 </p:panel>
                             </h:panelGroup>
 
@@ -266,6 +257,24 @@
                             </p:inputText>
                         </p:column>
                     </p:dataTable>
+
+                    <p:panel id="creditAllocationPanel" styleClass="mx-1 my-3"
+                             rendered="#{bhtSummeryController.patientEncounter.paymentMethod eq 'Credit'
+                                         and not empty bhtSummeryController.creditCompanyAllocations}">
+                        <f:facet name="header">
+                            <h:outputLabel value="Credit Company Allocation" />
+                        </f:facet>
+                        <p:dataTable value="#{bhtSummeryController.creditCompanyAllocations}" var="alloc" styleClass="w-100">
+                            <p:column headerText="Company">
+                                <h:outputLabel value="#{alloc.companyName}" />
+                            </p:column>
+                            <p:column headerText="Allocated Amount" style="width: 200px;">
+                                <p:inputText value="#{alloc.allocatedAmount}" style="width: 150px;">
+                                    <f:convertNumber pattern="#,##0.00"/>
+                                </p:inputText>
+                            </p:column>
+                        </p:dataTable>
+                    </p:panel>
 
                     <p:spacer height="100"/>
 


### PR DESCRIPTION
3 files changed:
1. NEW CreditCompanyAllocation.java (com.divudi.core.data.dataStructure)
  - POJO with two constructors: one for EncounterCreditCompany rows, one for the fallback Institution row
  - getCompanyName() returns the institution name for display

  2. BhtSummeryController.java
  - New field: List<CreditCompanyAllocation> creditCompanyAllocations
  - updateTotal() now calls populateCreditCompanyAllocations() for credit admissions
  - populateCreditCompanyAllocations() — distributes remaining due across companies by credit limit; falls back to Admission.creditCompany if no EncounterCreditCompany rows exist
  - checkCreditAllocationTotal() — validates cashier-edited totals match net due; added to errorCheck()
  - settle() — now loops over creditCompanyAllocations instead of calling createCreditBillForCreditCompany()
  - saveCCBillForAllocation() — dispatches to saveCCBill() or saveCCBillByInstitution() based on row type
  - saveCCBillByInstitution() — new overload for the fallback case
  - createCreditBillForCreditCompany() unchanged (still used by settleProvisionalBill())

  3. inward_bill_final.xhtml
  - New <p:panel id="creditAllocationPanel"> with an editable p:dataTable placed between the charge items table and the tab view — only rendered for credit admissions after Process is clicked
  - "Credit Company Details" panel now shows a hint to click Process

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Inward final billing now supports intelligent allocation of charges across multiple credit companies with editable amounts based on available credit limits.

* **UI Improvements**
  * New credit company allocation panel allows users to review and adjust allocated amounts before processing the final bill.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->