### PR TITLE
perf: bulk fallback rate lookup in GrnCostingController.generateBillComponent

### DIFF
--- a/developer_docs/performance/pharmacy-po-grn-performance-optimization.md
+++ b/developer_docs/performance/pharmacy-po-grn-performance-optimization.md
@@ -1,0 +1,102 @@
+# Pharmacy PO / GRN Performance Optimization
+
+Tracking document for the multi-issue performance optimization of the pharmacy
+Purchase Order list page and GRN costing entry page.
+
+---
+
+## Background
+
+Two pages were identified as slow in April 2026:
+
+| Page | URL |
+|------|-----|
+| PO list (for receiving) | `pharmacy/pharmacy_purchase_order_list_for_recieve.xhtml` |
+| GRN costing (entry) | `pharmacy/pharmacy_grn_costing_with_save_approve.xhtml` |
+
+Investigation revealed two distinct root causes — each fixed separately.
+
+---
+
+## Fix 1 — GRN entry: bulk fallback rate queries (DONE)
+
+**Issue:** hmislk/hmis#19982
+**Branch:** `feature/19982-fix-grn-entry-bulk-rate-lookup`
+**File:** `src/main/java/com/divudi/bean/pharmacy/GrnCostingController.java`
+
+### Root cause
+
+`generateBillComponent()` called two per-item methods inside its loop:
+
+```java
+getPharmacyBean().getLastPurchaseRate(item, dept)
+getPharmacyBean().getLastRetailRateByBillItemFinanceDetails(item, dept)
+```
+
+Each method executes one `BillItem` query. For a 100-item PO with missing rates
+this produces **up to 200 extra DB queries** just to open the GRN page.
+
+### Fix applied
+
+- Added `buildLastRatesMap(List<Item> items)` — one query fetching
+  `bi.item.id`, `bi.billItemFinanceDetails.lineGrossRate`,
+  `bi.billItemFinanceDetails.retailSaleRate` for all items at once,
+  ordered `bi.id DESC`. First occurrence per item is kept (= latest).
+- `generateBillComponent()` now stores `getPharmaceuticalBillItems()` in a
+  local list, pre-collects all items, calls `buildLastRatesMap` once, and uses
+  the resulting map inside the loop.
+- N×2 per-item queries → **1 bulk query** regardless of PO size.
+
+### Testing checklist (for QA)
+
+- [ ] Open a PO with ≥20 items and click "Create GRN" — page should load noticeably faster.
+- [ ] Rates pre-filled correctly from the last GRN for each item.
+- [ ] Items with rates on the PO (non-zero) are unaffected — map lookup is only
+      used when `pr == 0.0` or `rr == 0.0`.
+- [ ] Ampp (pack) items: pack rate conversion still works correctly.
+- [ ] New PO items (never received before) show 0 rates as before.
+- [ ] Save / Finalize / Approve flow works end-to-end.
+
+---
+
+## Fix 2 — PO list: N+1 GRN loading (PENDING)
+
+**Issue:** TBD
+**Status:** Not yet started — waiting for Fix 1 QA to pass.
+
+### Root cause
+
+`createPoTable()` (`SearchController.java:7157`) loops over every loaded PO and
+calls `getGrns(b, referenceBillTypes)`, which runs **2 queries per PO**
+(one for `referenceBill = :ref`, one for `billedBill.referenceBill = :ref`).
+For 50 POs this is 101 total queries. Additionally, the PO main query loads full
+`Bill` entities, triggering lazy loads on `creater.webUserPerson.name`,
+`toInstitution.name`, `fromDepartment.name` per row.
+
+### Planned fix
+
+1. Replace per-PO `getGrns()` loop with one bulk query that loads all GRNs for
+   all matching POs at once, groups them by PO ID in a `Map<Long, List<Bill>>`,
+   then assigns in one pass.
+2. Add `JOIN FETCH` clauses to the main PO query for the common lazy paths.
+3. (Optional) Convert the always-visible nested GRN sub-table to
+   `p:rowExpansion` so GRN detail is loaded on demand.  Show a GRN count badge
+   in the main row as the indicator.
+
+**Key files:**
+- `src/main/java/com/divudi/bean/common/SearchController.java` — `createPoTable()` (line ~7103) and `getGrns()` (line ~7177)
+- `src/main/webapp/pharmacy/pharmacy_purchase_order_list_for_recieve.xhtml`
+
+---
+
+## Context for a new session
+
+If this conversation is disconnected, resume from here:
+
+1. Fix 1 is merged / in QA.
+2. Start Fix 2: create a new issue, branch from `origin/development`, bulk the
+   GRN load in `SearchController.createPoTable()`, optionally add row expansion
+   to the XHTML.
+3. After Fix 2: consider a `PurchaseOrderSummaryDto` with a JOIN FETCH
+   constructor query to eliminate remaining lazy loads on the PO list (lower
+   priority once the N+1 is gone).

--- a/src/main/java/com/divudi/bean/pharmacy/GrnCostingController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/GrnCostingController.java
@@ -1196,6 +1196,47 @@ public class GrnCostingController implements Serializable {
         return result;
     }
 
