### PR TITLE
perf: bulk GRN query + row expansion for PO list page

### DIFF
--- a/developer_docs/performance/pharmacy-po-grn-performance-optimization.md
+++ b/developer_docs/performance/pharmacy-po-grn-performance-optimization.md
@@ -59,33 +59,42 @@ this produces **up to 200 extra DB queries** just to open the GRN page.
 
 ---
 
-## Fix 2 — PO list: N+1 GRN loading (PENDING)
+## Fix 2 — PO list: N+1 GRN loading (DONE)
 
-**Issue:** TBD
-**Status:** Not yet started — waiting for Fix 1 QA to pass.
+**Issue:** hmislk/hmis#19987
+**Branch:** `feature/19987-fix-po-list-bulk-grn-load` (stacked on Fix 1)
+**Files:**
+- `src/main/java/com/divudi/bean/common/SearchController.java`
+- `src/main/webapp/pharmacy/pharmacy_purchase_order_list_for_recieve.xhtml`
 
 ### Root cause
 
-`createPoTable()` (`SearchController.java:7157`) loops over every loaded PO and
-calls `getGrns(b, referenceBillTypes)`, which runs **2 queries per PO**
-(one for `referenceBill = :ref`, one for `billedBill.referenceBill = :ref`).
-For 50 POs this is 101 total queries. Additionally, the PO main query loads full
-`Bill` entities, triggering lazy loads on `creater.webUserPerson.name`,
-`toInstitution.name`, `fromDepartment.name` per row.
+`createPoTable()` looped over every loaded PO and called `getGrns()` (2 queries
+per PO). For 50 POs → **101 total queries** just to load the list.
+GRN details were also rendered inline for every row (always-visible nested table).
 
-### Planned fix
+### Fix applied
 
-1. Replace per-PO `getGrns()` loop with one bulk query that loads all GRNs for
-   all matching POs at once, groups them by PO ID in a `Map<Long, List<Bill>>`,
-   then assigns in one pass.
-2. Add `JOIN FETCH` clauses to the main PO query for the common lazy paths.
-3. (Optional) Convert the always-visible nested GRN sub-table to
-   `p:rowExpansion` so GRN detail is loaded on demand.  Show a GRN count badge
-   in the main row as the indicator.
+- **Backend**: Replaced the per-PO loop with `fillGrnsByBulkQuery()`, which
+  runs **2 queries total** for all POs:
+  - Path 1: `g.referenceBill IN :pos`
+  - Path 2: `g.billedBill.referenceBill IN :pos`
+  Results grouped into `Map<Long, List<Bill>>` and assigned in one pass.
+- **Frontend**: Converted the always-visible nested GRN table to
+  `p:rowExpansion` — GRN details only render when the user expands a row.
+  Added a GRN count badge (green = has GRNs, grey = none) in a narrow column
+  as the at-a-glance indicator.
 
-**Key files:**
-- `src/main/java/com/divudi/bean/common/SearchController.java` — `createPoTable()` (line ~7103) and `getGrns()` (line ~7177)
-- `src/main/webapp/pharmacy/pharmacy_purchase_order_list_for_recieve.xhtml`
+### Testing checklist (for QA)
+
+- [ ] Search POs — list loads noticeably faster than before.
+- [ ] GRN count badge shows correct count for each PO row.
+- [ ] Expand a row — GRN table appears with correct GRN numbers, dates, values.
+- [ ] GRN "View" button navigates to finalized GRN page correctly.
+- [ ] GRN "Edit" button navigates to saved GRN edit page correctly.
+- [ ] Cancelled GRNs shown with correct red styling in expansion.
+- [ ] Action buttons (Create GRN, Receive, PO Close/Re-Open) still work correctly.
+- [ ] POs with no GRNs show "0" badge and empty expansion message.
 
 ---
 
@@ -93,10 +102,9 @@ For 50 POs this is 101 total queries. Additionally, the PO main query loads full
 
 If this conversation is disconnected, resume from here:
 
-1. Fix 1 is merged / in QA.
-2. Start Fix 2: create a new issue, branch from `origin/development`, bulk the
-   GRN load in `SearchController.createPoTable()`, optionally add row expansion
-   to the XHTML.
-3. After Fix 2: consider a `PurchaseOrderSummaryDto` with a JOIN FETCH
-   constructor query to eliminate remaining lazy loads on the PO list (lower
-   priority once the N+1 is gone).
+1. Fix 1 (GRN entry bulk rate) — branch `feature/19982-fix-grn-entry-bulk-rate-lookup`, PR #19983
+2. Fix 2 (PO list bulk GRN) — branch `feature/19987-fix-po-list-bulk-grn-load`, PR TBD (stacked on Fix 1)
+3. Both fixes are stacked (Fix 2 based on Fix 1). They should be merged together to `development`.
+4. After both pass QA: consider remaining lazy-load optimization on the PO list
+   main query (JOIN FETCH for `creater.webUserPerson`, `toInstitution`,
+   `fromDepartment`) — lower priority now that the N+1 is resolved.

