### PR TITLE
Add REST API for EMR Clinical Metadata (#19791)

### DIFF
--- a/.claude/skills/api-development/SKILL.md
+++ b/.claude/skills/api-development/SKILL.md
@@ -1,0 +1,152 @@
+---
+name: api-development
+description: >
+  REST API development guide for the HMIS project. Use when creating or extending any REST API
+  endpoint — covers file structure, auth pattern, response format, ApplicationConfig registration,
+  CapabilityStatementResource update, AnthropicApiService integration (system prompt module +
+  tool handler), and the full post-implementation checklist.
+user-invocable: true
+---
+
+# HMIS REST API Development Guide
+
+## When This Applies
+
+Any time a new `@Path` class is created under `com.divudi.ws.*`, or an existing API gets new endpoints.
+
+---
+
+## Mandatory Checklist — Every New API
+
+### 1. File placement
+- REST class: `src/main/java/com/divudi/ws/<module>/<Name>Api.java`
+- `@Path("<name>")`, `@RequestScoped`
+- No `@Stateless` on the REST class itself
+
+### 2. Auth — always `Finance` header (unless module uses a different scheme)
+```java
+String key = requestContext.getHeader("Finance");
+if (validateApiKey(key) == null) return errorResponse("Not a valid key", 401);
+```
+Copy `validateApiKey`, `errorResponse`, `successResponse` verbatim from `DepartmentApi.java` (lines 437–488). Do not reinvent.
+
+### 3. Response envelope — always this shape
+```json
+{"status":"success","code":200,"data":{...}}
+{"status":"error","code":400,"message":"..."}
+```
+For POST duplicate-detection: `{"status":"already_exists","id":...,"name":...}` (no wrapping envelope).
+
+### 4. Gson
+```java
+private static final Gson gson = new GsonBuilder().setDateFormat("yyyy-MM-dd HH:mm:ss").create();
+```
+
+### 5. Register in ApplicationConfig
+`src/main/java/com/divudi/ws/common/ApplicationConfig.java` — add one line to `addRestResourceClasses()`:
+```java
+resources.add(com.divudi.ws.<module>.<Name>Api.class);
+```
+
+### 6. Document in CapabilityStatementResource
+`src/main/java/com/divudi/ws/common/CapabilityStatementResource.java` — add a `resource(...)` entry to `buildResources()`.
+
+### 7. Expose to AI Chat (AnthropicApiService) — TWO places
+Both are required every time:
+
+**a) `buildSystemPrompt` — add an `appendModule(...)` block** so the system prompt tells Claude what the endpoint does:
+```java
+appendModule(sb, "My Module", "/my_module",
+    "Description of what this module manages.",
+    null,  // or githubUrl(branch, "developer_docs/API_MY_MODULE.md")
+    new String[][]{
+        {"GET",    "/my_module",      "List entries. Supports query, page, size"},
+        {"POST",   "/my_module",      "Create a new entry. Body: {name, code}"},
+        {"PUT",    "/my_module/{id}", "Update an entry by ID"},
+        {"DELETE", "/my_module/{id}", "Soft-delete an entry by ID"}
+    });
+```
+
+**b) `buildToolsArray` + `executeToolCall` — add a tool** so Claude can actually call the API:
+- Add a `JsonObject myModuleTool` in `buildToolsArray()` and include it in the returned array.
+- Add a `case "my_tool_name":` in `executeToolCall(...)` that calls a private `callMyModuleApi(...)` method.
+- The `callMyModuleApi` method uses `hmisBaseUrl` + `hmisApiKey` (both available as params to `executeToolCall`).
+- `AiChatController.sendMessage(...)` already passes `hmisApiBaseUrl` and `userHmisApiKey` through to `executeToolCall` — use them.
+
+See `ClinicalMetadataApi` + `manage_clinical_metadata` tool in `AnthropicApiService` as a reference implementation.
+
+### 8. Write a developer_docs API file (optional but recommended)
+`developer_docs/API_<MODULE>.md` — list all endpoints, params, example request/response.
+Reference it in the `appendModule(...)` call via `githubUrl(branch, "developer_docs/API_<MODULE>.md")`.
+
+---
+
+## JPQL Patterns for Simple CRUD APIs
+
+### List (with optional text search + limit)
+```java
+Map<String, Object> params = new HashMap<>();
+params.put("t", symanticType);  // if filtering by type
+String jpql;
+if (query != null && !query.isEmpty()) {
+    jpql = "select c from MyEntity c where c.retired=false and c.symanticType=:t"
+         + " and upper(c.name) like :n order by c.name";
+    params.put("n", "%" + query.trim().toUpperCase() + "%");
+} else {
+    jpql = "select c from MyEntity c where c.retired=false and c.symanticType=:t order by c.name";
+}
+List<MyEntity> items = facade.findByJpql(jpql, params, size);  // 3-arg: (jpql, map, maxRecords)
+```
+
+### Duplicate check before POST
+```java
+MyEntity existing = facade.findFirstByJpql(
+    "select c from MyEntity c where c.retired=false and upper(c.name)=:n",
+    Map.of("n", name.toUpperCase()));
+if (existing != null) {
+    // return already_exists response
+}
+```
+
+### Soft delete
+```java
+entity.setRetired(true);
+entity.setRetiredAt(new Date());
+facade.edit(entity);
+```
+
+---
+
+## No-service-layer Rule
+
+For thin CRUD over a single entity (like ClinicalMetadataApi), **no `@Stateless` service EJB is needed** — inject facades directly into the REST class. Only add a service layer when there is real business logic, multiple entity coordination, or the method is reused elsewhere.
+
+---
+
+## Testing After Implementation
+
+```bash
+# List
+curl -s -H "Finance: <key>" "http://localhost:9090/rh/api/<path>?type=X"
+
+# Create
+curl -s -H "Finance: <key>" -H "Content-Type: application/json" \
+  -X POST "http://localhost:9090/rh/api/<path>?type=X" \
+  -d '{"name":"Test"}' | python -m json.tool
+
+# Duplicate check (POST same name again — must return already_exists)
+# same command as above
+
+# Update
+curl -s -H "Finance: <key>" -H "Content-Type: application/json" \
+  -X PUT "http://localhost:9090/rh/api/<path>/<id>" \
+  -d '{"name":"Updated"}' | python -m json.tool
+
+# Delete
+curl -s -H "Finance: <key>" -X DELETE "http://localhost:9090/rh/api/<path>/<id>" | python -m json.tool
+
+# Capabilities (confirm new entry appears)
+curl -s http://localhost:9090/rh/api/capabilities | python -m json.tool
+```
+
+For complete reference: [developer_docs/api/rest-api-development-guide.md](../../developer_docs/api/rest-api-development-guide.md)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,6 +59,9 @@
 ### When Adding a New Privilege
 - [Privilege System Guide](developer_docs/security/privilege-system.md) - **All 3 steps required**: enum value + `getCategory()` case + `UserPrivilageController` tree node. Adding only the enum is NOT sufficient — the privilege will be invisible in the admin UI. This was missed for `InpatientClinicalDischarge` (PR #19658, issue #19677).
 
+### When Developing a REST API
+- [REST API Development Guide](developer_docs/api/rest-api-development-guide.md) - **All 4 registration steps required**: `ApplicationConfig` + `CapabilityStatementResource` + `AnthropicApiService.buildSystemPrompt` (module listing) + `AnthropicApiService.buildToolsArray`/`executeToolCall` (tool handler). Skipping any step means the API is invisible to the AI chat or undiscoverable via `/api/capabilities`.
+
 ### When Committing Code
 - [Commit Conventions](developer_docs/git/commit-conventions.md) - Message format
 

--- a/developer_docs/api/rest-api-development-guide.md
+++ b/developer_docs/api/rest-api-development-guide.md
@@ -1,0 +1,216 @@
+# HMIS REST API Development Guide
+
+## Overview
+
+This guide documents the mandatory steps and patterns for adding any new REST API to HMIS. It was established during the Clinical Metadata API implementation (hmislk/hmis#19791) and consolidates patterns from all prior API work.
+
+---
+
+## File Structure
+
+| Role | Location | Pattern |
+|---|---|---|
+| REST endpoint class | `com.divudi.ws.<module>/<Name>Api.java` | `@Path`, `@RequestScoped` |
+| Business service (only if needed) | `com.divudi.service.<module>/<Name>ApiService.java` | `@Stateless` EJB |
+| DTOs (only if needed) | `com.divudi.core.data.dto.<module>/` | JPQL constructor query targets |
+
+> **No-service-layer rule**: For thin CRUD over a single entity, inject facades directly into the REST class. Only add a `@Stateless` service EJB when there is real business logic or multi-entity coordination.
+
+---
+
+## Auth Pattern
+
+All standard APIs use the `Finance` header. Copy these methods verbatim from `DepartmentApi.java`:
+
+```java
+private WebUser validateApiKey(String key) {
+    if (key == null || key.trim().isEmpty()) return null;
+    ApiKey apiKey = apiKeyController.findApiKey(key);
+    if (apiKey == null) return null;
+    WebUser user = apiKey.getWebUser();
+    if (user == null || user.isRetired() || !user.isActivated()) return null;
+    if (apiKey.getDateOfExpiary() == null || apiKey.getDateOfExpiary().before(new Date())) return null;
+    return user;
+}
+```
+
+Different header schemes by module:
+| Header | Used by |
+|---|---|
+| `Finance` | All standard APIs (pharmacy, institution, clinical, users, finance…) |
+| `Token` | Channel/Booking, Consultant Management |
+| `FHIR` | FHIR Patient (`/fhir/Patient`) |
+| `Config` | Config Management (`/config`) |
+| Custom | LIMS (URL-embedded / JSON body / HTTP Basic) |
+
+---
+
+## Response Envelope
+
+**Always** use this shape — copy `errorResponse` and `successResponse` from `DepartmentApi.java`:
+
+```json
+{"status":"success","code":200,"data":{...}}
+{"status":"error","code":400,"message":"..."}
+```
+
+For POST duplicate detection (not wrapped in the success envelope):
+```json
+{"status":"already_exists","id":42,"name":"Fever","type":"symptom"}
+```
+
+---
+
+## Registering the API — 4 Required Files
+
+Every new API must touch **all four** of these files:
+
+### 1. `ApplicationConfig.java`
+`src/main/java/com/divudi/ws/common/ApplicationConfig.java`
+
+Add one line to `addRestResourceClasses()`:
+```java
+resources.add(com.divudi.ws.<module>.<Name>Api.class);
+```
+
+### 2. `CapabilityStatementResource.java`
+`src/main/java/com/divudi/ws/common/CapabilityStatementResource.java`
+
+Add a `resource(...)` entry to `buildResources()`:
+```java
+.add(resource("My Module", "/api/my_module",
+    "Description of what this module does.",
+    "API Key",
+    "GET", "POST", "PUT", "DELETE"))
+```
+
+### 3. `AnthropicApiService.java` — `buildSystemPrompt` (module listing)
+`src/main/java/com/divudi/service/AnthropicApiService.java`
+
+Add an `appendModule(...)` block so the AI chat system prompt knows what the endpoint does:
+```java
+appendModule(sb, "My Module", "/my_module",
+    "What this module manages.",
+    null,  // or githubUrl(branch, "developer_docs/API_MY_MODULE.md")
+    new String[][]{
+        {"GET",    "/my_module",      "List entries"},
+        {"POST",   "/my_module",      "Create entry. Returns already_exists if duplicate."},
+        {"PUT",    "/my_module/{id}", "Update entry by ID"},
+        {"DELETE", "/my_module/{id}", "Soft-delete entry by ID"}
+    });
+```
+
+### 4. `AnthropicApiService.java` — `buildToolsArray` + `executeToolCall` (tool)
+So the AI can **actually call** the API (not just know it exists), add:
+
+**In `buildToolsArray()`:**
+```java
+JsonObject myTool = Json.createObjectBuilder()
+    .add("name", "manage_my_module")
+    .add("description", "Create, list, update, or delete ...")
+    .add("input_schema", Json.createObjectBuilder()
+        .add("type", "object")
+        .add("properties", Json.createObjectBuilder()
+            .add("method", Json.createObjectBuilder()
+                .add("type", "string")
+                .add("enum", Json.createArrayBuilder().add("GET").add("POST").add("PUT").add("DELETE")))
+            // ... other inputs
+        )
+        .add("required", Json.createArrayBuilder().add("method")))
+    .build();
+// add to the returned Json.createArrayBuilder()
+```
+
+**In `executeToolCall(...)`:**
+```java
+case "manage_my_module": {
+    // extract inputs from toolInput
+    return callMyModuleApi(..., hmisBaseUrl, hmisApiKey);
+}
+```
+
+**New private method:**
+```java
+private String callMyModuleApi(..., String hmisBaseUrl, String hmisApiKey) {
+    // build URL, make HttpClient call with Finance header, return response body
+}
+```
+
+The `hmisBaseUrl` and `hmisApiKey` are already threaded through `sendMessage` → `executeToolCall`. Use them directly.
+
+**Also update `buildSystemPrompt` tools description** — the count in `"You have N tools"` and the tool listing.
+
+---
+
+## JPQL Patterns
+
+### List with optional search + limit
+```java
+Map<String, Object> params = new HashMap<>();
+params.put("t", symanticType);
+String jpql = query != null && !query.isEmpty()
+    ? "select c from MyEntity c where c.retired=false and c.symanticType=:t and upper(c.name) like :n order by c.name"
+    : "select c from MyEntity c where c.retired=false and c.symanticType=:t order by c.name";
+if (query != null && !query.isEmpty()) params.put("n", "%" + query.toUpperCase() + "%");
+List<MyEntity> items = facade.findByJpql(jpql, params, size);  // 3-arg variant
+```
+
+### Duplicate check before POST
+```java
+MyEntity existing = facade.findFirstByJpql(
+    "select c from MyEntity c where c.retired=false and upper(c.name)=:n",
+    Map.of("n", name.toUpperCase()));
+```
+
+### Soft delete
+```java
+entity.setRetired(true);
+entity.setRetiredAt(new Date());
+facade.edit(entity);
+```
+
+---
+
+## Reference Implementations
+
+| API | Class | Notes |
+|---|---|---|
+| Clinical Metadata | `ClinicalMetadataApi.java` | No service layer, inline maps, two entity types, `manage_clinical_metadata` tool |
+| Department | `DepartmentApi.java` | Service layer, DTOs, full CRUD |
+| Pharmaceutical Items | `PharmaceuticalItemApi.java` | Complex hierarchy, service layer |
+| Favourite Medicines | `FavouriteMedicineApi.java` | Service layer, clinical data |
+
+---
+
+## Post-Implementation Testing Checklist
+
+```bash
+BASE="http://localhost:9090/rh/api/<path>"
+KEY="<finance-api-key>"
+
+# 1. GET list
+curl -s -H "Finance: $KEY" "$BASE?type=X" | python -m json.tool
+
+# 2. POST create
+curl -s -H "Finance: $KEY" -H "Content-Type: application/json" \
+  -X POST "$BASE?type=X" -d '{"name":"Test Entry"}' | python -m json.tool
+
+# 3. POST same name → must return already_exists with id
+# (repeat same command)
+
+# 4. GET with search
+curl -s -H "Finance: $KEY" "$BASE?type=X&query=test" | python -m json.tool
+
+# 5. PUT update
+curl -s -H "Finance: $KEY" -H "Content-Type: application/json" \
+  -X PUT "$BASE/<id>" -d '{"name":"Updated Name"}' | python -m json.tool
+
+# 6. DELETE
+curl -s -H "Finance: $KEY" -X DELETE "$BASE/<id>" | python -m json.tool
+
+# 7. Capabilities endpoint shows new entry
+curl -s http://localhost:9090/rh/api/capabilities | python -m json.tool
+
+# 8. AI Chat can list and create via manage_* tool
+# Open /ai_chat.xhtml and prompt: "List all procedures in the clinical metadata API"
+```

--- a/src/main/java/com/divudi/bean/common/AiChatController.java
+++ b/src/main/java/com/divudi/bean/common/AiChatController.java
@@ -230,7 +230,9 @@ public class AiChatController implements Serializable {
                         pendingAttachmentBase64,
                         pendingAttachmentMimeType,
                         githubToken,
-                        githubBranch
+                        githubBranch,
+                        hmisApiBaseUrl,
+                        userHmisApiKey
                 );
 
                 AiMessage assistantMsg = new AiMessage();

--- a/src/main/java/com/divudi/service/AnthropicApiService.java
+++ b/src/main/java/com/divudi/service/AnthropicApiService.java
@@ -71,7 +71,9 @@ public class AnthropicApiService implements Serializable {
             String attachmentBase64,
             String attachmentMimeType,
             String githubToken,
-            String githubBranch) {
+            String githubBranch,
+            String hmisBaseUrl,
+            String hmisApiKey) {
 
         try {
             List<JsonObject> messages = new ArrayList<>();
@@ -180,7 +182,7 @@ public class AnthropicApiService implements Serializable {
                                     ? block.getJsonObject("input")
                                     : Json.createObjectBuilder().build();
 
-                            String result = executeToolCall(toolName, toolInput, githubToken, githubBranch);
+                            String result = executeToolCall(toolName, toolInput, githubToken, githubBranch, hmisBaseUrl, hmisApiKey);
                             LOG.log(Level.INFO, "Tool {0} returned {1} chars", new Object[]{toolName, result.length()});
 
                             toolResultsBuilder.add(Json.createObjectBuilder()
@@ -218,8 +220,25 @@ public class AnthropicApiService implements Serializable {
     }
 
     /**
-     * Backward-compatible overload — no GitHub token or branch supplied.
-     * Tools are still available; GitHub tools use unauthenticated access (60 req/hr).
+     * Backward-compatible overload — GitHub token/branch supplied, no HMIS base URL or key.
+     */
+    public AnthropicResponse sendMessage(
+            String apiKey,
+            String model,
+            int maxTokens,
+            String systemPrompt,
+            List<AiMessage> conversationHistory,
+            String userMessage,
+            String attachmentBase64,
+            String attachmentMimeType,
+            String githubToken,
+            String githubBranch) {
+        return sendMessage(apiKey, model, maxTokens, systemPrompt, conversationHistory,
+                userMessage, attachmentBase64, attachmentMimeType, githubToken, githubBranch, "", "");
+    }
+
+    /**
+     * Backward-compatible overload — no GitHub token, branch, or HMIS credentials supplied.
      */
     public AnthropicResponse sendMessage(
             String apiKey,
@@ -231,7 +250,7 @@ public class AnthropicApiService implements Serializable {
             String attachmentBase64,
             String attachmentMimeType) {
         return sendMessage(apiKey, model, maxTokens, systemPrompt, conversationHistory,
-                userMessage, attachmentBase64, attachmentMimeType, "", "development");
+                userMessage, attachmentBase64, attachmentMimeType, "", "development", "", "");
     }
 
     // -------------------------------------------------------------------------
@@ -289,10 +308,52 @@ public class AnthropicApiService implements Serializable {
                         .add("required", Json.createArrayBuilder().add("keyword")))
                 .build();
 
+        JsonObject clinicalMetadataTool = Json.createObjectBuilder()
+                .add("name", "manage_clinical_metadata")
+                .add("description",
+                        "Create, list, update, or delete EMR clinical metadata entries (symptoms, signs, diagnoses, "
+                        + "procedures, plans, vocabularies, and clinical entities such as race, religion, blood_group, "
+                        + "civil_status, employment, relationship). "
+                        + "Use this when the user wants to add, search, modify, or remove clinical master data.")
+                .add("input_schema", Json.createObjectBuilder()
+                        .add("type", "object")
+                        .add("properties", Json.createObjectBuilder()
+                                .add("method", Json.createObjectBuilder()
+                                        .add("type", "string")
+                                        .add("enum", Json.createArrayBuilder().add("GET").add("POST").add("PUT").add("DELETE"))
+                                        .add("description", "HTTP method: GET=list, POST=create, PUT=update, DELETE=soft-delete"))
+                                .add("type", Json.createObjectBuilder()
+                                        .add("type", "string")
+                                        .add("description", "Metadata type: symptom, sign, diagnosis, procedure, plan, vocabulary, race, religion, blood_group, civil_status, employment, relationship. Required for GET and POST."))
+                                .add("id", Json.createObjectBuilder()
+                                        .add("type", "string")
+                                        .add("description", "Record ID as a string. Required for PUT and DELETE."))
+                                .add("name", Json.createObjectBuilder()
+                                        .add("type", "string")
+                                        .add("description", "Name of the entry. Required for POST; optional for PUT."))
+                                .add("code", Json.createObjectBuilder()
+                                        .add("type", "string")
+                                        .add("description", "Short code for the entry (optional)."))
+                                .add("description", Json.createObjectBuilder()
+                                        .add("type", "string")
+                                        .add("description", "Description of the entry (optional)."))
+                                .add("query", Json.createObjectBuilder()
+                                        .add("type", "string")
+                                        .add("description", "Text filter for GET (optional)."))
+                                .add("page", Json.createObjectBuilder()
+                                        .add("type", "string")
+                                        .add("description", "Page number for GET, default 0 (optional)."))
+                                .add("size", Json.createObjectBuilder()
+                                        .add("type", "string")
+                                        .add("description", "Page size for GET, default 20 (optional).")))
+                        .add("required", Json.createArrayBuilder().add("method")))
+                .build();
+
         return Json.createArrayBuilder()
                 .add(searchCodeTool)
                 .add(fetchFileTool)
                 .add(searchConfigTool)
+                .add(clinicalMetadataTool)
                 .build();
     }
 
@@ -300,7 +361,8 @@ public class AnthropicApiService implements Serializable {
     // Tool execution
     // -------------------------------------------------------------------------
 
-    private String executeToolCall(String toolName, JsonObject toolInput, String githubToken, String githubBranch) {
+    private String executeToolCall(String toolName, JsonObject toolInput, String githubToken, String githubBranch,
+            String hmisBaseUrl, String hmisApiKey) {
         try {
             switch (toolName) {
                 case "search_github_code": {
@@ -322,6 +384,19 @@ public class AnthropicApiService implements Serializable {
                 case "search_config_options": {
                     String keyword = toolInput.getString("keyword", "");
                     return searchConfigOptions(keyword);
+                }
+                case "manage_clinical_metadata": {
+                    String method = toolInput.getString("method", "GET");
+                    String type   = toolInput.containsKey("type") ? toolInput.getString("type", "") : "";
+                    String id     = toolInput.containsKey("id")   ? toolInput.getString("id", "")   : "";
+                    String name   = toolInput.containsKey("name") ? toolInput.getString("name", "") : null;
+                    String code   = toolInput.containsKey("code") ? toolInput.getString("code", "") : null;
+                    String desc   = toolInput.containsKey("description") ? toolInput.getString("description", "") : null;
+                    String query  = toolInput.containsKey("query") ? toolInput.getString("query", "") : "";
+                    String page   = toolInput.containsKey("page")  ? toolInput.getString("page", "0") : "0";
+                    String size   = toolInput.containsKey("size")  ? toolInput.getString("size", "20") : "20";
+                    return callClinicalMetadataApi(method, type, id, name, code, desc, query, page, size,
+                            hmisBaseUrl, hmisApiKey);
                 }
                 default:
                     return "Unknown tool: " + toolName;
@@ -502,6 +577,91 @@ public class AnthropicApiService implements Serializable {
         return value;
     }
 
+    private String callClinicalMetadataApi(String method, String type, String id,
+            String name, String code, String desc, String query, String page, String size,
+            String hmisBaseUrl, String hmisApiKey) {
+        if (hmisBaseUrl == null || hmisBaseUrl.trim().isEmpty()) {
+            return "Error: HMIS base URL is not configured. Cannot call clinical metadata API.";
+        }
+        if (hmisApiKey == null || hmisApiKey.trim().isEmpty()) {
+            return "Error: No active HMIS API key found for the current user.";
+        }
+        try {
+            HttpClient client = HttpClient.newBuilder()
+                    .connectTimeout(Duration.ofSeconds(10))
+                    .build();
+
+            String base = hmisBaseUrl.trim().replaceAll("/+$", "") + "/api/clinical/metadata";
+            String url;
+            String requestBody = null;
+            String httpMethod;
+
+            switch (method.toUpperCase()) {
+                case "GET": {
+                    StringBuilder urlBuilder = new StringBuilder(base).append("?type=").append(type);
+                    if (query != null && !query.isEmpty()) urlBuilder.append("&query=").append(URLEncoder.encode(query, StandardCharsets.UTF_8));
+                    if (page != null && !page.isEmpty()) urlBuilder.append("&page=").append(page);
+                    if (size != null && !size.isEmpty()) urlBuilder.append("&size=").append(size);
+                    url = urlBuilder.toString();
+                    httpMethod = "GET";
+                    break;
+                }
+                case "POST": {
+                    url = base + "?type=" + type;
+                    httpMethod = "POST";
+                    javax.json.JsonObjectBuilder bodyBuilder = Json.createObjectBuilder();
+                    if (name != null) bodyBuilder.add("name", name);
+                    if (code != null && !code.isEmpty()) bodyBuilder.add("code", code);
+                    if (desc != null && !desc.isEmpty()) bodyBuilder.add("description", desc);
+                    requestBody = bodyBuilder.build().toString();
+                    break;
+                }
+                case "PUT": {
+                    if (id == null || id.trim().isEmpty()) return "Error: id is required for PUT.";
+                    url = base + "/" + id.trim();
+                    httpMethod = "PUT";
+                    javax.json.JsonObjectBuilder bodyBuilder = Json.createObjectBuilder();
+                    if (name != null && !name.isEmpty()) bodyBuilder.add("name", name);
+                    if (code != null && !code.isEmpty()) bodyBuilder.add("code", code);
+                    if (desc != null && !desc.isEmpty()) bodyBuilder.add("description", desc);
+                    requestBody = bodyBuilder.build().toString();
+                    break;
+                }
+                case "DELETE": {
+                    if (id == null || id.trim().isEmpty()) return "Error: id is required for DELETE.";
+                    url = base + "/" + id.trim();
+                    httpMethod = "DELETE";
+                    break;
+                }
+                default:
+                    return "Error: Unknown method: " + method;
+            }
+
+            HttpRequest.Builder reqBuilder = HttpRequest.newBuilder()
+                    .uri(URI.create(url))
+                    .timeout(Duration.ofSeconds(15))
+                    .header("Finance", hmisApiKey)
+                    .header("Content-Type", "application/json");
+
+            if (requestBody != null) {
+                reqBuilder.method(httpMethod, HttpRequest.BodyPublishers.ofString(requestBody));
+            } else if ("DELETE".equals(httpMethod)) {
+                reqBuilder.DELETE();
+            } else {
+                reqBuilder.GET();
+            }
+
+            HttpResponse<String> response = client.send(reqBuilder.build(), HttpResponse.BodyHandlers.ofString());
+            return "HTTP " + response.statusCode() + "\n" + response.body();
+
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            return "Clinical metadata API call interrupted.";
+        } catch (Exception e) {
+            return "Clinical metadata API error: " + e.getMessage();
+        }
+    }
+
     // -------------------------------------------------------------------------
     // Message building helpers
     // -------------------------------------------------------------------------
@@ -600,7 +760,7 @@ public class AnthropicApiService implements Serializable {
         }
 
         sb.append("## Tools Available to You\n");
-        sb.append("You have three tools to ground your answers in the actual codebase and live configuration:\n\n");
+        sb.append("You have four tools to ground your answers in the actual codebase, live configuration, and clinical master data:\n\n");
         sb.append("### search_github_code\n");
         sb.append("Searches the hmislk/hmis repository source code for files matching keywords. ");
         sb.append("Use this first when a user asks about system behaviour, page logic, or wants to understand how something works.\n\n");
@@ -611,6 +771,11 @@ public class AnthropicApiService implements Serializable {
         sb.append("Searches live application configuration options by keyword and returns the key name, type, and current value. ");
         sb.append("Use this to find config keys that control a behaviour the user is asking about. ");
         sb.append("You can then use POST /config/setBoolean, /config/setInteger, or /config/setLongText to change a value if the user asks.\n\n");
+        sb.append("### manage_clinical_metadata\n");
+        sb.append("Directly create, list, update, or delete EMR clinical metadata entries (symptoms, signs, diagnoses, procedures, plans, vocabularies, ")
+          .append("race, religion, blood_group, civil_status, employment, relationship). ")
+          .append("Use this when the user wants to add or manage clinical master data without navigating the UI. ")
+          .append("Always confirm with the user before creating or deleting entries.\n\n");
 
         sb.append("## How to Use the Tools\n");
         sb.append("- When a user describes a problem or asks why something behaves a certain way, search the source code first.\n");
@@ -862,6 +1027,20 @@ public class AnthropicApiService implements Serializable {
                 });
 
         // ── Clinical ──────────────────────────────────────────────────────────
+        appendModule(sb, "Clinical - Metadata", "/clinical/metadata",
+                "Manage EMR clinical master data. Required param: type. "
+                + "Types: symptom, sign, diagnosis, procedure, plan, vocabulary, "
+                + "race, religion, blood_group, civil_status, employment, relationship. "
+                + "POST returns success/already_exists (with id)/error. "
+                + "PUT and DELETE use /{id} and work across all types.",
+                null,
+                new String[][]{
+                    {"GET",    "/clinical/metadata?type=X",    "List entries of the given type. Supports query, page, size"},
+                    {"POST",   "/clinical/metadata?type=X",    "Create a new entry. Body: {name, code, description}. Returns already_exists with id if duplicate name"},
+                    {"PUT",    "/clinical/metadata/{id}",      "Update an entry by ID. Body: {name, code, description} (all optional)"},
+                    {"DELETE", "/clinical/metadata/{id}",      "Soft-delete an entry by ID"}
+                });
+
         appendModule(sb, "Clinical - Favourite Medicines", "/clinical/favourite_medicines",
                 "Manage clinician favourite medicine templates. "
                 + "/validate (bulk entity validation) is live. "

--- a/src/main/java/com/divudi/service/AnthropicApiService.java
+++ b/src/main/java/com/divudi/service/AnthropicApiService.java
@@ -618,7 +618,8 @@ public class AnthropicApiService implements Serializable {
                 }
                 case "PUT": {
                     if (id == null || id.trim().isEmpty()) return "Error: id is required for PUT.";
-                    url = base + "/" + id.trim();
+                    if (type == null || type.trim().isEmpty()) return "Error: type is required for PUT.";
+                    url = base + "/" + id.trim() + "?type=" + URLEncoder.encode(type.trim(), StandardCharsets.UTF_8);
                     httpMethod = "PUT";
                     javax.json.JsonObjectBuilder bodyBuilder = Json.createObjectBuilder();
                     if (name != null && !name.isEmpty()) bodyBuilder.add("name", name);

--- a/src/main/java/com/divudi/service/AnthropicApiService.java
+++ b/src/main/java/com/divudi/service/AnthropicApiService.java
@@ -598,7 +598,7 @@ public class AnthropicApiService implements Serializable {
 
             switch (method.toUpperCase()) {
                 case "GET": {
-                    StringBuilder urlBuilder = new StringBuilder(base).append("?type=").append(type);
+                    StringBuilder urlBuilder = new StringBuilder(base).append("?type=").append(URLEncoder.encode(type, StandardCharsets.UTF_8));
                     if (query != null && !query.isEmpty()) urlBuilder.append("&query=").append(URLEncoder.encode(query, StandardCharsets.UTF_8));
                     if (page != null && !page.isEmpty()) urlBuilder.append("&page=").append(page);
                     if (size != null && !size.isEmpty()) urlBuilder.append("&size=").append(size);
@@ -607,7 +607,7 @@ public class AnthropicApiService implements Serializable {
                     break;
                 }
                 case "POST": {
-                    url = base + "?type=" + type;
+                    url = base + "?type=" + URLEncoder.encode(type, StandardCharsets.UTF_8);
                     httpMethod = "POST";
                     javax.json.JsonObjectBuilder bodyBuilder = Json.createObjectBuilder();
                     if (name != null) bodyBuilder.add("name", name);

--- a/src/main/java/com/divudi/ws/clinical/ClinicalMetadataApi.java
+++ b/src/main/java/com/divudi/ws/clinical/ClinicalMetadataApi.java
@@ -1,0 +1,450 @@
+/*
+ * Open Hospital Management Information System
+ * Dr M H B Ariyaratne
+ * buddhika.ari@gmail.com
+ */
+package com.divudi.ws.clinical;
+
+import com.divudi.bean.common.ApiKeyController;
+import com.divudi.core.data.SymanticType;
+import com.divudi.core.entity.ApiKey;
+import com.divudi.core.entity.Vocabulary;
+import com.divudi.core.entity.WebUser;
+import com.divudi.core.entity.clinical.ClinicalEntity;
+import com.divudi.core.facade.ClinicalEntityFacade;
+import com.divudi.core.facade.VocabularyFacade;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonSyntaxException;
+
+import javax.ejb.EJB;
+import javax.enterprise.context.RequestScoped;
+import javax.inject.Inject;
+import javax.servlet.http.HttpServletRequest;
+import javax.ws.rs.*;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.UriInfo;
+import java.util.*;
+
+/**
+ * REST API for EMR Clinical Metadata management.
+ *
+ * Covers all types in the Clinical Metadata section of /emr/admin/index.xhtml:
+ * symptoms, signs, diagnosis, procedures, plans, vocabularies, and clinical
+ * entities (race, religion, blood_group, civil_status, employment, relationship).
+ *
+ * All operations require a valid Finance API key header.
+ */
+@Path("clinical/metadata")
+@RequestScoped
+public class ClinicalMetadataApi {
+
+    @Context
+    private HttpServletRequest requestContext;
+
+    @Context
+    private UriInfo uriInfo;
+
+    @Inject
+    private ApiKeyController apiKeyController;
+
+    @EJB
+    private ClinicalEntityFacade clinicalEntityFacade;
+
+    @EJB
+    private VocabularyFacade vocabularyFacade;
+
+    private static final Gson gson = new GsonBuilder()
+            .setDateFormat("yyyy-MM-dd HH:mm:ss")
+            .create();
+
+    // -------------------------------------------------------------------------
+    // GET /api/clinical/metadata?type=X[&query=text&page=0&size=20]
+    // -------------------------------------------------------------------------
+
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response list() {
+        try {
+            String key = requestContext.getHeader("Finance");
+            if (validateApiKey(key) == null) {
+                return errorResponse("Not a valid key", 401);
+            }
+
+            String typeStr = param("type");
+            if (typeStr == null || typeStr.trim().isEmpty()) {
+                return errorResponse("type parameter is required", 400);
+            }
+
+            String query = param("query");
+            int page = Math.max(parseInt(param("page"), 0), 0);
+            int size = Math.min(Math.max(parseInt(param("size"), 20), 1), 200);
+            int offset = page * size;
+
+            if ("vocabulary".equalsIgnoreCase(typeStr)) {
+                return listVocabularies(query, offset, size);
+            }
+
+            SymanticType st = resolveSymanticType(typeStr);
+            if (st == null) {
+                return errorResponse("Unknown type: " + typeStr, 400);
+            }
+
+            return listClinicalEntities(st, typeStr.toLowerCase(), query, offset, size);
+
+        } catch (Exception e) {
+            return errorResponse("An error occurred: " + e.getMessage(), 500);
+        }
+    }
+
+    private Response listClinicalEntities(SymanticType st, String typeLabel, String query, int offset, int size) {
+        Map<String, Object> params = new HashMap<>();
+        params.put("t", st);
+        String jpql;
+        if (query != null && !query.trim().isEmpty()) {
+            jpql = "select c from ClinicalEntity c where c.retired=false and c.symanticType=:t"
+                    + " and upper(c.name) like :n order by c.name";
+            params.put("n", "%" + query.trim().toUpperCase() + "%");
+        } else {
+            jpql = "select c from ClinicalEntity c where c.retired=false and c.symanticType=:t order by c.name";
+        }
+        List<ClinicalEntity> entities = clinicalEntityFacade.findByJpql(jpql, params, size);
+        List<Map<String, Object>> result = new ArrayList<>();
+        for (ClinicalEntity e : entities) {
+            result.add(toMap(e, typeLabel));
+        }
+        return successResponse(result);
+    }
+
+    private Response listVocabularies(String query, int offset, int size) {
+        Map<String, Object> params = new HashMap<>();
+        String jpql;
+        if (query != null && !query.trim().isEmpty()) {
+            jpql = "select v from Vocabulary v where v.retired=false and upper(v.name) like :n order by v.name";
+            params.put("n", "%" + query.trim().toUpperCase() + "%");
+        } else {
+            jpql = "select v from Vocabulary v where v.retired=false order by v.name";
+        }
+        List<Vocabulary> vocabs = vocabularyFacade.findByJpql(jpql, params, size);
+        List<Map<String, Object>> result = new ArrayList<>();
+        for (Vocabulary v : vocabs) {
+            result.add(toMap(v));
+        }
+        return successResponse(result);
+    }
+
+    // -------------------------------------------------------------------------
+    // POST /api/clinical/metadata?type=X   body: {name, code, description}
+    // -------------------------------------------------------------------------
+
+    @POST
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response create(String requestBody) {
+        try {
+            String key = requestContext.getHeader("Finance");
+            if (validateApiKey(key) == null) {
+                return errorResponse("Not a valid key", 401);
+            }
+
+            String typeStr = param("type");
+            if (typeStr == null || typeStr.trim().isEmpty()) {
+                return errorResponse("type parameter is required", 400);
+            }
+
+            Map<String, String> body;
+            try {
+                body = gson.fromJson(requestBody, Map.class);
+            } catch (JsonSyntaxException e) {
+                return errorResponse("Invalid JSON: " + e.getMessage(), 400);
+            }
+            if (body == null) {
+                return errorResponse("Request body is required", 400);
+            }
+
+            String name = body.get("name");
+            if (name == null || name.trim().isEmpty()) {
+                return errorResponse("name is required", 400);
+            }
+            name = name.trim();
+            String code = body.get("code");
+            String description = body.get("description");
+
+            if ("vocabulary".equalsIgnoreCase(typeStr)) {
+                return createVocabulary(name, code, description);
+            }
+
+            SymanticType st = resolveSymanticType(typeStr);
+            if (st == null) {
+                return errorResponse("Unknown type: " + typeStr, 400);
+            }
+
+            return createClinicalEntity(st, typeStr.toLowerCase(), name, code, description);
+
+        } catch (Exception e) {
+            return errorResponse("An error occurred: " + e.getMessage(), 500);
+        }
+    }
+
+    private Response createClinicalEntity(SymanticType st, String typeLabel, String name, String code, String description) {
+        // Duplicate check
+        Map<String, Object> params = new HashMap<>();
+        params.put("t", st);
+        params.put("n", name.toUpperCase());
+        ClinicalEntity existing = clinicalEntityFacade.findFirstByJpql(
+                "select c from ClinicalEntity c where c.retired=false and c.symanticType=:t and upper(c.name)=:n",
+                params);
+        if (existing != null) {
+            Map<String, Object> found = new HashMap<>();
+            found.put("status", "already_exists");
+            found.put("id", existing.getId());
+            found.put("name", existing.getName());
+            found.put("type", typeLabel);
+            return Response.ok(gson.toJson(found)).build();
+        }
+
+        ClinicalEntity entity = new ClinicalEntity();
+        entity.setName(name);
+        entity.setCode(code);
+        entity.setDescreption(description);
+        entity.setSymanticType(st);
+        entity.setCreatedAt(new Date());
+        entity.setRetired(false);
+        clinicalEntityFacade.create(entity);
+
+        return successResponse(toMap(entity, typeLabel));
+    }
+
+    private Response createVocabulary(String name, String code, String description) {
+        // Duplicate check
+        Map<String, Object> params = new HashMap<>();
+        params.put("n", name.toUpperCase());
+        Vocabulary existing = vocabularyFacade.findFirstByJpql(
+                "select v from Vocabulary v where v.retired=false and upper(v.name)=:n",
+                params);
+        if (existing != null) {
+            Map<String, Object> found = new HashMap<>();
+            found.put("status", "already_exists");
+            found.put("id", existing.getId());
+            found.put("name", existing.getName());
+            found.put("type", "vocabulary");
+            return Response.ok(gson.toJson(found)).build();
+        }
+
+        Vocabulary vocab = new Vocabulary();
+        vocab.setName(name);
+        vocab.setCode(code);
+        vocab.setDescription(description);
+        vocab.setRetired(false);
+        vocabularyFacade.create(vocab);
+
+        return successResponse(toMap(vocab));
+    }
+
+    // -------------------------------------------------------------------------
+    // PUT /api/clinical/metadata/{id}   body: {name, code, description}
+    // -------------------------------------------------------------------------
+
+    @PUT
+    @Path("/{id}")
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response update(@PathParam("id") Long id, String requestBody) {
+        try {
+            String key = requestContext.getHeader("Finance");
+            if (validateApiKey(key) == null) {
+                return errorResponse("Not a valid key", 401);
+            }
+
+            Map<String, String> body;
+            try {
+                body = gson.fromJson(requestBody, Map.class);
+            } catch (JsonSyntaxException e) {
+                return errorResponse("Invalid JSON: " + e.getMessage(), 400);
+            }
+            if (body == null) {
+                return errorResponse("Request body is required", 400);
+            }
+
+            // Try ClinicalEntity first, then Vocabulary
+            ClinicalEntity ce = clinicalEntityFacade.find(id);
+            if (ce != null && !ce.isRetired()) {
+                if (body.containsKey("name") && body.get("name") != null) {
+                    ce.setName(body.get("name").trim());
+                }
+                if (body.containsKey("code")) {
+                    ce.setCode(body.get("code"));
+                }
+                if (body.containsKey("description")) {
+                    ce.setDescreption(body.get("description"));
+                }
+                clinicalEntityFacade.edit(ce);
+                return successResponse(toMap(ce, typeLabel(ce.getSymanticType())));
+            }
+
+            Vocabulary vocab = vocabularyFacade.find(id);
+            if (vocab != null && !vocab.isRetired()) {
+                if (body.containsKey("name") && body.get("name") != null) {
+                    vocab.setName(body.get("name").trim());
+                }
+                if (body.containsKey("code")) {
+                    vocab.setCode(body.get("code"));
+                }
+                if (body.containsKey("description")) {
+                    vocab.setDescription(body.get("description"));
+                }
+                vocabularyFacade.edit(vocab);
+                return successResponse(toMap(vocab));
+            }
+
+            return errorResponse("Record not found with id: " + id, 404);
+
+        } catch (Exception e) {
+            return errorResponse("An error occurred: " + e.getMessage(), 500);
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // DELETE /api/clinical/metadata/{id}
+    // -------------------------------------------------------------------------
+
+    @DELETE
+    @Path("/{id}")
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response delete(@PathParam("id") Long id) {
+        try {
+            String key = requestContext.getHeader("Finance");
+            if (validateApiKey(key) == null) {
+                return errorResponse("Not a valid key", 401);
+            }
+
+            ClinicalEntity ce = clinicalEntityFacade.find(id);
+            if (ce != null && !ce.isRetired()) {
+                ce.setRetired(true);
+                ce.setRetiredAt(new Date());
+                clinicalEntityFacade.edit(ce);
+                Map<String, Object> result = new HashMap<>();
+                result.put("id", ce.getId());
+                result.put("deleted", true);
+                return successResponse(result);
+            }
+
+            Vocabulary vocab = vocabularyFacade.find(id);
+            if (vocab != null && !vocab.isRetired()) {
+                vocab.setRetired(true);
+                vocab.setRetiredAt(new Date());
+                vocabularyFacade.edit(vocab);
+                Map<String, Object> result = new HashMap<>();
+                result.put("id", vocab.getId());
+                result.put("deleted", true);
+                return successResponse(result);
+            }
+
+            return errorResponse("Record not found with id: " + id, 404);
+
+        } catch (Exception e) {
+            return errorResponse("An error occurred: " + e.getMessage(), 500);
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Helpers
+    // -------------------------------------------------------------------------
+
+    private SymanticType resolveSymanticType(String type) {
+        if (type == null) return null;
+        switch (type.toLowerCase()) {
+            case "symptom":     return SymanticType.Symptom;
+            case "sign":        return SymanticType.Sign;
+            case "diagnosis":   return SymanticType.Disease_or_Syndrome;
+            case "procedure":   return SymanticType.Therapeutic_Procedure;
+            case "plan":        return SymanticType.Preventive_Procedure;
+            case "race":        return SymanticType.Race;
+            case "religion":    return SymanticType.Religion;
+            case "employment":  return SymanticType.Employment;
+            case "blood_group": return SymanticType.Blood_Group;
+            case "civil_status":return SymanticType.Civil_status;
+            case "relationship":return SymanticType.Relationships;
+            default:            return null;
+        }
+    }
+
+    private String typeLabel(SymanticType st) {
+        if (st == null) return "unknown";
+        switch (st) {
+            case Symptom:                return "symptom";
+            case Sign:                   return "sign";
+            case Disease_or_Syndrome:    return "diagnosis";
+            case Therapeutic_Procedure:  return "procedure";
+            case Preventive_Procedure:   return "plan";
+            case Race:                   return "race";
+            case Religion:               return "religion";
+            case Employment:             return "employment";
+            case Blood_Group:            return "blood_group";
+            case Civil_status:           return "civil_status";
+            case Relationships:          return "relationship";
+            default:                     return st.name().toLowerCase();
+        }
+    }
+
+    private Map<String, Object> toMap(ClinicalEntity e, String typeLabel) {
+        Map<String, Object> m = new LinkedHashMap<>();
+        m.put("id", e.getId());
+        m.put("name", e.getName());
+        m.put("code", e.getCode());
+        m.put("description", e.getDescreption());
+        m.put("type", typeLabel);
+        return m;
+    }
+
+    private Map<String, Object> toMap(Vocabulary v) {
+        Map<String, Object> m = new LinkedHashMap<>();
+        m.put("id", v.getId());
+        m.put("name", v.getName());
+        m.put("code", v.getCode());
+        m.put("description", v.getDescription());
+        m.put("type", "vocabulary");
+        return m;
+    }
+
+    private String param(String key) {
+        return uriInfo.getQueryParameters().getFirst(key);
+    }
+
+    private int parseInt(String value, int defaultVal) {
+        if (value == null) return defaultVal;
+        try {
+            return Integer.parseInt(value.trim());
+        } catch (NumberFormatException e) {
+            return defaultVal;
+        }
+    }
+
+    private WebUser validateApiKey(String key) {
+        if (key == null || key.trim().isEmpty()) return null;
+        ApiKey apiKey = apiKeyController.findApiKey(key);
+        if (apiKey == null) return null;
+        WebUser user = apiKey.getWebUser();
+        if (user == null || user.isRetired() || !user.isActivated()) return null;
+        if (apiKey.getDateOfExpiary() == null || apiKey.getDateOfExpiary().before(new Date())) return null;
+        return user;
+    }
+
+    private Response errorResponse(String message, int code) {
+        Map<String, Object> response = new HashMap<>();
+        response.put("status", "error");
+        response.put("code", code);
+        response.put("message", message);
+        return Response.status(code).entity(gson.toJson(response)).build();
+    }
+
+    private Response successResponse(Object data) {
+        Map<String, Object> response = new HashMap<>();
+        response.put("status", "success");
+        response.put("code", 200);
+        response.put("data", data);
+        return Response.status(200).entity(gson.toJson(response)).build();
+    }
+}

--- a/src/main/java/com/divudi/ws/clinical/ClinicalMetadataApi.java
+++ b/src/main/java/com/divudi/ws/clinical/ClinicalMetadataApi.java
@@ -298,7 +298,7 @@ public class ClinicalMetadataApi {
             }
 
             ClinicalEntity ce = clinicalEntityFacade.find(id);
-            if (ce != null && !ce.isRetired()) {
+            if (ce != null && !ce.isRetired() && ce.getSymanticType() == st) {
                 if (body.containsKey("name") && body.get("name") != null) {
                     ce.setName(body.get("name").trim());
                 }
@@ -440,6 +440,7 @@ public class ClinicalMetadataApi {
         ApiKey apiKey = apiKeyController.findApiKey(key);
         if (apiKey == null) return null;
         if (apiKey.getDateOfExpiary() == null || apiKey.getDateOfExpiary().before(new Date())) return null;
+        if (apiKey.isRetired()) return null;
         if (apiKey.getKeyType() == ApiKeyType.Config) return new WebUser();
         WebUser user = apiKey.getWebUser();
         if (user == null || user.isRetired() || !user.isActivated()) return null;

--- a/src/main/java/com/divudi/ws/clinical/ClinicalMetadataApi.java
+++ b/src/main/java/com/divudi/ws/clinical/ClinicalMetadataApi.java
@@ -6,6 +6,7 @@
 package com.divudi.ws.clinical;
 
 import com.divudi.bean.common.ApiKeyController;
+import com.divudi.core.data.ApiKeyType;
 import com.divudi.core.data.SymanticType;
 import com.divudi.core.entity.ApiKey;
 import com.divudi.core.entity.Vocabulary;
@@ -110,7 +111,7 @@ public class ClinicalMetadataApi {
         } else {
             jpql = "select c from ClinicalEntity c where c.retired=false and c.symanticType=:t order by c.name";
         }
-        List<ClinicalEntity> entities = clinicalEntityFacade.findByJpql(jpql, params, size);
+        List<ClinicalEntity> entities = clinicalEntityFacade.findByJpql(jpql, params, offset, offset + size - 1);
         List<Map<String, Object>> result = new ArrayList<>();
         for (ClinicalEntity e : entities) {
             result.add(toMap(e, typeLabel));
@@ -127,7 +128,7 @@ public class ClinicalMetadataApi {
         } else {
             jpql = "select v from Vocabulary v where v.retired=false order by v.name";
         }
-        List<Vocabulary> vocabs = vocabularyFacade.findByJpql(jpql, params, size);
+        List<Vocabulary> vocabs = vocabularyFacade.findByJpql(jpql, params, offset, offset + size - 1);
         List<Map<String, Object>> result = new ArrayList<>();
         for (Vocabulary v : vocabs) {
             result.add(toMap(v));
@@ -258,6 +259,11 @@ public class ClinicalMetadataApi {
                 return errorResponse("Not a valid key", 401);
             }
 
+            String typeStr = param("type");
+            if (typeStr == null || typeStr.trim().isEmpty()) {
+                return errorResponse("type parameter is required", 400);
+            }
+
             Map<String, String> body;
             try {
                 body = gson.fromJson(requestBody, Map.class);
@@ -268,7 +274,29 @@ public class ClinicalMetadataApi {
                 return errorResponse("Request body is required", 400);
             }
 
-            // Try ClinicalEntity first, then Vocabulary
+            if ("vocabulary".equalsIgnoreCase(typeStr)) {
+                Vocabulary vocab = vocabularyFacade.find(id);
+                if (vocab == null || vocab.isRetired()) {
+                    return errorResponse("Record not found with id: " + id, 404);
+                }
+                if (body.containsKey("name") && body.get("name") != null) {
+                    vocab.setName(body.get("name").trim());
+                }
+                if (body.containsKey("code")) {
+                    vocab.setCode(body.get("code"));
+                }
+                if (body.containsKey("description")) {
+                    vocab.setDescription(body.get("description"));
+                }
+                vocabularyFacade.edit(vocab);
+                return successResponse(toMap(vocab));
+            }
+
+            SymanticType st = resolveSymanticType(typeStr);
+            if (st == null) {
+                return errorResponse("Unknown type: " + typeStr, 400);
+            }
+
             ClinicalEntity ce = clinicalEntityFacade.find(id);
             if (ce != null && !ce.isRetired()) {
                 if (body.containsKey("name") && body.get("name") != null) {
@@ -282,21 +310,6 @@ public class ClinicalMetadataApi {
                 }
                 clinicalEntityFacade.edit(ce);
                 return successResponse(toMap(ce, typeLabel(ce.getSymanticType())));
-            }
-
-            Vocabulary vocab = vocabularyFacade.find(id);
-            if (vocab != null && !vocab.isRetired()) {
-                if (body.containsKey("name") && body.get("name") != null) {
-                    vocab.setName(body.get("name").trim());
-                }
-                if (body.containsKey("code")) {
-                    vocab.setCode(body.get("code"));
-                }
-                if (body.containsKey("description")) {
-                    vocab.setDescription(body.get("description"));
-                }
-                vocabularyFacade.edit(vocab);
-                return successResponse(toMap(vocab));
             }
 
             return errorResponse("Record not found with id: " + id, 404);
@@ -426,9 +439,10 @@ public class ClinicalMetadataApi {
         if (key == null || key.trim().isEmpty()) return null;
         ApiKey apiKey = apiKeyController.findApiKey(key);
         if (apiKey == null) return null;
+        if (apiKey.getDateOfExpiary() == null || apiKey.getDateOfExpiary().before(new Date())) return null;
+        if (apiKey.getKeyType() == ApiKeyType.Config) return new WebUser();
         WebUser user = apiKey.getWebUser();
         if (user == null || user.isRetired() || !user.isActivated()) return null;
-        if (apiKey.getDateOfExpiary() == null || apiKey.getDateOfExpiary().before(new Date())) return null;
         return user;
     }
 

--- a/src/main/java/com/divudi/ws/common/ApplicationConfig.java
+++ b/src/main/java/com/divudi/ws/common/ApplicationConfig.java
@@ -38,6 +38,7 @@ public class ApplicationConfig extends Application {
     private void addRestResourceClasses(Set<Class<?>> resources) {
         resources.add(com.divudi.ws.channel.ChannelApi.class);
         resources.add(com.divudi.ws.channel.CorsResponseFilter.class);
+        resources.add(com.divudi.ws.clinical.ClinicalMetadataApi.class);
         resources.add(com.divudi.ws.clinical.FavouriteMedicineApi.class);
         resources.add(com.divudi.ws.common.ApiMembership.class);
         resources.add(com.divudi.ws.common.CapabilityStatementResource.class);

--- a/src/main/java/com/divudi/ws/common/CapabilityStatementResource.java
+++ b/src/main/java/com/divudi/ws/common/CapabilityStatementResource.java
@@ -62,6 +62,13 @@ public class CapabilityStatementResource {
                         + "specialityId, institutionId, registration, qualification, description.",
                         "API Key (Token header)",
                         "POST", "PUT"))
+                .add(resource("Clinical Metadata", "/api/clinical/metadata",
+                        "CRUD for EMR clinical metadata types: symptom, sign, diagnosis, procedure, plan, vocabulary, "
+                        + "race, religion, blood_group, civil_status, employment, relationship. "
+                        + "Required param: type. GET supports query/page/size. "
+                        + "POST returns success, already_exists (with id), or error.",
+                        "API Key",
+                        "GET", "POST", "PUT", "DELETE"))
                 .add(resource("Clinical Favourite Medicines", "/api/clinical/favourite_medicines",
                         "Clinical favourite medicine management",
                         "API Key",


### PR DESCRIPTION
## Summary

- Implements `GET/POST/PUT/DELETE /api/clinical/metadata?type=<type>` covering all 12 types in the **Clinical Metadata** section of `/emr/admin/index.xhtml`
- Single file: `com.divudi.ws.clinical.ClinicalMetadataApi` — no service layer, no DTOs (thin CRUD over two existing entities)
- Auth: standard `Finance` header API key
- Registered in `ApplicationConfig` and documented in `CapabilityStatementResource`

### Type mapping

| `type` param | Entity | SymanticType |
|---|---|---|
| `symptom`, `sign`, `diagnosis`, `procedure`, `plan` | ClinicalEntity | respective SymanticType |
| `race`, `religion`, `employment`, `blood_group`, `civil_status`, `relationship` | ClinicalEntity | respective SymanticType |
| `vocabulary` | Vocabulary | N/A |

### Endpoints

| Method | Path | Notes |
|---|---|---|
| `GET` | `/api/clinical/metadata?type=X` | Supports `query`, `page`, `size` |
| `POST` | `/api/clinical/metadata?type=X` | Returns `success` / `already_exists` (with id) / error |
| `PUT` | `/api/clinical/metadata/{id}` | Partial update (name/code/description) |
| `DELETE` | `/api/clinical/metadata/{id}` | Soft-delete (`retired=true`) |

## Test plan

- [ ] `GET /api/clinical/metadata?type=procedure` with Finance header → returns list
- [ ] `GET /api/clinical/metadata?type=procedure&query=append` → filtered list
- [ ] `POST /api/clinical/metadata?type=symptom` `{"name":"Fever"}` → `{"status":"success",...}`
- [ ] Repeat same POST → `{"status":"already_exists","id":...}`
- [ ] `POST /api/clinical/metadata?type=vocabulary` `{"name":"ICD-10"}` → created
- [ ] `PUT /api/clinical/metadata/{id}` `{"name":"Updated Name"}` → updated
- [ ] `DELETE /api/clinical/metadata/{id}` → soft-deleted
- [ ] `GET /api/capabilities` → shows "Clinical Metadata" entry

Closes #19791

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expose clinical metadata REST endpoints for vocabularies and clinical entities with full CRUD, search/filtering, pagination, duplicate detection, and soft-delete.
  * AI assistant can invoke clinical-metadata operations when HMIS credentials are provided.

* **Documentation**
  * Added developer guides and capability documentation detailing API registration, required request/response shapes, and testing steps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->