### PR TITLE
fix: move OPD bill number increment+flush inside lock to prevent duplicates

### DIFF
--- a/src/main/java/com/divudi/ejb/BillNumberGenerator.java
+++ b/src/main/java/com/divudi/ejb/BillNumberGenerator.java
@@ -710,10 +710,34 @@ public class BillNumberGenerator {
     }
 
     // Special method for Single Number strategy only
+    // Returns the next serial number, with the increment and flush performed inside the lock.
+    public Long fetchNextSerialForYearSingleNumber(Institution institution, Department toDepartment, List<BillTypeAtomic> billTypes) {
+        String lockKey = getLockKey(institution, toDepartment, billTypes);
+        ReentrantLock lock = lockMap.computeIfAbsent(lockKey, k -> new ReentrantLock());
+        lock.lock();
+        try {
+            return incrementAndFlushSingleNumber(toDepartment, billTypes);
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    // Returns the next serial number, with the increment and flush performed inside the lock.
+    public Long fetchNextSerialForYearOpdAndInpatientServiceBatchBills(Department department, List<BillTypeAtomic> billTypes) {
+        String lockKey = getLockKey(department, billTypes);
+        ReentrantLock lock = lockMap.computeIfAbsent(lockKey, k -> new ReentrantLock());
+        lock.lock();
+        try {
+            return incrementAndFlushBatchBills(department, billTypes);
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    // Kept for callers outside the single-number strategy path.
     public BillNumber fetchLastBillNumberForYearSingleNumber(Institution institution, Department toDepartment, List<BillTypeAtomic> billTypes) {
         String lockKey = getLockKey(institution, toDepartment, billTypes);
         ReentrantLock lock = lockMap.computeIfAbsent(lockKey, k -> new ReentrantLock());
-
         lock.lock();
         try {
             return fetchLastBillNumberSynchronizedSingleNumber(toDepartment, billTypes);
@@ -731,6 +755,24 @@ public class BillNumberGenerator {
         } finally {
             lock.unlock();
         }
+    }
+
+    // Fetches, increments, and flushes the individual-bill counter inside the caller's lock.
+    private Long incrementAndFlushSingleNumber(Department department, List<BillTypeAtomic> billTypes) {
+        BillNumber billNumber = fetchLastBillNumberSynchronizedSingleNumber(department, billTypes);
+        Long next = billNumber.getLastBillNumber() + 1;
+        billNumber.setLastBillNumber(next);
+        billNumberFacade.editAndFlush(billNumber);
+        return next;
+    }
+
+    // Fetches, increments, and flushes the batch-bill counter inside the caller's lock.
+    private Long incrementAndFlushBatchBills(Department department, List<BillTypeAtomic> billTypes) {
+        BillNumber billNumber = fetchLastBillNumberSynchronizedForOpdAndInpatientBatchBills(department, billTypes);
+        Long next = billNumber.getLastBillNumber() + 1;
+        billNumber.setLastBillNumber(next);
+        billNumberFacade.editAndFlush(billNumber);
+        return next;
     }
 
     // Special synchronized method for Single Number strategy only
@@ -2591,30 +2633,46 @@ public class BillNumberGenerator {
         boolean opdBillNumberGenerateStrategySingleNumberForOpdAndInpatientInvestigationsAndServices
                 = configOptionApplicationController.getBooleanValueByKey("OPD Bill Number Generation Strategy - Single Number for OPD and Inpatient Investigations and Services", false);
 
+        Long dd;
         if (commonBillNumberForAllDepartmentsInstitutionsBillTypeAtomic) {
             billNumber = fetchLastBillNumberForYear(null, null, billTypes);
+            dd = billNumber.getLastBillNumber() + 1;
+            billNumber.setLastBillNumber(dd);
+            billNumberFacade.edit(billNumber);
         } else if (separateBillNumberForAllDepartmentsInstitutionsBillTypeAtomic) {
             billNumber = fetchLastBillNumberForYear(dep.getInstitution(), dep, billTypes);
+            dd = billNumber.getLastBillNumber() + 1;
+            billNumber.setLastBillNumber(dd);
+            billNumberFacade.edit(billNumber);
         } else if (separateBillNumberForInstitutionsOnly) {
             billNumber = fetchLastBillNumberForYear(dep.getInstitution(), null, billTypes);
+            dd = billNumber.getLastBillNumber() + 1;
+            billNumber.setLastBillNumber(dd);
+            billNumberFacade.edit(billNumber);
         } else if (separateBillNumberForDepartmentsOnly) {
             billNumber = fetchLastBillNumberForYear(null, dep, billTypes);
+            dd = billNumber.getLastBillNumber() + 1;
+            billNumber.setLastBillNumber(dd);
+            billNumberFacade.edit(billNumber);
         } else if (separateBillNumberForBillTypesOnly) {
             billNumber = fetchLastBillNumberForYear(null, null, billTypes);
+            dd = billNumber.getLastBillNumber() + 1;
+            billNumber.setLastBillNumber(dd);
+            billNumberFacade.edit(billNumber);
         } else if (opdBillNumberGenerateStrategyForFromDepartmentAndToDepartmentCombination) {
             billNumber = fetchLastBillNumberForYear(null, dep, billTypes); //TODO: Correct this in a seperate issue
+            dd = billNumber.getLastBillNumber() + 1;
+            billNumber.setLastBillNumber(dd);
+            billNumberFacade.edit(billNumber);
         } else if (opdBillNumberGenerateStrategySingleNumberForOpdAndInpatientInvestigationsAndServices) {
-            billNumber = fetchLastBillNumberForYearSingleNumber(null, dep, billTypes);
+            // increment + flush happens inside the lock — no separate edit() needed
+            dd = fetchNextSerialForYearSingleNumber(null, dep, billTypes);
         } else {
             billNumber = fetchLastBillNumberForYear(dep.getInstitution());
+            dd = billNumber.getLastBillNumber() + 1;
+            billNumber.setLastBillNumber(dd);
+            billNumberFacade.edit(billNumber);
         }
-
-        Long dd = billNumber.getLastBillNumber();
-        dd = dd + 1;
-
-        billNumber.setLastBillNumber(dd);
-
-        billNumberFacade.edit(billNumber);
 
         StringBuilder result = new StringBuilder();
 
@@ -2656,13 +2714,8 @@ public class BillNumberGenerator {
     }
 
     public String departmentBatchBillNumberGeneratorYearlyForInpatientAndOpdServices(Department dep, List<BillTypeAtomic> billTypes) {
-        BillNumber billNumber = fetchLastBillNumberSynchronizedForOpdAndInpatientBatchBillForYear(dep, billTypes);
-
-        Long dd = billNumber.getLastBillNumber();
-        dd = dd + 1;
-        billNumber.setLastBillNumber(dd);
-
-        billNumberFacade.edit(billNumber);
+        // increment + flush happen inside the lock via fetchNextSerialForYearOpdAndInpatientServiceBatchBills
+        Long dd = fetchNextSerialForYearOpdAndInpatientServiceBatchBills(dep, billTypes);
 
         StringBuilder result = new StringBuilder();
 


### PR DESCRIPTION
## Summary

- The previous fix (#20003) ensured a fresh DB read but the increment and `edit()` still happened **outside the lock**, allowing two concurrent sessions to both read the same `lastBillNumber` and emit the same bill number
- `edit()` uses `merge()` without flush — the DB row is not updated until transaction commit, making it invisible to concurrent readers even after the write
- This fix introduces `incrementAndFlushSingleNumber()` and `incrementAndFlushBatchBills()` that perform the full **read → increment → flush** atomically **inside the `ReentrantLock`**

## Root Cause

```
lock.lock()
  fetch BillNumber entity          ← was protected
lock.unlock()

dd = billNumber.getLastBillNumber() + 1   ← NOT protected
billNumber.setLastBillNumber(dd)          ← NOT protected
billNumberFacade.edit(billNumber)         ← merge() only, no flush
```

Two sessions 2+ minutes apart can both see the same `lastBillNumber` because the first session's `edit()` hasn't flushed to DB yet.

## Fix

Both `departmentBillNumberGeneratorYearly` (single-number branch) and `departmentBatchBillNumberGeneratorYearlyForInpatientAndOpdServices` now call new methods that hold the lock for the entire read-increment-flush sequence using `editAndFlush()`.

## Files Changed

- `src/main/java/com/divudi/ejb/BillNumberGenerator.java`

Closes #20002

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved concurrency handling for bill number generation to prevent race conditions during simultaneous requests.
  * Enhanced sequential numbering reliability for single-number billing strategy.

* **Improvements**
  * Optimized batch bill generation for OPD and inpatient services with better synchronization mechanisms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->