### PR TITLE
Add FHIR API documentation and update Anthropic service

### DIFF
--- a/developer_docs/API_FHIR.md
+++ b/developer_docs/API_FHIR.md
@@ -1,0 +1,263 @@
+# FHIR API Documentation
+
+## Overview
+
+The HMIS exposes two FHIR-related API groups:
+
+1. **FHIR Financial Data** (`/api/fhir`) — HL7 FHIR R5-compliant access to invoices, GRN records, and payments. Uses the `Finance` header for authentication.
+2. **FHIR Patient** (`/api/fhir/Patient`) — FHIR R5 Patient resource operations (search, read, create, update). Uses the `FHIR` header for authentication.
+
+> **Important**: The two groups use **different authentication headers**. Do **not** mix them.
+
+---
+
+## 1. FHIR Financial Data (`/api/fhir`)
+
+### Authentication
+
+```
+Finance: <your-api-key>
+```
+
+### Base URL
+
+```
+/api/fhir
+```
+
+### Content Type
+
+`application/json`
+
+### Endpoints
+
+#### GET `/api/fhir/cash_invoice/{institution_code}/{last_invoice_id}`
+
+Returns cash invoices (pharmacy retail sale bills) for the given institution that have an ID greater than `last_invoice_id`. Use `0` for `last_invoice_id` to retrieve all invoices.
+
+**Path Parameters:**
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| institution_code | String | Institution code |
+| last_invoice_id | Long | Return invoices with ID > this value (use 0 for all) |
+
+---
+
+#### GET `/api/fhir/credit_invoice/{institution_code}/{last_invoice_id}`
+
+Returns credit invoices for the given institution.
+
+**Path Parameters:** same as `cash_invoice`.
+
+---
+
+#### GET `/api/fhir/invoicereturn/{institution_code}/{last_return_invoice_id}`
+
+Returns invoice return records for the given institution.
+
+**Path Parameters:**
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| institution_code | String | Institution code |
+| last_return_invoice_id | Long | Return records with ID > this value |
+
+---
+
+#### GET `/api/fhir/grn/{institution_code}/{last_grn_id}`
+
+Returns Goods Receipt Note (GRN) records for the given institution.
+
+**Path Parameters:**
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| institution_code | String | Institution code |
+| last_grn_id | Long | Return GRNs with ID > this value |
+
+---
+
+#### GET `/api/fhir/grnreturn/{institution_code}/{last_return_grn_id}`
+
+Returns GRN return records for the given institution.
+
+**Path Parameters:**
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| institution_code | String | Institution code |
+| last_return_grn_id | Long | Return GRN returns with ID > this value |
+
+---
+
+#### GET `/api/fhir/payment/{institution_code}/{last_payment_id}`
+
+Returns payment records for the given institution.
+
+**Path Parameters:**
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| institution_code | String | Institution code |
+| last_payment_id | Long | Return payments with ID > this value |
+
+---
+
+#### GET `/api/fhir/paymentreturn/{institution_code}/{last_return_payment_id}`
+
+Returns payment return records for the given institution.
+
+**Path Parameters:**
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| institution_code | String | Institution code |
+| last_return_payment_id | Long | Return payment returns with ID > this value |
+
+---
+
+## 2. FHIR Patient (`/api/fhir/Patient`)
+
+### Authentication
+
+```
+FHIR: <your-api-key>
+```
+
+> **Note**: This endpoint uses the `FHIR` header, **not** the `Finance` header used by most other HMIS APIs.
+
+### Base URL
+
+```
+/api/fhir/Patient
+```
+
+### Content Type
+
+`application/fhir+json`
+
+### Identifier Systems
+
+| System URI | Meaning |
+|------------|---------|
+| `urn:hmis:mrn` | HMIS internal Medical Record Number |
+| `urn:lk:phn` | Sri Lanka Personal Health Number |
+| `urn:lk:nic` | Sri Lanka National Identity Card |
+
+### Endpoints
+
+#### GET `/api/fhir/Patient/{id}`
+
+Retrieve a single patient by the HMIS internal database ID. Returns a FHIR R5 `Patient` resource.
+
+**Path Parameters:**
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| id | Long | HMIS internal patient ID |
+
+**Example:**
+
+```bash
+curl -H "FHIR: <your-api-key>" \
+     -H "Accept: application/fhir+json" \
+     http://localhost:8080/api/fhir/Patient/12345
+```
+
+---
+
+#### GET `/api/fhir/Patient?name=&phone=&identifier=`
+
+Search for patients. At least one query parameter must be provided. Returns a FHIR R5 `Bundle` (searchset) containing matching `Patient` resources (max 50 results).
+
+**Query Parameters:**
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| name | String | No* | Patient name (partial match) |
+| phone | String | No* | Phone number (partial match) |
+| identifier | String | No* | Identifier value (MRN, PHN, or NIC) |
+
+\* At least one parameter must be supplied.
+
+**Example:**
+
+```bash
+curl -H "FHIR: <your-api-key>" \
+     -H "Accept: application/fhir+json" \
+     "http://localhost:8080/api/fhir/Patient?name=Perera"
+```
+
+---
+
+#### POST `/api/fhir/Patient`
+
+Create a new patient from a FHIR R5 `Patient` resource. Returns the created patient as a FHIR `Patient` resource with HTTP 201 Created.
+
+**Request Body:** FHIR R5 `Patient` JSON (`application/fhir+json`)
+
+Mapped fields:
+- `name[0].given` → first name, `name[0].family` → last name
+- `gender` → sex
+- `birthDate` → date of birth
+- `telecom[system=phone].value` → phone number
+- `address[0].text` → address
+- `identifier[system=urn:hmis:mrn].value` → MRN
+- `identifier[system=urn:lk:phn].value` → PHN
+- `identifier[system=urn:lk:nic].value` → NIC
+
+**Example:**
+
+```bash
+curl -X POST \
+     -H "FHIR: <your-api-key>" \
+     -H "Content-Type: application/fhir+json" \
+     -d '{"resourceType":"Patient","name":[{"family":"Silva","given":["Nimal"]}],"gender":"male","birthDate":"1985-06-15"}' \
+     http://localhost:8080/api/fhir/Patient
+```
+
+---
+
+#### PUT `/api/fhir/Patient/{id}`
+
+Partially update an existing patient. Only fields present in the request body are updated. Returns the updated patient as a FHIR `Patient` resource.
+
+**Path Parameters:**
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| id | Long | HMIS internal patient ID |
+
+**Request Body:** FHIR R5 `Patient` JSON (`application/fhir+json`) — only include fields to update.
+
+**Example:**
+
+```bash
+curl -X PUT \
+     -H "FHIR: <your-api-key>" \
+     -H "Content-Type: application/fhir+json" \
+     -d '{"resourceType":"Patient","telecom":[{"system":"phone","value":"0771234567"}]}' \
+     http://localhost:8080/api/fhir/Patient/12345
+```
+
+---
+
+## Error Responses
+
+All endpoints return JSON error objects on failure:
+
+```json
+{
+  "status": "error",
+  "code": 401,
+  "message": "Invalid or missing FHIR API key"
+}
+```
+
+Common HTTP status codes:
+- `200 OK` — success
+- `201 Created` — patient created (POST)
+- `400 Bad Request` — invalid parameters or malformed FHIR JSON
+- `401 Unauthorized` — missing or invalid API key
+- `404 Not Found` — patient not found

