### PR TITLE
Fix Daily Stock Report Excel export: missing columns and colour indicators

### DIFF
--- a/src/main/java/com/divudi/bean/pharmacy/PharmacyDailyStockReportOptimizedController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacyDailyStockReportOptimizedController.java
@@ -540,12 +540,14 @@ public class PharmacyDailyStockReportOptimizedController implements Serializable
             }
             var s = dailyStockBalanceReport.getPharmacySalesByAdmissionTypeAndDiscountSchemeBundle().getSummaryRow();
             CellStyle totalGreen = makeSolidStyle(workbook, green, numFmt, true, false);
-            rowNum = writeTotalRow(sheet, rowNum, "Total Sales",
-                    new double[]{s.getGrossTotal(), s.getDiscount(), s.getServiceCharge(), s.getNetTotal(),
-                                 s.getValueOfStocksAtCostRate().doubleValue(),
-                                 s.getValueOfStocksAtPurchaseRate().doubleValue(),
-                                 s.getValueOfStocksAtRetailSaleRate().doubleValue()},
-                    totalGreen);
+            if (s != null) {
+                rowNum = writeTotalRow(sheet, rowNum, "Total Sales",
+                        new double[]{s.getGrossTotal(), s.getDiscount(), s.getServiceCharge(), s.getNetTotal(),
+                                     s.getValueOfStocksAtCostRate().doubleValue(),
+                                     s.getValueOfStocksAtPurchaseRate().doubleValue(),
+                                     s.getValueOfStocksAtRetailSaleRate().doubleValue()},
+                        totalGreen);
+            }
         }
         rowNum++; // blank row
 
@@ -570,12 +572,14 @@ public class PharmacyDailyStockReportOptimizedController implements Serializable
             }
             var s = dailyStockBalanceReport.getPharmacyPurchaseByBillTypeBundle().getSummaryRow();
             CellStyle totalOrange = makeSolidStyle(workbook, orange, numFmt, true, false);
-            rowNum = writeTotalRow(sheet, rowNum, "Total Purchases",
-                    new double[]{s.getGrossTotal(), 0, 0, 0,
-                                 s.getValueOfStocksAtCostRate().doubleValue(),
-                                 s.getValueOfStocksAtPurchaseRate().doubleValue(),
-                                 s.getValueOfStocksAtRetailSaleRate().doubleValue()},
-                    totalOrange);
+            if (s != null) {
+                rowNum = writeTotalRow(sheet, rowNum, "Total Purchases",
+                        new double[]{s.getGrossTotal(), 0, 0, s.getNetTotal(),
+                                     s.getValueOfStocksAtCostRate().doubleValue(),
+                                     s.getValueOfStocksAtPurchaseRate().doubleValue(),
+                                     s.getValueOfStocksAtRetailSaleRate().doubleValue()},
+                        totalOrange);
+            }
         }
         rowNum++; // blank row
 
@@ -600,12 +604,14 @@ public class PharmacyDailyStockReportOptimizedController implements Serializable
             }
             var s = dailyStockBalanceReport.getPharmacyTransferByBillTypeBundle().getSummaryRow();
             CellStyle totalCyan = makeSolidStyle(workbook, cyan, numFmt, true, false);
-            rowNum = writeTotalRow(sheet, rowNum, "Total Transfers",
-                    new double[]{s.getGrossTotal(), 0, 0, 0,
-                                 s.getValueOfStocksAtCostRate().doubleValue(),
-                                 s.getValueOfStocksAtPurchaseRate().doubleValue(),
-                                 s.getValueOfStocksAtRetailSaleRate().doubleValue()},
-                    totalCyan);
+            if (s != null) {
+                rowNum = writeTotalRow(sheet, rowNum, "Total Transfers",
+                        new double[]{s.getGrossTotal(), 0, 0, s.getNetTotal(),
+                                     s.getValueOfStocksAtCostRate().doubleValue(),
+                                     s.getValueOfStocksAtPurchaseRate().doubleValue(),
+                                     s.getValueOfStocksAtRetailSaleRate().doubleValue()},
+                        totalCyan);
+            }
         }
         rowNum++; // blank row
 
@@ -630,12 +636,14 @@ public class PharmacyDailyStockReportOptimizedController implements Serializable
             }
             var s = dailyStockBalanceReport.getPharmacyAdjustmentsByBillTypeBundle().getSummaryRow();
             CellStyle totalRed = makeSolidStyle(workbook, red, numFmt, true, false);
