### PR TITLE
Fix inward CC debtor report and Path 2 referenceBill gap

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,6 +55,7 @@
 
 ### When Working on Inward / Inpatient Module
 - [Inward Navigation & Reference](developer_docs/navigation/inward_navigation.md) - Pages, controllers, workflow, open issues
+- [Inward CC Settlement Tracking](developer_docs/billing/inward-cc-settlement-tracking.md) - Data model, settlement paths, cancellation flows, and debtor report pattern for inpatient credit company payments
 
 ### When Adding a New Privilege
 - [Privilege System Guide](developer_docs/security/privilege-system.md) - **All 3 steps required**: enum value + `getCategory()` case + `UserPrivilageController` tree node. Adding only the enum is NOT sufficient — the privilege will be invisible in the admin UI. This was missed for `InpatientClinicalDischarge` (PR #19658, issue #19677).

--- a/developer_docs/billing/inward-cc-settlement-tracking.md
+++ b/developer_docs/billing/inward-cc-settlement-tracking.md
@@ -1,0 +1,165 @@
+# Inward Credit Company Settlement Tracking — Developer Guide
+
+## Overview
+
+This document explains the data model and code flows for tracking inward (inpatient) credit company
+settlements. It covers how payments and cancellations are recorded across two settlement UI paths, and
+how reports must query this data correctly.
+
+---
+
+## Data Model: Three Tracking Levels
+
+When a patient's final inward bill is raised for a credit company (CC), the system maintains balances
+at three levels simultaneously:
+
+| Level | Entity / Bill type | Key fields | Scope |
+|---|---|---|---|
+| **Per-CC commitment** | `INWARD_FINAL_BILL_PAYMENT_BY_CREDIT_COMPANY` | `netTotal`, `paidAmount`, `settledAmountBySponsor` | One bill **per company per admission** |
+| **Admission aggregate** | Main `INWARD_FINAL_BILL` | `paidAmount`, `settledAmountBySponsor` | Total from **all CCs** for the admission |
+| **Encounter** | `PatientEncounter` | `creditPaidAmount` | Same total at encounter level |
+
+### CC Commitment Bills
+
+At finalization (`BhtSummeryController.saveCCBillForAllocation`), one `INWARD_FINAL_BILL_PAYMENT_BY_CREDIT_COMPANY`
+bill is created **per allocation**. A two-company admission produces two commitment bills:
+
+```
+Admission bill (INWARD_FINAL_BILL)  netTotal = 100,000
+  ├─ CC commitment bill A  (INWARD_FINAL_BILL_PAYMENT_BY_CREDIT_COMPANY)  netTotal = 70,000  creditCompany = Insurer A
+  └─ CC commitment bill B  (INWARD_FINAL_BILL_PAYMENT_BY_CREDIT_COMPANY)  netTotal = 30,000  creditCompany = Insurer B
+```
+
+Each commitment bill's `referenceBill` points back to the main `INWARD_FINAL_BILL`.
+
+---
+
+## Settlement Paths
+
+### Path 1 — CC Commitment Bill Based (recommended)
+
+**UI page**: `credit/credit_compnay_bill_payment_inward.xhtml`  
+**Controller method**: `CashRecieveBillController.settleCreditForInwardCreditCompanyPaymentBills()`  
+**Data load**: `selectInstitutionListenerInwardCC()` → `CreditBean.getUnpaidInwardCCBills()`
+
+Each bill item has:
+- `bill` = `INPATIENT_CREDIT_COMPANY_PAYMENT_RECEIVED`
+- `referenceBill` = **the specific CC commitment bill** ← critical link
+
+What gets updated on **payment**:
+- Per-CC commitment bill `paidAmount` ✅ via `updateReferanceBills()` + `updateSettlingCreditBillSettledValues()`
+- Per-CC commitment bill `settledAmountBySponsor` ✅ via `updateSettlingCreditBillSettledValues()`
+- Main final bill `paidAmount` + `settledAmountBySponsor` ✅ via `updateInwardDipositList()`
+
+What gets updated on **cancellation** (`CreditCompanyBillSearch.cancelCreditCompanyPaymentBill()`):
+- Per-CC commitment bill `paidAmount` ✅ via `cancelBillItems()` → `updateReferenceBill()` → `CreditBean.getSettledAmountByCompany()` (DB recalculation)
+- Main final bill ✅ via `updateInwardDipositList()`
+- Encounter `creditPaidAmount` ✅ via `CreditCompanyBillSearch.updateReferenceBht()`
+
+### Path 2 — BHT (Encounter) Based
+
+**UI page**: `credit/credit_compnay_bill_inward_all.xhtml`  
+**Controller method**: `CashRecieveBillController.settleBillBht()`  
+**Data load**: `selectInstitutionListenerBht()` → `AdmissionController.getCreditPaymentBillsBht()`
+
+Each bill item has:
+- `bill` = `INPATIENT_CREDIT_COMPANY_PAYMENT_RECEIVED`
+- `referenceBill` = **the specific CC commitment bill** ✅ (set via `setReferenceBill(b)` — see fix below)
+
+> **Historical note (pre-fix):** Before issue #19771, `selectInstitutionListenerBht` called
+> `setBill(b)` but never `setReferenceBill(b)`, leaving `referenceBill = null`. This meant Path 2
+> payments never updated the per-CC commitment bills. The fix added `setReferenceBill(b)` to align
+> Path 2 with Path 1.
+
+What gets updated on **payment** (post-fix):
+- Per-CC commitment bill `paidAmount` ✅ via `saveBillItemBht()` → `updateReferenceBht()` → `updateSettlingCreditBillSettledValues()`
+- Main final bill `paidAmount` + `settledAmountBySponsor` ✅ via `updateInwardDipositList()`
+
+What gets updated on **cancellation** (post-fix):
+- Per-CC commitment bill `paidAmount` ✅ via `cancelBillItems()` → `updateReferenceBill()`
+- Main final bill ✅ via `updateInwardDipositList()`
+- Encounter `creditPaidAmount` ✅ via `CreditCompanyBillSearch.updateReferenceBht()`
+
+---
+
+## The `getSettledAmountByCompany` Calculation
+
+`CreditBean.getSettledAmountByCompany(Bill ccCommitmentBill)` is the authoritative way to calculate
+how much a CC has paid for a specific commitment bill. It sums `BillItem.netValue` for all items where:
+- `retired = false`
+- `referenceBill = ccCommitmentBill`
+- `bill.billTypeAtomic IN` all types with `CountedServiceType.CREDIT_SETTLE_BY_COMPANY`
+
+Because cancellation bill types (`INPATIENT_CREDIT_COMPANY_PAYMENT_CANCELLATION`) also have
+`CountedServiceType.CREDIT_SETTLE_BY_COMPANY`, and their items have **negative** `netValue`
+(via `invertValue`), they naturally subtract from the total. The net result is always accurate
+regardless of how many payments or cancellations have occurred.
+
+---
+
+## Debtor Report Pattern (Issue #19771)
+
+### Problem
+
+`InwardReportController1.inwardCreditCompanyDebtors()` showed the "Total Paid" and "Settled by Company"
+columns from **stored** `paidAmount`/`settledAmountBySponsor` on the CC commitment bills. These stored
+values were:
+- Never updated for Path 2 (pre-fix)
+- Potentially stale after cancellation due to transaction timing
+
+### Fix
+
+The report now **recalculates per bill** using `BillItemFacade.findDoubleByJpql` with the same
+`CREDIT_SETTLE_BY_COMPANY` type list used by `getSettledAmountByCompany`. This is the same pattern
+applied to the BHT credit settlement report in issue #19772.
+
+Key points:
+1. The `outstandingOnly` SQL filter was moved from JPQL (where it used the stale stored `paidAmount`)
+   to a post-calculation Java filter using the freshly computed value.
+2. The computed `paidAmount` and `settledAmountBySponsor` are set **in memory** on the detached bill
+   entities — they are never persisted back.
+3. The approach is robust: includes both received and cancellation items, signed values naturally
+   offset, and is independent of stored fields.
+
+```java
+// Pattern for per-bill dynamic settlement calculation
+List<BillTypeAtomic> settlementTypes =
+    BillTypeAtomic.findByCountedServiceType(CountedServiceType.CREDIT_SETTLE_BY_COMPANY);
+
+for (Bill b : allBills) {
+    String settledSql = "Select sum(bi.netValue) from BillItem bi "
+        + " where bi.retired=false "
+        + " and bi.referenceBill=:bill "
+        + " and bi.bill.billTypeAtomic in :types";
+    Map<String, Object> params = new HashMap<>();
+    params.put("bill", b);
+    params.put("types", settlementTypes);
+    double settled = BillItemFacade.findDoubleByJpql(settledSql, params);
+    b.setPaidAmount(settled);
+    b.setSettledAmountBySponsor(settled);
+    // ... apply outstandingOnly filter, accumulate totals
+}
+```
+
+---
+
+## Related Files
+
+| File | Role |
+|---|---|
+| `bean/inward/BhtSummeryController.java` | Creates CC commitment bills at finalization |
+| `bean/common/CashRecieveBillController.java` | Processes CC payments (both paths) |
+| `bean/common/CreditCompanyBillSearch.java` | Cancellation logic |
+| `bean/common/BillBeanController.java` | `updateInwardDipositList()` — updates main final bill |
+| `ejb/CreditBean.java` | `getSettledAmountByCompany()` — authoritative settlement calculation |
+| `bean/inward/InwardReportController1.java` | Debtor report controller |
+| `webapp/credit/credit_compnay_bill_payment_inward.xhtml` | Path 1 settlement UI |
+| `webapp/credit/credit_compnay_bill_inward_all.xhtml` | Path 2 settlement UI |
+| `webapp/credit/inward_credit_company_debtor_report.xhtml` | Debtor report UI |
+
+---
+
+## Related Issues
+
+- **#19771** — Debtor report not reflecting cancelled CC payments → report fix + Path 2 `referenceBill` fix
+- **#19772** — BHT credit settlement report not reflecting cancelled CC payments → signed netValue fix in `BhtPaymentSummaryReportController`

--- a/src/main/java/com/divudi/bean/common/CashRecieveBillController.java
+++ b/src/main/java/com/divudi/bean/common/CashRecieveBillController.java
@@ -254,6 +254,7 @@ public class CashRecieveBillController implements Serializable {
             getCurrentBillItem().setPatientEncounter(b.getPatientEncounter());
             getCurrentBillItem().setNetValue(b.getNetTotal());
             getCurrentBillItem().getPatientEncounter().setCreditCompany(b.getCreditCompany());
+            getCurrentBillItem().setReferenceBill(b);
             getCurrentBillItem().setBill(b);
 //            selectBhtListener();
             addToBht();

--- a/src/main/java/com/divudi/bean/inward/InwardReportController1.java
+++ b/src/main/java/com/divudi/bean/inward/InwardReportController1.java
@@ -8,6 +8,7 @@ package com.divudi.bean.inward;
 import com.divudi.bean.common.PriceMatrixController;
 import com.divudi.core.data.BillType;
 import com.divudi.core.data.BillTypeAtomic;
+import com.divudi.core.data.CountedServiceType;
 import com.divudi.core.data.FeeType;
 import com.divudi.core.data.PaymentMethod;
 import com.divudi.core.data.inward.InwardChargeType;
@@ -2938,10 +2939,8 @@ public class InwardReportController1 implements Serializable {
             sql += " and b.patientEncounter.paymentMethod=:pm ";
             hm.put("pm", paymentMethod);
         }
-        if (outstandingOnly) {
-            sql += " and (abs(b.netTotal) - abs(b.paidAmount)) > :minVal ";
-            hm.put("minVal", 0.01);
-        }
+        // Note: outstandingOnly filter is applied in Java after recalculating settled amounts
+        // dynamically, so it reflects the true outstanding balance including any cancellations.
 
         sql += " order by b.creditCompany.name, b.billDate ";
 
@@ -2949,15 +2948,41 @@ public class InwardReportController1 implements Serializable {
         hm.put("frm", getFromDate());
         hm.put("to", getToDate());
 
-        bills = billFacade.findByJpql(sql, hm, TemporalType.TIMESTAMP);
+        List<Bill> allBills = billFacade.findByJpql(sql, hm, TemporalType.TIMESTAMP);
+
+        // Recalculate settled amounts per CC commitment bill dynamically from BillItems.
+        // This includes both RECEIVED (positive netValue) and CANCELLATION (negative netValue)
+        // bill types, so cancellations are naturally subtracted without relying on the stored
+        // paidAmount/settledAmountBySponsor fields which may be stale after a cancellation.
+        List<BillTypeAtomic> settlementTypes =
+                BillTypeAtomic.findByCountedServiceType(CountedServiceType.CREDIT_SETTLE_BY_COMPANY);
 
         debtorBillTotal = 0;
         debtorPaidTotal = 0;
         debtorOutstandingTotal = 0;
-        for (Bill b : bills) {
+        bills = new ArrayList<>();
+
+        for (Bill b : allBills) {
+            String settledSql = "Select sum(bi.netValue) from BillItem bi "
+                    + " where bi.retired=false "
+                    + " and bi.referenceBill=:bill "
+                    + " and bi.bill.billTypeAtomic in :types";
+            HashMap<String, Object> settledParams = new HashMap<>();
+            settledParams.put("bill", b);
+            settledParams.put("types", settlementTypes);
+            double settled = BillItemFacade.findDoubleByJpql(settledSql, settledParams);
+            b.setPaidAmount(settled);
+            b.setSettledAmountBySponsor(settled);
+
+            double outstanding = b.getNetTotal() - settled;
+            if (outstandingOnly && outstanding <= 0.01) {
+                continue;
+            }
+
+            bills.add(b);
             debtorBillTotal += b.getNetTotal();
-            debtorPaidTotal += b.getPaidAmount();
-            debtorOutstandingTotal += (b.getNetTotal() - b.getPaidAmount());
+            debtorPaidTotal += settled;
+            debtorOutstandingTotal += outstanding;
         }
     }
 


### PR DESCRIPTION
## Summary

- **Debtor report fix**: `InwardReportController1.inwardCreditCompanyDebtors()` was reading stored `paidAmount` from CC commitment bills, which became stale after cancellations. The method now dynamically recalculates settled amount per bill by summing `BillItem.netValue` for all items with `CREDIT_SETTLE_BY_COMPANY` types referencing each bill. Because cancellation bill types share the same `CountedServiceType` and carry negative `netValue`, they naturally subtract from the total. The `outstandingOnly` filter was moved from JPQL (stale stored value) to a post-calculation Java guard (fresh computed value).
- **Path 2 root-cause fix**: `CashRecieveBillController.selectInstitutionListenerBht()` was calling `setBill(b)` without `setReferenceBill(b)`. This left `referenceBill = null` on all BHT-path bill items, causing `updateReferenceBht` to skip updating the per-CC commitment bill's `paidAmount` on both payment and cancellation.
- **Developer doc**: Added `developer_docs/billing/inward-cc-settlement-tracking.md` covering the three-level data model, both settlement paths, the cancellation flow, and the dynamic recalculation pattern. Linked from `CLAUDE.md`.

## Test plan

- [ ] Run debtor report after posting and then cancelling a CC payment via Path 1 (`credit_compnay_bill_payment_inward.xhtml`) — verify outstanding balance updates correctly
- [ ] Run debtor report after posting and then cancelling a CC payment via Path 2 (`credit_compnay_bill_inward_all.xhtml`) — verify outstanding balance updates correctly
- [ ] Check `outstandingOnly` filter: fully-paid bills must be excluded, partially-paid bills must appear
- [ ] Verify multi-CC admissions (two companies) show correct per-company outstanding amounts

Closes #19771

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Corrected settlement amount calculations in the inpatient credit company debtor report to ensure outstanding balances accurately reflect payment and cancellation transactions across multiple settlement paths.

* **Documentation**
  * Added developer documentation for inpatient credit company settlement tracking, covering data model, settlement flows, and cancellation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->