### PR TITLE
Fix: Discharge Duplicate Encounters groups by physical room, not assignment ID

### DIFF
--- a/src/main/java/com/divudi/bean/common/DataAdministrationController.java
+++ b/src/main/java/com/divudi/bean/common/DataAdministrationController.java
@@ -4886,13 +4886,20 @@ public class DataAdministrationController implements Serializable {
     public void dischargeOldDuplicateEncounters() {
         try {
             String t = patientEncounterFacade.getTableName();
+            String pr = patientRoomFacade.getTableName();
+            // Group by the actual room (roomFacilityCharge_id in patientroom), not by the
+            // PatientRoom assignment ID. Multiple PatientRoom records can point to the same
+            // physical room, so grouping by currentPatientRoom_id only catches duplicates
+            // within the same assignment, not across different admissions to the same room.
             String sql = "UPDATE " + t + " pe "
+                    + "JOIN " + pr + " prm ON pe.currentPatientRoom_id = prm.id "
                     + "JOIN ( "
-                    + "  SELECT MAX(id) AS keep_id, currentPatientRoom_id "
-                    + "  FROM " + t + " "
-                    + "  WHERE discharged = 0 AND paymentFinalized = 0 AND currentPatientRoom_id IS NOT NULL "
-                    + "  GROUP BY currentPatientRoom_id "
-                    + ") latest ON pe.currentPatientRoom_id = latest.currentPatientRoom_id "
+                    + "  SELECT MAX(pe2.id) AS keep_id, prm2.roomFacilityCharge_id "
+                    + "  FROM " + t + " pe2 "
+                    + "  JOIN " + pr + " prm2 ON pe2.currentPatientRoom_id = prm2.id "
+                    + "  WHERE pe2.discharged = 0 AND pe2.paymentFinalized = 0 AND pe2.currentPatientRoom_id IS NOT NULL "
+                    + "  GROUP BY prm2.roomFacilityCharge_id "
+                    + ") latest ON prm.roomFacilityCharge_id = latest.roomFacilityCharge_id "
                     + "SET pe.discharged = 1 "
                     + "WHERE pe.discharged = 0 AND pe.paymentFinalized = 0 "
                     + "AND pe.id != latest.keep_id "


### PR DESCRIPTION
## Summary
- `dischargeOldDuplicateEncounters()` was grouping by `currentPatientRoom_id` (PatientRoom assignment entity), causing it to treat each admission as a unique room even when multiple admissions targeted the same physical room
- Fixed to join `patientroom` and group by `roomFacilityCharge_id` so only the latest encounter per physical room is kept

## Test plan
- [ ] Run **Discharge Duplicate Encounters** on `admin_functions.xhtml`
- [ ] Click **Clear JPA Shared Cache**
- [ ] Verify `nurse/index.xhtml` shows at most one entry per room (no duplicate room buttons)

Closes #19675

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced duplicate patient encounter discharge process to organize encounters by physical room location rather than assignment ID for improved accuracy in identifying and discharging old duplicate records.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->