### PR TITLE
fix: replace ID-based shift boundary with timestamp in handover queries

### DIFF
--- a/src/main/java/com/divudi/bean/cashTransaction/FinancialTransactionController.java
+++ b/src/main/java/com/divudi/bean/cashTransaction/FinancialTransactionController.java
@@ -4254,15 +4254,15 @@ public class FinancialTransactionController implements Serializable {
                 .append("FROM Payment p ")
                 .append("JOIN p.bill b ")
                 .append("WHERE p.creater=:cr ")
-                .append("AND p.retired=:ret AND p.id>:sid ")
+                .append("AND p.retired=:ret AND b.createdAt>=:startTime ")
                 .append("AND b.billTypeAtomic IN :btas ");
         m.put("cr", paymentUser);
         m.put("ret", false);
-        m.put("sid", startBill.getId());
+        m.put("startTime", startBill.getCreatedAt());
         m.put("btas", btas);
-        if (endBill != null && endBill.getId() != null) {
-            jpqlBuilder.append("AND p.id<:eid ");
-            m.put("eid", endBill.getId());
+        if (endBill != null && endBill.getCreatedAt() != null) {
+            jpqlBuilder.append("AND b.createdAt<=:endTime ");
+            m.put("endTime", endBill.getCreatedAt());
         }
         jpqlBuilder
                 .append("AND p.cashbookEntryStated =:cbes ")
@@ -4411,13 +4411,13 @@ public class FinancialTransactionController implements Serializable {
                 .append("AND b.billTypeAtomic IN :btas  ")
                 .append("AND (p.creater=:cr OR p.floatRecipient=:cr) ")
                 .append("AND p.cancelled=:can ")
-                .append("AND p.id > :sid ");
+                .append("AND b.createdAt >= :startTime ");
         m.put("btas", btas);
         m.put("cr", paymentUser);
         m.put("pr", false);
         m.put("br", false);
         m.put("can", false);
-        m.put("sid", startBill.getId());
+        m.put("startTime", startBill.getCreatedAt());
 
         jpqlBuilder
                 .append("AND p.cashbookEntryStated =:cbes ")
@@ -4425,9 +4425,9 @@ public class FinancialTransactionController implements Serializable {
         m.put("cbes", false);
         m.put("hos", false);
 
-        if (endBill != null && endBill.getId() != null) {
-            jpqlBuilder.append("AND p.id < :eid ");
-            m.put("eid", endBill.getId());
+        if (endBill != null && endBill.getCreatedAt() != null) {
+            jpqlBuilder.append("AND b.createdAt <= :endTime ");
+            m.put("endTime", endBill.getCreatedAt());
         }
         jpqlBuilder.append("ORDER BY p.createdAt, b.department, p.creater");
         String jpql = jpqlBuilder.toString();
@@ -4466,17 +4466,17 @@ public class FinancialTransactionController implements Serializable {
                 .append("AND b.billTypeAtomic IN :btas  ")
                 .append("AND p.creater=:cr ")
                 .append("AND p.cancelled=:can ")
-                .append("AND p.id > :sid ");
+                .append("AND b.createdAt >= :startTime ");
         m.put("btas", btas);
         m.put("cr", paymentUser);
         m.put("pr", false);
         m.put("br", false);
         m.put("can", false);
-        m.put("sid", startBill.getId());
+        m.put("startTime", startBill.getCreatedAt());
 
-        if (endBill != null && endBill.getId() != null) {
-            jpqlBuilder.append("AND p.id < :eid ");
-            m.put("eid", endBill.getId());
+        if (endBill != null && endBill.getCreatedAt() != null) {
+            jpqlBuilder.append("AND b.createdAt <= :endTime ");
+            m.put("endTime", endBill.getCreatedAt());
         }
         jpqlBuilder.append("ORDER BY p.createdAt, b.department, p.creater");
         String jpql = jpqlBuilder.toString();


### PR DESCRIPTION
## Summary

- Handover page showed incorrect (lower) totals vs Cashier Summary due to sequence pre-allocation causing some payment IDs to be lower than the shift start bill ID, even though they were collected after the shift started
- Replaced `p.id > shiftStartBillId` boundary with `b.createdAt >= startBill.createdAt` in three methods: `fetchPaymentsFromShiftStartToEndByDateAndDepartment`, `fetchShiftFloatsFromShiftStartToEnd`, and `fetchBankPayments`
- Verified on coop DB: 4 previously excluded payments (Cash 750 + Card 1,460) now correctly included

Closes #19965

## Test plan

- [ ] Log in as a cashier, start a shift, process several bills, then open Handover Current Shift
- [ ] Verify cash and card totals on the handover page match the Cashier Summary for the same period
- [ ] Confirm shift end and handover flows work normally (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved shift-scoped payment query accuracy by using Bill creation timestamps instead of ID-based ordering. This ensures cash, float, and bank payments are correctly associated with their respective shifts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->