### PR TITLE
Replace Previous/Next Shift autocomplete with dropdown and prevent se…

### DIFF
--- a/src/main/java/com/divudi/bean/hr/ShiftController.java
+++ b/src/main/java/com/divudi/bean/hr/ShiftController.java
@@ -24,6 +24,7 @@ import javax.faces.convert.Converter;
 import javax.faces.convert.FacesConverter;
 import javax.inject.Inject;
 import javax.inject.Named;
+import java.util.stream.Collectors;
 
 /**
  *
@@ -127,11 +128,36 @@ public class ShiftController implements Serializable {
 
         return shifts;
     }
+    
+    public List<Shift> getAvailablePreviousShifts() {
+        if (shiftList == null) {
+            return null;
+        }
+
+        if (current == null || current.getId() == null) {
+            return shiftList;
+        }
+
+        return shiftList.stream()
+                .filter(s -> s != null
+                        && s.getId() != null
+                        && !s.getId().equals(current.getId()))
+                .collect(Collectors.toList());
+    }
 
     public void saveSelected() {
         if (errorCheck()) {
             return;
         }
+
+        if (getCurrent().getPreviousShift() != null
+                && getCurrent().getId() != null
+                && getCurrent().getPreviousShift().getId() != null
+                && getCurrent().getPreviousShift().getId().equals(getCurrent().getId())) {
+            JsfUtil.addErrorMessage("A shift cannot be its own previous shift.");
+            return;
+        }
+
         if (getCurrent().getId() != null) {
             getFacade().edit(current);
             JsfUtil.addSuccessMessage("Updated Successfully.");

--- a/src/main/java/com/divudi/bean/hr/ShiftController.java
+++ b/src/main/java/com/divudi/bean/hr/ShiftController.java
@@ -150,11 +150,23 @@ public class ShiftController implements Serializable {
             return;
         }
 
-        if (getCurrent().getPreviousShift() != null
-                && getCurrent().getId() != null
-                && getCurrent().getPreviousShift().getId() != null
-                && getCurrent().getPreviousShift().getId().equals(getCurrent().getId())) {
+        if (
+                getCurrent().getPreviousShift() != null && 
+                getCurrent().getId() != null && 
+                getCurrent().getPreviousShift().getId() != null && 
+                getCurrent().getPreviousShift().getId().equals(getCurrent().getId())
+        ) {
             JsfUtil.addErrorMessage("A shift cannot be its own previous shift.");
+            return;
+        }
+
+        if (
+                getCurrent().getNextShift() != null && 
+                getCurrent().getId() != null && 
+                getCurrent().getNextShift().getId() != null && 
+                getCurrent().getNextShift().getId().equals(getCurrent().getId())
+        ) {
+            JsfUtil.addErrorMessage("A shift cannot be its own next shift.");
             return;
         }
 

--- a/src/main/java/com/divudi/bean/hr/ShiftController.java
+++ b/src/main/java/com/divudi/bean/hr/ShiftController.java
@@ -129,7 +129,7 @@ public class ShiftController implements Serializable {
         return shifts;
     }
     
-    public List<Shift> getAvailablePreviousShifts() {
+    public List<Shift> getAvailableShifts() {
         if (shiftList == null) {
             return null;
         }

--- a/src/main/webapp/hr/hr_shift.xhtml
+++ b/src/main/webapp/hr/hr_shift.xhtml
@@ -95,26 +95,17 @@
                                 </p:calendar>  
 
                                 <p:outputLabel value="Previous Shift"/>
-                                <p:autoComplete value="#{shiftController.current.previousShift}"
-                                                forceSelection="true"
-                                                completeMethod="#{shiftController.completeShift}"
-                                                var="mys"
-                                                class="w-100 mx-4"
-                                                inputStyleClass="w-100"
-                                                itemLabel="#{mys.name}" 
-                                                itemValue="#{mys}">                                  
-                                </p:autoComplete>
+                                <p:selectOneMenu value="#{shiftController.current.previousShift}" filter="true" class="w-100 mx-4" style="width:100%">
+                                    <f:selectItem itemLabel="Select Previous Shift" itemValue="#{null}" noSelectionOption="true" />
+                                    <f:selectItems value="#{shiftController.availablePreviousShifts}" var="mys" itemLabel="#{mys.name}" itemValue="#{mys}" />
+                                </p:selectOneMenu>
 
                                 <p:outputLabel value="Next Shift"/>
-                                <p:autoComplete value="#{shiftController.current.nextShift}"
-                                                forceSelection="true"
-                                                completeMethod="#{shiftController.completeShift}"
-                                                var="mys" 
-                                                class="w-100 mx-4"
-                                                inputStyleClass="w-100"
-                                                itemLabel="#{mys.name}" 
-                                                itemValue="#{mys}">                                  
-                                </p:autoComplete>
+                                <p:selectOneMenu value="#{shiftController.current.nextShift}" filter="true" class="w-100 mx-4" style="width:100%">
+                                    <f:selectItem itemLabel="Select Next Shift" itemValue="#{null}" noSelectionOption="true" />
+                                    <f:selectItems value="#{shiftController.availablePreviousShifts}" var="mys" itemLabel="#{mys.name}" itemValue="#{mys}" />
+                                </p:selectOneMenu>
+                                
                                 <h:outputLabel value="Leave Hour Full"/>
                                 <p:inputText class="w-100 mx-4" value="#{shiftController.current.leaveHourFull}"/>
                                 <h:outputLabel value="Leave Hour Half"/>

--- a/src/main/webapp/hr/hr_shift.xhtml
+++ b/src/main/webapp/hr/hr_shift.xhtml
@@ -97,13 +97,13 @@
                                 <p:outputLabel value="Previous Shift"/>
                                 <p:selectOneMenu value="#{shiftController.current.previousShift}" filter="true" class="w-100 mx-4" style="width:100%">
                                     <f:selectItem itemLabel="Select Previous Shift" itemValue="#{null}" noSelectionOption="true" />
-                                    <f:selectItems value="#{shiftController.availablePreviousShifts}" var="mys" itemLabel="#{mys.name}" itemValue="#{mys}" />
+                                    <f:selectItems value="#{shiftController.availableShifts}" var="mys" itemLabel="#{mys.name}" itemValue="#{mys}" />
                                 </p:selectOneMenu>
 
                                 <p:outputLabel value="Next Shift"/>
                                 <p:selectOneMenu value="#{shiftController.current.nextShift}" filter="true" class="w-100 mx-4" style="width:100%">
                                     <f:selectItem itemLabel="Select Next Shift" itemValue="#{null}" noSelectionOption="true" />
-                                    <f:selectItems value="#{shiftController.availablePreviousShifts}" var="mys" itemLabel="#{mys.name}" itemValue="#{mys}" />
+                                    <f:selectItems value="#{shiftController.availableShifts}" var="mys" itemLabel="#{mys.name}" itemValue="#{mys}" />
                                 </p:selectOneMenu>
                                 
                                 <h:outputLabel value="Leave Hour Full"/>

--- a/src/main/webapp/hr/hr_shift.xhtml
+++ b/src/main/webapp/hr/hr_shift.xhtml
@@ -94,14 +94,14 @@
                                 <p:calendar class="w-100 mx-4" inputStyleClass="w-100" value="#{shiftController.current.endingTime}" navigator="true" pattern="#{sessionController.applicationPreference.longTimeFormat}" timeOnly="true">                            
                                 </p:calendar>  
 
-                                <p:outputLabel value="Previous Shift"/>
-                                <p:selectOneMenu value="#{shiftController.current.previousShift}" filter="true" class="w-100 mx-4" style="width:100%">
+                                <p:outputLabel for="prevShift" value="Previous Shift"/>
+                                <p:selectOneMenu id="prevShift" value="#{shiftController.current.previousShift}" filter="true" class="w-100 mx-4" style="width:100%"  title="Select the previous shift">
                                     <f:selectItem itemLabel="Select Previous Shift" itemValue="#{null}" noSelectionOption="true" />
                                     <f:selectItems value="#{shiftController.availableShifts}" var="mys" itemLabel="#{mys.name}" itemValue="#{mys}" />
                                 </p:selectOneMenu>
 
-                                <p:outputLabel value="Next Shift"/>
-                                <p:selectOneMenu value="#{shiftController.current.nextShift}" filter="true" class="w-100 mx-4" style="width:100%">
+                                <p:outputLabel for="nextShift" value="Next Shift"/>
+                                <p:selectOneMenu id="nextShift" value="#{shiftController.current.nextShift}" filter="true" class="w-100 mx-4" style="width:100%"  title="Select the next shift">
                                     <f:selectItem itemLabel="Select Next Shift" itemValue="#{null}" noSelectionOption="true" />
                                     <f:selectItems value="#{shiftController.availableShifts}" var="mys" itemLabel="#{mys.name}" itemValue="#{mys}" />
                                 </p:selectOneMenu>


### PR DESCRIPTION
…lf-selection

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented saving a shift when it references itself as previous or next, avoiding invalid configurations.
  * Excluded the currently edited shift from selectable options to prevent accidental self-selection.

* **UI Improvements**
  * Replaced autocomplete inputs with filtered dropdowns for previous/next shift selection to improve clarity.
  * Added explicit placeholder options to make optional/empty selections clear to users.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->