### PR TITLE
Add Force Check button on missing_database_fields page (bypass wiki shortcut)

### DIFF
--- a/src/main/java/com/divudi/bean/common/DataAdministrationController.java
+++ b/src/main/java/com/divudi/bean/common/DataAdministrationController.java
@@ -2259,30 +2259,18 @@ public class DataAdministrationController implements Serializable {
         JsfUtil.addSuccessMessage("Migration marked as not necessary. The migration page is now restricted to administrators.");
     }
 
-    public void checkMissingFields1() {
+    public void checkMissingFieldsForced() {
         suggestedSql = "";
+        mainDatabaseSuggestedSql = "";
+        auditDatabaseSuggestedSql = "";
+        mainDatabaseErrors = "";
+        auditDatabaseErrors = "";
         errors = "";
-        StringBuilder allErrors = new StringBuilder();
-
-        for (Class<?> entityClass : findEntityClassNames()) {
-            String entityName = entityClass.getSimpleName();
-            try {
-                itemFacade.executeQueryFirstResult(entityClass, "SELECT e FROM " + entityName + " e");
-            } catch (PersistenceException pe) {
-                Throwable cause = pe.getCause();
-                while (cause != null && !(cause instanceof SQLSyntaxErrorException)) {
-                    cause = cause.getCause();
-                }
-                if (cause != null) {
-                    Matcher matcher = Pattern.compile("Unknown column '([^']+)' in 'field list'").matcher(getExceptionMessage(cause));
-                    if (matcher.find()) {
-                        String missingColumn = matcher.group(1);
-                        errors += String.format("Entity: %s, Missing Column: %s\n", entityName, missingColumn);
-                    }
-                }
-            } catch (Exception e) {
-                // Handle other exceptions as needed
-            }
+        if (runOnMainDatabase) {
+            checkMissingFieldsForDatabase(itemFacade, "Main Database");
+        }
+        if (runOnAuditDatabase) {
+            checkMissingFieldsForDatabase(auditDatabaseFacade, "Audit Database");
         }
     }
 

--- a/src/main/webapp/resources/ezcomp/midding_data_fields.xhtml
+++ b/src/main/webapp/resources/ezcomp/midding_data_fields.xhtml
@@ -85,6 +85,13 @@
                                 value="Check Missing Fields"
                                 class="w-25"
                                 />
+                            <p:commandButton
+                                ajax="false"
+                                action="#{dataAdministrationController.checkMissingFieldsForced()}"
+                                value="Force Check (Bypass Wiki)"
+                                styleClass="ui-button-warning w-25 ml-2"
+                                title="Bypasses the wiki version shortcut and always scans all tables"
+                                />
                         </f:facet>
 
                         <p:outputLabel value="Database Selection" />


### PR DESCRIPTION
## Summary

- Adds a **"Force Check (Bypass Wiki)"** button (warning style) that always runs the full entity-by-entity missing-fields scan, ignoring the wiki DDL version shortcut
- Removes the dead `checkMissingFields1()` method (was never wired to any UI)

## Changes

- `DataAdministrationController.java`: new `checkMissingFieldsForced()` method; removed unused `checkMissingFields1()`
- `midding_data_fields.xhtml`: second button added alongside existing "Check Missing Fields" button

## Test plan

- [ ] "Check Missing Fields" still short-circuits when wiki version matches stored version
- [ ] "Force Check (Bypass Wiki)" always performs full table scan regardless of wiki version
- [ ] Both buttons respect the Main/Audit database checkboxes

Closes #19854

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a "Check Missing Fields (Forced)" button in the Missing Data Fields tab to perform a comprehensive scan of all tables, with warning styling to indicate its advanced nature.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->