### PR TITLE
Enhance Admission by Consultant Report: DTO approach + new filters (Issue #19642)

### DIFF
--- a/src/main/java/com/divudi/bean/inward/AdmissionReportController.java
+++ b/src/main/java/com/divudi/bean/inward/AdmissionReportController.java
@@ -4,8 +4,11 @@ import com.divudi.core.data.PaymentMethod;
 import com.divudi.core.data.dto.AdmissionReportDTO;
 import com.divudi.core.entity.Department;
 import com.divudi.core.entity.Institution;
+import com.divudi.core.entity.Speciality;
+import com.divudi.core.entity.Staff;
 import com.divudi.core.entity.inward.AdmissionType;
 import com.divudi.core.facade.AdmissionFacade;
+import com.divudi.core.facade.StaffFacade;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Calendar;
@@ -19,10 +22,11 @@ import javax.inject.Named;
 import javax.persistence.TemporalType;
 
 /**
- * Controller for the enhanced Admission Report page (Issue #19640).
+ * Controller for the enhanced Admission Report (Issue #19640) and
+ * Admission by Consultant Report (Issue #19642).
  *
- * Replaces the entity-based query in MdInwardReportController.fillAdmissions()
- * with a DTO-based JPQL SELECT NEW approach so that all columns are populated
+ * Replaces the entity-based query in MdInwardReportController with a
+ * DTO-based JPQL SELECT NEW approach so that all columns are populated
  * in one query and there are no lazy-load round-trips during rendering.
  */
 @Named
@@ -32,8 +36,11 @@ public class AdmissionReportController implements Serializable {
     @EJB
     private AdmissionFacade admissionFacade;
 
+    @EJB
+    private StaffFacade staffFacade;
+
     // -------------------------------------------------------------------------
-    // Filter fields
+    // Filter fields — shared by both report pages
     // -------------------------------------------------------------------------
     private Date fromDate = startOfCurrentMonth();
     private Date toDate = new Date();
@@ -49,16 +56,29 @@ public class AdmissionReportController implements Serializable {
     private Institution site;
     private Department department;
 
+    // --- Admission-by-Consultant specific filters ---
+    private Speciality speciality;
+    private Staff consultant;
+
     // -------------------------------------------------------------------------
     // Report output
     // -------------------------------------------------------------------------
     private List<AdmissionReportDTO> admissions;
+    private List<AdmissionReportDTO> admissionsByConsultant;
 
     // -------------------------------------------------------------------------
-    // Main generate method
+    // Main generate methods
     // -------------------------------------------------------------------------
 
     public void fillAdmissions() {
+        admissions = executeAdmissionQuery(null, null);
+    }
+
+    public void fillAdmissionsByConsultant() {
+        admissionsByConsultant = executeAdmissionQuery(speciality, consultant);
+    }
+
+    private List<AdmissionReportDTO> executeAdmissionQuery(Speciality filterSpeciality, Staff filterConsultant) {
         Map<String, Object> params = new HashMap<>();
 
         StringBuilder jpql = new StringBuilder(
@@ -125,13 +145,52 @@ public class AdmissionReportController implements Serializable {
             params.put("dept", department);
         }
 
+        // --- speciality (consultant report only) ---
+        if (filterSpeciality != null) {
+            jpql.append(" and ad.referringConsultant.speciality = :sp");
+            params.put("sp", filterSpeciality);
+        }
+
+        // --- consultant/staff (consultant report only) ---
+        if (filterConsultant != null) {
+            jpql.append(" and ad.referringConsultant = :cs");
+            params.put("cs", filterConsultant);
+        }
+
         jpql.append(" order by ad.createdAt asc");
 
         List<Object> results = admissionFacade.findObjectByJpql(jpql.toString(), params, TemporalType.TIMESTAMP);
-        admissions = new ArrayList<>();
+        List<AdmissionReportDTO> list = new ArrayList<>();
         for (Object o : results) {
-            admissions.add((AdmissionReportDTO) o);
+            list.add((AdmissionReportDTO) o);
         }
+        return list;
+    }
+
+    // -------------------------------------------------------------------------
+    // AutoComplete for consultant filter
+    // -------------------------------------------------------------------------
+
+    public List<Staff> completeConsultant(String query) {
+        Map<String, Object> params = new HashMap<>();
+        String jpql;
+
+        if (speciality != null) {
+            jpql = "select p from Staff p"
+                    + " where p.retired = false"
+                    + " and (upper(p.person.name) like :q or p.code like :q)"
+                    + " and p.speciality = :sp"
+                    + " order by p.person.name";
+            params.put("sp", speciality);
+        } else {
+            jpql = "select p from Staff p"
+                    + " where p.retired = false"
+                    + " and p.speciality is not null"
+                    + " and (upper(p.person.name) like :q or p.code like :q)"
+                    + " order by p.person.name";
+        }
+        params.put("q", "%" + query.toUpperCase() + "%");
+        return staffFacade.findByJpql(jpql, params, 20);
     }
 
     // -------------------------------------------------------------------------
@@ -141,6 +200,11 @@ public class AdmissionReportController implements Serializable {
     /** Called when Institution or Site selection changes to prevent stale department. */
     public void clearDepartment() {
         department = null;
+    }
+
+    /** Called when Speciality changes to clear the consultant so the list refreshes. */
+    public void clearConsultant() {
+        consultant = null;
     }
 
     // -------------------------------------------------------------------------
@@ -156,7 +220,10 @@ public class AdmissionReportController implements Serializable {
         institution = null;
         site = null;
         department = null;
+        speciality = null;
+        consultant = null;
         admissions = null;
+        admissionsByConsultant = null;
     }
 
     // -------------------------------------------------------------------------
@@ -201,5 +268,13 @@ public class AdmissionReportController implements Serializable {
     public Department getDepartment() { return department; }
     public void setDepartment(Department department) { this.department = department; }
 
+    public Speciality getSpeciality() { return speciality; }
+    public void setSpeciality(Speciality speciality) { this.speciality = speciality; }
+
+    public Staff getConsultant() { return consultant; }
+    public void setConsultant(Staff consultant) { this.consultant = consultant; }
+
     public List<AdmissionReportDTO> getAdmissions() { return admissions; }
+
+    public List<AdmissionReportDTO> getAdmissionsByConsultant() { return admissionsByConsultant; }
 }

--- a/src/main/java/com/divudi/bean/report/MdInwardReportController.java
+++ b/src/main/java/com/divudi/bean/report/MdInwardReportController.java
@@ -323,7 +323,7 @@ public class MdInwardReportController implements Serializable {
 //        }
 //    }
 
-    // TODO: delete fillAdmissionsByConsultants() — superseded (Issue #19640)
+    // TODO: delete fillAdmissionsByConsultants() — superseded by AdmissionReportController (Issue #19642)
 //    public void fillAdmissionsByConsultants() {
 //        try {
 //            String sql;

--- a/src/main/java/com/divudi/core/data/dto/AdmissionReportDTO.java
+++ b/src/main/java/com/divudi/core/data/dto/AdmissionReportDTO.java
@@ -8,7 +8,7 @@ import java.io.Serializable;
 import java.util.Date;
 
 /**
- * DTO for the Admission Report (Issue #19640).
+ * DTO for the Admission Report (Issue #19640) and Admission by Consultant Report (Issue #19642).
  * One row per Admission (PatientEncounter subclass).
  *
  * Populated by a JPQL query in AdmissionReportController — avoids

--- a/src/main/webapp/inward/inward_reports.xhtml
+++ b/src/main/webapp/inward/inward_reports.xhtml
@@ -19,7 +19,7 @@
                                 <p:tab title="Admission Reports" closable="false">
                                     <div class="d-grid gap-2"> 
                                         <p:commandButton  ajax="false" value="Admission Report" action="report_admissions?faces-redirect=true" actionListener="#{admissionReportController.makeNull()}"/>
-                                        <p:commandButton ajax="false" value="Admission Report by Consultant" action="report_admission_by_consultant?faces-redirect=true" actionListener="#{mdInwardReportController.makeNull()}"/>
+                                        <p:commandButton ajax="false" value="Admission Report by Consultant" action="report_admission_by_consultant?faces-redirect=true" actionListener="#{admissionReportController.makeNull()}"/>
                                     </div>
                                 </p:tab>
                                 <p:tab title="Service Reports" closable="false">

--- a/src/main/webapp/inward/report_admission_by_consultant.xhtml
+++ b/src/main/webapp/inward/report_admission_by_consultant.xhtml
@@ -4,144 +4,357 @@
       xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
       xmlns:h="http://xmlns.jcp.org/jsf/html"
       xmlns:p="http://primefaces.org/ui"
-      xmlns:f="http://xmlns.jcp.org/jsf/core"
-      xmlns:bi="http://xmlns.jcp.org/jsf/composite/bill"
-      >
+      xmlns:f="http://xmlns.jcp.org/jsf/core">
 
     <h:body>
 
         <ui:composition template="/inward/inward_reports.xhtml">
 
             <ui:define name="subcontent">
-                <h:form>
-                    <p:panel header="Admission Report by Consultant" >
-                        <div class="row w-100">
-                            <div class="col-6">
-                                <h:panelGrid columns="2">
-                                    <p:outputLabel value="From" />
-                                    <p:calendar id="fdate"
-                                                class="mx-4 w-100"
-                                                inputStyleClass="w-100"
-                                                pattern="#{sessionController.applicationPreference.longDateTimeFormat}" 
-                                                value="#{mdInwardReportController.fromDate}"></p:calendar>
-                                    <p:outputLabel value="To" />
-                                    <p:calendar  id="tdate" 
-                                                 class="mx-4 w-100"
-                                                 inputStyleClass="w-100"
-                                                 pattern="#{sessionController.applicationPreference.longDateTimeFormat}" 
-                                                 value="#{mdInwardReportController.toDate}"></p:calendar>
+                <h:form id="frm">
 
-                                    <h:outputLabel  value="Speciality" ></h:outputLabel>
-                                    <p:autoComplete class="mx-4 w-100" forceSelection="true" value="#{mdInwardReportController.speciality}" id="acSpeciality"
-                                                    completeMethod="#{specialityController.completeSpeciality}"
-                                                    inputStyleClass="w-100"
-                                                    var="mysp" itemLabel="#{mysp.name}" itemValue="#{mysp}"
-                                                    >
-                                        <f:ajax event="itemSelect" execute="acSpeciality"  render="scStaff"  />
-                                    </p:autoComplete>
-                                    <h:outputLabel  value="Staff / Doctor" ></h:outputLabel>
-                                    <p:autoComplete class="mx-4 w-100" 
-                                                    inputStyleClass="w-100"
-                                                    forceSelection="true" 
-                                                    value="#{mdInwardReportController.currentStaff}" 
-                                                    id="scStaff"
-                                                    completeMethod="#{mdInwardReportController.completeStaff}" 
-                                                    var="mys" itemLabel="#{mys.person.nameWithTitle}" 
-                                                    itemValue="#{mys}"
-                                                    >
-                                    </p:autoComplete>
-                                </h:panelGrid>
-                            </div>
-                        </div>
+                    <p:panel header="Admission Report by Consultant" class="m-1">
 
+                        <h:panelGrid columns="8" styleClass="w-100 form-grid" columnClasses="label-icon-column, input-column">
 
+                            <!-- From date -->
+                            <h:panelGroup layout="block" styleClass="form-group">
+                                <h:outputText value="&#xf073;" styleClass="fa ml-5" />
+                                <h:outputLabel value="From" for="fromDate" class="mx-3"/>
+                            </h:panelGroup>
+                            <p:calendar
+                                styleClass="w-100"
+                                inputStyleClass="w-100 form-control"
+                                id="fromDate"
+                                value="#{admissionReportController.fromDate}"
+                                pattern="#{sessionController.applicationPreference.longDateTimeFormat}" />
 
-                        <h:panelGrid columns="4" class="my-4" >
-                            <p:commandButton ajax="false" value="Process" icon="fas fa-cogs" class="ui-button-warning mx-1" action="#{mdInwardReportController.fillAdmissionsByConsultants}"   />
-                            <p:commandButton value="Print" icon="fas fa-print" class="ui-button-info mx-1" ajax="false" action="#" >
-                                <p:printer target="gpBillPreview" ></p:printer>
-                            </p:commandButton>
+                            <p:spacer width="50" />
 
-                            <p:commandButton ajax="false" value="Excel" icon="fas fa-file-excel" class="ui-button-success mx-1"  >
-                                <p:dataExporter type="xlsx" target="tbl" fileName="admission_report_by_consultant" />
-                            </p:commandButton>
+                            <!-- To date -->
+                            <h:panelGroup layout="block" styleClass="form-group">
+                                <h:outputText value="&#xf073;" styleClass="fa mr-2" />
+                                <h:outputLabel value="To" for="toDate" class="mx-3"/>
+                            </h:panelGroup>
+                            <p:calendar
+                                styleClass="w-100"
+                                inputStyleClass="w-100 form-control"
+                                id="toDate"
+                                value="#{admissionReportController.toDate}"
+                                pattern="#{sessionController.applicationPreference.longDateTimeFormat}" />
 
+                            <p:spacer width="50" />
+
+                            <!-- Date basis -->
+                            <h:panelGroup layout="block" styleClass="form-group">
+                                <h:outputText value="&#xf017;" styleClass="fa mr-2" />
+                                <h:outputLabel value="Date Basis" for="dateBasisMenu" class="mx-3"/>
+                            </h:panelGroup>
+                            <p:selectOneMenu
+                                id="dateBasisMenu"
+                                styleClass="w-100 form-control"
+                                value="#{admissionReportController.dateBasis}">
+                                <f:selectItem itemValue="createdAt"     itemLabel="Created Date (default)" />
+                                <f:selectItem itemValue="admissionDate" itemLabel="Admission Date" />
+                            </p:selectOneMenu>
+
+                            <!-- Admission type -->
+                            <h:panelGroup layout="block" styleClass="form-group">
+                                <h:outputText value="&#xf0f0;" styleClass="fa mr-2" />
+                                <h:outputLabel value="Admission Type" for="admTypeMenu" class="mx-3"/>
+                            </h:panelGroup>
+                            <p:selectOneMenu
+                                id="admTypeMenu"
+                                styleClass="w-100 form-control"
+                                value="#{admissionReportController.admissionType}">
+                                <f:selectItem itemLabel="All" itemValue="#{null}" />
+                                <f:selectItems
+                                    value="#{admissionTypeController.items}"
+                                    var="at"
+                                    itemValue="#{at}"
+                                    itemLabel="#{at.name}" />
+                            </p:selectOneMenu>
+
+                            <p:spacer width="50" />
+
+                            <!-- Payment method -->
+                            <h:panelGroup layout="block" styleClass="form-group">
+                                <h:outputText value="&#xf09d;" styleClass="fa mr-2" />
+                                <h:outputLabel value="Payment Method" for="pmMenu" class="mx-3"/>
+                            </h:panelGroup>
+                            <p:selectOneMenu
+                                id="pmMenu"
+                                styleClass="w-100 form-control"
+                                value="#{admissionReportController.paymentMethod}">
+                                <f:selectItem itemLabel="All" itemValue="#{null}" />
+                                <f:selectItems value="#{enumController.paymentMethodForAdmission}" />
+                            </p:selectOneMenu>
+
+                            <p:spacer width="50" />
+
+                            <!-- Speciality -->
+                            <h:panelGroup layout="block" styleClass="form-group">
+                                <h:outputText value="&#xf7d9;" styleClass="fa mr-2" />
+                                <h:outputLabel value="Speciality" for="acSpeciality" class="mx-3"/>
+                            </h:panelGroup>
+                            <p:autoComplete
+                                id="acSpeciality"
+                                styleClass="w-100"
+                                inputStyleClass="w-100 form-control"
+                                forceSelection="true"
+                                value="#{admissionReportController.speciality}"
+                                completeMethod="#{specialityController.completeSpeciality}"
+                                var="sp"
+                                itemLabel="#{sp.name}"
+                                itemValue="#{sp}">
+                                <p:ajax event="itemSelect" process="acSpeciality" update="acConsultant" listener="#{admissionReportController.clearConsultant()}" />
+                            </p:autoComplete>
+
+                            <p:spacer width="50" />
+
+                            <!-- Consultant -->
+                            <h:panelGroup layout="block" styleClass="form-group">
+                                <h:outputText value="&#xf0f0;" styleClass="fa mr-2" />
+                                <h:outputLabel value="Consultant" for="acConsultant" class="mx-3"/>
+                            </h:panelGroup>
+                            <p:autoComplete
+                                id="acConsultant"
+                                styleClass="w-100"
+                                inputStyleClass="w-100 form-control"
+                                forceSelection="true"
+                                value="#{admissionReportController.consultant}"
+                                completeMethod="#{admissionReportController.completeConsultant}"
+                                var="st"
+                                itemLabel="#{st.person.nameWithTitle}"
+                                itemValue="#{st}" />
+
+                            <p:spacer width="50" />
+                            <p:spacer width="50" />
+                            <p:spacer width="50" />
+
+                            <!-- Institution -->
+                            <h:panelGroup layout="block" styleClass="form-group">
+                                <h:outputText value="&#xf19c;" styleClass="fa mr-2" />
+                                <h:outputLabel value="Institution" for="cmbIns" class="mx-3"/>
+                            </h:panelGroup>
+                            <p:selectOneMenu
+                                id="cmbIns"
+                                styleClass="w-100 form-control"
+                                value="#{admissionReportController.institution}"
+                                filter="true">
+                                <f:selectItem itemLabel="All Institutions" itemValue="#{null}" />
+                                <f:selectItems value="#{institutionController.companies}" var="ins" itemLabel="#{ins.name}" itemValue="#{ins}" />
+                                <p:ajax process="cmbIns" update="cmbDept" listener="#{admissionReportController.clearDepartment()}" />
+                            </p:selectOneMenu>
+
+                            <p:spacer />
+
+                            <!-- Site -->
+                            <h:panelGroup layout="block" styleClass="form-group">
+                                <h:outputText value="&#xf3c5;" styleClass="fa mr-2" />
+                                <h:outputLabel value="Site" for="siteMenu" class="mx-3"/>
+                            </h:panelGroup>
+                            <p:selectOneMenu
+                                id="siteMenu"
+                                styleClass="w-100 form-control"
+                                value="#{admissionReportController.site}"
+                                filter="true">
+                                <f:selectItem itemLabel="All Sites" itemValue="#{null}" />
+                                <f:selectItems value="#{institutionController.sites}" var="site" itemLabel="#{site.name}" itemValue="#{site}" />
+                                <p:ajax process="siteMenu" update="cmbDept" listener="#{admissionReportController.clearDepartment()}" />
+                            </p:selectOneMenu>
+
+                            <p:spacer />
+
+                            <!-- Department — four rendered variants matching institution+site selection -->
+                            <h:panelGroup layout="block" styleClass="form-group">
+                                <h:outputText value="&#xf0e8;" styleClass="fa mr-2" />
+                                <h:outputLabel value="Department" for="cmbDept" class="mx-3"/>
+                            </h:panelGroup>
+                            <h:panelGroup id="cmbDept">
+
+                                <p:selectOneMenu
+                                    rendered="#{admissionReportController.institution eq null and admissionReportController.site eq null}"
+                                    styleClass="w-100 form-control"
+                                    value="#{admissionReportController.department}"
+                                    filterMatchMode="contains"
+                                    filter="true">
+                                    <f:selectItem itemLabel="All Departments" itemValue="#{null}" />
+                                    <f:selectItems
+                                        value="#{departmentController.getDepartmentsOfInstitutionAndSite()}"
+                                        var="d" itemLabel="#{d.name}" itemValue="#{d}" />
+                                </p:selectOneMenu>
+
+                                <p:selectOneMenu
+                                    rendered="#{admissionReportController.institution eq null and admissionReportController.site ne null}"
+                                    styleClass="w-100 form-control"
+                                    value="#{admissionReportController.department}"
+                                    filterMatchMode="contains"
+                                    filter="true">
+                                    <f:selectItem itemLabel="All Departments" itemValue="#{null}" />
+                                    <f:selectItems
+                                        value="#{departmentController.getDepartmentsOfInstitutionAndSite(admissionReportController.site)}"
+                                        var="d" itemLabel="#{d.name}" itemValue="#{d}" />
+                                </p:selectOneMenu>
+
+                                <p:selectOneMenu
+                                    rendered="#{admissionReportController.institution ne null and admissionReportController.site eq null}"
+                                    styleClass="w-100 form-control"
+                                    value="#{admissionReportController.department}"
+                                    filterMatchMode="contains"
+                                    filter="true">
+                                    <f:selectItem itemLabel="All Departments" itemValue="#{null}" />
+                                    <f:selectItems
+                                        value="#{departmentController.getDepartmentsOfInstitutionAndSiteForInstitution(admissionReportController.institution)}"
+                                        var="d" itemLabel="#{d.name}" itemValue="#{d}" />
+                                </p:selectOneMenu>
+
+                                <p:selectOneMenu
+                                    rendered="#{admissionReportController.institution ne null and admissionReportController.site ne null}"
+                                    styleClass="w-100 form-control"
+                                    value="#{admissionReportController.department}"
+                                    filterMatchMode="contains"
+                                    filter="true">
+                                    <f:selectItem itemLabel="All Departments" itemValue="#{null}" />
+                                    <f:selectItems
+                                        value="#{departmentController.getDepartmentsOfInstitutionAndSite(admissionReportController.institution, admissionReportController.site)}"
+                                        var="d" itemLabel="#{d.name}" itemValue="#{d}" />
+                                </p:selectOneMenu>
+
+                            </h:panelGroup>
 
                         </h:panelGrid>
-                        <p:panel id="gpBillPreview">
 
-                            <p:dataTable id="tbl" value="#{mdInwardReportController.admissions}" var="ad" rowIndexVar="index" >
-                                
-                                <p:column style="width: 2%">
-                                    <p:outputLabel value="#{index+1}" />
-                                </p:column>
+                        <p:commandButton
+                            value="Generate"
+                            icon="fas fa-cogs"
+                            action="#{admissionReportController.fillAdmissionsByConsultant()}"
+                            ajax="false"
+                            class="ui-button-success m-1" />
 
-                                <p:column headerText="BHT No" filterBy="#{ad.bhtNo}" filterMatchMode="contains" sortBy="#{ad.bhtNo}">
-                                    <f:facet name="header">
-                                        <p:outputLabel value="BHT No" />
-                                    </f:facet>
-                                    <p:outputLabel value="#{ad.bhtNo}" >
-                                    </p:outputLabel>
-                                </p:column>
-
-                                <p:column headerText="Patient Name">
-                                    <f:facet name="header">
-                                        <p:outputLabel value="Patient Name" />
-                                    </f:facet>
-                                    <p:outputLabel value="#{ad.patient.person.nameWithTitle}" >
-                                    </p:outputLabel>
-                                </p:column>
-
-                                <p:column headerText="Telephone No">
-                                    <f:facet name="header">
-                                        <p:outputLabel value="Telephone No" />
-                                    </f:facet>
-                                    <p:outputLabel value="#{ad.patient.person.smsNumber}" >
-                                    </p:outputLabel>
-                                </p:column>
-
-                                <p:column headerText="Consultant Name">
-                                    <f:facet name="header">
-                                        <p:outputLabel value="Consultant Name" />
-                                    </f:facet>
-                                    <p:outputLabel value="#{ad.referringConsultant ne null ? ad.referringConsultant.person.nameWithTitle : 'N/A'}" >
-                                    </p:outputLabel>
-                                </p:column>
-
-                                <p:column headerText="Room No">
-                                    <f:facet name="header">
-                                        <p:outputLabel value="Room No" />
-                                    </f:facet>
-                                    <p:outputLabel value="#{ad.currentPatientRoom.roomFacilityCharge.name}" >
-                                    </p:outputLabel>
-                                </p:column>
-
-                                <p:column headerText="Date of Admission">
-                                    <f:facet name="header">
-                                        <p:outputLabel value="Date of Admission" />
-                                    </f:facet>
-                                    <p:outputLabel value="#{ad.dateOfAdmission}"  >
-                                        <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateFormat}"  />
-                                    </p:outputLabel>
-                                </p:column>
-
-                                <p:column headerText="Discharged Date">
-                                    <f:facet name="header">
-                                        <p:outputLabel value="Discharged Date" />
-                                    </f:facet>
-                                    <p:outputLabel value="#{ad.dateOfDischarge}" rendered="#{ad.dateOfDischarge ne null}" >
-                                        <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateFormat}"  />
-                                    </p:outputLabel>
-                                    <p:outputLabel value="N/A" rendered="#{ad.dateOfDischarge eq null}" />
-                                </p:column>
-
-                            </p:dataTable>
-
-                        </p:panel>
                     </p:panel>
+
+                    <!-- Results panel — only shown once data is available -->
+                    <p:panel id="pnlResults" rendered="#{admissionReportController.admissionsByConsultant != null}">
+
+                        <f:facet name="header">
+                            <div class="d-flex justify-content-between align-items-center">
+                                <h:outputText value="Results" />
+                                <div>
+                                    <p:commandButton
+                                        value="Print"
+                                        icon="fas fa-print"
+                                        class="ui-button-info me-1"
+                                        ajax="false">
+                                        <p:printer target="tblAdmissions" />
+                                    </p:commandButton>
+                                    <p:commandButton
+                                        value="Excel"
+                                        icon="fas fa-file-excel"
+                                        class="ui-button-success me-1"
+                                        ajax="false">
+                                        <p:dataExporter type="xlsx" target="tblAdmissions" fileName="admission_report_by_consultant" />
+                                    </p:commandButton>
+                                    <p:commandButton
+                                        value="PDF"
+                                        icon="fas fa-file-pdf"
+                                        class="ui-button-danger"
+                                        ajax="false">
+                                        <p:dataExporter type="pdf" target="tblAdmissions" fileName="admission_report_by_consultant" />
+                                    </p:commandButton>
+                                </div>
+                            </div>
+                        </f:facet>
+
+                        <p:dataTable
+                            id="tblAdmissions"
+                            value="#{admissionReportController.admissionsByConsultant}"
+                            var="ad"
+                            emptyMessage="No records found"
+                            paginator="true"
+                            rows="20"
+                            paginatorAlwaysVisible="false"
+                            paginatorPosition="bottom"
+                            paginatorTemplate="{CurrentPageReport} {FirstPageLink} {PreviousPageLink} {PageLinks} {NextPageLink} {LastPageLink} {RowsPerPageDropdown}"
+                            currentPageReportTemplate="{startRecord}-{endRecord} of {totalRecords} records"
+                            rowsPerPageTemplate="10,20,50,{ShowAll|'All'}"
+                            styleClass="w-100">
+
+                            <!-- BHT No — screen: link to inpatient profile; export: plain text via exportValue -->
+                            <p:column headerText="BHT No" style="white-space:nowrap;" exportValue="#{ad.bhtNo}">
+                                <p:commandButton
+                                    value="#{ad.bhtNo}"
+                                    icon="fas fa-bed"
+                                    styleClass="ui-button-link p-0"
+                                    ajax="false"
+                                    action="#{admissionController.navigateToAdmissionProfileById(ad.admissionId)}"
+                                    title="Open Inpatient Dashboard" />
+                            </p:column>
+
+                            <p:column headerText="Patient Name">
+                                <h:outputText value="#{ad.patientName}" />
+                            </p:column>
+
+                            <p:column headerText="Telephone No">
+                                <h:outputText value="#{ad.phone}" />
+                            </p:column>
+
+                            <p:column headerText="Consultant">
+                                <h:outputText value="#{not empty ad.consultantName ? ad.consultantName : 'N/A'}" />
+                            </p:column>
+
+                            <p:column headerText="Room No">
+                                <h:outputText value="#{not empty ad.roomName ? ad.roomName : 'N/A'}" />
+                            </p:column>
+
+                            <p:column headerText="Date of Admission" style="white-space:nowrap;">
+                                <h:outputText value="#{ad.dateOfAdmission}">
+                                    <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateFormat}" />
+                                </h:outputText>
+                            </p:column>
+
+                            <p:column headerText="Discharged Date" style="white-space:nowrap;">
+                                <h:outputText value="#{ad.dateOfDischarge}" rendered="#{ad.dateOfDischarge ne null}">
+                                    <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateFormat}" />
+                                </h:outputText>
+                                <h:outputText value="N/A" rendered="#{ad.dateOfDischarge eq null}" />
+                            </p:column>
+
+                            <p:column headerText="Admission Type">
+                                <h:outputText value="#{ad.admissionType != null ? ad.admissionType.name : ''}" />
+                            </p:column>
+
+                            <p:column headerText="BHT Type">
+                                <h:outputText value="#{ad.paymentMethod}" />
+                            </p:column>
+
+                            <p:column headerText="Credit Company">
+                                <h:outputText value="#{not empty ad.creditCompanyName ? ad.creditCompanyName : 'N/A'}" />
+                            </p:column>
+
+                            <!--
+                                Status column: badges on screen; plain text exported to Excel/PDF.
+                            -->
+                            <p:column headerText="Discharge Status" exportValue="#{ad.dischargeStatusText}">
+                                <h:panelGroup>
+                                    <p:badge value="Discharged"     styleClass="ui-badge-success w-100" rendered="#{ad.discharged}" />
+                                    <p:badge value="Not Discharged" styleClass="ui-badge-danger  w-100" rendered="#{!ad.discharged}" />
+                                </h:panelGroup>
+                            </p:column>
+
+                            <p:column headerText="Payment Status" exportValue="#{ad.paymentStatusText}">
+                                <h:panelGroup>
+                                    <p:badge value="Finalized"     styleClass="ui-badge-info    w-100" rendered="#{ad.paymentFinalized}" />
+                                    <p:badge value="Not Finalized" styleClass="ui-badge-warning w-100" rendered="#{!ad.paymentFinalized}" />
+                                </h:panelGroup>
+                            </p:column>
+
+                        </p:dataTable>
+
+                    </p:panel>
+
                 </h:form>
             </ui:define>
-
 
         </ui:composition>
 


### PR DESCRIPTION
## Summary

- **New `AdmissionReportController`** (`@SessionScoped`): shared bean for both Admission Report (#19640) and Admission by Consultant Report — replaces `mdInwardReportController` for these two pages
  - Shared filters: date range, date basis (`createdAt` default / admission date), admission type, payment method, institution, site, department
  - Consultant-specific filters: speciality (autocomplete) and consultant (autocomplete, filtered by selected speciality via `clearConsultant()` listener)
  - DTO-based JPQL `SELECT NEW` — no lazy-load N+1 round-trips
- **New `AdmissionReportDTO`**: projection DTO for both pages; null-safe `Boolean` unboxing; `dischargeStatusText`/`paymentStatusText` helpers for clean export
- **`report_admission_by_consultant.xhtml`**: full rewrite — all new filters, inpatient profile link per BHT No, Print/Excel/PDF export with `exportValue` for badge-free output, status badges on screen
- **`report_admissions.xhtml`**: rewritten to use `AdmissionReportController` (same enhancement as #19640, included here since both pages share the controller)
- **`AdmissionController`**: added `navigateToAdmissionProfileById(Long)` for DTO-context row navigation
- **`MdInwardReportController`**: `fillAdmissions()` and `fillAdmissionsByConsultants()` commented out with TODO markers
- **`inward_reports.xhtml`**: sidebar `makeNull()` calls switched to `admissionReportController`

## Test plan

- [ ] Open Admission by Consultant Report; verify all filter combinations work
- [ ] Select a speciality — consultant autocomplete should filter to that speciality; clearing speciality should not retain stale consultant
- [ ] Verify institution/site/department cascade (selecting institution clears department)
- [ ] Generate with date basis = Admission Date; verify results differ from Created Date when applicable
- [ ] Click BHT No link; verify inpatient profile opens for that admission
- [ ] Export to Excel and PDF; confirm no badge HTML in exported cells; status columns show plain text
- [ ] Open Admission Report; confirm it also works with the shared controller

Closes #19642

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced new "Admission by Consultant" report with comprehensive filtering options (Date Basis, Admission Type, Payment Method, Institution, Site, Department, Consultant, Speciality)
  * Enhanced report results view with pagination support
  * Improved export functionality with Print, Excel, and PDF options
  * Direct navigation to admission details from report results
<!-- end of auto-generated comment: release notes by coderabbit.ai -->