--- a/src/main/java/com/divudi/bean/common/SearchController.java
+++ b/src/main/java/com/divudi/bean/common/SearchController.java
@@ -7155,9 +7155,65 @@ public class SearchController implements Serializable {
         }
 
         if (bills != null && !bills.isEmpty()) {
-            for (Bill b : bills) {
-                b.setListOfBill(getGrns(b, referenceBillTypes)); // N+1; refactor if needed
+            fillGrnsByBulkQuery(bills, referenceBillTypes);
+        }
+    }
+
+    /**
+     * Bulk-loads GRNs for every PO in the list using 2 queries instead of
+     * 2×N per-PO queries, then assigns the results to each Bill.listOfBill.
+     * Two query paths match the original getGrns() logic:
+     *   1. g.referenceBill = po
+     *   2. g.billedBill.referenceBill = po
+     */
+    private void fillGrnsByBulkQuery(List<Bill> poList, List<BillTypeAtomic> grnBillTypesAtomicsToList) {
+        Map<Long, List<Bill>> grnsByPoId = new HashMap<>();
+        for (Bill po : poList) {
+            grnsByPoId.put(po.getId(), new ArrayList<>());
+        }
+
+        // Path 1: GRN.referenceBill is the PO
+        String jpql1 = "SELECT g.referenceBill.id, g FROM Bill g "
+                + "WHERE g.retired = false "
+                + "AND g.billTypeAtomic IN :btas "
+                + "AND g.referenceBill IN :pos";
+        Map<String, Object> params1 = new HashMap<>();
+        params1.put("btas", grnBillTypesAtomicsToList);
+        params1.put("pos", poList);
+        List<Object> rows1 = getBillFacade().findObjects(jpql1, params1);
+        if (rows1 != null) {
+            for (Object row : rows1) {
+                Object[] cols = (Object[]) row;
+                Long poId = ((Number) cols[0]).longValue();
+                Bill grn = (Bill) cols[1];
+                grnsByPoId.computeIfAbsent(poId, k -> new ArrayList<>()).add(grn);
             }
+        }
+
+        // Path 2: GRN.billedBill.referenceBill is the PO
+        String jpql2 = "SELECT g.billedBill.referenceBill.id, g FROM Bill g "
+                + "WHERE g.retired = false "
+                + "AND g.billTypeAtomic IN :btas "
+                + "AND g.billedBill IS NOT NULL "
+                + "AND g.billedBill.referenceBill IN :pos";
+        Map<String, Object> params2 = new HashMap<>();
+        params2.put("btas", grnBillTypesAtomicsToList);
+        params2.put("pos", poList);
+        List<Object> rows2 = getBillFacade().findObjects(jpql2, params2);
+        if (rows2 != null) {
+            for (Object row : rows2) {
+                Object[] cols = (Object[]) row;
+                Long poId = ((Number) cols[0]).longValue();
+                Bill grn = (Bill) cols[1];
+                List<Bill> grnList = grnsByPoId.computeIfAbsent(poId, k -> new ArrayList<>());
+                if (!grnList.contains(grn)) {
+                    grnList.add(grn);
+                }
+            }
+        }
+
+        for (Bill po : poList) {
+            po.setListOfBill(grnsByPoId.getOrDefault(po.getId(), new ArrayList<>()));
         }
     }
 

--- a/src/main/webapp/pharmacy/pharmacy_purchase_order_list_for_recieve.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_purchase_order_list_for_recieve.xhtml
@@ -216,6 +216,15 @@
                                         </h:outputLabel>
                                     </p:column>
 
+                                    <p:column headerText="GRNs" styleClass="text-center" exportable="false" width="60">
+                                        <h:panelGroup rendered="#{not empty p.listOfBill}">
+                                            <span class="badge bg-success">#{p.listOfBill.size()}</span>
+                                        </h:panelGroup>
+                                        <h:panelGroup rendered="#{empty p.listOfBill}">
+                                            <span class="badge bg-secondary">0</span>
+                                        </h:panelGroup>
+                                    </p:column>
+
                                     <p:column headerText="Actions" styleClass="text-center" exportable="false" width="160">
                                         <div class="d-flex flex-column align-items-center gap-2">
                                             <p:commandButton

