### PR TITLE
Fix CC statement report row order: sort by bill.createdAt, bill.id, ah.id (#18197)

### DIFF
--- a/src/main/java/com/divudi/bean/report/ReportController.java
+++ b/src/main/java/com/divudi/bean/report/ReportController.java
@@ -2420,7 +2420,7 @@ public class ReportController implements Serializable, ControllerWithReportFilte
                 jpql += " and (ah.bill.insId = :inv or ah.bill.deptId = :inv) ";
                 m.put("inv", invoiceNumber);
             }
-            jpql += " order by ah.id ";
+            jpql += " order by ah.bill.createdAt, ah.bill.id, ah.id ";
             agentHistories = agentHistoryFacade.findByJpql(jpql, m, TemporalType.TIMESTAMP);
         }, CollectionCenterReport.COLLECTION_CENTER_STATEMENT_REPORT, sessionController.getLoggedUser());
     }


### PR DESCRIPTION
## Summary

- Fixes wrong row order in the CC Statement Report causing incorrect Before/After balance display
- Changes `ORDER BY ah.id` to `ORDER BY ah.bill.createdAt, ah.bill.id, ah.id`
- One-line change in `ReportController.processCollectingCentreStatementReportNew()`

## History of this sort clause

| Commit | Date | Sort | Reason |
|--------|------|------|--------|
| 19e3b1ae | Apr 2025 | `ah.createdAt` | First version (#11967) |
| dbe9a8f3 | Jan 2026 | `ah.id` | Fixed concurrent-timestamp tie (#18220) |
| **this PR** | Apr 2026 | `ah.bill.createdAt, ah.bill.id, ah.id` | Fixed both failure modes |

## Why the previous approaches fail

**`ORDER BY ah.createdAt`** — set when the AgentHistory row is written. Concurrent transactions can produce identical millisecond timestamps, giving non-deterministic order. This caused issue #18220.

**`ORDER BY ah.id`** — reflects AgentHistory INSERT order, not bill submission order. A deposit that processes faster than a bill gets a lower id even if the bill was submitted first. This caused the RCC036 issue reported Jan 2026.

Both reflect **processing time**, not **user-initiated time**.

## Why the combined sort works

- **`ah.bill.createdAt`** — when the user submitted the bill. Bills are user-driven sequential actions; this is the true real-world order.
- **`ah.bill.id`** — tie-breaks same-second bills. Bill IDs are sequential AUTO_INCREMENT assigned at bill-creation, which is transactional and serialised.
- **`ah.id`** — tie-breaks multiple AgentHistory rows per bill.

## Data impact (RCC036 case)

The AgentHistory balance values for the affected RCC034 records are **correct** — the chain is consistent in chronological order. No data correction is needed. Only the display order was wrong.

## Test plan

- [ ] Open CC Statement Report for a CC with deposits and bills on the same day — verify rows appear in bill-submission time order
- [ ] Verify Before Balance of each row matches After Balance of the previous row
- [ ] Test with a date range containing concurrent transactions (deposit + bill within minutes of each other)

Closes #18197

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Refined the sorting mechanism in collecting center statement reports for improved consistency. Report data is now organized by bill creation date as the primary sort criterion, with bill and individual record identifiers as secondary sort keys. This provides more logical and predictable report ordering that better reflects actual business transactions and operational workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->