-            rowNum = writeTotalRow(sheet, rowNum, "Total Adjustments",
-                    new double[]{s.getGrossTotal(), 0, 0, 0,
-                                 s.getValueOfStocksAtCostRate().doubleValue(),
-                                 s.getValueOfStocksAtPurchaseRate().doubleValue(),
-                                 s.getValueOfStocksAtRetailSaleRate().doubleValue()},
-                    totalRed);
+            if (s != null) {
+                rowNum = writeTotalRow(sheet, rowNum, "Total Adjustments",
+                        new double[]{s.getGrossTotal(), 0, 0, s.getNetTotal(),
+                                     s.getValueOfStocksAtCostRate().doubleValue(),
+                                     s.getValueOfStocksAtPurchaseRate().doubleValue(),
+                                     s.getValueOfStocksAtRetailSaleRate().doubleValue()},
+                        totalRed);
+            }
         }
         rowNum++; // blank row
 

--- a/src/main/java/com/divudi/bean/pharmacy/PharmacyDailyStockReportOptimizedController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacyDailyStockReportOptimizedController.java
@@ -26,12 +26,16 @@ import javax.servlet.http.HttpServletResponse;
 import org.apache.poi.ss.usermodel.BorderStyle;
 import org.apache.poi.ss.usermodel.Cell;
 import org.apache.poi.ss.usermodel.CellStyle;
+import org.apache.poi.ss.usermodel.FillPatternType;
 import org.apache.poi.ss.usermodel.Font;
+import org.apache.poi.ss.usermodel.HorizontalAlignment;
 import org.apache.poi.ss.usermodel.IndexedColors;
 import org.apache.poi.ss.usermodel.Row;
 import org.apache.poi.ss.usermodel.Sheet;
 import org.apache.poi.ss.usermodel.Workbook;
 import org.apache.poi.ss.util.CellRangeAddress;