--- a/src/main/java/com/divudi/service/AnthropicApiService.java
+++ b/src/main/java/com/divudi/service/AnthropicApiService.java
@@ -320,6 +320,29 @@ public class AnthropicApiService implements Serializable {
                     {"GET", "/costing_data/by_bill_id/{bill_id}",         "Get a specific bill by internal ID"}
                 });
 
+        appendModule(sb, "FHIR - Financial Data", "/fhir",
+                "HL7 FHIR R5-compliant access to invoices, GRN records, and payments. Uses the 'Finance' header for authentication.",
+                githubUrl(branch, "developer_docs/API_FHIR.md"),
+                new String[][]{
+                    {"GET", "/fhir/cash_invoice/{institution_code}/{last_invoice_id}",          "Get cash invoices newer than last_invoice_id"},
+                    {"GET", "/fhir/credit_invoice/{institution_code}/{last_invoice_id}",        "Get credit invoices newer than last_invoice_id"},
+                    {"GET", "/fhir/invoicereturn/{institution_code}/{last_return_invoice_id}",  "Get invoice returns newer than last_return_invoice_id"},
+                    {"GET", "/fhir/grn/{institution_code}/{last_grn_id}",                       "Get GRN records newer than last_grn_id"},
+                    {"GET", "/fhir/grnreturn/{institution_code}/{last_return_grn_id}",          "Get GRN returns newer than last_return_grn_id"},
+                    {"GET", "/fhir/payment/{institution_code}/{last_payment_id}",               "Get payment records newer than last_payment_id"},
+                    {"GET", "/fhir/paymentreturn/{institution_code}/{last_return_payment_id}",  "Get payment returns newer than last_return_payment_id"}
+                });
+
+        appendModule(sb, "FHIR - Patient", "/fhir/Patient",
+                "FHIR R5 Patient resource operations. IMPORTANT: uses the 'FHIR' header for authentication, NOT the 'Finance' header.",
+                githubUrl(branch, "developer_docs/API_FHIR.md"),
+                new String[][]{
+                    {"GET",  "/fhir/Patient/{id}",  "Get patient by HMIS internal ID"},
+                    {"GET",  "/fhir/Patient",        "Search patients by name, phone, or identifier (at least one required; max 50 results)"},
+                    {"POST", "/fhir/Patient",        "Create a new patient from a FHIR R5 Patient resource"},
+                    {"PUT",  "/fhir/Patient/{id}",  "Partially update an existing patient"}
+                });
+
         sb.append("## Your Capabilities\n");
         sb.append("- Query and search HMIS data via REST API calls\n");
         sb.append("- Adjust stock, pharmacy, and financial data\n");


