### PR TITLE
Fix duplicate drawer entries on OPD bill cancellation (#19796)

### DIFF
--- a/src/main/java/com/divudi/bean/common/BillController.java
+++ b/src/main/java/com/divudi/bean/common/BillController.java
@@ -2753,13 +2753,14 @@ public class BillController implements Serializable, ControllerWithMultiplePayme
         }
 
         // Create payments using PaymentService
+        // NOTE: paymentService.createPayment() already calls drawerService.updateDrawer() internally
+        // for each payment. Do NOT call drawerController.updateDrawerForOuts() again — it would
+        // create duplicate DrawerEntry records and double-deduct from the drawer. See issue #19796.
         List<Payment> cancelPayments = paymentService.createPayment(cancellationBatchBill, paymentMethodData);
 
         if (cancellationBatchBill.getPaymentMethod() == PaymentMethod.MultiplePaymentMethods) {
             paymentService.updateBalances(cancelPayments);
         }
-
-        drawerController.updateDrawerForOuts(cancelPayments);
 
         WebUser wb = getCashTransactionBean().saveBillCashOutTransaction(cancellationBatchBill, getSessionController().getLoggedUser());
 

--- a/src/main/java/com/divudi/bean/common/BillSearch.java
+++ b/src/main/java/com/divudi/bean/common/BillSearch.java
@@ -2922,7 +2922,10 @@ public class BillSearch implements Serializable, ControllerWithMultiplePayments 
         // Update batch bill balance for credit payment method
         updateBatchBillFinancialFieldsForIndividualCancellation(bill, cancellationBill);
 
-        drawerController.updateDrawerForOuts(ps);
+        // NOTE: Do NOT call drawerController.updateDrawerForOuts(ps) here.
+        // paymentService.createPayment() already calls drawerService.updateDrawer() internally
+        // for each payment. A second call would create duplicate DrawerEntry records and
+        // double-deduct from the drawer balance. See issue #19796.
         JsfUtil.addSuccessMessage("Cancelled");
 
         if (cancellationBill.getPaymentMethod() == PaymentMethod.Credit) {

--- a/src/main/java/com/divudi/bean/common/OpdBillCancellationController.java
+++ b/src/main/java/com/divudi/bean/common/OpdBillCancellationController.java
@@ -822,7 +822,10 @@ public class OpdBillCancellationController implements Serializable, ControllerWi
         // Update batch bill balance for credit payment method
         updateBatchBillFinancialFieldsForIndividualCancellation(bill, cancellationBill);
 
-        drawerController.updateDrawerForOuts(ps);
+        // NOTE: Do NOT call drawerController.updateDrawerForOuts(ps) here.
+        // paymentService.createPayment() already calls drawerService.updateDrawer() internally
+        // for each payment. A second call would create duplicate DrawerEntry records and
+        // double-deduct from the drawer balance. See issue #19796.
         JsfUtil.addSuccessMessage("Cancelled");
 
         if (cancellationBill.getPaymentMethod() == PaymentMethod.Credit) {


### PR DESCRIPTION
## Summary

- OPD bill cancellation was creating two `DrawerEntry` records per payment and deducting the cancelled amount twice from the drawer balance
- Root cause: `PaymentService.createPayment()` already calls `drawerService.updateDrawer()` internally (added in #18167), but `cancelOpdBill()` in three controllers was still calling `drawerController.updateDrawerForOuts()` afterwards
- Fix: removed the redundant second drawer update call from `OpdBillCancellationController`, `BillSearch`, and `BillController`

## Verified impact (from test DB)

Three cancellations each created 2 `DrawerEntry` rows pointing to the same `BILL_ID`/`PAYMENT_ID`:

| Cancellation | Expected | Actual | Error |
|---|---|---|---|
| Cash bill cancel | -2,530 | -5,060 | extra -2,530 |
| Card bill cancel | -2,530 | -5,060 | extra -2,530 |
| Cash bill cancel | -2,530 | -5,060 | extra -2,530 |

Resulting drawer: Cash 84,940 / Card 5,060 / Total 90,000 instead of Cash 90,000 / Card 7,590 / Total 97,590.

## Test plan

- [ ] Cancel an OPD bill paid by Cash — verify only one `DrawerEntry` row is created and Cash balance decreases by the correct amount once
- [ ] Cancel an OPD bill paid by Card — same verification for Card balance
- [ ] Cancel an OPD batch bill via `BillController` path — verify no duplicate entry
- [ ] Confirm `OpdBatchBillCancellationController` (already fixed) still works correctly

Closes #19796

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed duplicate drawer entries and incorrect balance deductions that occurred when canceling OPD bills. Both individual and batch bill cancellations now correctly update drawer records once, ensuring accurate transaction tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->