--- a/src/main/webapp/pharmacy/pharmacy_purchase_order_list_for_recieve.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_purchase_order_list_for_recieve.xhtml
@@ -324,93 +324,87 @@
                                             </p:commandButton>
                                         </div>
                                     </p:column>
-                                    <p:column 
-                                        id="columnGrnDetails"
-                                        rendered="true"
-                                        headerText="Goods Received Notes" 
-                                        width="320"
-                                        styleClass="p-2">     
-                                        <p:dataTable 
-                                            var="b" 
-                                            value="#{p.listOfBill}" 
-                                            styleClass="ui-datatable-borderless ui-datatable-sm table-sm border"
-                                            rendered="#{not empty p.listOfBill}"
-                                            size="small"
-                                            emptyMessage="No GRNs created yet">
+                                    <p:rowExpansion>
+                                        <div class="p-2">
+                                            <p:dataTable
+                                                var="b"
+                                                value="#{p.listOfBill}"
+                                                styleClass="ui-datatable-borderless table-sm border"
+                                                emptyMessage="No GRNs created yet"
+                                                size="small">
+                                                <f:facet name="header">
+                                                    <span class="fw-bold text-secondary">Goods Received Notes for PO #{p.deptId}</span>
+                                                </f:facet>
 
-                                            <p:column headerText="GRN Number">
-                                                <h:outputText 
-                                                    value="#{b.deptId}" 
-                                                    styleClass="#{b.billTypeAtomic.billCategory eq 'BILL' ? 'text-success' : 
-                                                                  b.billTypeAtomic.billCategory eq 'CANCELLATION' ? 'text-danger' : 
-                                                                  b.billTypeAtomic.billCategory eq 'REFUND' ? 'text-warning' : ''}" />
-                                                <h:panelGroup rendered="#{b.cancelled}">
-                                                    <span class="ui-icon ui-icon-circle-close" title="Cancelled" style="margin-left:5px;"></span>
-                                                </h:panelGroup>
-                                                <h:panelGroup rendered="#{b.refunded}">
-                                                    <span class="ui-icon ui-icon-arrowreturnthick-1-w" title="Refunded" style="margin-left:5px;"></span>
-                                                </h:panelGroup>
-                                            </p:column>
+                                                <p:column headerText="GRN Number">
+                                                    <h:outputText
+                                                        value="#{b.deptId}"
+                                                        styleClass="#{b.billTypeAtomic.billCategory eq 'BILL' ? 'text-success' :
+                                                                      b.billTypeAtomic.billCategory eq 'CANCELLATION' ? 'text-danger' :
+                                                                      b.billTypeAtomic.billCategory eq 'REFUND' ? 'text-warning' : ''}" />
+                                                    <h:panelGroup rendered="#{b.cancelled}">
+                                                        <span class="ui-icon ui-icon-circle-close" title="Cancelled" style="margin-left:5px;"></span>
+                                                    </h:panelGroup>
+                                                    <h:panelGroup rendered="#{b.refunded}">
+                                                        <span class="ui-icon ui-icon-arrowreturnthick-1-w" title="Refunded" style="margin-left:5px;"></span>
+                                                    </h:panelGroup>
+                                                </p:column>
 
-                                            <p:column headerText="GRN Date" width="6em">
-                                                <h:outputText 
-                                                    value="#{b.createdAt}" 
-                                                    styleClass="#{b.billTypeAtomic.billCategory eq 'BILL' ? 'text-success' : 
-                                                                  b.billTypeAtomic.billCategory eq 'CANCELLATION' ? 'text-danger' : 
-                                                                  b.billTypeAtomic.billCategory eq 'REFUND' ? 'text-warning' : ''}">
-                                                    <f:convertDateTime timeZone="Asia/Colombo" pattern="#{sessionController.applicationPreference.shortDateFormat}" />
-                                                </h:outputText>
-                                            </p:column>
+                                                <p:column headerText="GRN Date" width="8em">
+                                                    <h:outputText
+                                                        value="#{b.createdAt}"
+                                                        styleClass="#{b.billTypeAtomic.billCategory eq 'BILL' ? 'text-success' :
+                                                                      b.billTypeAtomic.billCategory eq 'CANCELLATION' ? 'text-danger' :
+                                                                      b.billTypeAtomic.billCategory eq 'REFUND' ? 'text-warning' : ''}">
+                                                        <f:convertDateTime timeZone="Asia/Colombo" pattern="#{sessionController.applicationPreference.shortDateFormat}" />
+                                                    </h:outputText>
+                                                </p:column>
 
