### PR TITLE
19839 closing stock mismatch colour indicator on daily stock values report

### DIFF
--- a/src/main/java/com/divudi/core/data/pharmacy/DailyStockBalanceReport.java
+++ b/src/main/java/com/divudi/core/data/pharmacy/DailyStockBalanceReport.java
@@ -726,4 +726,49 @@ public class DailyStockBalanceReport {
         this.preBillStockMovementsBundle = preBillStockMovementsBundle;
     }
 
+    // ── Closing-stock reconciliation helpers ──────────────────────────────────
+    //
+    // Expected closing = opening
+    //                  + purchases  (always positive — stock in)
+    //                  - sales      (always positive in bundle — stock out, so subtract)
+    //                  + transfers  (net-signed: receives +, issues −)
+    //                  + adjustments (net-signed)
+    //
+    // A mismatch > 1.0 (tolerance to absorb rounding) flags a discrepancy.
+
+    private double bundleValue(PharmacyBundle bundle, java.util.function.Function<com.divudi.core.data.PharmacyRow, java.math.BigDecimal> extractor) {
+        if (bundle == null || bundle.getSummaryRow() == null) {
+            return 0.0;
+        }
+        java.math.BigDecimal v = extractor.apply(bundle.getSummaryRow());
+        return v == null ? 0.0 : v.doubleValue();
+    }
+
+    public boolean isClosingStockCostRateMismatch() {
+        double expected = openingStockValueAtCostRate
+                + bundleValue(pharmacyPurchaseByBillTypeBundle,    com.divudi.core.data.PharmacyRow::getValueOfStocksAtCostRate)
+                - bundleValue(pharmacySalesByAdmissionTypeAndDiscountSchemeBundle, com.divudi.core.data.PharmacyRow::getValueOfStocksAtCostRate)
+                + bundleValue(pharmacyTransferByBillTypeBundle,    com.divudi.core.data.PharmacyRow::getValueOfStocksAtCostRate)
+                + bundleValue(pharmacyAdjustmentsByBillTypeBundle, com.divudi.core.data.PharmacyRow::getValueOfStocksAtCostRate);
+        return Math.abs(closingStockValueAtCostRate - expected) > 1.0;
+    }
+
+    public boolean isClosingStockPurchaseRateMismatch() {
+        double expected = openingStockValueAtPurchaseRate
+                + bundleValue(pharmacyPurchaseByBillTypeBundle,    com.divudi.core.data.PharmacyRow::getValueOfStocksAtPurchaseRate)
+                - bundleValue(pharmacySalesByAdmissionTypeAndDiscountSchemeBundle, com.divudi.core.data.PharmacyRow::getValueOfStocksAtPurchaseRate)
+                + bundleValue(pharmacyTransferByBillTypeBundle,    com.divudi.core.data.PharmacyRow::getValueOfStocksAtPurchaseRate)
+                + bundleValue(pharmacyAdjustmentsByBillTypeBundle, com.divudi.core.data.PharmacyRow::getValueOfStocksAtPurchaseRate);
+        return Math.abs(closingStockValueAtPurchaseRate - expected) > 1.0;
+    }
+
+    public boolean isClosingStockRetailRateMismatch() {
+        double expected = openingStockValue
+                + bundleValue(pharmacyPurchaseByBillTypeBundle,    com.divudi.core.data.PharmacyRow::getValueOfStocksAtRetailSaleRate)
+                - bundleValue(pharmacySalesByAdmissionTypeAndDiscountSchemeBundle, com.divudi.core.data.PharmacyRow::getValueOfStocksAtRetailSaleRate)
+                + bundleValue(pharmacyTransferByBillTypeBundle,    com.divudi.core.data.PharmacyRow::getValueOfStocksAtRetailSaleRate)
+                + bundleValue(pharmacyAdjustmentsByBillTypeBundle, com.divudi.core.data.PharmacyRow::getValueOfStocksAtRetailSaleRate);
+        return Math.abs(closingStockValue - expected) > 1.0;
+    }
+
 }

--- a/src/main/webapp/pharmacy/reports/summary_reports/daily_stock_values_report_optimized.xhtml
+++ b/src/main/webapp/pharmacy/reports/summary_reports/daily_stock_values_report_optimized.xhtml
@@ -760,17 +760,20 @@
                                                         <td colspan="5">
                                                             <h:outputText value="Closing Stock Value"/>
                                                         </td>
-                                                        <td class="text-end">
+                                                        <td class="text-end"
+                                                            style="#{pharmacyDailyStockReportOptimizedController.dailyStockBalanceReport.closingStockCostRateMismatch ? 'background-color:#ffdddd;color:#cc0000;font-weight:bold;' : ''}">
                                                             <h:outputText value="#{pharmacyDailyStockReportOptimizedController.dailyStockBalanceReport.closingStockValueAtCostRate}">
                                                                 <f:convertNumber pattern="#,##0.00"/>
                                                             </h:outputText>
                                                         </td>
-                                                        <td class="text-end">
+                                                        <td class="text-end"
+                                                            style="#{pharmacyDailyStockReportOptimizedController.dailyStockBalanceReport.closingStockPurchaseRateMismatch ? 'background-color:#ffdddd;color:#cc0000;font-weight:bold;' : ''}">
                                                             <h:outputText value="#{pharmacyDailyStockReportOptimizedController.dailyStockBalanceReport.closingStockValueAtPurchaseRate}">
                                                                 <f:convertNumber pattern="#,##0.00"/>
                                                             </h:outputText>
                                                         </td>
-                                                        <td class="text-end">
+                                                        <td class="text-end"
+                                                            style="#{pharmacyDailyStockReportOptimizedController.dailyStockBalanceReport.closingStockRetailRateMismatch ? 'background-color:#ffdddd;color:#cc0000;font-weight:bold;' : ''}">
                                                             <h:outputText value="#{pharmacyDailyStockReportOptimizedController.dailyStockBalanceReport.closingStockValue}">
                                                                 <f:convertNumber pattern="#,##0.00"/>
                                                             </h:outputText>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added reconciliation checks to detect closing stock value mismatches across cost rate, purchase rate, and retail rate calculations in daily pharmacy reports.

* **Style**
  * Mismatched closing stock values are now highlighted in red with bold text in the daily stock balance report for quick visual identification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->