### PR TITLE
Fix BHT credit settlement report to reflect cancelled CC payments

### DIFF
--- a/src/main/java/com/divudi/bean/inward/BhtPaymentSummaryReportController.java
+++ b/src/main/java/com/divudi/bean/inward/BhtPaymentSummaryReportController.java
@@ -213,7 +213,7 @@ public class BhtPaymentSummaryReportController implements Serializable {
             if (bi.getReferenceBill() != null && bi.getReferenceBill().getCreditCompany() != null) {
                 companyName = bi.getReferenceBill().getCreditCompany().getName();
             }
-            row.addCreditSettlement(Math.abs(bi.getNetValue()), companyName);
+            row.addCreditSettlement(bi.getNetValue(), companyName);
         }
 
         return row;
@@ -237,18 +237,21 @@ public class BhtPaymentSummaryReportController implements Serializable {
     }
 
     /**
-     * Fetch BillItems from INPATIENT_CREDIT_COMPANY_PAYMENT_RECEIVED bills
-     * that reference this encounter.
+     * Fetch BillItems from INPATIENT_CREDIT_COMPANY_PAYMENT_RECEIVED and
+     * INPATIENT_CREDIT_COMPANY_PAYMENT_CANCELLATION bills that reference this encounter.
+     * Including both types allows cancellation items (negative netValue) to naturally
+     * offset the received items, so the net total is correct even when payments are cancelled.
      */
     private List<BillItem> fetchCreditSettlementItems(PatientEncounter enc) {
         String jpql = "select bi from BillItem bi"
                 + " where bi.retired = false"
                 + " and bi.bill.retired = false"
-                + " and bi.bill.cancelled = false"
-                + " and bi.bill.billTypeAtomic = :bta"
+                + " and bi.bill.billTypeAtomic in :btas"
                 + " and bi.patientEncounter = :enc";
         Map<String, Object> params = new HashMap<>();
-        params.put("bta", BillTypeAtomic.INPATIENT_CREDIT_COMPANY_PAYMENT_RECEIVED);
+        params.put("btas", java.util.Arrays.asList(
+                BillTypeAtomic.INPATIENT_CREDIT_COMPANY_PAYMENT_RECEIVED,
+                BillTypeAtomic.INPATIENT_CREDIT_COMPANY_PAYMENT_CANCELLATION));
         params.put("enc", enc);
         return billItemFacade.findByJpql(jpql, params);
     }


### PR DESCRIPTION
## Summary

- `fetchCreditSettlementItems` now queries for **both** `INPATIENT_CREDIT_COMPANY_PAYMENT_RECEIVED` and `INPATIENT_CREDIT_COMPANY_PAYMENT_CANCELLATION` bill items instead of only received items
- Removed the `bi.bill.cancelled = false` filter — no longer needed since cancellation items carry negative `netValue` and naturally offset the received amounts
- Changed `Math.abs(bi.getNetValue())` → `bi.getNetValue()` so that cancellation items (inverted/negative) correctly **reduce** the credit settlement total

This matches the pattern already used by `ReportsController` and `CreditCompanyDueController` which include both bill types when computing net credit settlement figures.

## Test plan

- [ ] Make a credit company payment for an inward BHT
- [ ] Generate the BHT Payment Summary report — credit settlement column should show the paid amount
- [ ] Cancel the credit company payment from `credit/credit_company_bill_search.xhtml`
- [ ] Generate the report again — credit settlement should now show **0** (fully cancelled) or the reduced net amount (partial cancellation)
- [ ] Verify non-cancelled payments for other BHTs are unaffected

Closes #19772

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed credit settlement calculations to correctly handle negative value adjustments
  * Enhanced credit settlement reports to include payment cancellations alongside receipts for more complete transaction visibility

<!-- end of auto-generated comment: release notes by coderabbit.ai -->