-                                            <p:column headerText="Value" width="6em" styleClass="text-end">
-                                                <div class="d-flex align-items-center justify-content-end">
-                                                    <h:outputText 
-                                                        value="#{b.netTotal lt 0 ? b.netTotal * -1 : b.netTotal}" 
-                                                        styleClass="fw-bold #{b.billTypeAtomic.billCategory eq 'BILL' ? 'text-success' : 
-                                                                              b.billTypeAtomic.billCategory eq 'CANCELLATION' ? 'text-danger' : 
+                                                <p:column headerText="Value" width="8em" styleClass="text-end">
+                                                    <h:outputText
+                                                        value="#{b.netTotal lt 0 ? b.netTotal * -1 : b.netTotal}"
+                                                        styleClass="fw-bold #{b.billTypeAtomic.billCategory eq 'BILL' ? 'text-success' :
+                                                                              b.billTypeAtomic.billCategory eq 'CANCELLATION' ? 'text-danger' :
                                                                               b.billTypeAtomic.billCategory eq 'REFUND' ? 'text-warning' : ''}">
                                                         <f:convertNumber pattern="#,##0.00" />
                                                     </h:outputText>
-                                                </div>
-                                            </p:column>
+                                                </p:column>
 
-                                            <p:column headerText="Actions" width="5em">
-                                                <h:panelGroup layout="block" styleClass="d-flex gap-1">
-                                                    <p:commandButton  
-                                                        class="ui-button-info"  
-                                                        icon="fas fa-eye"
-                                                        title="View Finalized GRN" 
-                                                        ajax="false"
-                                                        rendered="#{b.billTypeAtomic eq 'PHARMACY_GRN'}"
-                                                        action="#{pharmacyBillSearch.navigateToViewPharmacyGrn()}" 
-                                                        actionListener="#{pharmacyBillSearch.calTotalSaleRate(b)}">
-                                                        <f:setPropertyActionListener target="#{pharmacyBillSearch.bill}" value="#{b}"/>
-                                                    </p:commandButton>
-                                                    <p:commandButton  
-                                                        class="ui-button-warning"  
-                                                        icon="fas fa-edit"
-                                                        title="Edit Saved GRN" 
-                                                        ajax="false"
-                                                        rendered="#{b.billTypeAtomic eq 'PHARMACY_GRN_PRE' and !configOptionApplicationController.getBooleanValueByKey('Manage Costing', true)}"
-                                                        action="#{pharmacyBillSearch.navigateToEditSavedGrn()}">
-                                                        <f:setPropertyActionListener target="#{pharmacyBillSearch.bill}" value="#{b}"/>
-                                                    </p:commandButton>
-                                                    <p:commandButton  
-                                                        class="ui-button-warning"  
-                                                        icon="fas fa-edit"
-                                                        title="Edit Saved GRN with Costing" 
-                                                        ajax="false"
-                                                        rendered="#{b.billTypeAtomic eq 'PHARMACY_GRN_PRE' and configOptionApplicationController.getBooleanValueByKey('Manage Costing', true)}"
-                                                        action="#{pharmacyBillSearch.navigateToEditSavedGrnCosting()}">
-                                                        <f:setPropertyActionListener target="#{pharmacyBillSearch.bill}" value="#{b}"/>
-                                                    </p:commandButton>
-                                                </h:panelGroup>
-                                            </p:column>
-                                        </p:dataTable>
-
-
-
-                                    </p:column>
+                                                <p:column headerText="Actions" width="6em">
+                                                    <h:panelGroup layout="block" styleClass="d-flex gap-1">
+                                                        <p:commandButton
+                                                            class="ui-button-info"
+                                                            icon="fas fa-eye"
+                                                            title="View Finalized GRN"
+                                                            ajax="false"
+                                                            rendered="#{b.billTypeAtomic eq 'PHARMACY_GRN'}"
+                                                            action="#{pharmacyBillSearch.navigateToViewPharmacyGrn()}"
+                                                            actionListener="#{pharmacyBillSearch.calTotalSaleRate(b)}">
+                                                            <f:setPropertyActionListener target="#{pharmacyBillSearch.bill}" value="#{b}"/>
+                                                        </p:commandButton>
+                                                        <p:commandButton
+                                                            class="ui-button-warning"
+                                                            icon="fas fa-edit"
+                                                            title="Edit Saved GRN"
+                                                            ajax="false"
+                                                            rendered="#{b.billTypeAtomic eq 'PHARMACY_GRN_PRE' and !configOptionApplicationController.getBooleanValueByKey('Manage Costing', true)}"
+                                                            action="#{pharmacyBillSearch.navigateToEditSavedGrn()}">
+                                                            <f:setPropertyActionListener target="#{pharmacyBillSearch.bill}" value="#{b}"/>
+                                                        </p:commandButton>
+                                                        <p:commandButton
+                                                            class="ui-button-warning"
+                                                            icon="fas fa-edit"
+                                                            title="Edit Saved GRN with Costing"
+                                                            ajax="false"
+                                                            rendered="#{b.billTypeAtomic eq 'PHARMACY_GRN_PRE' and configOptionApplicationController.getBooleanValueByKey('Manage Costing', true)}"
+                                                            action="#{pharmacyBillSearch.navigateToEditSavedGrnCosting()}">
+                                                            <f:setPropertyActionListener target="#{pharmacyBillSearch.bill}" value="#{b}"/>
+                                                        </p:commandButton>
+                                                    </h:panelGroup>
+                                                </p:column>
+                                            </p:dataTable>
+                                        </div>
+                                    </p:rowExpansion>
                                 </p:dataTable>
                             </p:panel>
                         </div>

