### PR TITLE
Add config to skip cash difference validation on shift handover

### DIFF
--- a/src/main/java/com/divudi/bean/cashTransaction/FinancialTransactionController.java
+++ b/src/main/java/com/divudi/bean/cashTransaction/FinancialTransactionController.java
@@ -5571,11 +5571,14 @@ public class FinancialTransactionController implements Serializable {
             }
         }
 
-        Double maximumAllowedCashDifferenceForHandover = configOptionApplicationController.getDoubleValueByKey("Maximum Allowed Cash Difference for Handover", 1.0);
-        double expectedCashHandover = bundle.getCashValue() + bundle.getFloatNetTotal();
-        if (Math.abs(bundle.getDenominatorValue() - expectedCashHandover) > maximumAllowedCashDifferenceForHandover) {
-            JsfUtil.addErrorMessage("Cash Value Collected and the cash value Handing over are different. Cannot handover.");
-            return null;
+        boolean skipCashDiffValidation = configOptionApplicationController.getBooleanValueByKey("Skip Cash Difference Validation for Handover", false);
+        if (!skipCashDiffValidation) {
+            Double maximumAllowedCashDifferenceForHandover = configOptionApplicationController.getDoubleValueByKey("Maximum Allowed Cash Difference for Handover", 1.0);
+            double expectedCashHandover = bundle.getCashValue() + bundle.getFloatNetTotal();
+            if (Math.abs(bundle.getDenominatorValue() - expectedCashHandover) > maximumAllowedCashDifferenceForHandover) {
+                JsfUtil.addErrorMessage("Cash Value Collected and the cash value Handing over are different. Cannot handover.");
+                return null;
+            }
         }
         boolean shouldSelectAllCollectionsForHandover = configOptionApplicationController.getBooleanValueByKey("Should Select All Collections for Handover", false);
         boolean allBundlesSelected = true;


### PR DESCRIPTION
## Summary

- Adds new boolean config key **`Skip Cash Difference Validation for Handover`** (default: `false`)
- When `true`, the entire cash difference check in `settleHandoverStartBill()` is bypassed
- When `false` (default), the existing `Maximum Allowed Cash Difference for Handover` check runs exactly as before — no change to existing sites

## Test plan

- [ ] With `Skip Cash Difference Validation for Handover` = `false` (or not set): verify handover is still blocked when cash difference exceeds the maximum allowed value
- [ ] With `Skip Cash Difference Validation for Handover` = `true`: verify handover completes even when cash collected ≠ cash handing over
- [ ] Confirm `Maximum Allowed Cash Difference for Handover` still works normally when skip flag is `false`

Closes #19984

🤖 Generated with [Claude Code](https://claude.com/claude-code)