### PR TITLE
19805-missing-validation-when-saving-without-adding-plan

### DIFF
--- a/src/main/java/com/divudi/bean/clinical/PlanController.java
+++ b/src/main/java/com/divudi/bean/clinical/PlanController.java
@@ -142,15 +142,23 @@ public class PlanController implements Serializable {
     }
 
     public void saveSelected() {
+        if (getCurrent().getName() == null || getCurrent().getName().trim().isEmpty()) {
+            JsfUtil.addErrorMessage("Please enter a Plan Name before saving.");
+            return;
+        }
+        if (getCurrent().getCode() == null || getCurrent().getCode().trim().isEmpty()) {
+            JsfUtil.addErrorMessage("Please enter a Plan Code before saving.");
+            return;
+        }
         current.setSymanticType(SymanticType.Preventive_Procedure);
         if (getCurrent().getId() != null && getCurrent().getId() > 0) {
             getFacade().edit(current);
-            JsfUtil.addSuccessMessage("Saved");
+            JsfUtil.addSuccessMessage("Updated Successfully.");
         } else {
             current.setCreatedAt(new Date());
             current.setCreater(getSessionController().getLoggedUser());
             getFacade().create(current);
-            JsfUtil.addSuccessMessage("Updated");
+            JsfUtil.addSuccessMessage("Saved Successfully.");
         }
         recreateModel();
         getItems();

--- a/src/main/webapp/emr/admin/plans.xhtml
+++ b/src/main/webapp/emr/admin/plans.xhtml
@@ -68,8 +68,7 @@
                                             autocomplete="off" 
                                             id="txtName" 
                                             value="#{planController.current.name}" 
-                                            styleClass="form-control" 
-                                           ></p:inputText>
+                                            styleClass="form-control"></p:inputText>
                                     </div>
                                 </div>
                                 <div class="form-group row">
@@ -79,8 +78,7 @@
                                             autocomplete="off" 
                                             id="txtCode" 
                                             value="#{planController.current.code}" 
-                                            styleClass="form-control" 
-                                            ></p:inputText>
+                                            styleClass="form-control"></p:inputText>
                                     </div>
                                 </div>
                                 <div class="form-group row">

--- a/src/main/webapp/emr/admin/plans.xhtml
+++ b/src/main/webapp/emr/admin/plans.xhtml
@@ -15,10 +15,11 @@
                 <div class="container-fluid">
                     <div class="row">
                         <div class="col-md-5">
-                            <h:panelGrid columns="3"  class="w-100" >
+                            <h:panelGrid columns="3"  class="w-80" >
                                 <p:commandButton id="btnAdd"
                                                  value="Add" 
-                                                 class="w-100"
+                                                 class="m-1 ui-button-success w-23"
+                                                 icon="fa fa-plus"
                                                  update="gpDetail lstSelect detailFocus" 
                                                  action="#{planController.prepareAdd()}"  >
                                 </p:commandButton>
@@ -26,15 +27,17 @@
                                                  ajax="false"
                                                  onclick="if (!confirm('Are you sure you want to delete this record?'))
                                                              return false;" 
-                                                 class="w-100"
+                                                 class="m-1 ui-button-danger w-23"
+                                                 icon="fa fa-trash"
                                                  action="#{planController.delete()}" 
                                                  process="lstSelect btnDelete"
                                                  update="lstSelect gpDetail"
                                                  value="Delete">
                                 </p:commandButton>
                                 <p:commandButton 
-                                    value="Download as Excel" 
-                                    class="w-100"
+                                    value="Excel" 
+                                    class="m-1 ui-button-success"
+                                    icon="fas fa-file-excel"
                                     ajax="false"
                                     action="#{planController.downloadAsExcel}" />
 
@@ -91,6 +94,8 @@
                                     <div class="col-sm-10">
                                         <p:commandButton id="btnSave" 
                                                          value="Save"
+                                                         class="m-1"
+                                                         icon="fas fa-save"
                                                          process="gpDetail" 
                                                          update="growlMsg lstSelect selectFocus gpDetail" 
                                                          action="#{planController.saveSelected()}">

--- a/src/main/webapp/emr/admin/plans.xhtml
+++ b/src/main/webapp/emr/admin/plans.xhtml
@@ -8,7 +8,7 @@
                 xmlns:p="http://primefaces.org/ui">
     <ui:define name="subcontent">
         <h:form >
-            <p:growl/>
+            <p:growl id="growlMsg" life="4000"/>
             <p:focus id="selectFocus" context="gpSelect"/>
             <p:focus id="detailFocus" context="gpDetail"/>
             <p:panel header="Manage Plans">
@@ -64,13 +64,23 @@
                                 <div class="form-group row">
                                     <label for="txtName" class="col-sm-2 col-form-label">Name</label>
                                     <div class="col-sm-10">
-                                        <p:inputText autocomplete="off" id="txtName" value="#{planController.current.name}" styleClass="form-control"></p:inputText>
+                                        <p:inputText 
+                                            autocomplete="off" 
+                                            id="txtName" 
+                                            value="#{planController.current.name}" 
+                                            styleClass="form-control" 
+                                           ></p:inputText>
                                     </div>
                                 </div>
                                 <div class="form-group row">
                                     <label for="txtCode" class="col-sm-2 col-form-label">Code</label>
                                     <div class="col-sm-10">
-                                        <p:inputText autocomplete="off" id="txtCode" value="#{planController.current.code}" styleClass="form-control"></p:inputText>
+                                        <p:inputText 
+                                            autocomplete="off" 
+                                            id="txtCode" 
+                                            value="#{planController.current.code}" 
+                                            styleClass="form-control" 
+                                            ></p:inputText>
                                     </div>
                                 </div>
                                 <div class="form-group row">
@@ -84,8 +94,8 @@
                                         <p:commandButton id="btnSave" 
                                                          value="Save"
                                                          process="gpDetail" 
-                                                         update="lstSelect selectFocus" 
-                                                         action="#{planController.saveSelected()}" >
+                                                         update="growlMsg lstSelect selectFocus gpDetail" 
+                                                         action="#{planController.saveSelected()}">
                                         </p:commandButton>
                                     </div>
                                 </div>


### PR DESCRIPTION
changes
01) plans.xhtml -> added Id and life to <p:growl> , update attribute in save button added growlMsg
02) planController.java -> created field-specific validation messages, swapped the save message and update message to give correct responce

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented saving when required Name or Code are blank; users now receive inline error messages and the operation is halted.
  * Clarified success messages so creating vs. updating records are reported distinctly.

* **UI Improvements**
  * Notifications now reliably appear after save actions and use a fixed growl component.
  * Adjusted panel layout and button labels/icons for clearer controls.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->