### PR TITLE
fix: prevent duplicate OPD bill numbers caused by stale query cache in BillNumberGenerator

### DIFF
--- a/src/main/java/com/divudi/ejb/BillNumberGenerator.java
+++ b/src/main/java/com/divudi/ejb/BillNumberGenerator.java
@@ -749,7 +749,7 @@ public class BillNumberGenerator {
         }
         jpql += " order by b.id desc";
         hm.put("yr", currentYear);
-        BillNumber billNumber = billNumberFacade.findFirstByJpql(jpql, hm);
+        BillNumber billNumber = billNumberFacade.findFreshByJpql(jpql, hm);
 
         if (billNumber == null) {
             billNumber = new BillNumber();
@@ -801,7 +801,7 @@ public class BillNumberGenerator {
         }
         jpql += " order by b.id desc";
         hm.put("yr", currentYear);
-        BillNumber billNumber = billNumberFacade.findFirstByJpql(jpql, hm);
+        BillNumber billNumber = billNumberFacade.findFreshByJpql(jpql, hm);
         if (billNumber == null) {
             billNumber = new BillNumber();
             billNumber.setBillTypeAtomic(null);


### PR DESCRIPTION
## Summary

- `fetchLastBillNumberSynchronizedSingleNumber` and `fetchLastBillNumberSynchronizedForOpdAndInpatientBatchBills` in `BillNumberGenerator.java` were calling `findFirstByJpql` without cache-bypass hints
- EclipseLink's shared query result cache could return a stale `BillNumber` entity, causing two concurrent cashiers to read the same `lastBillNumber` and be issued identical bill numbers
- Changed both to `findFreshByJpql` (sets `retrieveMode=BYPASS` + `storeMode=REFRESH`), matching how `fetchLastBillNumberSynchronized` already handles shift/fund bills correctly

## Root Cause

When two cashiers bill concurrently in the same department with `OPD Bill Number Generation Strategy - Single Number for OPD and Inpatient Investigations and Services = true`, the second cashier's generator read a stale cached `lastBillNumber` value from before the first cashier's bills, resulting in already-issued numbers being re-issued.

Observed at Galle Co-operative Hospital on 2026-04-17: 11 duplicate individual bill numbers and 11 duplicate batch bill numbers issued between two concurrent cashiers.

## Files Changed

- `src/main/java/com/divudi/ejb/BillNumberGenerator.java`: 2 lines changed (`findFirstByJpql` → `findFreshByJpql` at lines 752 and 804)

## Test plan

- [ ] Two cashiers billing concurrently in the same department should get strictly sequential, non-overlapping bill numbers
- [ ] Shift start/end bill numbers unaffected
- [ ] Single-cashier billing unaffected

Closes #20002

🤖 Generated with [Claude Code](https://claude.com/claude-code)