+    /**
+     * Bulk-loads the last recorded purchase rate and retail rate for each item
+     * in the given list using a single query ordered by BillItem id descending.
+     * Only the most-recent BillItem row per item is kept (first occurrence in
+     * DESC order = latest).
+     *
+     * @return map of itemId → double[]{purchaseRate, retailRate}
+     */
+    private Map<Long, double[]> buildLastRatesMap(List<Item> items) {
+        if (items == null || items.isEmpty()) {
+            return new HashMap<>();
+        }
+        String jpql = "SELECT bi.item.id,"
+                + " bi.billItemFinanceDetails.lineGrossRate,"
+                + " bi.billItemFinanceDetails.retailSaleRate"
+                + " FROM BillItem bi"
+                + " WHERE bi.retired = false"
+                + " AND bi.bill.cancelled = false"
+                + " AND bi.item IN :items"
+                + " AND (bi.bill.billType = :t OR bi.bill.billType = :t1)"
+                + " ORDER BY bi.id DESC";
+        Map<String, Object> params = new HashMap<>();
+        params.put("items", items);
+        params.put("t", BillType.PharmacyGrnBill);
+        params.put("t1", BillType.PharmacyPurchaseBill);
+        Map<Long, double[]> result = new HashMap<>();
+        List<Object> rows = getBillItemFacade().findObjects(jpql, params);
+        if (rows != null) {
+            for (Object row : rows) {
+                Object[] cols = (Object[]) row;
+                Long itemId = ((Number) cols[0]).longValue();
+                if (!result.containsKey(itemId)) {
+                    double pr = cols[1] instanceof Number ? ((Number) cols[1]).doubleValue() : 0.0;
+                    double rr = cols[2] instanceof Number ? ((Number) cols[2]).doubleValue() : 0.0;
+                    result.put(itemId, new double[]{pr, rr});
+                }
+            }
+        }
+        return result;
+    }
+
     public void generateBillComponent() {
         // Pre-load all received/cancelled quantities for the entire PO in 4 bulk
         // queries instead of 4 individual queries per line item (N×4 → 4 total).
@@ -1205,7 +1246,19 @@ public class GrnCostingController implements Serializable {
         Map<Long, Double> grnFreeQtyMap = buildReceivedFreeQtyMap(poBill, BillTypeAtomic.PHARMACY_GRN);
         Map<Long, Double> grnCancelledFreeQtyMap = buildReceivedFreeQtyMap(poBill, BillTypeAtomic.PHARMACY_GRN_CANCELLED);
 
-        for (PharmaceuticalBillItem pbiInApprovedOrder : getPharmaceuticalBillItemFacade().getPharmaceuticalBillItems(poBill)) {
+        List<PharmaceuticalBillItem> poBillItems = getPharmaceuticalBillItemFacade().getPharmaceuticalBillItems(poBill);
+
+        // Pre-collect all items so we can bulk-fetch last rates in one query
+        // instead of one query per item inside the loop (N×2 → 1 total).
+        List<Item> allPoItems = new ArrayList<>();
+        for (PharmaceuticalBillItem pbi : poBillItems) {
+            if (pbi.getBillItem() != null && pbi.getBillItem().getItem() != null) {
+                allPoItems.add(pbi.getBillItem().getItem());
+            }
+        }
+        Map<Long, double[]> lastRatesMap = buildLastRatesMap(allPoItems);
+
+        for (PharmaceuticalBillItem pbiInApprovedOrder : poBillItems) {
 
             if (pbiInApprovedOrder.getBillItem() == null) {
                 continue;
@@ -1257,16 +1310,16 @@ public class GrnCostingController implements Serializable {
                 double rr = pbiInApprovedOrder.getRetailRate(); // This is per unit rate
 
                 if (pr == 0.0) {
-                    double fallbackPr = getPharmacyBean().getLastPurchaseRate(newlyCreatedBillItemForGrn.getItem(), sessionController.getDepartment());
-                    if (fallbackPr > 0.0) {
-                        pr = fallbackPr;
+                    double[] rates = lastRatesMap.get(newlyCreatedBillItemForGrn.getItem().getId());
+                    if (rates != null && rates[0] > 0.0) {
+                        pr = rates[0];
                     }
                 }
 
                 if (rr == 0.0) {
-                    double fallbackRr = getPharmacyBean().getLastRetailRateByBillItemFinanceDetails(newlyCreatedBillItemForGrn.getItem(), sessionController.getDepartment());
-                    if (fallbackRr > 0.0) {
-                        rr = fallbackRr;
+                    double[] rates = lastRatesMap.get(newlyCreatedBillItemForGrn.getItem().getId());
+                    if (rates != null && rates[1] > 0.0) {
+                        rr = rates[1];
                     }
                 }
 


### PR DESCRIPTION
## Summary

- Replaces N×2 per-item `PharmacyBean.getLastPurchaseRate` / `getLastRetailRateByBillItemFinanceDetails` calls in `generateBillComponent()` with a single bulk query
- New private method `buildLastRatesMap(List<Item>)` fetches last purchase rate and retail rate for all PO items in one query (ordered by `BillItem.id DESC`; first occurrence per item = latest)
- Also stores `getPharmaceuticalBillItems()` result in a local variable — avoids any risk of double-fetching the PO item list
- For a 100-item PO with missing rates: **200 queries → 1 query** just to open the GRN page

## Test plan

- [ ] Open a PO with ≥20 items → click "Create GRN" — page should load noticeably faster
- [ ] Rates are pre-filled correctly from the most recent GRN for each item
- [ ] Items with non-zero rates on the PO are unaffected (map lookup only fires when `pr == 0.0` or `rr == 0.0`)
- [ ] Ampp (pack) items: pack rate conversion still correct
- [ ] Items with no prior purchase history show 0.0 rates as before
- [ ] Save / Finalize / Approve flow works end-to-end

Closes #19982

🤖 Generated with [Claude Code](https://claude.com/claude-code)