### PR TITLE
Session Instance Management additional item tab UI improvement

### DIFF
--- a/src/main/java/com/divudi/bean/channel/ChannelScheduleController.java
+++ b/src/main/java/com/divudi/bean/channel/ChannelScheduleController.java
@@ -1203,6 +1203,11 @@ public class ChannelScheduleController implements Serializable {
 
     public void fillSessionInstance() {
         sessionInstances = fetchCreatedSessionsInstances(current);
+    }
+
+    // session_instance_managment load sessionInstances and fees for service session
+    public void handleSessionSelectionSessionManagement() {
+        fillSessionInstance();
         fillFees();
     }
 

--- a/src/main/webapp/channel/session_instance_management.xhtml
+++ b/src/main/webapp/channel/session_instance_management.xhtml
@@ -82,8 +82,7 @@
                                                         style="width: 100% !important;"
                                                         inputStyleClass="w-100">
                                                         <f:selectItems  value="#{channelScheduleController.items}" var="myItem" itemValue="#{myItem}" itemLabel="#{myItem.name}" ></f:selectItems>
-                                                        <f:ajax render="gpDetail lstSelectSi" execute="lstSelect"  event="click" listener="#{channelScheduleController.fillSessionInstance}" >
-                                                        </f:ajax>
+                                                        <f:ajax render="gpDetail lstSelectSi" execute="lstSelect"  event="click" listener="#{channelScheduleController.handleSessionSelectionSessionManagement}" ></f:ajax>
                                                     </p:selectOneListbox>
                                                 </div>
                                             </h:panelGroup>


### PR DESCRIPTION
Issue: #19661 

Files changed:
- session_instance_management
- ChannelSchedulerController

**fillSessionInstance()** method changed to load the relevant fee and additional item details for selected service session

**sendSmsOnChannelAppointmentTimeChange** method null checks improved

Additional Items and Details tabs UI improved

<hr/>

<img width="1919" height="940" alt="image" src="https://github.com/user-attachments/assets/cbd6f73b-ee91-4472-8aa6-f7da3ceab5cd" />

<hr/>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented crashes when sending SMS about appointment time changes by adding safer recipient checks.
  * Ensured fee totals refresh automatically when a session instance is selected.

* **Improvements**
  * Updated session selector layout and spacing for more consistent display.
  * Reworked "Additional Items" section into clearer columns and preserved add/remove actions.
  * Changed session date rendering for more consistent, read-only display.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->