--- a/src/main/webapp/pharmacy/pharmacy_purchase_order_list_for_recieve.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_purchase_order_list_for_recieve.xhtml
@@ -149,6 +149,7 @@
                                     reflow="true"
                                     stripedRows="true"
                                     rowExpandMode="multiple"
+                                    rowKey="#{p.id}"
                                     size="small">
                                     <p:column width="30" exportable="false">
                                         <p:rowToggler />

--- a/src/main/webapp/pharmacy/pharmacy_purchase_order_list_for_recieve.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_purchase_order_list_for_recieve.xhtml
@@ -133,9 +133,9 @@
                                         </small>
                                     </div>
                                 </f:facet>
-                                <p:dataTable 
+                                <p:dataTable
                                     id="tbl"
-                                    value="#{searchController.bills}" 
+                                    value="#{searchController.bills}"
                                     var="p"
                                     rows="15"
                                     paginator="true"
@@ -148,7 +148,11 @@
                                     resizableColumns="true"
                                     reflow="true"
                                     stripedRows="true"
+                                    rowExpandMode="multiple"
                                     size="small">
+                                    <p:column width="30" exportable="false">
+                                        <p:rowToggler />
+                                    </p:column>
                                     <p:column headerText="Request Details" sortBy="#{p.createdAt}" styleClass="text-nowrap" width="200">
                                         <div class="d-flex flex-column">
                                             <div class="d-flex align-items-center mb-1">


### PR DESCRIPTION
## Summary

- **Backend** (`SearchController.java`): Replaces the per-PO `getGrns()` loop with `fillGrnsByBulkQuery()` — 2 queries total for all POs instead of 2×N. GRNs grouped by PO ID in a `Map<Long, List<Bill>>` and assigned in one pass.
- **Frontend** (`pharmacy_purchase_order_list_for_recieve.xhtml`): Converts the always-visible nested GRN sub-table to `p:rowExpansion`. GRN details only render when the user expands a row. A GRN count badge (green = has GRNs, grey = none) is shown in a narrow column as the at-a-glance indicator.

For 50 POs: **101 queries → 3 queries** to load the list.

> **Note:** This PR is stacked on #19983. Base branch is `feature/19982-fix-grn-entry-bulk-rate-lookup`. Both should be merged together once QA passes.

## Test plan

- [ ] Search POs — list loads noticeably faster
- [ ] GRN count badge shows the correct count per PO row
- [ ] Expand a row — GRN table appears with correct GRN numbers, dates, values
- [ ] GRN "View" button navigates to finalized GRN correctly
- [ ] GRN "Edit" (with costing) button navigates to saved GRN edit correctly
- [ ] Cancelled GRNs show red styling in the expanded table
- [ ] Action buttons (Create GRN, Receive, PO Close/Re-Open) still work
- [ ] POs with no GRNs show "0" badge and empty expansion message

Closes #19987

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Significantly improved purchase order list loading performance by optimizing goods-received-notes data retrieval.

* **New Features**
  * Added count badges to purchase orders displaying the number of associated goods-received notes.
  * Converted goods-received-notes display from inline rendering to expandable rows for better navigation and reduced initial page load time.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->