### PR TITLE
Fix float request status: show 'Issued - Pending Acceptance' until requester accepts

### DIFF
--- a/src/main/java/com/divudi/bean/cashTransaction/FinancialTransactionController.java
+++ b/src/main/java/com/divudi/bean/cashTransaction/FinancialTransactionController.java
@@ -2518,6 +2518,29 @@ public class FinancialTransactionController implements Serializable {
         return Math.max(0.0, request.getNetTotal() - getFulfilledAmountForRequest(request));
     }
 
+    /**
+     * Returns true only when the requester has physically accepted the float
+     * transfer (i.e. a FundTransferReceivedBill exists that is linked back to
+     * a FundTransferBill that itself was created in response to this request).
+     * A forwardReferenceBill on the request means B has *issued* the transfer;
+     * it does NOT mean A has *accepted* it.
+     */
+    public boolean isFloatRequestAccepted(Bill request) {
+        if (request == null || request.getId() == null) {
+            return false;
+        }
+        String jpql = "select count(r) from Bill r "
+                + "where r.referenceBill.backwardReferenceBill = :req "
+                + "and r.billTypeAtomic = :btype "
+                + "and (r.cancelled = false or r.cancelled is null) "
+                + "and r.retired = false";
+        Map<String, Object> params = new HashMap<>();
+        params.put("req", request);
+        params.put("btype", BillTypeAtomic.FUND_TRANSFER_RECEIVED_BILL);
+        Long count = billFacade.findLongByJpql(jpql, params, TemporalType.TIMESTAMP);
+        return count != null && count > 0;
+    }
+
     private void prepareToAddNewFundDepositBill() {
         currentBill = new Bill();
         currentBill.setBillType(BillType.DepositFundBill);

--- a/src/main/java/com/divudi/bean/cashTransaction/FinancialTransactionController.java
+++ b/src/main/java/com/divudi/bean/cashTransaction/FinancialTransactionController.java
@@ -296,6 +296,8 @@ public class FinancialTransactionController implements Serializable {
     private Date myFloatRequestsFromDate;
     private Date myFloatRequestsToDate;
     boolean floatRequestStarted = false;
+    // Cache for accepted-status per request bill ID — keyed by bill ID, populated in fillMyFundTransferRequests()
+    private Map<Long, Boolean> floatRequestAcceptedCache = new HashMap<>();
 
     // Float Transfer Report Properties
     private List<Bill> fundTransferReportBills;
@@ -2493,6 +2495,15 @@ public class FinancialTransactionController implements Serializable {
         params.put("fd", getMyFloatRequestsFromDate());
         params.put("td", getMyFloatRequestsToDate());
         myFundTransferRequestsOut = billFacade.findByJpql(jpql, params, TemporalType.TIMESTAMP);
+        // Pre-compute accepted status once per load — avoids N×2 JPQL queries in the XHTML
+        floatRequestAcceptedCache = new HashMap<>();
+        if (myFundTransferRequestsOut != null) {
+            for (Bill req : myFundTransferRequestsOut) {
+                if (req.getForwardReferenceBill() != null && !req.isCancelled()) {
+                    floatRequestAcceptedCache.put(req.getId(), isFloatRequestAccepted(req));
+                }
+            }
+        }
     }
 
     public double getFulfilledAmountForRequest(Bill request) {
@@ -2520,25 +2531,42 @@ public class FinancialTransactionController implements Serializable {
 
     /**
      * Returns true only when the requester has physically accepted the float
-     * transfer (i.e. a FundTransferReceivedBill exists that is linked back to
-     * a FundTransferBill that itself was created in response to this request).
+     * transfer by checking that a FUND_TRANSFER_RECEIVED_BILL exists whose
+     * referenceBill is exactly the forwardReferenceBill of the request (i.e.
+     * the terminal issued transfer has been received). This avoids false
+     * positives from intermediate partial received bills in multi-transfer
+     * scenarios.
      * A forwardReferenceBill on the request means B has *issued* the transfer;
      * it does NOT mean A has *accepted* it.
      */
     public boolean isFloatRequestAccepted(Bill request) {
-        if (request == null || request.getId() == null) {
+        if (request == null || request.getId() == null || request.getForwardReferenceBill() == null) {
             return false;
         }
         String jpql = "select count(r) from Bill r "
-                + "where r.referenceBill.backwardReferenceBill = :req "
+                + "where r.referenceBill = :issuedBill "
                 + "and r.billTypeAtomic = :btype "
                 + "and (r.cancelled = false or r.cancelled is null) "
                 + "and r.retired = false";
         Map<String, Object> params = new HashMap<>();
-        params.put("req", request);
+        params.put("issuedBill", request.getForwardReferenceBill());
         params.put("btype", BillTypeAtomic.FUND_TRANSFER_RECEIVED_BILL);
         Long count = billFacade.findLongByJpql(jpql, params, TemporalType.TIMESTAMP);
         return count != null && count > 0;
+    }
+
+    /**
+     * Returns the precomputed accepted status for a request bill from the cache
+     * populated during fillMyFundTransferRequests(). Falls back to a live query
+     * if the cache does not contain the entry (e.g. when called from outside
+     * the My Float Requests page).
+     */
+    public boolean isFloatRequestAcceptedCached(Bill request) {
+        if (request == null || request.getId() == null) {
+            return false;
+        }
+        Boolean cached = floatRequestAcceptedCache.get(request.getId());
+        return cached != null ? cached : isFloatRequestAccepted(request);
     }
 
     private void prepareToAddNewFundDepositBill() {

--- a/src/main/webapp/cashier/fund_transfer_my_requests.xhtml
+++ b/src/main/webapp/cashier/fund_transfer_my_requests.xhtml
@@ -77,8 +77,13 @@
                             </p:column>
 
                             <p:column headerText="Status">
-                                <h:panelGroup rendered="#{bp.forwardReferenceBill ne null}">
+                                <!-- Fully Fulfilled: issued by the other party AND accepted by requester -->
+                                <h:panelGroup rendered="#{bp.forwardReferenceBill ne null and not bp.cancelled and financialTransactionController.isFloatRequestAccepted(bp)}">
                                     <span class="badge bg-success">Fully Fulfilled</span>
+                                </h:panelGroup>
+                                <!-- Issued but not yet accepted: money is in transit, requester must go to Float Transfers to Receive -->
+                                <h:panelGroup rendered="#{bp.forwardReferenceBill ne null and not bp.cancelled and not financialTransactionController.isFloatRequestAccepted(bp)}">
+                                    <span class="badge bg-primary">Issued - Pending Your Acceptance</span>
                                 </h:panelGroup>
                                 <h:panelGroup rendered="#{bp.forwardReferenceBill eq null and not bp.cancelled and financialTransactionController.getFulfilledAmountForRequest(bp) gt 0}">
                                     <span class="badge bg-info text-dark">Partially Fulfilled</span>

--- a/src/main/webapp/cashier/fund_transfer_my_requests.xhtml
+++ b/src/main/webapp/cashier/fund_transfer_my_requests.xhtml
@@ -78,11 +78,11 @@
 
                             <p:column headerText="Status">
                                 <!-- Fully Fulfilled: issued by the other party AND accepted by requester -->
-                                <h:panelGroup rendered="#{bp.forwardReferenceBill ne null and not bp.cancelled and financialTransactionController.isFloatRequestAccepted(bp)}">
+                                <h:panelGroup rendered="#{bp.forwardReferenceBill ne null and not bp.cancelled and financialTransactionController.isFloatRequestAcceptedCached(bp)}">
                                     <span class="badge bg-success">Fully Fulfilled</span>
                                 </h:panelGroup>
                                 <!-- Issued but not yet accepted: money is in transit, requester must go to Float Transfers to Receive -->
-                                <h:panelGroup rendered="#{bp.forwardReferenceBill ne null and not bp.cancelled and not financialTransactionController.isFloatRequestAccepted(bp)}">
+                                <h:panelGroup rendered="#{bp.forwardReferenceBill ne null and not bp.cancelled and not financialTransactionController.isFloatRequestAcceptedCached(bp)}">
                                     <span class="badge bg-primary">Issued - Pending Your Acceptance</span>
                                 </h:panelGroup>
                                 <h:panelGroup rendered="#{bp.forwardReferenceBill eq null and not bp.cancelled and financialTransactionController.getFulfilledAmountForRequest(bp) gt 0}">


### PR DESCRIPTION
## Summary
- Fixes hmislk/hmis#19822
- A float transfer request was showing **Fully Fulfilled** as soon as the issuer created the `FundTransferBill`, before the requester clicked **Receive Float**
- The requester's drawer is only credited on acceptance, so the status was misleading and could cause confusion

## Changes

### `FinancialTransactionController.java`
- Added `isFloatRequestAccepted(Bill request)` — queries for a `FUND_TRANSFER_RECEIVED_BILL` linked back through the chain (`referenceBill.backwardReferenceBill = request`). Uses `findLongByJpql` (correct for COUNT queries per project rules).

### `fund_transfer_my_requests.xhtml`
Updated status badge logic with four distinct states:
| Badge | Condition |
|-------|-----------|
| **Fully Fulfilled** (green) | Issued AND accepted by requester |
| **Issued - Pending Acceptance** (blue) | Issued by issuer, requester has NOT yet accepted |
| **Partially Fulfilled** (info) | Some amount issued, doesn't cover full request |
| **Pending** (yellow) | Nothing issued yet |
| **Cancelled** (grey) | Cancelled |

## Test plan
- [ ] User A requests float from User B → status shows **Pending**
- [ ] User B issues the transfer via "Initiate Transfer" → status shows **Issued - Pending Acceptance** (not Fully Fulfilled)
- [ ] User A clicks **Receive Float** in Float Transfers to Receive → status updates to **Fully Fulfilled**
- [ ] Partial fulfilment (B issues partial amount) → status shows **Partially Fulfilled**
- [ ] Cancelled request → status shows **Cancelled**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added "Issued - Pending Your Acceptance" status for fund transfer requests that have been issued but await your acceptance; fully fulfilled, partially fulfilled, pending, and cancelled statuses unchanged.

* **Performance**
  * Improved responsiveness of request status evaluation so status badges update more quickly and reliably.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->