### PR TITLE
Fix PO approval duplicating bill items on repeated clicks

### DIFF
--- a/src/main/java/com/divudi/bean/pharmacy/PurchaseOrderController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PurchaseOrderController.java
@@ -549,6 +549,8 @@ public class PurchaseOrderController implements Serializable {
     }
 
     public void generateBillComponent() {
+        // Clear any previously generated items to prevent duplicates from repeated calls
+        billItems = null;
 
         for (PharmaceuticalBillItem i : pharmaceuticalBillItemFacade.getPharmaceuticalBillItems(getRequestedBill())) {
             BillItem bi = new BillItem();

--- a/src/main/java/com/divudi/bean/store/StorePurchaseOrderController.java
+++ b/src/main/java/com/divudi/bean/store/StorePurchaseOrderController.java
@@ -272,6 +272,8 @@ public class StorePurchaseOrderController implements Serializable {
     }
 
     public void generateBillComponent() {
+        // Clear any previously generated items to prevent duplicates from repeated calls
+        billItems = null;
 
         for (PharmaceuticalBillItem i : getPharmaceuticalBillItemFacade().getPharmaceuticalBillItems(getRequestedBill())) {
             BillItem bi = new BillItem();


### PR DESCRIPTION
## Summary
- Clear `billItems` at the start of `generateBillComponent()` in both `PurchaseOrderController` and `StorePurchaseOrderController` to prevent duplicate bill items when the approval link is clicked multiple times rapidly.
- Production impact: Ruhunu Hospital PO/RH/GS/26/000336 had 1 item tripled to 3 identical lines (total inflated from Rs. 33,000 to Rs. 99,000). Data has been corrected.

## Test plan
- [ ] Create a PO Request with 1 item, qty > 1
- [ ] Navigate to PO approval list and click approve link rapidly multiple times
- [ ] Verify the approved PO shows the correct number of items (no duplicates)
- [ ] Verify Store PO approval also works correctly

Closes #19685

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed an issue where generating bill components multiple times could result in duplicate items appearing in purchase orders.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->