### PR TITLE
Fix shift update issue by properly initializing and binding roster

### DIFF
--- a/src/main/java/com/divudi/bean/hr/ShiftController.java
+++ b/src/main/java/com/divudi/bean/hr/ShiftController.java
@@ -149,7 +149,8 @@ public class ShiftController implements Serializable {
     }
 
     public void prepareAdd() {
-        current = null;
+        current = new Shift();
+        current.setRoster(getCurrentRoster());
     }
 
     private void recreateModel() {
@@ -207,8 +208,10 @@ public class ShiftController implements Serializable {
     }
 
     public void setCurrentRoster(Roster currentRoster) {
-        current = null;
         this.currentRoster = currentRoster;
+        if (current != null && current.getId() == null) {
+            current.setRoster(currentRoster);
+        }
     }
 
     public RosterFacade getRosterFacade() {


### PR DESCRIPTION
- Initialize new Shift instance in prepareAdd()
- Ensure roster is set when creating a new shift
- Prevent unintended updates of existing shifts when adding new ones
- Update setCurrentRoster() to only assign roster for new (unsaved) shifts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced shift and roster assignment handling to ensure proper state management when creating new shifts and switching between roster selections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->