### PR TITLE
feat: Credit Company Debtor Report grouped by company with subtotals

### DIFF
--- a/src/main/java/com/divudi/bean/inward/CreditCompanyDebtorGroupedReportController.java
+++ b/src/main/java/com/divudi/bean/inward/CreditCompanyDebtorGroupedReportController.java
@@ -1,0 +1,335 @@
+package com.divudi.bean.inward;
+
+import com.divudi.core.data.BillTypeAtomic;
+import com.divudi.core.data.CountedServiceType;
+import com.divudi.core.data.PaymentMethod;
+import com.divudi.core.data.dto.CreditCompanyDebtorGroupDTO;
+import com.divudi.core.data.inward.AdmissionStatus;
+import com.divudi.core.entity.Bill;
+import com.divudi.core.entity.Department;
+import com.divudi.core.entity.Institution;
+import com.divudi.core.entity.PatientEncounter;
+import com.divudi.core.entity.inward.AdmissionType;
+import com.divudi.core.facade.BillFacade;
+import com.divudi.core.facade.BillItemFacade;
+import com.divudi.core.facade.PatientEncounterFacade;
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Calendar;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import javax.ejb.EJB;
+import javax.enterprise.context.SessionScoped;
+import javax.inject.Named;
+import javax.persistence.TemporalType;
+
+/**
+ * Controller for the Credit Company Debtor Grouped Report.
+ * Produces the same data as the flat debtor report but groups rows by credit
+ * company, with per-company subtotals and a grand total.
+ */
+@Named
+@SessionScoped
+public class CreditCompanyDebtorGroupedReportController implements Serializable {
+
+    @EJB
+    private BillFacade billFacade;
+    @EJB
+    BillItemFacade BillItemFacade;
+    @EJB
+    private PatientEncounterFacade patientEncounterFacade;
+
+    private Date fromDate = startOfCurrentMonth();
+    private Date toDate = new Date();
+    private String dateBasis = "createdAt";
+    private Institution institution;
+    private Institution admittingInstitution;
+    private Institution site;
+    private Department department;
+    private AdmissionType admissionType;
+    private PaymentMethod paymentMethod;
+    private boolean outstandingOnly = false;
+
+    private List<CreditCompanyDebtorGroupDTO> groups;
+    private double grandBillTotal;
+    private double grandSettledByCompany;
+    private double grandSettledByPatient;
+    private double grandPaidTotal;
+    private double grandOutstandingTotal;
+
+    public void generateReport() {
+        groups = new ArrayList<>();
+        grandBillTotal = 0;
+        grandSettledByCompany = 0;
+        grandSettledByPatient = 0;
+        grandPaidTotal = 0;
+        grandOutstandingTotal = 0;
+
+        List<Bill> allBills = new ArrayList<>();
+
+        // --- Discharged patients: query INWARD_FINAL_BILL_PAYMENT_BY_CREDIT_COMPANY ---
+        HashMap<String, Object> hm = new HashMap<>();
+        String dateField = resolveDateField(dateBasis, "b.billDate", "b.patientEncounter");
+        String sql = "Select b from Bill b"
+                + " where b.retired=false"
+                + " and (b.cancelled=false or b.cancelled is null)"
+                + " and b.billTypeAtomic=:bta"
+                + " and " + dateField + " between :frm and :to";
+
+        if (institution != null) {
+            sql += " and b.creditCompany=:cc";
+            hm.put("cc", institution);
+        }
+        if (admittingInstitution != null) {
+            sql += " and b.patientEncounter.institution=:ins";
+            hm.put("ins", admittingInstitution);
+        }
+        if (site != null) {
+            sql += " and b.patientEncounter.department.site=:site";
+            hm.put("site", site);
+        }
+        if (department != null) {
+            sql += " and b.patientEncounter.department=:dept";
+            hm.put("dept", department);
+        }
+        if (admissionType != null) {
+            sql += " and b.patientEncounter.admissionType=:at";
+            hm.put("at", admissionType);
+        }
+        if (paymentMethod != null) {
+            sql += " and b.patientEncounter.paymentMethod=:pm";
+            hm.put("pm", paymentMethod);
+        }
+        sql += " order by b.creditCompany.name, b.billDate";
+        hm.put("bta", BillTypeAtomic.INWARD_FINAL_BILL_PAYMENT_BY_CREDIT_COMPANY);
+        hm.put("frm", fromDate);
+        hm.put("to", toDate);
+
+        List<Bill> dischargedBills = billFacade.findByJpql(sql, hm, TemporalType.TIMESTAMP);
+        List<BillTypeAtomic> settlementTypes =
+                BillTypeAtomic.findByCountedServiceType(CountedServiceType.CREDIT_SETTLE_BY_COMPANY);
+
+        for (Bill b : dischargedBills) {
+            String settledSql = "Select sum(bi.netValue) from BillItem bi"
+                    + " where bi.retired=false"
+                    + " and bi.referenceBill=:bill"
+                    + " and bi.bill.billTypeAtomic in :types";
+            HashMap<String, Object> settledParams = new HashMap<>();
+            settledParams.put("bill", b);
+            settledParams.put("types", settlementTypes);
+            double settled = BillItemFacade.findDoubleByJpql(settledSql, settledParams);
+            b.setPaidAmount(settled);
+            b.setSettledAmountBySponsor(settled);
+
+            double outstanding = b.getNetTotal() - settled;
+            if (outstandingOnly && outstanding <= 0.01) {
+                continue;
+            }
+            allBills.add(b);
+        }
+
+        // --- Non-discharged patients ---
+        List<BillTypeAtomic> chargeTypes = Arrays.asList(
+                BillTypeAtomic.INWARD_SERVICE_BILL,
+                BillTypeAtomic.INWARD_SERVICE_BILL_CANCELLATION,
+                BillTypeAtomic.INWARD_SERVICE_BILL_CANCELLATION_DURING_BATCH_BILL_CANCELLATION,
+                BillTypeAtomic.INWARD_SERVICE_BATCH_BILL,
+                BillTypeAtomic.INWARD_SERVICE_BATCH_BILL_CANCELLATION,
+                BillTypeAtomic.INWARD_OUTSIDE_CHARGES_BILL,
+                BillTypeAtomic.INWARD_OUTSIDE_CHARGES_BILL_CANCELLATION,
+                BillTypeAtomic.DIRECT_ISSUE_INWARD_MEDICINE,
+                BillTypeAtomic.DIRECT_ISSUE_INWARD_MEDICINE_CANCELLATION,
+                BillTypeAtomic.DIRECT_ISSUE_INWARD_MEDICINE_RETURN
+        );
+        List<BillTypeAtomic> ccPaymentTypes = Arrays.asList(
+                BillTypeAtomic.CREDIT_COMPANY_INPATIENT_PAYMENT,
+                BillTypeAtomic.CREDIT_COMPANY_INPATIENT_PAYMENT_CANCELLATION,
+                BillTypeAtomic.INPATIENT_CREDIT_COMPANY_PAYMENT_RECEIVED,
+                BillTypeAtomic.INPATIENT_CREDIT_COMPANY_PAYMENT_CANCELLATION
+        );
+        List<BillTypeAtomic> depositTypes = Arrays.asList(
+                BillTypeAtomic.INWARD_DEPOSIT,
+                BillTypeAtomic.INWARD_DEPOSIT_CANCELLATION,
+                BillTypeAtomic.INWARD_DEPOSIT_REFUND,
+                BillTypeAtomic.INWARD_DEPOSIT_REFUND_CANCELLATION
+        );
+
+        String encSql = "Select pe from PatientEncounter pe"
+                + " where pe.retired=false"
+                + " and (pe.discharged=false or pe.discharged is null)"
+                + " and pe.creditCompany is not null"
+                + " and pe.dateOfAdmission between :frm and :to";
+        HashMap<String, Object> encHm = new HashMap<>();
+        if (institution != null) {
+            encSql += " and pe.creditCompany=:cc";
+            encHm.put("cc", institution);
+        }
+        if (admittingInstitution != null) {
+            encSql += " and pe.institution=:ins";
+            encHm.put("ins", admittingInstitution);
+        }
+        if (site != null) {
+            encSql += " and pe.department.site=:site";
+            encHm.put("site", site);
+        }
+        if (department != null) {
+            encSql += " and pe.department=:dept";
+            encHm.put("dept", department);
+        }
+        if (admissionType != null) {
+            encSql += " and pe.admissionType=:at";
+            encHm.put("at", admissionType);
+        }
+        if (paymentMethod != null) {
+            encSql += " and pe.paymentMethod=:pm";
+            encHm.put("pm", paymentMethod);
+        }
+        encSql += " order by pe.creditCompany.name, pe.dateOfAdmission";
+        encHm.put("frm", fromDate);
+        encHm.put("to", toDate);
+
+        List<PatientEncounter> nonDischargedEncounters =
+                patientEncounterFacade.findByJpql(encSql, encHm, TemporalType.TIMESTAMP);
+
+        for (PatientEncounter pe : nonDischargedEncounters) {
+            HashMap<String, Object> chargeParams = new HashMap<>();
+            chargeParams.put("pe", pe);
+            chargeParams.put("chargeTypes", chargeTypes);
+            double chargeTotal = billFacade.findDoubleByJpql(
+                    "Select sum(b.netTotal) from Bill b where b.retired=false and b.patientEncounter=:pe and b.billTypeAtomic in :chargeTypes",
+                    chargeParams);
+
+            HashMap<String, Object> ccPaidParams = new HashMap<>();
+            ccPaidParams.put("pe", pe);
+            ccPaidParams.put("ccPaymentTypes", ccPaymentTypes);
+            double ccPaid = billFacade.findDoubleByJpql(
+                    "Select sum(b.netTotal) from Bill b where b.retired=false and b.patientEncounter=:pe and b.billTypeAtomic in :ccPaymentTypes",
+                    ccPaidParams);
+
+            HashMap<String, Object> depositParams = new HashMap<>();
+            depositParams.put("pe", pe);
+            depositParams.put("depositTypes", depositTypes);
+            double deposited = billFacade.findDoubleByJpql(
+                    "Select sum(b.netTotal) from Bill b where b.retired=false and b.patientEncounter=:pe and b.billTypeAtomic in :depositTypes",
+                    depositParams);
+
+            double totalPaid = ccPaid + deposited;
+            double outstanding = chargeTotal - totalPaid;
+
+            if (outstandingOnly && outstanding <= 0.01) {
+                continue;
+            }
+
+            Bill syntheticBill = new Bill();
+            syntheticBill.setPatientEncounter(pe);
+            syntheticBill.setPatient(pe.getPatient());
+            syntheticBill.setCreditCompany(pe.getCreditCompany());
+            syntheticBill.setDeptId("(Active)");
+            syntheticBill.setBillDate(pe.getDateOfAdmission());
+            syntheticBill.setNetTotal(chargeTotal);
+            syntheticBill.setSettledAmountBySponsor(ccPaid);
+            syntheticBill.setSettledAmountByPatient(deposited);
+            syntheticBill.setPaidAmount(totalPaid);
+            allBills.add(syntheticBill);
+        }
+
+        // --- Group bills by credit company ---
+        LinkedHashMap<String, CreditCompanyDebtorGroupDTO> groupMap = new LinkedHashMap<>();
+        for (Bill b : allBills) {
+            String companyName = b.getCreditCompany() != null ? b.getCreditCompany().getName() : "(Unknown)";
+            CreditCompanyDebtorGroupDTO group = groupMap.computeIfAbsent(companyName,
+                    CreditCompanyDebtorGroupDTO::new);
+            group.addBill(b);
+        }
+
+        groups = new ArrayList<>(groupMap.values());
+        for (CreditCompanyDebtorGroupDTO g : groups) {
+            grandBillTotal += g.getSubBillTotal();
+            grandSettledByCompany += g.getSubSettledByCompany();
+            grandSettledByPatient += g.getSubSettledByPatient();
+            grandPaidTotal += g.getSubTotalPaid();
+            grandOutstandingTotal += g.getSubOutstandingTotal();
+        }
+    }
+
+    private String resolveDateField(String basis, String defaultField, String encounterAlias) {
+        if ("dischargeDate".equals(basis)) {
+            return encounterAlias + ".dateOfDischarge";
+        } else if ("admissionDate".equals(basis)) {
+            return encounterAlias + ".dateOfAdmission";
+        }
+        return defaultField;
+    }
+
+    public void makeNull() {
+        fromDate = startOfCurrentMonth();
+        toDate = new Date();
+        dateBasis = "createdAt";
+        institution = null;
+        admittingInstitution = null;
+        site = null;
+        department = null;
+        admissionType = null;
+        paymentMethod = null;
+        outstandingOnly = false;
+        groups = null;
+        grandBillTotal = 0;
+        grandSettledByCompany = 0;
+        grandSettledByPatient = 0;
+        grandPaidTotal = 0;
+        grandOutstandingTotal = 0;
+    }
+
+    private static Date startOfCurrentMonth() {
+        Calendar cal = Calendar.getInstance();
+        cal.set(Calendar.DAY_OF_MONTH, 1);
+        cal.set(Calendar.HOUR_OF_DAY, 0);
+        cal.set(Calendar.MINUTE, 0);
+        cal.set(Calendar.SECOND, 0);
+        cal.set(Calendar.MILLISECOND, 0);
+        return cal.getTime();
+    }
+
+    // Getters and setters
+
+    public Date getFromDate() { return fromDate; }
+    public void setFromDate(Date fromDate) { this.fromDate = fromDate; }
+
+    public Date getToDate() { return toDate; }
+    public void setToDate(Date toDate) { this.toDate = toDate; }
+
+    public String getDateBasis() { return dateBasis; }
+    public void setDateBasis(String dateBasis) { this.dateBasis = dateBasis; }
+
+    public Institution getInstitution() { return institution; }
+    public void setInstitution(Institution institution) { this.institution = institution; }
+
+    public Institution getAdmittingInstitution() { return admittingInstitution; }
+    public void setAdmittingInstitution(Institution admittingInstitution) { this.admittingInstitution = admittingInstitution; }
+
+    public Institution getSite() { return site; }
+    public void setSite(Institution site) { this.site = site; }
+
+    public Department getDepartment() { return department; }
+    public void setDepartment(Department department) { this.department = department; }
+
+    public AdmissionType getAdmissionType() { return admissionType; }
+    public void setAdmissionType(AdmissionType admissionType) { this.admissionType = admissionType; }
+
+    public PaymentMethod getPaymentMethod() { return paymentMethod; }
+    public void setPaymentMethod(PaymentMethod paymentMethod) { this.paymentMethod = paymentMethod; }
+
+    public boolean isOutstandingOnly() { return outstandingOnly; }
+    public void setOutstandingOnly(boolean outstandingOnly) { this.outstandingOnly = outstandingOnly; }
+
+    public List<CreditCompanyDebtorGroupDTO> getGroups() { return groups; }
+    public double getGrandBillTotal() { return grandBillTotal; }
+    public double getGrandSettledByCompany() { return grandSettledByCompany; }
+    public double getGrandSettledByPatient() { return grandSettledByPatient; }
+    public double getGrandPaidTotal() { return grandPaidTotal; }
+    public double getGrandOutstandingTotal() { return grandOutstandingTotal; }
+}

