### PR TITLE
feat: Staff Welfare report enhancements — summary by staff and full payment breakdown (#20011)

### DIFF
--- a/src/main/java/com/divudi/bean/report/ServiceSummery.java
+++ b/src/main/java/com/divudi/bean/report/ServiceSummery.java
@@ -23,6 +23,9 @@ import com.divudi.core.entity.Institution;
 import com.divudi.core.entity.Item;
 import com.divudi.core.entity.ItemFee;
 import com.divudi.core.data.dto.StaffWelfarePaymentDTO;
+import com.divudi.core.data.dto.StaffWelfareSummaryDTO;
+import com.divudi.core.data.dto.StaffWelfarePaymentBreakdownDTO;
+import com.divudi.core.data.dto.StaffWelfarePaymentBreakdownSummaryDTO;
 import com.divudi.core.entity.Payment;
 import com.divudi.core.entity.RefundBill;
 import com.divudi.core.entity.ServiceCategory;
@@ -102,6 +105,9 @@ public class ServiceSummery implements Serializable {
     private List<BillItem> billItems;
     private List<Payment> payments;
     private List<StaffWelfarePaymentDTO> staffWelfarePayments;
+    private List<StaffWelfareSummaryDTO> staffWelfareSummary;
+    private List<StaffWelfarePaymentBreakdownDTO> staffWelfarePaymentBreakdown;
+    private List<StaffWelfarePaymentBreakdownSummaryDTO> staffWelfarePaymentBreakdownSummary;
     private List<Staff> staffs;
     private List<Bill> bills;
     private List<String1Value5> string1Value5;
@@ -1020,6 +1026,149 @@ public class ServiceSummery implements Serializable {
     public void setStaffWelfarePayments(List<StaffWelfarePaymentDTO> staffWelfarePayments) {
         this.staffWelfarePayments = staffWelfarePayments;
     }
+
+    /**
+     * Report 1b: Staff Welfare Summary grouped by staff.
+     * Aggregates gross, discount and paid value per staff member
+     * from payments where paymentMethod = Staff_Welfare.
+     */
+    public void opdPharmacyStaffWelfareSummaryDto() {
+        String jpql = "SELECT new com.divudi.core.data.dto.StaffWelfareSummaryDTO("
+                + " st.epfNo,"
+                + " per.title,"
+                + " per.name,"
+                + " SUM(b.total * (p.paidValue / b.netTotal)),"
+                + " SUM(b.discount * (p.paidValue / b.netTotal)),"
+                + " SUM(p.paidValue))"
+                + " FROM Payment p"
+                + " JOIN p.bill b"
+                + " JOIN b.toStaff st"
+                + " JOIN st.person per"
+                + " WHERE p.retired = false"
+                + " AND p.paymentMethod = :pm"
+                + " AND b.retired = false"
+                + " AND b.createdAt BETWEEN :fd AND :td"
+                + " AND b.billTypeAtomic IN :btas"
+                + " GROUP BY st.epfNo, per.title, per.name"
+                + " ORDER BY per.name";
+
+        Map<String, Object> m = new HashMap<>();
+        m.put("fd", fromDate);
+        m.put("td", toDate);
+        m.put("pm", PaymentMethod.Staff_Welfare);
+        m.put("btas", billService.fetchBillTypeAtomicsForPharmacyRetailSaleAndOpdSaleBills());
+
+        if (staff != null) {
+            jpql = jpql.replace(" GROUP BY", " AND st.id = :staffId GROUP BY");
+            m.put("staffId", staff.getId());
+        }
+
+        staffWelfareSummary = (List<StaffWelfareSummaryDTO>) paymentFacade.findLightsByJpql(jpql, m, TemporalType.TIMESTAMP);
+
+        totalBill = staffWelfareSummary.stream().mapToDouble(StaffWelfareSummaryDTO::getTotalGrossAmount).sum();
+        discountBill = staffWelfareSummary.stream().mapToDouble(StaffWelfareSummaryDTO::getTotalDiscount).sum();
+        netTotalBill = staffWelfareSummary.stream().mapToDouble(StaffWelfareSummaryDTO::getTotalPaidValue).sum();
+    }
+
+    /**
+     * Report 2: All payments on bills that have at least one Staff_Welfare payment.
+     * Shows every payment method used per bill, not just Staff_Welfare.
+     */
+    public void opdPharmacyStaffWelfarePaymentBreakdownDto() {
+        String jpql = "SELECT new com.divudi.core.data.dto.StaffWelfarePaymentBreakdownDTO("
+                + " b.deptId,"
+                + " st.epfNo,"
+                + " per.title,"
+                + " per.name,"
+                + " p.paymentMethod,"
+                + " p.paidValue)"
+                + " FROM Payment p"
+                + " JOIN p.bill b"
+                + " JOIN b.toStaff st"
+                + " JOIN st.person per"
+                + " WHERE p.retired = false"
+                + " AND b.retired = false"
+                + " AND b.createdAt BETWEEN :fd AND :td"
+                + " AND b.billTypeAtomic IN :btas"
+                + " AND b.id IN ("
+                + "   SELECT DISTINCT b2.id FROM Payment p2 JOIN p2.bill b2"
+                + "   WHERE p2.retired = false AND p2.paymentMethod = :pm"
+                + "   AND b2.retired = false AND b2.createdAt BETWEEN :fd AND :td"
+                + "   AND b2.billTypeAtomic IN :btas"
+                + " )"
+                + " ORDER BY b.id, p.paymentMethod";
+
+        Map<String, Object> m = new HashMap<>();
+        m.put("fd", fromDate);
+        m.put("td", toDate);
+        m.put("pm", PaymentMethod.Staff_Welfare);
+        m.put("btas", billService.fetchBillTypeAtomicsForPharmacyRetailSaleAndOpdSaleBills());
+
+        if (staff != null) {
+            jpql = jpql.replace(" ORDER BY", " AND st.id = :staffId ORDER BY");
+            m.put("staffId", staff.getId());
+        }
+
+        staffWelfarePaymentBreakdown = (List<StaffWelfarePaymentBreakdownDTO>) paymentFacade.findLightsByJpql(jpql, m, TemporalType.TIMESTAMP);
+
+        netTotalBill = staffWelfarePaymentBreakdown.stream().mapToDouble(StaffWelfarePaymentBreakdownDTO::getPaidValue).sum();
+        totalBill = 0.0;
+        discountBill = 0.0;
+    }
+
+    /**
+     * Report 2b: Summary of payment breakdown grouped by staff.
+     * Sums paidValue across ALL payment methods on staff welfare bills, per staff.
+     */
+    public void opdPharmacyStaffWelfarePaymentBreakdownSummaryDto() {
+        String jpql = "SELECT new com.divudi.core.data.dto.StaffWelfarePaymentBreakdownSummaryDTO("
+                + " st.epfNo,"
+                + " per.title,"
+                + " per.name,"
+                + " SUM(p.paidValue))"
+                + " FROM Payment p"
+                + " JOIN p.bill b"
+                + " JOIN b.toStaff st"
+                + " JOIN st.person per"
+                + " WHERE p.retired = false"
+                + " AND b.retired = false"
+                + " AND b.createdAt BETWEEN :fd AND :td"
+                + " AND b.billTypeAtomic IN :btas"
+                + " AND b.id IN ("
+                + "   SELECT DISTINCT b2.id FROM Payment p2 JOIN p2.bill b2"
+                + "   WHERE p2.retired = false AND p2.paymentMethod = :pm"
+                + "   AND b2.retired = false AND b2.createdAt BETWEEN :fd AND :td"
+                + "   AND b2.billTypeAtomic IN :btas"
+                + " )"
+                + " GROUP BY st.epfNo, per.title, per.name"
+                + " ORDER BY per.name";
+
+        Map<String, Object> m = new HashMap<>();
+        m.put("fd", fromDate);
+        m.put("td", toDate);
+        m.put("pm", PaymentMethod.Staff_Welfare);
+        m.put("btas", billService.fetchBillTypeAtomicsForPharmacyRetailSaleAndOpdSaleBills());
+
+        if (staff != null) {
+            jpql = jpql.replace(" GROUP BY", " AND st.id = :staffId GROUP BY");
+            m.put("staffId", staff.getId());
+        }
+
+        staffWelfarePaymentBreakdownSummary = (List<StaffWelfarePaymentBreakdownSummaryDTO>) paymentFacade.findLightsByJpql(jpql, m, TemporalType.TIMESTAMP);
+
+        netTotalBill = staffWelfarePaymentBreakdownSummary.stream().mapToDouble(StaffWelfarePaymentBreakdownSummaryDTO::getTotalPaidValue).sum();
+        totalBill = 0.0;
+        discountBill = 0.0;
+    }
+
+    public List<StaffWelfareSummaryDTO> getStaffWelfareSummary() { return staffWelfareSummary; }
+    public void setStaffWelfareSummary(List<StaffWelfareSummaryDTO> staffWelfareSummary) { this.staffWelfareSummary = staffWelfareSummary; }
+
+    public List<StaffWelfarePaymentBreakdownDTO> getStaffWelfarePaymentBreakdown() { return staffWelfarePaymentBreakdown; }
+    public void setStaffWelfarePaymentBreakdown(List<StaffWelfarePaymentBreakdownDTO> staffWelfarePaymentBreakdown) { this.staffWelfarePaymentBreakdown = staffWelfarePaymentBreakdown; }
+
+    public List<StaffWelfarePaymentBreakdownSummaryDTO> getStaffWelfarePaymentBreakdownSummary() { return staffWelfarePaymentBreakdownSummary; }
+    public void setStaffWelfarePaymentBreakdownSummary(List<StaffWelfarePaymentBreakdownSummaryDTO> staffWelfarePaymentBreakdownSummary) { this.staffWelfarePaymentBreakdownSummary = staffWelfarePaymentBreakdownSummary; }
 
     public void fixDiscountsAndMarginsInRows(List<Payment> payments) {
         for (Payment ir : payments) {

--- a/src/main/java/com/divudi/core/data/dto/StaffWelfarePaymentBreakdownDTO.java
+++ b/src/main/java/com/divudi/core/data/dto/StaffWelfarePaymentBreakdownDTO.java
@@ -1,0 +1,53 @@
+package com.divudi.core.data.dto;
+
+import com.divudi.core.data.PaymentMethod;
+import com.divudi.core.data.Title;
+import java.io.Serializable;
+
+/**
+ * DTO for Staff Welfare Payment Breakdown report — one row per payment,
+ * for all payments on bills that have at least one Staff_Welfare payment.
+ * Shows every payment method used, not just Staff_Welfare.
+ */
+public class StaffWelfarePaymentBreakdownDTO implements Serializable {
+
+    private String billDeptId;
+    private String staffEpfNo;
+    private Title staffTitle;
+    private String staffName;
+    private PaymentMethod paymentMethod;
+    private Double paidValue;
+
+    public StaffWelfarePaymentBreakdownDTO(
+            String billDeptId,
+            String staffEpfNo,
+            Title staffTitle,
+            String staffName,
+            PaymentMethod paymentMethod,
+            Double paidValue) {
+        this.billDeptId = billDeptId;
+        this.staffEpfNo = staffEpfNo;
+        this.staffTitle = staffTitle;
+        this.staffName = staffName;
+        this.paymentMethod = paymentMethod;
+        this.paidValue = paidValue != null ? paidValue : 0.0;
+    }
+
+    public String getStaffNameWithTitle() {
+        if (staffTitle != null) {
+            return staffTitle.name().replace("_", " ") + ". " + (staffName != null ? staffName : "");
+        }
+        return staffName != null ? staffName : "";
+    }
+
+    public String getPaymentMethodLabel() {
+        return paymentMethod != null ? paymentMethod.getLabel() : "";
+    }
+
+    public String getBillDeptId() { return billDeptId; }
+    public String getStaffEpfNo() { return staffEpfNo; }
+    public Title getStaffTitle() { return staffTitle; }
+    public String getStaffName() { return staffName; }
+    public PaymentMethod getPaymentMethod() { return paymentMethod; }
+    public Double getPaidValue() { return paidValue; }
+}

--- a/src/main/java/com/divudi/core/data/dto/StaffWelfarePaymentBreakdownSummaryDTO.java
+++ b/src/main/java/com/divudi/core/data/dto/StaffWelfarePaymentBreakdownSummaryDTO.java
@@ -1,0 +1,39 @@
+package com.divudi.core.data.dto;
+
+import com.divudi.core.data.Title;
+import java.io.Serializable;
+
+/**
+ * DTO for Staff Welfare Payment Breakdown Summary — one row per staff,
+ * summing paidValue across ALL payment methods on their staff welfare bills.
+ */
+public class StaffWelfarePaymentBreakdownSummaryDTO implements Serializable {
+
+    private String staffEpfNo;
+    private Title staffTitle;
+    private String staffName;
+    private Double totalPaidValue;
+
+    public StaffWelfarePaymentBreakdownSummaryDTO(
+            String staffEpfNo,
+            Title staffTitle,
+            String staffName,
+            Double totalPaidValue) {
+        this.staffEpfNo = staffEpfNo;
+        this.staffTitle = staffTitle;
+        this.staffName = staffName;
+        this.totalPaidValue = totalPaidValue != null ? totalPaidValue : 0.0;
+    }
+
+    public String getStaffNameWithTitle() {
+        if (staffTitle != null) {
+            return staffTitle.name().replace("_", " ") + ". " + (staffName != null ? staffName : "");
+        }
+        return staffName != null ? staffName : "";
+    }
+
+    public String getStaffEpfNo() { return staffEpfNo; }
+    public Title getStaffTitle() { return staffTitle; }
+    public String getStaffName() { return staffName; }
+    public Double getTotalPaidValue() { return totalPaidValue; }
+}

--- a/src/main/java/com/divudi/core/data/dto/StaffWelfareSummaryDTO.java
+++ b/src/main/java/com/divudi/core/data/dto/StaffWelfareSummaryDTO.java
@@ -1,0 +1,47 @@
+package com.divudi.core.data.dto;
+
+import com.divudi.core.data.Title;
+import java.io.Serializable;
+
+/**
+ * DTO for Staff Welfare Summary report — one row per staff member,
+ * aggregating paidValue across all Staff_Welfare payments.
+ */
+public class StaffWelfareSummaryDTO implements Serializable {
+
+    private String staffEpfNo;
+    private Title staffTitle;
+    private String staffName;
+    private Double totalGrossAmount;
+    private Double totalDiscount;
+    private Double totalPaidValue;
+
+    public StaffWelfareSummaryDTO(
+            String staffEpfNo,
+            Title staffTitle,
+            String staffName,
+            Double totalGrossAmount,
+            Double totalDiscount,
+            Double totalPaidValue) {
+        this.staffEpfNo = staffEpfNo;
+        this.staffTitle = staffTitle;
+        this.staffName = staffName;
+        this.totalGrossAmount = totalGrossAmount != null ? totalGrossAmount : 0.0;
+        this.totalDiscount = totalDiscount != null ? totalDiscount : 0.0;
+        this.totalPaidValue = totalPaidValue != null ? totalPaidValue : 0.0;
+    }
+
+    public String getStaffNameWithTitle() {
+        if (staffTitle != null) {
+            return staffTitle.name().replace("_", " ") + ". " + (staffName != null ? staffName : "");
+        }
+        return staffName != null ? staffName : "";
+    }
+
+    public String getStaffEpfNo() { return staffEpfNo; }
+    public Title getStaffTitle() { return staffTitle; }
+    public String getStaffName() { return staffName; }
+    public Double getTotalGrossAmount() { return totalGrossAmount; }
+    public Double getTotalDiscount() { return totalDiscount; }
+    public Double getTotalPaidValue() { return totalPaidValue; }
+}

--- a/src/main/webapp/reportInstitution/report_opd_pharmacy_staff_welfare_payments.xhtml
+++ b/src/main/webapp/reportInstitution/report_opd_pharmacy_staff_welfare_payments.xhtml
@@ -1,0 +1,127 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<!DOCTYPE composition PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<ui:composition xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
+                template="/reportInstitution/report_own.xhtml"
+                xmlns:h="http://xmlns.jcp.org/jsf/html"
+                xmlns:p="http://primefaces.org/ui"
+                xmlns:f="http://xmlns.jcp.org/jsf/core">
+
+    <ui:define name="subcontent">
+        <h:form>
+            <p:panel>
+                <f:facet name="header">
+                    <h:outputLabel value="All Payments on Staff Welfare Bills — Detail"/>
+                </f:facet>
+                <h:panelGrid columns="2" class="my-2">
+                    <h:outputLabel value="From Date"/>
+                    <p:calendar class="w-100 mx-4" inputStyleClass="w-100" id="frmDate"
+                                value="#{serviceSummery.fromDate}" pattern="dd MMMM yyyy  HH:mm:ss"/>
+
+                    <h:outputLabel value="To Date"/>
+                    <p:calendar class="w-100 mx-4" inputStyleClass="w-100" id="toDate"
+                                value="#{serviceSummery.toDate}" pattern="dd MMMM yyyy  HH:mm:ss"/>
+
+                    <h:outputLabel value="Staff (optional)"/>
+                    <p:autoComplete
+                        completeMethod="#{staffController.completeStaffWithoutDoctors}"
+                        class="w-100 mx-4"
+                        inputStyleClass="w-100"
+                        value="#{serviceSummery.staff}"
+                        var="w"
+                        scrollHeight="450"
+                        itemLabel="#{w.person.name}"
+                        itemValue="#{w}">
+                        <p:column headerText="Name">
+                            <h:outputText value="#{w.person.nameWithTitle}"/>
+                        </p:column>
+                        <p:column headerText="Code">
+                            <h:outputText value="#{w.staffCode}"/>
+                        </p:column>
+                    </p:autoComplete>
+                </h:panelGrid>
+                <h:panelGrid columns="6" class="my-2">
+                    <p:commandButton id="btnRefresh" value="Process" ajax="false"
+                                     class="ui-button-info m-1" icon="fas fa-cogs"
+                                     action="#{serviceSummery.opdPharmacyStaffWelfarePaymentBreakdownDto}"/>
+                    <p:defaultCommand target="btnRefresh"/>
+
+                    <p:commandButton value="Excel" ajax="false" class="ui-button-success m-1" icon="fas fa-file-excel">
+                        <p:dataExporter type="xlsx" target="tblBreakdown" fileName="Staff_Welfare_Payments"/>
+                    </p:commandButton>
+
+                    <p:commandButton value="Reports Menu" ajax="false" class="ui-button-secondary m-1"
+                                     icon="pi pi-home"
+                                     action="/reportInstitution/report_own?faces-redirect=true"/>
+                </h:panelGrid>
+
+                <p:panel styleClass="summeryBorder">
+                    <p:dataTable id="tblBreakdown"
+                                 rowIndexVar="i"
+                                 value="#{serviceSummery.staffWelfarePaymentBreakdown}"
+                                 var="row">
+
+                        <f:facet name="header">
+                            <h:outputLabel value="All Payments on Staff Welfare Bills"/>
+                            <h:outputLabel value="&emsp;&emsp;From : &nbsp;" style="white-space:pre-line;"/>
+                            <h:outputLabel value="#{serviceSummery.fromDate}">
+                                <f:convertDateTime pattern="dd MMMM yyyy hh:mm:ss a"/>
+                            </h:outputLabel>
+                            <h:outputLabel value="&emsp;&emsp;To : &nbsp;"/>
+                            <h:outputLabel value="#{serviceSummery.toDate}">
+                                <f:convertDateTime pattern="dd MMMM yyyy hh:mm:ss a"/>
+                            </h:outputLabel>
+                        </f:facet>
+
+                        <p:column headerText="No">
+                            <f:facet name="header"><p:outputLabel value="No"/></f:facet>
+                            <h:outputLabel value="#{i + 1}"/>
+                        </p:column>
+
+                        <p:column headerText="Bill No">
+                            <f:facet name="header"><p:outputLabel value="Bill No"/></f:facet>
+                            <p:outputLabel value="#{row.billDeptId}"/>
+                        </p:column>
+
+                        <p:column headerText="Staff EPF No"
+                                  filterBy="#{row.staffEpfNo}"
+                                  filterMatchMode="contains">
+                            <f:facet name="header"><p:outputLabel value="Staff EPF No"/></f:facet>
+                            <p:outputLabel value="#{row.staffEpfNo}"/>
+                        </p:column>
+
+                        <p:column headerText="Staff Name"
+                                  filterBy="#{row.staffNameWithTitle}"
+                                  filterMatchMode="contains">
+                            <f:facet name="header"><p:outputLabel value="Staff Name"/></f:facet>
+                            <p:outputLabel value="#{row.staffNameWithTitle}"/>
+                        </p:column>
+
+                        <p:column headerText="Payment Method"
+                                  filterBy="#{row.paymentMethodLabel}"
+                                  filterMatchMode="contains">
+                            <f:facet name="header"><p:outputLabel value="Payment Method"/></f:facet>
+                            <p:outputLabel value="#{row.paymentMethodLabel}"/>
+                        </p:column>
+
+                        <p:column headerText="Paid Value" style="text-align: right">
+                            <f:facet name="header"><p:outputLabel value="Paid Value"/></f:facet>
+                            <p:outputLabel value="#{row.paidValue}">
+                                <f:convertNumber pattern="#,##0.00"/>
+                            </p:outputLabel>
+                            <f:facet name="footer">
+                                <h:outputLabel value="#{serviceSummery.netTotalBill}">
+                                    <f:convertNumber pattern="#,##0.00"/>
+                                </h:outputLabel>
+                            </f:facet>
+                        </p:column>
+
+                        <f:facet name="footer">
+                            <h:outputLabel value="Printed By : #{sessionController.loggedUser.webUserPerson.name}" style="float: right"/>
+                        </f:facet>
+                    </p:dataTable>
+                </p:panel>
+            </p:panel>
+        </h:form>
+    </ui:define>
+
+</ui:composition>

--- a/src/main/webapp/reportInstitution/report_opd_pharmacy_staff_welfare_payments_summary.xhtml
+++ b/src/main/webapp/reportInstitution/report_opd_pharmacy_staff_welfare_payments_summary.xhtml
@@ -1,0 +1,115 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<!DOCTYPE composition PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<ui:composition xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
+                template="/reportInstitution/report_own.xhtml"
+                xmlns:h="http://xmlns.jcp.org/jsf/html"
+                xmlns:p="http://primefaces.org/ui"
+                xmlns:f="http://xmlns.jcp.org/jsf/core">
+
+    <ui:define name="subcontent">
+        <h:form>
+            <p:panel>
+                <f:facet name="header">
+                    <h:outputLabel value="All Payments on Staff Welfare Bills — Summary by Staff"/>
+                </f:facet>
+                <h:panelGrid columns="2" class="my-2">
+                    <h:outputLabel value="From Date"/>
+                    <p:calendar class="w-100 mx-4" inputStyleClass="w-100" id="frmDate"
+                                value="#{serviceSummery.fromDate}" pattern="dd MMMM yyyy  HH:mm:ss"/>
+
+                    <h:outputLabel value="To Date"/>
+                    <p:calendar class="w-100 mx-4" inputStyleClass="w-100" id="toDate"
+                                value="#{serviceSummery.toDate}" pattern="dd MMMM yyyy  HH:mm:ss"/>
+
+                    <h:outputLabel value="Staff (optional)"/>
+                    <p:autoComplete
+                        completeMethod="#{staffController.completeStaffWithoutDoctors}"
+                        class="w-100 mx-4"
+                        inputStyleClass="w-100"
+                        value="#{serviceSummery.staff}"
+                        var="w"
+                        scrollHeight="450"
+                        itemLabel="#{w.person.name}"
+                        itemValue="#{w}">
+                        <p:column headerText="Name">
+                            <h:outputText value="#{w.person.nameWithTitle}"/>
+                        </p:column>
+                        <p:column headerText="Code">
+                            <h:outputText value="#{w.staffCode}"/>
+                        </p:column>
+                    </p:autoComplete>
+                </h:panelGrid>
+                <h:panelGrid columns="6" class="my-2">
+                    <p:commandButton id="btnRefresh" value="Process" ajax="false"
+                                     class="ui-button-info m-1" icon="fas fa-cogs"
+                                     action="#{serviceSummery.opdPharmacyStaffWelfarePaymentBreakdownSummaryDto}"/>
+                    <p:defaultCommand target="btnRefresh"/>
+
+                    <p:commandButton value="Excel" ajax="false" class="ui-button-success m-1" icon="fas fa-file-excel">
+                        <p:dataExporter type="xlsx" target="tblBreakdownSummary" fileName="Staff_Welfare_Payments_Summary"/>
+                    </p:commandButton>
+
+                    <p:commandButton value="Reports Menu" ajax="false" class="ui-button-secondary m-1"
+                                     icon="pi pi-home"
+                                     action="/reportInstitution/report_own?faces-redirect=true"/>
+                </h:panelGrid>
+
+                <p:panel styleClass="summeryBorder">
+                    <p:dataTable id="tblBreakdownSummary"
+                                 rowIndexVar="i"
+                                 value="#{serviceSummery.staffWelfarePaymentBreakdownSummary}"
+                                 var="row">
+
+                        <f:facet name="header">
+                            <h:outputLabel value="All Payments on Staff Welfare Bills — Summary by Staff"/>
+                            <h:outputLabel value="&emsp;&emsp;From : &nbsp;" style="white-space:pre-line;"/>
+                            <h:outputLabel value="#{serviceSummery.fromDate}">
+                                <f:convertDateTime pattern="dd MMMM yyyy hh:mm:ss a"/>
+                            </h:outputLabel>
+                            <h:outputLabel value="&emsp;&emsp;To : &nbsp;"/>
+                            <h:outputLabel value="#{serviceSummery.toDate}">
+                                <f:convertDateTime pattern="dd MMMM yyyy hh:mm:ss a"/>
+                            </h:outputLabel>
+                        </f:facet>
+
+                        <p:column headerText="No">
+                            <f:facet name="header"><p:outputLabel value="No"/></f:facet>
+                            <h:outputLabel value="#{i + 1}"/>
+                        </p:column>
+
+                        <p:column headerText="Staff EPF No"
+                                  filterBy="#{row.staffEpfNo}"
+                                  filterMatchMode="contains">
+                            <f:facet name="header"><p:outputLabel value="Staff EPF No"/></f:facet>
+                            <p:outputLabel value="#{row.staffEpfNo}"/>
+                        </p:column>
+
+                        <p:column headerText="Staff Name"
+                                  filterBy="#{row.staffNameWithTitle}"
+                                  filterMatchMode="contains">
+                            <f:facet name="header"><p:outputLabel value="Staff Name"/></f:facet>
+                            <p:outputLabel value="#{row.staffNameWithTitle}"/>
+                        </p:column>
+
+                        <p:column headerText="Total Paid Value" style="text-align: right">
+                            <f:facet name="header"><p:outputLabel value="Total Paid Value"/></f:facet>
+                            <p:outputLabel value="#{row.totalPaidValue}">
+                                <f:convertNumber pattern="#,##0.00"/>
+                            </p:outputLabel>
+                            <f:facet name="footer">
+                                <h:outputLabel value="#{serviceSummery.netTotalBill}">
+                                    <f:convertNumber pattern="#,##0.00"/>
+                                </h:outputLabel>
+                            </f:facet>
+                        </p:column>
+
+                        <f:facet name="footer">
+                            <h:outputLabel value="Printed By : #{sessionController.loggedUser.webUserPerson.name}" style="float: right"/>
+                        </f:facet>
+                    </p:dataTable>
+                </p:panel>
+            </p:panel>
+        </h:form>
+    </ui:define>
+
+</ui:composition>

--- a/src/main/webapp/reportInstitution/report_opd_pharmacy_staff_welfare_summary.xhtml
+++ b/src/main/webapp/reportInstitution/report_opd_pharmacy_staff_welfare_summary.xhtml
@@ -4,25 +4,22 @@
                 template="/reportInstitution/report_own.xhtml"
                 xmlns:h="http://xmlns.jcp.org/jsf/html"
                 xmlns:p="http://primefaces.org/ui"
-                xmlns:f="http://xmlns.jcp.org/jsf/core"
-                xmlns:ca="http://xmlns.jcp.org/jsf/composite/cashSummery"
-                >
+                xmlns:f="http://xmlns.jcp.org/jsf/core">
 
     <ui:define name="subcontent">
-        <!--        <h:outputStylesheet library="css" name="printing.css"></h:outputStylesheet>-->
         <h:form>
             <p:panel>
-                <f:facet name="header" >                
-                    <h:outputLabel value="OPD And Pharmacy Staff Welfare Bills"/>
+                <f:facet name="header">
+                    <h:outputLabel value="OPD And Pharmacy Staff Welfare Bills — Summary by Staff"/>
                 </f:facet>
                 <h:panelGrid columns="2" class="my-2">
                     <h:outputLabel value="From Date"/>
-                    <p:calendar class="w-100 mx-4" inputStyleClass="w-100" id="frmDate" value="#{serviceSummery.fromDate}" pattern="dd MMMM yyyy  HH:mm:ss" >
-                    </p:calendar>
+                    <p:calendar class="w-100 mx-4" inputStyleClass="w-100" id="frmDate"
+                                value="#{serviceSummery.fromDate}" pattern="dd MMMM yyyy  HH:mm:ss"/>
 
                     <h:outputLabel value="To Date"/>
-                    <p:calendar class="w-100 mx-4" inputStyleClass="w-100" id="toDate" value="#{serviceSummery.toDate}" pattern="dd MMMM yyyy  HH:mm:ss" >
-                    </p:calendar>
+                    <p:calendar class="w-100 mx-4" inputStyleClass="w-100" id="toDate"
+                                value="#{serviceSummery.toDate}" pattern="dd MMMM yyyy  HH:mm:ss"/>
 
                     <h:outputLabel value="Staff (optional)"/>
                     <p:autoComplete
@@ -42,87 +39,61 @@
                         </p:column>
                     </p:autoComplete>
                 </h:panelGrid>
-                <h:panelGrid columns="6" class="my-2" >
+                <h:panelGrid columns="6" class="my-2">
                     <p:commandButton id="btnRefresh" value="Process" ajax="false"
                                      class="ui-button-info m-1" icon="fas fa-cogs"
-                                     action="#{serviceSummery.opdPharmacyStaffWelfarePaymentsDto}"/>
+                                     action="#{serviceSummery.opdPharmacyStaffWelfareSummaryDto}"/>
                     <p:defaultCommand target="btnRefresh"/>
 
-                    <p:commandButton
-                        value="To Print"
-                        ajax="false"
-                        styleClass="ui-button-warning m-1"
-                        action="report_opd_pharmacy_staff_welfare_print?faces-redirect=true"
-                        icon="pi pi-print">
-                    </p:commandButton>
-
                     <p:commandButton value="Excel" ajax="false" class="ui-button-success m-1" icon="fas fa-file-excel">
-                        <p:dataExporter type="xlsx" target="opd" fileName="Staff_Welfare"/>
+                        <p:dataExporter type="xlsx" target="tblSummary" fileName="Staff_Welfare_Summary"/>
                     </p:commandButton>
 
                     <p:commandButton value="Reports Menu" ajax="false" class="ui-button-secondary m-1"
                                      icon="pi pi-home"
                                      action="/reportInstitution/report_own?faces-redirect=true"/>
                 </h:panelGrid>
-                <p:panel id="panelPrint"  styleClass="summeryBorder">
-                    <p:dataTable
-                        id="opd"
-                        rowIndexVar="i"
-                        value="#{serviceSummery.staffWelfarePayments}"
-                        var="p">
+
+                <p:panel styleClass="summeryBorder">
+                    <p:dataTable id="tblSummary"
+                                 rowIndexVar="i"
+                                 value="#{serviceSummery.staffWelfareSummary}"
+                                 var="row">
 
                         <f:facet name="header">
-                            <h:outputLabel value="Staff Welfare Payments" />
-                            <h:outputLabel value="&emsp;&emsp;From : &nbsp;" style="white-space:pre-line;" />
+                            <h:outputLabel value="Staff Welfare Summary"/>
+                            <h:outputLabel value="&emsp;&emsp;From : &nbsp;" style="white-space:pre-line;"/>
                             <h:outputLabel value="#{serviceSummery.fromDate}">
-                                <f:convertDateTime pattern="dd MMMM yyyy hh:mm:ss a" />
+                                <f:convertDateTime pattern="dd MMMM yyyy hh:mm:ss a"/>
                             </h:outputLabel>
-                            <h:outputLabel value="&emsp;&emsp;To : &nbsp;" />
+                            <h:outputLabel value="&emsp;&emsp;To : &nbsp;"/>
                             <h:outputLabel value="#{serviceSummery.toDate}">
-                                <f:convertDateTime pattern="dd MMMM yyyy hh:mm:ss a" />
+                                <f:convertDateTime pattern="dd MMMM yyyy hh:mm:ss a"/>
                             </h:outputLabel>
                         </f:facet>
 
                         <p:column headerText="No">
                             <f:facet name="header"><p:outputLabel value="No"/></f:facet>
-                            <h:outputLabel value="#{i + 1}" />
-                        </p:column>
-
-                        <p:column headerText="Bill No">
-                            <f:facet name="header"><p:outputLabel value="Bill No"/></f:facet>
-                            <p:outputLabel value="#{p.billDeptId}" />
+                            <h:outputLabel value="#{i + 1}"/>
                         </p:column>
 
                         <p:column headerText="Staff EPF No"
-                                  filterBy="#{p.staffEpfNo}"
+                                  filterBy="#{row.staffEpfNo}"
                                   filterMatchMode="contains">
                             <f:facet name="header"><p:outputLabel value="Staff EPF No"/></f:facet>
-                            <p:outputLabel value="#{p.staffEpfNo}" />
+                            <p:outputLabel value="#{row.staffEpfNo}"/>
                         </p:column>
 
                         <p:column headerText="Staff Name"
-                                  filterBy="#{p.staffNameWithTitle}"
+                                  filterBy="#{row.staffNameWithTitle}"
                                   filterMatchMode="contains">
                             <f:facet name="header"><p:outputLabel value="Staff Name"/></f:facet>
-                            <p:outputLabel value="#{p.staffNameWithTitle}" />
-                        </p:column>
-
-                        <p:column headerText="Bill Type">
-                            <f:facet name="header"><p:outputLabel value="Bill Type"/></f:facet>
-                            <p:outputLabel value="Pharmacy Bill" rendered="#{p.pharmacyBill}" />
-                            <p:outputLabel value="OPD Bill" rendered="#{not p.pharmacyBill}" />
-                        </p:column>
-
-                        <p:column headerText="Date">
-                            <f:facet name="header"><p:outputLabel value="Date"/></f:facet>
-                            <h:outputLabel value="#{p.createdAt}">
-                                <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateFormat}" />
-                            </h:outputLabel>
+                            <p:outputLabel value="#{row.staffNameWithTitle}"/>
                         </p:column>
 
                         <p:column headerText="Gross Amount" style="text-align: right">
                             <f:facet name="header"><p:outputLabel value="Gross Amount"/></f:facet>
-                            <p:outputLabel value="#{p.grossAmount}">
+                            <p:outputLabel value="#{row.totalGrossAmount}">
                                 <f:convertNumber pattern="#,##0.00"/>
                             </p:outputLabel>
                             <f:facet name="footer">
@@ -134,7 +105,7 @@
 
                         <p:column headerText="Discount" style="text-align: right">
                             <f:facet name="header"><p:outputLabel value="Discount"/></f:facet>
-                            <p:outputLabel value="#{commonFunctionsProxy.reverseSign(p.discountValue)}">
+                            <p:outputLabel value="#{commonFunctionsProxy.reverseSign(row.totalDiscount)}">
                                 <f:convertNumber pattern="#,##0.00"/>
                             </p:outputLabel>
                             <f:facet name="footer">
@@ -146,7 +117,7 @@
 
                         <p:column headerText="Net Amount" style="text-align: right">
                             <f:facet name="header"><p:outputLabel value="Net Amount"/></f:facet>
-                            <p:outputLabel value="#{p.paidValue}">
+                            <p:outputLabel value="#{row.totalPaidValue}">
                                 <f:convertNumber pattern="#,##0.00"/>
                             </p:outputLabel>
                             <f:facet name="footer">
@@ -160,13 +131,9 @@
                             <h:outputLabel value="Printed By : #{sessionController.loggedUser.webUserPerson.name}" style="float: right"/>
                         </f:facet>
                     </p:dataTable>
-
-
                 </p:panel>
             </p:panel>
         </h:form>
-
     </ui:define>
-
 
 </ui:composition>

--- a/src/main/webapp/reportInstitution/report_own.xhtml
+++ b/src/main/webapp/reportInstitution/report_own.xhtml
@@ -89,8 +89,11 @@
                                     <p:tab title="Staff Credit" >
                                         <div class="d-grid gap-2">
 
-                                            <p:commandButton class="w-100" ajax="false" value="Staff Welfare" action="report_opd_pharmacy_staff_welfare" /> 
-                                            <p:commandButton class="w-100" ajax="false" value="OPD Cash Credit Bill Report" action="report_opd_cash_credit_by _institution" /> 
+                                            <p:commandButton class="w-100" ajax="false" value="Staff Welfare" action="report_opd_pharmacy_staff_welfare" />
+                                            <p:commandButton class="w-100" ajax="false" value="Staff Welfare — Summary by Staff" action="report_opd_pharmacy_staff_welfare_summary" />
+                                            <p:commandButton class="w-100" ajax="false" value="Staff Welfare Bill Payments — Detail" action="report_opd_pharmacy_staff_welfare_payments" />
+                                            <p:commandButton class="w-100" ajax="false" value="Staff Welfare Bill Payments — Summary by Staff" action="report_opd_pharmacy_staff_welfare_payments_summary" />
+                                            <p:commandButton class="w-100" ajax="false" value="OPD Cash Credit Bill Report" action="report_opd_cash_credit_by _institution" />
                                             <p:commandButton class="w-100" ajax="false" value="Staff Welfare Balance" action="report_staff_welfare" />
                                         </div>
                                     </p:tab>


### PR DESCRIPTION
## Summary

- Reverts the redundant payment method column added to the existing Staff Welfare detail report (every row was already `Staff_Welfare` due to the query filter — the column added no information)
- Adds a **Reports Menu** nav button to the existing detail report
- Adds three new reports to the Staff Credit tab in `report_own.xhtml`:

| Report | URL | Description |
|--------|-----|-------------|
| Staff Welfare — Summary by Staff | `report_opd_pharmacy_staff_welfare_summary` | Existing `Staff_Welfare` payments grouped by staff with gross, discount, net totals |
| Staff Welfare Bill Payments — Detail | `report_opd_pharmacy_staff_welfare_payments` | All payment rows (all methods) on bills that have at least one `Staff_Welfare` payment |
| Staff Welfare Bill Payments — Summary by Staff | `report_opd_pharmacy_staff_welfare_payments_summary` | Aggregates total paid value per staff across all payment methods on their welfare bills |

## New DTOs
- `StaffWelfareSummaryDTO` — grouped aggregate per staff (gross, discount, paid)
- `StaffWelfarePaymentBreakdownDTO` — one row per payment, all methods
- `StaffWelfarePaymentBreakdownSummaryDTO` — one row per staff, total paid value

## Test plan
- [ ] Verify existing Staff Welfare detail report is unchanged (no payment method column)
- [ ] Summary by Staff shows one row per staff with correct aggregated totals
- [ ] Payment Breakdown Detail shows all payment methods (Cash, Card, Staff Welfare, etc.) for bills that have a Staff Welfare component
- [ ] Payment Breakdown Summary groups correctly by staff with correct total paid values
- [ ] All four reports accessible from `report_own.xhtml` Staff Credit tab
- [ ] Excel export works on each new report
- [ ] Reports Menu button navigates back correctly

Closes #20011

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added three new OPD and pharmacy staff welfare reports: Summary by Staff, All Payments Detail, and Payments Summary
  * Included date-range filtering and optional staff selection for all new reports
  * Enabled Excel export capability for staff welfare report data
  * Added convenient navigation buttons to access reports menu

<!-- end of auto-generated comment: release notes by coderabbit.ai -->