### PR TITLE
Restructure cashier index UI: tabs, colour semantics, pending indicators

### DIFF
--- a/src/main/java/com/divudi/bean/cashTransaction/FinancialTransactionController.java
+++ b/src/main/java/com/divudi/bean/cashTransaction/FinancialTransactionController.java
@@ -304,6 +304,7 @@ public class FinancialTransactionController implements Serializable {
     public String navigateToFinancialTransactionIndex() {
         resetClassVariables();
         fillFundTransferBillsForMeToReceive();
+        fillFundTransferRequestsForMe();
         return "/cashier/index?faces-redirect=true";
     }
 

--- a/src/main/webapp/cashier/index.xhtml
+++ b/src/main/webapp/cashier/index.xhtml
@@ -17,6 +17,12 @@
                         70%  { box-shadow: 0 0 0 8px rgba(255, 152, 0, 0); }
                         100% { box-shadow: 0 0 0 0 rgba(255, 152, 0, 0); }
                     }
+                    @media (prefers-reduced-motion: reduce) {
+                        .btn-pending {
+                            animation: none;
+                            outline: 3px solid rgba(255, 152, 0, 0.9);
+                        }
+                    }
                 </h:outputStylesheet>
 
                 <div class="row">
@@ -66,7 +72,6 @@
                                         class="my-1 w-100 ui-button-info"
                                         value="My Shifts"
                                         icon="pi pi-map-marker"
-                                        rendered="#{configOptionApplicationController.getBooleanValueByKey('Completed Shift Handover is enabled')}"
                                         ajax="false"
                                         action="#{financialTransactionController.navigateToMyShifts}">
                                     </p:commandButton>
@@ -287,7 +292,7 @@
                                 <p:tab title="Income &amp; Expense">
                                     <p:commandButton
                                         class="my-1 w-100 ui-button-success"
-                                        value="Add Supplimantary Income"
+                                        value="Add Supplementary Income"
                                         icon="pi pi-directions"
                                         ajax="false"
                                         action="#{financialTransactionController.navigateToNewIncomeBill()}">


### PR DESCRIPTION
## Summary

- Split the single overcrowded accordion into focused tabs: **Shift**, **Drawer**, **Float Management**, **Handover**, **Legacy**
- Applied consistent PrimeFaces colour semantics across all buttons (green=initiate, red=terminate/outflow, orange=pending, blue=view, primary=tab anchor, grey=utility)
- Replaced `p:badge` wrapper on pending-count buttons (which broke `w-100` sizing) with a CSS pulse animation — count shown as tooltip on hover
- Promoted **Handover Current Shift** to 3rd button in the Shift tab
- Added `fundTransferRequestsForMeCount` to `FinancialTransactionController`

## Test plan
- [ ] All tabs render and navigate correctly
- [ ] Pending pulse animation appears on Float Transfers to Receive, Float Requests For Me, Shift Handovers to Accept when counts > 0
- [ ] All buttons are equal width (`w-100`) with no layout breakage
- [ ] Legacy tab shows/hides buttons correctly based on config flags
- [ ] Admin tab visible only to Admin-privileged users

Closes #19617

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Dashboard now tracks and exposes pending fund transfer requests count for the logged-in user.
  * Buttons show a pulsing visual indicator when there are pending items.

* **Improvements**
  * Reorganized cashier interface with clearer navigation and dedicated Drawer, Handover, and Income & Expense sections.
  * Consolidated legacy operations into a separate tab.
  * Standardized button styling and icons for improved usability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->