### PR TITLE
19619 On-Call Amount Incorrectly Displayed in Details Page but Correct After Payment 

### DIFF
--- a/src/main/java/com/divudi/bean/channel/BookingControllerViewScope.java
+++ b/src/main/java/com/divudi/bean/channel/BookingControllerViewScope.java
@@ -2233,6 +2233,13 @@ public class BookingControllerViewScope implements Serializable, ControllerWithP
             paymentScheme = viewScopeDataTransferController.getPaymentScheme();
         }
 
+        if (viewScopeDataTransferController.getNeedToFillFeeTotalsByBillFees() != null && viewScopeDataTransferController.getNeedToFillFeeTotalsByBillFees()) {
+            if (getBillSession() != null) {
+                calculateSelectedBillSessionTotalForSettling();
+            }
+            viewScopeDataTransferController.setNeedToFillFeeTotalsByBillFees(false);
+        }
+
     }
 
     public String navigateToChannelBookingFromMenuByDate() {
@@ -2416,7 +2423,6 @@ public class BookingControllerViewScope implements Serializable, ControllerWithP
     }
 
     public String navigateToManageBookingFromChannelBooking(BillSession bs, SessionInstance ss) {
-
         if (bs == null || bs.getId() == null || ss == null) {
             JsfUtil.addErrorMessage("Please select a Patient");
             return "";
@@ -2475,7 +2481,6 @@ public class BookingControllerViewScope implements Serializable, ControllerWithP
     }
 
     public String navigateToManageBooking(BillSession bs) {
-
         selectedBillSession = bs;
         if (selectedBillSession == null) {
             JsfUtil.addErrorMessage("Please select a Patient");
@@ -2496,6 +2501,13 @@ public class BookingControllerViewScope implements Serializable, ControllerWithP
         viewScopeDataTransferController.setNeedToFillMembershipDetails(false);
         viewScopeDataTransferController.setNeedToPrepareForNewBooking(false);
         printPreviewC = false;
+
+        // calculate feeTotals by bill fees for settling
+        Bill bill = getBillSession() != null ? getBillSession().getBill() : null;
+        if (bill != null && bill.getBillType().getParent() == BillType.ChannelOnCall.getParent() && bill.getPaidAmount() == 0 && !bill.isCancelled()) {
+            viewScopeDataTransferController.setNeedToFillFeeTotalsByBillFees(true);
+        }
+
         if (configOptionApplicationController.getBooleanValueByKey("Automatically Load and Display the Refund Amount Upon Page Load")) {
             if (configOptionApplicationController.getBooleanValueByKey("Disable Hospital Fee Refunds")) {
                 for (BillFee bf : bs.getBill().getBillFeesWIthoutZeroValue()) {
@@ -2514,9 +2526,9 @@ public class BookingControllerViewScope implements Serializable, ControllerWithP
             }
         }
 
-        fillBaseFees();
-        fillSessionInstanceByDoctor();
-        calculateSelectedBillSessionTotal();
+        // fillBaseFees();
+        // fillSessionInstanceByDoctor();
+        // calculateSelectedBillSessionTotal();
         return "/channel/manage_booking_by_date?faces-redirect=true";
     }
 
@@ -2553,6 +2565,13 @@ public class BookingControllerViewScope implements Serializable, ControllerWithP
         viewScopeDataTransferController.setNeedToFillMembershipDetails(false);
         viewScopeDataTransferController.setNeedToPrepareForNewBooking(false);
         printPreviewC = false;
+
+        // calculate feeTotals by bill fees for settling
+        Bill bill = getBillSession() != null ? getBillSession().getBill() : null;
+        if (bill != null && bill.getBillType().getParent() == BillType.ChannelOnCall.getParent() && bill.getPaidAmount() == 0 && !bill.isCancelled()) {
+            viewScopeDataTransferController.setNeedToFillFeeTotalsByBillFees(true);
+        }
+        
         if (configOptionApplicationController.getBooleanValueByKey("Automatically Load and Display the Refund Amount Upon Page Load")) {
             if (configOptionApplicationController.getBooleanValueByKey("Disable Hospital Fee Refunds")) {
                 for (BillFee bf : bs.getBill().getBillFeesWIthoutZeroValue()) {
@@ -6978,7 +6997,8 @@ public class BookingControllerViewScope implements Serializable, ControllerWithP
         billToCaclculate.setNetTotal(calculatingNetBillTotal);
         billToCaclculate.setTotal(calculatingGrossBillTotal);
         getBillFacade().edit(billToCaclculate);
-        feeTotalForSelectedBill = calculatingNetBillTotal;
+        feeTotalForSelectedBill = calculatingGrossBillTotal;
+        feeNetTotalForSelectedBill = calculatingNetBillTotal;
 
     }
 
@@ -8916,7 +8936,18 @@ public class BookingControllerViewScope implements Serializable, ControllerWithP
         feeNetTotalForSelectedBill = 0.0;
         if (paymentSchemeDiscount != null) {
             for (ItemFee itmf : getSelectedItemFees()) {
-                
+                if (paymentMethod != null) {
+                    if (paymentMethod != PaymentMethod.Agent) {
+                        if (itmf.getFeeType() == FeeType.OtherInstitution) {
+                            continue;
+                        }
+                    }
+                    if (paymentMethod != PaymentMethod.OnCall) {
+                        if (itmf.getFeeType() == FeeType.OwnInstitution && itmf.getName().equalsIgnoreCase("On-Call Fee")) {
+                            continue;
+                        }
+                    }
+                }
                 if (foriegn) {
                     feeTotalForSelectedBill += itmf.getFfee();
                     if (itmf.isDiscountAllowed()) {
@@ -8931,6 +8962,18 @@ public class BookingControllerViewScope implements Serializable, ControllerWithP
             }
         } else {
             for (ItemFee itmf : getSelectedItemFees()) {
+                if (paymentMethod != null) {
+                    if (paymentMethod != PaymentMethod.Agent) {
+                        if (itmf.getFeeType() == FeeType.OtherInstitution) {
+                            continue;
+                        }
+                    }
+                    if (paymentMethod != PaymentMethod.OnCall) {
+                        if (itmf.getFeeType() == FeeType.OwnInstitution && itmf.getName().equalsIgnoreCase("On-Call Fee")) {
+                            continue;
+                        }
+                    }
+                }
                 if (foriegn) {
                     feeTotalForSelectedBill += itmf.getFfee();
                 } else {
@@ -9053,8 +9096,9 @@ public class BookingControllerViewScope implements Serializable, ControllerWithP
                 }
             }
         } else {
-            for (ItemFee itmf : getSelectedItemFees()) {
+            for (BillFee bf : billFees) {
 //                System.out.println("itmf = " + itmf);
+                ItemFee itmf = (ItemFee) bf.getFee();
                 if (foriegn) {
                     feeTotalForSelectedBill += itmf.getFfee();
 //                    System.out.println("itmf = " + itmf);
@@ -9073,6 +9117,11 @@ public class BookingControllerViewScope implements Serializable, ControllerWithP
 //        System.out.println("feeNetTotalForSelectedBill 4 = " + feeNetTotalForSelectedBill);
         getBillSession().getBill().setNetTotal(feeNetTotalForSelectedBill);
         getBillSession().getBill().setDiscount(feeDiscountForSelectedBill);
+
+        // for paymentMethod.CARD set the value after total calculation
+        if (settlePaymentMethod == PaymentMethod.Card) {
+            getPaymentMethodData().getCreditCard().setTotalValue(getBillSession().getBill().getNetTotal());
+        }
     }
 
     public SmsFacade getSmsFacade() {
@@ -9516,11 +9565,11 @@ public class BookingControllerViewScope implements Serializable, ControllerWithP
     }
 
     public void calculateCashBalance() {
-        if (feeTotalForSelectedBill != null) {
-            cashBalance = feeTotalForSelectedBill - cashPaid;
+        if (feeNetTotalForSelectedBill != null) {
+            cashBalance = feeNetTotalForSelectedBill - cashPaid;
         } else {
-            feeTotalForSelectedBill = 0.0;
-            cashBalance = feeTotalForSelectedBill - cashPaid;
+            feeNetTotalForSelectedBill = 0.0;
+            cashBalance = feeNetTotalForSelectedBill - cashPaid;
         }
     }
 

--- a/src/main/java/com/divudi/bean/common/ViewScopeDataTransferController.java
+++ b/src/main/java/com/divudi/bean/common/ViewScopeDataTransferController.java
@@ -34,6 +34,7 @@ public class ViewScopeDataTransferController  implements Serializable {
     private Boolean needToCreateOpdBillForChannellingBillSession;
     private Boolean needToFillMembershipDetails;
     private Boolean needToPrepareForNewBooking;
+    private Boolean needToFillFeeTotalsByBillFees;
 
 
     private String sessionInstanceFilter;
@@ -208,7 +209,13 @@ public class ViewScopeDataTransferController  implements Serializable {
         this.paymentScheme = paymentScheme;
     }
 
+    public void setNeedToFillFeeTotalsByBillFees(Boolean needToFillFeeTotalsByBillFees) {
+        this.needToFillFeeTotalsByBillFees = needToFillFeeTotalsByBillFees;
+    }
 
+    public Boolean getNeedToFillFeeTotalsByBillFees() {
+        return needToFillFeeTotalsByBillFees;
+    }
 
 
 }

--- a/src/main/webapp/channel/manage_booking_by_date.xhtml
+++ b/src/main/webapp/channel/manage_booking_by_date.xhtml
@@ -488,16 +488,15 @@
                                                     class="w-100"
                                                     value="#{bookingControllerViewScope.settlePaymentMethod}"
                                                     >
-
                                                     <f:selectItems 
                                                         value="#{enumController.paymentMethodsForChannelSettling}"  
                                                         var="pm"
                                                         itemLabel="#{pm.label}"
                                                         itemValue="#{pm}"/>
                                                     <p:ajax process="@this" 
-                                                            update="paymentDetails"
+                                                            update="gdManageBookings :#{p:resolveFirstComponentWithId('totalsPanel',view).clientId} paymentDetails"
                                                             event="change"
-                                                            listener="#{bookingControllerViewScope.listnerForPaymentMethodChangeOnCreditSettle()}"/>
+                                                            listener="#{bookingControllerViewScope.calculateSelectedBillSessionTotalForSettling()}"/>
                                                 </p:selectOneMenu>
 
                                                 <p:outputLabel value="Discount Scheme"/>


### PR DESCRIPTION
Issue: #19619 

Files Changed:
- BookingControllerViewScope
- ViewScopeDataTransferController
- manage_booking_by_date

Fixed:
- Totals are displayed properly according to the payment method selected. (On-Call fee only considered for On-Call payment method) `channel_booking_by_date`
- Totals are displayed properly in `manage_booking_by_date`
- `channel_booking_by_date` and `manage_booking_by_date`, **Balance** correction

**init()** - method changed to check for `needToFillFeeTotalsByBillFees`, this is used to calculate `feeNetTotalForSelectedBill` when navigating to `manage_booking_by_date` for a bill with paymentMethod `OnCall`

**calculateSelectedBillSessionTotals** - changed to consider fee types and payment method when calculating totals


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**Bug Fixes**
* Improved accuracy of fee total calculations during booking settlement to correctly distinguish between gross and net amounts.
* Enhanced fee filtering based on payment method selection to exclude irrelevant fees.
* Corrected cash balance computations to use proper fee totals.

**Improvements**
* Refined payment method selection behavior during credit settlement for better accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->