### PR TITLE
F15 Daily Stock Report: Show PHARMACY_STOCK_ADJUSTMENT_BILL in Adjustment Transactions (#19687)

### DIFF
--- a/src/main/java/com/divudi/ejb/PharmacyService.java
+++ b/src/main/java/com/divudi/ejb/PharmacyService.java
@@ -515,6 +515,7 @@ public class PharmacyService {
                 BillTypeAtomic.PHARMACY_COST_RATE_ADJUSTMENT,
                 BillTypeAtomic.PHARMACY_WHOLESALE_RATE_ADJUSTMENT,
                 BillTypeAtomic.PHARMACY_STOCK_ADJUSTMENT,
+                BillTypeAtomic.PHARMACY_STOCK_ADJUSTMENT_BILL,
                 BillTypeAtomic.PHARMACY_ADJUSTMENT,
                 BillTypeAtomic.PHARMACY_ADJUSTMENT_CANCELLED
         );


### PR DESCRIPTION
## Summary

- Adds `PHARMACY_STOCK_ADJUSTMENT_BILL` to `PharmacyService.getPharmacyAdjustmentBillTypes()`
- This makes physical stock take adjustment bills visible in the F15 Daily Stock Values Report Adjustment Transactions section

## Root Cause

Stock take operations generate `PHARMACY_STOCK_ADJUSTMENT_BILL` records (linked to `PharmacyPhysicalCountBill` via `backwardReferenceBill`). These were not in the adjustment bill type list, so they were invisible in the report — causing unexplained opening/closing stock discrepancies.

Note: These bills store quantity changes only (monetary value = 0), so the adjustment value shown will be 0.00 but the transaction row will be visible.

## Test plan
- [ ] Run F15 report for a day with physical stock take adjustments — adjustment rows should now appear
- [ ] Verify totals still balance correctly
- [ ] Confirm no regression on other adjustment types (rate adjustments etc.)

Closes #19687

🤖 Generated with [Claude Code](https://claude.com/claude-code)