### PR TITLE
fix: switch GenerationType.AUTO to IDENTITY to eliminate SEQUENCE lock contention

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@
 ## Essential Rules (Always Apply)
 
 ### Working Directory
-0. **🚨 NEVER USE WORKTREE ISOLATION**: Always work directly in `/home/buddhika/development/rh/`. Do NOT use `isolation: "worktree"` when spawning agents. If you find yourself in a path like `.claude/worktrees/*`, stop and perform all file edits in the main project directory instead. Worktrees cause the developer's local branch to go out of sync with remote commits, leading to confusing stale-file compilation errors. (Issue: hmislk/hmis#19944)
+0. **🚨 NEVER USE WORKTREE ISOLATION**: Always work directly in the main project checkout directory. Do NOT use `isolation: "worktree"` when spawning agents. If you find yourself in a path like `.claude/worktrees/*`, stop and perform all file edits in the main project directory instead. Worktrees cause the developer's local branch to go out of sync with remote commits, leading to confusing stale-file compilation errors. (Issue: hmislk/hmis#19944)
 
 ### User Control
 1. **🚨 NO AUTO-ACTIONS**: Do NOT commit, build, run, or push code unless the user explicitly requests it

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,6 +7,9 @@
 
 ## Essential Rules (Always Apply)
 
+### Working Directory
+0. **🚨 NEVER USE WORKTREE ISOLATION**: Always work directly in `/home/buddhika/development/rh/`. Do NOT use `isolation: "worktree"` when spawning agents. If you find yourself in a path like `.claude/worktrees/*`, stop and perform all file edits in the main project directory instead. Worktrees cause the developer's local branch to go out of sync with remote commits, leading to confusing stale-file compilation errors. (Issue: hmislk/hmis#19944)
+
 ### User Control
 1. **🚨 NO AUTO-ACTIONS**: Do NOT commit, build, run, or push code unless the user explicitly requests it
 2. **🚨 EXPLICIT COMMANDS ONLY**: Wait for user confirmation before executing Git operations, Maven builds, or deployment commands