--- a/src/main/java/com/divudi/core/data/dto/CreditCompanyDebtorGroupDTO.java
+++ b/src/main/java/com/divudi/core/data/dto/CreditCompanyDebtorGroupDTO.java
@@ -1,0 +1,48 @@
+package com.divudi.core.data.dto;
+
+import com.divudi.core.entity.Bill;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Groups debtor bill rows by credit company, with per-company subtotals.
+ * Used by CreditCompanyDebtorGroupedReportController.
+ */
+public class CreditCompanyDebtorGroupDTO {
+
+    private String creditCompanyName;
+    private List<Bill> bills = new ArrayList<>();
+    private double subBillTotal;
+    private double subSettledByCompany;
+    private double subSettledByPatient;
+    private double subTotalPaid;
+    private double subOutstandingTotal;
+
+    public CreditCompanyDebtorGroupDTO(String creditCompanyName) {
+        this.creditCompanyName = creditCompanyName;
+    }
+
+    public void addBill(Bill b) {
+        bills.add(b);
+        double outstanding = b.getNetTotal() - b.getPaidAmount();
+        subBillTotal += b.getNetTotal();
+        subSettledByCompany += b.getSettledAmountBySponsor();
+        subSettledByPatient += b.getSettledAmountByPatient();
+        subTotalPaid += b.getPaidAmount();
+        subOutstandingTotal += outstanding;
+    }
+
+    public String getCreditCompanyName() { return creditCompanyName; }
+
+    public List<Bill> getBills() { return bills; }
+
+    public double getSubBillTotal() { return subBillTotal; }
+
+    public double getSubSettledByCompany() { return subSettledByCompany; }
+
+    public double getSubSettledByPatient() { return subSettledByPatient; }
+
+    public double getSubTotalPaid() { return subTotalPaid; }
+
+    public double getSubOutstandingTotal() { return subOutstandingTotal; }
+}

