### PR TITLE
Fix admin inward functions failing on uppercase table name databases

### DIFF
--- a/src/main/java/com/divudi/bean/common/DataAdministrationController.java
+++ b/src/main/java/com/divudi/bean/common/DataAdministrationController.java
@@ -4885,10 +4885,11 @@ public class DataAdministrationController implements Serializable {
 
     public void dischargeOldDuplicateEncounters() {
         try {
-            String sql = "UPDATE patientencounter pe "
+            String t = patientEncounterFacade.getTableName();
+            String sql = "UPDATE " + t + " pe "
                     + "JOIN ( "
                     + "  SELECT MAX(id) AS keep_id, currentPatientRoom_id "
-                    + "  FROM patientencounter "
+                    + "  FROM " + t + " "
                     + "  WHERE discharged = 0 AND paymentFinalized = 0 AND currentPatientRoom_id IS NOT NULL "
                     + "  GROUP BY currentPatientRoom_id "
                     + ") latest ON pe.currentPatientRoom_id = latest.currentPatientRoom_id "
@@ -4911,7 +4912,8 @@ public class DataAdministrationController implements Serializable {
             return;
         }
         try {
-            String sql = "UPDATE patientencounter "
+            String t = patientEncounterFacade.getTableName();
+            String sql = "UPDATE " + t + " "
                     + "SET discharged = 1 "
                     + "WHERE discharged = 0 AND paymentFinalized = 0 "
                     + "AND createdAt < DATE_SUB(NOW(), INTERVAL " + staleEncounterDays + " DAY)";

--- a/src/main/java/com/divudi/core/facade/AbstractFacade.java
+++ b/src/main/java/com/divudi/core/facade/AbstractFacade.java
@@ -25,6 +25,8 @@ import javax.persistence.TemporalType;
 import javax.persistence.TypedQuery;
 import javax.persistence.criteria.ParameterExpression;
 import javax.persistence.criteria.Predicate;
+import org.eclipse.persistence.descriptors.ClassDescriptor;
+import org.eclipse.persistence.jpa.JpaHelper;
 
 /**
  *
@@ -158,6 +160,22 @@ public abstract class AbstractFacade<T> {
     public void flushAndClear() {
         getEntityManager().flush();
         getEntityManager().clear();
+    }
+
+    /**
+     * Returns the actual database table name for this entity as known to
+     * EclipseLink. This correctly reflects the case used by the database
+     * (e.g. "PatientEncounter" vs "patientencounter") regardless of the
+     * MySQL lower_case_table_names setting, avoiding hard-coded table name
+     * issues in native SQL queries.
+     *
+     * Closes #19648
+     */
+    public String getTableName() {
+        ClassDescriptor descriptor = JpaHelper
+                .getServerSession(getEntityManager().getEntityManagerFactory())
+                .getDescriptor(entityClass);
+        return descriptor.getTableName();
     }
 
     public List<?> executeQuery(Class<?> entityType, String jpqlQuery) {


### PR DESCRIPTION
## Summary

- Adds `AbstractFacade.getTableName()` which uses EclipseLink's `ClassDescriptor` API to resolve the actual database table name at runtime
- Fixes `dischargeOldDuplicateEncounters()` and `dischargeStaleEncounters()` in `DataAdministrationController` to use the dynamic table name instead of the hardcoded lowercase `patientencounter`
- Works on both lowercase and uppercase MySQL table name configurations

## Test plan

- [ ] Test on a database with lowercase table names — both admin functions should still work
- [ ] Test on a database with uppercase table names (e.g., `PatientEncounter`) — both admin functions should now work without `Table not found` error

Closes #19648

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated database table name handling in data administration operations to use dynamic resolution instead of hardcoded references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->