### PR TITLE
Security hardening: remove backdoor, fix CORS, reduce session timeout, hide stack traces

### DIFF
--- a/src/main/java/com/divudi/bean/common/SecurityController.java
+++ b/src/main/java/com/divudi/bean/common/SecurityController.java
@@ -177,10 +177,6 @@ public class SecurityController implements Serializable {
         return en.checkPassword(planePassword, encryptedPassword);
     }
 
-    public static boolean matchPassword(String planePassword, String encryptedPassword, boolean fake) {
-        return true;
-    }
-
     public String generateRandomKey(int length) {
         if (length <= 0) {
             throw new IllegalArgumentException("Length must be a positive number");

--- a/src/main/java/com/divudi/ws/channel/CorsResponseFilter.java
+++ b/src/main/java/com/divudi/ws/channel/CorsResponseFilter.java
@@ -21,7 +21,10 @@ public class CorsResponseFilter implements ContainerResponseFilter{
         responseContext.getHeaders().add("Access-Control-Allow-Origin", "*");
         responseContext.getHeaders().add("Access-Control-Allow-Methods", "GET, POST, PUT, DELETE, OPTIONS");
         responseContext.getHeaders().add("Access-Control-Allow-Headers", "Content-Type, Authorization, Finance");
-        responseContext.getHeaders().add("Access-Control-Allow-Credentials", "true");
         responseContext.getHeaders().add("Access-Control-Max-Age", "3600");
+        // Access-Control-Allow-Credentials is intentionally omitted: the REST API
+        // authenticates via the custom Finance header (API key), not cookies. Sending
+        // Allow-Credentials: true alongside Allow-Origin: * is invalid per the CORS
+        // spec and was rejected by browsers anyway (issue #19867).
     }
 }

--- a/src/main/webapp/WEB-INF/web.xml
+++ b/src/main/webapp/WEB-INF/web.xml
@@ -58,7 +58,7 @@
 
     <!-- Session Configuration -->
     <session-config>
-        <session-timeout>180</session-timeout> <!-- minutes -->
+        <session-timeout>60</session-timeout> <!-- minutes (reduced from 180 for patient data security, issue #19867) -->
     </session-config>
 
 

--- a/src/main/webapp/errorPages/generalError.xhtml
+++ b/src/main/webapp/errorPages/generalError.xhtml
@@ -45,34 +45,18 @@
                         <h5 class="mb-0">Error Information</h5>
                     </div>
                     <div class="card-body">
-                        <h:panelGrid columns="2" styleClass="table table-sm table-borderless w-100" 
+                        <h:panelGrid columns="2" styleClass="table table-sm table-borderless w-100"
                                      columnClasses="font-weight-bold text-right pr-3,text-left">
                             <h:outputText value="Error Time:" />
                             <h:outputText value="#{errorHandler.errorTimeWithTimezone}" styleClass="text-danger font-weight-bold" />
-                            
-                            <h:outputText value="Request URL:" />
-                            <h:outputText value="#{errorHandler.requestURI}" />
-                            
+
                             <h:outputText value="Status Code:" />
                             <h:outputText value="#{errorHandler.statusCode}" />
-                            
-                            <h:outputText value="Exception Type:" />
-                            <h:outputText value="#{errorHandler.exceptionType}" />
-                            
-                            <h:outputText value="Error Message:" />
-                            <h:outputText value="#{errorHandler.message}" />
-                            
-                            <h:outputText value="Exception Details:" />
-                            <h:outputText value="#{errorHandler.exception}" />
                         </h:panelGrid>
-                        
-                        <div class="mt-3">
-                            <h6 class="font-weight-bold">Complete Stack Trace:</h6>
-                            <div class="bg-light p-3 border rounded" style="max-height: 300px; overflow-y: auto;">
-                                <h:outputText value="#{errorHandler.stackTrace}" escape="false" 
-                                              style="white-space: pre-wrap; font-family: monospace; font-size: 12px;" />
-                            </div>
-                        </div>
+                        <!-- Exception type, message, and stack trace are intentionally not
+                             rendered here — they would expose internal class names and paths
+                             to unauthenticated users. Full details are written to the server
+                             log (issue #19867). -->
                     </div>
                 </div>
 


### PR DESCRIPTION
## Summary

Four low-risk security hardening items from audit issue #19863. No migration required, no database changes.

- **Remove authentication backdoor** — `matchPassword(String,String,boolean)` in `SecurityController` unconditionally returned `true`, bypassing password verification for any caller that passed a third argument. No callers found in the codebase; method deleted.

- **Fix CORS misconfiguration** — `CorsResponseFilter` was sending `Access-Control-Allow-Credentials: true` alongside `Access-Control-Allow-Origin: *`. This combination is invalid per the CORS spec and was already silently rejected by all browsers. Removed the credentials header; the REST API authenticates via the `Finance` API key header, not cookies.

- **Reduce session timeout** — `web.xml` session timeout reduced from 180 minutes to 60 minutes. Three-hour idle sessions are excessive for a system handling patient data.

- **Remove stack trace from error page** — `generalError.xhtml` was rendering exception type, error message, and the full stack trace directly in the browser response, visible to unauthenticated users. Removed; full details continue to be written to the Payara server log.

## Files changed

| File | Change |
|---|---|
| `SecurityController.java` | Deleted `matchPassword(String,String,boolean)` overload |
| `CorsResponseFilter.java` | Removed `Access-Control-Allow-Credentials: true` header |
| `web.xml` | Session timeout 180 → 60 minutes |
| `errorPages/generalError.xhtml` | Removed exception type, message, and stack trace output |

## Test plan

- [ ] Login with correct credentials still works
- [ ] Login with wrong credentials is correctly rejected
- [ ] REST API calls from a browser-based client still receive correct CORS headers
- [ ] After 60 minutes of inactivity, session correctly expires with redirect to timeout page
- [ ] Triggering a 500 error shows the generic error page without any stack trace or exception details

Closes #19867
Part of #19863

🤖 Generated with [Claude Code](https://claude.com/claude-code)