### PR TITLE
Add InpatientClinicalDischarge to privilege tree; document 3-step privilege process

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,6 +55,9 @@
 ### When Working on Inward / Inpatient Module
 - [Inward Navigation & Reference](developer_docs/navigation/inward_navigation.md) - Pages, controllers, workflow, open issues
 
+### When Adding a New Privilege
+- [Privilege System Guide](developer_docs/security/privilege-system.md) - **All 3 steps required**: enum value + `getCategory()` case + `UserPrivilageController` tree node. Adding only the enum is NOT sufficient — the privilege will be invisible in the admin UI. This was missed for `InpatientClinicalDischarge` (PR #19658, issue #19677).
+
 ### When Committing Code
 - [Commit Conventions](developer_docs/git/commit-conventions.md) - Message format
 

--- a/developer_docs/security/privilege-system.md
+++ b/developer_docs/security/privilege-system.md
@@ -22,11 +22,23 @@ HMIS relies on enum-driven privileges to gate sensitive UI flows. Follow this gu
 4. **Coordinate with administrators** to assign the new privilege to appropriate roles in production.
 
 ### Adding a New Privilege
+
+> 🚨 **All three steps below are mandatory.** Adding only the enum value is NOT sufficient — the privilege will silently never appear in the admin UI, so administrators can never grant it. This was missed for `InpatientClinicalDischarge` in PR #19658, reported in issue #19677.
+
 Follow this checklist whenever a new privilege is required:
+
+**Step 1 — Declare it in `Privileges.java`**
 - Inspect `src/main/java/com/divudi/core/data/Privileges.java` and **reuse an existing privilege** if one with matching behaviour already exists. For backward compatibility, *never* rename or edit legacy enum values even if they contain spelling or convention issues.
 - If a new entry is necessary, add it to the most relevant section of the enum, keeping the alphabetical or functional grouping that already exists.
-- Update the admin privilege maintenance page `src/main/webapp/admin/users/user_privileges.xhtml` so the new privilege can be assigned through the UI.
-- Extend the `UserPrivilageController` implementation—specifically the `createPrivilegeHolderTreeNodes()` method—to place the new privilege in the appropriate branch of the tree structure so it renders correctly in the privileges UI.
+- Add a `case YourPrivilege:` entry in the `getCategory()` method in the same file so the privilege maps to the correct module.
+
+**Step 2 — Register it in `UserPrivilageController.java`**
+- Extend the `UserPrivilageController` implementation—specifically the method that builds the privilege tree—to place the new privilege as a `DefaultTreeNode` in the appropriate branch. Without this step the privilege **will not appear** in the admin UI at `/admin/users/user_privileges.xhtml` and can never be assigned.
+- Example: `new DefaultTreeNode(new PrivilegeHolder(Privileges.YourPrivilege, "Display Label"), parentNode);`
+
+**Step 3 — Guard the UI**
+- Reference the privilege from XHTML using `rendered="#{webUserController.hasPrivilege('YourPrivilege')}"`.
+- Update the admin privilege maintenance page `src/main/webapp/admin/users/user_privileges.xhtml` if static privilege rows are used (tree-based pages handle this automatically via Step 2).
 
 ## Testing Checklist
 - Log in with an account that lacks the privilege to confirm the UI element stays hidden or disabled.

--- a/src/main/java/com/divudi/bean/common/UserPrivilageController.java
+++ b/src/main/java/com/divudi/bean/common/UserPrivilageController.java
@@ -215,6 +215,7 @@ public class UserPrivilageController implements Serializable {
 
         TreeNode inwardClinicalNode = new DefaultTreeNode(new PrivilegeHolder(null, "Clinical"), inwardNode);
         new DefaultTreeNode(new PrivilegeHolder(Privileges.InpatientClinicalAssessment, "Clinical Notes / Assessments"), inwardClinicalNode);
+        new DefaultTreeNode(new PrivilegeHolder(Privileges.InpatientClinicalDischarge, "Clinical Discharge"), inwardClinicalNode);
 
         TreeNode additionalPrivilegesNode = new DefaultTreeNode(new PrivilegeHolder(null, "Additional Privileges"), inwardNode);
         new DefaultTreeNode(new PrivilegeHolder(Privileges.InwardAdditionalPrivilages, "Additional Privilege Menu"), additionalPrivilegesNode);


### PR DESCRIPTION
## Summary

- Register `InpatientClinicalDischarge` as a `DefaultTreeNode` under the **Clinical** branch of the Inward section in `UserPrivilageController.java` — it was missing, so administrators had no way to grant this privilege through the UI
- Update `developer_docs/security/privilege-system.md` with an explicit **3-step checklist** and a warning that adding the enum value alone is NOT sufficient (introduced after this was missed in PR #19658)
- Update `CLAUDE.md` with a *When Adding a New Privilege* section pointing to the guide

## Root Cause (PR #19658)
The `InpatientClinicalDischarge` privilege was added to `Privileges.java` in PR #19658 but the matching `DefaultTreeNode` registration in `UserPrivilageController.java` was omitted, making the privilege invisible in `/admin/users/user_privileges.xhtml`.

## Test plan
- [ ] Log in as admin and navigate to `/admin/users/user_privileges.xhtml`
- [ ] Select a user and click **List Privileges**
- [ ] Expand `Inward → Clinical` — verify **Clinical Discharge** now appears
- [ ] Grant the privilege to a test user and confirm `inward_clinical_discharge.xhtml` becomes accessible
- [ ] Confirm the privilege is denied when not granted

Closes #19677

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "Clinical Discharge" privilege option to the admin privilege management system.

* **Documentation**
  * Enhanced privilege integration documentation with comprehensive guidelines for configuring new privileges in the system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->