### PR TITLE
Add Pharmaceutical Config API documentation to system prompt

### DIFF
--- a/src/main/java/com/divudi/service/AnthropicApiService.java
+++ b/src/main/java/com/divudi/service/AnthropicApiService.java
@@ -293,6 +293,18 @@ public class AnthropicApiService implements Serializable {
                     {"DELETE", "/departments/{id}",   "Retire a department"}
                 });
 
+        appendModule(sb, "Pharmaceutical Config", "/pharmaceutical_config",
+                "Manage pharmaceutical configuration entities: categories, dosage forms, and measurement units.",
+                githubUrl(branch, "developer_docs/API_PHARMACEUTICAL_MANAGEMENT.md"),
+                new String[][]{
+                    {"GET",    "/pharmaceutical_config/{type}/search",         "Search config entries by name or code (types: categories, dosage_forms, units)"},
+                    {"GET",    "/pharmaceutical_config/{type}/{id}",            "Get config entry by ID"},
+                    {"POST",   "/pharmaceutical_config/{type}",                 "Create a new config entry"},
+                    {"PUT",    "/pharmaceutical_config/{type}/{id}",            "Update a config entry"},
+                    {"DELETE", "/pharmaceutical_config/{type}/{id}",            "Retire (soft-delete) a config entry"},
+                    {"PUT",    "/pharmaceutical_config/{type}/{id}/restore",    "Restore a retired config entry"}
+                });
+
         appendModule(sb, "Finance - Balance History", "/balance_history",
                 "Retrieve financial balance history: drawer entries, patient deposits, agent histories, staff welfare.",
                 githubUrl(branch, "developer_docs/API_BALANCE_HISTORY.md"),


### PR DESCRIPTION
## Summary
Added documentation for the Pharmaceutical Config API module to the system prompt builder, enabling the Anthropic API service to provide information about pharmaceutical configuration management endpoints.

## Key Changes
- Added a new "Pharmaceutical Config" module section to the `buildSystemPrompt()` method
- Documented 6 API endpoints for managing pharmaceutical configuration entities:
  - Search functionality for categories, dosage forms, and measurement units
  - CRUD operations (Create, Read, Update, Delete)
  - Restore functionality for retired entries
- Linked to the corresponding API documentation file (`API_PHARMACEUTICAL_MANAGEMENT.md`)

## Implementation Details
- The module follows the existing pattern used by other API modules in the system prompt
- Supports three configuration types: `categories`, `dosage_forms`, and `units`
- Includes soft-delete (retire) and restore capabilities for configuration entries
- All endpoints use the `/pharmaceutical_config` base path with `{type}` and `{id}` path parameters

https://claude.ai/code/session_014y4iNQFe4FpJUetzrNpXSU