### PR TITLE
Fix: Institution, Site & Department filters missing in Timed Service Report

### DIFF
--- a/developer_docs/navigation/inward_navigation.md
+++ b/developer_docs/navigation/inward_navigation.md
@@ -309,7 +309,7 @@ Two parallel workflows exist:
 | `/inward/report_doctor_payment.xhtml` | Doctor payment report |
 | `/inward/report_doctor_payment_summery.xhtml` | Doctor payment summary |
 | `/inward/inward_report_room.xhtml` | Room income report |
-| `/inward/inward_report_timed_service.xhtml` | Timed service report |
+| `/inward/inward_report_timed_service.xhtml` | Timed service report | `InwardTimedItemController` | Filters: date range, timed item, **institution, site, department** (fixed #19715) |
 | `/inward/report_income_room.xhtml` | Room income |
 | `/inward/inward_report_discount.xhtml` | Discount report |
 | `/inward/pharmacy_report_bht_issue_by_item.xhtml` | Pharmacy BHT issue by item |
@@ -333,3 +333,21 @@ Key areas with multiple open issues:
 - **Surgery management on BHT** — #19317 (duplicate surgery, cannot remove)
 - **Pharmacy privileges** — #19309 (medicine amount privilege), #19312 (qty limits)
 - **Lab privileges** — #19319 (sample receive/reject not enforced)
+
+## Timed Service Report — Filter Pattern
+
+**Controller**: `InwardTimedItemController` (`@SessionScoped`)
+
+The timed service report (`inward_report_timed_service.xhtml`) supports the following filters, all optional:
+
+| Filter | Field | JPQL path |
+|---|---|---|
+| Date range | `frmDate` / `toDate` | `i.patientEncounter.dateOfDischarge between :fd and :td` |
+| Timed item | `current.item` | `i.item = :item` |
+| Institution | `institution` (`Institution`) | `i.patientEncounter.institution = :ins` |
+| Site | `site` (`Institution`) | `i.patientEncounter.department.site = :site` |
+| Department | `department` (`Department`) | `i.patientEncounter.department = :dept` |
+
+**Department dropdown** uses 4 rendered variants (same pattern as `AdmissionReportController`) — the list of selectable departments is narrowed based on which of institution/site is currently selected. Selecting institution or site triggers a `p:ajax` call to `clearDepartment()` so a stale department from the previous selection is not silently applied.
+
+**Site** is stored as `Institution` (not a separate entity). Sites are loaded via `institutionController.sites`.

--- a/src/main/java/com/divudi/bean/inward/InwardTimedItemController.java
+++ b/src/main/java/com/divudi/bean/inward/InwardTimedItemController.java
@@ -20,6 +20,8 @@ import com.divudi.core.entity.Bill;
 import com.divudi.core.entity.BillFee;
 import com.divudi.core.entity.BillItem;
 import com.divudi.core.entity.BilledBill;
+import com.divudi.core.entity.Department;
+import com.divudi.core.entity.Institution;
 import com.divudi.core.entity.Item;
 import com.divudi.core.entity.PatientEncounter;
 import com.divudi.core.entity.PatientItem;
@@ -92,6 +94,9 @@ public class InwardTimedItemController implements Serializable {
     Date toDate;
     double total;
     double totalMins;
+    private Institution institution;
+    private Institution site;
+    private Department department;
 
     public BillNumberGenerator getBillNumberBean() {
         return billNumberBean;
@@ -178,9 +183,23 @@ public class InwardTimedItemController implements Serializable {
                 + " and i.retired=false ";
 
         if (getCurrent().getItem() != null) {
-
             sql += " and i.item=:item";
             m.put("item", getCurrent().getItem());
+        }
+
+        if (institution != null) {
+            sql += " and i.patientEncounter.institution=:ins";
+            m.put("ins", institution);
+        }
+
+        if (site != null) {
+            sql += " and i.patientEncounter.department.site=:site";
+            m.put("site", site);
+        }
+
+        if (department != null) {
+            sql += " and i.patientEncounter.department=:dept";
+            m.put("dept", department);
         }
 
         m.put("fd", frmDate);
@@ -738,6 +757,34 @@ public class InwardTimedItemController implements Serializable {
 
     public void setTotalMins(double totalMins) {
         this.totalMins = totalMins;
+    }
+
+    public Institution getInstitution() {
+        return institution;
+    }
+
+    public void setInstitution(Institution institution) {
+        this.institution = institution;
+    }
+
+    public Institution getSite() {
+        return site;
+    }
+
+    public void setSite(Institution site) {
+        this.site = site;
+    }
+
+    public Department getDepartment() {
+        return department;
+    }
+
+    public void setDepartment(Department department) {
+        this.department = department;
+    }
+
+    public void clearDepartment() {
+        department = null;
     }
 
 }

--- a/src/main/webapp/inward/inward_report_timed_service.xhtml
+++ b/src/main/webapp/inward/inward_report_timed_service.xhtml
@@ -15,31 +15,91 @@
             <h:form  >
                 <p:panel >
 
-                    <p:panel class="mt-2" header="Timed Sevice" id="gpBillPreview">       
-                       
-                            <h:panelGrid columns="2">
-                                <h:outputLabel value="From" ></h:outputLabel>
-                                <p:calendar class="mx-4" id="fd" value="#{inwardTimedItemController.frmDate}" pattern="#{sessionController.applicationPreference.longDateTimeFormat}"  ></p:calendar>
-                                <h:outputLabel value="To" ></h:outputLabel>
-                                <p:calendar class="mx-4" id="td" value="#{inwardTimedItemController.toDate}" pattern="#{sessionController.applicationPreference.longDateTimeFormat}"  ></p:calendar>
-                                <h:outputLabel value="Timed Item" ></h:outputLabel>
-                                <p:autoComplete class="mx-4" id="it" forceSelection="false" 
+                    <p:panel class="mt-2" header="Timed Service" id="gpBillPreview">
+
+                            <h:panelGrid columns="4" styleClass="w-100 form-grid">
+                                <h:outputLabel value="From" />
+                                <p:calendar class="mx-4" id="fd" value="#{inwardTimedItemController.frmDate}" pattern="#{sessionController.applicationPreference.longDateTimeFormat}" />
+                                <h:outputLabel value="To" />
+                                <p:calendar class="mx-4" id="td" value="#{inwardTimedItemController.toDate}" pattern="#{sessionController.applicationPreference.longDateTimeFormat}" />
+
+                                <h:outputLabel value="Timed Item" />
+                                <p:autoComplete class="mx-4" id="it" forceSelection="false"
                                                 value="#{inwardTimedItemController.current.item}"
-                                                completeMethod="#{timedItemController.completeInvest}" var="ix" 
+                                                completeMethod="#{timedItemController.completeInvest}" var="ix"
                                                 itemLabel="#{ix.name}" itemValue="#{ix}" >
-                                    <p:column>
-                                        #{ix.name}
-                                    </p:column>
-                                    <p:column>
-                                        #{ix.total}
-                                    </p:column>
+                                    <p:column>#{ix.name}</p:column>
+                                    <p:column>#{ix.total}</p:column>
                                 </p:autoComplete>
-                               
-                                
+                                <h:panelGroup />
+                                <h:panelGroup />
+
+                                <!-- Institution -->
+                                <h:outputLabel value="Institution" for="cmbIns" />
+                                <p:selectOneMenu id="cmbIns" styleClass="mx-4 w-100 form-control"
+                                                value="#{inwardTimedItemController.institution}" filter="true">
+                                    <f:selectItem itemLabel="All Institutions" itemValue="#{null}" />
+                                    <f:selectItems value="#{institutionController.companies}" var="ins"
+                                                   itemLabel="#{ins.name}" itemValue="#{ins}" />
+                                    <p:ajax process="cmbIns" update="cmbDept"
+                                           listener="#{inwardTimedItemController.clearDepartment()}" />
+                                </p:selectOneMenu>
+
+                                <!-- Site -->
+                                <h:outputLabel value="Site" for="siteMenu" />
+                                <p:selectOneMenu id="siteMenu" styleClass="mx-4 w-100 form-control"
+                                                value="#{inwardTimedItemController.site}" filter="true">
+                                    <f:selectItem itemLabel="All Sites" itemValue="#{null}" />
+                                    <f:selectItems value="#{institutionController.sites}" var="site"
+                                                   itemLabel="#{site.name}" itemValue="#{site}" />
+                                    <p:ajax process="siteMenu" update="cmbDept"
+                                           listener="#{inwardTimedItemController.clearDepartment()}" />
+                                </p:selectOneMenu>
+
+                                <!-- Department -->
+                                <h:outputLabel value="Department" for="cmbDept" />
+                                <h:panelGroup id="cmbDept">
+                                    <p:selectOneMenu
+                                        rendered="#{inwardTimedItemController.institution eq null and inwardTimedItemController.site eq null}"
+                                        styleClass="mx-4 w-100 form-control"
+                                        value="#{inwardTimedItemController.department}"
+                                        filterMatchMode="contains" filter="true">
+                                        <f:selectItem itemLabel="All Departments" itemValue="#{null}" />
+                                        <f:selectItems value="#{departmentController.getDepartmentsOfInstitutionAndSite()}"
+                                                       var="d" itemLabel="#{d.name}" itemValue="#{d}" />
+                                    </p:selectOneMenu>
+                                    <p:selectOneMenu
+                                        rendered="#{inwardTimedItemController.institution eq null and inwardTimedItemController.site ne null}"
+                                        styleClass="mx-4 w-100 form-control"
+                                        value="#{inwardTimedItemController.department}"
+                                        filterMatchMode="contains" filter="true">
+                                        <f:selectItem itemLabel="All Departments" itemValue="#{null}" />
+                                        <f:selectItems value="#{departmentController.getDepartmentsOfInstitutionAndSite(inwardTimedItemController.site)}"
+                                                       var="d" itemLabel="#{d.name}" itemValue="#{d}" />
+                                    </p:selectOneMenu>
+                                    <p:selectOneMenu
+                                        rendered="#{inwardTimedItemController.institution ne null and inwardTimedItemController.site eq null}"
+                                        styleClass="mx-4 w-100 form-control"
+                                        value="#{inwardTimedItemController.department}"
+                                        filterMatchMode="contains" filter="true">
+                                        <f:selectItem itemLabel="All Departments" itemValue="#{null}" />
+                                        <f:selectItems value="#{departmentController.getDepartmentsOfInstitutionAndSiteForInstitution(inwardTimedItemController.institution)}"
+                                                       var="d" itemLabel="#{d.name}" itemValue="#{d}" />
+                                    </p:selectOneMenu>
+                                    <p:selectOneMenu
+                                        rendered="#{inwardTimedItemController.institution ne null and inwardTimedItemController.site ne null}"
+                                        styleClass="mx-4 w-100 form-control"
+                                        value="#{inwardTimedItemController.department}"
+                                        filterMatchMode="contains" filter="true">
+                                        <f:selectItem itemLabel="All Departments" itemValue="#{null}" />
+                                        <f:selectItems value="#{departmentController.getDepartmentsOfInstitutionAndSite(inwardTimedItemController.institution, inwardTimedItemController.site)}"
+                                                       var="d" itemLabel="#{d.name}" itemValue="#{d}" />
+                                    </p:selectOneMenu>
+                                </h:panelGroup>
                             </h:panelGrid>
 
                             <div class="my-4">
-                                <p:commandButton ajax="false" class="ui-button-warning" icon="fas fa-fill" value="Fill" action="#{inwardTimedItemController.createTimeServiceList}"   />
+                                <p:commandButton ajax="false" class="ui-button-warning" icon="fas fa-fill" value="Fill" action="#{inwardTimedItemController.createTimeServiceList}" />
                                 
                                 <p:commandButton ajax="false" icon="fas fa-file-excel" value="Excel" class="ui-button-success mx-1 " actionListener="#{inwardTimedItemController.createTimeServiceList}">
                                     <p:dataExporter type="xlsx" target="tbl" fileName="inward_report_timed_service" />


### PR DESCRIPTION
## Summary
- Added `institution`, `site`, and `department` filter fields to `InwardTimedItemController` with getters/setters and `clearDepartment()` helper
- Updated `createTimeServiceList()` to conditionally apply each filter via JPQL (same path pattern as `AdmissionReportController`)
- Added Institution, Site, and Department dropdowns to `inward_report_timed_service.xhtml` using the 4-variant department rendering pattern so the department list narrows correctly when institution or site changes
- Updated `developer_docs/navigation/inward_navigation.md` with the filter pattern and JPQL paths for future reference

## Test plan
- [ ] Open the Timed Service Report (`/inward/inward_report_timed_service.xhtml`)
- [ ] Verify Institution, Site, and Department dropdowns appear in the filter panel
- [ ] Select an Institution — confirm Department dropdown narrows to that institution's departments
- [ ] Select a Site — confirm Department dropdown narrows to that site's departments
- [ ] Select both Institution and Site — confirm Department dropdown is further narrowed
- [ ] Run report with each filter combination and verify results match the selected scope
- [ ] Run report with all filters blank — confirm all records are returned (same behaviour as before)

Closes #19715

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added institution, site, and department filters to Timed Service Report for more granular data filtering.
  * Department dropdown now automatically narrows options based on selected institution and site.

* **Bug Fixes**
  * Corrected typo in Timed Service Report panel header.

* **Documentation**
  * Updated navigation documentation with Timed Service Report filter pattern details and controller scope information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->