### PR DESCRIPTION
## Summary
This PR adds comprehensive FHIR API documentation and updates the Anthropic API service to include FHIR endpoints in the system prompt for AI-assisted API discovery.

## Key Changes

- **New Documentation**: Added `developer_docs/API_FHIR.md` with complete FHIR API reference covering:
  - FHIR Financial Data endpoints (`/api/fhir`) for invoices, GRN records, and payments
  - FHIR Patient endpoints (`/api/fhir/Patient`) for patient resource operations (search, read, create, update)
  - Authentication requirements (separate `Finance` and `FHIR` headers)
  - Request/response examples and parameter documentation
  - FHIR R5 compliance details and identifier systems

- **Anthropic Service Update**: Modified `AnthropicApiService.java` to include FHIR endpoints in the system prompt:
  - Added "FHIR - Financial Data" module with 7 endpoints for financial data retrieval
  - Added "FHIR - Patient" module with 4 endpoints for patient operations
  - Both modules reference the new FHIR documentation
  - Includes critical authentication header distinction in the Patient module description

## Implementation Details

The documentation emphasizes the critical distinction between the two FHIR API groups' authentication mechanisms:
- Financial Data uses the `Finance` header (consistent with other HMIS APIs)
- Patient operations use the `FHIR` header (different authentication scheme)

The Anthropic service updates enable the AI assistant to discover and recommend FHIR endpoints when users query financial data or patient information, improving the API discovery experience.

https://claude.ai/code/session_01SRspuuG3Gtfv9V4L5BzD8J