### PR TITLE
Fix pharmacy adjustment pages to show items of all department types

### DIFF
--- a/src/main/java/com/divudi/bean/pharmacy/AmpController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/AmpController.java
@@ -474,6 +474,19 @@ public class AmpController implements Serializable {
         return suggestions;
     }
 
+    public List<Amp> completeAmpAny(String qry) {
+        List<Amp> suggestions;
+        if (qry == null || qry.trim().isEmpty()) {
+            suggestions = new ArrayList<>();
+        } else {
+            String jpql = "SELECT c FROM Amp c WHERE c.retired = false AND LOWER(c.name) LIKE :query ORDER BY c.name";
+            Map<String, Object> parameters = new HashMap<>();
+            parameters.put("query", "%" + qry.trim().toLowerCase() + "%");
+            suggestions = getFacade().findByJpqlWithoutCache(jpql, parameters);
+        }
+        return suggestions;
+    }
+
     public List<Amp> completeAmpWithRetired(String qry) {
         List<Amp> a = null;
         Map m = new HashMap();

--- a/src/main/webapp/pharmacy/adjustments/pharmacy_adjustment_cost_rate.xhtml
+++ b/src/main/webapp/pharmacy/adjustments/pharmacy_adjustment_cost_rate.xhtml
@@ -79,7 +79,7 @@
                                             <i class="fas fa-pills me-2"></i>Select Item
                                         </label>
                                         <p:autoComplete id="acAmp" class="w-100" inputStyleClass="w-100"
-                                                       completeMethod="#{ampController.completeAmp}" var="amp"
+                                                       completeMethod="#{ampController.completeAmpAny}" var="amp"
                                                        itemLabel="#{amp.name}" itemValue="#{amp}"
                                                        value="#{pharmacyAdjustmentController.amp}"
                                                        maxResults="10" minQueryLength="3">

--- a/src/main/webapp/pharmacy/adjustments/pharmacy_adjustment_department.xhtml
+++ b/src/main/webapp/pharmacy/adjustments/pharmacy_adjustment_department.xhtml
@@ -92,7 +92,7 @@
                                             id="acAmp"
                                             class="w-100"
                                             inputStyleClass="w-100"
-                                            completeMethod="#{ampController.completeAmp}"
+                                            completeMethod="#{ampController.completeAmpAny}"
                                             var="amp"
                                             itemLabel="#{amp.name}"
                                             itemValue="#{amp}"

--- a/src/main/webapp/pharmacy/adjustments/pharmacy_adjustment_expiry_date.xhtml
+++ b/src/main/webapp/pharmacy/adjustments/pharmacy_adjustment_expiry_date.xhtml
@@ -93,7 +93,7 @@
                                             id="acAmp"
                                             class="w-100"
                                             inputStyleClass="w-100"
-                                            completeMethod="#{ampController.completeAmp}"
+                                            completeMethod="#{ampController.completeAmpAny}"
                                             var="amp"
                                             itemLabel="#{amp.name}"
                                             itemValue="#{amp}"

--- a/src/main/webapp/pharmacy/adjustments/pharmacy_adjustment_purchase_rate.xhtml
+++ b/src/main/webapp/pharmacy/adjustments/pharmacy_adjustment_purchase_rate.xhtml
@@ -83,7 +83,7 @@
                                         id="acAmp"
                                         class="w-100"
                                         inputStyleClass="w-100"
-                                        completeMethod="#{ampController.completeAmp}"
+                                        completeMethod="#{ampController.completeAmpAny}"
                                         var="amp"
                                         itemLabel="#{amp.name}"
                                         itemValue="#{amp}"

--- a/src/main/webapp/pharmacy/adjustments/pharmacy_adjustment_retail_sale_rate.xhtml
+++ b/src/main/webapp/pharmacy/adjustments/pharmacy_adjustment_retail_sale_rate.xhtml
@@ -83,7 +83,7 @@
                                         id="acAmp"
                                         class="w-100"
                                         inputStyleClass="w-100"
-                                        completeMethod="#{ampController.completeAmp}"
+                                        completeMethod="#{ampController.completeAmpAny}"
                                         var="amp"
                                         itemLabel="#{amp.name}"
                                         itemValue="#{amp}"

--- a/src/main/webapp/pharmacy/adjustments/pharmacy_adjustment_whole_sale_rate.xhtml
+++ b/src/main/webapp/pharmacy/adjustments/pharmacy_adjustment_whole_sale_rate.xhtml
@@ -27,7 +27,7 @@
                                             id="acAmp"
                                             class="w-100"
                                             inputStyleClass="w-100"
-                                            completeMethod="#{ampController.completeAmp}"
+                                            completeMethod="#{ampController.completeAmpAny}"
                                             var="amp"
                                             itemLabel="#{amp.name}"
                                             itemValue="#{amp}"


### PR DESCRIPTION
## Summary

- `AmpController.completeAmp()` was filtering items by `departmentType = Pharmacy`, causing all 6 adjustment pages to only show Pharmacy-typed items
- Added `completeAmpAny()` — same query without the `departmentType` restriction — to avoid changing the existing method used on sale/optician pages
- Switched all 6 adjustment page autocompletes to use `#{ampController.completeAmpAny}`

## Affected pages
- `pharmacy_adjustment_department.xhtml` (Quantity Adjustment)
- `pharmacy_adjustment_purchase_rate.xhtml`
- `pharmacy_adjustment_retail_sale_rate.xhtml`
- `pharmacy_adjustment_whole_sale_rate.xhtml`
- `pharmacy_adjustment_cost_rate.xhtml`
- `pharmacy_adjustment_expiry_date.xhtml`

## Test plan
- [ ] Open each adjustment page, search for an item known to have `departmentType = Store` or `Inventry` — confirm it now appears in autocomplete
- [ ] Confirm Pharmacy-typed items still appear as before
- [ ] Verify pharmacy sale pages (fast retail, direct purchase report) still work correctly with the unchanged `completeAmp`

Closes #19849

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

- Enhanced autocomplete functionality across pharmacy adjustment forms (cost rate, department, expiry date, purchase rate, and retail/wholesale rates) to exclude retired items and provide case-insensitive item matching for improved search accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->