### PR TITLE
19828 admission type filter not working in inward due search

### DIFF
--- a/src/main/java/com/divudi/bean/common/CreditCompanyDueController.java
+++ b/src/main/java/com/divudi/bean/common/CreditCompanyDueController.java
@@ -1496,7 +1496,7 @@ public class CreditCompanyDueController implements Serializable {
     }
 
     public void createInwardCreditDue() {
-        List<Institution> companies = getCreditBean().getCreditCompaniesWithUnpaidInwardCCBills(getFromDate(), getToDate());
+        List<Institution> companies = getCreditBean().getCreditCompaniesWithUnpaidInwardCCBills(getFromDate(), getToDate(), admissionType, dateBasis);
         institutionEncounters = new ArrayList<>();
         finalTotal = 0.0;
         finalPaidTotal = 0.0;
@@ -1508,7 +1508,7 @@ public class CreditCompanyDueController implements Serializable {
             if (company == null) {
                 continue;
             }
-            List<Bill> bills = getCreditBean().getUnpaidInwardCCBills(company, getFromDate(), getToDate());
+            List<Bill> bills = getCreditBean().getUnpaidInwardCCBills(company, getFromDate(), getToDate(), admissionType, dateBasis);
             if (bills.isEmpty()) {
                 continue;
             }

--- a/src/main/java/com/divudi/ejb/CreditBean.java
+++ b/src/main/java/com/divudi/ejb/CreditBean.java
@@ -10,6 +10,7 @@ import com.divudi.core.data.BillTypeAtomic;
 import com.divudi.core.data.CountedServiceType;
 import com.divudi.core.data.PaymentMethod;
 import com.divudi.core.entity.*;
+import com.divudi.core.entity.inward.AdmissionType;
 import com.divudi.core.facade.BillFacade;
 import com.divudi.core.facade.BillItemFacade;
 import com.divudi.core.facade.InstitutionFacade;
@@ -572,22 +573,60 @@ public class CreditBean {
         return getBillFacade().findByJpql(sql, hm, TemporalType.TIMESTAMP);
     }
 
+    public List<Bill> getUnpaidInwardCCBills(Institution creditCompany, Date fromDate, Date toDate,
+            AdmissionType admissionType, String dateBasis) {
+        String dateField = "admissionDate".equals(dateBasis)
+                ? "b.patientEncounter.dateOfAdmission"
+                : "b.patientEncounter.dateOfDischarge";
+        String sql = "Select b From Bill b "
+                + " where b.retired=false "
+                + " and (b.cancelled=false or b.cancelled is null) "
+                + " and b.billTypeAtomic=:bta "
+                + " and b.creditCompany=:cc "
+                + " and " + dateField + " between :frm and :to "
+                + " and (abs(b.netTotal)-abs(b.paidAmount)) >:val ";
+        HashMap hm = new HashMap();
+        hm.put("bta", BillTypeAtomic.INWARD_FINAL_BILL_PAYMENT_BY_CREDIT_COMPANY);
+        hm.put("cc", creditCompany);
+        hm.put("frm", fromDate);
+        hm.put("to", toDate);
+        hm.put("val", 0.01);
+        if (admissionType != null) {
+            sql += " and b.patientEncounter.admissionType =:at ";
+            hm.put("at", admissionType);
+        }
+        sql += " order by " + dateField;
+        return getBillFacade().findByJpql(sql, hm, TemporalType.TIMESTAMP);
+    }
+
     /**
      * Returns distinct credit companies that have unpaid InwardFinalBillCCPayment bills
      * within the given date range.
      */
     public List<Institution> getCreditCompaniesWithUnpaidInwardCCBills(Date fromDate, Date toDate) {
+        return getCreditCompaniesWithUnpaidInwardCCBills(fromDate, toDate, null, "dischargeDate");
+    }
+
+    public List<Institution> getCreditCompaniesWithUnpaidInwardCCBills(Date fromDate, Date toDate,
+            AdmissionType admissionType, String dateBasis) {
+        String dateField = "admissionDate".equals(dateBasis)
+                ? "b.patientEncounter.dateOfAdmission"
+                : "b.patientEncounter.dateOfDischarge";
         String sql = "Select distinct(b.creditCompany) From Bill b "
                 + " where b.retired=false "
                 + " and (b.cancelled=false or b.cancelled is null) "
                 + " and b.billTypeAtomic=:bta "
-                + " and b.billDate between :frm and :to "
+                + " and " + dateField + " between :frm and :to "
                 + " and (abs(b.netTotal)-abs(b.paidAmount)) >:val ";
         HashMap hm = new HashMap();
         hm.put("bta", BillTypeAtomic.INWARD_FINAL_BILL_PAYMENT_BY_CREDIT_COMPANY);
         hm.put("frm", fromDate);
         hm.put("to", toDate);
         hm.put("val", 0.01);
+        if (admissionType != null) {
+            sql += " and b.patientEncounter.admissionType =:at ";
+            hm.put("at", admissionType);
+        }
         return getInstitutionFacade().findByJpql(sql, hm, TemporalType.TIMESTAMP);
     }
 

--- a/src/main/webapp/credit/inward_due_search_credit_company.xhtml
+++ b/src/main/webapp/credit/inward_due_search_credit_company.xhtml
@@ -80,6 +80,7 @@
                             <p:columnGroup type="header">
                                 <p:row>
                                     <p:column headerText="BHT No"/>
+                                    <p:column headerText="Date Of Admission"/>
                                     <p:column headerText="Date Of Discharge"/>
                                     <p:column headerText="Patient Name"/>
                                     <p:column headerText="Credit Company"/>
@@ -94,6 +95,11 @@
                                 </f:facet>
                                 <p:column>
                                     <h:outputLabel value="#{bill.patientEncounter.bhtNo}"/>
+                                </p:column>
+                                <p:column>
+                                    <h:outputLabel value="#{bill.patientEncounter.dateOfAdmission}">
+                                        <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateTimeFormat}"/>
+                                    </h:outputLabel>
                                 </p:column>
                                 <p:column>
                                     <h:outputLabel value="#{bill.patientEncounter.dateOfDischarge}">
@@ -123,7 +129,7 @@
                                 </p:column>
                                 <p:columnGroup type="footer">
                                     <p:row>
-                                        <p:column footerText="Sub Total" colspan="4"/>
+                                        <p:column footerText="Sub Total" colspan="5"/>
                                         <p:column style="text-align: right;">
                                             <f:facet name="footer">
                                                 <h:outputLabel value="#{i.total}">
@@ -150,7 +156,7 @@
                             </p:subTable>
                             <p:columnGroup type="footer">
                                 <p:row>
-                                    <p:column footerText="Grand Total" colspan="4"/>
+                                    <p:column footerText="Grand Total" colspan="5"/>
                                     <p:column style="text-align: right;">
                                         <f:facet name="footer">
                                             <h:outputLabel value="#{creditCompanyDueController.finalTotal}">


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Inward credit company due report now supports filtering by admission type for more precise bill tracking
  * Configurable date basis selection for due bill calculations (admission or discharge date)
  * New 'Date of Admission' column added to the due report table for enhanced visibility

<!-- end of auto-generated comment: release notes by coderabbit.ai -->