### PR TITLE
docs: prohibit root deployment to Payara; add recovery guide

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,6 +24,9 @@
 9. **🚨 JPQL FIRST, NATIVE SQL LAST**: Always use JPQL for database queries. Native SQL (`nativeScalarQuery`, `executeNativeSql`) is only permitted when there is a significant, demonstrated performance constraint that JPQL cannot address. Never reach for native SQL just because JPQL is harder to write.
 10. **🚨 USE `findLongByJpql` FOR COUNT QUERIES**: Always use `findLongByJpql` (not `findDoubleByJpql`) for JPQL `COUNT(...)` queries. `COUNT` returns a `Long`; using `findDoubleByJpql` causes a silent `ClassCastException` caught internally, returning `0.0` every time and making the check always pass.
 
+### Deployment
+16. **🚨 NEVER DEPLOY MANUALLY AS ROOT**: NEVER use `sudo` or root to copy WARs, run `asadmin`, or touch Payara's application/log directories directly. Root-owned files in `/opt/payara5/glassfish/domains/domain1/` (applications, generated, logs) block all future CI/CD deployments — `asadmin undeploy` and `deploy` will fail with permission errors. **All deployments MUST go through GitHub Actions CI/CD.** If a manual fix is absolutely needed, use `appuser` only. See [Deployment Recovery Guide](developer_docs/deployment/deployment-recovery-guide.md).
+
 ### Git & Branching
 11. **Include issue closing keywords** (`Closes #N`) in commit messages
 12. **JSF-only changes** (XHTML only, no Java) do not require compilation or testing
@@ -35,6 +38,7 @@
 
 ### When Working on Persistence/Deployment
 - [Persistence Configuration Guide](developer_docs/deployment/persistence-verification.md) - JNDI settings for dev vs production
+- [Deployment Recovery Guide](developer_docs/deployment/deployment-recovery-guide.md) - How to recover when root-owned files break CI/CD deployment
 
 ### When Working on UI/XHTML
 - [UI Development Handbook](developer_docs/ui/comprehensive-ui-guidelines.md) - Complete UI reference

