### PR TITLE
fix: patch IDENTITY migration side-effects causing production slowness (#19985)

### DIFF
--- a/src/main/java/com/divudi/core/entity/ReportTemplate.java
+++ b/src/main/java/com/divudi/core/entity/ReportTemplate.java
@@ -10,6 +10,7 @@ import java.util.Date;
 import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
+import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.Enumerated;
 import javax.persistence.GeneratedValue;
@@ -52,6 +53,7 @@ public class ReportTemplate implements Serializable {
     private String billTypes;
     @Lob
     private String columns;
+    @Column(name = "REPORT_ROWS")
     @Lob
     private String rows;
     @Lob

--- a/src/main/java/com/divudi/core/facade/BillItemFacade.java
+++ b/src/main/java/com/divudi/core/facade/BillItemFacade.java
@@ -71,6 +71,29 @@ public class BillItemFacade extends AbstractFacade<BillItem> {
         int blocks = (count + allocationSize - 1) / allocationSize;
         int toReserve = blocks * allocationSize;
 
+        // After the GenerationType.IDENTITY migration (v2.2.0), EclipseLink no longer
+        // updates the SEQUENCE table — MySQL per-table AUTO_INCREMENT handles ID
+        // assignment instead.  This means SEQUENCE.SEQ_COUNT can lag behind the real
+        // AUTO_INCREMENT values, causing allocateSequenceBlock() to hand out IDs that
+        // already exist in the target tables (PK conflicts on bulk INSERT).
+        //
+        // Guard: before advancing the counter, ensure SEQ_COUNT is at or above the
+        // highest AUTO_INCREMENT across all entity tables that have a BIGINT ID column.
+        // GREATEST() makes the UPDATE a no-op when the counter is already safe.
+        Query sync = em.createNativeQuery(
+                "UPDATE SEQUENCE s "
+                + "JOIN (SELECT COALESCE(MAX(t.AUTO_INCREMENT), 0) AS max_ai "
+                + "      FROM information_schema.TABLES t "
+                + "      JOIN information_schema.COLUMNS c "
+                + "        ON t.TABLE_NAME = c.TABLE_NAME AND t.TABLE_SCHEMA = c.TABLE_SCHEMA "
+                + "      WHERE t.TABLE_SCHEMA = DATABASE() "
+                + "        AND c.COLUMN_NAME = 'ID' "
+                + "        AND c.DATA_TYPE = 'bigint' "
+                + "        AND c.EXTRA LIKE '%auto_increment%') ai "
+                + "SET s.SEQ_COUNT = GREATEST(s.SEQ_COUNT, ai.max_ai) "
+                + "WHERE s.SEQ_NAME = 'SEQ_GEN'");
+        sync.executeUpdate();
+
         Query update = em.createNativeQuery(
                 "UPDATE sequence SET SEQ_COUNT = LAST_INSERT_ID(SEQ_COUNT + ?) WHERE SEQ_NAME = 'SEQ_GEN'");
         update.setParameter(1, toReserve);

--- a/src/main/resources/META-INF/persistence.xml
+++ b/src/main/resources/META-INF/persistence.xml
@@ -14,10 +14,11 @@
             <property name="eclipselink.concurrency.manager.allow.concurrencyexception" value="true"/>
             <!-- Log cache contention warnings for early detection -->
             <property name="eclipselink.concurrency.manager.maxfrequencytodumptinymessage" value="5000"/>
-            <!-- Sequence pre-allocation fix for SEQUENCE table lock contention (issue #19626) - Do NOT Remove -->
-            <!-- Explicit preallocation of 50 reduces database sequence contention in high-throughput environments; -->
-            <!-- without this, each ID allocation acquires a table-level lock causing retail sale slowness -->
-            <property name="eclipselink.sequence.default-sequence-preallocation-size" value="50"/>
+            <!-- JDBC batch writing for UPDATE/DELETE statements (issue #19985) -->
+            <!-- IDENTITY strategy prevents batching of INSERT statements (EclipseLink limitation), -->
+            <!-- but batch-writing still improves UPDATE and DELETE throughput under concurrent load. -->
+            <property name="eclipselink.jdbc.batch-writing" value="JDBC"/>
+            <property name="eclipselink.jdbc.batch-writing.size" value="100"/>
         </properties>
     </persistence-unit>
     <persistence-unit name="hmisAuditPU" transaction-type="JTA">


### PR DESCRIPTION
## Summary

Patches three side-effects introduced by the v2.2.0 `GenerationType.IDENTITY` migration (PR #19943) that are causing general system slowness and instability on coop-prod.

- **`persistence.xml`**: Remove dead `eclipselink.sequence.default-sequence-preallocation-size` (no effect with IDENTITY entities). Add `eclipselink.jdbc.batch-writing=JDBC` + `size=100` to recover batching for UPDATE/DELETE statements — IDENTITY prevents INSERT batching but UPDATE/DELETE can still be batched.
- **`BillItemFacade.allocateSequenceBlock()`**: Add a `GREATEST()` guard that syncs `SEQUENCE.SEQ_COUNT` up to the current max `AUTO_INCREMENT` across all entity tables before advancing the counter. After the IDENTITY migration EclipseLink stopped updating the SEQUENCE table, leaving `SEQ_COUNT` at 13,860,750 while table AUTO_INCREMENTs are already at 13,861,000+. Without this guard, bulk pharmacy stock-take operations hand out IDs that already exist → guaranteed PK conflicts → transaction rollbacks.
- **`ReportTemplate.java`**: Add `@Column(name = "REPORT_ROWS")` to the `rows` field. `ROWS` is a reserved keyword in MySQL 8.0+; without the override EclipseLink generates `ROWS AS a15` which throws `SQLSyntaxErrorException` on every `ReportTemplate` query.

## Test plan

- [ ] Deploy to coop-staging, run a full pharmacy stock take — confirm no PK conflict errors
- [ ] Create a bill with multiple items — confirm no regression in functionality
- [ ] Navigate to any page that loads `ReportTemplate` — confirm no SQL syntax error in logs
- [ ] Monitor Payara log under load for reduced lock-wait or connection-pool errors

## Related

Closes #19985

🤖 Generated with [Claude Code](https://claude.com/claude-code)