### PR TITLE
Fix TransferIssueController double-save causing duplicate stock deductions

### DIFF
--- a/src/main/java/com/divudi/bean/pharmacy/TransferIssueController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/TransferIssueController.java
@@ -558,6 +558,10 @@ public class TransferIssueController implements Serializable {
     }
 
     public void settleDirectIssue() {
+        if (getIssuedBill() != null && getIssuedBill().getId() != null) {
+            JsfUtil.addErrorMessage("This bill has already been saved.");
+            return;
+        }
         if (getIssuedBill().getToDepartment() == null) {
             JsfUtil.addErrorMessage("Please Select Department to Issue");
             return;
@@ -727,6 +731,10 @@ public class TransferIssueController implements Serializable {
     }
 
     public void settle() {
+        if (getIssuedBill() != null && getIssuedBill().getId() != null) {
+            JsfUtil.addErrorMessage("This bill has already been saved.");
+            return;
+        }
         if (getIssuedBill().getToDepartment() == null) {
             JsfUtil.addErrorMessage("Please Select Department to Issue");
             return;

--- a/src/main/java/com/divudi/bean/pharmacy/TransferIssueController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/TransferIssueController.java
@@ -557,7 +557,7 @@ public class TransferIssueController implements Serializable {
 
     }
 
-    public void settleDirectIssue() {
+    public synchronized void settleDirectIssue() {
         if (getIssuedBill() != null && getIssuedBill().getId() != null) {
             JsfUtil.addErrorMessage("This bill has already been saved.");
             return;
@@ -730,7 +730,7 @@ public class TransferIssueController implements Serializable {
         getBillFacade().edit(bill);
     }
 
-    public void settle() {
+    public synchronized void settle() {
         if (getIssuedBill() != null && getIssuedBill().getId() != null) {
             JsfUtil.addErrorMessage("This bill has already been saved.");
             return;


### PR DESCRIPTION
## Summary
- Adds server-side idempotency guard to `TransferIssueController.settle()` and `settleDirectIssue()`: if `issuedBill.id != null`, abort.
- Prevents duplicate deduction loops when the save is re-invoked (double-click / AJAX retry / JSF resubmission).

## Context
Coop DB incident: bill COOPPHTI/664 (OPPHTI/30) deducted every line twice 6s apart, driving Cetapin XR batch to -144. 14 other negative-stock rows across coop trace to the same shape; ETU gloves pbItem 8847958 was written 24 times in 15 seconds. Safety-net re-check in `PharmacyBean.deductFromStock` already landed in #19875; this PR fixes the actual root cause.

Client-side `PF('btn').disable()` was unreliable; existing JS `confirm()` remains as user-facing friction.

Closes #19894

## Test plan
- [ ] Save a transfer issue bill normally — works.
- [ ] Re-click settle on an already-saved bill — error message, no second deduction.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented duplicate bill settlement: if a bill has already been saved, the system shows an error and stops further processing.
  * Made bill processing resilient to concurrent attempts, reducing the risk of race conditions that could create duplicate or inconsistent records.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->