### PR TITLE
Add config to auto-mark credit admissions as claimable (#19646)

### DIFF
--- a/src/main/java/com/divudi/bean/inward/AdmissionController.java
+++ b/src/main/java/com/divudi/bean/inward/AdmissionController.java
@@ -497,6 +497,11 @@ public class AdmissionController implements Serializable, ControllerWithPatient 
                 current.setClaimable(false);
             }
         }
+        if (configOptionApplicationController.getBooleanValueByKey("Inward Admission - Auto Mark Claimable for Credit Admissions", false)) {
+            if (current.getPaymentMethod() == PaymentMethod.Credit) {
+                current.setClaimable(true);
+            }
+        }
         if (configOptionApplicationController.getBooleanValueByKey("Inward Admission - Find And Fill Last Used Credit Companies of a Patient", false)) {
             if (current.getPatient() == null) {
                 return;
@@ -1343,6 +1348,9 @@ public class AdmissionController implements Serializable, ControllerWithPatient 
         if (!configOptionApplicationController.getBooleanValueByKey("Inward Admission - Show Claimable Field", true)) {
             return false;
         }
+        if (configOptionApplicationController.getBooleanValueByKey("Inward Admission - Auto Mark Claimable for Credit Admissions", false)) {
+            return true;
+        }
         String claimableRequiredFor = configOptionApplicationController.getShortTextValueByKey(
                 "Inward Admission - Claimable Required For", "Credit");
         if ("None".equalsIgnoreCase(claimableRequiredFor)) {
@@ -1492,13 +1500,15 @@ public class AdmissionController implements Serializable, ControllerWithPatient 
         boolean showClaimable = configOptionApplicationController.getBooleanValueByKey(
                 "Inward Admission - Show Claimable Field", true);
         if (showClaimable) {
+            boolean autoMarkCredit = configOptionApplicationController.getBooleanValueByKey(
+                    "Inward Admission - Auto Mark Claimable for Credit Admissions", false);
             boolean claimableAllowed = isClaimableAllowed();
-            if (!claimableAllowed && getCurrent().isClaimable()) {
+            if (!autoMarkCredit && !claimableAllowed && getCurrent().isClaimable()) {
                 getCurrent().setClaimable(false);
                 JsfUtil.addErrorMessage("Claimable is not applicable for the selected payment method");
                 return true;
             }
-            if (claimableAllowed && !getCurrent().isClaimable()) {
+            if (!autoMarkCredit && claimableAllowed && !getCurrent().isClaimable()) {
                 JsfUtil.addErrorMessage("Please mark the admission as Claimable");
                 return true;
             }


### PR DESCRIPTION
## Summary

- Adds new boolean config key `Inward Admission - Auto Mark Claimable for Credit Admissions` (default `false`)
- When enabled, selecting **Credit** payment method on the admission form automatically checks the Claimable field
- The Claimable checkbox stays **enabled for all payment methods** — users can override for Credit or manually set it for Cash
- Save validation is bypassed when this config is active (no forced claimable required)
- Old config `Inward Admission - Auto Apply Claimable For Credit` preserved unchanged for backward compatibility

## How to Configure

1. Log in as **Admin**
2. Open Inward → Admission
3. Click the **Config** button (top-right, Admin only)
4. Filter by `Inward Admission`
5. Set `Inward Admission - Auto Mark Claimable for Credit Admissions` → `true`
6. Save

## Test Plan

- [ ] Enable new config; create admission with Credit → Claimable is auto-checked
- [ ] Uncheck Claimable for a Credit admission → save succeeds (no forced error)
- [ ] Create admission with Cash → Claimable checkbox is enabled and unchecked; manually check it → save succeeds
- [ ] Leave new config disabled → existing behaviour for old config unchanged
- [ ] Existing `Inward Admission - Auto Apply Claimable For Credit` config still works when enabled independently

Closes #19646

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new configuration flag "Inward Admission - Auto Mark Claimable for Credit Admissions" that automatically marks credit-based admissions as claimable when enabled. The setting defaults to off. When activated, credit admissions are automatically marked as claimable without requiring manual marking, improving the inward admission process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->