--- a/src/main/webapp/credit/inward_credit_company_debtor_grouped_report.xhtml
+++ b/src/main/webapp/credit/inward_credit_company_debtor_grouped_report.xhtml
@@ -1,0 +1,348 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
+      xmlns:h="http://xmlns.jcp.org/jsf/html"
+      xmlns:p="http://primefaces.org/ui"
+      xmlns:f="http://xmlns.jcp.org/jsf/core">
+
+    <h:body>
+        <ui:composition template="/inward/inward_reports.xhtml">
+            <ui:define name="subcontent">
+                <h:form id="frm">
+
+                    <p:panel header="Inpatient Credit Company Debtor Report (Grouped)" class="m-1">
+
+                        <h:panelGrid columns="8" styleClass="w-100 form-grid" columnClasses="label-icon-column, input-column">
+
+                            <!-- Row 1: From | To | Credit Company -->
+                            <h:panelGroup layout="block" styleClass="form-group">
+                                <h:outputText value="&#xf073;" styleClass="fa ml-5" />
+                                <h:outputLabel value="From" for="fromDate" class="mx-3"/>
+                            </h:panelGroup>
+                            <p:calendar styleClass="w-100" inputStyleClass="w-100 form-control"
+                                        id="fromDate"
+                                        value="#{creditCompanyDebtorGroupedReportController.fromDate}"
+                                        pattern="#{sessionController.applicationPreference.longDateTimeFormat}" />
+
+                            <p:spacer width="50" />
+
+                            <h:panelGroup layout="block" styleClass="form-group">
+                                <h:outputText value="&#xf073;" styleClass="fa mr-2" />
+                                <h:outputLabel value="To" for="toDate" class="mx-3"/>
+                            </h:panelGroup>
+                            <p:calendar styleClass="w-100" inputStyleClass="w-100 form-control"
+                                        id="toDate"
+                                        value="#{creditCompanyDebtorGroupedReportController.toDate}"
+                                        pattern="#{sessionController.applicationPreference.longDateTimeFormat}" />
+
+                            <p:spacer width="50" />
+
+                            <h:panelGroup layout="block" styleClass="form-group">
+                                <h:outputText value="&#xf19c;" styleClass="fa mr-2" />
+                                <h:outputLabel value="Credit Company" for="cmbCc" class="mx-3"/>
+                            </h:panelGroup>
+                            <p:autoComplete id="cmbCc" styleClass="w-100" inputStyleClass="w-100 form-control"
+                                            value="#{creditCompanyDebtorGroupedReportController.institution}"
+                                            completeMethod="#{institutionController.completeCreditCompany}"
+                                            var="cc" itemLabel="#{cc.name}" itemValue="#{cc}"
+                                            forceSelection="true" />
+
+                            <!-- Row 2: Date Basis -->
+                            <h:panelGroup layout="block" styleClass="form-group">
+                                <h:outputText value="&#xf017;" styleClass="fa mr-2" />
+                                <h:outputLabel value="Date Basis" for="dateBasisMenu" class="mx-3"/>
+                            </h:panelGroup>
+                            <p:selectOneMenu id="dateBasisMenu" styleClass="w-100 form-control"
+                                             value="#{creditCompanyDebtorGroupedReportController.dateBasis}">
+                                <f:selectItem itemValue="createdAt"     itemLabel="Payment/Bill Date" />
+                                <f:selectItem itemValue="dischargeDate" itemLabel="Discharge Date" />
+                                <f:selectItem itemValue="admissionDate" itemLabel="Admission Date" />
+                            </p:selectOneMenu>
+                            <p:spacer width="50" />
+                            <p:spacer width="50" />
+                            <p:spacer width="50" />
+                            <p:spacer width="50" />
+                            <p:spacer width="50" />
+                            <p:spacer width="50" />
+
+                            <!-- Row 3: Institution | Site | Department -->
+                            <h:panelGroup layout="block" styleClass="form-group">
+                                <h:outputText value="&#xf19c;" styleClass="fa mr-2" />
+                                <h:outputLabel value="Institution" for="cmbIns" class="mx-3"/>
+                            </h:panelGroup>
+                            <p:selectOneMenu id="cmbIns" styleClass="w-100 form-control"
+                                             value="#{creditCompanyDebtorGroupedReportController.admittingInstitution}"
+                                             filter="true">
+                                <f:selectItem itemLabel="All Institutions" itemValue="#{null}" />
+                                <f:selectItems value="#{institutionController.companies}" var="ins" itemLabel="#{ins.name}" itemValue="#{ins}" />
+                                <p:ajax process="cmbIns" update="cmbDept" />
+                            </p:selectOneMenu>
+
+                            <p:spacer width="50" />
+
+                            <h:panelGroup layout="block" styleClass="form-group">
+                                <h:outputText value="&#xf3c5;" styleClass="fa mr-2" />
+                                <h:outputLabel value="Site" for="siteMenu" class="mx-3"/>
+                            </h:panelGroup>
+                            <p:selectOneMenu id="siteMenu" styleClass="w-100 form-control"
+                                             value="#{creditCompanyDebtorGroupedReportController.site}"
+                                             filter="true">
+                                <f:selectItem itemLabel="All Sites" itemValue="#{null}" />
+                                <f:selectItems value="#{institutionController.sites}" var="site" itemLabel="#{site.name}" itemValue="#{site}" />
+                                <p:ajax process="siteMenu" update="cmbDept" />
+                            </p:selectOneMenu>
+
+                            <p:spacer width="50" />
+
+                            <h:panelGroup layout="block" styleClass="form-group">
+                                <h:outputText value="&#xf0e8;" styleClass="fa mr-2" />
+                                <h:outputLabel value="Department" for="cmbDept" class="mx-3"/>
+                            </h:panelGroup>
+                            <h:panelGroup id="cmbDept" layout="block">
+                                <p:selectOneMenu
+                                    rendered="#{creditCompanyDebtorGroupedReportController.admittingInstitution eq null and creditCompanyDebtorGroupedReportController.site eq null}"
+                                    styleClass="w-100 form-control"
+                                    value="#{creditCompanyDebtorGroupedReportController.department}"
+                                    filterMatchMode="contains" filter="true">
+                                    <f:selectItem itemLabel="All Departments" itemValue="#{null}" />
+                                    <f:selectItems value="#{departmentController.getDepartmentsOfInstitutionAndSite()}"
+                                                   var="d" itemLabel="#{d.name}" itemValue="#{d}" />
+                                </p:selectOneMenu>
+                                <p:selectOneMenu
+                                    rendered="#{creditCompanyDebtorGroupedReportController.admittingInstitution eq null and creditCompanyDebtorGroupedReportController.site ne null}"
+                                    styleClass="w-100 form-control"
+                                    value="#{creditCompanyDebtorGroupedReportController.department}"
+                                    filterMatchMode="contains" filter="true">
+                                    <f:selectItem itemLabel="All Departments" itemValue="#{null}" />
+                                    <f:selectItems value="#{departmentController.getDepartmentsOfInstitutionAndSite(creditCompanyDebtorGroupedReportController.site)}"
+                                                   var="d" itemLabel="#{d.name}" itemValue="#{d}" />
+                                </p:selectOneMenu>
+                                <p:selectOneMenu
+                                    rendered="#{creditCompanyDebtorGroupedReportController.admittingInstitution ne null and creditCompanyDebtorGroupedReportController.site eq null}"
+                                    styleClass="w-100 form-control"
+                                    value="#{creditCompanyDebtorGroupedReportController.department}"
+                                    filterMatchMode="contains" filter="true">
+                                    <f:selectItem itemLabel="All Departments" itemValue="#{null}" />
+                                    <f:selectItems value="#{departmentController.getDepartmentsOfInstitutionAndSiteForInstitution(creditCompanyDebtorGroupedReportController.admittingInstitution)}"
+                                                   var="d" itemLabel="#{d.name}" itemValue="#{d}" />
+                                </p:selectOneMenu>
+                                <p:selectOneMenu
+                                    rendered="#{creditCompanyDebtorGroupedReportController.admittingInstitution ne null and creditCompanyDebtorGroupedReportController.site ne null}"
+                                    styleClass="w-100 form-control"
+                                    value="#{creditCompanyDebtorGroupedReportController.department}"
+                                    filterMatchMode="contains" filter="true">
+                                    <f:selectItem itemLabel="All Departments" itemValue="#{null}" />
+                                    <f:selectItems value="#{departmentController.getDepartmentsOfInstitutionAndSite(creditCompanyDebtorGroupedReportController.admittingInstitution, creditCompanyDebtorGroupedReportController.site)}"
+                                                   var="d" itemLabel="#{d.name}" itemValue="#{d}" />
+                                </p:selectOneMenu>
+                            </h:panelGroup>
+
+                            <!-- Row 4: Admission Type | Outstanding Only | Payment Method -->
+                            <h:panelGroup layout="block" styleClass="form-group">
+                                <h:outputText value="&#xf0f0;" styleClass="fa mr-2" />
+                                <h:outputLabel value="Admission Type" for="admTypeMenu" class="mx-3"/>
+                            </h:panelGroup>
+                            <p:selectOneMenu id="admTypeMenu" styleClass="w-100 form-control"
+                                             value="#{creditCompanyDebtorGroupedReportController.admissionType}">
+                                <f:selectItem itemLabel="All Admission Types" itemValue="#{null}" />
+                                <f:selectItems value="#{admissionTypeController.items}"
+                                               var="at" itemValue="#{at}" itemLabel="#{at.name}" />
+                            </p:selectOneMenu>
+
+                            <p:spacer width="50" />
+
+                            <h:panelGroup layout="block" styleClass="form-group">
+                                <h:outputText value="&#xf0d1;" styleClass="fa mr-2" />
+                                <h:outputLabel value="Outstanding Only" for="chkOutstanding" class="mx-3"/>
+                            </h:panelGroup>
+                            <h:selectBooleanCheckbox id="chkOutstanding"
+                                                     value="#{creditCompanyDebtorGroupedReportController.outstandingOnly}"
+                                                     styleClass="form-check-input mt-2" />
+
+                            <p:spacer width="50" />
+
+                            <h:panelGroup layout="block" styleClass="form-group">
+                                <h:outputText value="&#xf09d;" styleClass="fa mr-2" />
+                                <h:outputLabel value="Payment Method" for="pmMenuDebtor" class="mx-3"/>
+                            </h:panelGroup>
+                            <p:selectOneMenu id="pmMenuDebtor" styleClass="w-100 form-control"
+                                             value="#{creditCompanyDebtorGroupedReportController.paymentMethod}">
+                                <f:selectItem itemLabel="All Methods" itemValue="#{null}" />
+                                <f:selectItems value="#{enumController.paymentMethodsWithoutCredit}" />
+                            </p:selectOneMenu>
+
+                        </h:panelGrid>
+
+                        <p:commandButton value="Process" icon="fas fa-cogs"
+                                         action="#{creditCompanyDebtorGroupedReportController.generateReport()}"
+                                         ajax="false" class="ui-button-warning m-1" />
+
+                    </p:panel>
+
+                    <p:panel id="pnlResults"
+                             rendered="#{creditCompanyDebtorGroupedReportController.groups != null}">
+
+                        <f:facet name="header">
+                            <div class="d-flex justify-content-between align-items-center">
+                                <h:outputText value="Inpatient Credit Company Debtors (Grouped)" />
+                                <p:commandButton value="Print" icon="fas fa-print"
+                                                 class="ui-button-info" ajax="false">
+                                    <p:printer target="debtorGroupedTable" />
+                                </p:commandButton>
+                            </div>
+                        </f:facet>
+
+                        <div id="debtorGroupedTable">
+                            <table class="table table-bordered table-sm w-100" style="font-size:0.9em;">
+                                <thead class="thead-dark">
+                                    <tr>
+                                        <th style="white-space:nowrap;">Bill No</th>
+                                        <th style="white-space:nowrap;">BHT No</th>
+                                        <th>Patient Name</th>
+                                        <th style="white-space:nowrap;">Bill Date</th>
+                                        <th style="white-space:nowrap;">Admitted</th>
+                                        <th style="white-space:nowrap;">Discharged</th>
+                                        <th style="text-align:right; white-space:nowrap;">Bill Total</th>
+                                        <th style="text-align:right; white-space:nowrap;">Settled by Company</th>
+                                        <th style="text-align:right; white-space:nowrap;">Settled by Patient</th>
+                                        <th style="text-align:right; white-space:nowrap;">Total Paid</th>
+                                        <th style="text-align:right; white-space:nowrap; font-weight:bold;">Outstanding</th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    <ui:repeat value="#{creditCompanyDebtorGroupedReportController.groups}" var="group">
+                                        <!-- Company group header row -->
+                                        <tr style="background-color:#dee2e6;">
+                                            <td colspan="11">
+                                                <strong><h:outputText value="#{group.creditCompanyName}" /></strong>
+                                            </td>
+                                        </tr>
+                                        <!-- Bill rows for this company -->
+                                        <ui:repeat value="#{group.bills}" var="b">
+                                            <tr>
+                                                <td style="white-space:nowrap;">
+                                                    <h:outputText value="#{b.deptId}" />
+                                                </td>
+                                                <td style="white-space:nowrap;">
+                                                    <h:outputText value="#{b.patientEncounter.bhtNo}" />
+                                                </td>
+                                                <td>
+                                                    <h:outputText value="#{b.patient.person.name}" />
+                                                </td>
+                                                <td style="white-space:nowrap;">
+                                                    <h:outputText value="#{b.billDate}">
+                                                        <f:convertDateTime pattern="#{sessionController.applicationPreference.shortDateFormat}" />
+                                                    </h:outputText>
+                                                </td>
+                                                <td style="white-space:nowrap;">
+                                                    <h:outputText value="#{b.patientEncounter.dateOfAdmission}">
+                                                        <f:convertDateTime pattern="#{sessionController.applicationPreference.shortDateFormat}" />
+                                                    </h:outputText>
+                                                </td>
+                                                <td style="white-space:nowrap;">
+                                                    <h:outputText value="#{b.patientEncounter.dateOfDischarge}">
+                                                        <f:convertDateTime pattern="#{sessionController.applicationPreference.shortDateFormat}" />
+                                                    </h:outputText>
+                                                </td>
+                                                <td style="text-align:right; white-space:nowrap;">
+                                                    <h:outputText value="#{b.netTotal}">
+                                                        <f:convertNumber minFractionDigits="2" maxFractionDigits="2" />
+                                                    </h:outputText>
+                                                </td>
+                                                <td style="text-align:right; white-space:nowrap;">
+                                                    <h:outputText value="#{b.settledAmountBySponsor}">
+                                                        <f:convertNumber minFractionDigits="2" maxFractionDigits="2" />
+                                                    </h:outputText>
+                                                </td>
+                                                <td style="text-align:right; white-space:nowrap;">
+                                                    <h:outputText value="#{b.settledAmountByPatient}">
+                                                        <f:convertNumber minFractionDigits="2" maxFractionDigits="2" />
+                                                    </h:outputText>
+                                                </td>
+                                                <td style="text-align:right; white-space:nowrap;">
+                                                    <h:outputText value="#{b.paidAmount}">
+                                                        <f:convertNumber minFractionDigits="2" maxFractionDigits="2" />
+                                                    </h:outputText>
+                                                </td>
+                                                <td style="text-align:right; white-space:nowrap; font-weight:bold;">
+                                                    <h:outputText value="#{b.netTotal - b.paidAmount}">
+                                                        <f:convertNumber minFractionDigits="2" maxFractionDigits="2" />
+                                                    </h:outputText>
+                                                </td>
+                                            </tr>
+                                        </ui:repeat>
+                                        <!-- Company subtotal row -->
+                                        <tr style="background-color:#f8f9fa; font-weight:bold;">
+                                            <td colspan="6" style="text-align:right;">
+                                                <h:outputText value="#{group.creditCompanyName} Subtotal" />
+                                            </td>
+                                            <td style="text-align:right; white-space:nowrap;">
+                                                <h:outputText value="#{group.subBillTotal}">
+                                                    <f:convertNumber minFractionDigits="2" maxFractionDigits="2" />
+                                                </h:outputText>
+                                            </td>
+                                            <td style="text-align:right; white-space:nowrap;">
+                                                <h:outputText value="#{group.subSettledByCompany}">
+                                                    <f:convertNumber minFractionDigits="2" maxFractionDigits="2" />
+                                                </h:outputText>
+                                            </td>
+                                            <td style="text-align:right; white-space:nowrap;">
+                                                <h:outputText value="#{group.subSettledByPatient}">
+                                                    <f:convertNumber minFractionDigits="2" maxFractionDigits="2" />
+                                                </h:outputText>
+                                            </td>
+                                            <td style="text-align:right; white-space:nowrap;">
+                                                <h:outputText value="#{group.subTotalPaid}">
+                                                    <f:convertNumber minFractionDigits="2" maxFractionDigits="2" />
+                                                </h:outputText>
+                                            </td>
+                                            <td style="text-align:right; white-space:nowrap;">
+                                                <h:outputText value="#{group.subOutstandingTotal}">
+                                                    <f:convertNumber minFractionDigits="2" maxFractionDigits="2" />
+                                                </h:outputText>
+                                            </td>
+                                        </tr>
+                                    </ui:repeat>
+                                </tbody>
+                                <tfoot>
+                                    <!-- Grand total row -->
+                                    <tr style="background-color:#343a40; color:#fff; font-weight:bold;">
+                                        <td colspan="6" style="text-align:right;">Grand Total</td>
+                                        <td style="text-align:right; white-space:nowrap;">
+                                            <h:outputText value="#{creditCompanyDebtorGroupedReportController.grandBillTotal}">
+                                                <f:convertNumber minFractionDigits="2" maxFractionDigits="2" />
+                                            </h:outputText>
+                                        </td>
+                                        <td style="text-align:right; white-space:nowrap;">
+                                            <h:outputText value="#{creditCompanyDebtorGroupedReportController.grandSettledByCompany}">
+                                                <f:convertNumber minFractionDigits="2" maxFractionDigits="2" />
+                                            </h:outputText>
+                                        </td>
+                                        <td style="text-align:right; white-space:nowrap;">
+                                            <h:outputText value="#{creditCompanyDebtorGroupedReportController.grandSettledByPatient}">
+                                                <f:convertNumber minFractionDigits="2" maxFractionDigits="2" />
+                                            </h:outputText>
+                                        </td>
+                                        <td style="text-align:right; white-space:nowrap;">
+                                            <h:outputText value="#{creditCompanyDebtorGroupedReportController.grandPaidTotal}">
+                                                <f:convertNumber minFractionDigits="2" maxFractionDigits="2" />
+                                            </h:outputText>
+                                        </td>
+                                        <td style="text-align:right; white-space:nowrap;">
+                                            <h:outputText value="#{creditCompanyDebtorGroupedReportController.grandOutstandingTotal}">
+                                                <f:convertNumber minFractionDigits="2" maxFractionDigits="2" />
+                                            </h:outputText>
+                                        </td>
+                                    </tr>
+                                </tfoot>
+                            </table>
+                        </div>
+
+                    </p:panel>
+
+                </h:form>
+            </ui:define>
+        </ui:composition>
+    </h:body>
+</html>

