### PR TITLE
Fix TOCTOU race in deductFromStock that drives stock negative

### DIFF
--- a/src/main/java/com/divudi/ejb/PharmacyBean.java
+++ b/src/main/java/com/divudi/ejb/PharmacyBean.java
@@ -1471,7 +1471,16 @@ public class PharmacyBean {
 //                }
 //            }
 //        }
+        // Re-check stock against FRESH DB state to prevent TOCTOU races where
+        // the in-memory Stock (selected in the UI) is stale vs. the actual
+        // committed value. Without this guard, a stale Stock snapshot can
+        // drive a batch/department row into negative values — see issue in
+        // coop database where Cetapin XR 500mg batch 1528539 in OPD Pharmacy
+        // went to -144 on 2025-10-12 (bill COOPPHTI/664).
         stock = getStockFacade().findWithoutCache(stock.getId());
+        if (stock == null || stock.getStock() < qty) {
+            return false;
+        }
         stock.setStock(stock.getStock() - qty);
         getStockFacade().editAndCommit(stock);
         addToStockHistory(pbi, stock, d);
@@ -1490,7 +1499,11 @@ public class PharmacyBean {
         if (stock.getStock() < qty) {
             return false;
         }
+        // Re-check with fresh DB state (see deductFromStock for rationale).
         stock = getStockFacade().findWithoutCache(stock.getId());
+        if (stock == null || stock.getStock() < qty) {
+            return false;
+        }
         stock.setStock(stock.getStock() - qty);
         getStockFacade().editAndCommit(stock);
         return true;


### PR DESCRIPTION
## Summary
- Re-check stock sufficiency after `findWithoutCache` in `PharmacyBean.deductFromStock` and `deductFromStockWithoutHistory` so a stale in-memory `Stock` can no longer drive a `(batch, department)` row negative.
- Root cause: classic TOCTOU — the guard used the in-memory snapshot, the fresh DB read was then subtracted from without re-checking.
- Observed in coop: Cetapin XR 500mg batch 1528539 in OPD Pharmacy went to −144 on 2025-10-12 via bill `COOPPHTI/664`. 14 other stock rows in coop are currently negative from the same cause (listed in `tmp/cetapin-xr-negative-stock-report.md` on the investigation branch).

Closes #19874

## Test plan
- [ ] Transfer Issue: issue a batch that another session has just depleted — expect the line to fall back to qty 0 with the "stock was not sufficient" message instead of going negative.
- [ ] Pharmacy Sale / Direct Issue: same concurrency scenario, same expected behavior.
- [ ] Regression: normal (non-concurrent) transfer / issue / sale still deducts correctly.
- [ ] Verify `stockhistory` is only written when the deduction actually succeeds.