### PR TITLE
Fix stale CC balance in billing page financial data panel (#18197)

### DIFF
--- a/src/main/java/com/divudi/bean/collectingCentre/CollectingCentreBillController.java
+++ b/src/main/java/com/divudi/bean/collectingCentre/CollectingCentreBillController.java
@@ -1733,7 +1733,7 @@ public class CollectingCentreBillController implements Serializable, ControllerW
     }
 
     public void loadCCFinancialData(Institution collectingCentre) {
-        Institution cc = institutionFacade.find(collectingCentre.getId());
+        Institution cc = institutionFacade.findWithoutCache(collectingCentre.getId());
 
         ccBalance = cc.getBallance();
         ccAllowedCreditLImit = cc.getAllowedCreditLimit();


### PR DESCRIPTION
## Summary

- Fixes the Balance / Available Balance / Credit Limit panel on the CC billing page showing a stale value after a bill or deposit is processed
- `loadCCFinancialData()` was using `institutionFacade.find()` which can return a cached entity from the EclipseLink L2 cache
- Changed to `institutionFacade.findWithoutCache()` (sets `CacheRetrieveMode.BYPASS` + `CacheStoreMode.REFRESH`) to ensure the panel always reads the latest committed balance from the database

## Context

The **root cause** of the wrong balance being written to `Institution.ballance` in the first place is fixed by PR #19753 (issue #19752 — stale L1 cache in `AgentAndCcApplicationController`).

This PR hardens the **read path** for the billing page display panel:
- `selectCollectingCentre()` → `loadCCFinancialData()` — called when user picks a CC
- `navigateToCollectingCenterBillingfromBillPriview()` → `loadCCFinancialData()` — called when returning from print preview to the billing page

Both paths now use `findWithoutCache()` so the panel reflects the correct balance immediately after returning from a transaction.

## Changed Files

- `CollectingCentreBillController.java` — one-line change: `find()` → `findWithoutCache()`

## Test Plan

- [ ] Open CC billing page, select a CC — verify Balance panel shows correct current balance
- [ ] Save a CC bill, go to print preview, click back to billing — verify Balance panel has updated to reflect the new balance
- [ ] Perform two bills back-to-back without re-selecting the CC — verify balance updates correctly each time

Closes #18197

🤖 Generated with [Claude Code](https://claude.com/claude-code)