### PR TITLE
19914-need-to-improve-collection-centre-reports-print--print-pdf-excel

### DIFF
--- a/src/main/java/com/divudi/bean/report/ReportController.java
+++ b/src/main/java/com/divudi/bean/report/ReportController.java
@@ -3045,7 +3045,20 @@ public class ReportController implements Serializable, ControllerWithReportFilte
                 table.addCell(textCell(row.getBillItem().getBill().getFromInstitution().getRoute()!= null ? row.getBillItem().getBill().getFromInstitution().getRoute().getName() : "-",bodyFontSmall));
                 table.addCell(textCell(row.getBillItem().getBill().getReferredInstituteOrDoctor()!=null ? row.getBillItem().getBill().getReferredInstituteOrDoctor().getName() : "-",bodyFontSmall));
                 table.addCell(textCell(row.getInvestigation()!= null ? row.getInvestigation().getName() : "-",bodyFontSmall));
-                table.addCell(textCell(row.getStatus()!= null ? row.getStatus().getLabel() : "-",bodyFontSmall));
+                StringBuilder statusBuilder = new StringBuilder();
+                statusBuilder.append(row.getStatus() != null ? row.getStatus().getLabel() : "-");
+
+                if (row.getBillItem() != null 
+                        && row.getBillItem().getBill() != null) {
+                    if (Boolean.TRUE.equals(row.getBillItem().getBill().isCancelled())) {
+                        statusBuilder.append(" [Cancelled]");
+                    }
+                    if (Boolean.TRUE.equals(row.getBillItem().getBill().isRefunded())) {
+                        statusBuilder.append(" [Refunded]");
+                    }
+                }
+                
+                table.addCell(textCell(statusBuilder.toString(),bodyFontSmall));
                 table.addCell(textCell(row.getPrintingUser()!= null ? row.getPrintingUser().getName() : "-",bodyFontSmall));
                 table.addCell(textCell(row.getPrintingAt() != null ? sdf.format(row.getPrintingAt()) : "-",bodyFontSmall));
                 indexNumber+=1;

--- a/src/main/webapp/reports/collectionCenterReports/collection_center_report_print.xhtml
+++ b/src/main/webapp/reports/collectionCenterReports/collection_center_report_print.xhtml
@@ -420,7 +420,7 @@
                             <p:outputLabel value="#{patientInvestigation.investigation.name}"/>
                         </p:column>
 
-                        <p:column headerText="Status" >
+                        <p:column headerText="Status" exportValue="#{patientInvestigation.status}#{patientInvestigation.billItem.bill.cancelled ? ' [Cancelled]' : ''}#{patientInvestigation.billItem.bill.refunded ? ' [Refunded]' : ''}">
                             <h:outputLabel value="#{patientInvestigation.status}"/>
                             <p:badge value="Cancelled" severity="warning" rendered="#{patientInvestigation.billItem.bill.cancelled}" ></p:badge>
                             <p:badge value="Refunded" severity="warning" rendered="#{patientInvestigation.billItem.bill.refunded}" ></p:badge>


### PR DESCRIPTION
Added cancelled and refunded status on status column
changed files
01) collection_center_report_print.xhtml (added exportValue attribute to show what want to export)
02) reportController (changed pdf generation method to give correct status)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced collection center report status information. Exported reports now include "[Cancelled]" and "[Refunded]" status suffixes to clearly indicate bill modifications, improving visibility into transaction changes and supporting better financial record auditability. This enhancement applies to report exports only; the on-screen display of collection center reports remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->