### PR TITLE
feat: Inward payment report suite + CC debtor fix for non-discharged patients

### DIFF
--- a/src/main/java/com/divudi/bean/inward/BhtDepositDetailReportController.java
+++ b/src/main/java/com/divudi/bean/inward/BhtDepositDetailReportController.java
@@ -145,27 +145,26 @@ public class BhtDepositDetailReportController implements Serializable {
             jpql.append(" and c.department = :dept");
             params.put("dept", department);
         }
-        if (paymentMethod != null) {
-            jpql.append(" and c.paymentMethod = :pm");
-            params.put("pm", paymentMethod);
-        }
-
         jpql.append(" order by c.bhtNo");
         return patientEncounterFacade.findByJpql(jpql.toString(), params, TemporalType.TIMESTAMP);
     }
 
     private List<Payment> fetchDepositPayments(PatientEncounter enc) {
-        String jpql = "select p from Payment p"
+        StringBuilder jpql = new StringBuilder("select p from Payment p"
                 + " where p.retired = false"
                 + " and p.bill.retired = false"
                 + " and p.bill.cancelled = false"
                 + " and p.bill.billTypeAtomic = :bta"
-                + " and p.bill.patientEncounter = :enc"
-                + " order by p.createdAt";
+                + " and p.bill.patientEncounter = :enc");
         Map<String, Object> params = new HashMap<>();
         params.put("bta", BillTypeAtomic.INWARD_DEPOSIT);
         params.put("enc", enc);
-        return paymentFacade.findByJpql(jpql, params);
+        if (paymentMethod != null) {
+            jpql.append(" and p.paymentMethod = :pm");
+            params.put("pm", paymentMethod);
+        }
+        jpql.append(" order by p.createdAt");
+        return paymentFacade.findByJpql(jpql.toString(), params);
     }
 
     public double getTotalForMethod(PaymentMethod pm) {

--- a/src/main/java/com/divudi/bean/inward/BhtDepositDetailReportController.java
+++ b/src/main/java/com/divudi/bean/inward/BhtDepositDetailReportController.java
@@ -1,0 +1,232 @@
+package com.divudi.bean.inward;
+
+import com.divudi.core.data.BillTypeAtomic;
+import com.divudi.core.data.PaymentMethod;
+import com.divudi.core.data.dto.BhtPaymentDetailDTO;
+import com.divudi.core.data.inward.AdmissionStatus;
+import com.divudi.core.entity.Department;
+import com.divudi.core.entity.Institution;
+import com.divudi.core.entity.Payment;
+import com.divudi.core.entity.PatientEncounter;
+import com.divudi.core.entity.inward.AdmissionType;
+import com.divudi.core.facade.PatientEncounterFacade;
+import com.divudi.core.facade.PaymentFacade;
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Calendar;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import javax.ejb.EJB;
+import javax.enterprise.context.SessionScoped;
+import javax.inject.Named;
+import javax.persistence.TemporalType;
+
+/**
+ * Controller for BHT Deposit Detail Report.
+ * One row per individual deposit payment. CC settlements excluded.
+ */
+@Named
+@SessionScoped
+public class BhtDepositDetailReportController implements Serializable {
+
+    @EJB
+    private PatientEncounterFacade patientEncounterFacade;
+    @EJB
+    private PaymentFacade paymentFacade;
+
+    private Date fromDate = startOfCurrentMonth();
+    private Date toDate = new Date();
+    private String dateBasis = "dischargeDate";
+    private AdmissionStatus admissionStatus = AdmissionStatus.DISCHARGED_AND_FINAL_BILL_COMPLETED;
+    private AdmissionType admissionType;
+    private PaymentMethod paymentMethod;
+    private Institution institution;
+    private Institution site;
+    private Department department;
+
+    private List<BhtPaymentDetailDTO> reportRows;
+    private double grandTotal;
+    private Map<PaymentMethod, Double> totalByMethod = new LinkedHashMap<>();
+    private List<PaymentMethod> usedPaymentMethods = new ArrayList<>();
+
+    public void generateReport() {
+        reportRows = new ArrayList<>();
+        grandTotal = 0;
+        totalByMethod = new LinkedHashMap<>();
+        usedPaymentMethods = new ArrayList<>();
+
+        List<PatientEncounter> encounters = fetchEncounters();
+        if (encounters == null || encounters.isEmpty()) {
+            return;
+        }
+
+        for (PatientEncounter enc : encounters) {
+            String patientName = enc.getPatient() != null && enc.getPatient().getPerson() != null
+                    ? enc.getPatient().getPerson().getNameWithTitle() : "";
+
+            List<Payment> deposits = fetchDepositPayments(enc);
+            for (Payment p : deposits) {
+                BhtPaymentDetailDTO row = new BhtPaymentDetailDTO();
+                row.setBhtNo(enc.getBhtNo());
+                row.setPatientName(patientName);
+                row.setAdmissionType(enc.getAdmissionType());
+                row.setDateOfAdmission(enc.getDateOfAdmission());
+                row.setDateOfDischarge(enc.getDateOfDischarge());
+                row.setBillNo(p.getBill() != null ? p.getBill().getDeptId() : "");
+                row.setCreatedAt(p.getCreatedAt());
+                row.setPaymentMethod(p.getPaymentMethod());
+                row.setAmount(Math.abs(p.getPaidValue()));
+                row.setReferenceNo(p.getReferenceNo());
+                reportRows.add(row);
+
+                double amt = Math.abs(p.getPaidValue());
+                grandTotal += amt;
+                if (p.getPaymentMethod() != null) {
+                    totalByMethod.merge(p.getPaymentMethod(), amt, Double::sum);
+                }
+            }
+        }
+
+        usedPaymentMethods = new ArrayList<>(totalByMethod.keySet());
+    }
+
+    private List<PatientEncounter> fetchEncounters() {
+        Map<String, Object> params = new HashMap<>();
+        StringBuilder jpql = new StringBuilder(
+                "select distinct c from PatientEncounter c where c.retired = false");
+
+        if (fromDate != null && toDate != null) {
+            if ("admissionDate".equals(dateBasis)) {
+                jpql.append(" and c.dateOfAdmission between :fromDate and :toDate");
+            } else {
+                jpql.append(" and c.dateOfDischarge between :fromDate and :toDate");
+            }
+            params.put("fromDate", fromDate);
+            params.put("toDate", toDate);
+        }
+
+        if (admissionStatus != null && admissionStatus != AdmissionStatus.ANY_STATUS) {
+            switch (admissionStatus) {
+                case ADMITTED_BUT_NOT_DISCHARGED:
+                    jpql.append(" and c.discharged = :dis");
+                    params.put("dis", false);
+                    break;
+                case DISCHARGED_BUT_FINAL_BILL_NOT_COMPLETED:
+                    jpql.append(" and c.discharged = :dis and c.paymentFinalized = :pf");
+                    params.put("dis", true);
+                    params.put("pf", false);
+                    break;
+                case DISCHARGED_AND_FINAL_BILL_COMPLETED:
+                    jpql.append(" and c.discharged = :dis and c.paymentFinalized = :pf");
+                    params.put("dis", true);
+                    params.put("pf", true);
+                    break;
+                default:
+                    break;
+            }
+        }
+
+        if (admissionType != null) {
+            jpql.append(" and c.admissionType = :admType");
+            params.put("admType", admissionType);
+        }
+        if (institution != null) {
+            jpql.append(" and c.institution = :ins");
+            params.put("ins", institution);
+        }
+        if (site != null) {
+            jpql.append(" and c.department.site = :site");
+            params.put("site", site);
+        }
+        if (department != null) {
+            jpql.append(" and c.department = :dept");
+            params.put("dept", department);
+        }
+        if (paymentMethod != null) {
+            jpql.append(" and c.paymentMethod = :pm");
+            params.put("pm", paymentMethod);
+        }
+
+        jpql.append(" order by c.bhtNo");
+        return patientEncounterFacade.findByJpql(jpql.toString(), params, TemporalType.TIMESTAMP);
+    }
+
+    private List<Payment> fetchDepositPayments(PatientEncounter enc) {
+        String jpql = "select p from Payment p"
+                + " where p.retired = false"
+                + " and p.bill.retired = false"
+                + " and p.bill.cancelled = false"
+                + " and p.bill.billTypeAtomic = :bta"
+                + " and p.bill.patientEncounter = :enc"
+                + " order by p.createdAt";
+        Map<String, Object> params = new HashMap<>();
+        params.put("bta", BillTypeAtomic.INWARD_DEPOSIT);
+        params.put("enc", enc);
+        return paymentFacade.findByJpql(jpql, params);
+    }
+
+    public double getTotalForMethod(PaymentMethod pm) {
+        return totalByMethod.getOrDefault(pm, 0.0);
+    }
+
+    public void makeNull() {
+        fromDate = startOfCurrentMonth();
+        toDate = new Date();
+        dateBasis = "dischargeDate";
+        admissionStatus = AdmissionStatus.DISCHARGED_AND_FINAL_BILL_COMPLETED;
+        admissionType = null;
+        paymentMethod = null;
+        institution = null;
+        site = null;
+        department = null;
+        reportRows = null;
+        grandTotal = 0;
+        totalByMethod = new LinkedHashMap<>();
+        usedPaymentMethods = new ArrayList<>();
+    }
+
+    private static Date startOfCurrentMonth() {
+        Calendar cal = Calendar.getInstance();
+        cal.set(Calendar.DAY_OF_MONTH, 1);
+        cal.set(Calendar.HOUR_OF_DAY, 0);
+        cal.set(Calendar.MINUTE, 0);
+        cal.set(Calendar.SECOND, 0);
+        cal.set(Calendar.MILLISECOND, 0);
+        return cal.getTime();
+    }
+
+    public Date getFromDate() { return fromDate; }
+    public void setFromDate(Date fromDate) { this.fromDate = fromDate; }
+
+    public Date getToDate() { return toDate; }
+    public void setToDate(Date toDate) { this.toDate = toDate; }
+
+    public String getDateBasis() { return dateBasis; }
+    public void setDateBasis(String dateBasis) { this.dateBasis = dateBasis; }
+
+    public AdmissionStatus getAdmissionStatus() { return admissionStatus; }
+    public void setAdmissionStatus(AdmissionStatus admissionStatus) { this.admissionStatus = admissionStatus; }
+
+    public AdmissionType getAdmissionType() { return admissionType; }
+    public void setAdmissionType(AdmissionType admissionType) { this.admissionType = admissionType; }
+
+    public PaymentMethod getPaymentMethod() { return paymentMethod; }
+    public void setPaymentMethod(PaymentMethod paymentMethod) { this.paymentMethod = paymentMethod; }
+
+    public Institution getInstitution() { return institution; }
+    public void setInstitution(Institution institution) { this.institution = institution; }
+
+    public Institution getSite() { return site; }
+    public void setSite(Institution site) { this.site = site; }
+
+    public Department getDepartment() { return department; }
+    public void setDepartment(Department department) { this.department = department; }
+
+    public List<BhtPaymentDetailDTO> getReportRows() { return reportRows; }
+    public double getGrandTotal() { return grandTotal; }
+    public List<PaymentMethod> getUsedPaymentMethods() { return usedPaymentMethods; }
+    public Map<PaymentMethod, Double> getTotalByMethod() { return totalByMethod; }
+}

--- a/src/main/java/com/divudi/bean/inward/BhtDepositSummaryReportController.java
+++ b/src/main/java/com/divudi/bean/inward/BhtDepositSummaryReportController.java
@@ -1,0 +1,232 @@
+package com.divudi.bean.inward;
+
+import com.divudi.core.data.BillTypeAtomic;
+import com.divudi.core.data.PaymentMethod;
+import com.divudi.core.data.dto.BhtPaymentSummaryDTO;
+import com.divudi.core.data.inward.AdmissionStatus;
+import com.divudi.core.entity.Department;
+import com.divudi.core.entity.Institution;
+import com.divudi.core.entity.Payment;
+import com.divudi.core.entity.PatientEncounter;
+import com.divudi.core.entity.inward.AdmissionType;
+import com.divudi.core.facade.PatientEncounterFacade;
+import com.divudi.core.facade.PaymentFacade;
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Calendar;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import javax.ejb.EJB;
+import javax.enterprise.context.SessionScoped;
+import javax.inject.Named;
+import javax.persistence.TemporalType;
+
+/**
+ * Controller for BHT Deposit Summary Report.
+ * One row per PatientEncounter; columns show deposit totals by PaymentMethod.
+ * CC settlements are excluded.
+ */
+@Named
+@SessionScoped
+public class BhtDepositSummaryReportController implements Serializable {
+
+    @EJB
+    private PatientEncounterFacade patientEncounterFacade;
+    @EJB
+    private PaymentFacade paymentFacade;
+
+    private Date fromDate = startOfCurrentMonth();
+    private Date toDate = new Date();
+    private String dateBasis = "dischargeDate";
+    private AdmissionStatus admissionStatus = AdmissionStatus.DISCHARGED_AND_FINAL_BILL_COMPLETED;
+    private AdmissionType admissionType;
+    private PaymentMethod paymentMethod;
+    private Institution institution;
+    private Institution site;
+    private Department department;
+
+    private List<BhtPaymentSummaryDTO> reportRows;
+    private List<PaymentMethod> allPaymentMethods = new ArrayList<>();
+    private Map<PaymentMethod, Double> columnTotals = new HashMap<>();
+    private double grandTotal;
+
+    public void generateReport() {
+        reportRows = new ArrayList<>();
+        columnTotals = new HashMap<>();
+        grandTotal = 0;
+
+        List<PatientEncounter> encounters = fetchEncounters();
+        if (encounters == null || encounters.isEmpty()) {
+            allPaymentMethods = new ArrayList<>();
+            return;
+        }
+
+        for (PatientEncounter enc : encounters) {
+            BhtPaymentSummaryDTO row = new BhtPaymentSummaryDTO();
+            row.setEncounterDatabaseId(enc.getId());
+            row.setBhtNo(enc.getBhtNo());
+            row.setPatientName(enc.getPatient() != null && enc.getPatient().getPerson() != null
+                    ? enc.getPatient().getPerson().getNameWithTitle() : "");
+            row.setDateOfAdmission(enc.getDateOfAdmission());
+            row.setDateOfDischarge(enc.getDateOfDischarge());
+            row.setAdmissionType(enc.getAdmissionType());
+
+            List<Payment> deposits = fetchDepositPayments(enc);
+            for (Payment p : deposits) {
+                row.addDeposit(p.getPaymentMethod(), Math.abs(p.getPaidValue()));
+            }
+
+            reportRows.add(row);
+
+            for (PaymentMethod pm : PaymentMethod.values()) {
+                columnTotals.merge(pm, row.getDepositForMethod(pm), Double::sum);
+            }
+            grandTotal += row.getTotalDeposits();
+        }
+
+        allPaymentMethods = new ArrayList<>();
+        for (PaymentMethod pm : PaymentMethod.values()) {
+            if (columnTotals.getOrDefault(pm, 0.0) != 0.0) {
+                allPaymentMethods.add(pm);
+            }
+        }
+    }
+
+    private List<PatientEncounter> fetchEncounters() {
+        Map<String, Object> params = new HashMap<>();
+        StringBuilder jpql = new StringBuilder(
+                "select distinct c from PatientEncounter c where c.retired = false");
+
+        if (fromDate != null && toDate != null) {
+            if ("admissionDate".equals(dateBasis)) {
+                jpql.append(" and c.dateOfAdmission between :fromDate and :toDate");
+            } else {
+                jpql.append(" and c.dateOfDischarge between :fromDate and :toDate");
+            }
+            params.put("fromDate", fromDate);
+            params.put("toDate", toDate);
+        }
+
+        if (admissionStatus != null && admissionStatus != AdmissionStatus.ANY_STATUS) {
+            switch (admissionStatus) {
+                case ADMITTED_BUT_NOT_DISCHARGED:
+                    jpql.append(" and c.discharged = :dis");
+                    params.put("dis", false);
+                    break;
+                case DISCHARGED_BUT_FINAL_BILL_NOT_COMPLETED:
+                    jpql.append(" and c.discharged = :dis and c.paymentFinalized = :pf");
+                    params.put("dis", true);
+                    params.put("pf", false);
+                    break;
+                case DISCHARGED_AND_FINAL_BILL_COMPLETED:
+                    jpql.append(" and c.discharged = :dis and c.paymentFinalized = :pf");
+                    params.put("dis", true);
+                    params.put("pf", true);
+                    break;
+                default:
+                    break;
+            }
+        }
+
+        if (admissionType != null) {
+            jpql.append(" and c.admissionType = :admType");
+            params.put("admType", admissionType);
+        }
+        if (institution != null) {
+            jpql.append(" and c.institution = :ins");
+            params.put("ins", institution);
+        }
+        if (site != null) {
+            jpql.append(" and c.department.site = :site");
+            params.put("site", site);
+        }
+        if (department != null) {
+            jpql.append(" and c.department = :dept");
+            params.put("dept", department);
+        }
+        if (paymentMethod != null) {
+            jpql.append(" and c.paymentMethod = :pm");
+            params.put("pm", paymentMethod);
+        }
+
+        jpql.append(" order by c.bhtNo");
+        return patientEncounterFacade.findByJpql(jpql.toString(), params, TemporalType.TIMESTAMP);
+    }
+
+    private List<Payment> fetchDepositPayments(PatientEncounter enc) {
+        String jpql = "select p from Payment p"
+                + " where p.retired = false"
+                + " and p.bill.retired = false"
+                + " and p.bill.cancelled = false"
+                + " and p.bill.billTypeAtomic = :bta"
+                + " and p.bill.patientEncounter = :enc";
+        Map<String, Object> params = new HashMap<>();
+        params.put("bta", BillTypeAtomic.INWARD_DEPOSIT);
+        params.put("enc", enc);
+        return paymentFacade.findByJpql(jpql, params);
+    }
+
+    public double getColumnTotal(PaymentMethod pm) {
+        return columnTotals.getOrDefault(pm, 0.0);
+    }
+
+    public void makeNull() {
+        fromDate = startOfCurrentMonth();
+        toDate = new Date();
+        dateBasis = "dischargeDate";
+        admissionStatus = AdmissionStatus.DISCHARGED_AND_FINAL_BILL_COMPLETED;
+        admissionType = null;
+        paymentMethod = null;
+        institution = null;
+        site = null;
+        department = null;
+        reportRows = null;
+        columnTotals = new HashMap<>();
+        grandTotal = 0;
+        allPaymentMethods = new ArrayList<>();
+    }
+
+    private static Date startOfCurrentMonth() {
+        Calendar cal = Calendar.getInstance();
+        cal.set(Calendar.DAY_OF_MONTH, 1);
+        cal.set(Calendar.HOUR_OF_DAY, 0);
+        cal.set(Calendar.MINUTE, 0);
+        cal.set(Calendar.SECOND, 0);
+        cal.set(Calendar.MILLISECOND, 0);
+        return cal.getTime();
+    }
+
+    public Date getFromDate() { return fromDate; }
+    public void setFromDate(Date fromDate) { this.fromDate = fromDate; }
+
+    public Date getToDate() { return toDate; }
+    public void setToDate(Date toDate) { this.toDate = toDate; }
+
+    public String getDateBasis() { return dateBasis; }
+    public void setDateBasis(String dateBasis) { this.dateBasis = dateBasis; }
+
+    public AdmissionStatus getAdmissionStatus() { return admissionStatus; }
+    public void setAdmissionStatus(AdmissionStatus admissionStatus) { this.admissionStatus = admissionStatus; }
+
+    public AdmissionType getAdmissionType() { return admissionType; }
+    public void setAdmissionType(AdmissionType admissionType) { this.admissionType = admissionType; }
+
+    public PaymentMethod getPaymentMethod() { return paymentMethod; }
+    public void setPaymentMethod(PaymentMethod paymentMethod) { this.paymentMethod = paymentMethod; }
+
+    public Institution getInstitution() { return institution; }
+    public void setInstitution(Institution institution) { this.institution = institution; }
+
+    public Institution getSite() { return site; }
+    public void setSite(Institution site) { this.site = site; }
+
+    public Department getDepartment() { return department; }
+    public void setDepartment(Department department) { this.department = department; }
+
+    public List<BhtPaymentSummaryDTO> getReportRows() { return reportRows; }
+    public List<PaymentMethod> getAllPaymentMethods() { return allPaymentMethods; }
+    public Map<PaymentMethod, Double> getColumnTotals() { return columnTotals; }
+    public double getGrandTotal() { return grandTotal; }
+}

--- a/src/main/java/com/divudi/bean/inward/BhtDepositSummaryReportController.java
+++ b/src/main/java/com/divudi/bean/inward/BhtDepositSummaryReportController.java
@@ -74,6 +74,9 @@ public class BhtDepositSummaryReportController implements Serializable {
             row.setAdmissionType(enc.getAdmissionType());
 
             List<Payment> deposits = fetchDepositPayments(enc);
+            if (deposits == null || deposits.isEmpty()) {
+                continue;
+            }
             for (Payment p : deposits) {
                 row.addDeposit(p.getPaymentMethod(), Math.abs(p.getPaidValue()));
             }

--- a/src/main/java/com/divudi/bean/inward/BhtDepositSummaryReportController.java
+++ b/src/main/java/com/divudi/bean/inward/BhtDepositSummaryReportController.java
@@ -103,7 +103,9 @@ public class BhtDepositSummaryReportController implements Serializable {
                 "select distinct c from PatientEncounter c where c.retired = false");
 
         if (fromDate != null && toDate != null) {
-            if ("admissionDate".equals(dateBasis)) {
+            boolean useAdmissionDate = "admissionDate".equals(dateBasis)
+                    || admissionStatus == AdmissionStatus.ADMITTED_BUT_NOT_DISCHARGED;
+            if (useAdmissionDate) {
                 jpql.append(" and c.dateOfAdmission between :fromDate and :toDate");
             } else {
                 jpql.append(" and c.dateOfDischarge between :fromDate and :toDate");

--- a/src/main/java/com/divudi/bean/inward/BhtDepositSummaryReportController.java
+++ b/src/main/java/com/divudi/bean/inward/BhtDepositSummaryReportController.java
@@ -146,26 +146,25 @@ public class BhtDepositSummaryReportController implements Serializable {
             jpql.append(" and c.department = :dept");
             params.put("dept", department);
         }
-        if (paymentMethod != null) {
-            jpql.append(" and c.paymentMethod = :pm");
-            params.put("pm", paymentMethod);
-        }
-
         jpql.append(" order by c.bhtNo");
         return patientEncounterFacade.findByJpql(jpql.toString(), params, TemporalType.TIMESTAMP);
     }
 
     private List<Payment> fetchDepositPayments(PatientEncounter enc) {
-        String jpql = "select p from Payment p"
+        StringBuilder jpql = new StringBuilder("select p from Payment p"
                 + " where p.retired = false"
                 + " and p.bill.retired = false"
                 + " and p.bill.cancelled = false"
                 + " and p.bill.billTypeAtomic = :bta"
-                + " and p.bill.patientEncounter = :enc";
+                + " and p.bill.patientEncounter = :enc");
         Map<String, Object> params = new HashMap<>();
         params.put("bta", BillTypeAtomic.INWARD_DEPOSIT);
         params.put("enc", enc);
-        return paymentFacade.findByJpql(jpql, params);
+        if (paymentMethod != null) {
+            jpql.append(" and p.paymentMethod = :pm");
+            params.put("pm", paymentMethod);
+        }
+        return paymentFacade.findByJpql(jpql.toString(), params);
     }
 
     public double getColumnTotal(PaymentMethod pm) {

--- a/src/main/java/com/divudi/bean/inward/BhtPaymentDetailReportController.java
+++ b/src/main/java/com/divudi/bean/inward/BhtPaymentDetailReportController.java
@@ -193,6 +193,7 @@ public class BhtPaymentDetailReportController implements Serializable {
     private List<Payment> fetchDepositPayments(PatientEncounter enc) {
         StringBuilder jpql = new StringBuilder("select p from Payment p"
                 + " where p.retired = false"
+                + " and p.cancelled = false"
                 + " and p.bill.retired = false"
                 + " and p.bill.cancelled = false"
                 + " and p.bill.billTypeAtomic = :bta"

--- a/src/main/java/com/divudi/bean/inward/BhtPaymentDetailReportController.java
+++ b/src/main/java/com/divudi/bean/inward/BhtPaymentDetailReportController.java
@@ -1,0 +1,290 @@
+package com.divudi.bean.inward;
+
+import com.divudi.core.data.BillTypeAtomic;
+import com.divudi.core.data.PaymentMethod;
+import com.divudi.core.data.dto.BhtPaymentDetailDTO;
+import com.divudi.core.data.inward.AdmissionStatus;
+import com.divudi.core.entity.BillItem;
+import com.divudi.core.entity.Department;
+import com.divudi.core.entity.Institution;
+import com.divudi.core.entity.Payment;
+import com.divudi.core.entity.PatientEncounter;
+import com.divudi.core.entity.inward.AdmissionType;
+import com.divudi.core.facade.BillItemFacade;
+import com.divudi.core.facade.PatientEncounterFacade;
+import com.divudi.core.facade.PaymentFacade;
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Calendar;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import javax.ejb.EJB;
+import javax.enterprise.context.SessionScoped;
+import javax.inject.Named;
+import javax.persistence.TemporalType;
+
+/**
+ * Controller for BHT Deposit and Credit Settlement Detail Report.
+ * One row per individual payment (deposit payment or CC settlement item).
+ */
+@Named
+@SessionScoped
+public class BhtPaymentDetailReportController implements Serializable {
+
+    @EJB
+    private PatientEncounterFacade patientEncounterFacade;
+    @EJB
+    private BillItemFacade billItemFacade;
+    @EJB
+    private PaymentFacade paymentFacade;
+
+    private Date fromDate = startOfCurrentMonth();
+    private Date toDate = new Date();
+    private String dateBasis = "dischargeDate";
+    private AdmissionStatus admissionStatus = AdmissionStatus.DISCHARGED_AND_FINAL_BILL_COMPLETED;
+    private AdmissionType admissionType;
+    private PaymentMethod paymentMethod;
+    private Institution institution;
+    private Institution site;
+    private Department department;
+
+    private List<BhtPaymentDetailDTO> reportRows;
+    private double grandTotal;
+    private double grandTotalCcSettlement;
+    /** Ordered map of payment method → deposit total; only methods with non-zero totals. */
+    private Map<PaymentMethod, Double> totalByMethod = new LinkedHashMap<>();
+    /** Payment methods in the order they appeared, for UI iteration. */
+    private List<PaymentMethod> usedPaymentMethods = new ArrayList<>();
+
+    public void generateReport() {
+        reportRows = new ArrayList<>();
+        grandTotal = 0;
+        grandTotalCcSettlement = 0;
+        totalByMethod = new LinkedHashMap<>();
+        usedPaymentMethods = new ArrayList<>();
+
+        List<PatientEncounter> encounters = fetchEncounters();
+        if (encounters == null || encounters.isEmpty()) {
+            return;
+        }
+
+        for (PatientEncounter enc : encounters) {
+            String patientName = enc.getPatient() != null && enc.getPatient().getPerson() != null
+                    ? enc.getPatient().getPerson().getNameWithTitle() : "";
+
+            // Deposit payments — one row per Payment record
+            List<Payment> deposits = fetchDepositPayments(enc);
+            for (Payment p : deposits) {
+                BhtPaymentDetailDTO row = new BhtPaymentDetailDTO();
+                row.setBhtNo(enc.getBhtNo());
+                row.setPatientName(patientName);
+                row.setAdmissionType(enc.getAdmissionType());
+                row.setDateOfAdmission(enc.getDateOfAdmission());
+                row.setDateOfDischarge(enc.getDateOfDischarge());
+                row.setBillNo(p.getBill() != null ? p.getBill().getDeptId() : "");
+                row.setCreatedAt(p.getCreatedAt());
+                row.setPaymentMethod(p.getPaymentMethod());
+                row.setAmount(Math.abs(p.getPaidValue()));
+                row.setReferenceNo(p.getReferenceNo());
+                row.setCreditCompanyName("");
+                reportRows.add(row);
+                double depositAmt = Math.abs(p.getPaidValue());
+                grandTotal += depositAmt;
+                if (p.getPaymentMethod() != null) {
+                    totalByMethod.merge(p.getPaymentMethod(), depositAmt, Double::sum);
+                }
+            }
+
+            // CC settlement items — one row per BillItem
+            List<BillItem> ccItems = fetchCreditSettlementItems(enc);
+            for (BillItem bi : ccItems) {
+                String companyName = "";
+                if (bi.getReferenceBill() != null && bi.getReferenceBill().getCreditCompany() != null) {
+                    companyName = bi.getReferenceBill().getCreditCompany().getName();
+                }
+                BhtPaymentDetailDTO row = new BhtPaymentDetailDTO();
+                row.setBhtNo(enc.getBhtNo());
+                row.setPatientName(patientName);
+                row.setAdmissionType(enc.getAdmissionType());
+                row.setDateOfAdmission(enc.getDateOfAdmission());
+                row.setDateOfDischarge(enc.getDateOfDischarge());
+                row.setBillNo(bi.getBill() != null ? bi.getBill().getDeptId() : "");
+                row.setCreatedAt(bi.getCreatedAt());
+                row.setPaymentMethod(null);
+                row.setAmount(bi.getNetValue());
+                row.setReferenceNo("");
+                row.setCreditCompanyName(companyName);
+                reportRows.add(row);
+                grandTotal += bi.getNetValue();
+                grandTotalCcSettlement += bi.getNetValue();
+            }
+        }
+
+        // Build ordered list of used payment methods for UI iteration
+        usedPaymentMethods = new ArrayList<>(totalByMethod.keySet());
+    }
+
+    public double getTotalForMethod(PaymentMethod pm) {
+        return totalByMethod.getOrDefault(pm, 0.0);
+    }
+
+    private List<PatientEncounter> fetchEncounters() {
+        Map<String, Object> params = new HashMap<>();
+        StringBuilder jpql = new StringBuilder(
+                "select distinct c from PatientEncounter c where c.retired = false");
+
+        if (fromDate != null && toDate != null) {
+            if ("admissionDate".equals(dateBasis)) {
+                jpql.append(" and c.dateOfAdmission between :fromDate and :toDate");
+            } else {
+                jpql.append(" and c.dateOfDischarge between :fromDate and :toDate");
+            }
+            params.put("fromDate", fromDate);
+            params.put("toDate", toDate);
+        }
+
+        if (admissionStatus != null && admissionStatus != AdmissionStatus.ANY_STATUS) {
+            switch (admissionStatus) {
+                case ADMITTED_BUT_NOT_DISCHARGED:
+                    jpql.append(" and c.discharged = :dis");
+                    params.put("dis", false);
+                    break;
+                case DISCHARGED_BUT_FINAL_BILL_NOT_COMPLETED:
+                    jpql.append(" and c.discharged = :dis and c.paymentFinalized = :pf");
+                    params.put("dis", true);
+                    params.put("pf", false);
+                    break;
+                case DISCHARGED_AND_FINAL_BILL_COMPLETED:
+                    jpql.append(" and c.discharged = :dis and c.paymentFinalized = :pf");
+                    params.put("dis", true);
+                    params.put("pf", true);
+                    break;
+                default:
+                    break;
+            }
+        }
+
+        if (admissionType != null) {
+            jpql.append(" and c.admissionType = :admType");
+            params.put("admType", admissionType);
+        }
+        if (institution != null) {
+            jpql.append(" and c.institution = :ins");
+            params.put("ins", institution);
+        }
+        if (site != null) {
+            jpql.append(" and c.department.site = :site");
+            params.put("site", site);
+        }
+        if (department != null) {
+            jpql.append(" and c.department = :dept");
+            params.put("dept", department);
+        }
+        if (paymentMethod != null) {
+            jpql.append(" and c.paymentMethod = :pm");
+            params.put("pm", paymentMethod);
+        }
+
+        jpql.append(" order by c.bhtNo");
+        return patientEncounterFacade.findByJpql(jpql.toString(), params, TemporalType.TIMESTAMP);
+    }
+
+    private List<Payment> fetchDepositPayments(PatientEncounter enc) {
+        String jpql = "select p from Payment p"
+                + " where p.retired = false"
+                + " and p.bill.retired = false"
+                + " and p.bill.cancelled = false"
+                + " and p.bill.billTypeAtomic = :bta"
+                + " and p.bill.patientEncounter = :enc"
+                + " order by p.createdAt";
+        Map<String, Object> params = new HashMap<>();
+        params.put("bta", BillTypeAtomic.INWARD_DEPOSIT);
+        params.put("enc", enc);
+        return paymentFacade.findByJpql(jpql, params);
+    }
+
+    private List<BillItem> fetchCreditSettlementItems(PatientEncounter enc) {
+        String jpql = "select bi from BillItem bi"
+                + " where bi.retired = false"
+                + " and bi.bill.retired = false"
+                + " and bi.bill.billTypeAtomic in :btas"
+                + " and bi.patientEncounter = :enc"
+                + " order by bi.createdAt";
+        Map<String, Object> params = new HashMap<>();
+        params.put("btas", Arrays.asList(
+                BillTypeAtomic.INPATIENT_CREDIT_COMPANY_PAYMENT_RECEIVED,
+                BillTypeAtomic.INPATIENT_CREDIT_COMPANY_PAYMENT_CANCELLATION));
+        params.put("enc", enc);
+        return billItemFacade.findByJpql(jpql, params);
+    }
+
+    public void makeNull() {
+        fromDate = startOfCurrentMonth();
+        toDate = new Date();
+        dateBasis = "dischargeDate";
+        admissionStatus = AdmissionStatus.DISCHARGED_AND_FINAL_BILL_COMPLETED;
+        admissionType = null;
+        paymentMethod = null;
+        institution = null;
+        site = null;
+        department = null;
+        reportRows = null;
+        grandTotal = 0;
+        grandTotalCcSettlement = 0;
+        totalByMethod = new LinkedHashMap<>();
+        usedPaymentMethods = new ArrayList<>();
+    }
+
+    private static Date startOfCurrentMonth() {
+        Calendar cal = Calendar.getInstance();
+        cal.set(Calendar.DAY_OF_MONTH, 1);
+        cal.set(Calendar.HOUR_OF_DAY, 0);
+        cal.set(Calendar.MINUTE, 0);
+        cal.set(Calendar.SECOND, 0);
+        cal.set(Calendar.MILLISECOND, 0);
+        return cal.getTime();
+    }
+
+    // Getters / setters
+
+    public Date getFromDate() { return fromDate; }
+    public void setFromDate(Date fromDate) { this.fromDate = fromDate; }
+
+    public Date getToDate() { return toDate; }
+    public void setToDate(Date toDate) { this.toDate = toDate; }
+
+    public String getDateBasis() { return dateBasis; }
+    public void setDateBasis(String dateBasis) { this.dateBasis = dateBasis; }
+
+    public AdmissionStatus getAdmissionStatus() { return admissionStatus; }
+    public void setAdmissionStatus(AdmissionStatus admissionStatus) { this.admissionStatus = admissionStatus; }
+
+    public AdmissionType getAdmissionType() { return admissionType; }
+    public void setAdmissionType(AdmissionType admissionType) { this.admissionType = admissionType; }
+
+    public PaymentMethod getPaymentMethod() { return paymentMethod; }
+    public void setPaymentMethod(PaymentMethod paymentMethod) { this.paymentMethod = paymentMethod; }
+
+    public Institution getInstitution() { return institution; }
+    public void setInstitution(Institution institution) { this.institution = institution; }
+
+    public Institution getSite() { return site; }
+    public void setSite(Institution site) { this.site = site; }
+
+    public Department getDepartment() { return department; }
+    public void setDepartment(Department department) { this.department = department; }
+
+    public List<BhtPaymentDetailDTO> getReportRows() { return reportRows; }
+
+    public double getGrandTotal() { return grandTotal; }
+
+    public double getGrandTotalCcSettlement() { return grandTotalCcSettlement; }
+
+    public List<PaymentMethod> getUsedPaymentMethods() { return usedPaymentMethods; }
+
+    public Map<PaymentMethod, Double> getTotalByMethod() { return totalByMethod; }
+}

--- a/src/main/java/com/divudi/bean/inward/BhtPaymentDetailReportController.java
+++ b/src/main/java/com/divudi/bean/inward/BhtPaymentDetailReportController.java
@@ -184,33 +184,33 @@ public class BhtPaymentDetailReportController implements Serializable {
             jpql.append(" and c.department = :dept");
             params.put("dept", department);
         }
-        if (paymentMethod != null) {
-            jpql.append(" and c.paymentMethod = :pm");
-            params.put("pm", paymentMethod);
-        }
-
         jpql.append(" order by c.bhtNo");
         return patientEncounterFacade.findByJpql(jpql.toString(), params, TemporalType.TIMESTAMP);
     }
 
     private List<Payment> fetchDepositPayments(PatientEncounter enc) {
-        String jpql = "select p from Payment p"
+        StringBuilder jpql = new StringBuilder("select p from Payment p"
                 + " where p.retired = false"
                 + " and p.bill.retired = false"
                 + " and p.bill.cancelled = false"
                 + " and p.bill.billTypeAtomic = :bta"
-                + " and p.bill.patientEncounter = :enc"
-                + " order by p.createdAt";
+                + " and p.bill.patientEncounter = :enc");
         Map<String, Object> params = new HashMap<>();
         params.put("bta", BillTypeAtomic.INWARD_DEPOSIT);
         params.put("enc", enc);
-        return paymentFacade.findByJpql(jpql, params);
+        if (paymentMethod != null) {
+            jpql.append(" and p.paymentMethod = :pm");
+            params.put("pm", paymentMethod);
+        }
+        jpql.append(" order by p.createdAt");
+        return paymentFacade.findByJpql(jpql.toString(), params);
     }
 
     private List<BillItem> fetchCreditSettlementItems(PatientEncounter enc) {
         String jpql = "select bi from BillItem bi"
                 + " where bi.retired = false"
                 + " and bi.bill.retired = false"
+                + " and bi.bill.cancelled = false"
                 + " and bi.bill.billTypeAtomic in :btas"
                 + " and bi.patientEncounter = :enc"
                 + " order by bi.createdAt";

--- a/src/main/java/com/divudi/bean/inward/BhtPaymentDetailReportController.java
+++ b/src/main/java/com/divudi/bean/inward/BhtPaymentDetailReportController.java
@@ -138,7 +138,9 @@ public class BhtPaymentDetailReportController implements Serializable {
                 "select distinct c from PatientEncounter c where c.retired = false");
 
         if (fromDate != null && toDate != null) {
-            if ("admissionDate".equals(dateBasis)) {
+            boolean useAdmissionDate = "admissionDate".equals(dateBasis)
+                    || admissionStatus == AdmissionStatus.ADMITTED_BUT_NOT_DISCHARGED;
+            if (useAdmissionDate) {
                 jpql.append(" and c.dateOfAdmission between :fromDate and :toDate");
             } else {
                 jpql.append(" and c.dateOfDischarge between :fromDate and :toDate");

--- a/src/main/java/com/divudi/bean/inward/InwardReportController1.java
+++ b/src/main/java/com/divudi/bean/inward/InwardReportController1.java
@@ -2984,6 +2984,125 @@ public class InwardReportController1 implements Serializable {
             debtorPaidTotal += settled;
             debtorOutstandingTotal += outstanding;
         }
+
+        // === Non-discharged (currently admitted) credit company patients ===
+        List<BillTypeAtomic> chargeTypes = Arrays.asList(
+                BillTypeAtomic.INWARD_SERVICE_BILL,
+                BillTypeAtomic.INWARD_SERVICE_BILL_CANCELLATION,
+                BillTypeAtomic.INWARD_SERVICE_BILL_CANCELLATION_DURING_BATCH_BILL_CANCELLATION,
+                BillTypeAtomic.INWARD_SERVICE_BATCH_BILL,
+                BillTypeAtomic.INWARD_SERVICE_BATCH_BILL_CANCELLATION,
+                BillTypeAtomic.INWARD_OUTSIDE_CHARGES_BILL,
+                BillTypeAtomic.INWARD_OUTSIDE_CHARGES_BILL_CANCELLATION,
+                BillTypeAtomic.DIRECT_ISSUE_INWARD_MEDICINE,
+                BillTypeAtomic.DIRECT_ISSUE_INWARD_MEDICINE_CANCELLATION,
+                BillTypeAtomic.DIRECT_ISSUE_INWARD_MEDICINE_RETURN
+        );
+
+        List<BillTypeAtomic> ccPaymentTypes = Arrays.asList(
+                BillTypeAtomic.CREDIT_COMPANY_INPATIENT_PAYMENT,
+                BillTypeAtomic.CREDIT_COMPANY_INPATIENT_PAYMENT_CANCELLATION,
+                BillTypeAtomic.INPATIENT_CREDIT_COMPANY_PAYMENT_RECEIVED,
+                BillTypeAtomic.INPATIENT_CREDIT_COMPANY_PAYMENT_CANCELLATION
+        );
+
+        List<BillTypeAtomic> depositTypes = Arrays.asList(
+                BillTypeAtomic.INWARD_DEPOSIT,
+                BillTypeAtomic.INWARD_DEPOSIT_CANCELLATION,
+                BillTypeAtomic.INWARD_DEPOSIT_REFUND,
+                BillTypeAtomic.INWARD_DEPOSIT_REFUND_CANCELLATION
+        );
+
+        // Non-discharged patients are always filtered by admission date regardless of dateBasis
+        String encSql = "Select pe from PatientEncounter pe"
+                + " where pe.retired=false"
+                + " and (pe.discharged=false or pe.discharged is null)"
+                + " and pe.creditCompany is not null"
+                + " and pe.dateOfAdmission between :frm and :to";
+
+        HashMap<String, Object> encHm = new HashMap<>();
+        if (institution != null) {
+            encSql += " and pe.creditCompany=:cc";
+            encHm.put("cc", institution);
+        }
+        if (admittingInstitution != null) {
+            encSql += " and pe.institution=:ins";
+            encHm.put("ins", admittingInstitution);
+        }
+        if (site != null) {
+            encSql += " and pe.department.site=:site";
+            encHm.put("site", site);
+        }
+        if (department != null) {
+            encSql += " and pe.department=:dept";
+            encHm.put("dept", department);
+        }
+        if (admissionType != null) {
+            encSql += " and pe.admissionType=:at";
+            encHm.put("at", admissionType);
+        }
+        if (paymentMethod != null) {
+            encSql += " and pe.paymentMethod=:pm";
+            encHm.put("pm", paymentMethod);
+        }
+
+        encSql += " order by pe.creditCompany.name, pe.dateOfAdmission";
+        encHm.put("frm", getFromDate());
+        encHm.put("to", getToDate());
+
+        List<PatientEncounter> nonDischargedEncounters = patientEncounterFacade.findByJpql(encSql, encHm, TemporalType.TIMESTAMP);
+
+        for (PatientEncounter pe : nonDischargedEncounters) {
+            String chargeSql = "Select sum(b.netTotal) from Bill b"
+                    + " where b.retired=false"
+                    + " and b.patientEncounter=:pe"
+                    + " and b.billTypeAtomic in :chargeTypes";
+            HashMap<String, Object> chargeParams = new HashMap<>();
+            chargeParams.put("pe", pe);
+            chargeParams.put("chargeTypes", chargeTypes);
+            double chargeTotal = billFacade.findDoubleByJpql(chargeSql, chargeParams);
+
+            String ccPaidSql = "Select sum(b.netTotal) from Bill b"
+                    + " where b.retired=false"
+                    + " and b.patientEncounter=:pe"
+                    + " and b.billTypeAtomic in :ccPaymentTypes";
+            HashMap<String, Object> ccPaidParams = new HashMap<>();
+            ccPaidParams.put("pe", pe);
+            ccPaidParams.put("ccPaymentTypes", ccPaymentTypes);
+            double ccPaid = billFacade.findDoubleByJpql(ccPaidSql, ccPaidParams);
+
+            String depositSql = "Select sum(b.netTotal) from Bill b"
+                    + " where b.retired=false"
+                    + " and b.patientEncounter=:pe"
+                    + " and b.billTypeAtomic in :depositTypes";
+            HashMap<String, Object> depositParams = new HashMap<>();
+            depositParams.put("pe", pe);
+            depositParams.put("depositTypes", depositTypes);
+            double deposited = billFacade.findDoubleByJpql(depositSql, depositParams);
+
+            double totalPaid = ccPaid + deposited;
+            double outstanding = chargeTotal - totalPaid;
+
+            if (outstandingOnly && outstanding <= 0.01) {
+                continue;
+            }
+
+            Bill syntheticBill = new Bill();
+            syntheticBill.setPatientEncounter(pe);
+            syntheticBill.setPatient(pe.getPatient());
+            syntheticBill.setCreditCompany(pe.getCreditCompany());
+            syntheticBill.setDeptId("(Active)");
+            syntheticBill.setBillDate(pe.getDateOfAdmission());
+            syntheticBill.setNetTotal(chargeTotal);
+            syntheticBill.setSettledAmountBySponsor(ccPaid);
+            syntheticBill.setSettledAmountByPatient(deposited);
+            syntheticBill.setPaidAmount(totalPaid);
+
+            bills.add(syntheticBill);
+            debtorBillTotal += chargeTotal;
+            debtorPaidTotal += totalPaid;
+            debtorOutstandingTotal += outstanding;
+        }
     }
 
     public void inwardCreditCompanyPayments() {

--- a/src/main/java/com/divudi/core/data/dto/BhtPaymentDetailDTO.java
+++ b/src/main/java/com/divudi/core/data/dto/BhtPaymentDetailDTO.java
@@ -1,0 +1,61 @@
+package com.divudi.core.data.dto;
+
+import com.divudi.core.data.PaymentMethod;
+import com.divudi.core.entity.inward.AdmissionType;
+import java.io.Serializable;
+import java.util.Date;
+
+/**
+ * DTO for BHT Deposit and Credit Settlement Detail Report.
+ * One instance per individual payment (deposit or CC settlement).
+ */
+public class BhtPaymentDetailDTO implements Serializable {
+
+    private String bhtNo;
+    private String patientName;
+    private AdmissionType admissionType;
+    private Date dateOfAdmission;
+    private Date dateOfDischarge;
+    private String billNo;
+    private Date createdAt;
+    private PaymentMethod paymentMethod;
+    private double amount;
+    private String referenceNo;
+    private String creditCompanyName;
+
+    public BhtPaymentDetailDTO() {
+    }
+
+    public String getBhtNo() { return bhtNo; }
+    public void setBhtNo(String bhtNo) { this.bhtNo = bhtNo; }
+
+    public String getPatientName() { return patientName; }
+    public void setPatientName(String patientName) { this.patientName = patientName; }
+
+    public AdmissionType getAdmissionType() { return admissionType; }
+    public void setAdmissionType(AdmissionType admissionType) { this.admissionType = admissionType; }
+
+    public Date getDateOfAdmission() { return dateOfAdmission; }
+    public void setDateOfAdmission(Date dateOfAdmission) { this.dateOfAdmission = dateOfAdmission; }
+
+    public Date getDateOfDischarge() { return dateOfDischarge; }
+    public void setDateOfDischarge(Date dateOfDischarge) { this.dateOfDischarge = dateOfDischarge; }
+
+    public String getBillNo() { return billNo; }
+    public void setBillNo(String billNo) { this.billNo = billNo; }
+
+    public Date getCreatedAt() { return createdAt; }
+    public void setCreatedAt(Date createdAt) { this.createdAt = createdAt; }
+
+    public PaymentMethod getPaymentMethod() { return paymentMethod; }
+    public void setPaymentMethod(PaymentMethod paymentMethod) { this.paymentMethod = paymentMethod; }
+
+    public double getAmount() { return amount; }
+    public void setAmount(double amount) { this.amount = amount; }
+
+    public String getReferenceNo() { return referenceNo != null ? referenceNo : ""; }
+    public void setReferenceNo(String referenceNo) { this.referenceNo = referenceNo; }
+
+    public String getCreditCompanyName() { return creditCompanyName != null ? creditCompanyName : ""; }
+    public void setCreditCompanyName(String creditCompanyName) { this.creditCompanyName = creditCompanyName; }
+}

--- a/src/main/webapp/inward/inward_report_bht_deposit_detail.xhtml
+++ b/src/main/webapp/inward/inward_report_bht_deposit_detail.xhtml
@@ -1,0 +1,267 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
+      xmlns:p="http://primefaces.org/ui"
+      xmlns:h="http://xmlns.jcp.org/jsf/html"
+      xmlns:f="http://xmlns.jcp.org/jsf/core">
+
+    <h:body>
+        <ui:composition template="/inward/inward_reports.xhtml">
+            <ui:define name="subcontent">
+                <h:form id="frm">
+
+                    <p:panel header="BHT Deposit Detail" class="m-1">
+
+                        <h:panelGrid columns="8" styleClass="w-100 form-grid" columnClasses="label-icon-column, input-column">
+
+                            <h:panelGroup layout="block" styleClass="form-group">
+                                <h:outputText value="&#xf073;" styleClass="fa ml-5" />
+                                <h:outputLabel value="From" for="fromDate" class="mx-3"/>
+                            </h:panelGroup>
+                            <p:calendar styleClass="w-100" inputStyleClass="w-100 form-control"
+                                        id="fromDate"
+                                        value="#{bhtDepositDetailReportController.fromDate}"
+                                        pattern="#{sessionController.applicationPreference.longDateTimeFormat}" />
+
+                            <p:spacer width="50" />
+
+                            <h:panelGroup layout="block" styleClass="form-group">
+                                <h:outputText value="&#xf073;" styleClass="fa mr-2" />
+                                <h:outputLabel value="To" for="toDate" class="mx-3"/>
+                            </h:panelGroup>
+                            <p:calendar styleClass="w-100" inputStyleClass="w-100 form-control"
+                                        id="toDate"
+                                        value="#{bhtDepositDetailReportController.toDate}"
+                                        pattern="#{sessionController.applicationPreference.longDateTimeFormat}" />
+
+                            <p:spacer width="50" />
+
+                            <h:panelGroup layout="block" styleClass="form-group">
+                                <h:outputText value="&#xf017;" styleClass="fa mr-2" />
+                                <h:outputLabel value="Date Basis" for="dateBasisMenu" class="mx-3"/>
+                            </h:panelGroup>
+                            <p:selectOneMenu id="dateBasisMenu" styleClass="w-100 form-control"
+                                             value="#{bhtDepositDetailReportController.dateBasis}">
+                                <f:selectItem itemValue="dischargeDate" itemLabel="Discharge Date" />
+                                <f:selectItem itemValue="admissionDate" itemLabel="Admission Date" />
+                            </p:selectOneMenu>
+
+                            <h:panelGroup layout="block" styleClass="form-group">
+                                <h:outputText value="&#xf05a;" styleClass="fa mr-2" />
+                                <h:outputLabel value="Admission Status" for="admStatusMenu" class="mx-3"/>
+                            </h:panelGroup>
+                            <p:selectOneMenu id="admStatusMenu" styleClass="w-100 form-control"
+                                             value="#{bhtDepositDetailReportController.admissionStatus}">
+                                <f:selectItems value="#{enumController.admissionStatuses}"
+                                               var="s" itemValue="#{s}" itemLabel="#{s.label}" />
+                            </p:selectOneMenu>
+
+                            <p:spacer width="50" />
+
+                            <h:panelGroup layout="block" styleClass="form-group">
+                                <h:outputText value="&#xf0f0;" styleClass="fa mr-2" />
+                                <h:outputLabel value="Admission Type" for="admTypeMenu" class="mx-3"/>
+                            </h:panelGroup>
+                            <p:selectOneMenu id="admTypeMenu" styleClass="w-100 form-control"
+                                             value="#{bhtDepositDetailReportController.admissionType}">
+                                <f:selectItem itemLabel="All" itemValue="#{null}" />
+                                <f:selectItems value="#{admissionTypeController.items}"
+                                               var="at" itemValue="#{at}" itemLabel="#{at.name}" />
+                            </p:selectOneMenu>
+
+                            <p:spacer width="50" />
+
+                            <h:panelGroup layout="block" styleClass="form-group">
+                                <h:outputText value="&#xf09d;" styleClass="fa mr-2" />
+                                <h:outputLabel value="Payment Method" for="pmMenu" class="mx-3"/>
+                            </h:panelGroup>
+                            <p:selectOneMenu id="pmMenu" styleClass="w-100 form-control"
+                                             value="#{bhtDepositDetailReportController.paymentMethod}">
+                                <f:selectItem itemLabel="All Methods" itemValue="#{null}" />
+                                <f:selectItems value="#{enumController.paymentMethodsWithoutCredit}" />
+                            </p:selectOneMenu>
+
+                            <h:panelGroup layout="block" styleClass="form-group">
+                                <h:outputText value="&#xf19c;" styleClass="fa mr-2" />
+                                <h:outputLabel value="Institution" for="cmbIns" class="mx-3"/>
+                            </h:panelGroup>
+                            <p:selectOneMenu id="cmbIns" styleClass="w-100 form-control"
+                                             value="#{bhtDepositDetailReportController.institution}" filter="true">
+                                <f:selectItem itemLabel="All Institutions" />
+                                <f:selectItems value="#{institutionController.companies}" var="ins" itemLabel="#{ins.name}" itemValue="#{ins}" />
+                                <p:ajax process="cmbIns" update="cmbDept" />
+                            </p:selectOneMenu>
+
+                            <p:spacer />
+
+                            <h:panelGroup layout="block" styleClass="form-group">
+                                <h:outputText value="&#xf3c5;" styleClass="fa mr-2" />
+                                <h:outputLabel value="Site" for="siteMenu" class="mx-3"/>
+                            </h:panelGroup>
+                            <p:selectOneMenu id="siteMenu" styleClass="w-100 form-control"
+                                             value="#{bhtDepositDetailReportController.site}" filter="true">
+                                <f:selectItem itemLabel="All Sites" />
+                                <f:selectItems value="#{institutionController.sites}" var="site" itemLabel="#{site.name}" itemValue="#{site}" />
+                                <p:ajax process="siteMenu" update="cmbDept" />
+                            </p:selectOneMenu>
+
+                            <p:spacer />
+
+                            <h:panelGroup layout="block" styleClass="form-group">
+                                <h:outputText value="&#xf0e8;" styleClass="fa mr-2" />
+                                <h:outputLabel value="Department" for="cmbDept" class="mx-3"/>
+                            </h:panelGroup>
+                            <h:panelGroup id="cmbDept">
+                                <p:selectOneMenu
+                                    rendered="#{bhtDepositDetailReportController.institution eq null and bhtDepositDetailReportController.site eq null}"
+                                    styleClass="w-100 form-control"
+                                    value="#{bhtDepositDetailReportController.department}"
+                                    filterMatchMode="contains" filter="true">
+                                    <f:selectItem itemLabel="All Departments" />
+                                    <f:selectItems value="#{departmentController.getDepartmentsOfInstitutionAndSite()}"
+                                                   var="d" itemLabel="#{d.name}" itemValue="#{d}" />
+                                </p:selectOneMenu>
+                                <p:selectOneMenu
+                                    rendered="#{bhtDepositDetailReportController.institution eq null and bhtDepositDetailReportController.site ne null}"
+                                    styleClass="w-100 form-control"
+                                    value="#{bhtDepositDetailReportController.department}"
+                                    filterMatchMode="contains" filter="true">
+                                    <f:selectItem itemLabel="All Departments" />
+                                    <f:selectItems value="#{departmentController.getDepartmentsOfInstitutionAndSite(bhtDepositDetailReportController.site)}"
+                                                   var="d" itemLabel="#{d.name}" itemValue="#{d}" />
+                                </p:selectOneMenu>
+                                <p:selectOneMenu
+                                    rendered="#{bhtDepositDetailReportController.institution ne null and bhtDepositDetailReportController.site eq null}"
+                                    styleClass="w-100 form-control"
+                                    value="#{bhtDepositDetailReportController.department}"
+                                    filterMatchMode="contains" filter="true">
+                                    <f:selectItem itemLabel="All Departments" />
+                                    <f:selectItems value="#{departmentController.getDepartmentsOfInstitutionAndSiteForInstitution(bhtDepositDetailReportController.institution)}"
+                                                   var="d" itemLabel="#{d.name}" itemValue="#{d}" />
+                                </p:selectOneMenu>
+                                <p:selectOneMenu
+                                    rendered="#{bhtDepositDetailReportController.institution ne null and bhtDepositDetailReportController.site ne null}"
+                                    styleClass="w-100 form-control"
+                                    value="#{bhtDepositDetailReportController.department}"
+                                    filterMatchMode="contains" filter="true">
+                                    <f:selectItem itemLabel="All Departments" />
+                                    <f:selectItems value="#{departmentController.getDepartmentsOfInstitutionAndSite(bhtDepositDetailReportController.institution, bhtDepositDetailReportController.site)}"
+                                                   var="d" itemLabel="#{d.name}" itemValue="#{d}" />
+                                </p:selectOneMenu>
+                            </h:panelGroup>
+
+                        </h:panelGrid>
+
+                        <p:commandButton value="Generate" icon="fas fa-cogs"
+                                         action="#{bhtDepositDetailReportController.generateReport()}"
+                                         ajax="false" class="ui-button-success m-1" />
+
+                    </p:panel>
+
+                    <p:panel id="pnlResults"
+                             rendered="#{bhtDepositDetailReportController.reportRows != null}">
+
+                        <f:facet name="header">
+                            <div class="d-flex justify-content-between align-items-center">
+                                <h:outputText value="Results" />
+                                <div>
+                                    <p:commandButton value="Print" icon="fas fa-print"
+                                                     class="ui-button-info me-1" ajax="false">
+                                        <p:printer target="tblReport" />
+                                    </p:commandButton>
+                                    <p:commandButton value="Excel" icon="fas fa-file-excel"
+                                                     class="ui-button-success" ajax="false">
+                                        <p:dataExporter type="xlsx" target="tblReport"
+                                                        fileName="BHT_Deposit_Detail" />
+                                    </p:commandButton>
+                                </div>
+                            </div>
+                        </f:facet>
+
+                        <p:dataTable id="tblReport"
+                                     value="#{bhtDepositDetailReportController.reportRows}"
+                                     var="row"
+                                     emptyMessage="No records found"
+                                     paginator="true" rows="20"
+                                     paginatorAlwaysVisible="false" paginatorPosition="bottom"
+                                     paginatorTemplate="{CurrentPageReport} {FirstPageLink} {PreviousPageLink} {PageLinks} {NextPageLink} {LastPageLink} {RowsPerPageDropdown}"
+                                     currentPageReportTemplate="{startRecord}-{endRecord} of {totalRecords} records"
+                                     rowsPerPageTemplate="10,20,50,{ShowAll|'All'}"
+                                     styleClass="w-100">
+
+                            <p:column headerText="BHT No" style="white-space:nowrap;">
+                                <h:outputText value="#{row.bhtNo}" />
+                            </p:column>
+
+                            <p:column headerText="Patient Name">
+                                <h:outputText value="#{row.patientName}" />
+                            </p:column>
+
+                            <p:column headerText="Admission Type" style="white-space:nowrap;">
+                                <h:outputText value="#{row.admissionType != null ? row.admissionType.name : ''}" />
+                            </p:column>
+
+                            <p:column headerText="Admitted" style="white-space:nowrap;">
+                                <h:outputText value="#{row.dateOfAdmission}">
+                                    <f:convertDateTime pattern="#{sessionController.applicationPreference.shortDateFormat}" />
+                                </h:outputText>
+                            </p:column>
+
+                            <p:column headerText="Discharged" style="white-space:nowrap;">
+                                <h:outputText value="#{row.dateOfDischarge}">
+                                    <f:convertDateTime pattern="#{sessionController.applicationPreference.shortDateFormat}" />
+                                </h:outputText>
+                            </p:column>
+
+                            <p:column headerText="Bill No" style="white-space:nowrap;">
+                                <h:outputText value="#{row.billNo}" />
+                            </p:column>
+
+                            <p:column headerText="Date / Time" style="white-space:nowrap;">
+                                <h:outputText value="#{row.createdAt}">
+                                    <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateTimeFormat}" />
+                                </h:outputText>
+                            </p:column>
+
+                            <p:column headerText="Payment Method" style="white-space:nowrap;">
+                                <h:outputText value="#{row.paymentMethod != null ? row.paymentMethod.label : ''}" />
+                            </p:column>
+
+                            <p:column headerText="Amount" style="text-align:right; white-space:nowrap;">
+                                <h:outputText value="#{row.amount}">
+                                    <f:convertNumber minFractionDigits="2" maxFractionDigits="2" />
+                                </h:outputText>
+                            </p:column>
+
+                            <p:column headerText="Reference No" style="white-space:nowrap;">
+                                <h:outputText value="#{row.referenceNo}" />
+                            </p:column>
+
+                            <f:facet name="footer">
+                                <div class="text-end">
+                                    <ui:repeat value="#{bhtDepositDetailReportController.usedPaymentMethods}" var="pm">
+                                        <strong>
+                                            <h:outputText value="#{pm.label}" />:
+                                        </strong>
+                                        <h:outputText value="#{bhtDepositDetailReportController.getTotalForMethod(pm)}">
+                                            <f:convertNumber minFractionDigits="2" maxFractionDigits="2" />
+                                        </h:outputText>
+                                        &#160;&#160;&#160;
+                                    </ui:repeat>
+                                    <strong>Grand Total: </strong>
+                                    <h:outputText value="#{bhtDepositDetailReportController.grandTotal}">
+                                        <f:convertNumber minFractionDigits="2" maxFractionDigits="2" />
+                                    </h:outputText>
+                                </div>
+                            </f:facet>
+
+                        </p:dataTable>
+
+                    </p:panel>
+
+                </h:form>
+            </ui:define>
+        </ui:composition>
+    </h:body>
+</html>

--- a/src/main/webapp/inward/inward_report_bht_deposit_summary.xhtml
+++ b/src/main/webapp/inward/inward_report_bht_deposit_summary.xhtml
@@ -1,0 +1,249 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
+      xmlns:p="http://primefaces.org/ui"
+      xmlns:h="http://xmlns.jcp.org/jsf/html"
+      xmlns:f="http://xmlns.jcp.org/jsf/core">
+
+    <h:body>
+        <ui:composition template="/inward/inward_reports.xhtml">
+            <ui:define name="subcontent">
+                <h:form id="frm">
+
+                    <p:panel header="BHT Deposit Summary" class="m-1">
+
+                        <h:panelGrid columns="8" styleClass="w-100 form-grid" columnClasses="label-icon-column, input-column">
+
+                            <h:panelGroup layout="block" styleClass="form-group">
+                                <h:outputText value="&#xf073;" styleClass="fa ml-5" />
+                                <h:outputLabel value="From" for="fromDate" class="mx-3"/>
+                            </h:panelGroup>
+                            <p:calendar styleClass="w-100" inputStyleClass="w-100 form-control"
+                                        id="fromDate"
+                                        value="#{bhtDepositSummaryReportController.fromDate}"
+                                        pattern="#{sessionController.applicationPreference.longDateTimeFormat}" />
+
+                            <p:spacer width="50" />
+
+                            <h:panelGroup layout="block" styleClass="form-group">
+                                <h:outputText value="&#xf073;" styleClass="fa mr-2" />
+                                <h:outputLabel value="To" for="toDate" class="mx-3"/>
+                            </h:panelGroup>
+                            <p:calendar styleClass="w-100" inputStyleClass="w-100 form-control"
+                                        id="toDate"
+                                        value="#{bhtDepositSummaryReportController.toDate}"
+                                        pattern="#{sessionController.applicationPreference.longDateTimeFormat}" />
+
+                            <p:spacer width="50" />
+
+                            <h:panelGroup layout="block" styleClass="form-group">
+                                <h:outputText value="&#xf017;" styleClass="fa mr-2" />
+                                <h:outputLabel value="Date Basis" for="dateBasisMenu" class="mx-3"/>
+                            </h:panelGroup>
+                            <p:selectOneMenu id="dateBasisMenu" styleClass="w-100 form-control"
+                                             value="#{bhtDepositSummaryReportController.dateBasis}">
+                                <f:selectItem itemValue="dischargeDate" itemLabel="Discharge Date" />
+                                <f:selectItem itemValue="admissionDate" itemLabel="Admission Date" />
+                            </p:selectOneMenu>
+
+                            <h:panelGroup layout="block" styleClass="form-group">
+                                <h:outputText value="&#xf05a;" styleClass="fa mr-2" />
+                                <h:outputLabel value="Admission Status" for="admStatusMenu" class="mx-3"/>
+                            </h:panelGroup>
+                            <p:selectOneMenu id="admStatusMenu" styleClass="w-100 form-control"
+                                             value="#{bhtDepositSummaryReportController.admissionStatus}">
+                                <f:selectItems value="#{enumController.admissionStatuses}"
+                                               var="s" itemValue="#{s}" itemLabel="#{s.label}" />
+                            </p:selectOneMenu>
+
+                            <p:spacer width="50" />
+
+                            <h:panelGroup layout="block" styleClass="form-group">
+                                <h:outputText value="&#xf0f0;" styleClass="fa mr-2" />
+                                <h:outputLabel value="Admission Type" for="admTypeMenu" class="mx-3"/>
+                            </h:panelGroup>
+                            <p:selectOneMenu id="admTypeMenu" styleClass="w-100 form-control"
+                                             value="#{bhtDepositSummaryReportController.admissionType}">
+                                <f:selectItem itemLabel="All" itemValue="#{null}" />
+                                <f:selectItems value="#{admissionTypeController.items}"
+                                               var="at" itemValue="#{at}" itemLabel="#{at.name}" />
+                            </p:selectOneMenu>
+
+                            <p:spacer width="50" />
+
+                            <h:panelGroup layout="block" styleClass="form-group">
+                                <h:outputText value="&#xf09d;" styleClass="fa mr-2" />
+                                <h:outputLabel value="Payment Method" for="pmMenu" class="mx-3"/>
+                            </h:panelGroup>
+                            <p:selectOneMenu id="pmMenu" styleClass="w-100 form-control"
+                                             value="#{bhtDepositSummaryReportController.paymentMethod}">
+                                <f:selectItem itemLabel="All Methods" itemValue="#{null}" />
+                                <f:selectItems value="#{enumController.paymentMethodsWithoutCredit}" />
+                            </p:selectOneMenu>
+
+                            <h:panelGroup layout="block" styleClass="form-group">
+                                <h:outputText value="&#xf19c;" styleClass="fa mr-2" />
+                                <h:outputLabel value="Institution" for="cmbIns" class="mx-3"/>
+                            </h:panelGroup>
+                            <p:selectOneMenu id="cmbIns" styleClass="w-100 form-control"
+                                             value="#{bhtDepositSummaryReportController.institution}" filter="true">
+                                <f:selectItem itemLabel="All Institutions" />
+                                <f:selectItems value="#{institutionController.companies}" var="ins" itemLabel="#{ins.name}" itemValue="#{ins}" />
+                                <p:ajax process="cmbIns" update="cmbDept" />
+                            </p:selectOneMenu>
+
+                            <p:spacer />
+
+                            <h:panelGroup layout="block" styleClass="form-group">
+                                <h:outputText value="&#xf3c5;" styleClass="fa mr-2" />
+                                <h:outputLabel value="Site" for="siteMenu" class="mx-3"/>
+                            </h:panelGroup>
+                            <p:selectOneMenu id="siteMenu" styleClass="w-100 form-control"
+                                             value="#{bhtDepositSummaryReportController.site}" filter="true">
+                                <f:selectItem itemLabel="All Sites" />
+                                <f:selectItems value="#{institutionController.sites}" var="site" itemLabel="#{site.name}" itemValue="#{site}" />
+                                <p:ajax process="siteMenu" update="cmbDept" />
+                            </p:selectOneMenu>
+
+                            <p:spacer />
+
+                            <h:panelGroup layout="block" styleClass="form-group">
+                                <h:outputText value="&#xf0e8;" styleClass="fa mr-2" />
+                                <h:outputLabel value="Department" for="cmbDept" class="mx-3"/>
+                            </h:panelGroup>
+                            <h:panelGroup id="cmbDept">
+                                <p:selectOneMenu
+                                    rendered="#{bhtDepositSummaryReportController.institution eq null and bhtDepositSummaryReportController.site eq null}"
+                                    styleClass="w-100 form-control"
+                                    value="#{bhtDepositSummaryReportController.department}"
+                                    filterMatchMode="contains" filter="true">
+                                    <f:selectItem itemLabel="All Departments" />
+                                    <f:selectItems value="#{departmentController.getDepartmentsOfInstitutionAndSite()}"
+                                                   var="d" itemLabel="#{d.name}" itemValue="#{d}" />
+                                </p:selectOneMenu>
+                                <p:selectOneMenu
+                                    rendered="#{bhtDepositSummaryReportController.institution eq null and bhtDepositSummaryReportController.site ne null}"
+                                    styleClass="w-100 form-control"
+                                    value="#{bhtDepositSummaryReportController.department}"
+                                    filterMatchMode="contains" filter="true">
+                                    <f:selectItem itemLabel="All Departments" />
+                                    <f:selectItems value="#{departmentController.getDepartmentsOfInstitutionAndSite(bhtDepositSummaryReportController.site)}"
+                                                   var="d" itemLabel="#{d.name}" itemValue="#{d}" />
+                                </p:selectOneMenu>
+                                <p:selectOneMenu
+                                    rendered="#{bhtDepositSummaryReportController.institution ne null and bhtDepositSummaryReportController.site eq null}"
+                                    styleClass="w-100 form-control"
+                                    value="#{bhtDepositSummaryReportController.department}"
+                                    filterMatchMode="contains" filter="true">
+                                    <f:selectItem itemLabel="All Departments" />
+                                    <f:selectItems value="#{departmentController.getDepartmentsOfInstitutionAndSiteForInstitution(bhtDepositSummaryReportController.institution)}"
+                                                   var="d" itemLabel="#{d.name}" itemValue="#{d}" />
+                                </p:selectOneMenu>
+                                <p:selectOneMenu
+                                    rendered="#{bhtDepositSummaryReportController.institution ne null and bhtDepositSummaryReportController.site ne null}"
+                                    styleClass="w-100 form-control"
+                                    value="#{bhtDepositSummaryReportController.department}"
+                                    filterMatchMode="contains" filter="true">
+                                    <f:selectItem itemLabel="All Departments" />
+                                    <f:selectItems value="#{departmentController.getDepartmentsOfInstitutionAndSite(bhtDepositSummaryReportController.institution, bhtDepositSummaryReportController.site)}"
+                                                   var="d" itemLabel="#{d.name}" itemValue="#{d}" />
+                                </p:selectOneMenu>
+                            </h:panelGroup>
+
+                        </h:panelGrid>
+
+                        <p:commandButton value="Generate" icon="fas fa-cogs"
+                                         action="#{bhtDepositSummaryReportController.generateReport()}"
+                                         ajax="false" class="ui-button-success m-1" />
+
+                    </p:panel>
+
+                    <p:panel id="pnlResults"
+                             rendered="#{bhtDepositSummaryReportController.reportRows != null}">
+
+                        <f:facet name="header">
+                            <div class="d-flex justify-content-between align-items-center">
+                                <h:outputText value="Results" />
+                                <div>
+                                    <p:commandButton value="Print" icon="fas fa-print"
+                                                     class="ui-button-info me-1" ajax="false">
+                                        <p:printer target="tblReport" />
+                                    </p:commandButton>
+                                    <p:commandButton value="Excel" icon="fas fa-file-excel"
+                                                     class="ui-button-success" ajax="false">
+                                        <p:dataExporter type="xlsx" target="tblReport"
+                                                        fileName="BHT_Deposit_Summary" />
+                                    </p:commandButton>
+                                </div>
+                            </div>
+                        </f:facet>
+
+                        <p:dataTable id="tblReport"
+                                     value="#{bhtDepositSummaryReportController.reportRows}"
+                                     var="row"
+                                     emptyMessage="No records found"
+                                     paginator="true" rows="20"
+                                     paginatorAlwaysVisible="false" paginatorPosition="bottom"
+                                     paginatorTemplate="{CurrentPageReport} {FirstPageLink} {PreviousPageLink} {PageLinks} {NextPageLink} {LastPageLink} {RowsPerPageDropdown}"
+                                     currentPageReportTemplate="{startRecord}-{endRecord} of {totalRecords} records"
+                                     rowsPerPageTemplate="10,20,50,{ShowAll|'All'}"
+                                     styleClass="w-100">
+
+                            <p:column headerText="BHT No" style="white-space:nowrap;">
+                                <h:outputText value="#{row.bhtNo}" />
+                            </p:column>
+
+                            <p:column headerText="Patient Name">
+                                <h:outputText value="#{row.patientName}" />
+                            </p:column>
+
+                            <p:column headerText="Admission Type" style="white-space:nowrap;">
+                                <h:outputText value="#{row.admissionType != null ? row.admissionType.name : ''}" />
+                            </p:column>
+
+                            <p:column headerText="Admitted" style="white-space:nowrap;">
+                                <h:outputText value="#{row.dateOfAdmission}">
+                                    <f:convertDateTime pattern="#{sessionController.applicationPreference.shortDateFormat}" />
+                                </h:outputText>
+                            </p:column>
+
+                            <p:column headerText="Discharged" style="white-space:nowrap;">
+                                <h:outputText value="#{row.dateOfDischarge}">
+                                    <f:convertDateTime pattern="#{sessionController.applicationPreference.shortDateFormat}" />
+                                </h:outputText>
+                            </p:column>
+
+                            <p:columns value="#{bhtDepositSummaryReportController.allPaymentMethods}"
+                                       var="pm" headerText="#{pm.label}"
+                                       style="text-align:right; white-space:nowrap;">
+                                <h:outputText value="#{row.getDepositForMethod(pm)}">
+                                    <f:convertNumber minFractionDigits="2" maxFractionDigits="2" />
+                                </h:outputText>
+                                <f:facet name="footer">
+                                    <h:outputText value="#{bhtDepositSummaryReportController.getColumnTotal(pm)}">
+                                        <f:convertNumber minFractionDigits="2" maxFractionDigits="2" />
+                                    </h:outputText>
+                                </f:facet>
+                            </p:columns>
+
+                            <p:column headerText="Total Deposits" style="text-align:right; white-space:nowrap; font-weight:bold;">
+                                <h:outputText value="#{row.totalDeposits}">
+                                    <f:convertNumber minFractionDigits="2" maxFractionDigits="2" />
+                                </h:outputText>
+                                <f:facet name="footer">
+                                    <h:outputText value="#{bhtDepositSummaryReportController.grandTotal}">
+                                        <f:convertNumber minFractionDigits="2" maxFractionDigits="2" />
+                                    </h:outputText>
+                                </f:facet>
+                            </p:column>
+
+                        </p:dataTable>
+
+                    </p:panel>
+
+                </h:form>
+            </ui:define>
+        </ui:composition>
+    </h:body>
+</html>

--- a/src/main/webapp/inward/inward_report_bht_payment_detail.xhtml
+++ b/src/main/webapp/inward/inward_report_bht_payment_detail.xhtml
@@ -1,0 +1,322 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
+      xmlns:p="http://primefaces.org/ui"
+      xmlns:h="http://xmlns.jcp.org/jsf/html"
+      xmlns:f="http://xmlns.jcp.org/jsf/core">
+
+    <h:body>
+        <ui:composition template="/inward/inward_reports.xhtml">
+            <ui:define name="subcontent">
+                <h:form id="frm">
+
+                    <p:panel header="BHT Deposit and Credit Settlement Detail" class="m-1">
+
+                        <h:panelGrid columns="8" styleClass="w-100 form-grid" columnClasses="label-icon-column, input-column">
+
+                            <h:panelGroup layout="block" styleClass="form-group">
+                                <h:outputText value="&#xf073;" styleClass="fa ml-5" />
+                                <h:outputLabel value="From" for="fromDate" class="mx-3"/>
+                            </h:panelGroup>
+                            <p:calendar
+                                styleClass="w-100"
+                                inputStyleClass="w-100 form-control"
+                                id="fromDate"
+                                value="#{bhtPaymentDetailReportController.fromDate}"
+                                pattern="#{sessionController.applicationPreference.longDateTimeFormat}" />
+
+                            <p:spacer width="50" />
+
+                            <h:panelGroup layout="block" styleClass="form-group">
+                                <h:outputText value="&#xf073;" styleClass="fa mr-2" />
+                                <h:outputLabel value="To" for="toDate" class="mx-3"/>
+                            </h:panelGroup>
+                            <p:calendar
+                                styleClass="w-100"
+                                inputStyleClass="w-100 form-control"
+                                id="toDate"
+                                value="#{bhtPaymentDetailReportController.toDate}"
+                                pattern="#{sessionController.applicationPreference.longDateTimeFormat}" />
+
+                            <p:spacer width="50" />
+
+                            <h:panelGroup layout="block" styleClass="form-group">
+                                <h:outputText value="&#xf017;" styleClass="fa mr-2" />
+                                <h:outputLabel value="Date Basis" for="dateBasisMenu" class="mx-3"/>
+                            </h:panelGroup>
+                            <p:selectOneMenu
+                                id="dateBasisMenu"
+                                styleClass="w-100 form-control"
+                                value="#{bhtPaymentDetailReportController.dateBasis}">
+                                <f:selectItem itemValue="dischargeDate" itemLabel="Discharge Date" />
+                                <f:selectItem itemValue="admissionDate" itemLabel="Admission Date" />
+                            </p:selectOneMenu>
+
+                            <h:panelGroup layout="block" styleClass="form-group">
+                                <h:outputText value="&#xf05a;" styleClass="fa mr-2" />
+                                <h:outputLabel value="Admission Status" for="admStatusMenu" class="mx-3"/>
+                            </h:panelGroup>
+                            <p:selectOneMenu
+                                id="admStatusMenu"
+                                styleClass="w-100 form-control"
+                                value="#{bhtPaymentDetailReportController.admissionStatus}">
+                                <f:selectItems
+                                    value="#{enumController.admissionStatuses}"
+                                    var="s"
+                                    itemValue="#{s}"
+                                    itemLabel="#{s.label}" />
+                            </p:selectOneMenu>
+
+                            <p:spacer width="50" />
+
+                            <h:panelGroup layout="block" styleClass="form-group">
+                                <h:outputText value="&#xf0f0;" styleClass="fa mr-2" />
+                                <h:outputLabel value="Admission Type" for="admTypeMenu" class="mx-3"/>
+                            </h:panelGroup>
+                            <p:selectOneMenu
+                                id="admTypeMenu"
+                                styleClass="w-100 form-control"
+                                value="#{bhtPaymentDetailReportController.admissionType}">
+                                <f:selectItem itemLabel="All" itemValue="#{null}" />
+                                <f:selectItems
+                                    value="#{admissionTypeController.items}"
+                                    var="at"
+                                    itemValue="#{at}"
+                                    itemLabel="#{at.name}" />
+                            </p:selectOneMenu>
+
+                            <p:spacer width="50" />
+
+                            <h:panelGroup layout="block" styleClass="form-group">
+                                <h:outputText value="&#xf09d;" styleClass="fa mr-2" />
+                                <h:outputLabel value="Payment Method" for="pmMenu" class="mx-3"/>
+                            </h:panelGroup>
+                            <p:selectOneMenu id="pmMenu" styleClass="w-100 form-control"
+                                             value="#{bhtPaymentDetailReportController.paymentMethod}">
+                                <f:selectItem itemLabel="All Methods" itemValue="#{null}" />
+                                <f:selectItems value="#{enumController.paymentMethodsWithoutCredit}" />
+                            </p:selectOneMenu>
+
+                            <h:panelGroup layout="block" styleClass="form-group">
+                                <h:outputText value="&#xf19c;" styleClass="fa mr-2" />
+                                <h:outputLabel value="Institution" for="cmbIns" class="mx-3"/>
+                            </h:panelGroup>
+                            <p:selectOneMenu
+                                id="cmbIns"
+                                styleClass="w-100 form-control"
+                                value="#{bhtPaymentDetailReportController.institution}"
+                                filter="true">
+                                <f:selectItem itemLabel="All Institutions" />
+                                <f:selectItems value="#{institutionController.companies}" var="ins" itemLabel="#{ins.name}" itemValue="#{ins}" />
+                                <p:ajax process="cmbIns" update="cmbDept" />
+                            </p:selectOneMenu>
+
+                            <p:spacer />
+
+                            <h:panelGroup layout="block" styleClass="form-group">
+                                <h:outputText value="&#xf3c5;" styleClass="fa mr-2" />
+                                <h:outputLabel value="Site" for="siteMenu" class="mx-3"/>
+                            </h:panelGroup>
+                            <p:selectOneMenu
+                                id="siteMenu"
+                                styleClass="w-100 form-control"
+                                value="#{bhtPaymentDetailReportController.site}"
+                                filter="true">
+                                <f:selectItem itemLabel="All Sites" />
+                                <f:selectItems value="#{institutionController.sites}" var="site" itemLabel="#{site.name}" itemValue="#{site}" />
+                                <p:ajax process="siteMenu" update="cmbDept" />
+                            </p:selectOneMenu>
+
+                            <p:spacer />
+
+                            <h:panelGroup layout="block" styleClass="form-group">
+                                <h:outputText value="&#xf0e8;" styleClass="fa mr-2" />
+                                <h:outputLabel value="Department" for="cmbDept" class="mx-3"/>
+                            </h:panelGroup>
+                            <h:panelGroup id="cmbDept">
+
+                                <p:selectOneMenu
+                                    rendered="#{bhtPaymentDetailReportController.institution eq null and bhtPaymentDetailReportController.site eq null}"
+                                    styleClass="w-100 form-control"
+                                    value="#{bhtPaymentDetailReportController.department}"
+                                    filterMatchMode="contains"
+                                    filter="true">
+                                    <f:selectItem itemLabel="All Departments" />
+                                    <f:selectItems
+                                        value="#{departmentController.getDepartmentsOfInstitutionAndSite()}"
+                                        var="d" itemLabel="#{d.name}" itemValue="#{d}" />
+                                </p:selectOneMenu>
+
+                                <p:selectOneMenu
+                                    rendered="#{bhtPaymentDetailReportController.institution eq null and bhtPaymentDetailReportController.site ne null}"
+                                    styleClass="w-100 form-control"
+                                    value="#{bhtPaymentDetailReportController.department}"
+                                    filterMatchMode="contains"
+                                    filter="true">
+                                    <f:selectItem itemLabel="All Departments" />
+                                    <f:selectItems
+                                        value="#{departmentController.getDepartmentsOfInstitutionAndSite(bhtPaymentDetailReportController.site)}"
+                                        var="d" itemLabel="#{d.name}" itemValue="#{d}" />
+                                </p:selectOneMenu>
+
+                                <p:selectOneMenu
+                                    rendered="#{bhtPaymentDetailReportController.institution ne null and bhtPaymentDetailReportController.site eq null}"
+                                    styleClass="w-100 form-control"
+                                    value="#{bhtPaymentDetailReportController.department}"
+                                    filterMatchMode="contains"
+                                    filter="true">
+                                    <f:selectItem itemLabel="All Departments" />
+                                    <f:selectItems
+                                        value="#{departmentController.getDepartmentsOfInstitutionAndSiteForInstitution(bhtPaymentDetailReportController.institution)}"
+                                        var="d" itemLabel="#{d.name}" itemValue="#{d}" />
+                                </p:selectOneMenu>
+
+                                <p:selectOneMenu
+                                    rendered="#{bhtPaymentDetailReportController.institution ne null and bhtPaymentDetailReportController.site ne null}"
+                                    styleClass="w-100 form-control"
+                                    value="#{bhtPaymentDetailReportController.department}"
+                                    filterMatchMode="contains"
+                                    filter="true">
+                                    <f:selectItem itemLabel="All Departments" />
+                                    <f:selectItems
+                                        value="#{departmentController.getDepartmentsOfInstitutionAndSite(bhtPaymentDetailReportController.institution, bhtPaymentDetailReportController.site)}"
+                                        var="d" itemLabel="#{d.name}" itemValue="#{d}" />
+                                </p:selectOneMenu>
+
+                            </h:panelGroup>
+
+                        </h:panelGrid>
+
+                        <p:commandButton
+                            value="Generate"
+                            icon="fas fa-cogs"
+                            action="#{bhtPaymentDetailReportController.generateReport()}"
+                            ajax="false"
+                            class="ui-button-success m-1" />
+
+                    </p:panel>
+
+                    <p:panel id="pnlResults"
+                             rendered="#{bhtPaymentDetailReportController.reportRows != null}">
+
+                        <f:facet name="header">
+                            <div class="d-flex justify-content-between align-items-center">
+                                <h:outputText value="Results" />
+                                <div>
+                                    <p:commandButton value="Print"
+                                                     icon="fas fa-print"
+                                                     class="ui-button-info me-1"
+                                                     ajax="false">
+                                        <p:printer target="tblReport" />
+                                    </p:commandButton>
+                                    <p:commandButton value="Excel"
+                                                     icon="fas fa-file-excel"
+                                                     class="ui-button-success"
+                                                     ajax="false">
+                                        <p:dataExporter type="xlsx"
+                                                        target="tblReport"
+                                                        fileName="BHT_Payment_Detail" />
+                                    </p:commandButton>
+                                </div>
+                            </div>
+                        </f:facet>
+
+                        <p:dataTable
+                            id="tblReport"
+                            value="#{bhtPaymentDetailReportController.reportRows}"
+                            var="row"
+                            emptyMessage="No records found"
+                            paginator="true"
+                            rows="20"
+                            paginatorAlwaysVisible="false"
+                            paginatorPosition="bottom"
+                            paginatorTemplate="{CurrentPageReport} {FirstPageLink} {PreviousPageLink} {PageLinks} {NextPageLink} {LastPageLink} {RowsPerPageDropdown}"
+                            currentPageReportTemplate="{startRecord}-{endRecord} of {totalRecords} records"
+                            rowsPerPageTemplate="10,20,50,{ShowAll|'All'}"
+                            styleClass="w-100">
+
+                            <p:column headerText="BHT No" style="white-space:nowrap;">
+                                <h:outputText value="#{row.bhtNo}" />
+                            </p:column>
+
+                            <p:column headerText="Patient Name">
+                                <h:outputText value="#{row.patientName}" />
+                            </p:column>
+
+                            <p:column headerText="Admission Type" style="white-space:nowrap;">
+                                <h:outputText value="#{row.admissionType != null ? row.admissionType.name : ''}" />
+                            </p:column>
+
+                            <p:column headerText="Admitted" style="white-space:nowrap;">
+                                <h:outputText value="#{row.dateOfAdmission}">
+                                    <f:convertDateTime pattern="#{sessionController.applicationPreference.shortDateFormat}" />
+                                </h:outputText>
+                            </p:column>
+
+                            <p:column headerText="Discharged" style="white-space:nowrap;">
+                                <h:outputText value="#{row.dateOfDischarge}">
+                                    <f:convertDateTime pattern="#{sessionController.applicationPreference.shortDateFormat}" />
+                                </h:outputText>
+                            </p:column>
+
+                            <p:column headerText="Bill No" style="white-space:nowrap;">
+                                <h:outputText value="#{row.billNo}" />
+                            </p:column>
+
+                            <p:column headerText="Date / Time" style="white-space:nowrap;">
+                                <h:outputText value="#{row.createdAt}">
+                                    <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateTimeFormat}" />
+                                </h:outputText>
+                            </p:column>
+
+                            <p:column headerText="Payment Method" style="white-space:nowrap;">
+                                <h:outputText value="#{row.paymentMethod != null ? row.paymentMethod.label : 'CC Settlement'}" />
+                            </p:column>
+
+                            <p:column headerText="Amount" style="text-align:right; white-space:nowrap;">
+                                <h:outputText value="#{row.amount}">
+                                    <f:convertNumber minFractionDigits="2" maxFractionDigits="2" />
+                                </h:outputText>
+                            </p:column>
+
+                            <p:column headerText="Reference No" style="white-space:nowrap;">
+                                <h:outputText value="#{row.referenceNo}" />
+                            </p:column>
+
+                            <p:column headerText="Credit Company">
+                                <h:outputText value="#{row.creditCompanyName}" />
+                            </p:column>
+
+                            <f:facet name="footer">
+                                <div class="text-end">
+                                    <ui:repeat value="#{bhtPaymentDetailReportController.usedPaymentMethods}" var="pm">
+                                        <strong>
+                                            <h:outputText value="#{pm.label}" />:
+                                        </strong>
+                                        <h:outputText value="#{bhtPaymentDetailReportController.getTotalForMethod(pm)}">
+                                            <f:convertNumber minFractionDigits="2" maxFractionDigits="2" />
+                                        </h:outputText>
+                                        &#160;&#160;&#160;
+                                    </ui:repeat>
+                                    <strong>CC Settlement: </strong>
+                                    <h:outputText value="#{bhtPaymentDetailReportController.grandTotalCcSettlement}">
+                                        <f:convertNumber minFractionDigits="2" maxFractionDigits="2" />
+                                    </h:outputText>
+                                    &#160;&#160;&#160;
+                                    <strong>Grand Total: </strong>
+                                    <h:outputText value="#{bhtPaymentDetailReportController.grandTotal}">
+                                        <f:convertNumber minFractionDigits="2" maxFractionDigits="2" />
+                                    </h:outputText>
+                                </div>
+                            </f:facet>
+
+                        </p:dataTable>
+
+                    </p:panel>
+
+                </h:form>
+            </ui:define>
+        </ui:composition>
+    </h:body>
+</html>

--- a/src/main/webapp/inward/inward_reports.xhtml
+++ b/src/main/webapp/inward/inward_reports.xhtml
@@ -73,6 +73,27 @@
                                             class="ui-button-success"
                                             ajax="false" />
                                         <p:commandButton
+                                            value="BHT Deposit and Credit Settlement Detail"
+                                            icon="fa fa-fw fa-list-alt"
+                                            action="inward_report_bht_payment_detail?faces-redirect=true"
+                                            actionListener="#{bhtPaymentDetailReportController.makeNull()}"
+                                            class="ui-button-success"
+                                            ajax="false" />
+                                        <p:commandButton
+                                            value="BHT Deposit Summary"
+                                            icon="fa fa-fw fa-coins"
+                                            action="inward_report_bht_deposit_summary?faces-redirect=true"
+                                            actionListener="#{bhtDepositSummaryReportController.makeNull()}"
+                                            class="ui-button-success"
+                                            ajax="false" />
+                                        <p:commandButton
+                                            value="BHT Deposit Detail"
+                                            icon="fa fa-fw fa-receipt"
+                                            action="inward_report_bht_deposit_detail?faces-redirect=true"
+                                            actionListener="#{bhtDepositDetailReportController.makeNull()}"
+                                            class="ui-button-success"
+                                            ajax="false" />
+                                        <p:commandButton
                                             value="Inpatient Invoice Journal"
                                             icon="fa fa-fw fa-book"
                                             action="inward_report_invoice_journal?faces-redirect=true"


### PR DESCRIPTION
## Summary

- **Bug fix**: Inpatient Credit Company Debtor Report now includes non-discharged admissions. Previously only `INWARD_FINAL_BILL_PAYMENT_BY_CREDIT_COMPANY` bills were queried (discharge-only). A second query now finds active `PatientEncounter` records where `creditCompany` is set and `discharged = false`, computes their charge/payment totals, and adds synthetic rows marked `(Active)`.
- **New report**: BHT Deposit and Credit Settlement Detail — one row per individual deposit `Payment` or CC settlement `BillItem`, with card reference number and per-method footer breakdown.
- **New report**: BHT Deposit Summary — one row per admission, dynamic payment-method columns, deposits only.
- **New report**: BHT Deposit Detail — one row per deposit `Payment`, deposits only, per-method footer breakdown.
- Four new navigation buttons added to the Payment Reports tab in `inward_reports.xhtml`.

Closes #19901

## Test plan

- [ ] Open Inpatient Credit Company Debtor Report; confirm currently admitted CC patients now appear with `(Active)` in Bill No column and correct charge/deposit totals
- [ ] Confirm discharged patients still appear correctly and settlement recalculation is unaffected
- [ ] Open BHT Deposit and Credit Settlement Detail; verify one row per deposit and one row per CC settlement, card reference numbers visible for card payments
- [ ] Open BHT Deposit Summary; verify one row per BHT, dynamic payment-method columns, no CC Settlement column
- [ ] Open BHT Deposit Detail; verify one row per deposit payment, no CC settlement rows
- [ ] Verify all four new nav buttons appear in correct order in the Payment Reports tab
- [ ] Verify Print and Excel export work on all new reports

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added three BHT reports: Deposit Detail, Deposit Summary, and Deposit & Credit Settlement Detail with configurable filters (date-basis, range, admission status/type, payment method, institution/site/department).
  * Reports display per-method columns/totals, CC-settlement totals, grand totals, and support Print and Excel export; new navigation buttons added.

* **Enhancements**
  * Inward reporting now includes active (non-discharged) credit-company patient accounting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->