### PR TITLE
Replace jasypt URL tokens with HMAC-SHA256 for bill notification links

### DIFF
--- a/src/main/java/com/divudi/bean/common/BillSearch.java
+++ b/src/main/java/com/divudi/bean/common/BillSearch.java
@@ -626,34 +626,48 @@ public class BillSearch implements Serializable, ControllerWithMultiplePayments 
         if (encryptedPatientReportId == null) {
             return;
         }
-        if (encryptedExpiary != null) {
-            Date expiaryDate;
-            try {
-                String ed = encryptedExpiary;
-                ed = securityController.decrypt(ed);
-                if (ed == null) {
+        if (encryptedPatientReportId.startsWith("hmac.")) {
+            // New HMAC-SHA256 path — token embeds both bill ID and expiry
+            String hmacKey = sessionController.getApplicationPreference().getEncrptionKey();
+            if (hmacKey == null || hmacKey.trim().isEmpty()) {
+                return;
+            }
+            long[] decoded = securityController.decodeBillToken(encryptedPatientReportId, hmacKey);
+            if (decoded == null) {
+                return;
+            }
+            if (new Date().getTime() > decoded[1]) {
+                return; // link expired
+            }
+            bill = getBillFacade().find(decoded[0]);
+        } else {
+            // TODO: Remove this legacy block after 2026-07-09.
+            // Backward compatibility for links sent before HMAC migration (issue #19863).
+            // Old links have a 1-month TTL so none will be valid after that date.
+            if (encryptedExpiary != null) {
+                Date expiaryDate;
+                try {
+                    String ed = securityController.decrypt(encryptedExpiary);
+                    if (ed == null) {
+                        return;
+                    }
+                    expiaryDate = new SimpleDateFormat("ddMMMMyyyyhhmmss").parse(ed);
+                } catch (ParseException ex) {
                     return;
                 }
-                expiaryDate = new SimpleDateFormat("ddMMMMyyyyhhmmss").parse(ed);
-            } catch (ParseException ex) {
+                if (expiaryDate.before(new Date())) {
+                    return;
+                }
+            }
+            String idStr = getSecurityController().decrypt(encryptedPatientReportId);
+            Long id = 0L;
+            try {
+                id = Long.parseLong(idStr);
+            } catch (Exception e) {
                 return;
             }
-            if (expiaryDate.before(new Date())) {
-                return;
-            }
+            bill = getBillFacade().find(id);
         }
-        String idStr = getSecurityController().decrypt(encryptedPatientReportId);
-        Long id = 0l;
-        try {
-            id = Long.parseLong(idStr);
-        } catch (Exception e) {
-            return;
-        }
-        Bill pr = getBillFacade().find(id);
-        if (pr == null) {
-            return;
-        }
-        bill = pr;
     }
 
     public void fillBillTypeSummery() {

--- a/src/main/java/com/divudi/bean/common/NotificationController.java
+++ b/src/main/java/com/divudi/bean/common/NotificationController.java
@@ -277,20 +277,20 @@ public class NotificationController implements Serializable {
         Calendar c = Calendar.getInstance();
         c.add(Calendar.MONTH, 1);
 
-        String temId = bill.getId() + "";
-        temId = securityController.encrypt(temId);
-        try {
-            temId = URLEncoder.encode(temId, "UTF-8");
-        } catch (UnsupportedEncodingException ignored) {
+        String hmacKey = sessionController.getApplicationPreference().getEncrptionKey();
+        if (hmacKey == null || hmacKey.trim().isEmpty()) {
+            hmacKey = securityController.generateRandomKey(32);
+            sessionController.getApplicationPreference().setEncrptionKey(hmacKey);
+            sessionController.savePreferences(sessionController.getApplicationPreference());
         }
-
-        String ed = CommonFunctions.getDateFormat(c.getTime(), sessionController.getApplicationPreference().getLongDateFormat());
-        ed = securityController.encrypt(ed);
+        String token = securityController.createBillToken(bill.getId(), c.getTime(), hmacKey);
+        String encodedToken;
         try {
-            ed = URLEncoder.encode(ed, "UTF-8");
+            encodedToken = URLEncoder.encode(token, "UTF-8");
         } catch (UnsupportedEncodingException ignored) {
+            encodedToken = token;
         }
-        String url = CommonFunctions.getBaseUrl() + "faces/requests/bill.xhtml?id=" + temId + "&user=" + ed;
+        String url = CommonFunctions.getBaseUrl() + "faces/requests/bill.xhtml?id=" + encodedToken;
         messageBody += "<p>"
                 + "Your Report is attached"
                 + "<br/>"
@@ -353,20 +353,20 @@ public class NotificationController implements Serializable {
         Calendar c = Calendar.getInstance();
         c.add(Calendar.MONTH, 1);
 
-        String temId = bill.getId() + "";
-        temId = securityController.encrypt(temId);
-        try {
-            temId = URLEncoder.encode(temId, "UTF-8");
-        } catch (UnsupportedEncodingException ex) {
+        String hmacKey2 = sessionController.getApplicationPreference().getEncrptionKey();
+        if (hmacKey2 == null || hmacKey2.trim().isEmpty()) {
+            hmacKey2 = securityController.generateRandomKey(32);
+            sessionController.getApplicationPreference().setEncrptionKey(hmacKey2);
+            sessionController.savePreferences(sessionController.getApplicationPreference());
         }
-
-        String ed = CommonFunctions.getDateFormat(c.getTime(), sessionController.getApplicationPreference().getLongDateFormat());
-        ed = securityController.encrypt(ed);
+        String token2 = securityController.createBillToken(bill.getId(), c.getTime(), hmacKey2);
+        String encodedToken2;
         try {
-            ed = URLEncoder.encode(ed, "UTF-8");
+            encodedToken2 = URLEncoder.encode(token2, "UTF-8");
         } catch (UnsupportedEncodingException ignored) {
+            encodedToken2 = token2;
         }
-        String url = CommonFunctions.getBaseUrl() + "faces/requests/bill.xhtml?id=" + temId + "&user=" + ed;
+        String url = CommonFunctions.getBaseUrl() + "faces/requests/bill.xhtml?id=" + encodedToken2;
         messageBody += "<p>"
                 + "Your Report is attached"
                 + "<br/>"

--- a/src/main/java/com/divudi/bean/common/NotificationController.java
+++ b/src/main/java/com/divudi/bean/common/NotificationController.java
@@ -277,13 +277,7 @@ public class NotificationController implements Serializable {
         Calendar c = Calendar.getInstance();
         c.add(Calendar.MONTH, 1);
 
-        String hmacKey = sessionController.getApplicationPreference().getEncrptionKey();
-        if (hmacKey == null || hmacKey.trim().isEmpty()) {
-            hmacKey = securityController.generateRandomKey(32);
-            sessionController.getApplicationPreference().setEncrptionKey(hmacKey);
-            sessionController.savePreferences(sessionController.getApplicationPreference());
-        }
-        String token = securityController.createBillToken(bill.getId(), c.getTime(), hmacKey);
+        String token = securityController.createBillToken(bill.getId(), c.getTime(), securityController.obtainHmacSigningKey(sessionController));
         String encodedToken;
         try {
             encodedToken = URLEncoder.encode(token, "UTF-8");
@@ -353,13 +347,7 @@ public class NotificationController implements Serializable {
         Calendar c = Calendar.getInstance();
         c.add(Calendar.MONTH, 1);
 
-        String hmacKey2 = sessionController.getApplicationPreference().getEncrptionKey();
-        if (hmacKey2 == null || hmacKey2.trim().isEmpty()) {
-            hmacKey2 = securityController.generateRandomKey(32);
-            sessionController.getApplicationPreference().setEncrptionKey(hmacKey2);
-            sessionController.savePreferences(sessionController.getApplicationPreference());
-        }
-        String token2 = securityController.createBillToken(bill.getId(), c.getTime(), hmacKey2);
+        String token2 = securityController.createBillToken(bill.getId(), c.getTime(), securityController.obtainHmacSigningKey(sessionController));
         String encodedToken2;
         try {
             encodedToken2 = URLEncoder.encode(token2, "UTF-8");

--- a/src/main/java/com/divudi/bean/common/SecurityController.java
+++ b/src/main/java/com/divudi/bean/common/SecurityController.java
@@ -10,6 +10,7 @@ package com.divudi.bean.common;
 import java.io.Serializable;
 import java.nio.charset.StandardCharsets;
 import java.security.InvalidKeyException;
+import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.Base64;
 import java.util.Date;
@@ -258,13 +259,38 @@ public class SecurityController implements Serializable {
             long billId = Long.parseLong(parts[0]);
             long expiryEpoch = Long.parseLong(parts[1]);
             String expectedSig = computeHmacSha256(parts[0] + "." + parts[1], hmacKey);
-            if (expectedSig == null || !expectedSig.equals(parts[2])) {
+            if (expectedSig == null) {
+                return null;
+            }
+            // Use constant-time comparison to prevent timing side-channel attacks
+            byte[] expectedBytes = Base64.getUrlDecoder().decode(expectedSig);
+            byte[] providedBytes = Base64.getUrlDecoder().decode(parts[2]);
+            if (!MessageDigest.isEqual(expectedBytes, providedBytes)) {
                 return null;
             }
             return new long[]{billId, expiryEpoch};
-        } catch (NumberFormatException e) {
+        } catch (NumberFormatException | IllegalArgumentException e) {
             return null;
         }
+    }
+
+    /**
+     * Returns the HMAC signing key from ApplicationPreference, generating and
+     * persisting a new 32-character random key if none exists yet.
+     * Use this in preference to inline get-or-generate logic to keep key
+     * management centralised.
+     *
+     * @param sessionController the caller's session controller
+     * @return the signing key; never null or empty
+     */
+    public String obtainHmacSigningKey(SessionController sessionController) {
+        String key = sessionController.getApplicationPreference().getEncrptionKey();
+        if (key == null || key.trim().isEmpty()) {
+            key = generateRandomKey(32);
+            sessionController.getApplicationPreference().setEncrptionKey(key);
+            sessionController.savePreferences(sessionController.getApplicationPreference());
+        }
+        return key;
     }
 
     private String computeHmacSha256(String data, String key) {

--- a/src/main/java/com/divudi/bean/common/SecurityController.java
+++ b/src/main/java/com/divudi/bean/common/SecurityController.java
@@ -8,6 +8,13 @@
 package com.divudi.bean.common;
 
 import java.io.Serializable;
+import java.nio.charset.StandardCharsets;
+import java.security.InvalidKeyException;
+import java.security.NoSuchAlgorithmException;
+import java.util.Base64;
+import java.util.Date;
+import javax.crypto.Mac;
+import javax.crypto.spec.SecretKeySpec;
 import javax.enterprise.context.SessionScoped;
 import javax.inject.Named;
 import org.jasypt.util.password.BasicPasswordEncryptor;
@@ -198,6 +205,76 @@ public class SecurityController implements Serializable {
         try {
             return en.decrypt(word);
         } catch (Exception ex) {
+            return null;
+        }
+    }
+
+    /**
+     * Creates a tamper-proof, self-expiring HMAC-SHA256 token for bill
+     * notification URLs. Replaces the legacy jasypt encrypt/decrypt pair that
+     * used a hardcoded key.
+     *
+     * Token format: "hmac.{billId}.{expiryEpochMs}.{base64url_signature}"
+     *
+     * @param billId   the bill database ID to embed
+     * @param expiry   when the link should stop working
+     * @param hmacKey  the signing key (from ApplicationPreference.encrptionKey)
+     * @return the URL-safe token string, or null if hmacKey is blank
+     */
+    public String createBillToken(long billId, Date expiry, String hmacKey) {
+        if (hmacKey == null || hmacKey.trim().isEmpty()) {
+            return null;
+        }
+        long expiryEpoch = expiry.getTime();
+        String payload = billId + "." + expiryEpoch;
+        String signature = computeHmacSha256(payload, hmacKey);
+        if (signature == null) {
+            return null;
+        }
+        return "hmac." + payload + "." + signature;
+    }
+
+    /**
+     * Verifies and decodes an HMAC bill token produced by
+     * {@link #createBillToken}.
+     *
+     * @param token    the raw token string (already URL-decoded)
+     * @param hmacKey  the signing key (from ApplicationPreference.encrptionKey)
+     * @return long[]{billId, expiryEpochMs} if the signature is valid, or null
+     *         if the token is missing, malformed, or tampered
+     */
+    public long[] decodeBillToken(String token, String hmacKey) {
+        if (token == null || hmacKey == null || hmacKey.trim().isEmpty()) {
+            return null;
+        }
+        if (!token.startsWith("hmac.")) {
+            return null;
+        }
+        String[] parts = token.substring(5).split("\\.", 3);
+        if (parts.length != 3) {
+            return null;
+        }
+        try {
+            long billId = Long.parseLong(parts[0]);
+            long expiryEpoch = Long.parseLong(parts[1]);
+            String expectedSig = computeHmacSha256(parts[0] + "." + parts[1], hmacKey);
+            if (expectedSig == null || !expectedSig.equals(parts[2])) {
+                return null;
+            }
+            return new long[]{billId, expiryEpoch};
+        } catch (NumberFormatException e) {
+            return null;
+        }
+    }
+
+    private String computeHmacSha256(String data, String key) {
+        try {
+            Mac mac = Mac.getInstance("HmacSHA256");
+            SecretKeySpec secretKey = new SecretKeySpec(key.getBytes(StandardCharsets.UTF_8), "HmacSHA256");
+            mac.init(secretKey);
+            byte[] rawHmac = mac.doFinal(data.getBytes(StandardCharsets.UTF_8));
+            return Base64.getUrlEncoder().withoutPadding().encodeToString(rawHmac);
+        } catch (NoSuchAlgorithmException | InvalidKeyException e) {
             return null;
         }
     }

--- a/src/main/java/com/divudi/bean/common/SecurityController.java
+++ b/src/main/java/com/divudi/bean/common/SecurityController.java
@@ -269,7 +269,7 @@ public class SecurityController implements Serializable {
                 return null;
             }
             return new long[]{billId, expiryEpoch};
-        } catch (NumberFormatException | IllegalArgumentException e) {
+        } catch (IllegalArgumentException e) {
             return null;
         }
     }

--- a/src/main/java/com/divudi/bean/lab/PatientReportController.java
+++ b/src/main/java/com/divudi/bean/lab/PatientReportController.java
@@ -387,7 +387,9 @@ public class PatientReportController implements Serializable {
         } else {
             // TODO: Remove this legacy block after 2026-07-09.
             // Backward compatibility for links sent before HMAC migration (issue #19863).
-            // Old links have a 1-month TTL so none will be valid after that date.
+            // All link generators in this class now emit HMAC tokens, so no new legacy
+            // links are created. Old links had a 1-month TTL so none will be valid after
+            // that date.
             if (encryptedExpiary != null) {
                 Date expiaryDate;
                 try {
@@ -1522,21 +1524,14 @@ public class PatientReportController implements Serializable {
         Calendar c = Calendar.getInstance();
         c.add(Calendar.MONTH, 1);
 
-        String temId = currentPatientReport.getId() + "";
-        temId = getSecurityController().encrypt(temId);
+        String emailToken = getSecurityController().createBillToken(currentPatientReport.getId(), c.getTime(), getSecurityController().obtainHmacSigningKey(sessionController));
+        String encodedEmailToken;
         try {
-            temId = URLEncoder.encode(temId, "UTF-8");
+            encodedEmailToken = URLEncoder.encode(emailToken, "UTF-8");
         } catch (UnsupportedEncodingException ex) {
+            encodedEmailToken = emailToken;
         }
-
-        String ed = CommonFunctions.getDateFormat(c.getTime(), "ddMMMMyyyyhhmmss");
-        ed = getSecurityController().encrypt(ed);
-        try {
-            ed = URLEncoder.encode(ed, "UTF-8");
-        } catch (UnsupportedEncodingException ex) {
-        }
-
-        String url = CommonFunctions.getBaseUrl() + "faces/requests/report.xhtml?id=" + temId + "&user=" + ed;
+        String url = CommonFunctions.getBaseUrl() + "faces/requests/report.xhtml?id=" + encodedEmailToken;
         b += "<p>"
                 + "Your Report is attached"
                 + "<br/>"
@@ -1621,21 +1616,14 @@ public class PatientReportController implements Serializable {
         Calendar c = Calendar.getInstance();
         c.add(Calendar.MONTH, 1);
 
-        String temId = currentPatientReport.getId() + "";
-        temId = getSecurityController().encrypt(temId);
+        String cancelToken = getSecurityController().createBillToken(currentPatientReport.getId(), c.getTime(), getSecurityController().obtainHmacSigningKey(sessionController));
+        String encodedCancelToken;
         try {
-            temId = URLEncoder.encode(temId, "UTF-8");
+            encodedCancelToken = URLEncoder.encode(cancelToken, "UTF-8");
         } catch (UnsupportedEncodingException ex) {
+            encodedCancelToken = cancelToken;
         }
-
-        String ed = CommonFunctions.getDateFormat(c.getTime(), "ddMMMMyyyyhhmmss");
-        ed = getSecurityController().encrypt(ed);
-        try {
-            ed = URLEncoder.encode(ed, "UTF-8");
-        } catch (UnsupportedEncodingException ex) {
-        }
-
-        String url = CommonFunctions.getBaseUrl() + "faces/requests/report.xhtml?id=" + temId + "&user=" + ed;
+        String url = CommonFunctions.getBaseUrl() + "faces/requests/report.xhtml?id=" + encodedCancelToken;
         b += "<p>"
                 + "The report before reversing approval is attached. The current report can be viewed at following link"
                 + "<br/>"
@@ -1766,37 +1754,20 @@ public class PatientReportController implements Serializable {
     public String generateQrCodeLink(PatientReport r) {
         Calendar c = Calendar.getInstance();
         c.add(Calendar.MONTH, 1);
-        String temId = currentPatientReport.getId() + "";
-        temId = getSecurityController().encrypt(temId);
+        String qrToken = getSecurityController().createBillToken(currentPatientReport.getId(), c.getTime(), getSecurityController().obtainHmacSigningKey(sessionController));
+        String encodedQrToken;
         try {
-            temId = URLEncoder.encode(temId, "UTF-8");
+            encodedQrToken = URLEncoder.encode(qrToken, "UTF-8");
         } catch (UnsupportedEncodingException ex) {
+            encodedQrToken = qrToken;
         }
-        String ed = CommonFunctions.getDateFormat(c.getTime(), "ddMMMMyyyyhhmmss");
-        ed = getSecurityController().encrypt(ed);
-        try {
-            ed = URLEncoder.encode(ed, "UTF-8");
-        } catch (UnsupportedEncodingException ex) {
-        }
-        String url = CommonFunctions.getBaseUrl() + "faces/requests/report.xhtml?id=" + temId + "&user=" + ed;
-        return url;
+        return CommonFunctions.getBaseUrl() + "faces/requests/report.xhtml?id=" + encodedQrToken;
     }
 
     public String generateQrCodeDetails(PatientReport r) {
         if (r != null) {
             Calendar c = Calendar.getInstance();
             c.add(Calendar.MONTH, 1);
-
-            // Ensure currentPatientReport is not null
-            if (currentPatientReport != null) {
-                String temId = currentPatientReport.getId() + "";
-                temId = getSecurityController().encrypt(temId);
-                try {
-                    temId = URLEncoder.encode(temId, "UTF-8");
-                } catch (UnsupportedEncodingException ex) {
-                    // Handle the exception
-                }
-            }
 
             // Ensure all chained method calls do not result in null
             if (r.getPatientInvestigation() != null
@@ -1839,26 +1810,16 @@ public class PatientReportController implements Serializable {
                 }
 
                 // Construct the URL
-                String temId = ""; // Initialize temId
+                String qrDetailsToken = "";
                 if (currentPatientReport != null) {
-                    temId = currentPatientReport.getId() + "";
-                    temId = getSecurityController().encrypt(temId);
+                    String rawToken = getSecurityController().createBillToken(currentPatientReport.getId(), c.getTime(), getSecurityController().obtainHmacSigningKey(sessionController));
                     try {
-                        temId = URLEncoder.encode(temId, "UTF-8");
+                        qrDetailsToken = URLEncoder.encode(rawToken, "UTF-8");
                     } catch (UnsupportedEncodingException ex) {
-                        // Handle the exception
+                        qrDetailsToken = rawToken;
                     }
                 }
-
-                String ed = CommonFunctions.getDateFormat(c.getTime(), "ddMMMMyyyyhhmmss");
-                ed = getSecurityController().encrypt(ed);
-                try {
-                    ed = URLEncoder.encode(ed, "UTF-8");
-                } catch (UnsupportedEncodingException ex) {
-                    // Handle the exception
-                }
-
-                String url = CommonFunctions.getBaseUrl() + "faces/requests/report.xhtml?id=" + temId + "&user=" + ed;
+                String url = CommonFunctions.getBaseUrl() + "faces/requests/report.xhtml?id=" + qrDetailsToken;
 
                 // Create the QR code contents using the variables and URL
                 String qrCodeContents = "Patient Name: " + patientName + "\n"

--- a/src/main/java/com/divudi/bean/lab/PatientReportController.java
+++ b/src/main/java/com/divudi/bean/lab/PatientReportController.java
@@ -370,34 +370,52 @@ public class PatientReportController implements Serializable {
         if (encryptedPatientReportId == null) {
             return;
         }
-        if (encryptedExpiary != null) {
-            Date expiaryDate;
-            try {
-                String ed = encryptedExpiary;
-                ed = securityController.decrypt(ed);
-                if (ed == null) {
+        if (encryptedPatientReportId.startsWith("hmac.")) {
+            // New HMAC-SHA256 path — token embeds both report ID and expiry
+            String hmacKey = sessionController.getApplicationPreference().getEncrptionKey();
+            if (hmacKey == null || hmacKey.trim().isEmpty()) {
+                return;
+            }
+            long[] decoded = securityController.decodeBillToken(encryptedPatientReportId, hmacKey);
+            if (decoded == null) {
+                return;
+            }
+            if (new Date().getTime() > decoded[1]) {
+                return; // link expired
+            }
+            currentPatientReport = getFacade().find(decoded[0]);
+        } else {
+            // TODO: Remove this legacy block after 2026-07-09.
+            // Backward compatibility for links sent before HMAC migration (issue #19863).
+            // Old links have a 1-month TTL so none will be valid after that date.
+            if (encryptedExpiary != null) {
+                Date expiaryDate;
+                try {
+                    String ed = securityController.decrypt(encryptedExpiary);
+                    if (ed == null) {
+                        return;
+                    }
+                    expiaryDate = new SimpleDateFormat("ddMMMMyyyyhhmmss").parse(ed);
+                } catch (ParseException ex) {
                     return;
                 }
-                expiaryDate = new SimpleDateFormat("ddMMMMyyyyhhmmss").parse(ed);
-            } catch (ParseException ex) {
+                if (expiaryDate.before(new Date())) {
+                    return;
+                }
+            }
+            String idStr = getSecurityController().decrypt(encryptedPatientReportId);
+            Long id = 0L;
+            try {
+                id = Long.parseLong(idStr);
+            } catch (Exception e) {
                 return;
             }
-            if (expiaryDate.before(new Date())) {
+            PatientReport pr = getFacade().find(id);
+            if (pr == null) {
                 return;
             }
+            currentPatientReport = pr;
         }
-        String idStr = getSecurityController().decrypt(encryptedPatientReportId);
-        Long id = 0l;
-        try {
-            id = Long.parseLong(idStr);
-        } catch (Exception e) {
-            return;
-        }
-        PatientReport pr = getFacade().find(id);
-        if (pr == null) {
-            return;
-        }
-        currentPatientReport = pr;
     }
 
     public void preparePatientReportByIdForRequestsWithoutExpiary() {

--- a/src/main/java/com/divudi/bean/lab/PatientReportController.java
+++ b/src/main/java/com/divudi/bean/lab/PatientReportController.java
@@ -1524,7 +1524,7 @@ public class PatientReportController implements Serializable {
         Calendar c = Calendar.getInstance();
         c.add(Calendar.MONTH, 1);
 
-        String emailToken = getSecurityController().createBillToken(currentPatientReport.getId(), c.getTime(), getSecurityController().obtainHmacSigningKey(sessionController));
+        String emailToken = getSecurityController().createBillToken(r.getId(), c.getTime(), getSecurityController().obtainHmacSigningKey(sessionController));
         String encodedEmailToken;
         try {
             encodedEmailToken = URLEncoder.encode(emailToken, "UTF-8");
@@ -1616,7 +1616,7 @@ public class PatientReportController implements Serializable {
         Calendar c = Calendar.getInstance();
         c.add(Calendar.MONTH, 1);
 
-        String cancelToken = getSecurityController().createBillToken(currentPatientReport.getId(), c.getTime(), getSecurityController().obtainHmacSigningKey(sessionController));
+        String cancelToken = getSecurityController().createBillToken(r.getId(), c.getTime(), getSecurityController().obtainHmacSigningKey(sessionController));
         String encodedCancelToken;
         try {
             encodedCancelToken = URLEncoder.encode(cancelToken, "UTF-8");
@@ -1754,7 +1754,7 @@ public class PatientReportController implements Serializable {
     public String generateQrCodeLink(PatientReport r) {
         Calendar c = Calendar.getInstance();
         c.add(Calendar.MONTH, 1);
-        String qrToken = getSecurityController().createBillToken(currentPatientReport.getId(), c.getTime(), getSecurityController().obtainHmacSigningKey(sessionController));
+        String qrToken = getSecurityController().createBillToken(r.getId(), c.getTime(), getSecurityController().obtainHmacSigningKey(sessionController));
         String encodedQrToken;
         try {
             encodedQrToken = URLEncoder.encode(qrToken, "UTF-8");
@@ -1811,8 +1811,8 @@ public class PatientReportController implements Serializable {
 
                 // Construct the URL
                 String qrDetailsToken = "";
-                if (currentPatientReport != null) {
-                    String rawToken = getSecurityController().createBillToken(currentPatientReport.getId(), c.getTime(), getSecurityController().obtainHmacSigningKey(sessionController));
+                if (r != null) {
+                    String rawToken = getSecurityController().createBillToken(r.getId(), c.getTime(), getSecurityController().obtainHmacSigningKey(sessionController));
                     try {
                         qrDetailsToken = URLEncoder.encode(rawToken, "UTF-8");
                     } catch (UnsupportedEncodingException ex) {


### PR DESCRIPTION
## Summary

- Bill notification URLs (OPD cancellation emails/SMS) were signed with a hardcoded Jasypt symmetric key (`"health"`), making tokens forgeable by anyone who reads the source code
- Replaces encrypt/decrypt pair with **HMAC-SHA256** tokens signed by the per-installation key already stored in `ApplicationPreference.encrptionKey`
- New token format: `hmac.{billId}.{expiryEpochMs}.{base64url_signature}` — self-expiring, tamper-proof, no separate `&user=` expiry param needed
- No database migration required; the signing key already exists in every installation

## Files changed

| File | Change |
|---|---|
| `SecurityController.java` | Added `createBillToken()`, `decodeBillToken()`, `computeHmacSha256()` |
| `NotificationController.java` | Both OPD cancellation notification methods now use `createBillToken()` |
| `BillSearch.java` | `preparePatientReportByIdForRequests()` — HMAC path + legacy fallback |
| `PatientReportController.java` | `preparePatientReportByIdForRequests()` — same pattern |

## Backward compatibility

Old jasypt-encrypted links already sent are still valid via a legacy fallback block in both receivers. Both blocks carry:

```java
// TODO: Remove this legacy block after 2026-07-09.
// Backward compatibility for links sent before HMAC migration (issue #19863).
// Old links have a 1-month TTL so none will be valid after that date.
```

## Test plan

- [ ] Send an OPD bill cancellation notification and verify the link in the email/SMS opens the correct bill
- [ ] Verify an expired HMAC token (manually set past expiry) shows "No Such Bill Found"
- [ ] Verify a tampered token (modify a character in the signature) shows "No Such Bill Found"
- [ ] Confirm old-format links (jasypt-encrypted, `?id=...&user=...`) still work during the transition window

Closes #19863

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security**
  * Added HMAC-signed tokens for bill/report access links with expiry and signature validation.
  * Improved signing key management and safer token decoding.

* **Bug Fixes / UX**
  * Links (email/QR/cancel) now carry a single opaque token parameter, reducing exposed query parameters.

* **Refactor**
  * Dual support for new HMAC tokens and legacy links to preserve compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->