### PR TITLE
Add PR review workflow skill and documentation

### DIFF
--- a/.claude/skills/review-pr/SKILL.md
+++ b/.claude/skills/review-pr/SKILL.md
@@ -32,7 +32,8 @@ Always fetch first — automated tools may have pushed fixes not yet local.
 
 ```bash
 gh pr view $0 --comments
-gh api repos/hmislk/hmis/pulls/<number>/comments
+pr_number=$(gh pr view $0 --json number --jq '.number')
+gh api repos/hmislk/hmis/pulls/$pr_number/comments
 ```
 
 List all review comments. Group them by file/topic.
@@ -64,7 +65,7 @@ Wait for user confirmation before making any changes.
 
 Apply all confirmed fixes. Group into one or a few logical commits:
 
-```
+```text
 Fix CodeRabbit review comments (#<issue>)
 
 Closes #<issue>

--- a/.claude/skills/review-pr/SKILL.md
+++ b/.claude/skills/review-pr/SKILL.md
@@ -1,0 +1,112 @@
+---
+name: review-pr
+description: >
+  Handle CodeRabbit and Codex review comments on a GitHub PR. Fetches the PR,
+  investigates each comment against the codebase, discusses validity with the user,
+  batches valid fixes, and guides through push and reply steps.
+disable-model-invocation: true
+allowed-tools: Read, Grep, Glob, Bash
+argument-hint: "<pr-url-or-number>"
+---
+
+# PR Review Workflow
+
+Handle review comments (CodeRabbit, Codex, human reviewers) on a GitHub pull request.
+
+## Arguments
+
+- `$0` — GitHub PR URL or PR number (required)
+
+## Steps
+
+### 1. Fetch and Checkout
+
+```bash
+git fetch origin
+gh pr checkout $0
+```
+
+Always fetch first — automated tools may have pushed fixes not yet local.
+
+### 2. Load PR Comments
+
+```bash
+gh pr view $0 --comments
+gh api repos/hmislk/hmis/pulls/<number>/comments
+```
+
+List all review comments. Group them by file/topic.
+
+### 3. Investigate Each Comment
+
+For each comment:
+- Read the referenced file and line range with `Read`
+- Search for related patterns with `Grep`
+- Determine if the comment is valid, a false positive, or project-specific intent
+
+**Common false positives in this project:**
+- Null checks where lazy init already handles it (e.g., `getBillFinanceDetails()`)
+- Constructor changes — NEVER modify existing constructors (HMIS rule)
+- "Fix" for intentional typos like `purcahseRate` — database compatibility
+- Native SQL suggestions when JPQL works fine
+- Bootstrap CSS classes when project uses PrimeFaces
+
+### 4. Present Findings to User
+
+For each comment, report:
+- Comment summary
+- Your assessment: **Valid** / **False positive** / **Discuss**
+- Reasoning with file:line reference
+
+Wait for user confirmation before making any changes.
+
+### 5. Batch Valid Fixes
+
+Apply all confirmed fixes. Group into one or a few logical commits:
+
+```
+Fix CodeRabbit review comments (#<issue>)
+
+Closes #<issue>
+
+Co-Authored-By: Claude <noreply@anthropic.com>
+```
+
+### 6. Pre-Push Checklist
+
+- `persistence.xml` uses `${JDBC_DATASOURCE}` / `${JDBC_AUDIT_DATASOURCE}` — not hardcoded JNDI names
+- No credentials or `.env` files staged
+- JSF-only changes do not need compilation
+
+### 7. Push
+
+```bash
+git push
+```
+
+Verify CI passes before proceeding.
+
+### 8. Reply to Each Comment
+
+For each comment on GitHub, post an individual reply:
+- Valid + fixed: describe what was changed
+- Dismissed: explain why (with reasoning)
+
+Do NOT resolve other reviewers' conversations. CodeRabbit auto-resolves on detection.
+
+### 9. Re-Request Review
+
+Click "Re-request review" on the PR page after pushing. Do not rely on reviewers noticing the new push.
+
+### 10. Post-Merge Cleanup
+
+After merge:
+```bash
+git branch -d <branch-name>
+```
+
+Also confirm "Delete branch" was checked in the GitHub merge dialog.
+
+## Reference
+
+Full workflow documentation: `developer_docs/git/pr-review-workflow.md`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,6 +59,10 @@
 ### When Adding a New Privilege
 - [Privilege System Guide](developer_docs/security/privilege-system.md) - **All 3 steps required**: enum value + `getCategory()` case + `UserPrivilageController` tree node. Adding only the enum is NOT sufficient — the privilege will be invisible in the admin UI. This was missed for `InpatientClinicalDischarge` (PR #19658, issue #19677).
 
+### When Reviewing a PR
+- [PR Review Workflow](developer_docs/git/pr-review-workflow.md) - Full checklist for handling CodeRabbit/Codex comments: fetch → investigate → discuss → batch-fix → persistence check → push → reply → re-request review → cleanup
+- Use `/review-pr <pr-url>` skill to automate investigation and fix steps
+
 ### When Committing Code
 - [Commit Conventions](developer_docs/git/commit-conventions.md) - Message format
 

--- a/developer_docs/git/pr-review-workflow.md
+++ b/developer_docs/git/pr-review-workflow.md
@@ -11,8 +11,8 @@ git fetch origin
 → discuss with user (SOS)
 → batch-fix valid comments
 → check persistence.xml
-→ verify CI is green
 → push
+→ verify CI is green
 → reply to each comment individually
 → re-request review
 → merge → delete branch (GitHub UI)

--- a/developer_docs/git/pr-review-workflow.md
+++ b/developer_docs/git/pr-review-workflow.md
@@ -1,0 +1,96 @@
+# PR Review Workflow — Handling CodeRabbit and Codex Comments
+
+This guide covers the standard workflow for reviewing and resolving comments from automated reviewers (CodeRabbit, Codex) and human reviewers on GitHub pull requests.
+
+## Full Workflow
+
+```
+git fetch origin
+→ checkout branch locally
+→ investigate comments with Claude
+→ discuss with user (SOS)
+→ batch-fix valid comments
+→ check persistence.xml
+→ verify CI is green
+→ push
+→ reply to each comment individually
+→ re-request review
+→ merge → delete branch (GitHub UI)
+→ git branch -d locally
+```
+
+## Step-by-Step
+
+### 1. Fetch and Checkout
+
+```bash
+git fetch origin
+git checkout <branch-name>
+```
+
+Always fetch first — Codex may have auto-pushed fixes you don't have locally.
+
+### 2. Investigate Comments
+
+- Read the PR link and each reviewer comment carefully
+- Use Claude to read the relevant code context (`Read`, `Grep`, `Glob`)
+- Understand *why* the comment was raised before deciding if it's valid
+
+### 3. Discuss Before Fixing (SOS)
+
+- Not all review comments are correct — automated tools often flag false positives
+- Discuss each comment with the user before acting
+- Common false positives in this project:
+  - Suggesting null checks where lazy init already handles it (e.g., `getBillFinanceDetails()`)
+  - Recommending constructor changes (violates HMIS rule: never modify existing constructors)
+  - Flagging intentional typos like `purcahseRate` (database compatibility)
+  - Suggesting native SQL when JPQL is perfectly adequate
+
+### 4. Batch Valid Fixes
+
+- Group all valid fixes into one commit (or a few logical commits)
+- Do NOT make one commit per comment — keep history clean
+- Use imperative mood in commit message, include `Closes #N` if this resolves the issue
+
+### 5. Pre-Push Checklist
+
+- **persistence.xml** — must use `${JDBC_DATASOURCE}` and `${JDBC_AUDIT_DATASOURCE}`, not hardcoded JNDI names. See [Persistence Configuration Guide](../deployment/persistence-verification.md)
+- No credentials or `.env` files staged
+- JSF-only changes (XHTML, no Java) do not require compilation
+
+### 6. Push and Reply
+
+```bash
+git push
+```
+
+Then on GitHub, reply to **each reviewer comment individually** with:
+- What was fixed (if valid)
+- Why it was not changed (if dismissed) — be specific
+
+Do **not** resolve other reviewers' conversations yourself. CodeRabbit auto-resolves when it detects the fix. For human reviewers, let them resolve.
+
+### 7. Re-Request Review
+
+After pushing fixes, click **"Re-request review"** on the PR page to notify reviewers. Do not wait for them to notice the new push.
+
+### 8. Verify CI Before Replying
+
+Check that CI is green after pushing before replying to comments. A fix that breaks CI is not ready.
+
+### 9. Merge and Cleanup
+
+- Merge via GitHub UI (squash or merge commit per project convention)
+- Check **"Delete branch"** on the merge confirmation dialog
+- Delete locally:
+
+```bash
+git branch -d <branch-name>
+```
+
+## Notes
+
+- All PRs target `development`, never `master`
+- "Re-request review" is distinct from just pushing — always click it
+- Replying to each comment individually maintains a clean audit trail
+- The `/review-pr` skill automates the investigation and fix steps of this workflow


### PR DESCRIPTION
## Summary

- Adds `/review-pr` skill (`.claude/skills/review-pr/SKILL.md`) — guides the full workflow for handling CodeRabbit/Codex review comments: fetch → checkout → investigate → discuss → batch-fix → persistence check → push → reply → re-request review → cleanup
- Adds `developer_docs/git/pr-review-workflow.md` — reference checklist with project-specific false positive guidance
- Updates `CLAUDE.md` — new "When Reviewing a PR" section linking to both

## Test plan

- [ ] Verify `/review-pr` skill is discoverable in Claude Code
- [ ] Confirm CLAUDE.md "When Reviewing a PR" section renders correctly
- [ ] Confirm `developer_docs/git/pr-review-workflow.md` is accessible

Closes #19833

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated PR review workflow to streamline investigation and batching of reviewer feedback into logical commits.

* **Documentation**
  * Added comprehensive PR review workflow guide covering comment classification, investigation strategies, commit batching, and reply best practices.
  * Updated main documentation with PR review process overview and workflow usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->