--- a/src/main/webapp/inward/inward_reports.xhtml
+++ b/src/main/webapp/inward/inward_reports.xhtml
@@ -93,6 +93,13 @@
                                             actionListener="#{inwardReportController1.resetCreditCompanyReports()}"
                                             ajax="false"
                                             class="ui-button-success" />
+                                        <p:commandButton
+                                            value="Credit Company Debtor Report (Grouped)"
+                                            icon="fa fa-fw fa-layer-group"
+                                            action="/credit/inward_credit_company_debtor_grouped_report?faces-redirect=true"
+                                            actionListener="#{creditCompanyDebtorGroupedReportController.makeNull()}"
+                                            ajax="false"
+                                            class="ui-button-success" />
                                         <p:commandButton ajax="false" value="Deposits of Undischarged Patient and Complete Payments of Discharged Patients" icon="fa fa-fw fa-coins" action="bht_deposit_by_discharge_date_and_created_date?faces-redirect=true" actionListener="#{mdInwardReportController.makeNull()}" />
                                         <p:commandButton ajax="false" value="Complete Payments of Discharged Patient" icon="fa fa-fw fa-check-circle" action="bht_deposit_by_discharge_date" actionListener="#{mdInwardReportController.makeNull()}" />
                                         <p:commandButton ajax="false" value="Deposit of Undischarged Patient" icon="fa fa-fw fa-hourglass-half" action="bht_deposit_by_created_date_not_discharge" actionListener="#{mdInwardReportController.makeNull()}" />


