### PR TITLE
19483 - If entered DOB age isn't calculated

### DIFF
--- a/src/main/webapp/patient_portal/portal_login.xhtml
+++ b/src/main/webapp/patient_portal/portal_login.xhtml
@@ -1533,9 +1533,10 @@
                                                         value="#{patientPortalController.patient.person.dob}"
                                                         placeholder="DD/MM/YYYY"
                                                         pattern="dd/MM/yyyy"
-                                                        monthNavigator="true" 
+                                                        monthNavigator="true"
                                                         yearNavigator="true"
                                                         styleClass="portal-datepicker">
+                                                        <p:ajax event="dateSelect" process="newPatientDob" update="ageYears ageMonths ageDays"/>
                                                     </p:datePicker>
                                                 </div>
                                             </div>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved date of birth selection in the patient portal - age fields now automatically calculate and display instantly when a date is selected, eliminating the need for manual updates or page refresh.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->