### PR TITLE
Apply transfer issue idempotency guard to correct controllers

### DIFF
--- a/src/main/java/com/divudi/bean/pharmacy/TransferIssueDirectController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/TransferIssueDirectController.java
@@ -212,7 +212,11 @@ public class TransferIssueDirectController implements Serializable {
     /**
      * Settles the direct issue transaction
      */
-    public void settleDirectIssue() {
+    public synchronized void settleDirectIssue() {
+        if (issuedBill != null && issuedBill.getId() != null) {
+            JsfUtil.addErrorMessage("This bill has already been saved.");
+            return;
+        }
         if (issuedBill.getToDepartment() == null) {
             JsfUtil.addErrorMessage("Please Select Department to Issue");
             return;

--- a/src/main/java/com/divudi/bean/pharmacy/TransferIssueForRequestsController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/TransferIssueForRequestsController.java
@@ -403,7 +403,11 @@ public class TransferIssueForRequestsController implements Serializable {
         }
     }
 
-    public void settle() {
+    public synchronized void settle() {
+        if (getIssuedBill() != null && getIssuedBill().getId() != null) {
+            JsfUtil.addErrorMessage("This bill has already been saved.");
+            return;
+        }
         if (getIssuedBill().getToDepartment() == null) {
             JsfUtil.addErrorMessage("Please Select Department to Issue");
             return;


### PR DESCRIPTION
## Summary
Follow-up to #19895. The settle buttons on `pharmacy_transfer_issue.xhtml` and `pharmacy_transfer_issue_direct_department.xhtml` bind to `TransferIssueForRequestsController.settle` and `TransferIssueDirectController.settleDirectIssue` — not `TransferIssueController`, which #19895 patched. This PR applies the same `synchronized` + id-null guard to the real targets so the double-save fix actually protects the incident path (Cetapin XR −144 on COOPPHTI/664).

Both XHTML pages already use a JS `confirm()` dialog; the server-side guard is the authoritative layer.

Refs #19894

## Test plan
- [ ] Settle a transfer-request-based bill — works.
- [ ] Settle a direct department transfer — works.
- [ ] Re-click on already-saved bill — error message, no second deduction.