### PR TITLE
hotfix: sync development to coop-prod (PRs #19962–#19995)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,6 +24,9 @@
 9. **🚨 JPQL FIRST, NATIVE SQL LAST**: Always use JPQL for database queries. Native SQL (`nativeScalarQuery`, `executeNativeSql`) is only permitted when there is a significant, demonstrated performance constraint that JPQL cannot address. Never reach for native SQL just because JPQL is harder to write.
 10. **🚨 USE `findLongByJpql` FOR COUNT QUERIES**: Always use `findLongByJpql` (not `findDoubleByJpql`) for JPQL `COUNT(...)` queries. `COUNT` returns a `Long`; using `findDoubleByJpql` causes a silent `ClassCastException` caught internally, returning `0.0` every time and making the check always pass.
 
+### Deployment
+16. **🚨 NEVER DEPLOY MANUALLY AS ROOT**: NEVER use `sudo` or root to copy WARs, run `asadmin`, or touch Payara's application/log directories directly. Root-owned files in `/opt/payara5/glassfish/domains/domain1/` (applications, generated, logs) block all future CI/CD deployments — `asadmin undeploy` and `deploy` will fail with permission errors. **All deployments MUST go through GitHub Actions CI/CD.** If a manual fix is absolutely needed, use `appuser` only. See [Deployment Recovery Guide](developer_docs/deployment/deployment-recovery-guide.md).
+
 ### Git & Branching
 11. **Include issue closing keywords** (`Closes #N`) in commit messages
 12. **JSF-only changes** (XHTML only, no Java) do not require compilation or testing
@@ -35,6 +38,7 @@
 
 ### When Working on Persistence/Deployment
 - [Persistence Configuration Guide](developer_docs/deployment/persistence-verification.md) - JNDI settings for dev vs production
+- [Deployment Recovery Guide](developer_docs/deployment/deployment-recovery-guide.md) - How to recover when root-owned files break CI/CD deployment
 
 ### When Working on UI/XHTML
 - [UI Development Handbook](developer_docs/ui/comprehensive-ui-guidelines.md) - Complete UI reference

--- a/developer_docs/bugfix/cross-entity-id-boundary-issues.md
+++ b/developer_docs/bugfix/cross-entity-id-boundary-issues.md
@@ -1,0 +1,79 @@
+# Cross-Entity ID Boundary Bug — Shift Queries
+
+## Background
+
+Before the sequence pre-allocation change, all entities shared a single `AUTO` sequence table, so IDs were globally monotonic. Queries like `payment.id > shiftStartBill.id` were valid for temporal ordering because both IDs came from the same sequence.
+
+After switching to `GenerationType.IDENTITY` (per-table `AUTO_INCREMENT`), **each table has its own independent ID series**. Comparing a `payment.id` against a `bill.id` is now meaningless — they count independently from different starting points.
+
+## How the Bug Manifests
+
+A payment created *after* a bill can receive an ID that is numerically *lower* than that bill's ID, because payment IDs come from the `payment` table's counter and bill IDs from the `bill` table's counter. The queries that used `payment.id > shiftStartBill.id` silently exclude those payments from shift totals, handover pages, and cashbook entries.
+
+**Confirmed on coop DB (2026-04-16, user Dilka):**
+
+| Payment ID | Bill ID | Created At | Shift Start Bill ID |
+|---|---|---|---|
+| 13860728 | 13860808 | 14:08:21 | 13860802 |
+| 13860758 | 13860817 | 14:09:54 | 13860802 |
+| 13860766 | 13860834 | 14:22:42 | 13860802 |
+| 13860767 | 13860839 | 14:27:28 | 13860802 |
+
+Payment IDs are lower than the shift start bill ID (13860802) even though they were collected after the shift started. However, their **own bill IDs** are all higher than 13860802.
+
+## The Fix Pattern
+
+**Wrong (cross-entity):**
+```java
+// p is Payment, :sid is a Bill ID — different tables, different counters
+"AND p.id > :sid"
+m.put("sid", startBill.getId());
+```
+
+**Correct option A — use the payment's own bill ID (simplest, same-table Bill-to-Bill):**
+```java
+// JOIN p.bill b is already in the query — b.id is same table as startBill.id
+"AND b.id > :sid"
+m.put("sid", startBill.getId());
+```
+
+**Correct option B — use timestamp:**
+```java
+"AND b.createdAt >= :startTime"
+m.put("startTime", startBill.getCreatedAt());
+```
+
+Option A is preferred for queries that already `JOIN p.bill b`, as it avoids any clock-skew concern and keeps the comparison within the `bill` table's ID series.
+
+---
+
+## Issues
+
+### Fixed
+
+| Issue | PR | Methods Fixed |
+|---|---|---|
+| [#19965](https://github.com/hmislk/hmis/issues/19965) | [#19966](https://github.com/hmislk/hmis/pull/19966) | `fetchPaymentsFromShiftStartToEndByDateAndDepartment(Bill,Bill)`, `fetchShiftFloatsFromShiftStartToEnd(Bill,Bill,WebUser)`, `fetchBankPayments(Bill,Bill,WebUser)` |
+| [#19969](https://github.com/hmislk/hmis/issues/19969) | [#19973](https://github.com/hmislk/hmis/pull/19973) | `fillPaymentsFromShiftStartToNow()`, `fillPaymentsFromShiftStartToNow(Bill,WebUser)`, `fillPaymentsFromShiftStartToEnd(Bill,Bill,WebUser)` |
+| [#19970](https://github.com/hmislk/hmis/issues/19970) | [#19974](https://github.com/hmislk/hmis/pull/19974) | `fillPaymentsFromShiftStartToNowNotYetStartedToEntereToCashbook()`, `fillPaymentsFromShiftStartToNowNotYetStartedToEntereToCashbookFilteredByDateAndDepartment()`, `generatePaymentsFromShiftStartToEndToEnterToCashbookFilteredByDateAndDepartment(Bill,Bill)` |
+| [#19971](https://github.com/hmislk/hmis/issues/19971) | [#19975](https://github.com/hmislk/hmis/pull/19975) | `fillBillsFromShiftStartToNow()` |
+| [#19972](https://github.com/hmislk/hmis/issues/19972) | [#19976](https://github.com/hmislk/hmis/pull/19976) | `rejectToReceiveHandoverBill()`, `recallMyHandoverBill()`, `settleHandoverStartBill()` |
+
+Notes:
+- PR #19966 used Option B (timestamp). These can be revised to Option A if preferred.
+- PR #19973 used Option A (`b.id`) for shift summary display — adds `JOIN p.bill b` where missing.
+- PR #19974 used Option A (`b.id`) for cashbook entry — all three already had `JOIN p.bill b`.
+- PR #19975 used Option B (timestamp) for `fillBillsFromShiftStartToNow()` — Bill-to-Bill, robustness fix.
+- PR #19976 used Option A (`b.id`) for float marking/reset — all three already had `JOIN p.bill b`.
+
+---
+
+## Summary Table
+
+| Issue | Area | Severity | Status |
+|---|---|---|---|
+| [#19965](https://github.com/hmislk/hmis/issues/19965) | Handover totals | Critical | Fixed ([PR #19966](https://github.com/hmislk/hmis/pull/19966)) |
+| [#19969](https://github.com/hmislk/hmis/issues/19969) | Shift summary display | Critical | Fixed ([PR #19973](https://github.com/hmislk/hmis/pull/19973)) |
+| [#19970](https://github.com/hmislk/hmis/issues/19970) | Cashbook entry | Critical | Fixed ([PR #19974](https://github.com/hmislk/hmis/pull/19974)) |
+| [#19971](https://github.com/hmislk/hmis/issues/19971) | Shift end bills list | Low | Fixed ([PR #19975](https://github.com/hmislk/hmis/pull/19975)) |
+| [#19972](https://github.com/hmislk/hmis/issues/19972) | Float marking/reset | High | Fixed ([PR #19976](https://github.com/hmislk/hmis/pull/19976)) |

--- a/developer_docs/deployment/deployment-recovery-guide.md
+++ b/developer_docs/deployment/deployment-recovery-guide.md
@@ -1,0 +1,87 @@
+# Deployment Recovery Guide
+
+## Root-Owned Files Breaking CI/CD Deployment
+
+### What Happened
+
+If a Claude Code session (or any manual process) runs `asadmin`, copies WARs, or touches
+Payara directories **as root** (e.g. via `sudo`), it leaves files owned by `root` inside
+Payara's domain directories. The normal CI/CD pipeline runs as `appuser`, so subsequent
+`asadmin undeploy` / `deploy` commands fail with errors like:
+
+```
+Command deploy failed.
+remote failure: Error occurred during deployment: Exception while loading the app :
+Error in committing security policy for ejbs of coop --
+javax.security.jacc.PolicyContextException: java.lang.RuntimeException:
+Failure removing policy file: .../generated/policy/coop/...granted.policy.
+
+java.io.FileNotFoundException: .../applications/__internal/coop/coop.war (Permission denied)
+```
+
+The app gets **completely undeployed** and cannot be redeployed until the stale files are removed.
+
+### Prevention
+
+**Never run `asadmin`, `sudo cp`, `sudo rsync`, or any Payara command as root.**
+All deployments must go through GitHub Actions CI/CD. See rule #16 in CLAUDE.md.
+
+### Recovery Steps
+
+Run these commands (SSH to the affected VM, e.g. `ssh hmis08`):
+
+**Step 1 — Fix log file ownership** (blocks Payara from writing logs):
+```bash
+sudo chown appuser:appuser /opt/payara5/glassfish/domains/domain1/logs/server.log
+```
+
+**Step 2 — Remove stale root-owned application files:**
+```bash
+sudo rm -rf /opt/payara5/glassfish/domains/domain1/applications/__internal/<appname>
+sudo rm -rf /opt/payara5/glassfish/domains/domain1/applications/<appname>
+sudo rm -rf /opt/payara5/glassfish/domains/domain1/generated/policy/<appname>
+sudo rm -rf /opt/payara5/glassfish/domains/domain1/generated/ejb/<appname>
+sudo rm -rf /opt/payara5/glassfish/domains/domain1/generated/xml/<appname>
+```
+
+**Step 3 — Fix ownership of the entire Payara domain:**
+```bash
+sudo chown -R appuser:appuser /opt/payara5/glassfish/domains/domain1/applications/
+sudo chown -R appuser:appuser /opt/payara5/glassfish/domains/domain1/generated/
+```
+
+**Step 4 — Redeploy via asadmin** (only if CI/CD pipeline cannot be re-run):
+```bash
+echo 'AS_ADMIN_PASSWORD=<payara-admin-password>' > /tmp/p.txt
+/opt/payara5/bin/asadmin --user admin --passwordfile /tmp/p.txt deploy \
+  --contextroot <appname> /home/appuser/app/latest/<appname>.war
+rm /tmp/p.txt
+```
+
+Replace `<appname>` with the app context (e.g. `coop`, `roseth`) and use the Payara admin
+password from `C:\Credentials\Credentials.txt`.
+
+**Step 5 — Verify the app is up:**
+```bash
+curl -s -o /dev/null -w '%{http_code}' http://localhost:8080/<appname>/
+# Expected: 302 (redirect to login)
+```
+
+### Preferred Alternative to Step 4
+
+Re-run the existing CI/CD pipeline from the GitHub Actions UI instead of deploying manually:
+
+1. Go to https://github.com/hmislk/hmis/actions
+2. Find the relevant prod pipeline (e.g. "COOP-PROD Build & Deployment Pipeline")
+3. Click the failed/cancelled run → **Re-run all jobs**
+
+This is safer than manual `asadmin` because the pipeline also handles WAR upload, health
+checks, and correct file permissions.
+
+### Why This Is Dangerous
+
+- Root-owned files persist across Payara restarts and VM reboots
+- A root-owned `server.log` silently swallows all startup logs — making diagnosis very hard
+- `asadmin undeploy` removes the application directory but leaves `__internal/` and
+  `generated/policy/` stale, blocking any subsequent deploy
+- The app ends up completely undeployed with no error visible to users until they try to log in

--- a/src/main/java/com/divudi/bean/cashTransaction/FinancialTransactionController.java
+++ b/src/main/java/com/divudi/bean/cashTransaction/FinancialTransactionController.java
@@ -3833,14 +3833,13 @@ public class FinancialTransactionController implements Serializable {
         if (nonClosedShiftStartFundBill == null) {
             return;
         }
-        Long shiftStartBillId = nonClosedShiftStartFundBill.getId();
         String jpql = "SELECT p "
-                + "FROM Payment p "
+                + "FROM Payment p JOIN p.bill b "
                 + "WHERE p.creater = :cr "
                 + "AND p.retired = :ret "
-                + "AND p.id > :cid "
+                + "AND b.id > :cid "
                 + "AND p.cashbookEntryStated = :started "
-                + "ORDER BY p.id DESC";
+                + "ORDER BY b.id DESC";
         Map<String, Object> m = new HashMap<>();
         m.put("started", false);
         m.put("cr", nonClosedShiftStartFundBill.getCreater());
@@ -4821,17 +4820,16 @@ public class FinancialTransactionController implements Serializable {
             JsfUtil.addErrorMessage("No User");
             return;
         }
-        Long shiftStartBillId = startBill.getId();
         String jpql = "SELECT p "
-                + "FROM Payment p "
+                + "FROM Payment p JOIN p.bill b "
                 + "WHERE p.creater = :cr "
                 + "AND p.retired = :ret "
-                + "AND p.id > :cid "
-                + "ORDER BY p.id DESC";
+                + "AND b.id > :cid "
+                + "ORDER BY b.id DESC";
         Map<String, Object> m = new HashMap<>();
         m.put("cr", user);
         m.put("ret", false);
-        m.put("cid", shiftStartBillId);
+        m.put("cid", startBill.getId());
         paymentsFromShiftSratToNow = paymentFacade.findByJpql(jpql, m, TemporalType.TIMESTAMP);
         atomicBillTypeTotalsByPayments = new AtomicBillTypeTotals();
         for (Payment p : paymentsFromShiftSratToNow) {
@@ -4890,20 +4888,18 @@ public class FinancialTransactionController implements Serializable {
             JsfUtil.addErrorMessage("No User");
             return;
         }
-        Long shiftStartBillId = startBill.getId();
-        Long shiftEndBillId = endBill.getId();
         String jpql = "SELECT p "
-                + "FROM Payment p "
+                + "FROM Payment p JOIN p.bill b "
                 + "WHERE p.creater = :cr "
                 + "AND p.retired = :ret "
-                + "AND p.id > :sid "
-                + "AND p.id < :eid "
-                + "ORDER BY p.id DESC";
+                + "AND b.id > :sid "
+                + "AND b.id < :eid "
+                + "ORDER BY b.id DESC";
         Map<String, Object> m = new HashMap<>();
         m.put("cr", user);
         m.put("ret", false);
-        m.put("sid", shiftStartBillId);
-        m.put("eid", shiftEndBillId);
+        m.put("sid", startBill.getId());
+        m.put("eid", endBill.getId());
 
         paymentsFromShiftSratToNow = paymentFacade.findByJpql(jpql, m, TemporalType.TIMESTAMP);
         atomicBillTypeTotalsByPayments = new AtomicBillTypeTotals();

--- a/src/main/java/com/divudi/bean/cashTransaction/FinancialTransactionController.java
+++ b/src/main/java/com/divudi/bean/cashTransaction/FinancialTransactionController.java
@@ -5571,11 +5571,14 @@ public class FinancialTransactionController implements Serializable {
             }
         }
 
-        Double maximumAllowedCashDifferenceForHandover = configOptionApplicationController.getDoubleValueByKey("Maximum Allowed Cash Difference for Handover", 1.0);
-        double expectedCashHandover = bundle.getCashValue() + bundle.getFloatNetTotal();
-        if (Math.abs(bundle.getDenominatorValue() - expectedCashHandover) > maximumAllowedCashDifferenceForHandover) {
-            JsfUtil.addErrorMessage("Cash Value Collected and the cash value Handing over are different. Cannot handover.");
-            return null;
+        boolean skipCashDiffValidation = configOptionApplicationController.getBooleanValueByKey("Skip Cash Difference Validation for Handover", false);
+        if (!skipCashDiffValidation) {
+            Double maximumAllowedCashDifferenceForHandover = configOptionApplicationController.getDoubleValueByKey("Maximum Allowed Cash Difference for Handover", 1.0);
+            double expectedCashHandover = bundle.getCashValue() + bundle.getFloatNetTotal();
+            if (Math.abs(bundle.getDenominatorValue() - expectedCashHandover) > maximumAllowedCashDifferenceForHandover) {
+                JsfUtil.addErrorMessage("Cash Value Collected and the cash value Handing over are different. Cannot handover.");
+                return null;
+            }
         }
         boolean shouldSelectAllCollectionsForHandover = configOptionApplicationController.getBooleanValueByKey("Should Select All Collections for Handover", false);
         boolean allBundlesSelected = true;

--- a/src/main/java/com/divudi/bean/cashTransaction/FinancialTransactionController.java
+++ b/src/main/java/com/divudi/bean/cashTransaction/FinancialTransactionController.java
@@ -2019,7 +2019,7 @@ public class FinancialTransactionController implements Serializable {
                     + "AND p.handingOverStarted = true "
                     + "AND p.cashbookEntryStated = false "
                     + "AND b.billTypeAtomic IN :btas "
-                    + "AND p.id > :sid";
+                    + "AND b.id > :sid";
             floatParams.put("cu", selectedBill.getFromWebUser());
             floatParams.put("btas", floatTransferBtas);
             floatParams.put("sid", shiftStartBill.getId());
@@ -2098,7 +2098,7 @@ public class FinancialTransactionController implements Serializable {
                     + "AND p.handingOverStarted = true "
                     + "AND p.cashbookEntryStated = false "
                     + "AND b.billTypeAtomic IN :btas "
-                    + "AND p.id > :sid";
+                    + "AND b.id > :sid";
             floatParams.put("cu", selectedBill.getFromWebUser());
             floatParams.put("btas", floatTransferBtas);
             floatParams.put("sid", shiftStartBill.getId());
@@ -5769,7 +5769,7 @@ public class FinancialTransactionController implements Serializable {
                     + "AND p.handingOverStarted = false "
                     + "AND p.cashbookEntryStated = false "
                     + "AND b.billTypeAtomic IN :btas "
-                    + "AND p.id > :sid";
+                    + "AND b.id > :sid";
             floatParams.put("cu", sessionController.getLoggedUser());
             floatParams.put("btas", floatTransferBtas);
             floatParams.put("sid", shiftStartBillForFloats.getId());

--- a/src/main/java/com/divudi/bean/cashTransaction/FinancialTransactionController.java
+++ b/src/main/java/com/divudi/bean/cashTransaction/FinancialTransactionController.java
@@ -3924,21 +3924,18 @@ public class FinancialTransactionController implements Serializable {
         if (nonClosedShiftStartFundBill == null) {
             return;
         }
-        Long shiftStartBillId = nonClosedShiftStartFundBill.getId();
         Map<String, Object> m = new HashMap<>();
         String jpql = "SELECT p "
-                + "FROM Payment p "
+                + "FROM Payment p JOIN p.bill b "
                 + "WHERE p.creater = :cr "
                 + "AND p.retired = :ret "
-                + "AND p.id > :cid "
-                + "AND p.cashbookEntryStated = :started ";
+                + "AND b.id > :cid "
+                + "AND p.cashbookEntryStated = :started "
+                + "ORDER BY b.id DESC";
         m.put("started", false);
-
-        jpql += "ORDER BY p.id DESC";
-
         m.put("cr", nonClosedShiftStartFundBill.getCreater());
         m.put("ret", false);
-        m.put("cid", shiftStartBillId);
+        m.put("cid", nonClosedShiftStartFundBill.getId());
         paymentsFromShiftSratToNow = paymentFacade.findByJpql(jpql, m, TemporalType.TIMESTAMP);
 
         atomicBillTypeTotalsByPayments = new AtomicBillTypeTotals();
@@ -4047,8 +4044,6 @@ public class FinancialTransactionController implements Serializable {
         if (nonClosedShiftStartFundBill == null) {
             return;
         }
-        Long shiftStartBillId = nonClosedShiftStartFundBill.getId();
-
         List<BillTypeAtomic> btas = new ArrayList<>();
         btas.addAll(BillTypeAtomic.findByFinanceType(BillFinanceType.CASH_IN));
         btas.addAll(BillTypeAtomic.findByFinanceType(BillFinanceType.CASH_OUT));
@@ -4057,12 +4052,12 @@ public class FinancialTransactionController implements Serializable {
         String jpql = "SELECT p FROM Payment p JOIN p.bill b "
                 + "WHERE p.creater = :cr "
                 + "AND p.retired = :ret "
-                + "AND p.id > :cid "
+                + "AND b.id > :cid "
                 + "AND b.billTypeAtomic IN :btas "
                 + "AND p.cashbookEntryStated = :started "
                 + "AND FUNCTION('DATE', p.createdAt) = :createdDate "
                 + "AND b.department = :dept "
-                + "ORDER BY p.id DESC";
+                + "ORDER BY b.id DESC";
 
         m.put("dept", cashbookDepartment);
         m.put("btas", btas);
@@ -4070,7 +4065,7 @@ public class FinancialTransactionController implements Serializable {
         m.put("started", false);
         m.put("cr", nonClosedShiftStartFundBill.getCreater());
         m.put("ret", false);
-        m.put("cid", shiftStartBillId);
+        m.put("cid", nonClosedShiftStartFundBill.getId());
         paymentsFromShiftSratToNow = paymentFacade.findByJpql(jpql, m, TemporalType.TIMESTAMP);
 
 // Filter and collect unique cancelled bills
@@ -4754,10 +4749,10 @@ public class FinancialTransactionController implements Serializable {
         m.put("sid", startBill.getId());
 
         StringBuilder jpqlBuilder = new StringBuilder("SELECT p FROM Payment p JOIN p.bill b WHERE p.creater = :cr ")
-                .append("AND p.retired = :ret AND p.id > :sid ");
+                .append("AND p.retired = :ret AND b.id > :sid ");
 
         if (endBill != null && endBill.getId() != null) {
-            jpqlBuilder.append("AND p.id < :eid ");
+            jpqlBuilder.append("AND b.id < :eid ");
             m.put("eid", endBill.getId());
         }
 

--- a/src/main/java/com/divudi/bean/cashTransaction/FinancialTransactionController.java
+++ b/src/main/java/com/divudi/bean/cashTransaction/FinancialTransactionController.java
@@ -5191,16 +5191,26 @@ public class FinancialTransactionController implements Serializable {
             return "";
         }
 
-        // Guard: outgoing pending handover — unconditional, must be accepted before shift closes (#19824)
-        if (hasAtLeastOneHandoverBillToReceive(sessionController.getLoggedUser(), null, null, null)) {
+        boolean allowShiftEndWithoutHandoverAcceptance = configOptionApplicationController
+                .getBooleanValueByKey("Allow Shift End Without Handover Acceptance", false);
+
+        // Guard: outgoing pending handover — bypassed when 'Allow Shift End Without Handover Acceptance' is true (#19963)
+        if (!allowShiftEndWithoutHandoverAcceptance
+                && hasAtLeastOneHandoverBillToReceive(sessionController.getLoggedUser(), null, null, null)) {
             JsfUtil.addErrorMessage("You have a handover awaiting acceptance by the recipient. Please wait for them to accept before closing your shift.");
             return "";
         }
 
-        // Guard: incoming pending handover — unconditional, must be accepted before shift closes (#19824)
-        if (hasAtLeastOneHandoverBillToReceive(null, null, sessionController.getLoggedUser(), null)) {
+        // Guard: incoming pending handover — bypassed when 'Allow Shift End Without Handover Acceptance' is true (#19963)
+        if (!allowShiftEndWithoutHandoverAcceptance
+                && hasAtLeastOneHandoverBillToReceive(null, null, sessionController.getLoggedUser(), null)) {
             JsfUtil.addErrorMessage("You have a pending handover to accept. Please accept it before closing your shift.");
             return "";
+        }
+
+        if (allowShiftEndWithoutHandoverAcceptance
+                && hasAtLeastOneHandoverBillToReceive(sessionController.getLoggedUser(), null, null, null)) {
+            JsfUtil.addInfoMessage("Warning: You are ending your shift while a handover is still pending acceptance by the recipient.");
         }
 
         if (mustReceiveAllFundTransfersBeforeClosingShift) {
@@ -5254,11 +5264,10 @@ public class FinancialTransactionController implements Serializable {
                     return null;
                 }
             }
-            // Also block if a handover has been created but not yet accepted by the recipient.
-            // This covers the case where all collections are already included in a pending handover
-            // (bundle.getTotal() == 0) but the recipient has not confirmed receipt yet.
+            // Also block if a handover has been created but not yet accepted by the recipient,
+            // unless 'Allow Shift End Without Handover Acceptance' is enabled (#19963).
             boolean hasPendingHandover = hasAtLeastOneHandoverBillToReceive(sessionController.getLoggedUser(), null, null, null);
-            if (hasPendingHandover) {
+            if (hasPendingHandover && !allowShiftEndWithoutHandoverAcceptance) {
                 JsfUtil.addErrorMessage("Handover pending acceptance. Please wait for the recipient to accept your handover before ending your shift.");
                 return null;
             }
@@ -9369,6 +9378,12 @@ public class FinancialTransactionController implements Serializable {
         shiftEndMetadata.addConfigOption(new ConfigOptionInfo(
                 "Require Handover Before Shift End",
                 "When enabled, shift end is blocked until the total of all accepted handovers for the current shift matches the collection total within the configured tolerance (see 'Maximum Allowed Difference for Shift End Handover'). Shifts with no collections are unaffected. Default: false.",
+                OptionScope.APPLICATION
+        ));
+
+        shiftEndMetadata.addConfigOption(new ConfigOptionInfo(
+                "Allow Shift End Without Handover Acceptance",
+                "When enabled, a shift can be ended even if a handover has been created but not yet accepted by the recipient. A warning message is shown so the user is aware of the pending handover. Default: false (strict mode — shift end is blocked until all handovers are accepted).",
                 OptionScope.APPLICATION
         ));
 

--- a/src/main/java/com/divudi/bean/cashTransaction/FinancialTransactionController.java
+++ b/src/main/java/com/divudi/bean/cashTransaction/FinancialTransactionController.java
@@ -4931,19 +4931,18 @@ public class FinancialTransactionController implements Serializable {
         billTypesToFilter.addAll(BillTypeAtomic.findByFinanceType(BillFinanceType.FLOAT_STARTING_BALANCE));
         billTypesToFilter.addAll(BillTypeAtomic.findByFinanceType(BillFinanceType.FLOAT_CLOSING_BALANCE));
 
-        Long shiftStartBillId = nonClosedShiftStartFundBill.getId();
         String jpql = "SELECT p "
                 + "FROM Bill p "
                 + "WHERE p.creater = :cr "
                 + "AND p.retired = :ret "
                 + "AND p.billTypeAtomic in :btas "
-                + "AND p.id > :cid "
-                + "ORDER BY p.id DESC";
+                + "AND p.createdAt >= :startTime "
+                + "ORDER BY p.createdAt DESC";
         Map<String, Object> m = new HashMap<>();
         m.put("cr", nonClosedShiftStartFundBill.getCreater());
         m.put("btas", billTypesToFilter);
         m.put("ret", false);
-        m.put("cid", shiftStartBillId);
+        m.put("startTime", nonClosedShiftStartFundBill.getCreatedAt());
         currentBills = billFacade.findByJpql(jpql, m, TemporalType.TIMESTAMP);
 //        paymentMethodValues = new PaymentMethodValues(PaymentMethod.values());
         atomicBillTypeTotalsByBills = new AtomicBillTypeTotals();

--- a/src/main/java/com/divudi/bean/cashTransaction/FinancialTransactionController.java
+++ b/src/main/java/com/divudi/bean/cashTransaction/FinancialTransactionController.java
@@ -4254,15 +4254,15 @@ public class FinancialTransactionController implements Serializable {
                 .append("FROM Payment p ")
                 .append("JOIN p.bill b ")
                 .append("WHERE p.creater=:cr ")
-                .append("AND p.retired=:ret AND p.id>:sid ")
+                .append("AND p.retired=:ret AND b.createdAt>=:startTime ")
                 .append("AND b.billTypeAtomic IN :btas ");
         m.put("cr", paymentUser);
         m.put("ret", false);
-        m.put("sid", startBill.getId());
+        m.put("startTime", startBill.getCreatedAt());
         m.put("btas", btas);
-        if (endBill != null && endBill.getId() != null) {
-            jpqlBuilder.append("AND p.id<:eid ");
-            m.put("eid", endBill.getId());
+        if (endBill != null && endBill.getCreatedAt() != null) {
+            jpqlBuilder.append("AND b.createdAt<=:endTime ");
+            m.put("endTime", endBill.getCreatedAt());
         }
         jpqlBuilder
                 .append("AND p.cashbookEntryStated =:cbes ")
@@ -4411,13 +4411,13 @@ public class FinancialTransactionController implements Serializable {
                 .append("AND b.billTypeAtomic IN :btas  ")
                 .append("AND (p.creater=:cr OR p.floatRecipient=:cr) ")
                 .append("AND p.cancelled=:can ")
-                .append("AND p.id > :sid ");
+                .append("AND b.createdAt >= :startTime ");
         m.put("btas", btas);
         m.put("cr", paymentUser);
         m.put("pr", false);
         m.put("br", false);
         m.put("can", false);
-        m.put("sid", startBill.getId());
+        m.put("startTime", startBill.getCreatedAt());
 
         jpqlBuilder
                 .append("AND p.cashbookEntryStated =:cbes ")
@@ -4425,9 +4425,9 @@ public class FinancialTransactionController implements Serializable {
         m.put("cbes", false);
         m.put("hos", false);
 
-        if (endBill != null && endBill.getId() != null) {
-            jpqlBuilder.append("AND p.id < :eid ");
-            m.put("eid", endBill.getId());
+        if (endBill != null && endBill.getCreatedAt() != null) {
+            jpqlBuilder.append("AND b.createdAt <= :endTime ");
+            m.put("endTime", endBill.getCreatedAt());
         }
         jpqlBuilder.append("ORDER BY p.createdAt, b.department, p.creater");
         String jpql = jpqlBuilder.toString();
@@ -4466,17 +4466,17 @@ public class FinancialTransactionController implements Serializable {
                 .append("AND b.billTypeAtomic IN :btas  ")
                 .append("AND p.creater=:cr ")
                 .append("AND p.cancelled=:can ")
-                .append("AND p.id > :sid ");
+                .append("AND b.createdAt >= :startTime ");
         m.put("btas", btas);
         m.put("cr", paymentUser);
         m.put("pr", false);
         m.put("br", false);
         m.put("can", false);
-        m.put("sid", startBill.getId());
+        m.put("startTime", startBill.getCreatedAt());
 
-        if (endBill != null && endBill.getId() != null) {
-            jpqlBuilder.append("AND p.id < :eid ");
-            m.put("eid", endBill.getId());
+        if (endBill != null && endBill.getCreatedAt() != null) {
+            jpqlBuilder.append("AND b.createdAt <= :endTime ");
+            m.put("endTime", endBill.getCreatedAt());
         }
         jpqlBuilder.append("ORDER BY p.createdAt, b.department, p.creater");
         String jpql = jpqlBuilder.toString();

--- a/src/main/java/com/divudi/bean/cashTransaction/FinancialTransactionController.java
+++ b/src/main/java/com/divudi/bean/cashTransaction/FinancialTransactionController.java
@@ -3241,14 +3241,24 @@ public class FinancialTransactionController implements Serializable {
             return null;
         }
 
-        // Guard: outgoing pending handover — block until recipient accepts (unconditional, #19824)
-        if (hasAtLeastOneHandoverBillToReceive(sessionController.getLoggedUser(), null, null, null)) {
+        boolean allowShiftEndWithoutHandoverAcceptance = configOptionApplicationController
+                .getBooleanValueByKey("Allow Shift End Without Handover Acceptance", false);
+
+        // Guard: outgoing pending handover — bypassed when 'Allow Shift End Without Handover Acceptance' is true
+        if (!allowShiftEndWithoutHandoverAcceptance
+                && hasAtLeastOneHandoverBillToReceive(sessionController.getLoggedUser(), null, null, null)) {
             JsfUtil.addErrorMessage("You have a handover awaiting acceptance by the recipient. Please wait for them to accept before closing your shift.");
             return null;
         }
 
-        // Guard: incoming pending handover — block until this user accepts (unconditional, #19824)
-        if (hasAtLeastOneHandoverBillToReceive(null, null, sessionController.getLoggedUser(), null)) {
+        if (allowShiftEndWithoutHandoverAcceptance
+                && hasAtLeastOneHandoverBillToReceive(sessionController.getLoggedUser(), null, null, null)) {
+            JsfUtil.addInfoMessage("Warning: You are ending your shift while a handover is still pending acceptance by the recipient.");
+        }
+
+        // Guard: incoming pending handover — bypassed when 'Allow Shift End Without Handover Acceptance' is true
+        if (!allowShiftEndWithoutHandoverAcceptance
+                && hasAtLeastOneHandoverBillToReceive(null, null, sessionController.getLoggedUser(), null)) {
             JsfUtil.addErrorMessage("You have a pending handover to accept. Please accept it before closing your shift.");
             return null;
         }

--- a/src/main/java/com/divudi/bean/common/BankAccountController.java
+++ b/src/main/java/com/divudi/bean/common/BankAccountController.java
@@ -68,7 +68,7 @@ public class BankAccountController implements Serializable {
         HashMap params = new HashMap();
         jpql = "select b from BankAccount b "
                 + " where b.retired=false "
-                + " and (b.accountNo like :q or b.accountName like :q ) "
+                + " and (UPPER(b.accountNo) like :q or UPPER(b.accountName) like :q ) "
                 + " order by b.accountName";
         params.put("q", "%" + qry.toUpperCase() + "%");
         list = getFacade().findByJpql(jpql, params);

--- a/src/main/java/com/divudi/bean/common/DataAdministrationController.java
+++ b/src/main/java/com/divudi/bean/common/DataAdministrationController.java
@@ -2620,6 +2620,15 @@ public class DataAdministrationController implements Serializable {
         mainDatabaseExecutionFeedback = "";
         auditDatabaseExecutionFeedback = "";
 
+        // Require DDL content — do not mark schema current if nothing to apply
+        boolean hasDdl = allCreateStetements != null && !allCreateStetements.trim().isEmpty();
+        if (!hasDdl) {
+            executionFeedback = "DDL content is empty. Paste the full createDDL.jdbc contents into the 'DDL Content' field before clicking Update Database.";
+            mainDatabaseExecutionFeedback = executionFeedback;
+            auditDatabaseExecutionFeedback = executionFeedback;
+            return;
+        }
+
         // Run on both databases if enabled
         boolean executionPerformed = false;
         if (runOnMainDatabase) {
@@ -2726,6 +2735,15 @@ public class DataAdministrationController implements Serializable {
         executionFeedback = "";
         mainDatabaseExecutionFeedback = "";
         auditDatabaseExecutionFeedback = "";
+
+        // Require SQL content — do not mark schema current if nothing to apply
+        boolean hasSql = suggestedSql != null && !suggestedSql.trim().isEmpty();
+        if (!hasSql) {
+            executionFeedback = "SQL field is empty. Enter SQL statements before clicking RUN SQL.";
+            mainDatabaseExecutionFeedback = executionFeedback;
+            auditDatabaseExecutionFeedback = executionFeedback;
+            return;
+        }
 
         // Run on both databases if enabled
         boolean executionPerformed = false;

--- a/src/main/java/com/divudi/bean/pharmacy/GrnCostingController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/GrnCostingController.java
@@ -1137,17 +1137,88 @@ public class GrnCostingController implements Serializable {
         }
     }
 
-    public void generateBillComponent() {
+    /**
+     * Bulk-loads received-quantity totals for every BillItem in the given PO
+     * with a single aggregate query, returning a map of BillItem.id →
+     * total qty (in pharmaceutical units).
+     */
+    private Map<Long, Double> buildReceivedQtyMap(Bill poBill, BillTypeAtomic billTypeAtomic) {
+        String jpql = "SELECT bi.referanceBillItem.id,"
+                + " COALESCE(SUM(COALESCE(bi.pharmaceuticalBillItem.qty, 0)), 0)"
+                + " FROM BillItem bi"
+                + " WHERE bi.referanceBillItem.bill = :poBill"
+                + " AND (bi.retired = false OR bi.retired IS NULL)"
+                + " AND (bi.bill.retired = false OR bi.bill.retired IS NULL)"
+                + " AND bi.bill.billTypeAtomic = :bta"
+                + " GROUP BY bi.referanceBillItem.id";
+        Map<String, Object> params = new HashMap<>();
+        params.put("poBill", poBill);
+        params.put("bta", billTypeAtomic);
+        Map<Long, Double> result = new HashMap<>();
+        List<Object> rows = getBillItemFacade().findObjects(jpql, params);
+        if (rows != null) {
+            for (Object row : rows) {
+                Object[] cols = (Object[]) row;
+                Long billItemId = ((Number) cols[0]).longValue();
+                double qty = cols[1] instanceof Number ? ((Number) cols[1]).doubleValue() : 0.0;
+                result.put(billItemId, qty);
+            }
+        }
+        return result;
+    }
 
-        for (PharmaceuticalBillItem pbiInApprovedOrder : getPharmaceuticalBillItemFacade().getPharmaceuticalBillItems(getApproveBill())) {
+    /**
+     * Bulk-loads received free-quantity totals for every BillItem in the given
+     * PO with a single aggregate query.
+     */
+    private Map<Long, Double> buildReceivedFreeQtyMap(Bill poBill, BillTypeAtomic billTypeAtomic) {
+        String jpql = "SELECT bi.referanceBillItem.id,"
+                + " COALESCE(SUM(COALESCE(bi.pharmaceuticalBillItem.freeQty, 0)), 0)"
+                + " FROM BillItem bi"
+                + " WHERE bi.referanceBillItem.bill = :poBill"
+                + " AND (bi.retired = false OR bi.retired IS NULL)"
+                + " AND (bi.bill.retired = false OR bi.bill.retired IS NULL)"
+                + " AND bi.bill.billTypeAtomic = :bta"
+                + " GROUP BY bi.referanceBillItem.id";
+        Map<String, Object> params = new HashMap<>();
+        params.put("poBill", poBill);
+        params.put("bta", billTypeAtomic);
+        Map<Long, Double> result = new HashMap<>();
+        List<Object> rows = getBillItemFacade().findObjects(jpql, params);
+        if (rows != null) {
+            for (Object row : rows) {
+                Object[] cols = (Object[]) row;
+                Long billItemId = ((Number) cols[0]).longValue();
+                double qty = cols[1] instanceof Number ? ((Number) cols[1]).doubleValue() : 0.0;
+                result.put(billItemId, qty);
+            }
+        }
+        return result;
+    }
+
+    public void generateBillComponent() {
+        // Pre-load all received/cancelled quantities for the entire PO in 4 bulk
+        // queries instead of 4 individual queries per line item (N×4 → 4 total).
+        Bill poBill = getApproveBill();
+        Map<Long, Double> grnQtyMap = buildReceivedQtyMap(poBill, BillTypeAtomic.PHARMACY_GRN);
+        Map<Long, Double> grnCancelledQtyMap = buildReceivedQtyMap(poBill, BillTypeAtomic.PHARMACY_GRN_CANCELLED);
+        Map<Long, Double> grnFreeQtyMap = buildReceivedFreeQtyMap(poBill, BillTypeAtomic.PHARMACY_GRN);
+        Map<Long, Double> grnCancelledFreeQtyMap = buildReceivedFreeQtyMap(poBill, BillTypeAtomic.PHARMACY_GRN_CANCELLED);
+
+        for (PharmaceuticalBillItem pbiInApprovedOrder : getPharmaceuticalBillItemFacade().getPharmaceuticalBillItems(poBill)) {
 
             if (pbiInApprovedOrder.getBillItem() == null) {
                 continue;
             }
 
-            double calculatedReturns = calculateRemainigQtyFromOrder(pbiInApprovedOrder);
-            double remains = Math.abs(pbiInApprovedOrder.getQty()) - Math.abs(calculatedReturns);
-            double remainFreeQty = pbiInApprovedOrder.getFreeQty() - calculateRemainingFreeQtyFromOrder(pbiInApprovedOrder);
+            Long poItemId = pbiInApprovedOrder.getBillItem().getId();
+            double receivedQty = Math.abs(grnQtyMap.getOrDefault(poItemId, 0.0))
+                    - Math.abs(grnCancelledQtyMap.getOrDefault(poItemId, 0.0));
+            double receivedFreeQty = Math.abs(grnFreeQtyMap.getOrDefault(poItemId, 0.0))
+                    - Math.abs(grnCancelledFreeQtyMap.getOrDefault(poItemId, 0.0));
+
+            double remains = Math.abs(pbiInApprovedOrder.getQty()) - Math.abs(receivedQty);
+            double remainFreeQty = pbiInApprovedOrder.getFreeQty() - receivedFreeQty;
 
             if (remains > 0 || remainFreeQty > 0) {
                 BillItem newlyCreatedBillItemForGrn = new BillItem();

--- a/src/main/java/com/divudi/bean/pharmacy/GrnCostingController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/GrnCostingController.java
@@ -1218,7 +1218,7 @@ public class GrnCostingController implements Serializable {
                     - Math.abs(grnCancelledFreeQtyMap.getOrDefault(poItemId, 0.0));
 
             double remains = Math.abs(pbiInApprovedOrder.getQty()) - Math.abs(receivedQty);
-            double remainFreeQty = pbiInApprovedOrder.getFreeQty() - receivedFreeQty;
+            double remainFreeQty = pbiInApprovedOrder.getFreeQty() - Math.abs(receivedFreeQty);
 
             if (remains > 0 || remainFreeQty > 0) {
                 BillItem newlyCreatedBillItemForGrn = new BillItem();

--- a/src/main/java/com/divudi/core/entity/ReportTemplate.java
+++ b/src/main/java/com/divudi/core/entity/ReportTemplate.java
@@ -10,6 +10,7 @@ import java.util.Date;
 import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
+import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.Enumerated;
 import javax.persistence.GeneratedValue;
@@ -52,6 +53,7 @@ public class ReportTemplate implements Serializable {
     private String billTypes;
     @Lob
     private String columns;
+    @Column(name = "REPORT_ROWS")
     @Lob
     private String rows;
     @Lob

--- a/src/main/java/com/divudi/core/entity/WebUserRolePrivilege.java
+++ b/src/main/java/com/divudi/core/entity/WebUserRolePrivilege.java
@@ -48,6 +48,11 @@ public class WebUserRolePrivilege implements Serializable {
     String retireComments;
     String sname;
     String tname;
+    //Last Update Properties
+    @Temporal(javax.persistence.TemporalType.TIMESTAMP)
+    private Date lastUpdateAt;
+    @ManyToOne
+    private WebUser lastUpdater;
 
     public Long getId() {
         return id;
@@ -193,5 +198,20 @@ public class WebUserRolePrivilege implements Serializable {
         this.webUserRole = webUserRole;
     }
 
+    public Date getLastUpdateAt() {
+        return lastUpdateAt;
+    }
+
+    public void setLastUpdateAt(Date lastUpdateAt) {
+        this.lastUpdateAt = lastUpdateAt;
+    }
+
+    public WebUser getLastUpdater() {
+        return lastUpdater;
+    }
+
+    public void setLastUpdater(WebUser lastUpdater) {
+        this.lastUpdater = lastUpdater;
+    }
 
 }

--- a/src/main/java/com/divudi/core/entity/WebUserRoleUser.java
+++ b/src/main/java/com/divudi/core/entity/WebUserRoleUser.java
@@ -52,6 +52,12 @@ public class WebUserRoleUser implements Serializable {
     @Temporal(javax.persistence.TemporalType.TIMESTAMP)
     private Date editedAt;
 
+    //Last Update Properties
+    @Temporal(javax.persistence.TemporalType.TIMESTAMP)
+    private Date lastUpdateAt;
+    @ManyToOne
+    private WebUser lastUpdater;
+
     @Transient
     private Boolean needUpdateUserRole;
 
@@ -190,5 +196,21 @@ public class WebUserRoleUser implements Serializable {
 
     public void setNeedUpdateUserRole(Boolean needUpdateUserRole) {
         this.needUpdateUserRole = needUpdateUserRole;
+    }
+
+    public Date getLastUpdateAt() {
+        return lastUpdateAt;
+    }
+
+    public void setLastUpdateAt(Date lastUpdateAt) {
+        this.lastUpdateAt = lastUpdateAt;
+    }
+
+    public WebUser getLastUpdater() {
+        return lastUpdater;
+    }
+
+    public void setLastUpdater(WebUser lastUpdater) {
+        this.lastUpdater = lastUpdater;
     }
 }

--- a/src/main/java/com/divudi/core/facade/BillItemFacade.java
+++ b/src/main/java/com/divudi/core/facade/BillItemFacade.java
@@ -71,6 +71,29 @@ public class BillItemFacade extends AbstractFacade<BillItem> {
         int blocks = (count + allocationSize - 1) / allocationSize;
         int toReserve = blocks * allocationSize;
 
+        // After the GenerationType.IDENTITY migration (v2.2.0), EclipseLink no longer
+        // updates the SEQUENCE table — MySQL per-table AUTO_INCREMENT handles ID
+        // assignment instead.  This means SEQUENCE.SEQ_COUNT can lag behind the real
+        // AUTO_INCREMENT values, causing allocateSequenceBlock() to hand out IDs that
+        // already exist in the target tables (PK conflicts on bulk INSERT).
+        //
+        // Guard: before advancing the counter, ensure SEQ_COUNT is at or above the
+        // highest AUTO_INCREMENT across all entity tables that have a BIGINT ID column.
+        // GREATEST() makes the UPDATE a no-op when the counter is already safe.
+        Query sync = em.createNativeQuery(
+                "UPDATE SEQUENCE s "
+                + "JOIN (SELECT COALESCE(MAX(t.AUTO_INCREMENT), 0) AS max_ai "
+                + "      FROM information_schema.TABLES t "
+                + "      JOIN information_schema.COLUMNS c "
+                + "        ON t.TABLE_NAME = c.TABLE_NAME AND t.TABLE_SCHEMA = c.TABLE_SCHEMA "
+                + "      WHERE t.TABLE_SCHEMA = DATABASE() "
+                + "        AND c.COLUMN_NAME = 'ID' "
+                + "        AND c.DATA_TYPE = 'bigint' "
+                + "        AND c.EXTRA LIKE '%auto_increment%') ai "
+                + "SET s.SEQ_COUNT = GREATEST(s.SEQ_COUNT, ai.max_ai) "
+                + "WHERE s.SEQ_NAME = 'SEQ_GEN'");
+        sync.executeUpdate();
+
         Query update = em.createNativeQuery(
                 "UPDATE sequence SET SEQ_COUNT = LAST_INSERT_ID(SEQ_COUNT + ?) WHERE SEQ_NAME = 'SEQ_GEN'");
         update.setParameter(1, toReserve);

--- a/src/main/resources/META-INF/persistence.xml
+++ b/src/main/resources/META-INF/persistence.xml
@@ -1,41 +1,31 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<persistence version="2.2"
-             xmlns="http://java.sun.com/xml/ns/persistence"
-             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-             xsi:schemaLocation="
-        http://xmlns.jcp.org/xml/ns/persistence
-        http://xmlns.jcp.org/xml/ns/persistence/persistence_2_2.xsd">
-
+<persistence version="2.2" xmlns="http://java.sun.com/xml/ns/persistence" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/persistence http://xmlns.jcp.org/xml/ns/persistence/persistence_2_2.xsd">
     <persistence-unit name="hmisPU" transaction-type="JTA">
         <provider>org.eclipse.persistence.jpa.PersistenceProvider</provider>
         <jta-data-source>${JDBC_DATASOURCE}</jta-data-source>
         <exclude-unlisted-classes>false</exclude-unlisted-classes>
         <properties>
-            <property name="eclipselink.logging.level" value="FINEST"/>
-            <property name="eclipselink.logging.parameters" value="true"/>
-            <!-- Generate DDL scripts without applying them -->
-            <property name="eclipselink.ddl-generation" value="create-or-extend-tables"/>
-            <property name="eclipselink.ddl-generation.output-mode" value="sql-script"/>
-            <!-- Use an environment-agnostic path for the application location -->
-            <property name="eclipselink.application-location" value="C:/Development/hmis/tmp"/>
-            <!-- After generation, set ddl-generation to 'none' -->
-            <!-- <property name="eclipselink.ddl-generation" value="none"/> -->
-
+            <property name="eclipselink.logging.level.sql" value="SEVERE"/>
+            <property name="eclipselink.logging.level" value="SEVERE"/>
+            <!-- EclipseLink concurrency manager tuning (issue #19397) - Do NOT Remove -->
+            <!-- Reduce cache lock wait from default 900s to 10s to fail fast -->
+            <property name="eclipselink.concurrency.manager.waittime" value="10000"/>
+            <!-- Throw exception instead of silently waiting on cache lock contention -->
+            <property name="eclipselink.concurrency.manager.allow.concurrencyexception" value="true"/>
+            <!-- Log cache contention warnings for early detection -->
+            <property name="eclipselink.concurrency.manager.maxfrequencytodumptinymessage" value="5000"/>
+            <!-- Sequence pre-allocation fix for SEQUENCE table lock contention (issue #19626) - Do NOT Remove -->
+            <!-- Explicit preallocation of 50 reduces database sequence contention in high-throughput environments; -->
+            <!-- without this, each ID allocation acquires a table-level lock causing retail sale slowness -->
+            <property name="eclipselink.sequence.default-sequence-preallocation-size" value="50"/>
         </properties>
     </persistence-unit>
     <persistence-unit name="hmisAuditPU" transaction-type="JTA">
         <jta-data-source>${JDBC_AUDIT_DATASOURCE}</jta-data-source>
         <exclude-unlisted-classes>false</exclude-unlisted-classes>
         <properties>
-            <property name="eclipselink.logging.level" value="FINEST"/>
-            <property name="eclipselink.logging.parameters" value="true"/>
-            <!-- Generate DDL scripts without applying them -->
-            <property name="eclipselink.ddl-generation" value="create-or-extend-tables"/>
-            <property name="eclipselink.ddl-generation.output-mode" value="sql-script"/>
-            <!-- Use an environment-agnostic path for the application location -->
-            <property name="eclipselink.application-location" value="C:/Development/hmis/tmp"/>
-            <!-- After generation, set ddl-generation to 'none' -->
-            <!-- <property name="eclipselink.ddl-generation" value="none"/> -->
+            <property name="eclipselink.logging.level.sql" value="SEVERE"/>
+            <property name="eclipselink.logging.level" value="SEVERE"/>
         </properties>
     </persistence-unit>
 </persistence>

--- a/src/main/resources/META-INF/persistence.xml
+++ b/src/main/resources/META-INF/persistence.xml
@@ -27,21 +27,21 @@
             <property name="eclipselink.jdbc.batch-writing" value="JDBC"/>
             <property name="eclipselink.jdbc.batch-writing.size" value="1000"/>
 
-            <!-- Prepared statement cache: reuse parsed SQL instead of          -->
-            <!-- re-sending to the DB engine on every request. High impact for  -->
-            <!-- a system with repetitive billing, pharmacy and lab queries.     -->
-            <property name="eclipselink.jdbc.cache-statements" value="true"/>
-            <property name="eclipselink.jdbc.cache-statements.size" value="200"/>
+            <!-- NOTE: eclipselink.jdbc.cache-statements must NOT be set here.   -->
+            <!-- hmisPU uses transaction-type="JTA" with an external Payara     -->
+            <!-- connection pool; EclipseLink's internal statement cache        -->
+            <!-- conflicts with external pooling and can cause premature        -->
+            <!-- statement closure. Configure statement caching on the Payara   -->
+            <!-- pool instead: Admin Console → pool → statement-cache-size=200, -->
+            <!-- or add cachePrepStmts=true to the MySQL Connector/J URL.       -->
 
-            <!-- Allow per-expression parameter binding decisions instead of    -->
-            <!-- per-query, giving the optimizer more flexibility.              -->
-            <property name="eclipselink.jdbc.allow-partial-bind-parameters" value="true"/>
-
-            <!-- Increase shared L2 cache from the default 100 objects per      -->
-            <!-- entity class to 5000. The default causes constant eviction     -->
-            <!-- for frequently-looked-up entities (departments, items, users), -->
-            <!-- forcing unnecessary DB round trips on every cache miss.        -->
-            <property name="eclipselink.cache.size.default" value="5000"/>
+            <!-- Increase shared L2 cache default from 100 → 1000 per entity   -->
+            <!-- class. 100 causes constant eviction for reference data         -->
+            <!-- (departments, items, users); 1000 gives breathing room without -->
+            <!-- the heap risk of a blanket 5000 across all 188 entity classes. -->
+            <!-- For the busiest reference entities (Department, Item, WebUser, -->
+            <!-- Fee) add @Cache(size=5000) on those classes individually.      -->
+            <property name="eclipselink.cache.size.default" value="1000"/>
 
             <!-- Skip re-reading LOB columns (description, filters, columns,   -->
             <!-- rows, totals on ReportTemplate etc.) when the object is        -->

--- a/src/main/resources/META-INF/persistence.xml
+++ b/src/main/resources/META-INF/persistence.xml
@@ -1,31 +1,41 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<persistence version="2.2" xmlns="http://java.sun.com/xml/ns/persistence" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/persistence http://xmlns.jcp.org/xml/ns/persistence/persistence_2_2.xsd">
+<persistence version="2.2"
+             xmlns="http://java.sun.com/xml/ns/persistence"
+             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+             xsi:schemaLocation="
+        http://xmlns.jcp.org/xml/ns/persistence
+        http://xmlns.jcp.org/xml/ns/persistence/persistence_2_2.xsd">
+
     <persistence-unit name="hmisPU" transaction-type="JTA">
         <provider>org.eclipse.persistence.jpa.PersistenceProvider</provider>
         <jta-data-source>${JDBC_DATASOURCE}</jta-data-source>
         <exclude-unlisted-classes>false</exclude-unlisted-classes>
         <properties>
-            <property name="eclipselink.logging.level.sql" value="SEVERE"/>
-            <property name="eclipselink.logging.level" value="SEVERE"/>
-            <!-- EclipseLink concurrency manager tuning (issue #19397) - Do NOT Remove -->
-            <!-- Reduce cache lock wait from default 900s to 10s to fail fast -->
-            <property name="eclipselink.concurrency.manager.waittime" value="10000"/>
-            <!-- Throw exception instead of silently waiting on cache lock contention -->
-            <property name="eclipselink.concurrency.manager.allow.concurrencyexception" value="true"/>
-            <!-- Log cache contention warnings for early detection -->
-            <property name="eclipselink.concurrency.manager.maxfrequencytodumptinymessage" value="5000"/>
-            <!-- Sequence pre-allocation fix for SEQUENCE table lock contention (issue #19626) - Do NOT Remove -->
-            <!-- Explicit preallocation of 50 reduces database sequence contention in high-throughput environments; -->
-            <!-- without this, each ID allocation acquires a table-level lock causing retail sale slowness -->
-            <property name="eclipselink.sequence.default-sequence-preallocation-size" value="50"/>
+            <property name="eclipselink.logging.level" value="FINEST"/>
+            <property name="eclipselink.logging.parameters" value="true"/>
+            <!-- Generate DDL scripts without applying them -->
+            <property name="eclipselink.ddl-generation" value="create-or-extend-tables"/>
+            <property name="eclipselink.ddl-generation.output-mode" value="sql-script"/>
+            <!-- Use an environment-agnostic path for the application location -->
+            <property name="eclipselink.application-location" value="C:/Development/hmis/tmp"/>
+            <!-- After generation, set ddl-generation to 'none' -->
+            <!-- <property name="eclipselink.ddl-generation" value="none"/> -->
+
         </properties>
     </persistence-unit>
     <persistence-unit name="hmisAuditPU" transaction-type="JTA">
         <jta-data-source>${JDBC_AUDIT_DATASOURCE}</jta-data-source>
         <exclude-unlisted-classes>false</exclude-unlisted-classes>
         <properties>
-            <property name="eclipselink.logging.level.sql" value="SEVERE"/>
-            <property name="eclipselink.logging.level" value="SEVERE"/>
+            <property name="eclipselink.logging.level" value="FINEST"/>
+            <property name="eclipselink.logging.parameters" value="true"/>
+            <!-- Generate DDL scripts without applying them -->
+            <property name="eclipselink.ddl-generation" value="create-or-extend-tables"/>
+            <property name="eclipselink.ddl-generation.output-mode" value="sql-script"/>
+            <!-- Use an environment-agnostic path for the application location -->
+            <property name="eclipselink.application-location" value="C:/Development/hmis/tmp"/>
+            <!-- After generation, set ddl-generation to 'none' -->
+            <!-- <property name="eclipselink.ddl-generation" value="none"/> -->
         </properties>
     </persistence-unit>
 </persistence>

--- a/src/main/resources/META-INF/persistence.xml
+++ b/src/main/resources/META-INF/persistence.xml
@@ -14,10 +14,11 @@
             <property name="eclipselink.concurrency.manager.allow.concurrencyexception" value="true"/>
             <!-- Log cache contention warnings for early detection -->
             <property name="eclipselink.concurrency.manager.maxfrequencytodumptinymessage" value="5000"/>
-            <!-- Sequence pre-allocation fix for SEQUENCE table lock contention (issue #19626) - Do NOT Remove -->
-            <!-- Explicit preallocation of 50 reduces database sequence contention in high-throughput environments; -->
-            <!-- without this, each ID allocation acquires a table-level lock causing retail sale slowness -->
-            <property name="eclipselink.sequence.default-sequence-preallocation-size" value="50"/>
+            <!-- JDBC batch writing for UPDATE/DELETE statements (issue #19985) -->
+            <!-- IDENTITY strategy prevents batching of INSERT statements (EclipseLink limitation), -->
+            <!-- but batch-writing still improves UPDATE and DELETE throughput under concurrent load. -->
+            <property name="eclipselink.jdbc.batch-writing" value="JDBC"/>
+            <property name="eclipselink.jdbc.batch-writing.size" value="100"/>
         </properties>
     </persistence-unit>
     <persistence-unit name="hmisAuditPU" transaction-type="JTA">

--- a/src/main/resources/META-INF/persistence.xml
+++ b/src/main/resources/META-INF/persistence.xml
@@ -14,11 +14,40 @@
             <property name="eclipselink.concurrency.manager.allow.concurrencyexception" value="true"/>
             <!-- Log cache contention warnings for early detection -->
             <property name="eclipselink.concurrency.manager.maxfrequencytodumptinymessage" value="5000"/>
-            <!-- JDBC batch writing for UPDATE/DELETE statements (issue #19985) -->
-            <!-- IDENTITY strategy prevents batching of INSERT statements (EclipseLink limitation), -->
-            <!-- but batch-writing still improves UPDATE and DELETE throughput under concurrent load. -->
+            <!-- ================================================================ -->
+            <!-- PERFORMANCE TUNING (issue #19985)                             -->
+            <!-- ================================================================ -->
+
+            <!-- JDBC batch writing for UPDATE/DELETE statements.               -->
+            <!-- IDENTITY strategy prevents batching of INSERT statements       -->
+            <!-- (EclipseLink limitation), but batch-writing still improves     -->
+            <!-- UPDATE and DELETE throughput under concurrent load.            -->
+            <!-- IMPORTANT: requires rewriteBatchedStatements=true on the       -->
+            <!-- Payara JDBC pool — without it MySQL silently ignores batching. -->
             <property name="eclipselink.jdbc.batch-writing" value="JDBC"/>
-            <property name="eclipselink.jdbc.batch-writing.size" value="100"/>
+            <property name="eclipselink.jdbc.batch-writing.size" value="1000"/>
+
+            <!-- Prepared statement cache: reuse parsed SQL instead of          -->
+            <!-- re-sending to the DB engine on every request. High impact for  -->
+            <!-- a system with repetitive billing, pharmacy and lab queries.     -->
+            <property name="eclipselink.jdbc.cache-statements" value="true"/>
+            <property name="eclipselink.jdbc.cache-statements.size" value="200"/>
+
+            <!-- Allow per-expression parameter binding decisions instead of    -->
+            <!-- per-query, giving the optimizer more flexibility.              -->
+            <property name="eclipselink.jdbc.allow-partial-bind-parameters" value="true"/>
+
+            <!-- Increase shared L2 cache from the default 100 objects per      -->
+            <!-- entity class to 5000. The default causes constant eviction     -->
+            <!-- for frequently-looked-up entities (departments, items, users), -->
+            <!-- forcing unnecessary DB round trips on every cache miss.        -->
+            <property name="eclipselink.cache.size.default" value="5000"/>
+
+            <!-- Skip re-reading LOB columns (description, filters, columns,   -->
+            <!-- rows, totals on ReportTemplate etc.) when the object is        -->
+            <!-- already in the L2 cache. Avoids fetching large blobs on        -->
+            <!-- every cache hit.                                               -->
+            <property name="eclipselink.jdbc.result-set-access-optimization" value="true"/>
         </properties>
     </persistence-unit>
     <persistence-unit name="hmisAuditPU" transaction-type="JTA">

--- a/src/main/resources/META-INF/persistence_for_database_generation_script.xml
+++ b/src/main/resources/META-INF/persistence_for_database_generation_script.xml
@@ -16,8 +16,8 @@
             <!-- Generate DDL scripts without applying them -->
             <property name="eclipselink.ddl-generation" value="create-or-extend-tables"/>
             <property name="eclipselink.ddl-generation.output-mode" value="sql-script"/>
-            <!-- Use an environment-agnostic path for the application location -->
-            <property name="eclipselink.application-location" value="C:/Development/hmis/tmp"/>
+            <!-- Set eclipselink.application-location to your local output dir before running -->
+            <property name="eclipselink.application-location" value="${DDL_OUTPUT_DIR}"/>
             <!-- After generation, set ddl-generation to 'none' -->
             <!-- <property name="eclipselink.ddl-generation" value="none"/> -->
 
@@ -32,8 +32,8 @@
             <!-- Generate DDL scripts without applying them -->
             <property name="eclipselink.ddl-generation" value="create-or-extend-tables"/>
             <property name="eclipselink.ddl-generation.output-mode" value="sql-script"/>
-            <!-- Use an environment-agnostic path for the application location -->
-            <property name="eclipselink.application-location" value="C:/Development/hmis/tmp"/>
+            <!-- Set eclipselink.application-location to your local output dir before running -->
+            <property name="eclipselink.application-location" value="${DDL_OUTPUT_DIR}"/>
             <!-- After generation, set ddl-generation to 'none' -->
             <!-- <property name="eclipselink.ddl-generation" value="none"/> -->
         </properties>

--- a/src/main/resources/META-INF/persistence_for_database_generation_script.xml
+++ b/src/main/resources/META-INF/persistence_for_database_generation_script.xml
@@ -8,7 +8,7 @@
 
     <persistence-unit name="hmisPU" transaction-type="JTA">
         <provider>org.eclipse.persistence.jpa.PersistenceProvider</provider>
-        <jta-data-source>jdbc/coop</jta-data-source>
+        <jta-data-source>${JDBC_DATASOURCE}</jta-data-source>
         <exclude-unlisted-classes>false</exclude-unlisted-classes>
         <properties>
             <property name="eclipselink.logging.level" value="FINEST"/>
@@ -17,14 +17,14 @@
             <property name="eclipselink.ddl-generation" value="create-or-extend-tables"/>
             <property name="eclipselink.ddl-generation.output-mode" value="sql-script"/>
             <!-- Use an environment-agnostic path for the application location -->
-            <property name="eclipselink.application-location" value="/home/buddhika/bin"/>
+            <property name="eclipselink.application-location" value="C:/Development/hmis/tmp"/>
             <!-- After generation, set ddl-generation to 'none' -->
             <!-- <property name="eclipselink.ddl-generation" value="none"/> -->
 
         </properties>
     </persistence-unit>
     <persistence-unit name="hmisAuditPU" transaction-type="JTA">
-        <jta-data-source>jdbc/ruhunuAudit</jta-data-source>
+        <jta-data-source>${JDBC_AUDIT_DATASOURCE}</jta-data-source>
         <exclude-unlisted-classes>false</exclude-unlisted-classes>
         <properties>
             <property name="eclipselink.logging.level" value="FINEST"/>
@@ -33,7 +33,7 @@
             <property name="eclipselink.ddl-generation" value="create-or-extend-tables"/>
             <property name="eclipselink.ddl-generation.output-mode" value="sql-script"/>
             <!-- Use an environment-agnostic path for the application location -->
-            <property name="eclipselink.application-location" value="/home/buddhika/bin"/>
+            <property name="eclipselink.application-location" value="C:/Development/hmis/tmp"/>
             <!-- After generation, set ddl-generation to 'none' -->
             <!-- <property name="eclipselink.ddl-generation" value="none"/> -->
         </properties>

--- a/src/main/webapp/admin/institutions/bank_account.xhtml
+++ b/src/main/webapp/admin/institutions/bank_account.xhtml
@@ -64,8 +64,8 @@
                                     </h:panelGroup>
                                     <p:selectOneMenu
                                         id="cmbIns"
-                                        styleClass="w-100 form-control" 
-                                        value="#{searchController.institution}" 
+                                        styleClass="w-100 form-control"
+                                        value="#{bankAccountController.current.institution}"
                                         filter="true">
                                         <f:selectItem itemLabel="All Institutions" />
                                         <f:selectItems value="#{institutionController.companies}" var="ins" itemLabel="#{ins.name}" itemValue="#{ins}" />
@@ -77,37 +77,35 @@
                                     </h:panelGroup>
                                     <h:panelGroup id="cmbDept">
 
-                                        <!-- Component 1: Without Institution and Site -->
+                                        <!-- Component 1: Without Institution -->
                                         <p:selectOneMenu
-                                            rendered="#{searchController.institution eq null}"
+                                            rendered="#{bankAccountController.current.institution eq null}"
                                             styleClass="w-100 form-control"
-                                            value="#{searchController.department}"
+                                            value="#{bankAccountController.current.department}"
                                             filterMatchMode="contains"
                                             filter="true">
                                             <f:selectItem itemLabel="All Departments" />
-                                            <f:selectItems 
+                                            <f:selectItems
                                                 value="#{departmentController.getDepartmentsOfInstitutionAndSite()}"
                                                 var="d"
                                                 itemLabel="#{d.name}"
                                                 itemValue="#{d}" />
                                         </p:selectOneMenu>
 
-                                        <!-- Component 3: With Institution Only -->
+                                        <!-- Component 2: With Institution -->
                                         <p:selectOneMenu
-                                            rendered="#{searchController.institution ne null}"
+                                            rendered="#{bankAccountController.current.institution ne null}"
                                             styleClass="w-100 form-control"
-                                            value="#{searchController.department}"
+                                            value="#{bankAccountController.current.department}"
                                             filterMatchMode="contains"
                                             filter="true">
                                             <f:selectItem itemLabel="All Departments" />
-                                            <f:selectItems 
-                                                value="#{departmentController.getDepartmentsOfInstitutionAndSiteForInstitution(searchController.institution)}"
+                                            <f:selectItems
+                                                value="#{departmentController.getDepartmentsOfInstitutionAndSiteForInstitution(bankAccountController.current.institution)}"
                                                 var="d"
                                                 itemLabel="#{d.name}"
                                                 itemValue="#{d}" />
                                         </p:selectOneMenu>
-
-                                        
 
                                     </h:panelGroup>
 

--- a/src/main/webapp/admin/institutions/bank_account.xhtml
+++ b/src/main/webapp/admin/institutions/bank_account.xhtml
@@ -73,7 +73,7 @@
                                     </p:selectOneMenu>
                                     <h:panelGroup layout="block" styleClass="form-group">
                                         <h:outputText value="&#xf19c;" styleClass="fa mr-2" /> <!-- FontAwesome building icon -->
-                                        <h:outputLabel value="Department"  class="mx-3"/>
+                                        <h:outputLabel value="Department" for="cmbDept" class="mx-3"/>
                                     </h:panelGroup>
                                     <h:panelGroup id="cmbDept">
 


### PR DESCRIPTION
## Summary

Syncs all recent `development` merges into `coop-prod`.

### Included PRs
- #19995 — Allow shift end without handover acceptance
- #19990 — EclipseLink/Payara performance tuning (#19985)
- #19988 — Skip cash difference validation on shift handover (#19984)
- #19986 — Patch IDENTITY migration side-effects causing production slowness (#19985)
- #19980 — Fix BankAccount institution/department not saved + autocomplete case-mismatch (#19979)
- #19976 — Fix float reset ID boundary (#19972)
- #19975 — Fix bills-from-shift ID boundary (#19971)
- #19974 — Fix cashbook ID boundary (#19970)
- #19973 — Fix shift summary ID boundary (#19969)
- #19966 — Fix handover ID boundary (#19965)
- #19964 — Allow shift end without handover acceptance (config option) (#19963)
- #19962 — GRN generateBillComponent bulk queries (#19961)
- #19948 — Guard Update Database against empty DDL; add lastUpdateAt to WebUserRolePrivilege/WebUserRoleUser (#19947)

## Test plan
- [ ] Verify shift handover and shift end flows work correctly
- [ ] Verify GRN costing page loads without N+1 slowness
- [ ] Verify cashbook and float reset totals are correct after deployment
- [ ] Confirm BankAccount saves institution/department correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)