### PR TITLE
Fix remaining CodeRabbit issues from PR #19575

### DIFF
--- a/src/main/java/com/divudi/bean/common/BillController.java
+++ b/src/main/java/com/divudi/bean/common/BillController.java
@@ -877,7 +877,8 @@ public class BillController implements Serializable, ControllerWithMultiplePayme
                     + " and c.retired=false "
                     + " and ((c.deptId) like :q or"
                     + " (c.patient.person.name) like :q "
-                    + " or (c.creditCompany.name) like :q ) "
+                    + " or (c.creditCompany.name) like :q "
+                    + " or (c.patientEncounter.bhtNo) like :q ) "
                     + " order by c.creditCompany.name";
             List<BillTypeAtomic> btas = new ArrayList<>();
             btas.add(BillTypeAtomic.INWARD_FINAL_BILL_PAYMENT_BY_CREDIT_COMPANY);

--- a/src/main/java/com/divudi/bean/common/CreditCompanyDueController.java
+++ b/src/main/java/com/divudi/bean/common/CreditCompanyDueController.java
@@ -495,7 +495,9 @@ public class CreditCompanyDueController implements Serializable {
         reportTimerController.trackReportExecution(() -> {
             Date startTime = new Date();
 
-            makeNull();
+            // Reset only output lists — preserve scope/filter fields (institution, dates, etc.)
+            creditCompanyAge = null;
+            filteredList = null;
 
             Map<Institution, List<Bill>> institutionMap = getCreditCompanyBillsGroupedByCreditCompany();
             final List<PatientEncounter> allPatientEncounters = new ArrayList<>();
@@ -1197,7 +1199,9 @@ public class CreditCompanyDueController implements Serializable {
 
     private void setInwardValues(String1Value5 dataTable5Value, List<Bill> bills) {
         for (Bill b : bills) {
-            long dayCount = CommonFunctions.getDayCountTillNow(b.getCreatedAt());
+            // Use billDate (financial obligation date) not createdAt (DB insert timestamp)
+            Date ageFrom = b.getBillDate() != null ? b.getBillDate() : b.getCreatedAt();
+            long dayCount = CommonFunctions.getDayCountTillNow(ageFrom);
 
             double finalValue = b.getNetTotal() - b.getPaidAmount();
 

--- a/src/main/java/com/divudi/bean/common/DataAdministrationController.java
+++ b/src/main/java/com/divudi/bean/common/DataAdministrationController.java
@@ -5003,7 +5003,7 @@ public class DataAdministrationController implements Serializable {
                                     ? pe.getFinalBill().getCreatedAt() : pe.getCreatedAt());
                     ccBill.setBillDate(billDate);
                     ccBill.setBillTime(billDate);
-                    ccBill.setCreatedAt(billDate);
+                    ccBill.setCreatedAt(new Date()); // audit timestamp — when the migration ran
                     ccBill.setCreater(sessionController.getLoggedUser());
 
                     ccBill.setPatientEncounter(pe);

--- a/src/main/java/com/divudi/bean/inward/BhtSummeryController.java
+++ b/src/main/java/com/divudi/bean/inward/BhtSummeryController.java
@@ -1467,7 +1467,7 @@ public class BhtSummeryController implements Serializable {
             return;
         }
         creditCompanyAllocations = new ArrayList<>();
-        double remaining = (grantTotal - discount) - paidByPatient - paidByCompany;
+        double remaining = Math.max(0.0, (grantTotal - discount) - paidByPatient - paidByCompany);
         List<EncounterCreditCompany> eccs = fillCreditCompaniesByPatient(patientEncounter);
         if (eccs != null && !eccs.isEmpty()) {
             // Sort by institution name for a stable, deterministic split order
@@ -1482,7 +1482,7 @@ public class BhtSummeryController implements Serializable {
                 creditCompanyAllocations.add(new CreditCompanyAllocation(ecc, alloc));
                 remaining -= alloc;
             }
-        } else if (patientEncounter.getCreditCompany() != null) {
+        } else if (remaining > 0 && patientEncounter.getCreditCompany() != null) {
             creditCompanyAllocations.add(new CreditCompanyAllocation(patientEncounter.getCreditCompany(), remaining));
         }
     }
@@ -1492,7 +1492,7 @@ public class BhtSummeryController implements Serializable {
                 || getPatientEncounter().getPaymentMethod() != PaymentMethod.Credit) {
             return false;
         }
-        double expected = (grantTotal - discount) - paidByPatient - paidByCompany;
+        double expected = Math.max(0.0, (grantTotal - discount) - paidByPatient - paidByCompany);
         if (expected > 0 && (creditCompanyAllocations == null || creditCompanyAllocations.isEmpty())) {
             JsfUtil.addErrorMessage("Please allocate the full credit due amount before settlement");
             return true;


### PR DESCRIPTION
## Summary

Follow-up to PR #19575 — addresses the remaining CodeRabbit review comments that were not included in the earlier fix commit.

- **Option B ageing fix**: `setInwardValues()` now ages inward CC bills by `billDate` (the financial obligation date) instead of `createdAt` (DB insert timestamp). This correctly ages migrated historical bills regardless of when the migration ran.
- **Honest `createdAt`**: Reverts `ccBill.setCreatedAt(billDate)` back to `new Date()` in `migrateInwardCreditCompanyBills()` — `createdAt` is an audit field recording when the row was inserted; `billDate` carries the correct historical date for ageing and reporting.
- **`createInwardAgeTableWithFilters()` scope fix**: Removed `makeNull()` call; only resets output lists (`creditCompanyAge`, `filteredList`) so user-selected scope/filter fields (institution, dates) are preserved across the report run.
- **Clamp credit remaining to zero**: `Math.max(0.0, ...)` in `populateCreditCompanyAllocations()` and `checkCreditAllocationTotal()` prevents fully-paid credit admissions from blocking settlement with a negative-allocation error.
- **BHT number search**: Added `patientEncounter.bhtNo` to `completeInwardCreditCompanyPaymentBill()` so cashiers can search by BHT number as the autocomplete placeholder promises.

## Test plan
- [ ] Run inward due age report — verify historical bills appear in the correct age bucket (not all in 0-30 days)
- [ ] Settle a credit admission where patient/company payments already cover the bill — verify no allocation error
- [ ] On credit payment inward page, type a BHT number in the autocomplete — verify matching bills appear
- [ ] Run inward age report with an institution pre-selected — verify institution filter is still applied after the report runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Extended search functionality to include billing encounter reference numbers when searching credit company payment records.

* **Bug Fixes**
  * Improved credit company aging calculations by using bill date for more accurate age reporting.
  * Enhanced credit allocation validation to prevent negative remaining balances in credit calculations.
  * Corrected timestamp assignment during billing record migration processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->