### PR TITLE
Fix newly added users not appearing in user list

### DIFF
--- a/src/main/java/com/divudi/bean/common/WebUserController.java
+++ b/src/main/java/com/divudi/bean/common/WebUserController.java
@@ -582,7 +582,11 @@ public class WebUserController implements Serializable {
 
         getCurrent().setLoginPage(loginPage);
 
-        getCurrent().setSite(site);
+        if (site != null) {
+            getCurrent().setSite(site);
+        } else {
+            getCurrent().setSite(sessionController.getLoggedSite());
+        }
 
         getPersonFacade().create(getCurrent().getWebUserPerson());
         if (createOnlyUserForExsistingUser) {
@@ -595,19 +599,22 @@ public class WebUserController implements Serializable {
             if (getStaff().getWorkingDepartment() != null) {
                 getCurrent().setInstitution(getStaff().getWorkingDepartment().getInstitution());
                 getCurrent().setDepartment(getStaff().getWorkingDepartment());
+            } else {
+                getCurrent().setInstitution(sessionController.getInstitution());
+                getCurrent().setDepartment(sessionController.getDepartment());
             }
 
         } else {
-            getCurrent().setInstitution(getInstitution());
-            getCurrent().setDepartment(getDepartment());
+            getCurrent().setInstitution(getInstitution() != null ? getInstitution() : sessionController.getInstitution());
+            getCurrent().setDepartment(getDepartment() != null ? getDepartment() : sessionController.getDepartment());
             if (!createOnlyUser) {
                 Staff staff = new Staff();
                 //Save Staff
                 staff.setPerson(getCurrent().getWebUserPerson());
                 staff.setCreatedAt(Calendar.getInstance().getTime());
-                staff.setDepartment(department);
-                staff.setWorkingDepartment(department);
-                staff.setInstitution(institution);
+                staff.setDepartment(getCurrent().getDepartment());
+                staff.setWorkingDepartment(getCurrent().getDepartment());
+                staff.setInstitution(getCurrent().getInstitution());
                 staff.setSpeciality(speciality);
                 staff.setCode(getCurrent().getCode());
                 getStaffFacade().create(staff);
@@ -740,12 +747,15 @@ public class WebUserController implements Serializable {
                 + "wu.webUserPerson.name, "
                 + "wu.id, "
                 + "wu.code, "
-                + "wu.staff.person.name, "
-                + "wu.institution.name, "
-                + "wu.department.name) "
+                + "COALESCE(sp.name, ''), "
+                + "COALESCE(i.name, ''), "
+                + "COALESCE(d.name, '')) "
                 + "from WebUser wu "
+                + "left join wu.staff s "
+                + "left join s.person sp "
+                + "left join wu.institution i "
+                + "left join wu.department d "
                 + "where wu.retired=:ret "
-                + "and wu.staff is not null "
                 + "order by wu.name";
         m.put("ret", false);
         webUseLights = (List<WebUserLight>) getPersonFacade().findLightsByJpql(jpql, m);
@@ -759,12 +769,15 @@ public class WebUserController implements Serializable {
                 + "wu.webUserPerson.name, "
                 + "wu.id, "
                 + "wu.code, "
-                + "wu.staff.person.name, "
-                + "wu.institution.name, "
-                + "wu.department.name) "
+                + "COALESCE(sp.name, ''), "
+                + "COALESCE(i.name, ''), "
+                + "COALESCE(d.name, '')) "
                 + "from WebUser wu "
+                + "left join wu.staff s "
+                + "left join s.person sp "
+                + "left join wu.institution i "
+                + "left join wu.department d "
                 + "where wu.retired=:ret "
-                + "and wu.staff is not null "
                 + "order by wu.name";
         m.put("ret", true);
         webUseLights = (List<WebUserLight>) getPersonFacade().findLightsByJpql(jpql, m);


### PR DESCRIPTION
## Summary
- **List query fix**: Replaced implicit inner joins with explicit `LEFT JOIN` + `COALESCE` in `fillLightUsers()` and `fillLightUsersRetired()`, and removed the `wu.staff is not null` filter that excluded user-only accounts
- **Save defaults**: When institution, site, or department is not selected during user creation, defaults to the logged-in user's session values instead of saving null
- **Staff creation consistency**: Staff entity now uses the resolved values from `getCurrent()` instead of raw field variables

## Root Cause
Users created without selecting institution/department (or with "Add Only User" checkbox) were saved successfully but invisible in the list due to implicit inner joins silently excluding rows with null relationships.

## Test plan
- [ ] Create a user with all fields filled — verify it appears in the list
- [ ] Create a user with "Add Only User" checked (no staff) — verify it appears in the list
- [ ] Create a user without selecting institution/department — verify it defaults to session values and appears in the list
- [ ] Create a user with "Add User To Existing Staff" — verify it appears in the list
- [ ] Verify retired users list also shows all retired users correctly

Closes #19809

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved user creation process with more robust fallback mechanisms for site, institution, and department assignments.
  * Enhanced system resilience to handle edge cases where staff or institutional data may be missing or incomplete.
  * Optimized data retrieval to gracefully handle unavailable relationships and provide consistent user setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->