--- a/src/main/java/com/divudi/bean/common/DatabaseMigrationController.java
+++ b/src/main/java/com/divudi/bean/common/DatabaseMigrationController.java
@@ -539,87 +539,107 @@ public class DatabaseMigrationController implements Serializable {
     }
 
     /**
-     * Execute SQL script using EntityManager through facade
+     * Execute SQL script, routing each statement to the correct executor.
+     *
+     * DDL statements (CREATE, ALTER, DROP, CALL, DELIMITER blocks) are
+     * executed via executeDdlNative() which uses a raw JDBC connection
+     * outside JTA — necessary because MySQL auto-commits DDL implicitly,
+     * which would otherwise abort the JTA transaction.
+     *
+     * DML/query statements (SELECT, INSERT, UPDATE, DELETE) continue to
+     * use executeNativeSql() through the EntityManager.
      */
     private void executeSqlScript(String sql, StringBuilder logBuilder) throws Exception {
-        List<String> statements = splitSqlStatements(sql);
-        for (String stmt : statements) {
-            String trimmedStmt = stmt.trim();
-            if (!trimmedStmt.isEmpty() && !trimmedStmt.startsWith("--")) {
+        try {
+            List<String> statements = splitSqlStatements(sql);
+
+            for (String stmt : statements) {
+                String trimmedStmt = stmt.trim();
+                if (trimmedStmt.isEmpty() || trimmedStmt.startsWith("--")) {
+                    continue;
+                }
                 logBuilder.append("Executing: ").append(trimmedStmt.substring(0, Math.min(100, trimmedStmt.length()))).append("...\n");
                 try {
-                    migrationFacade.executeNativeSql(trimmedStmt);
+                    if (isDdlStatement(trimmedStmt)) {
+                        migrationFacade.executeDdlNative(trimmedStmt);
+                    } else {
+                        migrationFacade.executeNativeSql(trimmedStmt);
+                    }
                 } catch (Exception e) {
                     if (isCreateIndexStatement(trimmedStmt) && isDuplicateIndexError(e)) {
-                        logBuilder.append("Index already exists, skipping: ").append(e.getMessage()).append("\n");
+                        logBuilder.append("Index already exists, skipping...\n");
                     } else {
                         throw e;
                     }
                 }
             }
+
+            logBuilder.append("All statements executed successfully\n");
+
+        } catch (Exception e) {
+            logBuilder.append("Error executing SQL: ").append(e.getMessage()).append("\n");
+            throw e;
         }
     }
 
     /**
      * Splits a SQL script into individual executable statements.
-     * Handles DELIMITER changes used in stored procedure definitions.
-     * DELIMITER lines are MySQL client directives — they are stripped and the
-     * procedure body is submitted as a single JDBC statement (JDBC does not
-     * use client-side delimiters).
+     * Handles DELIMITER directives used in stored procedure definitions.
+     * DELIMITER is a MySQL client convention — the directive itself is
+     * stripped; the procedure body is submitted as a single JDBC call.
      */
     private List<String> splitSqlStatements(String sql) {
         List<String> statements = new ArrayList<>();
         String currentDelimiter = ";";
-        StringBuilder currentStatement = new StringBuilder();
+        StringBuilder current = new StringBuilder();
 
         for (String line : sql.split("\n")) {
-            String trimmedLine = line.trim();
+            String trimmed = line.trim();
 
-            if (trimmedLine.toUpperCase().startsWith("DELIMITER")) {
-                // Flush any buffered statement before changing delimiter
-                String buffered = currentStatement.toString().trim();
+            if (trimmed.toUpperCase().startsWith("DELIMITER")) {
+                String buffered = current.toString().trim();
                 if (!buffered.isEmpty()) {
                     statements.add(buffered);
-                    currentStatement = new StringBuilder();
+                    current = new StringBuilder();
                 }
-                // Extract new delimiter (e.g. "DELIMITER //" → "//")
-                String[] parts = trimmedLine.split("\\s+", 2);
+                String[] parts = trimmed.split("\\s+", 2);
                 currentDelimiter = parts.length > 1 ? parts[1].trim() : ";";
                 continue;
             }
 
-            if (!currentDelimiter.equals(";") && trimmedLine.endsWith(currentDelimiter)) {
-                // End of a procedure/function block — strip trailing delimiter and flush
-                String withoutDelim = line.substring(0, line.lastIndexOf(currentDelimiter));
-                currentStatement.append(withoutDelim).append("\n");
-                statements.add(currentStatement.toString().trim());
-                currentStatement = new StringBuilder();
+            if (!currentDelimiter.equals(";") && trimmed.endsWith(currentDelimiter)) {
+                // End of a procedure block — strip the custom delimiter and flush
+                int delimIdx = line.lastIndexOf(currentDelimiter);
+                current.append(line, 0, delimIdx).append("\n");
+                statements.add(current.toString().trim());
+                current = new StringBuilder();
                 currentDelimiter = ";";
-            } else if (currentDelimiter.equals(";")) {
-                // Normal statement splitting by semicolon
-                if (trimmedLine.endsWith(";")) {
-                    currentStatement.append(line, 0, line.lastIndexOf(";")).append("\n");
-                    String stmt = currentStatement.toString().trim();
-                    if (!stmt.isEmpty()) {
-                        statements.add(stmt);
-                    }
-                    currentStatement = new StringBuilder();
-                } else {
-                    currentStatement.append(line).append("\n");
+            } else if (currentDelimiter.equals(";") && trimmed.endsWith(";")) {
+                // Normal semicolon-terminated statement
+                int semiIdx = line.lastIndexOf(";");
+                current.append(line, 0, semiIdx).append("\n");
+                String stmt = current.toString().trim();
+                if (!stmt.isEmpty()) {
+                    statements.add(stmt);
                 }
+                current = new StringBuilder();
             } else {
-                // Inside a procedure block — accumulate lines
-                currentStatement.append(line).append("\n");
+                current.append(line).append("\n");
             }
         }
 
-        // Flush any remaining content
-        String remaining = currentStatement.toString().trim();
+        String remaining = current.toString().trim();
         if (!remaining.isEmpty()) {
             statements.add(remaining);
         }
-
         return statements;
+    }
+
+    private boolean isDdlStatement(String sql) {
+        String upper = sql.toUpperCase().trim();
+        return upper.startsWith("CREATE") || upper.startsWith("ALTER")
+                || upper.startsWith("DROP") || upper.startsWith("CALL")
+                || upper.startsWith("RENAME") || upper.startsWith("TRUNCATE");
     }
 
     private boolean isCreateIndexStatement(String sql) {

--- a/src/main/java/com/divudi/bean/common/DatabaseMigrationController.java
+++ b/src/main/java/com/divudi/bean/common/DatabaseMigrationController.java
@@ -70,29 +70,7 @@ public class DatabaseMigrationController implements Serializable {
 
     @PostConstruct
     public void init() {
-        bootstrapDatabaseMigrationTable();
         refreshMigrationLists();
-    }
-
-    /**
-     * Ensures the DATABASEMIGRATION table itself has AUTO_INCREMENT on its ID
-     * column before any migration tracking record is inserted.
-     *
-     * Bootstrap problem: after deploying the GenerationType.IDENTITY build,
-     * EclipseLink omits ID from INSERT statements. If DATABASEMIGRATION.ID
-     * has no AUTO_INCREMENT yet (migration v2.2.0 hasn't run), MySQL throws
-     * "Field 'ID' doesn't have a default value" and the tracking insert fails.
-     *
-     * This method detects that condition and self-heals the one table that
-     * the migration controller itself depends on, before touching any other
-     * table. The remaining 186 tables are handled by migration v2.2.0.
-     */
-    private void bootstrapDatabaseMigrationTable() {
-        try {
-            migrationFacade.ensureAutoIncrementOnMigrationTable();
-        } catch (Exception e) {
-            LOGGER.log(Level.WARNING, "Could not bootstrap DATABASEMIGRATION AUTO_INCREMENT — migration v2.2.0 may fail if not yet applied", e);
-        }
     }
 
     public String navigateToDatabaseMigration(){

--- a/src/main/java/com/divudi/bean/common/DatabaseMigrationController.java
+++ b/src/main/java/com/divudi/bean/common/DatabaseMigrationController.java
@@ -70,7 +70,29 @@ public class DatabaseMigrationController implements Serializable {
 
     @PostConstruct
     public void init() {
+        bootstrapDatabaseMigrationTable();
         refreshMigrationLists();
+    }
+
+    /**
+     * Ensures the DATABASEMIGRATION table itself has AUTO_INCREMENT on its ID
+     * column before any migration tracking record is inserted.
+     *
+     * Bootstrap problem: after deploying the GenerationType.IDENTITY build,
+     * EclipseLink omits ID from INSERT statements. If DATABASEMIGRATION.ID
+     * has no AUTO_INCREMENT yet (migration v2.2.0 hasn't run), MySQL throws
+     * "Field 'ID' doesn't have a default value" and the tracking insert fails.
+     *
+     * This method detects that condition and self-heals the one table that
+     * the migration controller itself depends on, before touching any other
+     * table. The remaining 186 tables are handled by migration v2.2.0.
+     */
+    private void bootstrapDatabaseMigrationTable() {
+        try {
+            migrationFacade.ensureAutoIncrementOnMigrationTable();
+        } catch (Exception e) {
+            LOGGER.log(Level.WARNING, "Could not bootstrap DATABASEMIGRATION AUTO_INCREMENT — migration v2.2.0 may fail if not yet applied", e);
+        }
     }
 
     public String navigateToDatabaseMigration(){

--- a/src/main/java/com/divudi/bean/common/DatabaseMigrationController.java
+++ b/src/main/java/com/divudi/bean/common/DatabaseMigrationController.java
@@ -542,36 +542,84 @@ public class DatabaseMigrationController implements Serializable {
      * Execute SQL script using EntityManager through facade
      */
     private void executeSqlScript(String sql, StringBuilder logBuilder) throws Exception {
-        try {
-            // Split SQL into individual statements (simple approach)
-            String[] statements = sql.split(";");
-
-            for (String stmt : statements) {
-                String trimmedStmt = stmt.trim();
-                if (!trimmedStmt.isEmpty() && !trimmedStmt.startsWith("--")) {
-                    logBuilder.append("Executing: ").append(trimmedStmt.substring(0, Math.min(100, trimmedStmt.length()))).append("...\\n");
-
-                    try {
-                        // Use facade to execute native SQL
-                        migrationFacade.executeNativeSql(trimmedStmt);
-                    } catch (Exception e) {
-                        // Check if this is a "duplicate index" error (MySQL error 1061)
-                        // for CREATE INDEX statements - safe to skip
-                        if (isCreateIndexStatement(trimmedStmt) && isDuplicateIndexError(e)) {
-                            logBuilder.append("Index already exists, skipping...\\n");
-                        } else {
-                            throw e;
-                        }
+        List<String> statements = splitSqlStatements(sql);
+        for (String stmt : statements) {
+            String trimmedStmt = stmt.trim();
+            if (!trimmedStmt.isEmpty() && !trimmedStmt.startsWith("--")) {
+                logBuilder.append("Executing: ").append(trimmedStmt.substring(0, Math.min(100, trimmedStmt.length()))).append("...\n");
+                try {
+                    migrationFacade.executeNativeSql(trimmedStmt);
+                } catch (Exception e) {
+                    if (isCreateIndexStatement(trimmedStmt) && isDuplicateIndexError(e)) {
+                        logBuilder.append("Index already exists, skipping: ").append(e.getMessage()).append("\n");
+                    } else {
+                        throw e;
                     }
                 }
             }
-
-            logBuilder.append("All statements executed successfully\\n");
-
-        } catch (Exception e) {
-            logBuilder.append("Error executing SQL: ").append(e.getMessage()).append("\\n");
-            throw e;
         }
+    }
+
+    /**
+     * Splits a SQL script into individual executable statements.
+     * Handles DELIMITER changes used in stored procedure definitions.
+     * DELIMITER lines are MySQL client directives — they are stripped and the
+     * procedure body is submitted as a single JDBC statement (JDBC does not
+     * use client-side delimiters).
+     */
+    private List<String> splitSqlStatements(String sql) {
+        List<String> statements = new ArrayList<>();
+        String currentDelimiter = ";";
+        StringBuilder currentStatement = new StringBuilder();
+
+        for (String line : sql.split("\n")) {
+            String trimmedLine = line.trim();
+
+            if (trimmedLine.toUpperCase().startsWith("DELIMITER")) {
+                // Flush any buffered statement before changing delimiter
+                String buffered = currentStatement.toString().trim();
+                if (!buffered.isEmpty()) {
+                    statements.add(buffered);
+                    currentStatement = new StringBuilder();
+                }
+                // Extract new delimiter (e.g. "DELIMITER //" → "//")
+                String[] parts = trimmedLine.split("\\s+", 2);
+                currentDelimiter = parts.length > 1 ? parts[1].trim() : ";";
+                continue;
+            }
+
+            if (!currentDelimiter.equals(";") && trimmedLine.endsWith(currentDelimiter)) {
+                // End of a procedure/function block — strip trailing delimiter and flush
+                String withoutDelim = line.substring(0, line.lastIndexOf(currentDelimiter));
+                currentStatement.append(withoutDelim).append("\n");
+                statements.add(currentStatement.toString().trim());
+                currentStatement = new StringBuilder();
+                currentDelimiter = ";";
+            } else if (currentDelimiter.equals(";")) {
+                // Normal statement splitting by semicolon
+                if (trimmedLine.endsWith(";")) {
+                    currentStatement.append(line, 0, line.lastIndexOf(";")).append("\n");
+                    String stmt = currentStatement.toString().trim();
+                    if (!stmt.isEmpty()) {
+                        statements.add(stmt);
+                    }
+                    currentStatement = new StringBuilder();
+                } else {
+                    currentStatement.append(line).append("\n");
+                }
+            } else {
+                // Inside a procedure block — accumulate lines
+                currentStatement.append(line).append("\n");
+            }
+        }
+
+        // Flush any remaining content
+        String remaining = currentStatement.toString().trim();
+        if (!remaining.isEmpty()) {
+            statements.add(remaining);
+        }
+
+        return statements;
     }
 
     private boolean isCreateIndexStatement(String sql) {

--- a/src/main/java/com/divudi/core/data/PaymentMethodValue.java
+++ b/src/main/java/com/divudi/core/data/PaymentMethodValue.java
@@ -19,7 +19,7 @@ public class PaymentMethodValue implements Serializable {
 
     private static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     private PaymentMethod paymentMethod;

--- a/src/main/java/com/divudi/core/data/clinical/PersonRelationship.java
+++ b/src/main/java/com/divudi/core/data/clinical/PersonRelationship.java
@@ -28,7 +28,7 @@ public class PersonRelationship implements Serializable {
 
     private static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     @ManyToOne

--- a/src/main/java/com/divudi/core/entity/AgentHistory.java
+++ b/src/main/java/com/divudi/core/entity/AgentHistory.java
@@ -31,7 +31,7 @@ public class AgentHistory implements Serializable {
 
     private static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
     @ManyToOne
     BillItem billItem;

--- a/src/main/java/com/divudi/core/entity/AiConversation.java
+++ b/src/main/java/com/divudi/core/entity/AiConversation.java
@@ -18,7 +18,7 @@ public class AiConversation implements Serializable {
 
     private static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     private String title;

--- a/src/main/java/com/divudi/core/entity/AiMessage.java
+++ b/src/main/java/com/divudi/core/entity/AiMessage.java
@@ -19,7 +19,7 @@ public class AiMessage implements Serializable {
 
     private static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     @ManyToOne

--- a/src/main/java/com/divudi/core/entity/ApiKey.java
+++ b/src/main/java/com/divudi/core/entity/ApiKey.java
@@ -19,7 +19,7 @@ public class ApiKey implements Serializable {
 
     private static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     private ApiKeyType keyType;

--- a/src/main/java/com/divudi/core/entity/AppEmail.java
+++ b/src/main/java/com/divudi/core/entity/AppEmail.java
@@ -29,7 +29,7 @@ public class AppEmail implements Serializable {
 
     private static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     @ManyToOne

--- a/src/main/java/com/divudi/core/entity/Appointment.java
+++ b/src/main/java/com/divudi/core/entity/Appointment.java
@@ -32,7 +32,7 @@ public class Appointment extends PatientEncounter implements Serializable {
 
     private static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     //Created Properties

--- a/src/main/java/com/divudi/core/entity/AppointmentScheduleDateOverride.java
+++ b/src/main/java/com/divudi/core/entity/AppointmentScheduleDateOverride.java
@@ -17,7 +17,7 @@ public class AppointmentScheduleDateOverride implements Serializable {
 
     private static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     @ManyToOne

--- a/src/main/java/com/divudi/core/entity/AppointmentScheduleInstance.java
+++ b/src/main/java/com/divudi/core/entity/AppointmentScheduleInstance.java
@@ -14,7 +14,7 @@ public class AppointmentScheduleInstance implements Serializable {
 
     private static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     @ManyToOne

--- a/src/main/java/com/divudi/core/entity/AppointmentScheduleTemplate.java
+++ b/src/main/java/com/divudi/core/entity/AppointmentScheduleTemplate.java
@@ -18,7 +18,7 @@ public class AppointmentScheduleTemplate implements Serializable {
 
     private static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     private String name;

--- a/src/main/java/com/divudi/core/entity/Area.java
+++ b/src/main/java/com/divudi/core/entity/Area.java
@@ -29,7 +29,7 @@ public class Area implements Serializable {
 
      static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
      Long id;
      String name;
      String description;

--- a/src/main/java/com/divudi/core/entity/AuditEvent.java
+++ b/src/main/java/com/divudi/core/entity/AuditEvent.java
@@ -28,7 +28,7 @@ public class AuditEvent implements Serializable {
 
     private static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
     @Temporal(javax.persistence.TemporalType.TIMESTAMP)
     private Date eventDataTime;

--- a/src/main/java/com/divudi/core/entity/Bill.java
+++ b/src/main/java/com/divudi/core/entity/Bill.java
@@ -53,7 +53,7 @@ import javax.persistence.JoinColumn;
 public class Bill implements Serializable, RetirableEntity {
 
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     Long id;
 
     static final long serialVersionUID = 1L;

--- a/src/main/java/com/divudi/core/entity/BillComponent.java
+++ b/src/main/java/com/divudi/core/entity/BillComponent.java
@@ -22,7 +22,7 @@ public class BillComponent implements Serializable, RetirableEntity  {
 
     static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     //Main Properties
     Long id;
     @ManyToOne

--- a/src/main/java/com/divudi/core/entity/BillEntry.java
+++ b/src/main/java/com/divudi/core/entity/BillEntry.java
@@ -24,7 +24,7 @@ public class BillEntry implements Serializable, RetirableEntity  {
 
     static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     Long id;
     @Transient
     BillItem billItem;

--- a/src/main/java/com/divudi/core/entity/BillFee.java
+++ b/src/main/java/com/divudi/core/entity/BillFee.java
@@ -28,7 +28,7 @@ public class BillFee implements Serializable, RetirableEntity {
 
     static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     Long id;
     //Created Properties
     @ManyToOne

--- a/src/main/java/com/divudi/core/entity/BillFeePayment.java
+++ b/src/main/java/com/divudi/core/entity/BillFeePayment.java
@@ -24,7 +24,7 @@ import javax.persistence.Temporal;
 public class BillFeePayment implements Serializable {
     private static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     //Created Properties

--- a/src/main/java/com/divudi/core/entity/BillFinanceDetails.java
+++ b/src/main/java/com/divudi/core/entity/BillFinanceDetails.java
@@ -24,7 +24,7 @@ public class BillFinanceDetails implements Serializable {
 
     private static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     // Inverse side of the relationship - Bill entity owns the FK BILLFINANCEDETAILS_ID

--- a/src/main/java/com/divudi/core/entity/BillItem.java
+++ b/src/main/java/com/divudi/core/entity/BillItem.java
@@ -41,7 +41,7 @@ import javax.persistence.Transient;
 public class BillItem implements Serializable, RetirableEntity {
 
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     Long id;
 
     static final long serialVersionUID = 1L;

--- a/src/main/java/com/divudi/core/entity/BillItemFinanceDetails.java
+++ b/src/main/java/com/divudi/core/entity/BillItemFinanceDetails.java
@@ -24,7 +24,7 @@ public class BillItemFinanceDetails implements Serializable {
 
     private static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     @OneToOne(mappedBy = "billItemFinanceDetails")

--- a/src/main/java/com/divudi/core/entity/BillNumber.java
+++ b/src/main/java/com/divudi/core/entity/BillNumber.java
@@ -31,7 +31,7 @@ public class BillNumber implements Serializable {
 
     private static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
     private Long lastBillNumber;
     @ManyToOne

--- a/src/main/java/com/divudi/core/entity/BillSession.java
+++ b/src/main/java/com/divudi/core/entity/BillSession.java
@@ -27,7 +27,7 @@ public class BillSession implements Serializable, RetirableEntity  {
 
     static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     Long id;
     @ManyToOne
     Packege packege;

--- a/src/main/java/com/divudi/core/entity/CategoryItem.java
+++ b/src/main/java/com/divudi/core/entity/CategoryItem.java
@@ -18,7 +18,7 @@ public class CategoryItem implements Serializable {
 
     private static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     @ManyToOne

--- a/src/main/java/com/divudi/core/entity/ConfigOption.java
+++ b/src/main/java/com/divudi/core/entity/ConfigOption.java
@@ -23,7 +23,7 @@ public class ConfigOption implements Serializable {
 
     private static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     public Long getId() {

--- a/src/main/java/com/divudi/core/entity/DatabaseMigration.java
+++ b/src/main/java/com/divudi/core/entity/DatabaseMigration.java
@@ -30,7 +30,7 @@ public class DatabaseMigration implements Serializable, Comparable<DatabaseMigra
     private static final long serialVersionUID = 1L;
 
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     @Column(nullable = false, unique = true, length = 50)

--- a/src/main/java/com/divudi/core/entity/DefaultServiceDepartment.java
+++ b/src/main/java/com/divudi/core/entity/DefaultServiceDepartment.java
@@ -20,7 +20,7 @@ public class DefaultServiceDepartment implements Serializable {
 
     private static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     @ManyToOne

--- a/src/main/java/com/divudi/core/entity/Department.java
+++ b/src/main/java/com/divudi/core/entity/Department.java
@@ -29,7 +29,7 @@ public class Department implements Serializable {
 
     static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     //Main Properties
     Long id;
     String departmentCode;

--- a/src/main/java/com/divudi/core/entity/EncounterCreditCompany.java
+++ b/src/main/java/com/divudi/core/entity/EncounterCreditCompany.java
@@ -22,7 +22,7 @@ public class EncounterCreditCompany implements Serializable {
 
     private static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     @ManyToOne

--- a/src/main/java/com/divudi/core/entity/Family.java
+++ b/src/main/java/com/divudi/core/entity/Family.java
@@ -30,7 +30,7 @@ public class Family implements Serializable {
 
     private static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     @OneToMany(mappedBy = "family", cascade = CascadeType.ALL, fetch = FetchType.EAGER)

--- a/src/main/java/com/divudi/core/entity/FamilyMember.java
+++ b/src/main/java/com/divudi/core/entity/FamilyMember.java
@@ -23,7 +23,7 @@ public class FamilyMember implements Serializable {
 
     private static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
 

--- a/src/main/java/com/divudi/core/entity/Fee.java
+++ b/src/main/java/com/divudi/core/entity/Fee.java
@@ -29,7 +29,7 @@ public class Fee implements Serializable {
 
     static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     //Main Properties
     Long id;
     String name;

--- a/src/main/java/com/divudi/core/entity/FeeChange.java
+++ b/src/main/java/com/divudi/core/entity/FeeChange.java
@@ -25,7 +25,7 @@ import javax.persistence.Temporal;
 public class FeeChange implements Serializable {
     private static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
     @Temporal(javax.persistence.TemporalType.DATE)
     Date validFrom;

--- a/src/main/java/com/divudi/core/entity/FeeValue.java
+++ b/src/main/java/com/divudi/core/entity/FeeValue.java
@@ -19,7 +19,7 @@ public class FeeValue implements Serializable {
 
     private static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     @ManyToOne(fetch = FetchType.EAGER)

--- a/src/main/java/com/divudi/core/entity/Form.java
+++ b/src/main/java/com/divudi/core/entity/Form.java
@@ -26,7 +26,7 @@ public class Form implements Serializable {
 
     private static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     //Created Properties

--- a/src/main/java/com/divudi/core/entity/FormItemValue.java
+++ b/src/main/java/com/divudi/core/entity/FormItemValue.java
@@ -30,7 +30,7 @@ public class FormItemValue implements Serializable {
 
     private static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
     @ManyToOne
     Patient patient;

--- a/src/main/java/com/divudi/core/entity/HistoricalRecord.java
+++ b/src/main/java/com/divudi/core/entity/HistoricalRecord.java
@@ -24,7 +24,7 @@ public class HistoricalRecord implements Serializable {
 
     private static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
 

--- a/src/main/java/com/divudi/core/entity/Institution.java
+++ b/src/main/java/com/divudi/core/entity/Institution.java
@@ -37,7 +37,7 @@ public class Institution implements Serializable, IdentifiableWithNameOrCode {
 
     static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     Long id;
     // NOTE: No UNIQUE constraint on institutionCode - different institution types
     // (suppliers, labs, hospitals) can legitimately have the same codes (e.g., RH2003)

--- a/src/main/java/com/divudi/core/entity/IssueRateMargins.java
+++ b/src/main/java/com/divudi/core/entity/IssueRateMargins.java
@@ -23,7 +23,7 @@ import javax.persistence.Temporal;
 public class IssueRateMargins implements Serializable {
     private static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
     String name;
     @Temporal(javax.persistence.TemporalType.TIMESTAMP)

--- a/src/main/java/com/divudi/core/entity/Item.java
+++ b/src/main/java/com/divudi/core/entity/Item.java
@@ -72,7 +72,7 @@ public class Item implements Serializable, Comparable<Item>, RetirableEntity {
     static final long serialVersionUID = 1L;
 
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     Long id;
     int orderNo;
 

--- a/src/main/java/com/divudi/core/entity/ItemMapping.java
+++ b/src/main/java/com/divudi/core/entity/ItemMapping.java
@@ -19,7 +19,7 @@ public class ItemMapping implements Serializable {
 
     private static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     @ManyToOne

--- a/src/main/java/com/divudi/core/entity/ItemPackage.java
+++ b/src/main/java/com/divudi/core/entity/ItemPackage.java
@@ -18,7 +18,7 @@ import javax.persistence.Id;
 public class ItemPackage implements Serializable {
      static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
      Long id;
 
     public Long getId() {

--- a/src/main/java/com/divudi/core/entity/ItemsCategories.java
+++ b/src/main/java/com/divudi/core/entity/ItemsCategories.java
@@ -22,7 +22,7 @@ public class ItemsCategories implements Serializable {
 
     static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     Long id;
     //Created Properties
     @ManyToOne

--- a/src/main/java/com/divudi/core/entity/Logins.java
+++ b/src/main/java/com/divudi/core/entity/Logins.java
@@ -22,7 +22,7 @@ public class Logins implements Serializable {
 
      static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
      Long id;
     @ManyToOne
     WebUser webUser;

--- a/src/main/java/com/divudi/core/entity/Mapping.java
+++ b/src/main/java/com/divudi/core/entity/Mapping.java
@@ -20,7 +20,7 @@ import javax.persistence.ManyToOne;
 public class Mapping implements Serializable {
      static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
      Long id;
 
 

--- a/src/main/java/com/divudi/core/entity/MedicalPackageItem.java
+++ b/src/main/java/com/divudi/core/entity/MedicalPackageItem.java
@@ -22,7 +22,7 @@ public class MedicalPackageItem implements Serializable {
 
      static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
      Long id;
     @ManyToOne
      Item packege;

--- a/src/main/java/com/divudi/core/entity/Notification.java
+++ b/src/main/java/com/divudi/core/entity/Notification.java
@@ -26,7 +26,7 @@ public class Notification implements Serializable {
 
     private static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     @ManyToOne

--- a/src/main/java/com/divudi/core/entity/OnlineBooking.java
+++ b/src/main/java/com/divudi/core/entity/OnlineBooking.java
@@ -24,7 +24,7 @@ import javax.persistence.TemporalType;
 public class OnlineBooking implements Serializable, RetirableEntity {
 
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
 //    class level variables

--- a/src/main/java/com/divudi/core/entity/PackageItem.java
+++ b/src/main/java/com/divudi/core/entity/PackageItem.java
@@ -22,7 +22,7 @@ public class PackageItem implements Serializable {
 
     static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     Long id;
     @ManyToOne
     Packege packege;

--- a/src/main/java/com/divudi/core/entity/Patient.java
+++ b/src/main/java/com/divudi/core/entity/Patient.java
@@ -40,7 +40,7 @@ public class Patient implements Serializable, RetirableEntity {
 
     static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     Long id;
 
     private Long patientPhoneNumber;

--- a/src/main/java/com/divudi/core/entity/PatientDeposit.java
+++ b/src/main/java/com/divudi/core/entity/PatientDeposit.java
@@ -22,7 +22,7 @@ public class PatientDeposit implements Serializable, RetirableEntity {
 
     private static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
     @ManyToOne
     private Patient patient;

--- a/src/main/java/com/divudi/core/entity/PatientDepositHistory.java
+++ b/src/main/java/com/divudi/core/entity/PatientDepositHistory.java
@@ -25,7 +25,7 @@ public class PatientDepositHistory implements Serializable, RetirableEntity {
 
     private static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     @ManyToOne

--- a/src/main/java/com/divudi/core/entity/PatientEncounter.java
+++ b/src/main/java/com/divudi/core/entity/PatientEncounter.java
@@ -49,7 +49,7 @@ public class PatientEncounter implements Serializable, RetirableEntity {
 
     static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     //Main Properties
     Long id;
     String bhtNo;

--- a/src/main/java/com/divudi/core/entity/PatientFlag.java
+++ b/src/main/java/com/divudi/core/entity/PatientFlag.java
@@ -23,7 +23,7 @@ public class PatientFlag implements Serializable, RetirableEntity {
 
      static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     //Main Properties
      Long id;
     @ManyToOne

--- a/src/main/java/com/divudi/core/entity/PatientItem.java
+++ b/src/main/java/com/divudi/core/entity/PatientItem.java
@@ -23,7 +23,7 @@ public class PatientItem implements Serializable, RetirableEntity {
 
     static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     //Main Properties
     Long id;
     String name;

--- a/src/main/java/com/divudi/core/entity/Payment.java
+++ b/src/main/java/com/divudi/core/entity/Payment.java
@@ -34,7 +34,7 @@ public class Payment implements Serializable, RetirableEntity {
     static final long serialVersionUID = 1L;
 
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     Long id;
 
     @ManyToOne

--- a/src/main/java/com/divudi/core/entity/PaymentGatewayTransaction.java
+++ b/src/main/java/com/divudi/core/entity/PaymentGatewayTransaction.java
@@ -20,7 +20,7 @@ public class PaymentGatewayTransaction implements Serializable {
 
     private static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     @ManyToOne

--- a/src/main/java/com/divudi/core/entity/PaymentHandoverItem.java
+++ b/src/main/java/com/divudi/core/entity/PaymentHandoverItem.java
@@ -19,7 +19,7 @@ public class PaymentHandoverItem implements Serializable {
 
     private static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     @ManyToOne

--- a/src/main/java/com/divudi/core/entity/PaymentScheme.java
+++ b/src/main/java/com/divudi/core/entity/PaymentScheme.java
@@ -29,7 +29,7 @@ public class PaymentScheme implements Serializable {
 
     static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     //Main Properties
     Long id;
     String name;

--- a/src/main/java/com/divudi/core/entity/PersonInstitution.java
+++ b/src/main/java/com/divudi/core/entity/PersonInstitution.java
@@ -26,7 +26,7 @@ public class PersonInstitution implements Serializable {
 
     private static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     @ManyToOne

--- a/src/main/java/com/divudi/core/entity/PharmacyBill.java
+++ b/src/main/java/com/divudi/core/entity/PharmacyBill.java
@@ -18,7 +18,7 @@ public class PharmacyBill implements Serializable {
 
     private static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
     // Bidirectional One-to-One relationship with Bill
     @OneToOne(mappedBy = "pharmacyBill", cascade = CascadeType.ALL)

--- a/src/main/java/com/divudi/core/entity/PriceMatrix.java
+++ b/src/main/java/com/divudi/core/entity/PriceMatrix.java
@@ -30,7 +30,7 @@ public class PriceMatrix implements Serializable {
 
     static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     Long id;
     BillType billType;
     @ManyToOne

--- a/src/main/java/com/divudi/core/entity/ReportTemplate.java
+++ b/src/main/java/com/divudi/core/entity/ReportTemplate.java
@@ -30,7 +30,7 @@ public class ReportTemplate implements Serializable {
     private static final long serialVersionUID = 1L;
 
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     @Enumerated

--- a/src/main/java/com/divudi/core/entity/Request.java
+++ b/src/main/java/com/divudi/core/entity/Request.java
@@ -24,7 +24,7 @@ public class Request implements Serializable {
     private static final long serialVersionUID = 1L;
 
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
     
     private String requestNo;

--- a/src/main/java/com/divudi/core/entity/ScheduledProcessConfiguration.java
+++ b/src/main/java/com/divudi/core/entity/ScheduledProcessConfiguration.java
@@ -25,7 +25,7 @@ public class ScheduledProcessConfiguration implements Serializable {
 
     private static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     @Enumerated(EnumType.STRING)

--- a/src/main/java/com/divudi/core/entity/ServiceSessionInstance.java
+++ b/src/main/java/com/divudi/core/entity/ServiceSessionInstance.java
@@ -29,7 +29,7 @@ public class ServiceSessionInstance implements Serializable {
 
     private static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     private Double total = 0.0;

--- a/src/main/java/com/divudi/core/entity/Sex.java
+++ b/src/main/java/com/divudi/core/entity/Sex.java
@@ -26,7 +26,7 @@ public class Sex implements Serializable {
 
      static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
      Long id;
      String name;
      String sname;

--- a/src/main/java/com/divudi/core/entity/Sms.java
+++ b/src/main/java/com/divudi/core/entity/Sms.java
@@ -29,7 +29,7 @@ public class Sms implements Serializable {
 
     private static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     @ManyToOne

--- a/src/main/java/com/divudi/core/entity/Staff.java
+++ b/src/main/java/com/divudi/core/entity/Staff.java
@@ -46,7 +46,7 @@ import javax.persistence.Transient;
 public class Staff implements Serializable, IdentifiableWithNameOrCode {
 
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     Long id;
 
     static final long serialVersionUID = 1L;

--- a/src/main/java/com/divudi/core/entity/StockBill.java
+++ b/src/main/java/com/divudi/core/entity/StockBill.java
@@ -19,7 +19,7 @@ public class StockBill implements Serializable {
 
     private static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     private double stockValueAtPurchaseRates;

--- a/src/main/java/com/divudi/core/entity/Token.java
+++ b/src/main/java/com/divudi/core/entity/Token.java
@@ -22,7 +22,7 @@ public class Token implements Serializable {
 
     private static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     // <editor-fold defaultstate="collapsed" desc="Class variables">

--- a/src/main/java/com/divudi/core/entity/TriggerSubscription.java
+++ b/src/main/java/com/divudi/core/entity/TriggerSubscription.java
@@ -21,7 +21,7 @@ public class TriggerSubscription implements Serializable {
 
     private static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     @Enumerated(EnumType.ORDINAL)

--- a/src/main/java/com/divudi/core/entity/Upload.java
+++ b/src/main/java/com/divudi/core/entity/Upload.java
@@ -54,7 +54,7 @@ public class Upload implements Serializable {
 
     static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     Long id;
 
     @Lob

--- a/src/main/java/com/divudi/core/entity/UserIcon.java
+++ b/src/main/java/com/divudi/core/entity/UserIcon.java
@@ -19,7 +19,7 @@ public class UserIcon implements Serializable {
 
     private static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     @ManyToOne

--- a/src/main/java/com/divudi/core/entity/UserNotification.java
+++ b/src/main/java/com/divudi/core/entity/UserNotification.java
@@ -22,7 +22,7 @@ public class UserNotification implements Serializable {
 
     private static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     @ManyToOne

--- a/src/main/java/com/divudi/core/entity/UserPreference.java
+++ b/src/main/java/com/divudi/core/entity/UserPreference.java
@@ -35,7 +35,7 @@ public class UserPreference implements Serializable {
 
     private static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     /*

--- a/src/main/java/com/divudi/core/entity/WebContent.java
+++ b/src/main/java/com/divudi/core/entity/WebContent.java
@@ -22,7 +22,7 @@ public class WebContent implements Serializable {
 
     private static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
     private String name;
     private boolean retired;

--- a/src/main/java/com/divudi/core/entity/WebLanguage.java
+++ b/src/main/java/com/divudi/core/entity/WebLanguage.java
@@ -15,7 +15,7 @@ public class WebLanguage  implements Serializable {
 
     private static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
     private String name;
     private String code;

--- a/src/main/java/com/divudi/core/entity/WebTheme.java
+++ b/src/main/java/com/divudi/core/entity/WebTheme.java
@@ -25,7 +25,7 @@ import javax.persistence.Temporal;
 public class WebTheme implements Serializable {
      static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
      Long id;
 
     //Main Properties

--- a/src/main/java/com/divudi/core/entity/WebUser.java
+++ b/src/main/java/com/divudi/core/entity/WebUser.java
@@ -34,7 +34,7 @@ public class WebUser implements Serializable {
 
     static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     Long id;
 //    @ManyToOne(fetch = FetchType.LAZY)
 //    Drawer drawer;

--- a/src/main/java/com/divudi/core/entity/WebUserDashboard.java
+++ b/src/main/java/com/divudi/core/entity/WebUserDashboard.java
@@ -25,7 +25,7 @@ public class WebUserDashboard implements Serializable {
 
     private static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     @ManyToOne

--- a/src/main/java/com/divudi/core/entity/WebUserDepartment.java
+++ b/src/main/java/com/divudi/core/entity/WebUserDepartment.java
@@ -21,7 +21,7 @@ import javax.persistence.Temporal;
 public class WebUserDepartment implements Serializable {
      static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
      Long id;
 
     //Created Properties

--- a/src/main/java/com/divudi/core/entity/WebUserPasswordHistory.java
+++ b/src/main/java/com/divudi/core/entity/WebUserPasswordHistory.java
@@ -18,7 +18,7 @@ public class WebUserPasswordHistory implements Serializable, RetirableEntity {
 
     private static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     @ManyToOne

--- a/src/main/java/com/divudi/core/entity/WebUserPaymentScheme.java
+++ b/src/main/java/com/divudi/core/entity/WebUserPaymentScheme.java
@@ -21,7 +21,7 @@ import javax.persistence.Temporal;
 public class WebUserPaymentScheme implements Serializable {
      static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
      Long id;
 
     //Created Properties

--- a/src/main/java/com/divudi/core/entity/WebUserPrivilege.java
+++ b/src/main/java/com/divudi/core/entity/WebUserPrivilege.java
@@ -24,7 +24,7 @@ import javax.persistence.Temporal;
 public class WebUserPrivilege implements Serializable {
     static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     Long id;
     String name;
     String description;

--- a/src/main/java/com/divudi/core/entity/WebUserRole.java
+++ b/src/main/java/com/divudi/core/entity/WebUserRole.java
@@ -27,7 +27,7 @@ public class WebUserRole implements Serializable {
 
     static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     Long id;
 
     //Main Properties

--- a/src/main/java/com/divudi/core/entity/WebUserRolePrivilege.java
+++ b/src/main/java/com/divudi/core/entity/WebUserRolePrivilege.java
@@ -24,7 +24,7 @@ import javax.persistence.Temporal;
 public class WebUserRolePrivilege implements Serializable {
     static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     Long id;
     String name;
     String description;

--- a/src/main/java/com/divudi/core/entity/WebUserRoleUser.java
+++ b/src/main/java/com/divudi/core/entity/WebUserRoleUser.java
@@ -23,7 +23,7 @@ public class WebUserRoleUser implements Serializable {
 
     private static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     @ManyToOne

--- a/src/main/java/com/divudi/core/entity/WebUserRoute.java
+++ b/src/main/java/com/divudi/core/entity/WebUserRoute.java
@@ -22,7 +22,7 @@ public class WebUserRoute implements Serializable {
 
     static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     Long id;
 
     //Created Properties

--- a/src/main/java/com/divudi/core/entity/analytics/AggregatedRecord.java
+++ b/src/main/java/com/divudi/core/entity/analytics/AggregatedRecord.java
@@ -25,7 +25,7 @@ public class AggregatedRecord implements Serializable {
 
     private static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     public Long getId() {

--- a/src/main/java/com/divudi/core/entity/cashTransaction/CashBook.java
+++ b/src/main/java/com/divudi/core/entity/cashTransaction/CashBook.java
@@ -22,7 +22,7 @@ public class CashBook implements Serializable, RetirableEntity  {
 
     private static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
     private String Name;
     @ManyToOne

--- a/src/main/java/com/divudi/core/entity/cashTransaction/CashBookEntry.java
+++ b/src/main/java/com/divudi/core/entity/cashTransaction/CashBookEntry.java
@@ -26,7 +26,7 @@ public class CashBookEntry implements Serializable, RetirableEntity  {
 
     private static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     private String name;

--- a/src/main/java/com/divudi/core/entity/cashTransaction/CashTransaction.java
+++ b/src/main/java/com/divudi/core/entity/cashTransaction/CashTransaction.java
@@ -30,7 +30,7 @@ public class CashTransaction implements Serializable, RetirableEntity  {
 
     private static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
     @Enumerated(EnumType.STRING)
     private InOutType inOutType;

--- a/src/main/java/com/divudi/core/entity/cashTransaction/CashTransactionHistory.java
+++ b/src/main/java/com/divudi/core/entity/cashTransaction/CashTransactionHistory.java
@@ -29,7 +29,7 @@ public class CashTransactionHistory implements Serializable, RetirableEntity  {
 
     private static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     @Temporal(javax.persistence.TemporalType.DATE)

--- a/src/main/java/com/divudi/core/entity/cashTransaction/Denomination.java
+++ b/src/main/java/com/divudi/core/entity/cashTransaction/Denomination.java
@@ -19,7 +19,7 @@ public class Denomination implements Serializable {
 
     private static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     private String name;

--- a/src/main/java/com/divudi/core/entity/cashTransaction/DenominationTransaction.java
+++ b/src/main/java/com/divudi/core/entity/cashTransaction/DenominationTransaction.java
@@ -25,7 +25,7 @@ public class DenominationTransaction implements Serializable {
 
     private static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
     @ManyToOne
     private Denomination denomination;

--- a/src/main/java/com/divudi/core/entity/cashTransaction/DetailedFinancialBill.java
+++ b/src/main/java/com/divudi/core/entity/cashTransaction/DetailedFinancialBill.java
@@ -23,7 +23,7 @@ public class DetailedFinancialBill implements Serializable {
 
     private static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
     @OneToOne
     private Bill bill;

--- a/src/main/java/com/divudi/core/entity/cashTransaction/Drawer.java
+++ b/src/main/java/com/divudi/core/entity/cashTransaction/Drawer.java
@@ -17,7 +17,7 @@ public class Drawer implements Serializable, RetirableEntity  {
 
     private static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     Long id;
     private String name;
     private WebUser drawerUser;

--- a/src/main/java/com/divudi/core/entity/cashTransaction/DrawerEntry.java
+++ b/src/main/java/com/divudi/core/entity/cashTransaction/DrawerEntry.java
@@ -26,7 +26,7 @@ public class DrawerEntry implements Serializable, RetirableEntity {
 
     private static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     @ManyToOne

--- a/src/main/java/com/divudi/core/entity/channel/AgentReferenceBook.java
+++ b/src/main/java/com/divudi/core/entity/channel/AgentReferenceBook.java
@@ -31,7 +31,7 @@ public class AgentReferenceBook implements Serializable {
 
     private static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
     private double startingReferenceNumber = 0.0;
     private double endingReferenceNumber = 0.0;

--- a/src/main/java/com/divudi/core/entity/channel/AgentsFees.java
+++ b/src/main/java/com/divudi/core/entity/channel/AgentsFees.java
@@ -23,7 +23,7 @@ public class AgentsFees implements Serializable {
 
     private static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
     @ManyToOne
     private Institution agent;

--- a/src/main/java/com/divudi/core/entity/channel/AppointmentActivity.java
+++ b/src/main/java/com/divudi/core/entity/channel/AppointmentActivity.java
@@ -24,7 +24,7 @@ public class AppointmentActivity implements Serializable {
 
     private static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
     private String name;
     private String code;

--- a/src/main/java/com/divudi/core/entity/channel/DoctorInstitution.java
+++ b/src/main/java/com/divudi/core/entity/channel/DoctorInstitution.java
@@ -25,7 +25,7 @@ import javax.persistence.Temporal;
 public class DoctorInstitution implements Serializable {
     private static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
       private boolean booleanValue;

--- a/src/main/java/com/divudi/core/entity/channel/PatientSessionInstanceActivity.java
+++ b/src/main/java/com/divudi/core/entity/channel/PatientSessionInstanceActivity.java
@@ -21,7 +21,7 @@ public class PatientSessionInstanceActivity implements Serializable {
 
     private static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
 

--- a/src/main/java/com/divudi/core/entity/channel/SessionInstance.java
+++ b/src/main/java/com/divudi/core/entity/channel/SessionInstance.java
@@ -48,7 +48,7 @@ public class SessionInstance implements Serializable {
 
     private static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     private Double total = 0.0;

--- a/src/main/java/com/divudi/core/entity/channel/SessionInstanceActivity.java
+++ b/src/main/java/com/divudi/core/entity/channel/SessionInstanceActivity.java
@@ -24,7 +24,7 @@ public class SessionInstanceActivity implements Serializable {
 
     private static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
     @ManyToOne
     private SessionInstance sessionInstance;

--- a/src/main/java/com/divudi/core/entity/clinical/ClinicalFindingValue.java
+++ b/src/main/java/com/divudi/core/entity/clinical/ClinicalFindingValue.java
@@ -32,7 +32,7 @@ public class ClinicalFindingValue implements Serializable {
 
     private static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     @ManyToOne

--- a/src/main/java/com/divudi/core/entity/clinical/DocumentTemplate.java
+++ b/src/main/java/com/divudi/core/entity/clinical/DocumentTemplate.java
@@ -24,7 +24,7 @@ public class DocumentTemplate implements Serializable {
 
     private static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     @ManyToOne

--- a/src/main/java/com/divudi/core/entity/clinical/ItemUsage.java
+++ b/src/main/java/com/divudi/core/entity/clinical/ItemUsage.java
@@ -41,7 +41,7 @@ public class ItemUsage implements Serializable {
 
     private static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     @ManyToOne

--- a/src/main/java/com/divudi/core/entity/clinical/Prescription.java
+++ b/src/main/java/com/divudi/core/entity/clinical/Prescription.java
@@ -37,7 +37,7 @@ public class Prescription implements Serializable {
 
     private static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     @ManyToOne

--- a/src/main/java/com/divudi/core/entity/clinical/PrescriptionTemplate.java
+++ b/src/main/java/com/divudi/core/entity/clinical/PrescriptionTemplate.java
@@ -41,7 +41,7 @@ public class PrescriptionTemplate implements Serializable {
 
     private static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     @ManyToOne

--- a/src/main/java/com/divudi/core/entity/forms/ComponentAsignment.java
+++ b/src/main/java/com/divudi/core/entity/forms/ComponentAsignment.java
@@ -20,7 +20,7 @@ public class ComponentAsignment implements Serializable {
 
     private static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
     private String Name;
     private String description;

--- a/src/main/java/com/divudi/core/entity/hr/BankAccount.java
+++ b/src/main/java/com/divudi/core/entity/hr/BankAccount.java
@@ -31,7 +31,7 @@ public class BankAccount implements Serializable {
 
     private static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     @ManyToOne

--- a/src/main/java/com/divudi/core/entity/hr/FingerPrintRecord.java
+++ b/src/main/java/com/divudi/core/entity/hr/FingerPrintRecord.java
@@ -40,7 +40,7 @@ public class FingerPrintRecord implements Serializable {
     private FingerPrintRecord verifiedRecord;
     private static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
     @Enumerated(EnumType.STRING)
     FingerPrintRecordType fingerPrintRecordType;

--- a/src/main/java/com/divudi/core/entity/hr/FingerPrintRecordHistory.java
+++ b/src/main/java/com/divudi/core/entity/hr/FingerPrintRecordHistory.java
@@ -26,7 +26,7 @@ public class FingerPrintRecordHistory implements Serializable {
 
     private static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
     @ManyToOne
     private FingerPrintRecord fingerPrintRecord;

--- a/src/main/java/com/divudi/core/entity/hr/HrmVariables.java
+++ b/src/main/java/com/divudi/core/entity/hr/HrmVariables.java
@@ -31,7 +31,7 @@ public class HrmVariables implements Serializable {
 
     private static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
     /////////
     //Created Properties

--- a/src/main/java/com/divudi/core/entity/hr/Loan.java
+++ b/src/main/java/com/divudi/core/entity/hr/Loan.java
@@ -27,7 +27,7 @@ public class Loan implements Serializable {
 
     private static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
     private String name;
     private double loanValue;

--- a/src/main/java/com/divudi/core/entity/hr/PayeeTaxRange.java
+++ b/src/main/java/com/divudi/core/entity/hr/PayeeTaxRange.java
@@ -23,7 +23,7 @@ public class PayeeTaxRange implements Serializable {
 
     private static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
     private double fromSalary;
     private double toSalary;

--- a/src/main/java/com/divudi/core/entity/hr/PaysheetComponent.java
+++ b/src/main/java/com/divudi/core/entity/hr/PaysheetComponent.java
@@ -33,7 +33,7 @@ public class PaysheetComponent implements Serializable {
 
     private static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
     private String name;
     @Enumerated(EnumType.STRING)

--- a/src/main/java/com/divudi/core/entity/hr/PhDate.java
+++ b/src/main/java/com/divudi/core/entity/hr/PhDate.java
@@ -28,7 +28,7 @@ public class PhDate implements Serializable {
 
     private static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
     private String name;
     @Temporal(javax.persistence.TemporalType.DATE)

--- a/src/main/java/com/divudi/core/entity/hr/Roster.java
+++ b/src/main/java/com/divudi/core/entity/hr/Roster.java
@@ -34,7 +34,7 @@ public class Roster implements Serializable {
 
     private static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
     private String name;
     @OneToOne

--- a/src/main/java/com/divudi/core/entity/hr/SalaryCycle.java
+++ b/src/main/java/com/divudi/core/entity/hr/SalaryCycle.java
@@ -27,7 +27,7 @@ public class SalaryCycle implements Serializable {
 
     private static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     @Temporal(javax.persistence.TemporalType.TIMESTAMP)

--- a/src/main/java/com/divudi/core/entity/hr/SalaryHold.java
+++ b/src/main/java/com/divudi/core/entity/hr/SalaryHold.java
@@ -26,7 +26,7 @@ public class SalaryHold implements Serializable {
 
     private static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
     //Created Properties
     @ManyToOne

--- a/src/main/java/com/divudi/core/entity/hr/Shift.java
+++ b/src/main/java/com/divudi/core/entity/hr/Shift.java
@@ -37,7 +37,7 @@ public class Shift implements Serializable {
 
     private static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
     private String name;
     @ManyToOne

--- a/src/main/java/com/divudi/core/entity/hr/ShiftAmendment.java
+++ b/src/main/java/com/divudi/core/entity/hr/ShiftAmendment.java
@@ -26,7 +26,7 @@ public class ShiftAmendment implements Serializable {
 
     private static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
     @ManyToOne
     private Staff staff;

--- a/src/main/java/com/divudi/core/entity/hr/ShiftPreference.java
+++ b/src/main/java/com/divudi/core/entity/hr/ShiftPreference.java
@@ -29,7 +29,7 @@ public class ShiftPreference implements Serializable {
     private Shift shift;
     private static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
     @OneToOne
     private Staff staff;

--- a/src/main/java/com/divudi/core/entity/hr/StaffBasics.java
+++ b/src/main/java/com/divudi/core/entity/hr/StaffBasics.java
@@ -27,7 +27,7 @@ public class StaffBasics implements Serializable {
     private StaffEmployment staffEmployment;
     private static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     @OneToOne

--- a/src/main/java/com/divudi/core/entity/hr/StaffDesignation.java
+++ b/src/main/java/com/divudi/core/entity/hr/StaffDesignation.java
@@ -27,7 +27,7 @@ public class StaffDesignation implements Serializable {
     private StaffEmployment staffEmployment;
     private static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
     @OneToOne
     private Designation designation;

--- a/src/main/java/com/divudi/core/entity/hr/StaffEmployeeStatus.java
+++ b/src/main/java/com/divudi/core/entity/hr/StaffEmployeeStatus.java
@@ -29,7 +29,7 @@ public class StaffEmployeeStatus implements Serializable {
     private StaffEmployment staffEmployment;
     private static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
     @Enumerated(EnumType.STRING)
     private EmployeeStatus employeeStatus;

--- a/src/main/java/com/divudi/core/entity/hr/StaffEmployment.java
+++ b/src/main/java/com/divudi/core/entity/hr/StaffEmployment.java
@@ -51,7 +51,7 @@ public class StaffEmployment implements Serializable {
     private Staff staff;
     private static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
     /////////////////////
     @Enumerated(EnumType.STRING)

--- a/src/main/java/com/divudi/core/entity/hr/StaffGrade.java
+++ b/src/main/java/com/divudi/core/entity/hr/StaffGrade.java
@@ -26,7 +26,7 @@ public class StaffGrade implements Serializable {
     private StaffEmployment staffEmployment;
     private static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
     @OneToOne
     private Grade grade;

--- a/src/main/java/com/divudi/core/entity/hr/StaffLeave.java
+++ b/src/main/java/com/divudi/core/entity/hr/StaffLeave.java
@@ -32,7 +32,7 @@ public class StaffLeave implements Serializable {
 
     private static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
     //Created Properties
     @ManyToOne

--- a/src/main/java/com/divudi/core/entity/hr/StaffLeaveEntitle.java
+++ b/src/main/java/com/divudi/core/entity/hr/StaffLeaveEntitle.java
@@ -30,7 +30,7 @@ public class StaffLeaveEntitle implements Serializable {
 
     private static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
     @ManyToOne
     Staff staff;

--- a/src/main/java/com/divudi/core/entity/hr/StaffPaysheetComponent.java
+++ b/src/main/java/com/divudi/core/entity/hr/StaffPaysheetComponent.java
@@ -28,7 +28,7 @@ public class StaffPaysheetComponent implements Serializable {
 
     private static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
     @ManyToOne
     private PaysheetComponent paysheetComponent;

--- a/src/main/java/com/divudi/core/entity/hr/StaffSalary.java
+++ b/src/main/java/com/divudi/core/entity/hr/StaffSalary.java
@@ -40,7 +40,7 @@ public class StaffSalary implements Serializable {
 
     private static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
     private double payeeValue;
 //    private double otValue;

--- a/src/main/java/com/divudi/core/entity/hr/StaffSalaryComponant.java
+++ b/src/main/java/com/divudi/core/entity/hr/StaffSalaryComponant.java
@@ -29,7 +29,7 @@ public class StaffSalaryComponant implements Serializable {
 
     private static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
     private double componantValue;
     private double epfValue;

--- a/src/main/java/com/divudi/core/entity/hr/StaffShift.java
+++ b/src/main/java/com/divudi/core/entity/hr/StaffShift.java
@@ -45,7 +45,7 @@ public class StaffShift implements Serializable {
     Shift shift;
     private static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
     @OneToOne
     private Staff staff;

--- a/src/main/java/com/divudi/core/entity/hr/StaffShiftHistory.java
+++ b/src/main/java/com/divudi/core/entity/hr/StaffShiftHistory.java
@@ -26,7 +26,7 @@ public class StaffShiftHistory implements Serializable {
 
     private static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
     @ManyToOne
     StaffShift staffShift;

--- a/src/main/java/com/divudi/core/entity/hr/StaffStaffCategory.java
+++ b/src/main/java/com/divudi/core/entity/hr/StaffStaffCategory.java
@@ -27,7 +27,7 @@ public class StaffStaffCategory implements Serializable {
     private StaffEmployment staffEmployment;
     private static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     @OneToOne

--- a/src/main/java/com/divudi/core/entity/hr/StaffWorkDay.java
+++ b/src/main/java/com/divudi/core/entity/hr/StaffWorkDay.java
@@ -25,7 +25,7 @@ import javax.persistence.Temporal;
 public class StaffWorkDay implements Serializable {
     private static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
     @ManyToOne
     private Staff staff;

--- a/src/main/java/com/divudi/core/entity/hr/StaffWorkingDepartment.java
+++ b/src/main/java/com/divudi/core/entity/hr/StaffWorkingDepartment.java
@@ -28,7 +28,7 @@ public class StaffWorkingDepartment implements Serializable {
     private StaffEmployment staffEmployment;
     private static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     @OneToOne

--- a/src/main/java/com/divudi/core/entity/hr/WorkingTime.java
+++ b/src/main/java/com/divudi/core/entity/hr/WorkingTime.java
@@ -35,7 +35,7 @@ public class WorkingTime implements Serializable {
     private WorkingTime continuedFrom;
     private static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
     @ManyToOne
     StaffShift staffShift;

--- a/src/main/java/com/divudi/core/entity/inward/AdmissionNumber.java
+++ b/src/main/java/com/divudi/core/entity/inward/AdmissionNumber.java
@@ -31,7 +31,7 @@ public class AdmissionNumber implements Serializable {
 
     private static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
     private Long lastAdmissionNumber;
     @ManyToOne

--- a/src/main/java/com/divudi/core/entity/inward/EncounterComponent.java
+++ b/src/main/java/com/divudi/core/entity/inward/EncounterComponent.java
@@ -34,7 +34,7 @@ public class EncounterComponent implements Serializable {
 
     private static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
 

--- a/src/main/java/com/divudi/core/entity/inward/PatientRoom.java
+++ b/src/main/java/com/divudi/core/entity/inward/PatientRoom.java
@@ -35,7 +35,7 @@ public class PatientRoom implements Serializable, RetirableEntity {
     
     private static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 //Main Properties
     private String name;

--- a/src/main/java/com/divudi/core/entity/inward/PatientTransferRequest.java
+++ b/src/main/java/com/divudi/core/entity/inward/PatientTransferRequest.java
@@ -24,7 +24,7 @@ public class PatientTransferRequest implements Serializable {
     private static final long serialVersionUID = 1L;
 
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     @ManyToOne

--- a/src/main/java/com/divudi/core/entity/inward/Reservation.java
+++ b/src/main/java/com/divudi/core/entity/inward/Reservation.java
@@ -24,7 +24,7 @@ import javax.persistence.Temporal;
 public class Reservation implements Serializable {
     private static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
     @ManyToOne
     private Appointment appointment;

--- a/src/main/java/com/divudi/core/entity/inward/RoomFacilityCharge.java
+++ b/src/main/java/com/divudi/core/entity/inward/RoomFacilityCharge.java
@@ -31,7 +31,7 @@ public class RoomFacilityCharge implements Serializable {
 
     private static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
     private Double maintananceCharge = 0.0;
     private Double roomCharge = 0.0;

--- a/src/main/java/com/divudi/core/entity/lab/AnalyzerMessage.java
+++ b/src/main/java/com/divudi/core/entity/lab/AnalyzerMessage.java
@@ -19,7 +19,7 @@ public class AnalyzerMessage implements Serializable {
 
     private static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     private String messageType;

--- a/src/main/java/com/divudi/core/entity/lab/DepartmentMachine.java
+++ b/src/main/java/com/divudi/core/entity/lab/DepartmentMachine.java
@@ -23,7 +23,7 @@ public class DepartmentMachine implements Serializable {
 
     private static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
     private Department department;
     private Machine machine;

--- a/src/main/java/com/divudi/core/entity/lab/InvestigationComponent.java
+++ b/src/main/java/com/divudi/core/entity/lab/InvestigationComponent.java
@@ -21,7 +21,7 @@ public class InvestigationComponent implements Serializable {
 
     private static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
     @ManyToOne
     private Investigation investigation;

--- a/src/main/java/com/divudi/core/entity/lab/InvestigationItemValue.java
+++ b/src/main/java/com/divudi/core/entity/lab/InvestigationItemValue.java
@@ -28,7 +28,7 @@ public class InvestigationItemValue implements Serializable {
 
     private static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     @JsonIgnore
     //Main Properties
     Long id;

--- a/src/main/java/com/divudi/core/entity/lab/InvestigationReportItemValue.java
+++ b/src/main/java/com/divudi/core/entity/lab/InvestigationReportItemValue.java
@@ -23,7 +23,7 @@ public class InvestigationReportItemValue implements Serializable {
 
     private static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     //Main Properties
     private Long id;
     @ManyToOne

--- a/src/main/java/com/divudi/core/entity/lab/InvestigationValidaterComponent.java
+++ b/src/main/java/com/divudi/core/entity/lab/InvestigationValidaterComponent.java
@@ -30,7 +30,7 @@ public class InvestigationValidaterComponent implements Serializable {
 
     private static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
     //Created Properties
     @ManyToOne

--- a/src/main/java/com/divudi/core/entity/lab/InvestigationValidator.java
+++ b/src/main/java/com/divudi/core/entity/lab/InvestigationValidator.java
@@ -31,7 +31,7 @@ public class InvestigationValidator implements Serializable {
     private List<InvestigationValidaterComponent> investigationValidateComponents;
     private static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
     //Created Properties
     @ManyToOne

--- a/src/main/java/com/divudi/core/entity/lab/ItemForItem.java
+++ b/src/main/java/com/divudi/core/entity/lab/ItemForItem.java
@@ -23,7 +23,7 @@ import javax.persistence.Temporal;
 public class ItemForItem implements Serializable {
     private static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
 

--- a/src/main/java/com/divudi/core/entity/lab/IxCal.java
+++ b/src/main/java/com/divudi/core/entity/lab/IxCal.java
@@ -23,7 +23,7 @@ public class IxCal implements Serializable {
 
     private static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     Long id;
     @ManyToOne
     private InvestigationItem calIxItem;

--- a/src/main/java/com/divudi/core/entity/lab/LabTestHistory.java
+++ b/src/main/java/com/divudi/core/entity/lab/LabTestHistory.java
@@ -31,7 +31,7 @@ public class LabTestHistory implements Serializable {
 
     private static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
     
     @ManyToOne

--- a/src/main/java/com/divudi/core/entity/lab/PatientInvestigation.java
+++ b/src/main/java/com/divudi/core/entity/lab/PatientInvestigation.java
@@ -40,7 +40,7 @@ public class PatientInvestigation implements Serializable, RetirableEntity {
 
     private static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
     //Created Properties
     @ManyToOne

--- a/src/main/java/com/divudi/core/entity/lab/PatientReport.java
+++ b/src/main/java/com/divudi/core/entity/lab/PatientReport.java
@@ -50,7 +50,7 @@ public class PatientReport implements Serializable, RetirableEntity {
 
     private static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
     @ManyToOne
     private Item item;

--- a/src/main/java/com/divudi/core/entity/lab/PatientReportGroup.java
+++ b/src/main/java/com/divudi/core/entity/lab/PatientReportGroup.java
@@ -20,7 +20,7 @@ public class PatientReportGroup implements Serializable {
 
     private static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
     @ManyToOne
     private PatientReport patientReport;

--- a/src/main/java/com/divudi/core/entity/lab/PatientReportItemValue.java
+++ b/src/main/java/com/divudi/core/entity/lab/PatientReportItemValue.java
@@ -29,7 +29,7 @@ public class PatientReportItemValue implements Serializable, RetirableEntity {
 
     private static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
     @ManyToOne
     private Patient patient;

--- a/src/main/java/com/divudi/core/entity/lab/PatientSample.java
+++ b/src/main/java/com/divudi/core/entity/lab/PatientSample.java
@@ -38,7 +38,7 @@ public class PatientSample implements Serializable, RetirableEntity {
 
     private static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
     private Long sampleId;
 

--- a/src/main/java/com/divudi/core/entity/lab/PatientSampleComponant.java
+++ b/src/main/java/com/divudi/core/entity/lab/PatientSampleComponant.java
@@ -31,7 +31,7 @@ public class PatientSampleComponant implements Serializable, RetirableEntity {
 
     private static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
     @ManyToOne
     private Patient patient;

--- a/src/main/java/com/divudi/core/entity/lab/ReportItem.java
+++ b/src/main/java/com/divudi/core/entity/lab/ReportItem.java
@@ -46,7 +46,7 @@ public class ReportItem implements Serializable {
 
     static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     @JsonIgnore
     Long id;
     //Main Properties

--- a/src/main/java/com/divudi/core/entity/membership/AllowedPaymentMethod.java
+++ b/src/main/java/com/divudi/core/entity/membership/AllowedPaymentMethod.java
@@ -26,7 +26,7 @@ import javax.persistence.Temporal;
 public class AllowedPaymentMethod implements Serializable {
     private static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
     PaymentMethod paymentMethod;
     @ManyToOne

--- a/src/main/java/com/divudi/core/entity/pharmacy/AdjustmentBillItem.java
+++ b/src/main/java/com/divudi/core/entity/pharmacy/AdjustmentBillItem.java
@@ -26,7 +26,7 @@ public class AdjustmentBillItem implements Serializable {
 
     private static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     private double qty;

--- a/src/main/java/com/divudi/core/entity/pharmacy/ItemBatch.java
+++ b/src/main/java/com/divudi/core/entity/pharmacy/ItemBatch.java
@@ -30,7 +30,7 @@ public class ItemBatch implements Serializable, RetirableEntity {
 
     private static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
     @Temporal(TemporalType.TIMESTAMP)
     private Date dateOfManufacture;

--- a/src/main/java/com/divudi/core/entity/pharmacy/ItemsDistributors.java
+++ b/src/main/java/com/divudi/core/entity/pharmacy/ItemsDistributors.java
@@ -25,7 +25,7 @@ public class ItemsDistributors implements Serializable {
 
     private static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
     //Created Properties
     @ManyToOne

--- a/src/main/java/com/divudi/core/entity/pharmacy/PharmaceuticalBillItem.java
+++ b/src/main/java/com/divudi/core/entity/pharmacy/PharmaceuticalBillItem.java
@@ -32,7 +32,7 @@ public class PharmaceuticalBillItem implements Serializable {
     private StockHistory stockHistory;
     private static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     @OneToOne(fetch = FetchType.EAGER)

--- a/src/main/java/com/divudi/core/entity/pharmacy/Price.java
+++ b/src/main/java/com/divudi/core/entity/pharmacy/Price.java
@@ -24,7 +24,7 @@ public class Price implements Serializable {
 
     private static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
     @ManyToOne
     ItemBatch itemBatch;

--- a/src/main/java/com/divudi/core/entity/pharmacy/Reorder.java
+++ b/src/main/java/com/divudi/core/entity/pharmacy/Reorder.java
@@ -26,7 +26,7 @@ public class Reorder implements Serializable {
 
     private static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
     @ManyToOne
     Item item;

--- a/src/main/java/com/divudi/core/entity/pharmacy/Stock.java
+++ b/src/main/java/com/divudi/core/entity/pharmacy/Stock.java
@@ -28,7 +28,7 @@ public class Stock implements Serializable, RetirableEntity {
 
     private static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
     @Deprecated // Use Item Batch > Item > barcode
     @Column

--- a/src/main/java/com/divudi/core/entity/pharmacy/StockHistory.java
+++ b/src/main/java/com/divudi/core/entity/pharmacy/StockHistory.java
@@ -56,7 +56,7 @@ public class StockHistory implements Serializable, RetirableEntity {
 
     private static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     @Temporal(javax.persistence.TemporalType.DATE)

--- a/src/main/java/com/divudi/core/entity/pharmacy/StockVarientBillItem.java
+++ b/src/main/java/com/divudi/core/entity/pharmacy/StockVarientBillItem.java
@@ -26,7 +26,7 @@ import javax.persistence.Temporal;
 public class StockVarientBillItem implements Serializable, RetirableEntity  {
 
      @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     private static final long serialVersionUID = 1L;

--- a/src/main/java/com/divudi/core/entity/pharmacy/UserStock.java
+++ b/src/main/java/com/divudi/core/entity/pharmacy/UserStock.java
@@ -28,7 +28,7 @@ public class UserStock implements Serializable, RetirableEntity  {
     private UserStockContainer userStockContainer;
     private static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
     //Created Properties
     @ManyToOne

--- a/src/main/java/com/divudi/core/entity/pharmacy/UserStockContainer.java
+++ b/src/main/java/com/divudi/core/entity/pharmacy/UserStockContainer.java
@@ -29,7 +29,7 @@ public class UserStockContainer implements Serializable, RetirableEntity  {
 
     private static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
     //Created Properties
     @ManyToOne

--- a/src/main/java/com/divudi/core/entity/pharmacy/VirtualProductIngredient.java
+++ b/src/main/java/com/divudi/core/entity/pharmacy/VirtualProductIngredient.java
@@ -30,7 +30,7 @@ public class VirtualProductIngredient implements Serializable {
 
     private static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
     @ManyToOne
     Vtm vtm;

--- a/src/main/java/com/divudi/core/entity/process/ProcessInstance.java
+++ b/src/main/java/com/divudi/core/entity/process/ProcessInstance.java
@@ -25,7 +25,7 @@ public class ProcessInstance implements Serializable {
 
     private static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     private String status;

--- a/src/main/java/com/divudi/core/entity/process/ProcessStepActionDefinition.java
+++ b/src/main/java/com/divudi/core/entity/process/ProcessStepActionDefinition.java
@@ -26,7 +26,7 @@ public class ProcessStepActionDefinition implements Serializable {
     private static final long serialVersionUID = 1L;
 
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     @JoinColumn(nullable = false)

--- a/src/main/java/com/divudi/core/entity/process/ProcessStepDefinition.java
+++ b/src/main/java/com/divudi/core/entity/process/ProcessStepDefinition.java
@@ -25,7 +25,7 @@ public class ProcessStepDefinition implements Serializable {
 
     private static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     @JoinColumn(nullable = false)

--- a/src/main/java/com/divudi/core/entity/process/ProcessStepInstance.java
+++ b/src/main/java/com/divudi/core/entity/process/ProcessStepInstance.java
@@ -23,7 +23,7 @@ public class ProcessStepInstance implements Serializable {
 
     private static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     @ManyToOne

--- a/src/main/java/com/divudi/core/entity/report/ReportLog.java
+++ b/src/main/java/com/divudi/core/entity/report/ReportLog.java
@@ -10,7 +10,7 @@ import java.util.Date;
 @Entity
 public class ReportLog implements Serializable {
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     static final long serialVersionUID = 1L;

--- a/src/main/java/com/divudi/core/entity/web/CaptureComponent.java
+++ b/src/main/java/com/divudi/core/entity/web/CaptureComponent.java
@@ -29,7 +29,7 @@ public class CaptureComponent implements Serializable {
 
     private static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     private String name;

--- a/src/main/java/com/divudi/core/entity/web/DesignComponent.java
+++ b/src/main/java/com/divudi/core/entity/web/DesignComponent.java
@@ -23,7 +23,7 @@ public class DesignComponent implements Serializable {
 
     private static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     private String name;

--- a/src/main/java/com/divudi/core/entity/web/DesignComponentAssignment.java
+++ b/src/main/java/com/divudi/core/entity/web/DesignComponentAssignment.java
@@ -19,7 +19,7 @@ public class DesignComponentAssignment implements Serializable {
 
     private static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
     @ManyToOne
     private DesignComponent designComponent;

--- a/src/main/java/com/divudi/core/entity/web/TemplateComponent.java
+++ b/src/main/java/com/divudi/core/entity/web/TemplateComponent.java
@@ -20,7 +20,7 @@ public class TemplateComponent implements Serializable {
 
     private static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     private String name;

--- a/src/main/java/com/divudi/core/entity/web/WebTemplate.java
+++ b/src/main/java/com/divudi/core/entity/web/WebTemplate.java
@@ -16,7 +16,7 @@ public class WebTemplate implements Serializable {
 
     private static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
     private String name;
     @Lob

--- a/src/main/java/com/divudi/core/facade/DatabaseMigrationFacade.java
+++ b/src/main/java/com/divudi/core/facade/DatabaseMigrationFacade.java
@@ -7,10 +7,15 @@ package com.divudi.core.facade;
 import com.divudi.core.entity.DatabaseMigration;
 import com.divudi.core.data.MigrationStatus;
 import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
 import java.sql.Statement;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import javax.ejb.Stateless;
 import javax.ejb.TransactionAttribute;
 import javax.ejb.TransactionAttributeType;
@@ -65,6 +70,68 @@ public class DatabaseMigrationFacade extends AbstractFacade<DatabaseMigration> {
         } finally {
             conn.close();
         }
+    }
+
+    private static final Logger LOGGER = Logger.getLogger(DatabaseMigrationFacade.class.getName());
+
+    /**
+     * Scan every table in the current schema for a BIGINT column named ID that
+     * lacks AUTO_INCREMENT and apply it.  Runs outside JTA so DDL implicit
+     * COMMITs cannot desync the transaction manager.
+     *
+     * Safe to call at every startup: tables that already have AUTO_INCREMENT are
+     * skipped by the information_schema query.  FK checks are disabled for the
+     * duration so child-table ALTER statements do not fail.
+     *
+     * @return list of table names that were altered (empty when nothing needed)
+     */
+    @TransactionAttribute(TransactionAttributeType.NOT_SUPPORTED)
+    public List<String> applyAutoIncrementToAllEntityTables() throws Exception {
+        List<String> altered = new ArrayList<>();
+        EntityManagerImpl emImpl = em.unwrap(EntityManagerImpl.class);
+        Connection conn = emImpl.getServerSession().getDatasource().getConnection();
+        try {
+            conn.setAutoCommit(true);
+            // Find all BIGINT ID columns that do NOT yet have auto_increment
+            String query = "SELECT TABLE_NAME FROM information_schema.COLUMNS "
+                    + "WHERE TABLE_SCHEMA = DATABASE() "
+                    + "AND COLUMN_NAME = 'ID' "
+                    + "AND DATA_TYPE = 'bigint' "
+                    + "AND EXTRA NOT LIKE '%auto_increment%' "
+                    + "ORDER BY TABLE_NAME";
+            List<String> tables = new ArrayList<>();
+            try (PreparedStatement ps = conn.prepareStatement(query);
+                 ResultSet rs = ps.executeQuery()) {
+                while (rs.next()) {
+                    tables.add(rs.getString(1));
+                }
+            }
+            if (tables.isEmpty()) {
+                return altered;
+            }
+            // Disable FK checks so child-table ALTERs succeed
+            try (Statement fkOff = conn.createStatement()) {
+                fkOff.execute("SET FOREIGN_KEY_CHECKS=0");
+            }
+            try {
+                for (String tableName : tables) {
+                    try (Statement stmt = conn.createStatement()) {
+                        stmt.execute("ALTER TABLE `" + tableName + "` MODIFY COLUMN ID BIGINT NOT NULL AUTO_INCREMENT");
+                        altered.add(tableName);
+                        LOGGER.info("AutoIncrement: applied to table `" + tableName + "`");
+                    } catch (Exception e) {
+                        LOGGER.log(Level.WARNING, "AutoIncrement: could not alter `" + tableName + "` — skipping", e);
+                    }
+                }
+            } finally {
+                try (Statement fkOn = conn.createStatement()) {
+                    fkOn.execute("SET FOREIGN_KEY_CHECKS=1");
+                }
+            }
+        } finally {
+            conn.close();
+        }
+        return altered;
     }
 
     /**

--- a/src/main/java/com/divudi/core/facade/DatabaseMigrationFacade.java
+++ b/src/main/java/com/divudi/core/facade/DatabaseMigrationFacade.java
@@ -6,12 +6,17 @@ package com.divudi.core.facade;
 
 import com.divudi.core.entity.DatabaseMigration;
 import com.divudi.core.data.MigrationStatus;
+import java.sql.Connection;
+import java.sql.Statement;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import javax.ejb.Stateless;
+import javax.ejb.TransactionAttribute;
+import javax.ejb.TransactionAttributeType;
 import javax.persistence.EntityManager;
 import javax.persistence.PersistenceContext;
+import org.eclipse.persistence.internal.jpa.EntityManagerImpl;
 
 /**
  * Facade for DatabaseMigration entity operations
@@ -31,6 +36,35 @@ public class DatabaseMigrationFacade extends AbstractFacade<DatabaseMigration> {
 
     public DatabaseMigrationFacade() {
         super(DatabaseMigration.class);
+    }
+
+    /**
+     * Execute a DDL statement (CREATE, ALTER, DROP, CALL) outside JTA.
+     *
+     * DDL statements cause MySQL to issue an implicit COMMIT, which
+     * desynchronises the JTA transaction manager and causes "Transaction
+     * aborted". This method obtains a raw JDBC connection directly from
+     * EclipseLink's datasource — bypassing JTA entirely — and sets
+     * autoCommit=true so MySQL's implicit commits are harmless.
+     *
+     * Must NOT be called inside an active JTA transaction; the
+     * NOT_SUPPORTED attribute suspends any surrounding transaction.
+     */
+    @TransactionAttribute(TransactionAttributeType.NOT_SUPPORTED)
+    public void executeDdlNative(String sql) throws Exception {
+        if (sql == null || sql.trim().isEmpty()) {
+            throw new IllegalArgumentException("SQL statement cannot be null or empty");
+        }
+        EntityManagerImpl emImpl = em.unwrap(EntityManagerImpl.class);
+        Connection conn = emImpl.getServerSession().getDatasource().getConnection();
+        try {
+            conn.setAutoCommit(true);
+            try (Statement stmt = conn.createStatement()) {
+                stmt.execute(sql);
+            }
+        } finally {
+            conn.close();
+        }
     }
 
     /**

--- a/src/main/java/com/divudi/core/facade/DatabaseMigrationFacade.java
+++ b/src/main/java/com/divudi/core/facade/DatabaseMigrationFacade.java
@@ -21,7 +21,10 @@ import javax.ejb.TransactionAttribute;
 import javax.ejb.TransactionAttributeType;
 import javax.persistence.EntityManager;
 import javax.persistence.PersistenceContext;
+import javax.sql.DataSource;
 import org.eclipse.persistence.internal.jpa.EntityManagerImpl;
+import org.eclipse.persistence.sessions.JNDIConnector;
+import org.eclipse.persistence.sessions.server.ServerSession;
 
 /**
  * Facade for DatabaseMigration entity operations
@@ -60,19 +63,26 @@ public class DatabaseMigrationFacade extends AbstractFacade<DatabaseMigration> {
         if (sql == null || sql.trim().isEmpty()) {
             throw new IllegalArgumentException("SQL statement cannot be null or empty");
         }
-        EntityManagerImpl emImpl = em.unwrap(EntityManagerImpl.class);
-        Connection conn = emImpl.getServerSession().getDatasource().getConnection();
-        try {
+        try (Connection conn = getRawJdbcConnection()) {
             conn.setAutoCommit(true);
             try (Statement stmt = conn.createStatement()) {
                 stmt.execute(sql);
             }
-        } finally {
-            conn.close();
         }
     }
 
     private static final Logger LOGGER = Logger.getLogger(DatabaseMigrationFacade.class.getName());
+
+    /**
+     * Obtain a raw JDBC connection from EclipseLink's JNDI datasource,
+     * completely outside JTA.  Caller is responsible for closing it.
+     */
+    private Connection getRawJdbcConnection() throws Exception {
+        EntityManagerImpl emImpl = em.unwrap(EntityManagerImpl.class);
+        ServerSession serverSession = emImpl.getServerSession();
+        DataSource ds = ((JNDIConnector) serverSession.getLogin().getConnector()).getDataSource();
+        return ds.getConnection();
+    }
 
     /**
      * Scan every table in the current schema for a BIGINT column named ID that
@@ -88,8 +98,7 @@ public class DatabaseMigrationFacade extends AbstractFacade<DatabaseMigration> {
     @TransactionAttribute(TransactionAttributeType.NOT_SUPPORTED)
     public List<String> applyAutoIncrementToAllEntityTables() throws Exception {
         List<String> altered = new ArrayList<>();
-        EntityManagerImpl emImpl = em.unwrap(EntityManagerImpl.class);
-        Connection conn = emImpl.getServerSession().getDatasource().getConnection();
+        Connection conn = getRawJdbcConnection();
         try {
             conn.setAutoCommit(true);
             // Find all BIGINT ID columns that do NOT yet have auto_increment

--- a/src/main/java/com/divudi/core/facade/DatabaseMigrationFacade.java
+++ b/src/main/java/com/divudi/core/facade/DatabaseMigrationFacade.java
@@ -68,6 +68,55 @@ public class DatabaseMigrationFacade extends AbstractFacade<DatabaseMigration> {
     }
 
     /**
+     * Ensures the DATABASEMIGRATION table's ID column has AUTO_INCREMENT.
+     *
+     * After deploying the GenerationType.IDENTITY build, EclipseLink stops
+     * providing ID values in INSERT statements. If the DB hasn't been migrated
+     * yet, the very first INSERT into DATABASEMIGRATION (to track a migration)
+     * will fail with "Field 'ID' doesn't have a default value".
+     *
+     * This method is called at startup from DatabaseMigrationController and
+     * self-heals only the one table the controller depends on. The remaining
+     * entity tables are handled by migration v2.2.0.
+     */
+    @TransactionAttribute(TransactionAttributeType.NOT_SUPPORTED)
+    public void ensureAutoIncrementOnMigrationTable() throws Exception {
+        EntityManagerImpl emImpl = em.unwrap(EntityManagerImpl.class);
+        Connection conn = emImpl.getServerSession().getDatasource().getConnection();
+        try {
+            conn.setAutoCommit(true);
+            // Check whether AUTO_INCREMENT is already set for DATABASEMIGRATION
+            try (java.sql.PreparedStatement check = conn.prepareStatement(
+                    "SELECT COUNT(*) FROM information_schema.COLUMNS " +
+                    "WHERE TABLE_SCHEMA = DATABASE() " +
+                    "AND LOWER(TABLE_NAME) = 'databasemigration' " +
+                    "AND COLUMN_NAME = 'ID' " +
+                    "AND EXTRA LIKE '%auto_increment%'")) {
+                java.sql.ResultSet rs = check.executeQuery();
+                rs.next();
+                if (rs.getInt(1) == 0) {
+                    // Not yet set — find the actual table name (handles upper/lowercase)
+                    try (java.sql.PreparedStatement nameQuery = conn.prepareStatement(
+                            "SELECT TABLE_NAME FROM information_schema.COLUMNS " +
+                            "WHERE TABLE_SCHEMA = DATABASE() " +
+                            "AND LOWER(TABLE_NAME) = 'databasemigration' " +
+                            "AND COLUMN_NAME = 'ID' LIMIT 1")) {
+                        java.sql.ResultSet nameRs = nameQuery.executeQuery();
+                        if (nameRs.next()) {
+                            String tableName = nameRs.getString(1);
+                            try (Statement stmt = conn.createStatement()) {
+                                stmt.execute("ALTER TABLE `" + tableName + "` MODIFY COLUMN ID BIGINT NOT NULL AUTO_INCREMENT");
+                            }
+                        }
+                    }
+                }
+            }
+        } finally {
+            conn.close();
+        }
+    }
+
+    /**
      * Find migration by version
      */
     public DatabaseMigration findByVersion(String version) {

--- a/src/main/java/com/divudi/core/facade/DatabaseMigrationFacade.java
+++ b/src/main/java/com/divudi/core/facade/DatabaseMigrationFacade.java
@@ -68,55 +68,6 @@ public class DatabaseMigrationFacade extends AbstractFacade<DatabaseMigration> {
     }
 
     /**
-     * Ensures the DATABASEMIGRATION table's ID column has AUTO_INCREMENT.
-     *
-     * After deploying the GenerationType.IDENTITY build, EclipseLink stops
-     * providing ID values in INSERT statements. If the DB hasn't been migrated
-     * yet, the very first INSERT into DATABASEMIGRATION (to track a migration)
-     * will fail with "Field 'ID' doesn't have a default value".
-     *
-     * This method is called at startup from DatabaseMigrationController and
-     * self-heals only the one table the controller depends on. The remaining
-     * entity tables are handled by migration v2.2.0.
-     */
-    @TransactionAttribute(TransactionAttributeType.NOT_SUPPORTED)
-    public void ensureAutoIncrementOnMigrationTable() throws Exception {
-        EntityManagerImpl emImpl = em.unwrap(EntityManagerImpl.class);
-        Connection conn = emImpl.getServerSession().getDatasource().getConnection();
-        try {
-            conn.setAutoCommit(true);
-            // Check whether AUTO_INCREMENT is already set for DATABASEMIGRATION
-            try (java.sql.PreparedStatement check = conn.prepareStatement(
-                    "SELECT COUNT(*) FROM information_schema.COLUMNS " +
-                    "WHERE TABLE_SCHEMA = DATABASE() " +
-                    "AND LOWER(TABLE_NAME) = 'databasemigration' " +
-                    "AND COLUMN_NAME = 'ID' " +
-                    "AND EXTRA LIKE '%auto_increment%'")) {
-                java.sql.ResultSet rs = check.executeQuery();
-                rs.next();
-                if (rs.getInt(1) == 0) {
-                    // Not yet set — find the actual table name (handles upper/lowercase)
-                    try (java.sql.PreparedStatement nameQuery = conn.prepareStatement(
-                            "SELECT TABLE_NAME FROM information_schema.COLUMNS " +
-                            "WHERE TABLE_SCHEMA = DATABASE() " +
-                            "AND LOWER(TABLE_NAME) = 'databasemigration' " +
-                            "AND COLUMN_NAME = 'ID' LIMIT 1")) {
-                        java.sql.ResultSet nameRs = nameQuery.executeQuery();
-                        if (nameRs.next()) {
-                            String tableName = nameRs.getString(1);
-                            try (Statement stmt = conn.createStatement()) {
-                                stmt.execute("ALTER TABLE `" + tableName + "` MODIFY COLUMN ID BIGINT NOT NULL AUTO_INCREMENT");
-                            }
-                        }
-                    }
-                }
-            }
-        } finally {
-            conn.close();
-        }
-    }
-
-    /**
      * Find migration by version
      */
     public DatabaseMigration findByVersion(String version) {

--- a/src/main/java/com/divudi/service/AutoIncrementBootstrapService.java
+++ b/src/main/java/com/divudi/service/AutoIncrementBootstrapService.java
@@ -1,0 +1,123 @@
+/*
+ * Dr M H B Ariyaratne
+ * buddhika.ari@gmail.com
+ */
+package com.divudi.service;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.Statement;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import javax.annotation.PostConstruct;
+import javax.ejb.Singleton;
+import javax.ejb.Startup;
+import javax.ejb.TransactionAttribute;
+import javax.ejb.TransactionAttributeType;
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+import org.eclipse.persistence.internal.jpa.EntityManagerImpl;
+
+/**
+ * Ensures all entity table ID columns have AUTO_INCREMENT at application
+ * startup.
+ *
+ * Background: switching from GenerationType.AUTO (shared SEQUENCE table) to
+ * GenerationType.IDENTITY (per-table AUTO_INCREMENT) requires every entity
+ * table's ID column to have AUTO_INCREMENT set. If the application is deployed
+ * with the new GenerationType.IDENTITY code before the DB migration has run,
+ * every INSERT fails with "Field 'ID' doesn't have a default value" (MySQL
+ * 1364).
+ *
+ * This @Singleton @Startup EJB runs once when Payara starts, before any user
+ * can interact, and self-heals the database. It uses a raw JDBC connection
+ * outside JTA so that DDL implicit-commit behaviour cannot abort a JTA
+ * transaction. MySQL automatically sets AUTO_INCREMENT = MAX(ID) + 1 when
+ * adding AUTO_INCREMENT to an existing column, so no existing data is affected.
+ *
+ * The migration page (v2.2.0) performs the same work; if this service has
+ * already run, the v2.2.0 cursor finds no tables to alter and completes
+ * immediately as a no-op.
+ *
+ * @author Dr M H B Ariyaratne
+ */
+@Singleton
+@Startup
+public class AutoIncrementBootstrapService {
+
+    private static final Logger LOGGER = Logger.getLogger(AutoIncrementBootstrapService.class.getName());
+
+    @PersistenceContext(unitName = "hmisPU")
+    private EntityManager em;
+
+    @PostConstruct
+    @TransactionAttribute(TransactionAttributeType.NOT_SUPPORTED)
+    public void applyAutoIncrementIfNeeded() {
+        try {
+            List<String> altered = applyToAllEntityTables();
+            if (altered.isEmpty()) {
+                LOGGER.info("AutoIncrementBootstrap: all entity tables already have AUTO_INCREMENT — nothing to do.");
+            } else {
+                LOGGER.info("AutoIncrementBootstrap: applied AUTO_INCREMENT to " + altered.size()
+                        + " table(s): " + altered);
+            }
+        } catch (Exception e) {
+            LOGGER.log(Level.SEVERE, "AutoIncrementBootstrap: failed to apply AUTO_INCREMENT — "
+                    + "entity INSERTs may fail until migration v2.2.0 is run manually", e);
+        }
+    }
+
+    /**
+     * Finds every bigint ID column without AUTO_INCREMENT in the current
+     * database and alters it. Works with both uppercase and lowercase table
+     * names (uses information_schema, does not hardcode table names).
+     *
+     * @return list of table names that were altered
+     */
+    @TransactionAttribute(TransactionAttributeType.NOT_SUPPORTED)
+    public List<String> applyToAllEntityTables() throws Exception {
+        List<String> altered = new ArrayList<>();
+        EntityManagerImpl emImpl = em.unwrap(EntityManagerImpl.class);
+        Connection conn = emImpl.getServerSession().getDatasource().getConnection();
+        try {
+            conn.setAutoCommit(true);
+
+            // Find all bigint ID columns without AUTO_INCREMENT in current DB
+            String query =
+                    "SELECT TABLE_NAME FROM information_schema.COLUMNS " +
+                    "WHERE TABLE_SCHEMA = DATABASE() " +
+                    "  AND COLUMN_NAME = 'ID' " +
+                    "  AND DATA_TYPE = 'bigint' " +
+                    "  AND EXTRA NOT LIKE '%auto_increment%' " +
+                    "ORDER BY TABLE_NAME";
+
+            try (PreparedStatement ps = conn.prepareStatement(query);
+                 ResultSet rs = ps.executeQuery()) {
+
+                List<String> tables = new ArrayList<>();
+                while (rs.next()) {
+                    tables.add(rs.getString(1));
+                }
+
+                for (String tableName : tables) {
+                    try (Statement stmt = conn.createStatement()) {
+                        stmt.execute(
+                                "ALTER TABLE `" + tableName +
+                                "` MODIFY COLUMN ID BIGINT NOT NULL AUTO_INCREMENT");
+                        altered.add(tableName);
+                        LOGGER.fine("AutoIncrementBootstrap: altered `" + tableName + "`");
+                    } catch (Exception e) {
+                        LOGGER.log(Level.WARNING,
+                                "AutoIncrementBootstrap: could not alter `" + tableName + "` — skipping", e);
+                    }
+                }
+            }
+        } finally {
+            conn.close();
+        }
+        return altered;
+    }
+}

--- a/src/main/java/com/divudi/service/AutoIncrementBootstrapService.java
+++ b/src/main/java/com/divudi/service/AutoIncrementBootstrapService.java
@@ -4,22 +4,16 @@
  */
 package com.divudi.service;
 
-import java.sql.Connection;
-import java.sql.PreparedStatement;
-import java.sql.ResultSet;
-import java.sql.Statement;
-import java.util.ArrayList;
+import com.divudi.core.facade.DatabaseMigrationFacade;
 import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.annotation.PostConstruct;
+import javax.ejb.EJB;
 import javax.ejb.Singleton;
 import javax.ejb.Startup;
 import javax.ejb.TransactionAttribute;
 import javax.ejb.TransactionAttributeType;
-import javax.persistence.EntityManager;
-import javax.persistence.PersistenceContext;
-import org.eclipse.persistence.internal.jpa.EntityManagerImpl;
 
 /**
  * Ensures all entity table ID columns have AUTO_INCREMENT at application
@@ -29,18 +23,16 @@ import org.eclipse.persistence.internal.jpa.EntityManagerImpl;
  * GenerationType.IDENTITY (per-table AUTO_INCREMENT) requires every entity
  * table's ID column to have AUTO_INCREMENT set. If the application is deployed
  * with the new GenerationType.IDENTITY code before the DB migration has run,
- * every INSERT fails with "Field 'ID' doesn't have a default value" (MySQL
- * 1364).
+ * every INSERT fails with "Field 'ID' doesn't have a default value" (MySQL 1364).
  *
  * This @Singleton @Startup EJB runs once when Payara starts, before any user
- * can interact, and self-heals the database. It uses a raw JDBC connection
- * outside JTA so that DDL implicit-commit behaviour cannot abort a JTA
- * transaction. MySQL automatically sets AUTO_INCREMENT = MAX(ID) + 1 when
- * adding AUTO_INCREMENT to an existing column, so no existing data is affected.
+ * can interact, and self-heals the database. The actual JDBC work is delegated
+ * to DatabaseMigrationFacade.applyAutoIncrementToAllEntityTables() which uses
+ * a proven raw-JDBC pattern (same as executeDdlNative) outside JTA.
  *
- * The migration page (v2.2.0) performs the same work; if this service has
- * already run, the v2.2.0 cursor finds no tables to alter and completes
- * immediately as a no-op.
+ * Pattern follows DatabaseMigrationService — inject facade via @EJB, not
+ * @PersistenceContext directly, to avoid EclipseLink session initialisation
+ * ordering issues at @Startup time.
  *
  * @author Dr M H B Ariyaratne
  */
@@ -50,14 +42,14 @@ public class AutoIncrementBootstrapService {
 
     private static final Logger LOGGER = Logger.getLogger(AutoIncrementBootstrapService.class.getName());
 
-    @PersistenceContext(unitName = "hmisPU")
-    private EntityManager em;
+    @EJB
+    private DatabaseMigrationFacade migrationFacade;
 
     @PostConstruct
     @TransactionAttribute(TransactionAttributeType.NOT_SUPPORTED)
     public void applyAutoIncrementIfNeeded() {
         try {
-            List<String> altered = applyToAllEntityTables();
+            List<String> altered = migrationFacade.applyAutoIncrementToAllEntityTables();
             if (altered.isEmpty()) {
                 LOGGER.info("AutoIncrementBootstrap: all entity tables already have AUTO_INCREMENT — nothing to do.");
             } else {
@@ -68,65 +60,5 @@ public class AutoIncrementBootstrapService {
             LOGGER.log(Level.SEVERE, "AutoIncrementBootstrap: failed to apply AUTO_INCREMENT — "
                     + "entity INSERTs may fail until migration v2.2.0 is run manually", e);
         }
-    }
-
-    /**
-     * Finds every bigint ID column without AUTO_INCREMENT in the current
-     * database and alters it. Works with both uppercase and lowercase table
-     * names (uses information_schema, does not hardcode table names).
-     *
-     * @return list of table names that were altered
-     */
-    @TransactionAttribute(TransactionAttributeType.NOT_SUPPORTED)
-    public List<String> applyToAllEntityTables() throws Exception {
-        List<String> altered = new ArrayList<>();
-        EntityManagerImpl emImpl = em.unwrap(EntityManagerImpl.class);
-        Connection conn = emImpl.getServerSession().getDatasource().getConnection();
-        try {
-            conn.setAutoCommit(true);
-
-            // Find all bigint ID columns without AUTO_INCREMENT in current DB
-            String query =
-                    "SELECT TABLE_NAME FROM information_schema.COLUMNS " +
-                    "WHERE TABLE_SCHEMA = DATABASE() " +
-                    "  AND COLUMN_NAME = 'ID' " +
-                    "  AND DATA_TYPE = 'bigint' " +
-                    "  AND EXTRA NOT LIKE '%auto_increment%' " +
-                    "ORDER BY TABLE_NAME";
-
-            try (PreparedStatement ps = conn.prepareStatement(query);
-                 ResultSet rs = ps.executeQuery()) {
-
-                List<String> tables = new ArrayList<>();
-                while (rs.next()) {
-                    tables.add(rs.getString(1));
-                }
-
-                try (Statement fkOff = conn.createStatement()) {
-                    fkOff.execute("SET FOREIGN_KEY_CHECKS=0");
-                }
-                try {
-                    for (String tableName : tables) {
-                        try (Statement stmt = conn.createStatement()) {
-                            stmt.execute(
-                                    "ALTER TABLE `" + tableName +
-                                    "` MODIFY COLUMN ID BIGINT NOT NULL AUTO_INCREMENT");
-                            altered.add(tableName);
-                            LOGGER.fine("AutoIncrementBootstrap: altered `" + tableName + "`");
-                        } catch (Exception e) {
-                            LOGGER.log(Level.WARNING,
-                                    "AutoIncrementBootstrap: could not alter `" + tableName + "` — skipping", e);
-                        }
-                    }
-                } finally {
-                    try (Statement fkOn = conn.createStatement()) {
-                        fkOn.execute("SET FOREIGN_KEY_CHECKS=1");
-                    }
-                }
-            }
-        } finally {
-            conn.close();
-        }
-        return altered;
     }
 }

--- a/src/main/java/com/divudi/service/AutoIncrementBootstrapService.java
+++ b/src/main/java/com/divudi/service/AutoIncrementBootstrapService.java
@@ -102,16 +102,25 @@ public class AutoIncrementBootstrapService {
                     tables.add(rs.getString(1));
                 }
 
-                for (String tableName : tables) {
-                    try (Statement stmt = conn.createStatement()) {
-                        stmt.execute(
-                                "ALTER TABLE `" + tableName +
-                                "` MODIFY COLUMN ID BIGINT NOT NULL AUTO_INCREMENT");
-                        altered.add(tableName);
-                        LOGGER.fine("AutoIncrementBootstrap: altered `" + tableName + "`");
-                    } catch (Exception e) {
-                        LOGGER.log(Level.WARNING,
-                                "AutoIncrementBootstrap: could not alter `" + tableName + "` — skipping", e);
+                try (Statement fkOff = conn.createStatement()) {
+                    fkOff.execute("SET FOREIGN_KEY_CHECKS=0");
+                }
+                try {
+                    for (String tableName : tables) {
+                        try (Statement stmt = conn.createStatement()) {
+                            stmt.execute(
+                                    "ALTER TABLE `" + tableName +
+                                    "` MODIFY COLUMN ID BIGINT NOT NULL AUTO_INCREMENT");
+                            altered.add(tableName);
+                            LOGGER.fine("AutoIncrementBootstrap: altered `" + tableName + "`");
+                        } catch (Exception e) {
+                            LOGGER.log(Level.WARNING,
+                                    "AutoIncrementBootstrap: could not alter `" + tableName + "` — skipping", e);
+                        }
+                    }
+                } finally {
+                    try (Statement fkOn = conn.createStatement()) {
+                        fkOn.execute("SET FOREIGN_KEY_CHECKS=1");
                     }
                 }
             }

--- a/src/main/resources/META-INF/persistence.xml
+++ b/src/main/resources/META-INF/persistence.xml
@@ -2,7 +2,7 @@
 <persistence version="2.2" xmlns="http://java.sun.com/xml/ns/persistence" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/persistence http://xmlns.jcp.org/xml/ns/persistence/persistence_2_2.xsd">
     <persistence-unit name="hmisPU" transaction-type="JTA">
         <provider>org.eclipse.persistence.jpa.PersistenceProvider</provider>
-        <jta-data-source>${JDBC_DATASOURCE}</jta-data-source>
+        <jta-data-source>jdbc/coop</jta-data-source>
         <exclude-unlisted-classes>false</exclude-unlisted-classes>
         <properties>
             <property name="eclipselink.logging.level.sql" value="SEVERE"/>
@@ -14,14 +14,10 @@
             <property name="eclipselink.concurrency.manager.allow.concurrencyexception" value="true"/>
             <!-- Log cache contention warnings for early detection -->
             <property name="eclipselink.concurrency.manager.maxfrequencytodumptinymessage" value="5000"/>
-            <!-- Sequence pre-allocation fix for SEQUENCE table lock contention (issue #19626) - Do NOT Remove -->
-            <!-- Explicit preallocation of 50 reduces database sequence contention in high-throughput environments; -->
-            <!-- without this, each ID allocation acquires a table-level lock causing retail sale slowness -->
-            <property name="eclipselink.sequence.default-sequence-preallocation-size" value="50"/>
         </properties>
     </persistence-unit>
     <persistence-unit name="hmisAuditPU" transaction-type="JTA">
-        <jta-data-source>${JDBC_AUDIT_DATASOURCE}</jta-data-source>
+        <jta-data-source>jdbc/rhAuditDS</jta-data-source>
         <exclude-unlisted-classes>false</exclude-unlisted-classes>
         <properties>
             <property name="eclipselink.logging.level.sql" value="SEVERE"/>

--- a/src/main/resources/META-INF/persistence.xml
+++ b/src/main/resources/META-INF/persistence.xml
@@ -2,7 +2,7 @@
 <persistence version="2.2" xmlns="http://java.sun.com/xml/ns/persistence" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/persistence http://xmlns.jcp.org/xml/ns/persistence/persistence_2_2.xsd">
     <persistence-unit name="hmisPU" transaction-type="JTA">
         <provider>org.eclipse.persistence.jpa.PersistenceProvider</provider>
-        <jta-data-source>jdbc/coop</jta-data-source>
+        <jta-data-source>${JDBC_DATASOURCE}</jta-data-source>
         <exclude-unlisted-classes>false</exclude-unlisted-classes>
         <properties>
             <property name="eclipselink.logging.level.sql" value="SEVERE"/>
@@ -14,10 +14,14 @@
             <property name="eclipselink.concurrency.manager.allow.concurrencyexception" value="true"/>
             <!-- Log cache contention warnings for early detection -->
             <property name="eclipselink.concurrency.manager.maxfrequencytodumptinymessage" value="5000"/>
+            <!-- Sequence pre-allocation fix for SEQUENCE table lock contention (issue #19626) - Do NOT Remove -->
+            <!-- Explicit preallocation of 50 reduces database sequence contention in high-throughput environments; -->
+            <!-- without this, each ID allocation acquires a table-level lock causing retail sale slowness -->
+            <property name="eclipselink.sequence.default-sequence-preallocation-size" value="50"/>
         </properties>
     </persistence-unit>
     <persistence-unit name="hmisAuditPU" transaction-type="JTA">
-        <jta-data-source>jdbc/rhAuditDS</jta-data-source>
+        <jta-data-source>${JDBC_AUDIT_DATASOURCE}</jta-data-source>
         <exclude-unlisted-classes>false</exclude-unlisted-classes>
         <properties>
             <property name="eclipselink.logging.level.sql" value="SEVERE"/>

--- a/src/main/resources/db/migrations/v2.2.0/README.md
+++ b/src/main/resources/db/migrations/v2.2.0/README.md
@@ -1,0 +1,18 @@
+# Migration v2.2.0 — Switch to AUTO_INCREMENT (IDENTITY strategy)
+
+## Summary
+Replaces the shared `SEQUENCE` table generator with MySQL's native `AUTO_INCREMENT` per table.
+
+## Why
+All entity inserts shared one `SEQ_GEN` row. Under concurrent load, multiple threads competing for the same row lock caused `MySQL Error 1205: Lock wait timeout exceeded`, resulting in a production incident at COOP on 2026-04-11 where a pharmacy stock receive transaction silently rolled back.
+
+## Requirements
+- **Payara must be STOPPED** before running
+- Full database backup required
+- Deploy new app build (with `GenerationType.IDENTITY`) immediately after
+
+## Backward Compatibility
+MySQL sets `AUTO_INCREMENT = MAX(ID) + 1` for each table automatically — no existing IDs change, no data loss.
+
+## Hotfix Application (COOP production)
+Run `migration.sql` directly against the production database via SSH tunnel after taking a backup.

--- a/src/main/resources/db/migrations/v2.2.0/migration-info.json
+++ b/src/main/resources/db/migrations/v2.2.0/migration-info.json
@@ -1,0 +1,47 @@
+{
+    "version": "v2.2.0",
+    "description": "Switch all entity tables from TABLE sequence generator to AUTO_INCREMENT (IDENTITY strategy) to eliminate SEQUENCE table lock contention",
+    "author": "Dr M H B Ariyaratne",
+    "date": "2026-04-12",
+    "githubIssue": "19941",
+    "branch": "feature/19941-generationtype-identity-fix",
+    "estimatedDurationMinutes": 15,
+    "requiresDowntime": true,
+    "affectedTables": ["ALL entity tables (187 tables)"],
+    "affectedModules": ["All modules — system-wide primary key generation change"],
+    "dependencies": [],
+    "preRequisites": [
+        "Full database backup completed and verified before running",
+        "Application server (Payara) must be STOPPED before running this migration",
+        "Ensure no active transactions on the database",
+        "New application build with GenerationType.IDENTITY deployed immediately after migration"
+    ],
+    "migrationSteps": [
+        {
+            "step": 1,
+            "description": "Verify database connection and check current SEQUENCE table",
+            "sql": "SELECT SEQ_NAME, SEQ_COUNT FROM SEQUENCE WHERE SEQ_NAME = 'SEQ_GEN'"
+        },
+        {
+            "step": 2,
+            "description": "Create and execute stored procedure to add AUTO_INCREMENT to all entity ID columns",
+            "sql": "CALL hmis_add_auto_increment()"
+        },
+        {
+            "step": 3,
+            "description": "Verify AUTO_INCREMENT was set on key tables",
+            "sql": "SELECT TABLE_NAME, AUTO_INCREMENT FROM information_schema.TABLES WHERE TABLE_SCHEMA = DATABASE() AND LOWER(TABLE_NAME) IN ('bill','stock','billitem','pharmaceuticalbillitem','stockhistory') ORDER BY TABLE_NAME"
+        }
+    ],
+    "rollbackNotes": [
+        "Rollback removes AUTO_INCREMENT from all entity ID columns",
+        "After rollback, redeploy the previous application version (with GenerationType.AUTO)",
+        "The SEQUENCE table (SEQ_GEN) remains intact and will resume being used"
+    ],
+    "postMigrationVerification": [
+        "Start Payara and verify application deploys without errors",
+        "Create a test bill and confirm the new ID is MAX(id)+1 (not from SEQUENCE table)",
+        "Verify SEQUENCE table SEQ_COUNT is no longer incrementing",
+        "Check server logs for any sequence-related errors"
+    ]
+}

--- a/src/main/resources/db/migrations/v2.2.0/migration.sql
+++ b/src/main/resources/db/migrations/v2.2.0/migration.sql
@@ -1,0 +1,53 @@
+-- ============================================================
+-- Migration v2.2.0: Switch entity ID generation to AUTO_INCREMENT
+-- Issue: #19941
+-- Root cause: Single shared SEQUENCE row causes lock contention
+--             under concurrent load (MySQL Error 1205)
+-- Impact: All entity tables — adds AUTO_INCREMENT to ID column
+-- Requires: Application server STOPPED, full backup taken
+-- ============================================================
+
+-- Step 1: Verify current state
+SELECT SEQ_NAME, SEQ_COUNT FROM SEQUENCE WHERE SEQ_NAME = 'SEQ_GEN';
+
+-- Step 2: Create stored procedure to add AUTO_INCREMENT dynamically
+-- Uses information_schema so it works with both uppercase and lowercase table names
+DELIMITER //
+CREATE PROCEDURE hmis_add_auto_increment()
+BEGIN
+    DECLARE done INT DEFAULT FALSE;
+    DECLARE tbl VARCHAR(255);
+    DECLARE cur CURSOR FOR
+        SELECT TABLE_NAME
+        FROM information_schema.COLUMNS
+        WHERE TABLE_SCHEMA = DATABASE()
+          AND COLUMN_NAME = 'ID'
+          AND DATA_TYPE = 'bigint'
+          AND EXTRA NOT LIKE '%auto_increment%';
+    DECLARE CONTINUE HANDLER FOR NOT FOUND SET done = TRUE;
+
+    OPEN cur;
+    read_loop: LOOP
+        FETCH cur INTO tbl;
+        IF done THEN LEAVE read_loop; END IF;
+        SET @alter_sql = CONCAT('ALTER TABLE `', tbl, '` MODIFY COLUMN ID BIGINT NOT NULL AUTO_INCREMENT');
+        PREPARE stmt FROM @alter_sql;
+        EXECUTE stmt;
+        DEALLOCATE PREPARE stmt;
+    END LOOP;
+    CLOSE cur;
+END//
+DELIMITER ;
+
+-- Step 3: Execute the procedure
+CALL hmis_add_auto_increment();
+
+-- Step 4: Drop the procedure (cleanup)
+DROP PROCEDURE IF EXISTS hmis_add_auto_increment;
+
+-- Step 5: Verify results — all tables should now have AUTO_INCREMENT set
+SELECT TABLE_NAME, AUTO_INCREMENT
+FROM information_schema.TABLES
+WHERE TABLE_SCHEMA = DATABASE()
+  AND AUTO_INCREMENT IS NOT NULL
+ORDER BY TABLE_NAME;

--- a/src/main/resources/db/migrations/v2.2.0/rollback.sql
+++ b/src/main/resources/db/migrations/v2.2.0/rollback.sql
@@ -1,0 +1,34 @@
+-- ============================================================
+-- Rollback v2.2.0: Remove AUTO_INCREMENT from all entity tables
+-- WARNING: After rollback, redeploy previous app version (GenerationType.AUTO)
+-- ============================================================
+
+DELIMITER //
+CREATE PROCEDURE hmis_remove_auto_increment()
+BEGIN
+    DECLARE done INT DEFAULT FALSE;
+    DECLARE tbl VARCHAR(255);
+    DECLARE cur CURSOR FOR
+        SELECT TABLE_NAME
+        FROM information_schema.COLUMNS
+        WHERE TABLE_SCHEMA = DATABASE()
+          AND COLUMN_NAME = 'ID'
+          AND DATA_TYPE = 'bigint'
+          AND EXTRA LIKE '%auto_increment%';
+    DECLARE CONTINUE HANDLER FOR NOT FOUND SET done = TRUE;
+
+    OPEN cur;
+    read_loop: LOOP
+        FETCH cur INTO tbl;
+        IF done THEN LEAVE read_loop; END IF;
+        SET @alter_sql = CONCAT('ALTER TABLE `', tbl, '` MODIFY COLUMN ID BIGINT NOT NULL');
+        PREPARE stmt FROM @alter_sql;
+        EXECUTE stmt;
+        DEALLOCATE PREPARE stmt;
+    END LOOP;
+    CLOSE cur;
+END//
+DELIMITER ;
+
+CALL hmis_remove_auto_increment();
+DROP PROCEDURE IF EXISTS hmis_remove_auto_increment;


### PR DESCRIPTION
## Summary

- **Root cause**: All 187+ entity tables shared a single `SEQ_GEN` row in the `SEQUENCE` table for primary key generation via `GenerationType.AUTO`. Under concurrent load, all entity inserts competed for the same row-level lock — held for the entire surrounding transaction duration.
- **Incident**: COOP production on 2026-04-11 — MySQL Error 1205 (Lock wait timeout exceeded) caused three concurrent subsystems (Lab, Notification, Pharmacy stock) to fail simultaneously. Pharmacy stock receive rolled back silently, requiring manual data correction.
- **Fix**: Switch all 188 entity classes from `GenerationType.AUTO` to `GenerationType.IDENTITY` (MySQL `AUTO_INCREMENT` per table), add migration v2.2.0 to apply `ALTER TABLE` to all entity tables, fix the SQL migration executor to handle `DELIMITER`/stored-procedure syntax, and remove the now-redundant `eclipselink.sequence.default-sequence-preallocation-size` property.

## Changes

- `GenerationType.IDENTITY` applied to all 188 entity files (mechanical `sed` replacement)
- `persistence.xml`: removed `eclipselink.sequence.default-sequence-preallocation-size` (no longer uses SEQUENCE table)
- `DatabaseMigrationController.java`: replaced naive `split(";")` executor with `splitSqlStatements()` that handles `DELIMITER` blocks for stored procedures
- `db/migrations/v2.2.0/`: migration SQL (dynamic `information_schema` procedure — case-safe for mixed-case table names), rollback SQL, `migration-info.json`, and `README.md`

## WARNING — DB Migration Required

**Payara must be STOPPED before running `migration.sql`.** The migration adds `AUTO_INCREMENT` to every entity table ID column. MySQL automatically sets `AUTO_INCREMENT = MAX(ID) + 1` — no existing IDs change, no data loss.

A full database backup must be taken and verified before running the migration.

## Test Plan

- [ ] Deploy new build to QA (Payara stopped, run `migration.sql`, start Payara)
- [ ] Create a test bill — verify the new ID is `MAX(id)+1` for that table (not from `SEQUENCE` table)
- [ ] Confirm `SELECT SEQ_COUNT FROM SEQUENCE WHERE SEQ_NAME='SEQ_GEN'` stops incrementing after entity inserts
- [ ] Check Payara server logs for any sequence-related errors during normal operation
- [ ] Run concurrent load test (Lab + Pharmacy stock + Notification simultaneously) — no Error 1205 should occur
- [ ] Verify rollback SQL successfully removes `AUTO_INCREMENT` if needed

## Hotfix for COOP Production

Run `src/main/resources/db/migrations/v2.2.0/migration.sql` directly against the COOP production database via SSH tunnel after taking a backup, then deploy this build.

Closes #19941

🤖 Generated with [Claude Code](https://claude.com/claude-code)