### PR TITLE
Fix: inward CC payment report not reflecting cancellations (#19770)

### DIFF
--- a/developer_docs/billing/inward-cc-settlement-tracking.md
+++ b/developer_docs/billing/inward-cc-settlement-tracking.md
@@ -143,6 +143,51 @@ for (Bill b : allBills) {
 
 ---
 
+## Payment Transaction Report Pattern (Issue #19770)
+
+### Problem
+
+`InwardReportController1.inwardCreditCompanyPayments()` fetched bill items using
+`b.bill.billTypeAtomic = INPATIENT_CREDIT_COMPANY_PAYMENT_RECEIVED` and `b.bill.cancelled = false`.
+This caused cancelled payments to remain visible in the report because relying on the `cancelled` flag
+alone is fragile (see billing cancellation query pattern in memory).
+
+Additionally, `totalInwardCreditCompanyPayments()` hardcoded `b.bill.createdAt` for the date range
+regardless of the `dateBasis` selected by the user (`createdAt`, `dischargeDate`, `admissionDate`),
+making the total inconsistent with the list when a non-default date basis was used.
+
+### Fix
+
+Both methods now:
+1. Query `b.bill.billTypeAtomic in :btas` with both `INPATIENT_CREDIT_COMPANY_PAYMENT_RECEIVED`
+   and `INPATIENT_CREDIT_COMPANY_PAYMENT_CANCELLATION`
+2. Drop the `b.bill.cancelled = false` filter
+3. Use `resolveDateField(dateBasis, ...)` for the date range in both the list and the total
+
+Cancellation bill items carry **negative** `netValue` (set by `invertValue()` in `cancelBillItems()`),
+so they naturally offset the matching received items in any SUM. The list shows both rows —
+the positive payment and the negative cancellation — which preserves the full audit trail.
+
+### Cross-Period Cancellation Behaviour
+
+This is expected and correct: if a payment is billed on day N and cancelled on day N+1, the
+day-N report shows a positive row and the day-(N+1) report shows a negative row. The total for
+each period is accurate as a ledger. Running totals over the full date range always net to zero
+for fully cancelled transactions.
+
+```java
+// Pattern used in inwardCreditCompanyPayments() and totalInwardCreditCompanyPayments()
+List<BillTypeAtomic> btas = new ArrayList<>();
+btas.add(BillTypeAtomic.INPATIENT_CREDIT_COMPANY_PAYMENT_RECEIVED);
+btas.add(BillTypeAtomic.INPATIENT_CREDIT_COMPANY_PAYMENT_CANCELLATION);
+hm.put("btas", btas);
+
+String dateField = resolveDateField(dateBasis, "b.bill.createdAt", "b.patientEncounter");
+// use dateField for both list and total queries — never hardcode b.bill.createdAt
+```
+
+---
+
 ## Related Files
 
 | File | Role |
@@ -152,14 +197,16 @@ for (Bill b : allBills) {
 | `bean/common/CreditCompanyBillSearch.java` | Cancellation logic |
 | `bean/common/BillBeanController.java` | `updateInwardDipositList()` — updates main final bill |
 | `ejb/CreditBean.java` | `getSettledAmountByCompany()` — authoritative settlement calculation |
-| `bean/inward/InwardReportController1.java` | Debtor report controller |
+| `bean/inward/InwardReportController1.java` | Payment + debtor report controller |
 | `webapp/credit/credit_compnay_bill_payment_inward.xhtml` | Path 1 settlement UI |
 | `webapp/credit/credit_compnay_bill_inward_all.xhtml` | Path 2 settlement UI |
 | `webapp/credit/inward_credit_company_debtor_report.xhtml` | Debtor report UI |
+| `webapp/credit/inward_credit_company_payment_report.xhtml` | Payment transaction report UI |
 
 ---
 
 ## Related Issues
 
+- **#19770** — Payment report not reflecting cancelled CC payments → RECEIVED+CANCELLATION types, drop `cancelled=false`, align total date field with dateBasis
 - **#19771** — Debtor report not reflecting cancelled CC payments → report fix + Path 2 `referenceBill` fix
 - **#19772** — BHT credit settlement report not reflecting cancelled CC payments → signed netValue fix in `BhtPaymentSummaryReportController`

--- a/src/main/java/com/divudi/bean/inward/InwardReportController1.java
+++ b/src/main/java/com/divudi/bean/inward/InwardReportController1.java
@@ -2992,8 +2992,7 @@ public class InwardReportController1 implements Serializable {
         String sql = "Select b from BillItem b "
                 + " where b.retired=false "
                 + " and b.bill.retired=false "
-                + " and b.bill.cancelled=false "
-                + " and b.bill.billTypeAtomic=:bta "
+                + " and b.bill.billTypeAtomic in :btas "
                 + " and " + dateField + " between :frm and :to ";
 
         if (institution != null) {
@@ -3023,7 +3022,10 @@ public class InwardReportController1 implements Serializable {
 
         sql += " order by b.referenceBill.creditCompany.name, b.bill.createdAt ";
 
-        hm.put("bta", BillTypeAtomic.INPATIENT_CREDIT_COMPANY_PAYMENT_RECEIVED);
+        List<BillTypeAtomic> btas = new ArrayList<>();
+        btas.add(BillTypeAtomic.INPATIENT_CREDIT_COMPANY_PAYMENT_RECEIVED);
+        btas.add(BillTypeAtomic.INPATIENT_CREDIT_COMPANY_PAYMENT_CANCELLATION);
+        hm.put("btas", btas);
         hm.put("frm", getFromDate());
         hm.put("to", getToDate());
 
@@ -3033,12 +3035,12 @@ public class InwardReportController1 implements Serializable {
 
     public Double totalInwardCreditCompanyPayments() {
         HashMap hm = new HashMap();
+        String dateField = resolveDateField(dateBasis, "b.bill.createdAt", "b.patientEncounter");
         String sql = "Select sum(b.netValue) from BillItem b "
                 + " where b.retired=false "
                 + " and b.bill.retired=false "
-                + " and b.bill.cancelled=false "
-                + " and b.bill.billTypeAtomic=:bta "
-                + " and b.bill.createdAt between :frm and :to ";
+                + " and b.bill.billTypeAtomic in :btas "
+                + " and " + dateField + " between :frm and :to ";
 
         if (institution != null) {
             sql += " and b.referenceBill.creditCompany=:cc ";
@@ -3065,7 +3067,10 @@ public class InwardReportController1 implements Serializable {
             hm.put("pm", paymentMethod);
         }
 
-        hm.put("bta", BillTypeAtomic.INPATIENT_CREDIT_COMPANY_PAYMENT_RECEIVED);
+        List<BillTypeAtomic> btas = new ArrayList<>();
+        btas.add(BillTypeAtomic.INPATIENT_CREDIT_COMPANY_PAYMENT_RECEIVED);
+        btas.add(BillTypeAtomic.INPATIENT_CREDIT_COMPANY_PAYMENT_CANCELLATION);
+        hm.put("btas", btas);
         hm.put("frm", getFromDate());
         hm.put("to", getToDate());
 


### PR DESCRIPTION
## Summary

- Replace single `INPATIENT_CREDIT_COMPANY_PAYMENT_RECEIVED` filter with both `RECEIVED` + `CANCELLATION` types in `inwardCreditCompanyPayments()` and `totalInwardCreditCompanyPayments()`
- Drop fragile `b.bill.cancelled = false` filter — cancellation items carry negative `netValue` via `invertValue()` and naturally offset received amounts
- Fix `totalInwardCreditCompanyPayments()` which hardcoded `b.bill.createdAt` for the date range regardless of the user-selected `dateBasis` — now uses `resolveDateField(dateBasis, ...)` to stay consistent with the list query
- Update `inward-cc-settlement-tracking.md` with cross-period cancellation behaviour and the payment report pattern

## Behaviour after fix

The list shows both payment rows (positive) and cancellation rows (negative), preserving the full audit trail. Cross-period cancellations (payment on day N, cancellation on day N+1) appear in their respective date-range reports as separate ledger entries — this is by design and matches established practice.

## Test plan

- [ ] Run the Inpatient Credit Company Payment Report for a date range that includes a paid-then-cancelled CC payment — verify the cancellation row appears with a negative amount and the footer total nets correctly
- [ ] Run the same report using "Discharge Date" and "Admission Date" basis — verify the total matches the displayed rows (previously the total used a different date field)
- [ ] Verify a date range containing only non-cancelled payments is unchanged

Closes #19770

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Inward credit company payment reports now include payment cancellations displayed as negative values for accurate ledger tracking.
  * Report date filtering now dynamically aligns with user-selected date basis across all calculations instead of using a fixed date field.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->