+import org.apache.poi.xssf.usermodel.XSSFCellStyle;
+import org.apache.poi.xssf.usermodel.XSSFColor;
 import org.apache.poi.xssf.usermodel.XSSFWorkbook;
 
 /**
@@ -435,56 +439,60 @@ public class PharmacyDailyStockReportOptimizedController implements Serializable
     }
 
     /**
-     * Creates Excel workbook for the daily stock report
+     * Creates Excel workbook for the daily stock report.
+     * The layout mirrors the on-screen display: coloured section headers,
+     * all columns for each section, and red highlighting on closing stock
+     * cells when a mismatch is detected.
      */
     private Workbook createExcelReport() {
-        Workbook workbook = new XSSFWorkbook();
+        XSSFWorkbook workbook = new XSSFWorkbook();
         Sheet sheet = workbook.createSheet("Daily Stock Report");
 
-        // Create styles
-        CellStyle headerStyle = workbook.createCellStyle();
-        Font headerFont = workbook.createFont();
-        headerFont.setBold(true);
-        headerFont.setColor(IndexedColors.WHITE.getIndex());
-        headerStyle.setFont(headerFont);
-        headerStyle.setFillForegroundColor(IndexedColors.DARK_BLUE.getIndex());
-        headerStyle.setFillPattern(org.apache.poi.ss.usermodel.FillPatternType.SOLID_FOREGROUND);
-        headerStyle.setBorderBottom(BorderStyle.THIN);
-        headerStyle.setBorderTop(BorderStyle.THIN);
-        headerStyle.setBorderRight(BorderStyle.THIN);
-        headerStyle.setBorderLeft(BorderStyle.THIN);
+        short numFmt = workbook.createDataFormat().getFormat("#,##0.00");
 
+        // ── Title style ───────────────────────────────────────────────────────
         CellStyle titleStyle = workbook.createCellStyle();
         Font titleFont = workbook.createFont();
         titleFont.setBold(true);
-        titleFont.setFontHeightInPoints((short) 16);
+        titleFont.setFontHeightInPoints((short) 14);
         titleStyle.setFont(titleFont);
-        titleStyle.setAlignment(org.apache.poi.ss.usermodel.HorizontalAlignment.CENTER);
+        titleStyle.setAlignment(HorizontalAlignment.CENTER);
 
-        CellStyle numberStyle = workbook.createCellStyle();
-        numberStyle.setDataFormat(workbook.createDataFormat().getFormat("#,##0.00"));
+        // ── Plain number style ────────────────────────────────────────────────
+        CellStyle numStyle = workbook.createCellStyle();
+        numStyle.setDataFormat(numFmt);
+        numStyle.setAlignment(HorizontalAlignment.RIGHT);
 
-        CellStyle totalStyle = workbook.createCellStyle();
-        totalStyle.setDataFormat(workbook.createDataFormat().getFormat("#,##0.00"));
-        Font totalFont = workbook.createFont();
-        totalFont.setBold(true);
-        totalStyle.setFont(totalFont);
-        totalStyle.setFillForegroundColor(IndexedColors.GREY_25_PERCENT.getIndex());
-        totalStyle.setFillPattern(org.apache.poi.ss.usermodel.FillPatternType.SOLID_FOREGROUND);
+        // ── Helper: section-header style (coloured background, white bold text) ──
+        // colours: Opening/Closing=blue(0x2196F3), Sales=green(0x28a745),
+        //          Purchase=orange(0xFF8C00), Transfer=cyan(0x17A2B8),
+        //          Adjustment=red(0xDC3545)
+
+        // ── Section total rows are created inline per section with their own colour.
+
+        // ── Mismatch cell style (red background, dark-red bold text) ─────────
+        XSSFCellStyle mismatchStyle = (XSSFCellStyle) workbook.createCellStyle();
+        mismatchStyle.setDataFormat(numFmt);
+        mismatchStyle.setAlignment(HorizontalAlignment.RIGHT);
+        mismatchStyle.setFillPattern(FillPatternType.SOLID_FOREGROUND);
+        mismatchStyle.setFillForegroundColor(new XSSFColor(new byte[]{(byte)0xFF,(byte)0xDD,(byte)0xDD}, null));
+        Font mismatchFont = workbook.createFont();
+        mismatchFont.setBold(true);
+        mismatchFont.setColor(IndexedColors.DARK_RED.getIndex());
+        mismatchStyle.setFont(mismatchFont);
 
         int rowNum = 0;
 
-        // Title
+        // ── Report title ──────────────────────────────────────────────────────
         Row titleRow = sheet.createRow(rowNum++);
         Cell titleCell = titleRow.createCell(0);
         titleCell.setCellValue("Daily Stock Value Report");
         titleCell.setCellStyle(titleStyle);
-        sheet.addMergedRegion(new CellRangeAddress(0, 0, 0, 2));
+        sheet.addMergedRegion(new CellRangeAddress(rowNum - 1, rowNum - 1, 0, 7));
 
-        // Empty row
-        rowNum++;
+        rowNum++; // blank row
 
-        // Date and Department info
+        // ── Date / Department info ─────────────────────────────────────────────
         SimpleDateFormat dateFormat = new SimpleDateFormat("dd-MM-yyyy");
         Row dateRow = sheet.createRow(rowNum++);
         dateRow.createCell(0).setCellValue("Date:");
@@ -494,141 +502,235 @@ public class PharmacyDailyStockReportOptimizedController implements Serializable
         deptRow.createCell(0).setCellValue("Department:");
         deptRow.createCell(1).setCellValue(department != null ? department.getName() : "");
 
-        // Empty row
-        rowNum++;
+        rowNum++; // blank row
 
-        // Headers
-        Row headerRow = sheet.createRow(rowNum++);
-        Cell descHeader = headerRow.createCell(0);
-        descHeader.setCellValue("Description");
-        descHeader.setCellStyle(headerStyle);
-
-        Cell retailValueHeader = headerRow.createCell(1);
-        retailValueHeader.setCellValue("Value (Retail Rate)");
-        retailValueHeader.setCellStyle(headerStyle);
-
-        Cell costValueHeader = headerRow.createCell(2);
-        costValueHeader.setCellValue("Value (Cost Rate)");
-        costValueHeader.setCellStyle(headerStyle);
-
-        // Opening Stock
+        // ═════════════════════════════════════════════════════════════════════
+        // OPENING STOCK  (blue header, 3 value columns)
+        // ═════════════════════════════════════════════════════════════════════
+        byte[] blue = {(byte)0x0D,(byte)0x6E,(byte)0xFD};
+        rowNum = writeSectionHeader(sheet, workbook, rowNum, "Opening Stock",
+                new String[]{"Description","","","","","Cost Rate","Purchase Rate","Retail Rate"}, blue);
         Row openingRow = sheet.createRow(rowNum++);
-        openingRow.createCell(0).setCellValue("Opening Stock");
+        openingRow.createCell(0).setCellValue("Opening Stock Value");
+        setCellNum(openingRow, 5, dailyStockBalanceReport.getOpeningStockValueAtCostRate(), numStyle);
+        setCellNum(openingRow, 6, dailyStockBalanceReport.getOpeningStockValueAtPurchaseRate(), numStyle);
+        setCellNum(openingRow, 7, dailyStockBalanceReport.getOpeningStockValue(), numStyle);
+        rowNum++; // blank row
 
-        Cell openingRetailCell = openingRow.createCell(1);
-        openingRetailCell.setCellValue(dailyStockBalanceReport.getOpeningStockValue());
-        openingRetailCell.setCellStyle(numberStyle);
+        // ═════════════════════════════════════════════════════════════════════
+        // SALES  (green header, 8 columns)
+        // ═════════════════════════════════════════════════════════════════════
+        byte[] green = {(byte)0x19,(byte)0x87,(byte)0x54};
+        String[] salesCols = {"Sale Type","Gross Value","Discount","Service Charge","Net Value",
+                              "Stock Value (Cost)","Stock Value (Purchase)","Stock Value (Retail)"};
+        rowNum = writeSectionHeader(sheet, workbook, rowNum, "Sales Transactions", salesCols, green);
 
-        Cell openingCostCell = openingRow.createCell(2);
-        openingCostCell.setCellValue(dailyStockBalanceReport.getOpeningStockValueAtCostRate());
-        openingCostCell.setCellStyle(numberStyle);
-
-        // Sales
         if (dailyStockBalanceReport.getPharmacySalesByAdmissionTypeAndDiscountSchemeBundle() != null
-            && dailyStockBalanceReport.getPharmacySalesByAdmissionTypeAndDiscountSchemeBundle().getRows() != null) {
+                && dailyStockBalanceReport.getPharmacySalesByAdmissionTypeAndDiscountSchemeBundle().getRows() != null) {
             for (var sale : dailyStockBalanceReport.getPharmacySalesByAdmissionTypeAndDiscountSchemeBundle().getRows()) {
-                Row saleRow = sheet.createRow(rowNum++);
-                saleRow.createCell(0).setCellValue(sale.getRowType());
-                Cell saleCell = saleRow.createCell(1);
-                saleCell.setCellValue(sale.getNetTotal());
-                saleCell.setCellStyle(numberStyle);
+                Row r = sheet.createRow(rowNum++);
+                r.createCell(0).setCellValue(sale.getRowType());
+                setCellNum(r, 1, sale.getGrossTotal(), numStyle);
+                setCellNum(r, 2, sale.getDiscount(), numStyle);
+                setCellNum(r, 3, sale.getServiceCharge(), numStyle);
+                setCellNum(r, 4, sale.getNetTotal(), numStyle);
+                setCellNum(r, 5, sale.getValueOfStocksAtCostRate().doubleValue(), numStyle);
+                setCellNum(r, 6, sale.getValueOfStocksAtPurchaseRate().doubleValue(), numStyle);
+                setCellNum(r, 7, sale.getValueOfStocksAtRetailSaleRate().doubleValue(), numStyle);
             }
-
-            // Total Sales
-            Row totalSalesRow = sheet.createRow(rowNum++);
-            Cell totalSalesDesc = totalSalesRow.createCell(0);
-            totalSalesDesc.setCellValue("Total Sales");
-            totalSalesDesc.setCellStyle(totalStyle);
-
-            Cell totalSalesCell = totalSalesRow.createCell(1);
-            totalSalesCell.setCellValue(dailyStockBalanceReport.getPharmacySalesByAdmissionTypeAndDiscountSchemeBundle().getSummaryRow().getNetTotal());
-            totalSalesCell.setCellStyle(totalStyle);
+            var s = dailyStockBalanceReport.getPharmacySalesByAdmissionTypeAndDiscountSchemeBundle().getSummaryRow();
+            CellStyle totalGreen = makeSolidStyle(workbook, green, numFmt, true, false);
+            rowNum = writeTotalRow(sheet, rowNum, "Total Sales",
+                    new double[]{s.getGrossTotal(), s.getDiscount(), s.getServiceCharge(), s.getNetTotal(),
+                                 s.getValueOfStocksAtCostRate().doubleValue(),
+                                 s.getValueOfStocksAtPurchaseRate().doubleValue(),
+                                 s.getValueOfStocksAtRetailSaleRate().doubleValue()},
+                    totalGreen);
         }
+        rowNum++; // blank row
 
-        // Purchases
+        // ═════════════════════════════════════════════════════════════════════
+        // PURCHASES  (orange header, 8 columns)
+        // ═════════════════════════════════════════════════════════════════════
+        byte[] orange = {(byte)0xFF,(byte)0x8C,(byte)0x00};
+        String[] purchaseCols = {"Purchase Type","Gross Value","","","Net Value",
+                                 "Stock Value (Cost)","Stock Value (Purchase)","Stock Value (Retail)"};
+        rowNum = writeSectionHeader(sheet, workbook, rowNum, "Purchase Transactions", purchaseCols, orange);
+
         if (dailyStockBalanceReport.getPharmacyPurchaseByBillTypeBundle() != null
-            && dailyStockBalanceReport.getPharmacyPurchaseByBillTypeBundle().getRows() != null) {
-            for (var purchase : dailyStockBalanceReport.getPharmacyPurchaseByBillTypeBundle().getRows()) {
-                Row purchaseRow = sheet.createRow(rowNum++);
-                purchaseRow.createCell(0).setCellValue(purchase.getRowType());
-                Cell purchaseCell = purchaseRow.createCell(1);
-                purchaseCell.setCellValue(purchase.getValueOfStocksAtRetailSaleRate().doubleValue());
-                purchaseCell.setCellStyle(numberStyle);
+                && dailyStockBalanceReport.getPharmacyPurchaseByBillTypeBundle().getRows() != null) {
+            for (var p : dailyStockBalanceReport.getPharmacyPurchaseByBillTypeBundle().getRows()) {
+                Row r = sheet.createRow(rowNum++);
+                r.createCell(0).setCellValue(p.getRowType());
+                setCellNum(r, 1, p.getGrossTotal(), numStyle);
+                setCellNum(r, 4, p.getNetTotal(), numStyle);
+                setCellNum(r, 5, p.getValueOfStocksAtCostRate().doubleValue(), numStyle);
+                setCellNum(r, 6, p.getValueOfStocksAtPurchaseRate().doubleValue(), numStyle);
+                setCellNum(r, 7, p.getValueOfStocksAtRetailSaleRate().doubleValue(), numStyle);
             }
-
-            // Total Purchases
-            Row totalPurchasesRow = sheet.createRow(rowNum++);
-            Cell totalPurchasesDesc = totalPurchasesRow.createCell(0);
-            totalPurchasesDesc.setCellValue("Total Purchases");
-            totalPurchasesDesc.setCellStyle(totalStyle);
-
-            Cell totalPurchasesCell = totalPurchasesRow.createCell(1);
-            totalPurchasesCell.setCellValue(dailyStockBalanceReport.getPharmacyPurchaseByBillTypeBundle().getSummaryRow().getValueOfStocksAtRetailSaleRate().doubleValue());
-            totalPurchasesCell.setCellStyle(totalStyle);
+            var s = dailyStockBalanceReport.getPharmacyPurchaseByBillTypeBundle().getSummaryRow();
+            CellStyle totalOrange = makeSolidStyle(workbook, orange, numFmt, true, false);
+            rowNum = writeTotalRow(sheet, rowNum, "Total Purchases",
+                    new double[]{s.getGrossTotal(), 0, 0, 0,
+                                 s.getValueOfStocksAtCostRate().doubleValue(),
+                                 s.getValueOfStocksAtPurchaseRate().doubleValue(),
+                                 s.getValueOfStocksAtRetailSaleRate().doubleValue()},
+                    totalOrange);
         }
+        rowNum++; // blank row
 
-        // Transfers
+        // ═════════════════════════════════════════════════════════════════════
+        // TRANSFERS  (cyan header, 8 columns)
+        // ═════════════════════════════════════════════════════════════════════
+        byte[] cyan = {(byte)0x0D,(byte)0xA2,(byte)0xB8};
+        String[] transferCols = {"Transfer Type","Gross Value","","","Net Value",
+                                 "Stock Value (Cost)","Stock Value (Purchase)","Stock Value (Retail)"};
+        rowNum = writeSectionHeader(sheet, workbook, rowNum, "Transfer Transactions", transferCols, cyan);
+
         if (dailyStockBalanceReport.getPharmacyTransferByBillTypeBundle() != null
-            && dailyStockBalanceReport.getPharmacyTransferByBillTypeBundle().getRows() != null) {
-            for (var transfer : dailyStockBalanceReport.getPharmacyTransferByBillTypeBundle().getRows()) {
-                Row transferRow = sheet.createRow(rowNum++);
-                transferRow.createCell(0).setCellValue(transfer.getRowType());
-                Cell transferCell = transferRow.createCell(1);
-                transferCell.setCellValue(transfer.getValueOfStocksAtRetailSaleRate().doubleValue());
-                transferCell.setCellStyle(numberStyle);
+                && dailyStockBalanceReport.getPharmacyTransferByBillTypeBundle().getRows() != null) {
+            for (var t : dailyStockBalanceReport.getPharmacyTransferByBillTypeBundle().getRows()) {
+                Row r = sheet.createRow(rowNum++);
+                r.createCell(0).setCellValue(t.getRowType());
+                setCellNum(r, 1, t.getGrossTotal(), numStyle);
+                setCellNum(r, 4, t.getNetTotal(), numStyle);
+                setCellNum(r, 5, t.getValueOfStocksAtCostRate().doubleValue(), numStyle);
+                setCellNum(r, 6, t.getValueOfStocksAtPurchaseRate().doubleValue(), numStyle);
+                setCellNum(r, 7, t.getValueOfStocksAtRetailSaleRate().doubleValue(), numStyle);
             }
-
-            // Total Transfers
-            Row totalTransfersRow = sheet.createRow(rowNum++);
-            Cell totalTransfersDesc = totalTransfersRow.createCell(0);
-            totalTransfersDesc.setCellValue("Total Transfers");
-            totalTransfersDesc.setCellStyle(totalStyle);
-
-            Cell totalTransfersCell = totalTransfersRow.createCell(1);
-            totalTransfersCell.setCellValue(dailyStockBalanceReport.getPharmacyTransferByBillTypeBundle().getSummaryRow().getValueOfStocksAtRetailSaleRate().doubleValue());
-            totalTransfersCell.setCellStyle(totalStyle);
+            var s = dailyStockBalanceReport.getPharmacyTransferByBillTypeBundle().getSummaryRow();
+            CellStyle totalCyan = makeSolidStyle(workbook, cyan, numFmt, true, false);
+            rowNum = writeTotalRow(sheet, rowNum, "Total Transfers",
+                    new double[]{s.getGrossTotal(), 0, 0, 0,
+                                 s.getValueOfStocksAtCostRate().doubleValue(),
+                                 s.getValueOfStocksAtPurchaseRate().doubleValue(),
+                                 s.getValueOfStocksAtRetailSaleRate().doubleValue()},
+                    totalCyan);
         }
+        rowNum++; // blank row
 
-        // Adjustments
+        // ═════════════════════════════════════════════════════════════════════
+        // ADJUSTMENTS  (red header, 8 columns)
+        // ═════════════════════════════════════════════════════════════════════
+        byte[] red = {(byte)0xDC,(byte)0x35,(byte)0x45};
+        String[] adjustCols = {"Adjustment Type","Gross Value","","","Net Value",
+                               "Stock Value (Cost)","Stock Value (Purchase)","Stock Value (Retail)"};
+        rowNum = writeSectionHeader(sheet, workbook, rowNum, "Adjustment Transactions", adjustCols, red);
+
         if (dailyStockBalanceReport.getPharmacyAdjustmentsByBillTypeBundle() != null
-            && dailyStockBalanceReport.getPharmacyAdjustmentsByBillTypeBundle().getRows() != null) {
-            for (var adjustment : dailyStockBalanceReport.getPharmacyAdjustmentsByBillTypeBundle().getRows()) {
-                Row adjustmentRow = sheet.createRow(rowNum++);
-                adjustmentRow.createCell(0).setCellValue(adjustment.getRowType());
-                Cell adjustmentCell = adjustmentRow.createCell(1);
-                adjustmentCell.setCellValue(adjustment.getGrossTotal());
-                adjustmentCell.setCellStyle(numberStyle);
+                && dailyStockBalanceReport.getPharmacyAdjustmentsByBillTypeBundle().getRows() != null) {
+            for (var a : dailyStockBalanceReport.getPharmacyAdjustmentsByBillTypeBundle().getRows()) {
+                Row r = sheet.createRow(rowNum++);
+                r.createCell(0).setCellValue(a.getRowType());
+                setCellNum(r, 1, a.getGrossTotal(), numStyle);
+                setCellNum(r, 4, a.getNetTotal(), numStyle);
+                setCellNum(r, 5, a.getValueOfStocksAtCostRate().doubleValue(), numStyle);
+                setCellNum(r, 6, a.getValueOfStocksAtPurchaseRate().doubleValue(), numStyle);
+                setCellNum(r, 7, a.getValueOfStocksAtRetailSaleRate().doubleValue(), numStyle);
             }
-
-            // Total Adjustments
-            Row totalAdjustmentsRow = sheet.createRow(rowNum++);
-            Cell totalAdjustmentsDesc = totalAdjustmentsRow.createCell(0);
-            totalAdjustmentsDesc.setCellValue("Total Adjustments");
-            totalAdjustmentsDesc.setCellStyle(totalStyle);
-
-            Cell totalAdjustmentsCell = totalAdjustmentsRow.createCell(1);
-            totalAdjustmentsCell.setCellValue(dailyStockBalanceReport.getPharmacyAdjustmentsByBillTypeBundle().getSummaryRow().getValueOfStocksAtRetailSaleRate().doubleValue());
-            totalAdjustmentsCell.setCellStyle(totalStyle);
+            var s = dailyStockBalanceReport.getPharmacyAdjustmentsByBillTypeBundle().getSummaryRow();
+            CellStyle totalRed = makeSolidStyle(workbook, red, numFmt, true, false);
+            rowNum = writeTotalRow(sheet, rowNum, "Total Adjustments",
+                    new double[]{s.getGrossTotal(), 0, 0, 0,
+                                 s.getValueOfStocksAtCostRate().doubleValue(),
+                                 s.getValueOfStocksAtPurchaseRate().doubleValue(),
+                                 s.getValueOfStocksAtRetailSaleRate().doubleValue()},
+                    totalRed);
         }
+        rowNum++; // blank row
 
-        // Closing Stock
+        // ═════════════════════════════════════════════════════════════════════
+        // CLOSING STOCK  (blue header, 3 value columns, mismatch highlighting)
+        // ═════════════════════════════════════════════════════════════════════
+        rowNum = writeSectionHeader(sheet, workbook, rowNum, "Closing Stock",
+                new String[]{"Description","","","","","Cost Rate","Purchase Rate","Retail Rate"}, blue);
         Row closingRow = sheet.createRow(rowNum++);
-        closingRow.createCell(0).setCellValue("Closing Stock");
+        closingRow.createCell(0).setCellValue("Closing Stock Value");
+        setCellNum(closingRow, 5, dailyStockBalanceReport.getClosingStockValueAtCostRate(),
+                dailyStockBalanceReport.isClosingStockCostRateMismatch() ? mismatchStyle : numStyle);
+        setCellNum(closingRow, 6, dailyStockBalanceReport.getClosingStockValueAtPurchaseRate(),
+                dailyStockBalanceReport.isClosingStockPurchaseRateMismatch() ? mismatchStyle : numStyle);
+        setCellNum(closingRow, 7, dailyStockBalanceReport.getClosingStockValue(),
+                dailyStockBalanceReport.isClosingStockRetailRateMismatch() ? mismatchStyle : numStyle);
 
-        Cell closingRetailCell = closingRow.createCell(1);
-        closingRetailCell.setCellValue(dailyStockBalanceReport.getClosingStockValue());
-        closingRetailCell.setCellStyle(numberStyle);
-
-        Cell closingCostCell = closingRow.createCell(2);
-        closingCostCell.setCellValue(dailyStockBalanceReport.getClosingStockValueAtCostRate());
-        closingCostCell.setCellStyle(numberStyle);
-
-        // Auto-size columns
-        sheet.autoSizeColumn(0);
-        sheet.autoSizeColumn(1);
-        sheet.autoSizeColumn(2);
+        // ── Auto-size all 8 columns ───────────────────────────────────────────
+        for (int c = 0; c < 8; c++) {
+            sheet.autoSizeColumn(c);
+        }
 
         return workbook;
+    }
+
+    /** Writes a coloured section-header row followed by a column-header row.
+     *  Returns the next available row index. */
+    private int writeSectionHeader(Sheet sheet, XSSFWorkbook wb, int rowNum,
+                                   String sectionTitle, String[] colHeaders, byte[] rgb) {
+        CellStyle sectionStyle = makeSolidStyle(wb, rgb, (short) 0, true, true);
+        Row sectionRow = sheet.createRow(rowNum++);
+        Cell sectionCell = sectionRow.createCell(0);
+        sectionCell.setCellValue(sectionTitle);
+        sectionCell.setCellStyle(sectionStyle);
+        sheet.addMergedRegion(new CellRangeAddress(rowNum - 1, rowNum - 1, 0, 7));
+
+        // lighter shade for column-header row
+        byte[] lightRgb = lighten(rgb);
+        CellStyle colStyle = makeSolidStyle(wb, lightRgb, (short) 0, true, false);
+        Row colRow = sheet.createRow(rowNum++);
+        for (int i = 0; i < colHeaders.length; i++) {
+            Cell c = colRow.createCell(i);
+            c.setCellValue(colHeaders[i]);
+            c.setCellStyle(colStyle);
+        }
+        return rowNum;
+    }
+
+    /** Writes a bold total row across columns 0–7. Returns next row index. */
+    private int writeTotalRow(Sheet sheet, int rowNum, String label, double[] values, CellStyle style) {
+        Row r = sheet.createRow(rowNum++);
+        Cell labelCell = r.createCell(0);
+        labelCell.setCellValue(label);
+        labelCell.setCellStyle(style);
+        for (int i = 0; i < values.length; i++) {
+            Cell c = r.createCell(i + 1);
+            c.setCellValue(values[i]);
+            c.setCellStyle(style);
+        }
+        return rowNum;
+    }
+
+    /** Sets a numeric cell at the given column index with the provided style. */
+    private void setCellNum(Row row, int col, double value, CellStyle style) {
+        Cell c = row.createCell(col);
+        c.setCellValue(value);
+        c.setCellStyle(style);
+    }
+
+    /** Creates a solid-fill cell style with the given RGB background. */
+    private XSSFCellStyle makeSolidStyle(XSSFWorkbook wb, byte[] rgb, short numFmt, boolean bold, boolean whiteText) {
+        XSSFCellStyle style = wb.createCellStyle();
+        style.setFillPattern(FillPatternType.SOLID_FOREGROUND);
+        style.setFillForegroundColor(new XSSFColor(rgb, null));
+        if (numFmt != 0) {
+            style.setDataFormat(numFmt);
+        }
+        style.setAlignment(HorizontalAlignment.LEFT);
+        Font font = wb.createFont();
+        font.setBold(bold);
+        if (whiteText) {
+            font.setColor(IndexedColors.WHITE.getIndex());
+        }
+        style.setFont(font);
+        return style;
+    }
+
+    /** Returns a lightened version of an RGB colour for sub-header rows. */
+    private byte[] lighten(byte[] rgb) {
+        byte[] out = new byte[3];
+        for (int i = 0; i < 3; i++) {
+            int v = (rgb[i] & 0xFF);
+            out[i] = (byte) Math.min(255, v + 80);
+        }
+        return out;
     }
 
     /**


### PR DESCRIPTION
## Summary

- All columns are now exported for each section (Sales: Gross/Discount/Service Charge/Net/Stock Cost+Purchase+Retail; Purchases, Transfers, Adjustments: same structure)
- Opening Stock and Closing Stock now include the missing Purchase Rate column
- Coloured section-header rows added matching the on-screen card-header colours (blue for Opening/Closing, green for Sales, orange for Purchases, cyan for Transfers, red for Adjustments)
- Closing stock cells are highlighted in red when a mismatch is detected (`isClosingStockCostRateMismatch` / `isClosingStockPurchaseRateMismatch` / `isClosingStockRetailRateMismatch`)

## Test plan
- [ ] Generate the Daily Stock Values Report for a date with data (Sales, Purchases, Transfers, Adjustments present)
- [ ] Click **Download Excel** and open the file
- [ ] Verify all 8 columns are present for Sales, Purchases, Transfers, Adjustments sections
- [ ] Verify Opening/Closing Stock sections each show Cost Rate, Purchase Rate, Retail Rate
- [ ] Verify section header rows have the correct colours
- [ ] For a date where closing stock has a mismatch, verify the affected cell is highlighted in red in the Excel file (same cell the on-screen report highlights red)

Closes #19841

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Redesigned Excel pharmacy stock report with multi-section layout featuring dedicated, color-coded section headers for improved visual organization.
  * Standardized column structure across all transaction sections for consistent data presentation.
  * Implemented red highlighting for closing stock discrepancies to easily identify mismatches.
  * Enhanced automatic column sizing for optimal readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->