### PR TITLE
Fix: Inward Charge Type Detail report and Invoice Journal charge doubling

### DIFF
--- a/src/main/java/com/divudi/bean/inward/InwardChargeTypeDetailController.java
+++ b/src/main/java/com/divudi/bean/inward/InwardChargeTypeDetailController.java
@@ -16,6 +16,7 @@ import com.divudi.core.entity.BillItem;
 import com.divudi.core.entity.PatientItem;
 import com.divudi.core.facade.BillFeeFacade;
 import com.divudi.core.facade.BillItemFacade;
+import com.divudi.core.facade.PatientEncounterFacade;
 import com.divudi.core.facade.PatientItemFacade;
 import java.io.Serializable;
 import java.util.ArrayList;
@@ -53,6 +54,8 @@ public class InwardChargeTypeDetailController implements Serializable {
     private PatientItemFacade patientItemFacade;
     @EJB
     private BillFeeFacade billFeeFacade;
+    @EJB
+    private PatientEncounterFacade patientEncounterFacade;
     @Inject
     private ConfigOptionApplicationController configOptionApplicationController;
 
@@ -124,6 +127,9 @@ public class InwardChargeTypeDetailController implements Serializable {
 
         // --- BillFee rows (InwardProfessional — ProfessionalCharge, DoctorAndNurses) ---
         rows.addAll(fetchProfessionalFeeRows());
+
+        // --- Admission Fee rows (derived from PatientEncounter.admissionType.admissionFee) ---
+        rows.addAll(fetchAdmissionFeeRows());
 
         // --- Sort: BHT No (natural string sort), then sortTime ascending ---
         rows.sort(Comparator
@@ -222,12 +228,13 @@ public class InwardChargeTypeDetailController implements Serializable {
         switch (cm) {
             case BILL_FEE:
             case PATIENT_ROOM:
+            case ADMISSION_FEE:
                 return new ArrayList<>();
             case PHARMACY_BILL:
                 return fetchPharmacyBillItemRows();
             case STORE_BILL:
                 return fetchStoreBillItemRows();
-            default: // BILL_ITEM and ADMISSION_FEE
+            default: // BILL_ITEM
                 return fetchInwardBillItemRows();
         }
     }
@@ -390,6 +397,49 @@ public class InwardChargeTypeDetailController implements Serializable {
             row.setDiscount(disc);
             row.setNetValue(gross - disc);
             row.setSortTime(bf.getFeeAt());
+            rows.add(row);
+        }
+        return rows;
+    }
+
+    /**
+     * Fetches admission fee rows for ADMISSION_FEE charge types.
+     * The fee is derived from PatientEncounter.admissionType.admissionFee —
+     * it is not stored as a BillItem.
+     */
+    private List<InwardChargeTypeDetailRowDto> fetchAdmissionFeeRows() {
+        if (selectedChargeType.getCalculationMethod() != CalculationMethod.ADMISSION_FEE) {
+            return new ArrayList<>();
+        }
+        StringBuilder jpql = new StringBuilder(
+                "select enc from PatientEncounter enc where enc.retired = false");
+        Map<String, Object> params = new HashMap<>();
+        appendEncounterFilters(jpql, params, "enc");
+
+        List<PatientEncounter> encounters = patientEncounterFacade.findByJpql(
+                jpql.toString(), params, TemporalType.TIMESTAMP);
+
+        List<InwardChargeTypeDetailRowDto> rows = new ArrayList<>();
+        if (encounters == null) {
+            return rows;
+        }
+        for (PatientEncounter enc : encounters) {
+            double fee = (enc.getAdmissionType() != null)
+                    ? enc.getAdmissionType().getAdmissionFee() : 0.0;
+            if (fee == 0.0) {
+                continue;
+            }
+            InwardChargeTypeDetailRowDto row = new InwardChargeTypeDetailRowDto();
+            row.setBhtNo(enc.getBhtNo());
+            row.setPatientName(enc.getPatient() != null && enc.getPatient().getPerson() != null
+                    ? enc.getPatient().getPerson().getNameWithTitle() : "");
+            row.setDateOfAdmission(enc.getDateOfAdmission());
+            row.setDateOfDischarge(enc.getDateOfDischarge());
+            row.setItemName(getChargeTypeLabel(selectedChargeType));
+            row.setGrossValue(fee);
+            row.setDiscount(0.0);
+            row.setNetValue(fee);
+            row.setSortTime(enc.getDateOfAdmission());
             rows.add(row);
         }
         return rows;

--- a/src/main/java/com/divudi/bean/inward/InwardInvoiceJournalController.java
+++ b/src/main/java/com/divudi/bean/inward/InwardInvoiceJournalController.java
@@ -226,12 +226,14 @@ public class InwardInvoiceJournalController implements Serializable {
                 + " where bi.retired = false"
                 + " and bi.bill.retired = false"
                 + " and bi.bill.cancelled = false"
+                + " and bi.bill.billTypeAtomic != :originalFinalBillType"
                 + " and bi.bill.patientEncounter in :encs"
                 + " and bi.inwardChargeType is not null"
                 + " group by bi.bill.patientEncounter.id, bi.inwardChargeType";
 
         Map<String, Object> params = new HashMap<>();
         params.put("encs", encounters);
+        params.put("originalFinalBillType", BillTypeAtomic.INWARD_ORIGINAL_FINAL_BILL);
 
         List<Object[]> rows = patientEncounterFacade.findObjectArrayByJpql(jpql, params, TemporalType.TIMESTAMP);
         if (rows != null) {

--- a/src/main/webapp/inward/inward_bill_final.xhtml
+++ b/src/main/webapp/inward/inward_bill_final.xhtml
@@ -68,7 +68,7 @@
                                                  rendered="#{configOptionApplicationController.getBooleanValueByKey('Show Save Provisional on Final Bill Edit',false)}">
 
                                 </p:commandButton>
-                                <p:commandButton value="Settle" 
+                                <p:commandButton value="Settle"
                                                  action="#{bhtSummeryController.settle}"
                                                  id="settle"
                                                  ajax="false"
@@ -78,6 +78,18 @@
                                                  style="width: 150px; padding: 1px;border: 1px solid ; margin: auto;">
 
                                 </p:commandButton>
+                                <h:panelGroup rendered="#{webUserController.hasPrivilege('InwardSearch')}">
+                                    <p:commandButton
+                                        ajax="false"
+                                        value="Inpatient Profile"
+                                        icon="fa fa-id-card"
+                                        styleClass="ui-button-secondary mx-1"
+                                        action="#{bhtSummeryController.navigateToInpatientProfile()}">
+                                        <f:setPropertyActionListener
+                                            target="#{admissionController.current}"
+                                            value="#{bhtSummeryController.patientEncounter}" />
+                                    </p:commandButton>
+                                </h:panelGroup>
                             </div>
                         </div>
                     </f:facet>


### PR DESCRIPTION
## Summary

- **Invoice Journal (#19899):** `InwardInvoiceJournalController.fetchChargesByEncounter()` now excludes `INWARD_ORIGINAL_FINAL_BILL` from the charge aggregation query. This audit-trail copy is created when a final bill is recreated, and its presence caused every charge column (Admission, Room Charges, X-Ray, etc.) to be doubled.
- **Charge Type Detail (#19761):** Added `fetchAdmissionFeeRows()` to correctly handle `ADMISSION_FEE` charge types, which are derived from `PatientEncounter.admissionType.admissionFee` rather than stored as `BillItem` records.
- **Final Bill toolbar:** Added an "Inpatient Profile" navigation button in `inward_bill_final.xhtml`.

## Test plan

- [ ] Open Inpatient Invoice Journal for a patient whose final bill was recreated (has `INWARD_ORIGINAL_FINAL_BILL`); confirm charges are no longer doubled
- [ ] Run Inward Charge Type Detail report for an `ADMISSION_FEE` charge type; confirm rows appear correctly
- [ ] Open Final Bill for an inpatient; confirm the "Inpatient Profile" button is visible and navigates correctly

Closes #19899
Closes #19761

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Charge type reports now include admission fee information and related line items.
  * New "Inpatient Profile" button provides quick access to patient admission details from inpatient bill pages.

* **Improvements**
  * Enhanced bill filtering to exclude specific bill types from report generation, improving data clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->