### PR TITLE
Rename 'Balance' to 'Current Balance' in CC Balance Report autocomplete (#19806)

### DIFF
--- a/src/main/webapp/reports/collectionCenterReports/collection_center_balance_report.xhtml
+++ b/src/main/webapp/reports/collectionCenterReports/collection_center_balance_report.xhtml
@@ -52,7 +52,7 @@
                                         <f:ajax  event="itemSelect" execute="creditCom"  />
                                         <p:column headerText="Code" style="padding: 5px; width: 150px;">#{ix.institutionCode}</p:column>
                                         <p:column headerText="Collecting Centre Name" style="padding: 5px;">#{ix.name}</p:column>
-                                        <p:column headerText="Balance" style="padding: 5px; width: 150px; text-align: right;">
+                                        <p:column headerText="Current Balance" style="padding: 5px; width: 150px; text-align: right;">
                                             <p:outputLabel value="#{ix.ballance}" >
                                                 <f:convertNumber pattern="#,##0.00" ></f:convertNumber>
                                             </p:outputLabel>


### PR DESCRIPTION
## Summary

- Renamed the `Balance` column header to `Current Balance` in the Collection Center Name autocomplete dropdown on the Collection Center Balance Report page.

## Reason

Users were confused thinking the displayed balance was for the selected date filter. The label "Current Balance" clarifies it always shows the live/current balance regardless of the date selected.

## Test plan

- [ ] Open `/reports/collectionCenterReports/collection_center_balance_report.xhtml`
- [ ] Type in the Collection Center Name autocomplete field
- [ ] Verify the dropdown column now shows **Current Balance** instead of **Balance**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the column header label in the collection center balance report from "Balance" to "Current Balance" for improved clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->