### PR TITLE
perf: eager-fetch billItem/item/category in GRN generateBillComponent

### DIFF
--- a/src/main/java/com/divudi/bean/pharmacy/GrnCostingController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/GrnCostingController.java
@@ -1246,7 +1246,8 @@ public class GrnCostingController implements Serializable {
         Map<Long, Double> grnFreeQtyMap = buildReceivedFreeQtyMap(poBill, BillTypeAtomic.PHARMACY_GRN);
         Map<Long, Double> grnCancelledFreeQtyMap = buildReceivedFreeQtyMap(poBill, BillTypeAtomic.PHARMACY_GRN_CANCELLED);
 
-        List<PharmaceuticalBillItem> poBillItems = getPharmaceuticalBillItemFacade().getPharmaceuticalBillItems(poBill);
+        // Eager-fetch billItem + item + category in one query to avoid N×3 lazy loads.
+        List<PharmaceuticalBillItem> poBillItems = getPharmaceuticalBillItemFacade().getPharmaceuticalBillItemsWithItemAndCategory(poBill);
 
         // Pre-collect all items so we can bulk-fetch last rates in one query
         // instead of one query per item inside the loop (N×2 → 1 total).

--- a/src/main/java/com/divudi/core/facade/PharmaceuticalBillItemFacade.java
+++ b/src/main/java/com/divudi/core/facade/PharmaceuticalBillItemFacade.java
@@ -51,6 +51,24 @@ public class PharmaceuticalBillItemFacade extends AbstractFacade<PharmaceuticalB
         return btm;
     }
 
+    /**
+     * Fetches PharmaceuticalBillItems for a bill with billItem, item, and
+     * item.category eagerly loaded in a single query. Use this in GRN entry
+     * flows where all three associations are accessed per item, to avoid
+     * N×3 lazy-load queries.
+     */
+    public List<PharmaceuticalBillItem> getPharmaceuticalBillItemsWithItemAndCategory(Bill bill) {
+        String sql = "SELECT p FROM PharmaceuticalBillItem p "
+                + "JOIN FETCH p.billItem bi "
+                + "JOIN FETCH bi.item i "
+                + "LEFT JOIN FETCH i.category "
+                + "WHERE bi.bill = :b "
+                + "AND bi.retired = false";
+        HashMap hm = new HashMap();
+        hm.put("b", bill);
+        return findByJpql(sql, hm);
+    }
+
     public List<ItemMovementSummaryDTO> findItemMovementSummaryDTOs(String jpql, Map<String, Object> parameters, TemporalType tt) {
         TypedQuery<ItemMovementSummaryDTO> qry = getEntityManager().createQuery(jpql, ItemMovementSummaryDTO.class);
         for (Map.Entry<String, Object> e : parameters.entrySet()) {


### PR DESCRIPTION
## Summary

- Adds `getPharmaceuticalBillItemsWithItemAndCategory(Bill)` to `PharmaceuticalBillItemFacade` — same query as the existing method but with `JOIN FETCH p.billItem`, `JOIN FETCH bi.item`, `LEFT JOIN FETCH i.category`
- `generateBillComponent()` in `GrnCostingController` now uses this variant, eliminating N×3 lazy-load queries per PO item:
  - `pbi.getBillItem()` was lazy → now eager
  - `pbi.getBillItem().getItem()` was lazy → now eager
  - `bi.item.category` (accessed in XHTML `profitMargin` check per row) was lazy → now eager
- All other callers of `getPharmaceuticalBillItems()` are **unchanged**

For a 100-item PO: **300+ lazy queries → 0**.

> **Note:** Stacked on #19989 → #19983. Base branch is `feature/19987-fix-po-list-bulk-grn-load`.

## Test plan

- [ ] Click "Create GRN" on a PO with ≥20 items — page loads faster than before
- [ ] Item names, codes, profit margin colours all display correctly
- [ ] Ordered Qty / Ordered Free Qty shown correctly per row
- [ ] Rates pre-filled correctly (purchase rate, retail rate)
- [ ] Ampp (pack) items: pack conversion and rates still correct
- [ ] Save / Finalize / Approve flow works end-to-end

Closes #19991

🤖 Generated with [Claude Code](https://claude.com/claude-code)