### PR TITLE
Fix BankAccount: institution/department not saved and autocomplete case-mismatch

### DIFF
--- a/src/main/java/com/divudi/bean/common/BankAccountController.java
+++ b/src/main/java/com/divudi/bean/common/BankAccountController.java
@@ -68,7 +68,7 @@ public class BankAccountController implements Serializable {
         HashMap params = new HashMap();
         jpql = "select b from BankAccount b "
                 + " where b.retired=false "
-                + " and (b.accountNo like :q or b.accountName like :q ) "
+                + " and (UPPER(b.accountNo) like :q or UPPER(b.accountName) like :q ) "
                 + " order by b.accountName";
         params.put("q", "%" + qry.toUpperCase() + "%");
         list = getFacade().findByJpql(jpql, params);

--- a/src/main/webapp/admin/institutions/bank_account.xhtml
+++ b/src/main/webapp/admin/institutions/bank_account.xhtml
@@ -64,8 +64,8 @@
                                     </h:panelGroup>
                                     <p:selectOneMenu
                                         id="cmbIns"
-                                        styleClass="w-100 form-control" 
-                                        value="#{searchController.institution}" 
+                                        styleClass="w-100 form-control"
+                                        value="#{bankAccountController.current.institution}"
                                         filter="true">
                                         <f:selectItem itemLabel="All Institutions" />
                                         <f:selectItems value="#{institutionController.companies}" var="ins" itemLabel="#{ins.name}" itemValue="#{ins}" />
@@ -77,37 +77,35 @@
                                     </h:panelGroup>
                                     <h:panelGroup id="cmbDept">
 
-                                        <!-- Component 1: Without Institution and Site -->
+                                        <!-- Component 1: Without Institution -->
                                         <p:selectOneMenu
-                                            rendered="#{searchController.institution eq null}"
+                                            rendered="#{bankAccountController.current.institution eq null}"
                                             styleClass="w-100 form-control"
-                                            value="#{searchController.department}"
+                                            value="#{bankAccountController.current.department}"
                                             filterMatchMode="contains"
                                             filter="true">
                                             <f:selectItem itemLabel="All Departments" />
-                                            <f:selectItems 
+                                            <f:selectItems
                                                 value="#{departmentController.getDepartmentsOfInstitutionAndSite()}"
                                                 var="d"
                                                 itemLabel="#{d.name}"
                                                 itemValue="#{d}" />
                                         </p:selectOneMenu>
 
-                                        <!-- Component 3: With Institution Only -->
+                                        <!-- Component 2: With Institution -->
                                         <p:selectOneMenu
-                                            rendered="#{searchController.institution ne null}"
+                                            rendered="#{bankAccountController.current.institution ne null}"
                                             styleClass="w-100 form-control"
-                                            value="#{searchController.department}"
+                                            value="#{bankAccountController.current.department}"
                                             filterMatchMode="contains"
                                             filter="true">
                                             <f:selectItem itemLabel="All Departments" />
-                                            <f:selectItems 
-                                                value="#{departmentController.getDepartmentsOfInstitutionAndSiteForInstitution(searchController.institution)}"
+                                            <f:selectItems
+                                                value="#{departmentController.getDepartmentsOfInstitutionAndSiteForInstitution(bankAccountController.current.institution)}"
                                                 var="d"
                                                 itemLabel="#{d.name}"
                                                 itemValue="#{d}" />
                                         </p:selectOneMenu>
-
-                                        
 
                                     </h:panelGroup>
 

--- a/src/main/webapp/admin/institutions/bank_account.xhtml
+++ b/src/main/webapp/admin/institutions/bank_account.xhtml
@@ -73,7 +73,7 @@
                                     </p:selectOneMenu>
                                     <h:panelGroup layout="block" styleClass="form-group">
                                         <h:outputText value="&#xf19c;" styleClass="fa mr-2" /> <!-- FontAwesome building icon -->
-                                        <h:outputLabel value="Department"  class="mx-3"/>
+                                        <h:outputLabel value="Department" for="cmbDept" class="mx-3"/>
                                     </h:panelGroup>
                                     <h:panelGroup id="cmbDept">
 


### PR DESCRIPTION
## Summary

- **`bank_account.xhtml`**: Institution and Department dropdowns were bound to `searchController.institution/department` instead of `bankAccountController.current.institution/department`. These values were silently discarded on save; now bound directly to the entity being edited.
- **`BankAccountController.completeBankAccount`**: Added `UPPER()` around the JPQL column references so the autocomplete search is case-insensitive, consistent with the `toUpperCase()` applied to the query parameter.

## Test plan

- [ ] Open `admin/institutions/bank_account.xhtml`, add a new bank account with an institution and department selected, save — verify the institution and department are persisted in the DB
- [ ] Open `cashier/deposit_funds.xhtml`, type lowercase characters in the "Deposit To" autocomplete — verify matching bank accounts appear regardless of case

Closes #19979

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Bank account search now performs case-insensitive matching, ensuring search results are found regardless of text capitalization.

* **Improvements**
  * Reorganized institution and department dropdown bindings in the bank account management interface for improved data consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->