### PR TITLE
Fix: missing charges in Inward Charge Type Breakdown by BHT (#19762)

### DIFF
--- a/src/main/java/com/divudi/bean/inward/BillBhtController.java
+++ b/src/main/java/com/divudi/bean/inward/BillBhtController.java
@@ -442,6 +442,11 @@ public class BillBhtController implements Serializable {
         billItem.setCreater(wu);
         billItem.setBill(bill);
 
+        if (billItem.getInwardChargeType() == null && billItem.getItem() != null
+                && billItem.getItem().getInwardChargeType() != null) {
+            billItem.setInwardChargeType(billItem.getItem().getInwardChargeType());
+        }
+
         if (billItem.getId() == null) {
             getBillItemFacade().create(billItem);
         }

--- a/src/main/java/com/divudi/bean/inward/InwardChargeTypeBreakdownController.java
+++ b/src/main/java/com/divudi/bean/inward/InwardChargeTypeBreakdownController.java
@@ -11,11 +11,13 @@ import com.divudi.core.entity.Institution;
 import com.divudi.core.entity.PatientEncounter;
 import com.divudi.core.entity.BillFee;
 import com.divudi.core.entity.BillItem;
+import com.divudi.core.entity.PatientItem;
 import com.divudi.core.entity.inward.AdmissionType;
 import com.divudi.core.entity.inward.PatientRoom;
 import com.divudi.core.facade.BillFeeFacade;
 import com.divudi.core.facade.BillItemFacade;
 import com.divudi.core.facade.PatientEncounterFacade;
+import com.divudi.core.facade.PatientItemFacade;
 import com.divudi.core.facade.PatientRoomFacade;
 import java.io.Serializable;
 import java.util.ArrayList;
@@ -49,6 +51,8 @@ public class InwardChargeTypeBreakdownController implements Serializable {
     // -------------------------------------------------------------------------
     @EJB
     private BillItemFacade billItemFacade;
+    @EJB
+    private PatientItemFacade patientItemFacade;
     @EJB
     private PatientRoomFacade patientRoomFacade;
     @EJB
@@ -304,17 +308,21 @@ public class InwardChargeTypeBreakdownController implements Serializable {
     }
 
     // -------------------------------------------------------------------------
-    // BILL_ITEM
+    // BILL_ITEM — services, outside charges, and timed services
     // -------------------------------------------------------------------------
 
     private void buildFromBillItems() {
+        // --- Service / outside-charge BillItems ---
+        // Use OR so that:
+        //   InwardBill items  (item-based):  bi.item.inwardChargeType = :ct
+        //   InwardOutSideBill items (direct): bi.inwardChargeType = :ct
         StringBuilder jpql = new StringBuilder(
                 "select bi from BillItem bi join bi.bill b join b.patientEncounter enc"
                 + " where bi.retired = false"
                 + " and b.retired = false"
                 + " and b.cancelled = false"
                 + " and b.billType in :btps"
-                + " and bi.inwardChargeType = :ct");
+                + " and (bi.inwardChargeType = :ct or bi.item.inwardChargeType = :ct)");
 
         Map<String, Object> params = new HashMap<>();
         List<BillType> btps = new ArrayList<>();
@@ -324,11 +332,112 @@ public class InwardChargeTypeBreakdownController implements Serializable {
         params.put("ct", selectedChargeType);
         appendEncounterFilters(jpql, params, "enc");
 
-        List<BillItem> raw = billItemFacade.findByJpql(jpql.toString(), params, TemporalType.TIMESTAMP);
-        if (raw == null) {
-            raw = new ArrayList<>();
+        List<BillItem> rawBillItems = billItemFacade.findByJpql(jpql.toString(), params, TemporalType.TIMESTAMP);
+        if (rawBillItems == null) {
+            rawBillItems = new ArrayList<>();
         }
-        buildPivotFromBillItems(raw);
+
+        // --- PatientItems (timed services) for the same charge type ---
+        StringBuilder jpql2 = new StringBuilder(
+                "select pi from PatientItem pi join pi.patientEncounter enc"
+                + " where pi.retired = false"
+                + " and type(pi.item) = TimedItem"
+                + " and pi.item.inwardChargeType = :ct");
+        Map<String, Object> params2 = new HashMap<>();
+        params2.put("ct", selectedChargeType);
+        appendEncounterFilters(jpql2, params2, "enc");
+
+        List<PatientItem> rawPatientItems = patientItemFacade.findByJpql(jpql2.toString(), params2, TemporalType.TIMESTAMP);
+        if (rawPatientItems == null) {
+            rawPatientItems = new ArrayList<>();
+        }
+
+        buildPivotFromBillAndPatientItems(rawBillItems, rawPatientItems);
+    }
+
+    /**
+     * Builds the pivot from a mix of BillItems (services / outside charges) and
+     * PatientItems (timed services). Both item types are keyed by item.id so they
+     * share columns when the same item appears in both sources.
+     */
+    private void buildPivotFromBillAndPatientItems(List<BillItem> billItems, List<PatientItem> patientItems) {
+        // 1. Collect distinct columns from both sources
+        Map<String, String> keyToLabel = new LinkedHashMap<>();
+        for (BillItem bi : billItems) {
+            if (bi.getItem() == null) {
+                continue;
+            }
+            keyToLabel.put(String.valueOf(bi.getItem().getId()), bi.getItem().getName());
+        }
+        for (PatientItem pi : patientItems) {
+            if (pi.getItem() == null) {
+                continue;
+            }
+            keyToLabel.put(String.valueOf(pi.getItem().getId()), pi.getItem().getName());
+        }
+
+        // 2. Sort columns alphabetically by label
+        List<Map.Entry<String, String>> sortedEntries = new ArrayList<>(keyToLabel.entrySet());
+        sortedEntries.sort(Comparator.comparing(e -> e.getValue() == null ? "" : e.getValue()));
+        columnKeys   = new ArrayList<>();
+        columnLabels = new ArrayList<>();
+        for (Map.Entry<String, String> entry : sortedEntries) {
+            columnKeys.add(entry.getKey());
+            columnLabels.add(entry.getValue());
+        }
+
+        // 3. Accumulate BillItem values per BHT
+        Map<String, BhtBreakdownRow> bhtMap = new LinkedHashMap<>();
+        for (BillItem bi : billItems) {
+            if (bi.getItem() == null || bi.getBill() == null) {
+                continue;
+            }
+            PatientEncounter enc = bi.getBill().getPatientEncounter();
+            if (enc == null || enc.getBhtNo() == null) {
+                continue;
+            }
+            BhtBreakdownRow row = bhtMap.computeIfAbsent(enc.getBhtNo(), k -> createRow(enc));
+            row.getCellValues().merge(String.valueOf(bi.getItem().getId()), bi.getNetValue(), Double::sum);
+        }
+
+        // 4. Accumulate PatientItem (timed service) values per BHT
+        for (PatientItem pi : patientItems) {
+            if (pi.getItem() == null) {
+                continue;
+            }
+            PatientEncounter enc = pi.getPatientEncounter();
+            if (enc == null || enc.getBhtNo() == null) {
+                continue;
+            }
+            BhtBreakdownRow row = bhtMap.computeIfAbsent(enc.getBhtNo(), k -> createRow(enc));
+            double net = (pi.getServiceValue() != null ? pi.getServiceValue() : 0.0) - pi.getDiscount();
+            row.getCellValues().merge(String.valueOf(pi.getItem().getId()), net, Double::sum);
+        }
+
+        // 5. Sort rows and compute row totals
+        rows = new ArrayList<>(bhtMap.values());
+        rows.sort(Comparator.comparing(BhtBreakdownRow::getBhtNo,
+                Comparator.nullsLast(Comparator.naturalOrder())));
+        for (BhtBreakdownRow row : rows) {
+            double total = row.getCellValues().values().stream()
+                    .mapToDouble(Double::doubleValue).sum();
+            row.setRowTotal(total);
+        }
+
+        // 6. Compute column totals and grand total
+        columnTotals = new ArrayList<>();
+        grandTotal = 0.0;
+        for (String key : columnKeys) {
+            double colSum = 0;
+            for (BhtBreakdownRow row : rows) {
+                Double val = row.getCellValues().get(key);
+                if (val != null) {
+                    colSum += val;
+                }
+            }
+            columnTotals.add(colSum);
+            grandTotal += colSum;
+        }
     }
 
     // -------------------------------------------------------------------------

--- a/src/main/java/com/divudi/bean/inward/InwardChargeTypeBreakdownController.java
+++ b/src/main/java/com/divudi/bean/inward/InwardChargeTypeBreakdownController.java
@@ -313,16 +313,17 @@ public class InwardChargeTypeBreakdownController implements Serializable {
 
     private void buildFromBillItems() {
         // --- Service / outside-charge BillItems ---
-        // Use OR so that:
-        //   InwardBill items  (item-based):  bi.item.inwardChargeType = :ct
-        //   InwardOutSideBill items (direct): bi.inwardChargeType = :ct
+        // LEFT JOIN bi.item so that InwardOutSideBill items (bi.item = null) are
+        // not dropped by implicit inner-join semantics when the OR clause navigates
+        // through i.inwardChargeType.
         StringBuilder jpql = new StringBuilder(
                 "select bi from BillItem bi join bi.bill b join b.patientEncounter enc"
+                + " left join bi.item i"
                 + " where bi.retired = false"
                 + " and b.retired = false"
                 + " and b.cancelled = false"
                 + " and b.billType in :btps"
-                + " and (bi.inwardChargeType = :ct or bi.item.inwardChargeType = :ct)");
+                + " and (bi.inwardChargeType = :ct or i.inwardChargeType = :ct)");
 
         Map<String, Object> params = new HashMap<>();
         List<BillType> btps = new ArrayList<>();
@@ -338,9 +339,12 @@ public class InwardChargeTypeBreakdownController implements Serializable {
         }
 
         // --- PatientItems (timed services) for the same charge type ---
+        // pi.billItem is null guards against double-counting if a PatientItem is
+        // ever linked back to a BillItem in the future.
         StringBuilder jpql2 = new StringBuilder(
                 "select pi from PatientItem pi join pi.patientEncounter enc"
                 + " where pi.retired = false"
+                + " and pi.billItem is null"
                 + " and type(pi.item) = TimedItem"
                 + " and pi.item.inwardChargeType = :ct");
         Map<String, Object> params2 = new HashMap<>();


### PR DESCRIPTION
## Summary

- **`BillBhtController`** — copy `inwardChargeType` from the linked `Item` onto `BillItem` when null at save time, so all future service bills created via _Add Services & Investigations_ have the field populated
- **`InwardChargeTypeBreakdownController.buildFromBillItems()`** — change JPQL filter from `bi.inwardChargeType = :ct` to `(bi.inwardChargeType = :ct OR bi.item.inwardChargeType = :ct)`, covering both `InwardBill` items (item-based charge type) and `InwardOutSideBill` items (direct charge type)
- **`InwardChargeTypeBreakdownController`** — add a second JPQL query for `PatientItem` (`type(item) = TimedItem AND item.inwardChargeType = :ct`) and merge timed-service results with BillItem results in a new `buildPivotFromBillAndPatientItems()` method, so timed service charges are no longer silently omitted for every admission status

## Root causes fixed

| Symptom | Root cause |
|---|---|
| Services & Investigations missing for admitted patients | `BillItem.inwardChargeType` was NULL on `InwardBill` items; `BillBhtController` never copied it from the `Item` entity |
| Timed service charges missing for all admission statuses | `PatientItem` records (where timed services live) were never queried in the breakdown controller |
| Outside charges working but service charges not | `InwardOutSideBill` sets `bi.inwardChargeType` directly; `InwardBill` does not — single-field query silently excluded all service charges |

## Test plan

- [ ] Generate the Inward Charge Type Breakdown by BHT report for a BHT with **Admission Status = Admitted but not discharged**; verify Services & Investigations charges appear
- [ ] Generate for **Admission Status = Admitted but not discharged**; verify timed service charges (oxygen, phototherapy, etc.) appear
- [ ] Generate for **Admission Status = Discharged but final bill not completed**; verify timed service charges appear
- [ ] Generate for **Admission Status = Discharged but final bill completed**; verify timed service charges appear
- [ ] Add a new service charge to a BHT via _Add Services & Investigations_; confirm the new `BillItem.inwardChargeType` is now persisted (check DB or re-run report)
- [ ] Confirm `InwardOutSideBill` (outside charges) still appear correctly
- [ ] Confirm pharmacy, store, room, professional-fee, and admission-fee charge types are unaffected

Closes #19762

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved charge type field assignment in billing items with enhanced null-safe handling and fallback data from related items when necessary.

* **New Features**
  * Extended inward charge type breakdown reports to now include patient service item data alongside billing item data for a more comprehensive charge analysis and aggregation across all data sources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->