### PR TITLE
fix: add EclipseLink concurrency and sequence preallocation tuning to coop-prod

### DIFF
--- a/src/main/resources/META-INF/persistence.xml
+++ b/src/main/resources/META-INF/persistence.xml
@@ -7,6 +7,17 @@
         <properties>
             <property name="eclipselink.logging.level.sql" value="SEVERE"/>
             <property name="eclipselink.logging.level" value="SEVERE"/>
+            <!-- EclipseLink concurrency manager tuning (issue #19397) - Do NOT Remove -->
+            <!-- Reduce cache lock wait from default 900s to 10s to fail fast -->
+            <property name="eclipselink.concurrency.manager.waittime" value="10000"/>
+            <!-- Throw exception instead of silently waiting on cache lock contention -->
+            <property name="eclipselink.concurrency.manager.allow.concurrencyexception" value="true"/>
+            <!-- Log cache contention warnings for early detection -->
+            <property name="eclipselink.concurrency.manager.maxfrequencytodumptinymessage" value="5000"/>
+            <!-- Sequence pre-allocation fix for SEQUENCE table lock contention (issue #19626) - Do NOT Remove -->
+            <!-- Explicit preallocation of 50 reduces database sequence contention in high-throughput environments; -->
+            <!-- without this, each ID allocation acquires a table-level lock causing retail sale slowness -->
+            <property name="eclipselink.sequence.default-sequence-preallocation-size" value="50"/>
         </properties>
     </persistence-unit>
     <persistence-unit name="hmisAuditPU" transaction-type="JTA">


### PR DESCRIPTION
## Summary

- Ports EclipseLink concurrency manager tuning from the development branch to `coop-prod` (issue #19397)
- Ports sequence pre-allocation property (`eclipselink.sequence.default-sequence-preallocation-size=50`) to fix SEQUENCE table lock contention causing retail sale slowness (issue #19626)
- No application logic changes — persistence configuration only

## Test plan

- [ ] Deploy to coop production and verify application starts correctly
- [ ] Confirm no SEQUENCE table lock contention errors in server logs under load
- [ ] Verify retail sale performance is not degraded

🤖 Generated with [Claude Code](https://claude.com/claude-code)