### PR TITLE
Fix PreBill saved with NULL creator/patient due to create-before-populate bug

### DIFF
--- a/src/main/java/com/divudi/bean/pharmacy/PharmacySaleController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacySaleController.java
@@ -17,6 +17,7 @@ import com.divudi.bean.common.PriceMatrixController;
 import com.divudi.bean.common.SearchController;
 import com.divudi.bean.common.SessionController;
 import com.divudi.bean.common.TokenController;
+import com.divudi.core.entity.WebUser;
 import com.divudi.core.util.JsfUtil;
 import com.divudi.bean.membership.MembershipSchemeController;
 import com.divudi.bean.membership.PaymentSchemeController;
@@ -2161,14 +2162,17 @@ public class PharmacySaleController implements Serializable, ControllerWithPatie
     }
 
     private void savePreBillFinallyForRetailSaleForCashier(Patient pt) {
-        if (getPreBill().getId() == null) {
-            getBillFacade().create(getPreBill());
+        WebUser loggedUser = getSessionController().getLoggedUser();
+        if (loggedUser == null) {
+            JsfUtil.addErrorMessage("Session expired. Please log in again.");
+            return;
         }
-        getPreBill().setDepartment(getSessionController().getLoggedUser().getDepartment());
-        getPreBill().setInstitution(getSessionController().getLoggedUser().getDepartment().getInstitution());
+
+        getPreBill().setDepartment(loggedUser.getDepartment());
+        getPreBill().setInstitution(loggedUser.getDepartment().getInstitution());
 
         getPreBill().setCreatedAt(Calendar.getInstance().getTime());
-        getPreBill().setCreater(getSessionController().getLoggedUser());
+        getPreBill().setCreater(loggedUser);
 
         getPreBill().setPatient(pt);
 //        getPreBill().setMembershipScheme(membershipSchemeController.fetchPatientMembershipScheme(pt, getSessionController().getApplicationPreference().isMembershipExpires()));
@@ -2192,8 +2196,8 @@ public class PharmacySaleController implements Serializable, ControllerWithPatie
 
         getPreBill().setBillDate(new Date());
         getPreBill().setBillTime(new Date());
-        getPreBill().setFromDepartment(getSessionController().getLoggedUser().getDepartment());
-        getPreBill().setFromInstitution(getSessionController().getLoggedUser().getDepartment().getInstitution());
+        getPreBill().setFromDepartment(loggedUser.getDepartment());
+        getPreBill().setFromInstitution(loggedUser.getDepartment().getInstitution());
         getPreBill().setPaymentMethod(getPaymentMethod());
         getPreBill().setPaymentScheme(getPaymentScheme());
 
@@ -2234,6 +2238,11 @@ public class PharmacySaleController implements Serializable, ControllerWithPatie
         getPreBill().setBillTypeAtomic(BillTypeAtomic.PHARMACY_RETAIL_SALE_PRE_TO_SETTLE_AT_CASHIER);
         getPreBill().setInvoiceNumber(billNumberBean.fetchPaymentSchemeCount(getPreBill().getPaymentScheme(), getPreBill().getBillType(), getPreBill().getInstitution()));
 
+        if (getPreBill().getId() == null) {
+            getBillFacade().create(getPreBill());
+        } else {
+            getBillFacade().edit(getPreBill());
+        }
     }
 
     private void saveSaleBill() {

--- a/src/main/java/com/divudi/bean/pharmacy/PharmacySaleController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacySaleController.java
@@ -2624,6 +2624,11 @@ public class PharmacySaleController implements Serializable, ControllerWithPatie
 
     public String settlePreBillAndNavigateToPrint() {
         editingQty = null;
+        if (getSessionController().getLoggedUser() == null) {
+            billSettlingStarted = false;
+            JsfUtil.addErrorMessage("Session expired. Please log in again.");
+            return null;
+        }
         if (getPreBill().getBillItems().isEmpty()) {
             JsfUtil.addErrorMessage("No Items added to bill to sale");
             return null;
@@ -2834,6 +2839,11 @@ public class PharmacySaleController implements Serializable, ControllerWithPatie
     public void settlePreBill() {
         configOptionFacade.flush();
         editingQty = null;
+        if (getSessionController().getLoggedUser() == null) {
+            billSettlingStarted = false;
+            JsfUtil.addErrorMessage("Session expired. Please log in again.");
+            return;
+        }
 
         if (getPreBill().getBillItems().isEmpty()) {
             JsfUtil.addErrorMessage("No Items added to bill to sale");

--- a/src/main/java/com/divudi/bean/pharmacy/PharmacySaleController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacySaleController.java
@@ -2161,11 +2161,11 @@ public class PharmacySaleController implements Serializable, ControllerWithPatie
 
     }
 
-    private void savePreBillFinallyForRetailSaleForCashier(Patient pt) {
+    private boolean savePreBillFinallyForRetailSaleForCashier(Patient pt) {
         WebUser loggedUser = getSessionController().getLoggedUser();
         if (loggedUser == null) {
             JsfUtil.addErrorMessage("Session expired. Please log in again.");
-            return;
+            return false;
         }
 
         getPreBill().setDepartment(loggedUser.getDepartment());
@@ -2243,6 +2243,7 @@ public class PharmacySaleController implements Serializable, ControllerWithPatie
         } else {
             getBillFacade().edit(getPreBill());
         }
+        return true;
     }
 
     private void saveSaleBill() {
@@ -2792,7 +2793,10 @@ public class PharmacySaleController implements Serializable, ControllerWithPatie
         getPreBill().setBillItems(null);
         getPreBill().setBillTypeAtomic(BillTypeAtomic.PHARMACY_RETAIL_SALE_PRE_TO_SETTLE_AT_CASHIER);
 
-        savePreBillFinallyForRetailSaleForCashier(pt);
+        if (!savePreBillFinallyForRetailSaleForCashier(pt)) {
+            billSettlingStarted = false;
+            return null;
+        }
         savePreBillItemsFinally(tmpBillItems);
         setPrintBill(getBillFacade().find(getPreBill().getId()));
         if (configOptionController.getBooleanValueByKey("Enable token system in sale for cashier", false)) {
@@ -2997,7 +3001,10 @@ public class PharmacySaleController implements Serializable, ControllerWithPatie
         getPreBill().setBillItems(null);
         getPreBill().setBillTypeAtomic(BillTypeAtomic.PHARMACY_RETAIL_SALE_PRE_TO_SETTLE_AT_CASHIER);
 
-        savePreBillFinallyForRetailSaleForCashier(pt);
+        if (!savePreBillFinallyForRetailSaleForCashier(pt)) {
+            billSettlingStarted = false;
+            return;
+        }
         savePreBillItemsFinally(tmpBillItems);
         Long id = getPreBill().getId();
         if (id == null) {

--- a/src/main/java/com/divudi/bean/pharmacy/PharmacySaleForCashierController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacySaleForCashierController.java
@@ -3694,6 +3694,7 @@ public class PharmacySaleForCashierController implements Serializable, Controlle
         if (!stockValidation.isValid()) {
             // Display comprehensive error messages showing ALL stock shortfalls
             JsfUtil.addErrorMessage(stockValidation.getFormattedErrorMessage());
+            stockLockingService.releaseLocks(stockValidation.getLockedStocks(), "Stock validation failed");
             billSettlingStarted = false;
             return null;
         }
@@ -3708,6 +3709,7 @@ public class PharmacySaleForCashierController implements Serializable, Controlle
                 if (patientRequiredForPharmacySale) {
                     if (!hasValidName) {
                         JsfUtil.addErrorMessage("Please Select a Patient");
+                        stockLockingService.releaseLocks(stockValidation.getLockedStocks(), "Patient not selected");
                         billSettlingStarted = false;
                         return null;
                     } else {
@@ -3720,6 +3722,7 @@ public class PharmacySaleForCashierController implements Serializable, Controlle
                 }
             } else if (patientRequiredForPharmacySale) {
                 JsfUtil.addErrorMessage("Please Select a Patient");
+                stockLockingService.releaseLocks(stockValidation.getLockedStocks(), "Patient not selected");
                 billSettlingStarted = false;
                 return null;
             }
@@ -3735,6 +3738,8 @@ public class PharmacySaleForCashierController implements Serializable, Controlle
             getPreBill().setBillTypeAtomic(BillTypeAtomic.PHARMACY_RETAIL_SALE_PRE_TO_SETTLE_AT_CASHIER);
 
             if (!savePreBillFinallyForRetailSaleForCashier(pt)) {
+                getPreBill().setBillItems(tmpBillItems);
+                stockLockingService.releaseLocks(stockValidation.getLockedStocks(), "Session expired during settlement");
                 billSettlingStarted = false;
                 return null;
             }

--- a/src/main/java/com/divudi/bean/pharmacy/PharmacySaleForCashierController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacySaleForCashierController.java
@@ -18,6 +18,7 @@ import com.divudi.bean.common.PriceMatrixController;
 import com.divudi.bean.common.SearchController;
 import com.divudi.bean.common.SessionController;
 import com.divudi.bean.common.TokenController;
+import com.divudi.core.entity.WebUser;
 import com.divudi.core.util.JsfUtil;
 import com.divudi.bean.membership.MembershipSchemeController;
 import com.divudi.bean.membership.PaymentSchemeController;
@@ -2922,14 +2923,17 @@ public class PharmacySaleForCashierController implements Serializable, Controlle
     }
 
     private void savePreBillFinallyForRetailSaleForCashier(Patient pt) {
-        if (getPreBill().getId() == null) {
-            getBillFacade().create(getPreBill());
+        WebUser loggedUser = getSessionController().getLoggedUser();
+        if (loggedUser == null) {
+            JsfUtil.addErrorMessage("Session expired. Please log in again.");
+            return;
         }
-        getPreBill().setDepartment(getSessionController().getLoggedUser().getDepartment());
-        getPreBill().setInstitution(getSessionController().getLoggedUser().getDepartment().getInstitution());
+
+        getPreBill().setDepartment(loggedUser.getDepartment());
+        getPreBill().setInstitution(loggedUser.getDepartment().getInstitution());
 
         getPreBill().setCreatedAt(Calendar.getInstance().getTime());
-        getPreBill().setCreater(getSessionController().getLoggedUser());
+        getPreBill().setCreater(loggedUser);
 
         getPreBill().setPatient(pt);
 //        getPreBill().setMembershipScheme(membershipSchemeController.fetchPatientMembershipScheme(pt, getSessionController().getApplicationPreference().isMembershipExpires()));
@@ -2953,8 +2957,8 @@ public class PharmacySaleForCashierController implements Serializable, Controlle
 
         getPreBill().setBillDate(new Date());
         getPreBill().setBillTime(new Date());
-        getPreBill().setFromDepartment(getSessionController().getLoggedUser().getDepartment());
-        getPreBill().setFromInstitution(getSessionController().getLoggedUser().getDepartment().getInstitution());
+        getPreBill().setFromDepartment(loggedUser.getDepartment());
+        getPreBill().setFromInstitution(loggedUser.getDepartment().getInstitution());
         getPreBill().setPaymentMethod(getPaymentMethod());
         getPreBill().setPaymentScheme(getPaymentScheme());
 
@@ -2995,7 +2999,11 @@ public class PharmacySaleForCashierController implements Serializable, Controlle
         getPreBill().setBillTypeAtomic(BillTypeAtomic.PHARMACY_RETAIL_SALE_PRE_TO_SETTLE_AT_CASHIER);
         getPreBill().setInvoiceNumber(billNumberBean.fetchPaymentSchemeCount(getPreBill().getPaymentScheme(), getPreBill().getBillType(), getPreBill().getInstitution()));
 
-        getBillFacade().edit(getPreBill());
+        if (getPreBill().getId() == null) {
+            getBillFacade().create(getPreBill());
+        } else {
+            getBillFacade().edit(getPreBill());
+        }
     }
 
     private void saveSaleBill() {

--- a/src/main/java/com/divudi/bean/pharmacy/PharmacySaleForCashierController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacySaleForCashierController.java
@@ -2922,11 +2922,11 @@ public class PharmacySaleForCashierController implements Serializable, Controlle
 
     }
 
-    private void savePreBillFinallyForRetailSaleForCashier(Patient pt) {
+    private boolean savePreBillFinallyForRetailSaleForCashier(Patient pt) {
         WebUser loggedUser = getSessionController().getLoggedUser();
         if (loggedUser == null) {
             JsfUtil.addErrorMessage("Session expired. Please log in again.");
-            return;
+            return false;
         }
 
         getPreBill().setDepartment(loggedUser.getDepartment());
@@ -3004,6 +3004,7 @@ public class PharmacySaleForCashierController implements Serializable, Controlle
         } else {
             getBillFacade().edit(getPreBill());
         }
+        return true;
     }
 
     private void saveSaleBill() {
@@ -3728,7 +3729,10 @@ public class PharmacySaleForCashierController implements Serializable, Controlle
             getPreBill().setBillItems(null);
             getPreBill().setBillTypeAtomic(BillTypeAtomic.PHARMACY_RETAIL_SALE_PRE_TO_SETTLE_AT_CASHIER);
 
-            savePreBillFinallyForRetailSaleForCashier(pt);
+            if (!savePreBillFinallyForRetailSaleForCashier(pt)) {
+                billSettlingStarted = false;
+                return null;
+            }
             // Use locked stocks for settlement instead of re-validating
             savePreBillItemsFinallyWithLockedStocks(tmpBillItems, stockValidation.getLockedStocks());
             setPrintBill(getPreBill());
@@ -3959,7 +3963,10 @@ public class PharmacySaleForCashierController implements Serializable, Controlle
         getPreBill().setBillItems(null);
         getPreBill().setBillTypeAtomic(BillTypeAtomic.PHARMACY_RETAIL_SALE_PRE_TO_SETTLE_AT_CASHIER);
 
-        savePreBillFinallyForRetailSaleForCashier(pt);
+        if (!savePreBillFinallyForRetailSaleForCashier(pt)) {
+            billSettlingStarted = false;
+            return;
+        }
         savePreBillItemsFinally(tmpBillItems);
         // Create BFD for pre-bill at creation time so F15 stock movement report can track it
         if (getPreBill().getBillItems() != null && !getPreBill().getBillItems().isEmpty()) {

--- a/src/main/java/com/divudi/bean/pharmacy/PharmacySaleForCashierController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacySaleForCashierController.java
@@ -3495,6 +3495,11 @@ public class PharmacySaleForCashierController implements Serializable, Controlle
 
     public String settlePreBillAndNavigateToPrint() {
         editingQty = null;
+        if (getSessionController().getLoggedUser() == null) {
+            billSettlingStarted = false;
+            JsfUtil.addErrorMessage("Session expired. Please log in again.");
+            return null;
+        }
         if (getPreBill().getBillItems().isEmpty()) {
             JsfUtil.addErrorMessage("No Items added to bill to sale");
             return null;
@@ -3795,6 +3800,11 @@ public class PharmacySaleForCashierController implements Serializable, Controlle
     @Deprecated // Plse use settlePreBillAndNavigateToPrint
     public void settlePreBill() {
         editingQty = null;
+        if (getSessionController().getLoggedUser() == null) {
+            billSettlingStarted = false;
+            JsfUtil.addErrorMessage("Session expired. Please log in again.");
+            return;
+        }
 
         if (getPreBill().getBillItems().isEmpty()) {
             JsfUtil.addErrorMessage("No Items added to bill to sale");


### PR DESCRIPTION
## Summary
- Moves `BillFacade.create()` call **after** all fields (creator, patient, department, institution, etc.) are populated in `savePreBillFinallyForRetailSaleForCashier()`
- Adds session expiry guard to prevent NPE when logged user is null
- Applies fix to both `PharmacySaleController` and `PharmacySaleForCashierController`

Closes #19498

## Test plan
- [ ] Create a pharmacy retail sale for cashier and verify the PreBill is saved with correct creator and patient
- [ ] Verify the bill prints correctly after settling
- [ ] Test with both direct sale and sale-for-cashier workflows

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved session timeout handling in cashier pharmacy flows with clear "Session expired" feedback and safe abort to prevent further processing.
  * Pre-bill save now supports both creating new bills and updating existing ones to prevent data loss or duplicates.
  * Settlement routines stop cleanly when saving fails, avoiding incomplete or duplicated transactions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->