--- a/developer_docs/deployment/deployment-recovery-guide.md
+++ b/developer_docs/deployment/deployment-recovery-guide.md
@@ -1,0 +1,87 @@
+# Deployment Recovery Guide
+
+## Root-Owned Files Breaking CI/CD Deployment
+
+### What Happened
+
+If a Claude Code session (or any manual process) runs `asadmin`, copies WARs, or touches
+Payara directories **as root** (e.g. via `sudo`), it leaves files owned by `root` inside
+Payara's domain directories. The normal CI/CD pipeline runs as `appuser`, so subsequent
+`asadmin undeploy` / `deploy` commands fail with errors like:
+
+```
+Command deploy failed.
+remote failure: Error occurred during deployment: Exception while loading the app :
+Error in committing security policy for ejbs of coop --
+javax.security.jacc.PolicyContextException: java.lang.RuntimeException:
+Failure removing policy file: .../generated/policy/coop/...granted.policy.
+
+java.io.FileNotFoundException: .../applications/__internal/coop/coop.war (Permission denied)
+```
+
+The app gets **completely undeployed** and cannot be redeployed until the stale files are removed.
+
+### Prevention
+
+**Never run `asadmin`, `sudo cp`, `sudo rsync`, or any Payara command as root.**
+All deployments must go through GitHub Actions CI/CD. See rule #16 in CLAUDE.md.
+
+### Recovery Steps
+
+Run these commands (SSH to the affected VM, e.g. `ssh hmis08`):
+
+**Step 1 — Fix log file ownership** (blocks Payara from writing logs):
+```bash
+sudo chown appuser:appuser /opt/payara5/glassfish/domains/domain1/logs/server.log
+```
+
+**Step 2 — Remove stale root-owned application files:**
+```bash
+sudo rm -rf /opt/payara5/glassfish/domains/domain1/applications/__internal/<appname>
+sudo rm -rf /opt/payara5/glassfish/domains/domain1/applications/<appname>
+sudo rm -rf /opt/payara5/glassfish/domains/domain1/generated/policy/<appname>
+sudo rm -rf /opt/payara5/glassfish/domains/domain1/generated/ejb/<appname>
+sudo rm -rf /opt/payara5/glassfish/domains/domain1/generated/xml/<appname>
+```
+
+**Step 3 — Fix ownership of the entire Payara domain:**
+```bash
+sudo chown -R appuser:appuser /opt/payara5/glassfish/domains/domain1/applications/
+sudo chown -R appuser:appuser /opt/payara5/glassfish/domains/domain1/generated/
+```
+
+**Step 4 — Redeploy via asadmin** (only if CI/CD pipeline cannot be re-run):
+```bash
+echo 'AS_ADMIN_PASSWORD=<payara-admin-password>' > /tmp/p.txt
+/opt/payara5/bin/asadmin --user admin --passwordfile /tmp/p.txt deploy \
+  --contextroot <appname> /home/appuser/app/latest/<appname>.war
+rm /tmp/p.txt
+```
+
+Replace `<appname>` with the app context (e.g. `coop`, `roseth`) and use the Payara admin
+password from `C:\Credentials\Credentials.txt`.
+
+**Step 5 — Verify the app is up:**
+```bash
+curl -s -o /dev/null -w '%{http_code}' http://localhost:8080/<appname>/
+# Expected: 302 (redirect to login)
+```
+
+### Preferred Alternative to Step 4
+
+Re-run the existing CI/CD pipeline from the GitHub Actions UI instead of deploying manually:
+
+1. Go to https://github.com/hmislk/hmis/actions
+2. Find the relevant prod pipeline (e.g. "COOP-PROD Build & Deployment Pipeline")
+3. Click the failed/cancelled run → **Re-run all jobs**
+
+This is safer than manual `asadmin` because the pipeline also handles WAR upload, health
+checks, and correct file permissions.
+
+### Why This Is Dangerous
+
+- Root-owned files persist across Payara restarts and VM reboots
+- A root-owned `server.log` silently swallows all startup logs — making diagnosis very hard
+- `asadmin undeploy` removes the application directory but leaves `__internal/` and
+  `generated/policy/` stale, blocking any subsequent deploy
+- The app ends up completely undeployed with no error visible to users until they try to log in


### PR DESCRIPTION
## Summary

- Adds CLAUDE.md rule #16: **never deploy as root** to Payara (no `sudo asadmin`, no `sudo cp` of WARs, no touching Payara domain directories as root)
- Adds situational reference in CLAUDE.md pointing to new recovery doc
- Adds `developer_docs/deployment/deployment-recovery-guide.md` with step-by-step recovery instructions

## What went wrong today (2026-04-16)

A Claude session deployed the coop WAR manually using root/sudo instead of going through CI/CD. This left files owned by `root` inside Payara's domain directory (`applications/`, `generated/policy/`, `logs/server.log`). When the CI/CD pipeline subsequently ran as `appuser`:

1. `asadmin undeploy coop` — removed the app directory but left stale `__internal/` and `generated/policy/` files
2. `asadmin deploy coop` — failed with `PolicyContextException` / `Permission denied`
3. Coop went completely offline; the root-owned `server.log` also swallowed all startup logs silently

Recovery required: `sudo rm -rf` of stale generated files + `sudo chown -R appuser` + manual `asadmin deploy`.

## Test plan

- [x] CLAUDE.md rule is clear and machine-readable
- [x] Recovery guide covers all stale file locations (`applications/__internal`, `generated/policy`, `generated/ejb`, `generated/xml`, `logs/server.log`)
- [x] Recovery guide includes verification step and recommends CI/CD re-run over manual deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Established deployment security guidelines: all deployments must use GitHub Actions CI/CD; manual root-level deployments are prohibited
  * Added Deployment Recovery Guide with step-by-step procedures for resolving permission-related deployment failures

<!-- end of auto-generated comment: release notes by coderabbit.ai -->