### PR TITLE
 #18650 Need Bill Type Filter in OPD Credit Due Report (Include Pharmacy Credit Bill)

### DIFF
--- a/src/main/java/com/divudi/bean/common/CreditCompanyDueController.java
+++ b/src/main/java/com/divudi/bean/common/CreditCompanyDueController.java
@@ -1337,6 +1337,9 @@ public class CreditCompanyDueController implements Serializable {
                 case "OPD":
                     btas = billService.fetchBillTypeAtomicsForOnlyOpdBills();
                     break;
+                case "PHARMACY":
+                    btas = billService.fetchBillTypeAtomicsPharmacySale();
+                    break;
                 case "PACKAGE":
                     btas = billService.fetchBillTypeAtomicsForOnlyPackageBills();
                     break;

--- a/src/main/java/com/divudi/service/BillService.java
+++ b/src/main/java/com/divudi/service/BillService.java
@@ -726,6 +726,18 @@ public class BillService {
         btas.add(BillTypeAtomic.PHARMACY_GRN_WHOLESALE);
         return btas;
     }
+    
+     public List<BillTypeAtomic> fetchBillTypeAtomicsPharmacySale(){
+        List<BillTypeAtomic> btas = new ArrayList<>();
+        btas.add(BillTypeAtomic.PHARMACY_RETAIL_SALE);
+        btas.add(BillTypeAtomic.PHARMACY_RETAIL_SALE_PREBILL_SETTLED_AT_CASHIER);
+        btas.add(BillTypeAtomic.PHARMACY_RETAIL_SALE_CANCELLED);
+        btas.add(BillTypeAtomic.PHARMACY_RETAIL_SALE_REFUND);
+        btas.add(BillTypeAtomic.PHARMACY_RETAIL_SALE_RETURN_ITEM_PAYMENTS);
+        btas.add(BillTypeAtomic.PHARMACY_RETAIL_SALE_RETURN_ITEMS_AND_PAYMENTS);
+        
+        return btas;
+    }
 
     public List<BillTypeAtomic> fetchBillTypeAtomicsForOnlyOpdBills() {
         List<BillTypeAtomic> btas = new ArrayList<>();

--- a/src/main/webapp/credit/credit_company_opd_due.xhtml
+++ b/src/main/webapp/credit/credit_company_opd_due.xhtml
@@ -41,6 +41,7 @@
                             <p:selectOneMenu class="w-100" value="#{creditCompanyDueController.billType}">
                                 <f:selectItem itemValue="ALL" itemLabel="All Bills (ALL)"/>
                                 <f:selectItem itemValue="OPD" itemLabel="OPD Bills (OPD)"/>
+                                <f:selectItem itemValue="PHARMACY" itemLabel="Pharmacy Bills (PHARMACY)"/>
                                 <f:selectItem itemValue="PACKAGE" itemLabel="Package Bills (PACKAGE)"/>
                                 <p:ajax update="@all"/>
                             </p:selectOneMenu>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features

* Added pharmacy billing support to credit company due reports. Users can now select "Pharmacy" from the bill type dropdown filter to view and manage pharmacy-specific credit transactions and balances.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->