### PR TITLE
Add missing faces-redirect=true to EMR Admin index navigation

### DIFF
--- a/src/main/java/com/divudi/bean/clinical/ClinicalEntityController.java
+++ b/src/main/java/com/divudi/bean/clinical/ClinicalEntityController.java
@@ -50,11 +50,11 @@ public class ClinicalEntityController implements Serializable {
     Department department;
 
     public String navigateToManageClinicalEntities() {
-        return "/emr/admin/clinical_entities";
+        return "/emr/admin/clinical_entities?faces-redirect=true";
     }
 
     public String navigateToMangeSurgeries() {
-        return "/emr/admin/clinical_entities";
+        return "/emr/admin/clinical_entities?faces-redirect=true";
     }
 
     public ClinicalEntity findItemByName(String name,Department dept) {

--- a/src/main/java/com/divudi/bean/clinical/DiagnosisController.java
+++ b/src/main/java/com/divudi/bean/clinical/DiagnosisController.java
@@ -53,7 +53,7 @@ public class DiagnosisController implements Serializable {
     String selectText = "";
 
     public String navigateToManageDiagnoses() {
-        return "/emr/admin/diagnoses";
+        return "/emr/admin/diagnoses?faces-redirect=true";
     }
 
     // Method to generate the Excel file and initiate the download

--- a/src/main/java/com/divudi/bean/clinical/FavouriteController.java
+++ b/src/main/java/com/divudi/bean/clinical/FavouriteController.java
@@ -100,7 +100,7 @@ public class FavouriteController implements Serializable {
         item = null;
         items = null;
         current = null;
-        return "/clinical/clinical_favourite_diagnosis";
+        return "/clinical/clinical_favourite_diagnosis?faces-redirect=true";
     }
 
     public String toAddFavItem() {

--- a/src/main/java/com/divudi/bean/clinical/PlanController.java
+++ b/src/main/java/com/divudi/bean/clinical/PlanController.java
@@ -54,11 +54,11 @@ public class PlanController implements Serializable {
 
 
     public String navigateToManagePlans(){
-        return "/emr/admin/plans";
+        return "/emr/admin/plans?faces-redirect=true";
     }
 
     public String navigateToManageClinicaEntities(){
-        return "/emr/admin/clinical_entities";
+        return "/emr/admin/clinical_entities?faces-redirect=true";
     }
 
 

--- a/src/main/java/com/divudi/bean/clinical/ProcedureController.java
+++ b/src/main/java/com/divudi/bean/clinical/ProcedureController.java
@@ -54,7 +54,7 @@ public class ProcedureController implements Serializable {
     String selectText = "";
 
     public String navigateToManageProcedures() {
-        return "/emr/admin/procedures";
+        return "/emr/admin/procedures?faces-redirect=true";
     }
 
     public void downloadAsExcel() {

--- a/src/main/java/com/divudi/bean/clinical/SignController.java
+++ b/src/main/java/com/divudi/bean/clinical/SignController.java
@@ -53,7 +53,7 @@ public class SignController implements Serializable {
     String selectText = "";
 
     public String navigateToManageSigns(){
-        return "/emr/admin/signs";
+        return "/emr/admin/signs?faces-redirect=true";
     }
 
 

--- a/src/main/java/com/divudi/bean/clinical/SymptomController.java
+++ b/src/main/java/com/divudi/bean/clinical/SymptomController.java
@@ -53,7 +53,7 @@ public class SymptomController implements Serializable {
     String selectText = "";
 
     public String navigateToManageSymptoms(){
-        return "/emr/admin/symptoms";
+        return "/emr/admin/symptoms?faces-redirect=true";
     }
 
 

--- a/src/main/java/com/divudi/bean/common/VocabularyController.java
+++ b/src/main/java/com/divudi/bean/common/VocabularyController.java
@@ -50,7 +50,7 @@ public class VocabularyController implements Serializable {
 
     public String navigateToManageVocabularies(){
         getItems();
-        return "/emr/admin/vocabularies";
+        return "/emr/admin/vocabularies?faces-redirect=true";
     }
 
     // Method to generate the Excel file and initiate the download

--- a/src/main/java/com/divudi/bean/emr/EmrController.java
+++ b/src/main/java/com/divudi/bean/emr/EmrController.java
@@ -62,7 +62,7 @@ public class EmrController implements Serializable {
 
     public String navigateToManageDiagnoses() {
         diagnosisController.fillItems();
-        return "/clinical/clinical_diagnosis";
+        return "/clinical/clinical_diagnosis?faces-redirect=true";
     }
 
     public String navigateToEmrAdmin() {

--- a/src/main/webapp/emr/admin/index.xhtml
+++ b/src/main/webapp/emr/admin/index.xhtml
@@ -34,7 +34,7 @@
                                             <p:commandButton class="w-100" ajax="false" value="Favourite Medicines By Age" action="#{favouriteController.navigateToFavoriteMedicineByAge()}"  ></p:commandButton>
                                             <p:commandButton class="w-100" ajax="false" value="Favourite Medicines By Weight" action="#{favouriteController.navigateToFavoriteMedicineByWeight()}"  ></p:commandButton>
                                             <p:commandButton styleClass="linkButton" ajax="false"
-                                             value="Medicines" action="/clinical/clinical_favourite_item"  ></p:commandButton>
+                                             value="Medicines" action="/clinical/clinical_favourite_item?faces-redirect=true"  ></p:commandButton>
                                         </div>
                                     </p:tab>
                                     <p:tab title="Favourite Diagnosis">


### PR DESCRIPTION
## Summary
- Added `?faces-redirect=true` to all navigation methods called from the EMR Admin index page (`/emr/admin/index.xhtml`) that were missing it
- Fixed 10 navigation actions across 9 Java controllers and 1 XHTML direct action
- Without `faces-redirect=true`, JSF performs a forward (not a redirect), leaving the browser URL unchanged — breaking bookmarking, back button, and page refresh

## Files Changed
| Controller | Method |
|---|---|
| `VocabularyController` | `navigateToManageVocabularies()` |
| `SymptomController` | `navigateToManageSymptoms()` |
| `SignController` | `navigateToManageSigns()` |
| `DiagnosisController` | `navigateToManageDiagnoses()` |
| `ProcedureController` | `navigateToManageProcedures()` |
| `PlanController` | `navigateToManagePlans()`, `navigateToManageClinicaEntities()` |
| `ClinicalEntityController` | `navigateToManageClinicalEntities()`, `navigateToMangeSurgeries()` |
| `EmrController` | `navigateToManageDiagnoses()` |
| `FavouriteController` | `toAddFavDig()` |
| `index.xhtml` | Direct action for "Medicines" button |

## Test plan
- [ ] Navigate to EMR Admin index page
- [ ] Click each button in Clinical Metadata, Favourite Medicines, Favourite Diagnosis, and Upload tabs
- [ ] Verify the browser URL updates correctly after each navigation
- [ ] Verify back button works as expected

Closes #19789

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved navigation consistency and redirect behavior across clinical and administrative management modules. Updates enhance reliability for diagnosis management, procedure administration, symptom and sign configuration, treatment planning, vocabulary management, clinical entity administration, and favorite items management. These changes ensure more stable and predictable page transitions throughout the EMR system's administrative sections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->