### PR TITLE
fix: respect Allow Shift End Without Handover Acceptance config on End Shift button

### DIFF
--- a/src/main/java/com/divudi/bean/cashTransaction/FinancialTransactionController.java
+++ b/src/main/java/com/divudi/bean/cashTransaction/FinancialTransactionController.java
@@ -3241,14 +3241,24 @@ public class FinancialTransactionController implements Serializable {
             return null;
         }
 
-        // Guard: outgoing pending handover — block until recipient accepts (unconditional, #19824)
-        if (hasAtLeastOneHandoverBillToReceive(sessionController.getLoggedUser(), null, null, null)) {
+        boolean allowShiftEndWithoutHandoverAcceptance = configOptionApplicationController
+                .getBooleanValueByKey("Allow Shift End Without Handover Acceptance", false);
+
+        // Guard: outgoing pending handover — bypassed when 'Allow Shift End Without Handover Acceptance' is true
+        if (!allowShiftEndWithoutHandoverAcceptance
+                && hasAtLeastOneHandoverBillToReceive(sessionController.getLoggedUser(), null, null, null)) {
             JsfUtil.addErrorMessage("You have a handover awaiting acceptance by the recipient. Please wait for them to accept before closing your shift.");
             return null;
         }
 
-        // Guard: incoming pending handover — block until this user accepts (unconditional, #19824)
-        if (hasAtLeastOneHandoverBillToReceive(null, null, sessionController.getLoggedUser(), null)) {
+        if (allowShiftEndWithoutHandoverAcceptance
+                && hasAtLeastOneHandoverBillToReceive(sessionController.getLoggedUser(), null, null, null)) {
+            JsfUtil.addInfoMessage("Warning: You are ending your shift while a handover is still pending acceptance by the recipient.");
+        }
+
+        // Guard: incoming pending handover — bypassed when 'Allow Shift End Without Handover Acceptance' is true
+        if (!allowShiftEndWithoutHandoverAcceptance
+                && hasAtLeastOneHandoverBillToReceive(null, null, sessionController.getLoggedUser(), null)) {
             JsfUtil.addErrorMessage("You have a pending handover to accept. Please accept it before closing your shift.");
             return null;
         }


### PR DESCRIPTION
## Summary
- The `Allow Shift End Without Handover Acceptance` config key was already respected in `settleShiftEnd()` but had no effect on the **End Shift** button on `index.xhtml`, which calls `navigateToCreateShiftEndSummaryBillForHandover()`
- That method had an unconditional guard blocking shift end when a handover was pending recipient acceptance
- Applied the same config-gated pattern: when the config is `true`, the block is skipped and a warning is shown instead

## Test plan
- [ ] Enable config key `Allow Shift End Without Handover Acceptance` via `/api/config/setBoolean/...`
- [ ] Create a handover and leave it unaccepted
- [ ] Click End Shift on `cashier/index.xhtml` — should proceed with a warning instead of being blocked
- [ ] Disable the config key — verify the block is restored

🤖 Generated with [Claude Code](https://claude.com/claude-code)