### PR TITLE
Document Finance Legacy API and integrate into AI system prompt

### DIFF
--- a/developer_docs/API_FINANCE_LEGACY.md
+++ b/developer_docs/API_FINANCE_LEGACY.md
@@ -1,0 +1,275 @@
+# Finance Legacy API Documentation
+
+## Overview
+The Finance Legacy API provides bill query endpoints for retrieving billing data from the HMIS system. This is the **original** finance REST API (`/api/finance`) and returns Bill entities serialised directly to JSON.
+
+For richer financial data (including finance details, pharmaceutical item details, and payment breakdowns), prefer the newer [`/api/costing_data`](API_COSTING_DATA.md) endpoints. Use this legacy API when you need:
+- All bills or bill items for today (no parameters)
+- Bills filtered by a single date or a date range
+- Bills filtered by `BillType` category (not available in `/api/costing_data`)
+
+## Authentication
+All endpoints require API Key-based authentication using the `Finance` header.
+
+```
+Finance: <your-api-key>
+```
+
+## Base URL
+```
+/api/finance
+```
+
+## Date Formats
+| Context | Format | Example |
+|---------|--------|---------|
+| Single date path parameter | `dd-MM-yyyy` | `04-04-2026` |
+| Date-range path parameter | `dd-MM-yyyy-hh:mm:ss` | `01-04-2026-00:00:00` |
+
+## Endpoints
+
+### 1. Get All Bills (Today)
+Returns all non-retired bills created today.
+
+**Endpoint:** `GET /api/finance/bill`
+
+**Authentication:** Required
+
+**Example:**
+```bash
+curl -X GET http://localhost:8080/hmis/api/finance/bill \
+  -H 'Finance: your-api-key-here'
+```
+
+---
+
+### 2. Get Bills by Date
+Returns all non-retired bills created on the specified date (full day, midnight-to-midnight).
+
+**Endpoint:** `GET /api/finance/bill/{date}`
+
+**Path Parameters:**
+- `date` (string, required): Date in `dd-MM-yyyy` format
+
+**Example:**
+```bash
+curl -X GET http://localhost:8080/hmis/api/finance/bill/04-04-2026 \
+  -H 'Finance: your-api-key-here'
+```
+
+---
+
+### 3. Get Bills by Date Range
+Returns all non-retired bills created within the specified date-time range (inclusive).
+
+**Endpoint:** `GET /api/finance/bill/{from}/{to}`
+
+**Path Parameters:**
+- `from` (string, required): Start datetime in `dd-MM-yyyy-hh:mm:ss` format
+- `to` (string, required): End datetime in `dd-MM-yyyy-hh:mm:ss` format
+
+**Example:**
+```bash
+curl -X GET 'http://localhost:8080/hmis/api/finance/bill/01-04-2026-00:00:00/04-04-2026-23:59:59' \
+  -H 'Finance: your-api-key-here'
+```
+
+---
+
+### 4. Get Bill Items (Today)
+Returns all non-retired bills **with their line items** created today.
+
+**Endpoint:** `GET /api/finance/bill_item`
+
+**Authentication:** Required
+
+**Example:**
+```bash
+curl -X GET http://localhost:8080/hmis/api/finance/bill_item \
+  -H 'Finance: your-api-key-here'
+```
+
+---
+
+### 5. Get Bill Items by Date
+Returns all non-retired bills with line items created on the specified date.
+
+**Endpoint:** `GET /api/finance/bill_item/{date}`
+
+**Path Parameters:**
+- `date` (string, required): Date in `dd-MM-yyyy` format
+
+**Example:**
+```bash
+curl -X GET http://localhost:8080/hmis/api/finance/bill_item/04-04-2026 \
+  -H 'Finance: your-api-key-here'
+```
+
+---
+
+### 6. Get Bill Items by Date Range
+Returns all non-retired bills with line items created within the specified date-time range.
+
+**Endpoint:** `GET /api/finance/bill_item/{from}/{to}`
+
+**Path Parameters:**
+- `from` (string, required): Start datetime in `dd-MM-yyyy-hh:mm:ss` format
+- `to` (string, required): End datetime in `dd-MM-yyyy-hh:mm:ss` format
+
+**Example:**
+```bash
+curl -X GET 'http://localhost:8080/hmis/api/finance/bill_item/01-04-2026-00:00:00/04-04-2026-23:59:59' \
+  -H 'Finance: your-api-key-here'
+```
+
+---
+
+### 7. Get Bill Items by Category (All Dates)
+Returns all non-retired bills with line items for the specified `BillType` category (today by default — the underlying query defaults to today when no dates are supplied).
+
+**Endpoint:** `GET /api/finance/bill_item_cat/{bill_category}`
+
+**Path Parameters:**
+- `bill_category` (string, required): A valid `BillType` enum name (case-sensitive)
+
+**Example:**
+```bash
+curl -X GET http://localhost:8080/hmis/api/finance/bill_item_cat/OpdBill \
+  -H 'Finance: your-api-key-here'
+```
+
+---
+
+### 8. Get Bill Items by Category and Date
+Returns bills with line items for the specified category on the specified date.
+
+**Endpoint:** `GET /api/finance/bill_item_cat/{date}/{bill_category}`
+
+**Path Parameters:**
+- `date` (string, required): Date in `dd-MM-yyyy` format
+- `bill_category` (string, required): A valid `BillType` enum name (case-sensitive)
+
+**Example:**
+```bash
+curl -X GET http://localhost:8080/hmis/api/finance/bill_item_cat/04-04-2026/PharmacySale \
+  -H 'Finance: your-api-key-here'
+```
+
+---
+
+### 9. Get Bill Items by Category and Date Range
+Returns bills with line items for the specified category within the date-time range.
+
+**Endpoint:** `GET /api/finance/bill_item_cat/{from}/{to}/{bill_category}`
+
+**Path Parameters:**
+- `from` (string, required): Start datetime in `dd-MM-yyyy-hh:mm:ss` format
+- `to` (string, required): End datetime in `dd-MM-yyyy-hh:mm:ss` format
+- `bill_category` (string, required): A valid `BillType` enum name (case-sensitive)
+
+**Example:**
+```bash
+curl -X GET 'http://localhost:8080/hmis/api/finance/bill_item_cat/01-04-2026-00:00:00/04-04-2026-23:59:59/InwardFinalBill' \
+  -H 'Finance: your-api-key-here'
+```
+
+---
+
+## Common BillType Values
+
+| BillType | Description |
+|----------|-------------|
+| `OpdBill` | Outpatient department bill |
+| `InwardFinalBill` | Inpatient final bill |
+| `InwardProvisionalBill` | Inpatient provisional bill |
+| `PharmacySale` | Pharmacy retail sale |
+| `PharmacyIssue` | Pharmacy issue (internal transfer) |
+| `LabBill` | Laboratory bill |
+| `AdmissionBill` | Patient admission bill |
+| `PaymentBill` | Professional fee payment bill |
+| `PatientPaymentReceiveBill` | Patient deposit received |
+| `PatientPaymentRefundBill` | Patient deposit refunded |
+
+For the full list of `BillType` values see `com.divudi.core.data.BillType`.
+
+---
+
+## Response Format
+
+### Success (bill list, no items)
+```json
+{
+  "status": { "code": 200, "type": "success" },
+  "data": [
+    {
+      "id": 123456,
+      "bill_id_1": "INS-001",
+      "bill_id_2": "DEPT-001",
+      "bill_date": "2026-04-04",
+      "bill_time": "10:30:00",
+      "bill_categoty": "OpdBill",
+      "type": "BilledBill",
+      "gross_total": 1500.00,
+      "discount": 50.00,
+      "net_total": 1450.00,
+      "payment_method": "Cash",
+      "institution": "Main Hospital",
+      "department": "OPD",
+      "created_at": "2026-04-04 10:30:00",
+      "created_user": "Dr. Smith"
+    }
+  ]
+}
+```
+
+### Success (bill list with items)
+```json
+{
+  "status": { "code": 200, "type": "success" },
+  "data": [
+    {
+      "id": 123456,
+      "bill_date": "2026-04-04",
+      "bill_items": [
+        {
+          "Id": 789,
+          "item": "Paracetamol 500mg",
+          "item_type": "Drug",
+          "Qty": 10.0,
+          "Rate": 5.00,
+          "NetRate": 5.00,
+          "GrossValue": 50.00,
+          "NetValue": 50.00,
+          "Refunded": false
+        }
+      ],
+      "gross_total": 50.00,
+      "discount": 0.0,
+      "net_total": 50.00
+    }
+  ]
+}
+```
+
+### Error Responses
+```json
+{ "code": 401, "type": "error", "message": "Not a valid key." }
+{ "code": 400, "type": "error", "message": "No Data." }
+{ "code": 401, "type": "error", "message": "Not a valid path parameter." }
+```
+
+---
+
+## Comparison with `/api/costing_data`
+
+| Feature | `/api/finance` (legacy) | `/api/costing_data` (modern) |
+|---------|------------------------|------------------------------|
+| Response model | Bill entity fields | Rich DTOs (finance details, pharmaceutical details, payments) |
+| Filter by category | Yes (`bill_item_cat/*`) | No |
+| Filter by bill number | No | Yes (`bill?number=...`) |
+| Filter by bill ID | No | Yes (`by_bill_id/{id}`) |
+| Payment breakdown | Single `payment_method` field | Full `payments` array |
+| Finance cost details | No | Yes (cost, purchase, retail rates) |
+| Pharmaceutical details | No | Yes |
+
+Use `/api/finance` when you need category-based filtering. Use `/api/costing_data` when you need detailed financial or pharmaceutical cost breakdown.

