### PR TITLE
Add pharmaceutical items and config API documentation

### DIFF
--- a/src/main/java/com/divudi/service/AnthropicApiService.java
+++ b/src/main/java/com/divudi/service/AnthropicApiService.java
@@ -271,6 +271,31 @@ public class AnthropicApiService implements Serializable {
                     {"GET", "/stock_history", "Get stock history with date range, item, and department filters"}
                 });
 
+        appendModule(sb, "Pharmaceutical Items", "/pharmaceutical_items",
+                "Manage pharmaceutical item master data (VTM, ATM, VMP, AMP, VMPP, AMPP). Supports search, create, update, retire/restore, and activate/deactivate.",
+                githubUrl(branch, "developer_docs/API_PHARMACEUTICAL_MANAGEMENT.md"),
+                new String[][]{
+                    {"GET",    "/pharmaceutical_items/{type}/search", "Search items by name or code (types: vtm, atm, vmp, amp, vmpp, ampp)"},
+                    {"GET",    "/pharmaceutical_items/{type}/{id}",   "Get a pharmaceutical item by ID"},
+                    {"POST",   "/pharmaceutical_items/{type}",         "Create a new pharmaceutical item"},
+                    {"PUT",    "/pharmaceutical_items/{type}/{id}",   "Update an existing pharmaceutical item"},
+                    {"DELETE", "/pharmaceutical_items/{type}/{id}",   "Retire (soft-delete) a pharmaceutical item"},
+                    {"PUT",    "/pharmaceutical_items/{type}/{id}/restore", "Restore (unretire) a retired item"},
+                    {"PUT",    "/pharmaceutical_items/{type}/{id}/status",  "Activate or deactivate an item (?active=true/false)"}
+                });
+
+        appendModule(sb, "Pharmaceutical Config", "/pharmaceutical_config",
+                "Manage pharmaceutical configuration entities: categories, dosage forms, and measurement units.",
+                githubUrl(branch, "developer_docs/API_PHARMACEUTICAL_MANAGEMENT.md"),
+                new String[][]{
+                    {"GET",    "/pharmaceutical_config/{type}/search", "Search config items by name (types: categories, dosage_forms, units)"},
+                    {"GET",    "/pharmaceutical_config/{type}/{id}",   "Get a config item by ID"},
+                    {"POST",   "/pharmaceutical_config/{type}",         "Create a new config item"},
+                    {"PUT",    "/pharmaceutical_config/{type}/{id}",   "Update a config item"},
+                    {"DELETE", "/pharmaceutical_config/{type}/{id}",   "Retire a config item"},
+                    {"PUT",    "/pharmaceutical_config/{type}/{id}/restore", "Restore a retired config item"}
+                });
+
         appendModule(sb, "Institution Management", "/institutions",
                 "Manage hospitals, clinics, and other healthcare institutions.",
                 githubUrl(branch, "developer_docs/API_INSTITUTION_DEPARTMENT_MANAGEMENT.md"),


### PR DESCRIPTION
## Summary
Added API documentation for pharmaceutical management endpoints to the system prompt builder in the Anthropic API service. This enables the AI assistant to understand and help users interact with pharmaceutical item master data and configuration management APIs.

## Key Changes
- **Pharmaceutical Items Module**: Added documentation for VTM, ATM, VMP, AMP, VMPP, and AMPP item management with endpoints for:
  - Searching items by name or code
  - Retrieving, creating, and updating pharmaceutical items
  - Retiring/restoring items (soft-delete functionality)
  - Activating/deactivating items

- **Pharmaceutical Config Module**: Added documentation for configuration entity management with endpoints for:
  - Managing categories, dosage forms, and measurement units
  - Searching, retrieving, creating, and updating config items
  - Retiring and restoring config items

## Implementation Details
- Both modules reference the same documentation file (`API_PHARMACEUTICAL_MANAGEMENT.md`) for detailed API specifications
- Endpoints follow RESTful conventions with type-based routing (e.g., `/pharmaceutical_items/{type}`)
- Soft-delete pattern implemented via retire/restore operations rather than hard deletes
- Configuration follows the existing module documentation pattern used for other API endpoints

https://claude.ai/code/session_011FGAFTVEaRa5ZoDF5ePeUw