### PR TITLE
fix: use findFreshByJpql in OPD bill number generator to prevent stal…

### DIFF
--- a/src/main/java/com/divudi/ejb/BillNumberGenerator.java
+++ b/src/main/java/com/divudi/ejb/BillNumberGenerator.java
@@ -749,7 +749,7 @@ public class BillNumberGenerator {
         }
         jpql += " order by b.id desc";
         hm.put("yr", currentYear);
-        BillNumber billNumber = billNumberFacade.findFirstByJpql(jpql, hm);
+        BillNumber billNumber = billNumberFacade.findFreshByJpql(jpql, hm);
 
         if (billNumber == null) {
             billNumber = new BillNumber();
@@ -801,7 +801,7 @@ public class BillNumberGenerator {
         }
         jpql += " order by b.id desc";
         hm.put("yr", currentYear);
-        BillNumber billNumber = billNumberFacade.findFirstByJpql(jpql, hm);
+        BillNumber billNumber = billNumberFacade.findFreshByJpql(jpql, hm);
         if (billNumber == null) {
             billNumber = new BillNumber();
             billNumber.setBillTypeAtomic(null);


### PR DESCRIPTION
…e cache duplicates

fetchLastBillNumberSynchronizedSingleNumber and
fetchLastBillNumberSynchronizedForOpdAndInpatientBatchBills were using findFirstByJpql without cache-bypass hints, allowing EclipseLink's shared query result cache to return a stale BillNumber entity. When two cashiers billed concurrently, the second cashier's generator read the old lastBillNumber value and issued numbers already assigned to the first cashier.

Changed both methods to findFreshByJpql (sets retrieveMode=BYPASS and storeMode=REFRESH), consistent with fetchLastBillNumberSynchronized which already handles shift/fund bills correctly at line 297.

Closes #20002