--- a/src/main/java/com/divudi/service/AnthropicApiService.java
+++ b/src/main/java/com/divudi/service/AnthropicApiService.java
@@ -320,6 +320,23 @@ public class AnthropicApiService implements Serializable {
                     {"GET", "/costing_data/by_bill_id/{bill_id}",         "Get a specific bill by internal ID"}
                 });
 
+        appendModule(sb, "Finance - Legacy Bill Query", "/finance",
+                "Legacy bill query endpoints. Use for category-based filtering (BillType) or simple date-range queries. "
+                + "Prefer /costing_data for richer financial detail (cost rates, pharmaceutical data, payment breakdown). "
+                + "Authentication header: 'Finance'. Date format for single date: dd-MM-yyyy; for ranges: dd-MM-yyyy-hh:mm:ss.",
+                githubUrl(branch, "developer_docs/API_FINANCE_LEGACY.md"),
+                new String[][]{
+                    {"GET", "/finance/bill",                                   "Get all bills for today"},
+                    {"GET", "/finance/bill/{date}",                            "Get bills for a specific date (dd-MM-yyyy)"},
+                    {"GET", "/finance/bill/{from}/{to}",                       "Get bills for a date-time range"},
+                    {"GET", "/finance/bill_item",                              "Get all bills with line items for today"},
+                    {"GET", "/finance/bill_item/{date}",                       "Get bills with line items for a specific date"},
+                    {"GET", "/finance/bill_item/{from}/{to}",                  "Get bills with line items for a date-time range"},
+                    {"GET", "/finance/bill_item_cat/{bill_category}",          "Get bills with line items filtered by BillType category (today)"},
+                    {"GET", "/finance/bill_item_cat/{date}/{bill_category}",   "Get bills with line items by category and date"},
+                    {"GET", "/finance/bill_item_cat/{from}/{to}/{bill_category}", "Get bills with line items by category and date-time range"}
+                });
+
         sb.append("## Your Capabilities\n");
         sb.append("- Query and search HMIS data via REST API calls\n");
         sb.append("- Adjust stock, pharmacy, and financial data\n");


