### PR TITLE
Block shift end when outgoing or incoming handover is pending acceptance

### DIFF
--- a/src/main/java/com/divudi/bean/cashTransaction/FinancialTransactionController.java
+++ b/src/main/java/com/divudi/bean/cashTransaction/FinancialTransactionController.java
@@ -3190,6 +3190,18 @@ public class FinancialTransactionController implements Serializable {
             return null;
         }
 
+        // Guard: outgoing pending handover — block until recipient accepts (unconditional, #19824)
+        if (hasAtLeastOneHandoverBillToReceive(sessionController.getLoggedUser(), null, null, null)) {
+            JsfUtil.addErrorMessage("You have a handover awaiting acceptance by the recipient. Please wait for them to accept before closing your shift.");
+            return null;
+        }
+
+        // Guard: incoming pending handover — block until this user accepts (unconditional, #19824)
+        if (hasAtLeastOneHandoverBillToReceive(null, null, sessionController.getLoggedUser(), null)) {
+            JsfUtil.addErrorMessage("You have a pending handover to accept. Please accept it before closing your shift.");
+            return null;
+        }
+
         // Validate pending transactions before allowing shift end
         fillFundTransferBillsForMeToReceive();
 
@@ -5125,6 +5137,18 @@ public class FinancialTransactionController implements Serializable {
 
         if (fundTransferBillTocollect) {
             JsfUtil.addErrorMessage("Please collect funds transferred to you before closing.");
+            return "";
+        }
+
+        // Guard: outgoing pending handover — unconditional, must be accepted before shift closes (#19824)
+        if (hasAtLeastOneHandoverBillToReceive(sessionController.getLoggedUser(), null, null, null)) {
+            JsfUtil.addErrorMessage("You have a handover awaiting acceptance by the recipient. Please wait for them to accept before closing your shift.");
+            return "";
+        }
+
+        // Guard: incoming pending handover — unconditional, must be accepted before shift closes (#19824)
+        if (hasAtLeastOneHandoverBillToReceive(null, null, sessionController.getLoggedUser(), null)) {
+            JsfUtil.addErrorMessage("You have a pending handover to accept. Please accept it before closing your shift.");
             return "";
         }
 


### PR DESCRIPTION
## Summary
- Fixes hmislk/hmis#19824
- A user (e.g. Buddhika) could successfully close their shift while the recipient (e.g. Damith) had not yet accepted their handover
- The check for pending handovers was config-gated (`Must Wait Until Other User Accepts All Handovers Before Closing Shift`, default `false`) — off by default, so the guard was never applied

## Root Cause

Outgoing **fund transfers** are already blocked unconditionally:
```java
// Guard: outgoing pending floats — block until recipient accepts or sender cancels
if (hasAtLeastOneFundTransferBillToReceive(sessionController.getLoggedUser(), ...)) { ... }
```

But outgoing **handovers** were only blocked if the config key was enabled — inconsistent with the float transfer treatment, and unsafe as a default.

## Fix

Added unconditional guards in both blocking points:

| Method | Guard added |
|--------|------------|
| `navigateToCreateShiftEndSummaryBillForHandover()` | Outgoing + incoming handover guards, placed immediately after the float guards |
| `settleShiftEnd()` | Same outgoing + incoming guards, placed after the `fundTransferBillTocollect` check |

The config-based checks are preserved unchanged as additional belt-and-braces layers.

## Test plan
- [ ] User A creates a handover to User B → User A clicks **End Shift** → blocked with message
- [ ] User B accepts the handover → User A can now end shift
- [ ] User B has an unaccepted incoming handover from A → User B clicks **End Shift** → blocked
- [ ] No pending handovers → End Shift proceeds normally
- [ ] Pending outgoing float transfer still blocks (existing behaviour unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Shift closure is now prevented when pending payment handover bills await acceptance, ensuring all handovers are properly completed before closing operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->