### PR TITLE
docs: add hotfix branch naming rule to CLAUDE.md and create /hotfix-deploy skill

### DIFF
--- a/.claude/skills/hotfix-deploy/SKILL.md
+++ b/.claude/skills/hotfix-deploy/SKILL.md
@@ -1,0 +1,120 @@
+---
+name: hotfix-deploy
+description: >
+  Full hotfix workflow for deploying urgent fixes to a production branch
+  (coop-prod, ruhunu-prod, southernlanka-prod, etc.). Covers branch creation,
+  fix, commit, push, and PR targeting the production branch. Use when you need
+  to apply an urgent fix directly to a production environment without going
+  through the normal development → QA → prod pipeline.
+disable-model-invocation: true
+allowed-tools: Bash, Read, Grep, Edit, Write
+argument-hint: "<prod-branch> <description>"
+---
+
+# Hotfix Deployment Workflow
+
+Deploy an urgent fix directly to a production branch.
+
+## Arguments
+
+- `$0` — Target production branch (e.g., `coop-prod`, `ruhunu-prod`, `southernlanka-prod`)
+- `$1` — Short description of the fix (e.g., `sequence-preallocation`, `critical-billing-fix`)
+
+## Critical Rule
+
+**The branch name MUST end with `-hotfix`.**
+CI merge validation will block PRs from branches that do not end with `-hotfix`.
+
+## Step 1 — Stash Any Uncommitted Work
+
+```bash
+git stash
+```
+
+## Step 2 — Create Hotfix Branch from Production
+
+```bash
+git fetch origin
+git checkout -b $1-hotfix origin/$0
+```
+
+Branch name format: `<description>-hotfix`
+
+Examples:
+- `sequence-preallocation-hotfix`
+- `critical-billing-fix-hotfix`
+- `persistence-tuning-hotfix`
+
+## Step 3 — Apply the Fix
+
+Make only the minimal changes required. Do NOT port unrelated features or refactors.
+
+Before editing `persistence.xml`, compare against the target production branch to understand the current state:
+```bash
+git show origin/$0:src/main/resources/META-INF/persistence.xml
+```
+
+## Step 4 — Pre-Commit Checklist
+
+- [ ] `persistence.xml` uses `${JDBC_DATASOURCE}` / `${JDBC_AUDIT_DATASOURCE}` — not hardcoded JNDI names (e.g., `jdbc/coop`)
+- [ ] No credentials or sensitive files staged
+- [ ] Changes are minimal — only what is needed for the hotfix
+
+> **Note:** The `persistence.xml` on production branches typically uses `${JDBC_DATASOURCE}` environment variable placeholders, while the local development `persistence.xml` has hardcoded JNDI names (e.g., `jdbc/coop`). Never copy the hardcoded JNDI name into the production branch.
+
+## Step 5 — Commit
+
+```bash
+git add <changed-files>
+git commit -m "fix: <description of fix>
+
+<Explanation of why this was needed and what it fixes.>
+References issues #NNNN.
+
+Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>"
+```
+
+## Step 6 — Push
+
+```bash
+git push origin $1-hotfix
+```
+
+## Step 7 — Create PR Targeting the Production Branch
+
+```bash
+gh pr create \
+  --title "fix: <description>" \
+  --base $0 \
+  --head $1-hotfix \
+  --body "..."
+```
+
+The PR **must** target `$0` (the production branch), not `development` or `master`.
+
+## Step 8 — Restore Stashed Work
+
+```bash
+git checkout <your-previous-branch>
+git stash pop
+```
+
+## Step 9 — Clean Up Old Branch (Post-Merge)
+
+After the PR is merged:
+```bash
+git branch -d $1-hotfix
+```
+
+## Common Production Branches
+
+| Hospital/Environment | Branch         |
+|----------------------|----------------|
+| COOP hospitals       | `coop-prod`    |
+| Ruhunu hospital      | `ruhunu-prod`  |
+| Southern Lanka       | `southernlanka-prod` |
+
+## Reference
+
+- [Commit Conventions — Hotfix Branches](../../developer_docs/git/commit-conventions.md#hotfix-branches)
+- [Production Deployment Guide](../../wiki-docs/Deployment/Production-Deployment-Guide.md)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,6 +26,7 @@
 12. **JSF-only changes** (XHTML only, no Java) do not require compilation or testing
 13. **🚨 ALWAYS BASE FEATURE BRANCHES ON `development`**: When creating a new local branch for feature development, ALWAYS branch from `origin/development`, NEVER from `master`. The `master` branch is managed exclusively by system admins. Use: `git checkout -b <branch-name> origin/development`
 14. **🚨 `development` IS THE DEFAULT BRANCH**: All PRs MUST target `development`, NOT `master`. When checking what already exists in the codebase (to avoid duplicate fields/methods), ALWAYS compare against `origin/development`, not `origin/master`. The CI validates against `development`. Never reference or merge into `master` during feature development.
+15. **🚨 HOTFIX BRANCHES MUST END WITH `-hotfix`**: When creating a branch targeting a production branch (e.g., `coop-prod`, `ruhunu-prod`, `southernlanka-prod`), the branch name **MUST** end with `-hotfix`. CI merge validation will block PRs from branches that do not end with `-hotfix`. Format: `<description>-hotfix` (e.g., `sequence-preallocation-hotfix`, `critical-billing-fix-hotfix`). See the `/hotfix-deploy` skill.
 
 ## Situational Guidelines (Reference When Needed)
 
@@ -69,6 +70,11 @@
 
 ### When Committing Code
 - [Commit Conventions](developer_docs/git/commit-conventions.md) - Message format
+
+### When Creating a Hotfix for a Production Branch
+- **Branch name MUST end with `-hotfix`** (rule #15 above) — CI blocks merges otherwise
+- Use the `/hotfix-deploy` skill to run the full workflow: branch from prod → fix → commit → push → PR targeting prod branch
+- [Commit Conventions — Hotfix Branches](developer_docs/git/commit-conventions.md#hotfix-branches) - naming format and examples
 
 ## Common Abbreviations & Terms
 - **TIA**: Thanks In Advance


### PR DESCRIPTION
## Summary

- Adds rule #15 to `CLAUDE.md` Git & Branching section: hotfix branch names **must** end with `-hotfix` — CI merge validation blocks PRs that don't comply
- Adds a "When Creating a Hotfix" section to Situational Guidelines in `CLAUDE.md`
- Creates `.claude/skills/hotfix-deploy/SKILL.md` — a `/hotfix-deploy` skill covering the full workflow: stash → branch from prod → fix → pre-commit checklist → commit → push → PR → restore stash → cleanup

Closes #19926

## Test plan

- [ ] Verify `CLAUDE.md` rule #15 is visible and clearly worded
- [ ] Verify "When Creating a Hotfix" appears in Situational Guidelines
- [ ] Run `/hotfix-deploy` skill and confirm it guides through the complete workflow correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Introduced hotfix deployment workflow guide containing step-by-step procedures, branch naming conventions, pre-deployment validation checklists, and configuration requirements
  * Updated production deployment guidelines with hotfix-specific branching rules and workflow references

<!-- end of auto-generated comment: release notes by coderabbit.ai -->