### PR DESCRIPTION
## Summary
This PR adds comprehensive documentation for the Finance Legacy API (`/api/finance`) and integrates it into the Anthropic AI service's system prompt to enable AI-assisted API queries.

## Key Changes

- **Added `developer_docs/API_FINANCE_LEGACY.md`**: Complete API documentation covering:
  - 9 bill query endpoints with authentication, date formats, and examples
  - Response format examples for both bill lists and bills with line items
  - Common BillType enum values and their descriptions
  - Comparison table with the newer `/api/costing_data` API to guide users on endpoint selection
  - Clear guidance on when to use legacy vs. modern endpoints

- **Updated `AnthropicApiService.java`**: Integrated Finance Legacy API into the AI system prompt:
  - Added new "Finance - Legacy Bill Query" module with `/finance` base path
  - Included all 9 endpoints with brief descriptions
  - Documented authentication header (`Finance`) and date format requirements
  - Added reference to the new documentation file
  - Provided context that this is a legacy API with guidance to prefer `/costing_data` for richer financial data

## Implementation Details

The documentation emphasizes the legacy API's strengths (category-based filtering via `BillType`, simple date-range queries) while directing users to the modern `/api/costing_data` endpoints when they need richer financial details like cost rates, pharmaceutical data, or payment breakdowns. The AI system prompt integration ensures the AI assistant can intelligently recommend and construct queries against these endpoints.

https://claude.ai/code/session_0114U53ZD1FrkfQfoxoDzVxK