### PR DESCRIPTION
## Summary

- Add a new **Credit Company Debtor Report (Grouped)** accessible from the inward reports index
- Groups the same debtor data by credit company, with a subtotal row per company and a grand total footer row
- Uses a plain HTML `<table>` with `ui:repeat` (not PrimeFaces subtables) for clean rendering and print support

## Files changed

| File | Type |
|------|------|
| `CreditCompanyDebtorGroupDTO.java` | New DTO — company name, bill list, subtotals |
| `CreditCompanyDebtorGroupedReportController.java` | New `@SessionScoped` controller |
| `inward_credit_company_debtor_grouped_report.xhtml` | New report page |
| `inward_reports.xhtml` | Added navigation button |

## Test plan

- [ ] Navigate to Inward Reports → Payment Reports tab → "Credit Company Debtor Report (Grouped)"
- [ ] Generate with default date range — verify rows are grouped by company with subtotal rows
- [ ] Verify grand total row matches sum of all subtotals
- [ ] Test Outstanding Only checkbox — rows with outstanding ≤ 0.01 should be excluded
- [ ] Test with a specific Credit Company filter
- [ ] Verify non-discharged active patients appear under their company group
- [ ] Print button produces a clean table layout

Closes #19903

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Credit Company Debtor Report (Grouped) under Payment Reports in the Inward module. This report enables filtering by date range, credit company, date basis, institution, department, admission type, payment method, and outstanding amount threshold. Results display bills grouped by credit company with detailed financial metrics (bill totals, settled amounts, paid totals, outstanding balances) for each group and grand totals. Print functionality included.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->