### PR TITLE
fix: hide fee columns for CC payment bill types in CC Statement Report

### DIFF
--- a/src/main/webapp/resources/ezcomp/reports/cc_statement.xhtml
+++ b/src/main/webapp/resources/ezcomp/reports/cc_statement.xhtml
@@ -286,7 +286,8 @@
                     headerText="Hospital Fee" 
                     sortBy="#{agentHx.bill.totalHospitalFee}" 
                     filterBy="#{agentHx.bill.totalHospitalFee}">
-                    <h:outputText value="#{agentHx.companyTransactionValue}" style="text-align: right; display: block;">
+                    <h:outputText value="#{agentHx.companyTransactionValue}" style="text-align: right; display: block;"
+                                  rendered="#{agentHx.bill.billTypeAtomic ne 'CC_PAYMENT_RECEIVED_BILL' and agentHx.bill.billTypeAtomic ne 'CC_PAYMENT_CANCELLATION_BILL' and agentHx.bill.billTypeAtomic ne 'CC_AGENT_PAYMENT'}">
                         <f:convertNumber pattern="#,##0.00" />
                     </h:outputText>
                 </p:column>
@@ -297,7 +298,8 @@
                     headerText="Staff Fee" 
                     sortBy="#{agentHx.bill.totalStaffFee}" 
                     filterBy="#{agentHx.bill.totalStaffFee}">
-                    <h:outputText value="#{agentHx.staffTrasnactionValue}" style="text-align: right; display: block;">
+                    <h:outputText value="#{agentHx.staffTrasnactionValue}" style="text-align: right; display: block;"
+                                  rendered="#{agentHx.bill.billTypeAtomic ne 'CC_PAYMENT_RECEIVED_BILL' and agentHx.bill.billTypeAtomic ne 'CC_PAYMENT_CANCELLATION_BILL' and agentHx.bill.billTypeAtomic ne 'CC_AGENT_PAYMENT'}">
                         <f:convertNumber pattern="#,##0.00" />
                     </h:outputText>
                 </p:column>
@@ -308,7 +310,8 @@
                     headerText="CC Fee" 
                     sortBy="#{agentHx.bill.totalCenterFee}" 
                     filterBy="#{agentHx.bill.totalCenterFee}">
-                    <h:outputText value="#{agentHx.agentTransactionValue}" style="text-align: right; display: block;">
+                    <h:outputText value="#{agentHx.agentTransactionValue}" style="text-align: right; display: block;"
+                                  rendered="#{agentHx.bill.billTypeAtomic ne 'CC_PAYMENT_RECEIVED_BILL' and agentHx.bill.billTypeAtomic ne 'CC_PAYMENT_CANCELLATION_BILL' and agentHx.bill.billTypeAtomic ne 'CC_AGENT_PAYMENT'}">
                         <f:convertNumber pattern="#,##0.00" />
                     </h:outputText>
                 </p:column>


### PR DESCRIPTION
## Summary
- For `CC_PAYMENT_RECEIVED_BILL`, `CC_PAYMENT_CANCELLATION_BILL`, and `CC_AGENT_PAYMENT` rows in the Collection Centre Statement Report, blank out the **Hospital Fee**, **Staff Fee**, and **CC Fee** columns.
- Those payment bills already appear in the dedicated `Received from CC` / `Paid to CC` / `Adjustments to CC Balance` columns, so showing values in the fee columns is misleading.
- JSF-only change (`cc_statement.xhtml`), applies to both on-screen table and Excel export.

Closes #19907

## Test plan
- [ ] Open Collection Centre Statement Report for a period containing CC payment/cancellation/agent-payment bills
- [ ] Verify Hospital Fee, Staff Fee, CC Fee cells are blank for those rows
- [ ] Verify other bill types still show fees normally
- [ ] Export to Excel and confirm the same behavior