### PR TITLE
fix: replace b.id>shiftStartBillId with createdAt timestamp in fillBillsFromShiftStartToNow

### DIFF
--- a/src/main/java/com/divudi/bean/cashTransaction/FinancialTransactionController.java
+++ b/src/main/java/com/divudi/bean/cashTransaction/FinancialTransactionController.java
@@ -4931,19 +4931,18 @@ public class FinancialTransactionController implements Serializable {
         billTypesToFilter.addAll(BillTypeAtomic.findByFinanceType(BillFinanceType.FLOAT_STARTING_BALANCE));
         billTypesToFilter.addAll(BillTypeAtomic.findByFinanceType(BillFinanceType.FLOAT_CLOSING_BALANCE));
 
-        Long shiftStartBillId = nonClosedShiftStartFundBill.getId();
         String jpql = "SELECT p "
                 + "FROM Bill p "
                 + "WHERE p.creater = :cr "
                 + "AND p.retired = :ret "
                 + "AND p.billTypeAtomic in :btas "
-                + "AND p.id > :cid "
-                + "ORDER BY p.id DESC";
+                + "AND p.createdAt >= :startTime "
+                + "ORDER BY p.createdAt DESC";
         Map<String, Object> m = new HashMap<>();
         m.put("cr", nonClosedShiftStartFundBill.getCreater());
         m.put("btas", billTypesToFilter);
         m.put("ret", false);
-        m.put("cid", shiftStartBillId);
+        m.put("startTime", nonClosedShiftStartFundBill.getCreatedAt());
         currentBills = billFacade.findByJpql(jpql, m, TemporalType.TIMESTAMP);
 //        paymentMethodValues = new PaymentMethodValues(PaymentMethod.values());
         atomicBillTypeTotalsByBills = new AtomicBillTypeTotals();


### PR DESCRIPTION
## Summary

- `fillBillsFromShiftStartToNow()` used `p.id > shiftStartBillId` — while this is Bill-to-Bill (same table), within-table sequence pre-allocation can still produce IDs out of timestamp order under concurrent load
- Replaced with `p.createdAt >= :startTime` using the shift start bill's timestamp

Closes #19971

## Test plan

- [ ] Start a shift, process several bills, open shift end page — verify the bill list is complete
- [ ] Verify the running total on the shift matches the cashier summary

🤖 Generated with [Claude Code](https://claude.com/claude-code)