### PR TITLE
feat: REST API for collecting centre item fees management

### DIFF
--- a/src/main/java/com/divudi/core/data/dto/pricing/CollectingCentreFeeCreateRequestDTO.java
+++ b/src/main/java/com/divudi/core/data/dto/pricing/CollectingCentreFeeCreateRequestDTO.java
@@ -1,0 +1,125 @@
+/*
+ * Open Hospital Management Information System
+ * Dr M H B Ariyaratne
+ * buddhika.ari@gmail.com
+ */
+package com.divudi.core.data.dto.pricing;
+
+/**
+ * DTO for creating a new ItemFee for a collecting centre.
+ * Both collectingCentreId and itemId are required.
+ * For feeType OwnInstitution, OtherInstitution, or Referral, departmentId is also required.
+ */
+public class CollectingCentreFeeCreateRequestDTO {
+
+    private Long collectingCentreId; // required — Institution with institutionType=CollectingCentre
+    private Long itemId;             // required — the Item (service/investigation) this fee covers
+    private String name;             // required
+    private String feeType;          // required — FeeType enum value
+    private Double fee;              // required — local fee amount
+    private Double ffee;             // optional, defaults to fee if null or 0
+    private boolean discountAllowed;
+    private Long institutionId;      // optional — contextual institution
+    private Long departmentId;       // required for OwnInstitution/OtherInstitution/Referral fee types
+    private Long specialityId;       // optional — for Staff fee type
+    private Long staffId;            // optional — for Staff fee type
+
+    public CollectingCentreFeeCreateRequestDTO() {
+    }
+
+    public boolean isValid() {
+        return collectingCentreId != null
+                && itemId != null
+                && name != null && !name.trim().isEmpty()
+                && feeType != null && !feeType.trim().isEmpty()
+                && fee != null;
+    }
+
+    public Long getCollectingCentreId() {
+        return collectingCentreId;
+    }
+
+    public void setCollectingCentreId(Long collectingCentreId) {
+        this.collectingCentreId = collectingCentreId;
+    }
+
+    public Long getItemId() {
+        return itemId;
+    }
+
+    public void setItemId(Long itemId) {
+        this.itemId = itemId;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getFeeType() {
+        return feeType;
+    }
+
+    public void setFeeType(String feeType) {
+        this.feeType = feeType;
+    }
+
+    public Double getFee() {
+        return fee;
+    }
+
+    public void setFee(Double fee) {
+        this.fee = fee;
+    }
+
+    public Double getFfee() {
+        return ffee;
+    }
+
+    public void setFfee(Double ffee) {
+        this.ffee = ffee;
+    }
+
+    public boolean isDiscountAllowed() {
+        return discountAllowed;
+    }
+
+    public void setDiscountAllowed(boolean discountAllowed) {
+        this.discountAllowed = discountAllowed;
+    }
+
+    public Long getInstitutionId() {
+        return institutionId;
+    }
+
+    public void setInstitutionId(Long institutionId) {
+        this.institutionId = institutionId;
+    }
+
+    public Long getDepartmentId() {
+        return departmentId;
+    }
+
+    public void setDepartmentId(Long departmentId) {
+        this.departmentId = departmentId;
+    }
+
+    public Long getSpecialityId() {
+        return specialityId;
+    }
+
+    public void setSpecialityId(Long specialityId) {
+        this.specialityId = specialityId;
+    }
+
+    public Long getStaffId() {
+        return staffId;
+    }
+
+    public void setStaffId(Long staffId) {
+        this.staffId = staffId;
+    }
+}

--- a/src/main/java/com/divudi/core/data/dto/pricing/CollectingCentreFeeDTO.java
+++ b/src/main/java/com/divudi/core/data/dto/pricing/CollectingCentreFeeDTO.java
@@ -1,0 +1,213 @@
+/*
+ * Open Hospital Management Information System
+ * Dr M H B Ariyaratne
+ * buddhika.ari@gmail.com
+ */
+package com.divudi.core.data.dto.pricing;
+
+/**
+ * DTO representing a single ItemFee associated with a collecting centre.
+ * Extends the data in ItemFeeDTO by including item and collecting centre
+ * identification fields, since these fees are queried cross-item.
+ */
+public class CollectingCentreFeeDTO {
+
+    private Long id;
+    private String name;
+    private String feeType;
+    private double fee;
+    private double ffee;
+    private boolean discountAllowed;
+    private boolean retired;
+
+    // The collecting centre (forInstitution)
+    private Long collectingCentreId;
+    private String collectingCentreName;
+    private String collectingCentreCode;
+
+    // The item this fee belongs to
+    private Long itemId;
+    private String itemName;
+    private String itemCode;
+
+    // Contextual fee modifiers (institution, department, speciality, staff)
+    private Long institutionId;
+    private String institutionName;
+    private Long departmentId;
+    private String departmentName;
+    private Long specialityId;
+    private String specialityName;
+    private Long staffId;
+    private String staffName;
+
+    public CollectingCentreFeeDTO() {
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getFeeType() {
+        return feeType;
+    }
+
+    public void setFeeType(String feeType) {
+        this.feeType = feeType;
+    }
+
+    public double getFee() {
+        return fee;
+    }
+
+    public void setFee(double fee) {
+        this.fee = fee;
+    }
+
+    public double getFfee() {
+        return ffee;
+    }
+
+    public void setFfee(double ffee) {
+        this.ffee = ffee;
+    }
+
+    public boolean isDiscountAllowed() {
+        return discountAllowed;
+    }
+
+    public void setDiscountAllowed(boolean discountAllowed) {
+        this.discountAllowed = discountAllowed;
+    }
+
+    public boolean isRetired() {
+        return retired;
+    }
+
+    public void setRetired(boolean retired) {
+        this.retired = retired;
+    }
+
+    public Long getCollectingCentreId() {
+        return collectingCentreId;
+    }
+
+    public void setCollectingCentreId(Long collectingCentreId) {
+        this.collectingCentreId = collectingCentreId;
+    }
+
+    public String getCollectingCentreName() {
+        return collectingCentreName;
+    }
+
+    public void setCollectingCentreName(String collectingCentreName) {
+        this.collectingCentreName = collectingCentreName;
+    }
+
+    public String getCollectingCentreCode() {
+        return collectingCentreCode;
+    }
+
+    public void setCollectingCentreCode(String collectingCentreCode) {
+        this.collectingCentreCode = collectingCentreCode;
+    }
+
+    public Long getItemId() {
+        return itemId;
+    }
+
+    public void setItemId(Long itemId) {
+        this.itemId = itemId;
+    }
+
+    public String getItemName() {
+        return itemName;
+    }
+
+    public void setItemName(String itemName) {
+        this.itemName = itemName;
+    }
+
+    public String getItemCode() {
+        return itemCode;
+    }
+
+    public void setItemCode(String itemCode) {
+        this.itemCode = itemCode;
+    }
+
+    public Long getInstitutionId() {
+        return institutionId;
+    }
+
+    public void setInstitutionId(Long institutionId) {
+        this.institutionId = institutionId;
+    }
+
+    public String getInstitutionName() {
+        return institutionName;
+    }
+
+    public void setInstitutionName(String institutionName) {
+        this.institutionName = institutionName;
+    }
+
+    public Long getDepartmentId() {
+        return departmentId;
+    }
+
+    public void setDepartmentId(Long departmentId) {
+        this.departmentId = departmentId;
+    }
+
+    public String getDepartmentName() {
+        return departmentName;
+    }
+
+    public void setDepartmentName(String departmentName) {
+        this.departmentName = departmentName;
+    }
+
+    public Long getSpecialityId() {
+        return specialityId;
+    }
+
+    public void setSpecialityId(Long specialityId) {
+        this.specialityId = specialityId;
+    }
+
+    public String getSpecialityName() {
+        return specialityName;
+    }
+
+    public void setSpecialityName(String specialityName) {
+        this.specialityName = specialityName;
+    }
+
+    public Long getStaffId() {
+        return staffId;
+    }
+
+    public void setStaffId(Long staffId) {
+        this.staffId = staffId;
+    }
+
+    public String getStaffName() {
+        return staffName;
+    }
+
+    public void setStaffName(String staffName) {
+        this.staffName = staffName;
+    }
+}

--- a/src/main/java/com/divudi/core/data/dto/pricing/CollectingCentreFeeDTO.java
+++ b/src/main/java/com/divudi/core/data/dto/pricing/CollectingCentreFeeDTO.java
@@ -15,8 +15,8 @@ public class CollectingCentreFeeDTO {
     private Long id;
     private String name;
     private String feeType;
-    private double fee;
-    private double ffee;
+    private Double fee;
+    private Double ffee;
     private boolean discountAllowed;
     private boolean retired;
 
@@ -67,19 +67,19 @@ public class CollectingCentreFeeDTO {
         this.feeType = feeType;
     }
 
-    public double getFee() {
+    public Double getFee() {
         return fee;
     }
 
-    public void setFee(double fee) {
+    public void setFee(Double fee) {
         this.fee = fee;
     }
 
-    public double getFfee() {
+    public Double getFfee() {
         return ffee;
     }
 
-    public void setFfee(double ffee) {
+    public void setFfee(Double ffee) {
         this.ffee = ffee;
     }
 

--- a/src/main/java/com/divudi/service/AnthropicApiService.java
+++ b/src/main/java/com/divudi/service/AnthropicApiService.java
@@ -788,14 +788,14 @@ public class AnthropicApiService implements Serializable {
                     url = base;
                     httpMethod = "POST";
                     javax.json.JsonObjectBuilder bodyBuilder = Json.createObjectBuilder();
-                    if (ccId != null && !ccId.isEmpty()) bodyBuilder.add("collectingCentreId", Long.parseLong(ccId.trim()));
-                    if (itemId != null && !itemId.isEmpty()) bodyBuilder.add("itemId", Long.parseLong(itemId.trim()));
+                    if (ccId != null && !ccId.trim().isEmpty()) bodyBuilder.add("collectingCentreId", Long.parseLong(ccId.trim()));
+                    if (itemId != null && !itemId.trim().isEmpty()) bodyBuilder.add("itemId", Long.parseLong(itemId.trim()));
                     if (name != null) bodyBuilder.add("name", name);
                     if (feeType != null) bodyBuilder.add("feeType", feeType);
                     if (fee != null && !fee.trim().isEmpty()) bodyBuilder.add("fee", Double.parseDouble(fee.trim()));
-                    if (ffee != null && !ffee.isEmpty()) bodyBuilder.add("ffee", Double.parseDouble(ffee.trim()));
-                    if (departmentId != null && !departmentId.isEmpty()) bodyBuilder.add("departmentId", Long.parseLong(departmentId.trim()));
-                    if (discountAllowed != null) bodyBuilder.add("discountAllowed", Boolean.parseBoolean(discountAllowed.trim()));
+                    if (ffee != null && !ffee.trim().isEmpty()) bodyBuilder.add("ffee", Double.parseDouble(ffee.trim()));
+                    if (departmentId != null && !departmentId.trim().isEmpty()) bodyBuilder.add("departmentId", Long.parseLong(departmentId.trim()));
+                    if (discountAllowed != null && !discountAllowed.trim().isEmpty()) bodyBuilder.add("discountAllowed", Boolean.parseBoolean(discountAllowed.trim()));
                     requestBody = bodyBuilder.build().toString();
                     break;
                 }
@@ -806,10 +806,10 @@ public class AnthropicApiService implements Serializable {
                     javax.json.JsonObjectBuilder bodyBuilder = Json.createObjectBuilder();
                     if (name != null && !name.isEmpty()) bodyBuilder.add("name", name);
                     if (feeType != null && !feeType.isEmpty()) bodyBuilder.add("feeType", feeType);
-                    if (fee != null && !fee.isEmpty()) bodyBuilder.add("fee", Double.parseDouble(fee.trim()));
-                    if (ffee != null && !ffee.isEmpty()) bodyBuilder.add("ffee", Double.parseDouble(ffee.trim()));
-                    if (departmentId != null && !departmentId.isEmpty()) bodyBuilder.add("departmentId", Long.parseLong(departmentId.trim()));
-                    if (discountAllowed != null && !discountAllowed.isEmpty()) bodyBuilder.add("discountAllowed", Boolean.parseBoolean(discountAllowed.trim()));
+                    if (fee != null && !fee.trim().isEmpty()) bodyBuilder.add("fee", Double.parseDouble(fee.trim()));
+                    if (ffee != null && !ffee.trim().isEmpty()) bodyBuilder.add("ffee", Double.parseDouble(ffee.trim()));
+                    if (departmentId != null && !departmentId.trim().isEmpty()) bodyBuilder.add("departmentId", Long.parseLong(departmentId.trim()));
+                    if (discountAllowed != null && !discountAllowed.trim().isEmpty()) bodyBuilder.add("discountAllowed", Boolean.parseBoolean(discountAllowed.trim()));
                     requestBody = bodyBuilder.build().toString();
                     break;
                 }

--- a/src/main/java/com/divudi/service/AnthropicApiService.java
+++ b/src/main/java/com/divudi/service/AnthropicApiService.java
@@ -792,7 +792,7 @@ public class AnthropicApiService implements Serializable {
                     if (itemId != null && !itemId.isEmpty()) bodyBuilder.add("itemId", Long.parseLong(itemId.trim()));
                     if (name != null) bodyBuilder.add("name", name);
                     if (feeType != null) bodyBuilder.add("feeType", feeType);
-                    if (fee != null) bodyBuilder.add("fee", Double.parseDouble(fee.trim()));
+                    if (fee != null && !fee.trim().isEmpty()) bodyBuilder.add("fee", Double.parseDouble(fee.trim()));
                     if (ffee != null && !ffee.isEmpty()) bodyBuilder.add("ffee", Double.parseDouble(ffee.trim()));
                     if (departmentId != null && !departmentId.isEmpty()) bodyBuilder.add("departmentId", Long.parseLong(departmentId.trim()));
                     if (discountAllowed != null) bodyBuilder.add("discountAllowed", Boolean.parseBoolean(discountAllowed.trim()));

--- a/src/main/java/com/divudi/service/AnthropicApiService.java
+++ b/src/main/java/com/divudi/service/AnthropicApiService.java
@@ -349,11 +349,73 @@ public class AnthropicApiService implements Serializable {
                         .add("required", Json.createArrayBuilder().add("method")))
                 .build();
 
+        JsonObject collectingCentreFeesTool = Json.createObjectBuilder()
+                .add("name", "manage_collecting_centre_fees")
+                .add("description",
+                        "List, create, update, retire, or recalculate item fees for a collecting centre. "
+                        + "Use GET to list active fees for a centre (institutionId required). "
+                        + "Use POST to add a new fee (collectingCentreId, itemId, name, feeType, fee required). "
+                        + "Use PUT to update a fee (feeId required). "
+                        + "Use DELETE_ONE to soft-retire a single fee (feeId required). "
+                        + "Use DELETE_ALL to retire all active fees for a collecting centre (institutionId required). "
+                        + "Use RECALCULATE to refresh item totals after bulk changes (institutionId required).")
+                .add("input_schema", Json.createObjectBuilder()
+                        .add("type", "object")
+                        .add("properties", Json.createObjectBuilder()
+                                .add("method", Json.createObjectBuilder()
+                                        .add("type", "string")
+                                        .add("enum", Json.createArrayBuilder()
+                                                .add("GET").add("POST").add("PUT")
+                                                .add("DELETE_ONE").add("DELETE_ALL").add("RECALCULATE"))
+                                        .add("description", "Operation: GET=list, POST=create, PUT=update, DELETE_ONE=retire single fee, DELETE_ALL=retire all fees for CC, RECALCULATE=refresh item totals"))
+                                .add("institutionId", Json.createObjectBuilder()
+                                        .add("type", "string")
+                                        .add("description", "Collecting centre institution ID. Required for GET, DELETE_ALL, RECALCULATE."))
+                                .add("feeId", Json.createObjectBuilder()
+                                        .add("type", "string")
+                                        .add("description", "Fee ID. Required for PUT and DELETE_ONE."))
+                                .add("collectingCentreId", Json.createObjectBuilder()
+                                        .add("type", "string")
+                                        .add("description", "Collecting centre institution ID for POST (body field)."))
+                                .add("itemId", Json.createObjectBuilder()
+                                        .add("type", "string")
+                                        .add("description", "Item (service/investigation) ID. Required for POST."))
+                                .add("name", Json.createObjectBuilder()
+                                        .add("type", "string")
+                                        .add("description", "Fee name. Required for POST; optional for PUT."))
+                                .add("feeType", Json.createObjectBuilder()
+                                        .add("type", "string")
+                                        .add("description", "Fee type enum value, e.g. OwnInstitution, OtherInstitution, Referral, Staff. Required for POST; optional for PUT."))
+                                .add("fee", Json.createObjectBuilder()
+                                        .add("type", "string")
+                                        .add("description", "Local fee amount. Required for POST; optional for PUT."))
+                                .add("ffee", Json.createObjectBuilder()
+                                        .add("type", "string")
+                                        .add("description", "Foreigner fee amount. Optional; defaults to fee if omitted."))
+                                .add("departmentId", Json.createObjectBuilder()
+                                        .add("type", "string")
+                                        .add("description", "Department ID. Required for OwnInstitution/OtherInstitution/Referral fee types."))
+                                .add("discountAllowed", Json.createObjectBuilder()
+                                        .add("type", "string")
+                                        .add("description", "Whether discount is allowed: true or false. Optional."))
+                                .add("query", Json.createObjectBuilder()
+                                        .add("type", "string")
+                                        .add("description", "Filter by item name or code for GET. Optional."))
+                                .add("limit", Json.createObjectBuilder()
+                                        .add("type", "string")
+                                        .add("description", "Max results for GET, default 100. Optional."))
+                                .add("retireComments", Json.createObjectBuilder()
+                                        .add("type", "string")
+                                        .add("description", "Reason for retirement. Optional for DELETE_ONE and DELETE_ALL.")))
+                        .add("required", Json.createArrayBuilder().add("method")))
+                .build();
+
         return Json.createArrayBuilder()
                 .add(searchCodeTool)
                 .add(fetchFileTool)
                 .add(searchConfigTool)
                 .add(clinicalMetadataTool)
+                .add(collectingCentreFeesTool)
                 .build();
     }
 
@@ -397,6 +459,25 @@ public class AnthropicApiService implements Serializable {
                     String size   = toolInput.containsKey("size")  ? toolInput.getString("size", "20") : "20";
                     return callClinicalMetadataApi(method, type, id, name, code, desc, query, page, size,
                             hmisBaseUrl, hmisApiKey);
+                }
+                case "manage_collecting_centre_fees": {
+                    String method          = toolInput.getString("method", "GET");
+                    String institutionId   = toolInput.containsKey("institutionId")     ? toolInput.getString("institutionId", "")     : "";
+                    String feeId           = toolInput.containsKey("feeId")             ? toolInput.getString("feeId", "")             : "";
+                    String ccId            = toolInput.containsKey("collectingCentreId") ? toolInput.getString("collectingCentreId", "") : "";
+                    String itemId          = toolInput.containsKey("itemId")             ? toolInput.getString("itemId", "")            : "";
+                    String name            = toolInput.containsKey("name")              ? toolInput.getString("name", null)             : null;
+                    String feeType         = toolInput.containsKey("feeType")           ? toolInput.getString("feeType", null)          : null;
+                    String fee             = toolInput.containsKey("fee")               ? toolInput.getString("fee", null)              : null;
+                    String ffee            = toolInput.containsKey("ffee")              ? toolInput.getString("ffee", null)             : null;
+                    String departmentId    = toolInput.containsKey("departmentId")      ? toolInput.getString("departmentId", null)     : null;
+                    String discountAllowed = toolInput.containsKey("discountAllowed")   ? toolInput.getString("discountAllowed", null)  : null;
+                    String query           = toolInput.containsKey("query")             ? toolInput.getString("query", "")             : "";
+                    String limit           = toolInput.containsKey("limit")             ? toolInput.getString("limit", "100")          : "100";
+                    String retireComments  = toolInput.containsKey("retireComments")    ? toolInput.getString("retireComments", "")    : "";
+                    return callCollectingCentreFeesApi(method, institutionId, feeId, ccId, itemId,
+                            name, feeType, fee, ffee, departmentId, discountAllowed,
+                            query, limit, retireComments, hmisBaseUrl, hmisApiKey);
                 }
                 default:
                     return "Unknown tool: " + toolName;
@@ -660,6 +741,132 @@ public class AnthropicApiService implements Serializable {
             return "Clinical metadata API call interrupted.";
         } catch (Exception e) {
             return "Clinical metadata API error: " + e.getMessage();
+        }
+    }
+
+    private String callCollectingCentreFeesApi(
+            String method, String institutionId, String feeId, String ccId, String itemId,
+            String name, String feeType, String fee, String ffee, String departmentId,
+            String discountAllowed, String query, String limit, String retireComments,
+            String hmisBaseUrl, String hmisApiKey) {
+
+        if (hmisBaseUrl == null || hmisBaseUrl.trim().isEmpty()) {
+            return "Error: HMIS base URL is not configured.";
+        }
+        if (hmisApiKey == null || hmisApiKey.trim().isEmpty()) {
+            return "Error: No active HMIS API key found for the current user.";
+        }
+
+        try {
+            HttpClient client = HttpClient.newBuilder()
+                    .connectTimeout(Duration.ofSeconds(10))
+                    .build();
+
+            String base = hmisBaseUrl.trim().replaceAll("/+$", "") + "/api/pricing/collecting_centre_fees";
+            String url;
+            String requestBody = null;
+            String httpMethod;
+
+            switch (method.toUpperCase()) {
+                case "GET": {
+                    if (institutionId == null || institutionId.trim().isEmpty()) {
+                        return "Error: institutionId is required for GET.";
+                    }
+                    StringBuilder urlBuilder = new StringBuilder(base)
+                            .append("?institutionId=").append(URLEncoder.encode(institutionId.trim(), StandardCharsets.UTF_8));
+                    if (query != null && !query.isEmpty()) {
+                        urlBuilder.append("&query=").append(URLEncoder.encode(query, StandardCharsets.UTF_8));
+                    }
+                    if (limit != null && !limit.isEmpty()) {
+                        urlBuilder.append("&limit=").append(limit);
+                    }
+                    url = urlBuilder.toString();
+                    httpMethod = "GET";
+                    break;
+                }
+                case "POST": {
+                    url = base;
+                    httpMethod = "POST";
+                    javax.json.JsonObjectBuilder bodyBuilder = Json.createObjectBuilder();
+                    if (ccId != null && !ccId.isEmpty()) bodyBuilder.add("collectingCentreId", Long.parseLong(ccId.trim()));
+                    if (itemId != null && !itemId.isEmpty()) bodyBuilder.add("itemId", Long.parseLong(itemId.trim()));
+                    if (name != null) bodyBuilder.add("name", name);
+                    if (feeType != null) bodyBuilder.add("feeType", feeType);
+                    if (fee != null) bodyBuilder.add("fee", Double.parseDouble(fee.trim()));
+                    if (ffee != null && !ffee.isEmpty()) bodyBuilder.add("ffee", Double.parseDouble(ffee.trim()));
+                    if (departmentId != null && !departmentId.isEmpty()) bodyBuilder.add("departmentId", Long.parseLong(departmentId.trim()));
+                    if (discountAllowed != null) bodyBuilder.add("discountAllowed", Boolean.parseBoolean(discountAllowed.trim()));
+                    requestBody = bodyBuilder.build().toString();
+                    break;
+                }
+                case "PUT": {
+                    if (feeId == null || feeId.trim().isEmpty()) return "Error: feeId is required for PUT.";
+                    url = base + "/" + feeId.trim();
+                    httpMethod = "PUT";
+                    javax.json.JsonObjectBuilder bodyBuilder = Json.createObjectBuilder();
+                    if (name != null && !name.isEmpty()) bodyBuilder.add("name", name);
+                    if (feeType != null && !feeType.isEmpty()) bodyBuilder.add("feeType", feeType);
+                    if (fee != null && !fee.isEmpty()) bodyBuilder.add("fee", Double.parseDouble(fee.trim()));
+                    if (ffee != null && !ffee.isEmpty()) bodyBuilder.add("ffee", Double.parseDouble(ffee.trim()));
+                    if (departmentId != null && !departmentId.isEmpty()) bodyBuilder.add("departmentId", Long.parseLong(departmentId.trim()));
+                    if (discountAllowed != null && !discountAllowed.isEmpty()) bodyBuilder.add("discountAllowed", Boolean.parseBoolean(discountAllowed.trim()));
+                    requestBody = bodyBuilder.build().toString();
+                    break;
+                }
+                case "DELETE_ONE": {
+                    if (feeId == null || feeId.trim().isEmpty()) return "Error: feeId is required for DELETE_ONE.";
+                    StringBuilder urlBuilder = new StringBuilder(base).append("/").append(feeId.trim());
+                    if (retireComments != null && !retireComments.isEmpty()) {
+                        urlBuilder.append("?retireComments=").append(URLEncoder.encode(retireComments, StandardCharsets.UTF_8));
+                    }
+                    url = urlBuilder.toString();
+                    httpMethod = "DELETE";
+                    break;
+                }
+                case "DELETE_ALL": {
+                    if (institutionId == null || institutionId.trim().isEmpty()) return "Error: institutionId is required for DELETE_ALL.";
+                    StringBuilder urlBuilder = new StringBuilder(base)
+                            .append("?institutionId=").append(URLEncoder.encode(institutionId.trim(), StandardCharsets.UTF_8));
+                    if (retireComments != null && !retireComments.isEmpty()) {
+                        urlBuilder.append("&retireComments=").append(URLEncoder.encode(retireComments, StandardCharsets.UTF_8));
+                    }
+                    url = urlBuilder.toString();
+                    httpMethod = "DELETE";
+                    break;
+                }
+                case "RECALCULATE": {
+                    if (institutionId == null || institutionId.trim().isEmpty()) return "Error: institutionId is required for RECALCULATE.";
+                    url = base + "/recalculate?institutionId=" + URLEncoder.encode(institutionId.trim(), StandardCharsets.UTF_8);
+                    httpMethod = "POST";
+                    requestBody = "{}";
+                    break;
+                }
+                default:
+                    return "Error: Unknown method: " + method;
+            }
+
+            HttpRequest.Builder reqBuilder = HttpRequest.newBuilder()
+                    .uri(URI.create(url))
+                    .timeout(Duration.ofSeconds(15))
+                    .header("Finance", hmisApiKey)
+                    .header("Content-Type", "application/json");
+
+            if (requestBody != null) {
+                reqBuilder.method(httpMethod, HttpRequest.BodyPublishers.ofString(requestBody));
+            } else if ("DELETE".equals(httpMethod)) {
+                reqBuilder.DELETE();
+            } else {
+                reqBuilder.GET();
+            }
+
+            HttpResponse<String> response = client.send(reqBuilder.build(), HttpResponse.BodyHandlers.ofString());
+            return "HTTP " + response.statusCode() + "\n" + response.body();
+
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            return "Collecting centre fees API call interrupted.";
+        } catch (Exception e) {
+            return "Collecting centre fees API error: " + e.getMessage();
         }
     }
 
@@ -1117,6 +1324,22 @@ public class AnthropicApiService implements Serializable {
                     {"GET", "/apiMembership/savePatient/{title}/{name}/{sex}/{dob}/{address}/{phone}/{nic}",         "Register a new patient under the membership scheme"},
                     {"GET", "/apiMembership/patient/{patient_id}",                                                  "Get patient details by internal ID"},
                     {"GET", "/apiMembership/serviceValue",                                                           "Get membership service fee, VAT, and total payable amount"}
+                });
+
+        // ── Pricing / Collecting Centre Fees ─────────────────────────────────
+        appendModule(sb, "Collecting Centre Fees", "/pricing/collecting_centre_fees",
+                "Manage item fees for collecting centres (view from the centre perspective). "
+                + "GET lists active fees for a centre. POST adds a new fee. PUT updates a fee. "
+                + "DELETE /{feeId} retires a single fee. DELETE ?institutionId=X retires all fees for a centre. "
+                + "POST /recalculate?institutionId=X recalculates item totals after bulk changes.",
+                null,
+                new String[][]{
+                    {"GET",    "/pricing/collecting_centre_fees?institutionId=X",             "List active fees for a collecting centre. Optional: query, limit"},
+                    {"POST",   "/pricing/collecting_centre_fees",                              "Add a new fee. Body: collectingCentreId, itemId, name, feeType, fee, ffee, departmentId, discountAllowed"},
+                    {"PUT",    "/pricing/collecting_centre_fees/{feeId}",                      "Update a fee. Body: name, fee, ffee, feeType, departmentId, discountAllowed (all optional)"},
+                    {"DELETE", "/pricing/collecting_centre_fees/{feeId}",                      "Soft-retire a single fee. Optional query param: retireComments"},
+                    {"DELETE", "/pricing/collecting_centre_fees?institutionId=X",              "Retire ALL active fees for a collecting centre. Optional query param: retireComments"},
+                    {"POST",   "/pricing/collecting_centre_fees/recalculate?institutionId=X",  "Recalculate item totals for all items with fees for this centre"}
                 });
 
         // ── Inward / Admissions ───────────────────────────────────────────────

--- a/src/main/java/com/divudi/service/pricing/CollectingCentreFeesApiService.java
+++ b/src/main/java/com/divudi/service/pricing/CollectingCentreFeesApiService.java
@@ -88,8 +88,8 @@ public class CollectingCentreFeesApiService implements Serializable {
                 + "AND f.forCategory IS NULL ");
 
         if (query != null && !query.trim().isEmpty()) {
-            jpql.append("AND (UPPER(f.item.name) LIKE :q OR UPPER(f.item.code) LIKE :q) ");
-            params.put("q", "%" + query.trim().toUpperCase() + "%");
+            jpql.append("AND (f.item.name LIKE :q OR f.item.code LIKE :q) ");
+            params.put("q", "%" + query.trim() + "%");
         }
 
         jpql.append("ORDER BY f.item.name, f.name");
@@ -391,6 +391,12 @@ public class CollectingCentreFeesApiService implements Serializable {
         }
         if (fee.isRetired()) {
             throw new Exception("Fee with ID " + feeId + " is already retired");
+        }
+        // Scope guard: only allow mutation of actual collecting-centre fees
+        if (fee.getForInstitution() == null
+                || fee.getForInstitution().getInstitutionType() != InstitutionType.CollectingCentre
+                || fee.getForCategory() != null) {
+            throw new Exception("Fee with ID " + feeId + " is not a collecting centre fee");
         }
         return fee;
     }

--- a/src/main/java/com/divudi/service/pricing/CollectingCentreFeesApiService.java
+++ b/src/main/java/com/divudi/service/pricing/CollectingCentreFeesApiService.java
@@ -1,0 +1,457 @@
+/*
+ * Open Hospital Management Information System
+ * Dr M H B Ariyaratne
+ * buddhika.ari@gmail.com
+ */
+package com.divudi.service.pricing;
+
+import com.divudi.core.data.FeeType;
+import com.divudi.core.data.InstitutionType;
+import com.divudi.core.data.dto.pricing.CollectingCentreFeeCreateRequestDTO;
+import com.divudi.core.data.dto.pricing.CollectingCentreFeeDTO;
+import com.divudi.core.data.dto.service.ItemFeeUpdateRequestDTO;
+import com.divudi.core.entity.Department;
+import com.divudi.core.entity.Institution;
+import com.divudi.core.entity.Item;
+import com.divudi.core.entity.ItemFee;
+import com.divudi.core.entity.Speciality;
+import com.divudi.core.entity.Staff;
+import com.divudi.core.entity.WebUser;
+import com.divudi.core.facade.DepartmentFacade;
+import com.divudi.core.facade.InstitutionFacade;
+import com.divudi.core.facade.ItemFacade;
+import com.divudi.core.facade.ItemFeeFacade;
+import com.divudi.core.facade.SpecialityFacade;
+import com.divudi.core.facade.StaffFacade;
+
+import javax.ejb.EJB;
+import javax.ejb.Stateless;
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Calendar;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Service for Collecting Centre Fees API operations.
+ * Provides business logic for listing, creating, updating, retiring,
+ * and recalculating item fees associated with a specific collecting centre.
+ *
+ * Fees are identified by ItemFee.forInstitution pointing to an Institution
+ * with institutionType = CollectingCentre, and ItemFee.forCategory = null.
+ */
+@Stateless
+public class CollectingCentreFeesApiService implements Serializable {
+
+    @EJB
+    private ItemFeeFacade itemFeeFacade;
+
+    @EJB
+    private InstitutionFacade institutionFacade;
+
+    @EJB
+    private ItemFacade itemFacade;
+
+    @EJB
+    private DepartmentFacade departmentFacade;
+
+    @EJB
+    private SpecialityFacade specialityFacade;
+
+    @EJB
+    private StaffFacade staffFacade;
+
+    // =========================================================================
+    // List
+    // =========================================================================
+
+    /**
+     * List all active (non-retired) fees for the given collecting centre.
+     * Optionally filter by item name/code query.
+     */
+    public List<CollectingCentreFeeDTO> listFeesForCollectingCentre(
+            Long institutionId, String query, int limit) throws Exception {
+
+        Institution cc = loadAndValidateCollectingCentre(institutionId);
+
+        Map<String, Object> params = new HashMap<>();
+        params.put("ret", false);
+        params.put("cc", cc);
+
+        StringBuilder jpql = new StringBuilder(
+                "SELECT f FROM ItemFee f "
+                + "WHERE f.retired = :ret "
+                + "AND f.forInstitution = :cc "
+                + "AND f.forCategory IS NULL ");
+
+        if (query != null && !query.trim().isEmpty()) {
+            jpql.append("AND (UPPER(f.item.name) LIKE :q OR UPPER(f.item.code) LIKE :q) ");
+            params.put("q", "%" + query.trim().toUpperCase() + "%");
+        }
+
+        jpql.append("ORDER BY f.item.name, f.name");
+
+        List<ItemFee> fees = itemFeeFacade.findByJpql(jpql.toString(), params, limit);
+        List<CollectingCentreFeeDTO> dtos = new ArrayList<>();
+        for (ItemFee fee : fees) {
+            dtos.add(buildDTO(fee));
+        }
+        return dtos;
+    }
+
+    // =========================================================================
+    // Create
+    // =========================================================================
+
+    /**
+     * Create a new collecting centre fee.
+     * The collecting centre is set via forInstitution; forCategory is left null.
+     */
+    public CollectingCentreFeeDTO addFee(CollectingCentreFeeCreateRequestDTO request, WebUser user) throws Exception {
+        if (request == null || !request.isValid()) {
+            throw new Exception("Valid request is required: collectingCentreId, itemId, name, feeType, and fee are all required");
+        }
+
+        Institution cc = loadAndValidateCollectingCentre(request.getCollectingCentreId());
+
+        Item item = itemFacade.find(request.getItemId());
+        if (item == null) {
+            throw new Exception("Item not found with ID: " + request.getItemId());
+        }
+        if (item.isRetired()) {
+            throw new Exception("Item with ID " + request.getItemId() + " is retired");
+        }
+
+        FeeType feeType;
+        try {
+            feeType = FeeType.valueOf(request.getFeeType().trim());
+        } catch (IllegalArgumentException e) {
+            throw new Exception("Invalid feeType: " + request.getFeeType());
+        }
+
+        // Department is required for institution-linked fee types
+        boolean requiresDepartment = feeType == FeeType.OtherInstitution
+                || feeType == FeeType.OwnInstitution
+                || feeType == FeeType.Referral;
+
+        ItemFee itemFee = new ItemFee();
+        itemFee.setName(request.getName().trim());
+        itemFee.setFeeType(feeType);
+        itemFee.setFee(request.getFee());
+        itemFee.setFfee(request.getFfee() != null && request.getFfee() > 0
+                ? request.getFfee() : request.getFee());
+        itemFee.setDiscountAllowed(request.isDiscountAllowed());
+        itemFee.setForInstitution(cc);
+        itemFee.setItem(item);
+        itemFee.setCreater(user);
+        itemFee.setCreatedAt(Calendar.getInstance().getTime());
+
+        if (request.getDepartmentId() != null) {
+            Department dept = departmentFacade.find(request.getDepartmentId());
+            if (dept == null) {
+                throw new Exception("Department not found with ID: " + request.getDepartmentId());
+            }
+            itemFee.setDepartment(dept);
+        } else if (requiresDepartment) {
+            throw new Exception("departmentId is required for feeType: " + feeType.name());
+        }
+
+        if (request.getInstitutionId() != null) {
+            Institution inst = institutionFacade.find(request.getInstitutionId());
+            if (inst == null) {
+                throw new Exception("Institution not found with ID: " + request.getInstitutionId());
+            }
+            itemFee.setInstitution(inst);
+        }
+
+        if (request.getSpecialityId() != null) {
+            Speciality speciality = specialityFacade.find(request.getSpecialityId());
+            if (speciality == null) {
+                throw new Exception("Speciality not found with ID: " + request.getSpecialityId());
+            }
+            itemFee.setSpeciality(speciality);
+        }
+
+        if (request.getStaffId() != null) {
+            Staff staff = staffFacade.find(request.getStaffId());
+            if (staff == null) {
+                throw new Exception("Staff not found with ID: " + request.getStaffId());
+            }
+            itemFee.setStaff(staff);
+        }
+
+        itemFeeFacade.create(itemFee);
+        recalculateItemTotal(item);
+
+        return buildDTO(itemFee);
+    }
+
+    // =========================================================================
+    // Update
+    // =========================================================================
+
+    /**
+     * Update an existing collecting centre fee.
+     * Only non-null fields in the request are applied.
+     */
+    public CollectingCentreFeeDTO updateFee(Long feeId, ItemFeeUpdateRequestDTO request, WebUser user) throws Exception {
+        if (request == null || !request.isValid()) {
+            throw new Exception("Valid update request is required (at least one field must be provided)");
+        }
+
+        ItemFee itemFee = loadAndValidateFee(feeId);
+
+        if (request.getName() != null && !request.getName().trim().isEmpty()) {
+            itemFee.setName(request.getName().trim());
+        }
+        if (request.getFeeType() != null && !request.getFeeType().trim().isEmpty()) {
+            try {
+                itemFee.setFeeType(FeeType.valueOf(request.getFeeType().trim()));
+            } catch (IllegalArgumentException e) {
+                throw new Exception("Invalid feeType: " + request.getFeeType());
+            }
+        }
+        if (request.getFee() != null) {
+            itemFee.setFee(request.getFee());
+        }
+        if (request.getFfee() != null) {
+            itemFee.setFfee(request.getFfee());
+        }
+        if (request.getDiscountAllowed() != null) {
+            itemFee.setDiscountAllowed(request.getDiscountAllowed());
+        }
+        if (request.getDepartmentId() != null) {
+            Department dept = departmentFacade.find(request.getDepartmentId());
+            if (dept == null) {
+                throw new Exception("Department not found with ID: " + request.getDepartmentId());
+            }
+            itemFee.setDepartment(dept);
+        }
+        if (request.getInstitutionId() != null) {
+            Institution inst = institutionFacade.find(request.getInstitutionId());
+            if (inst == null) {
+                throw new Exception("Institution not found with ID: " + request.getInstitutionId());
+            }
+            itemFee.setInstitution(inst);
+        }
+        if (request.getSpecialityId() != null) {
+            Speciality speciality = specialityFacade.find(request.getSpecialityId());
+            if (speciality == null) {
+                throw new Exception("Speciality not found with ID: " + request.getSpecialityId());
+            }
+            itemFee.setSpeciality(speciality);
+        }
+        if (request.getStaffId() != null) {
+            Staff staff = staffFacade.find(request.getStaffId());
+            if (staff == null) {
+                throw new Exception("Staff not found with ID: " + request.getStaffId());
+            }
+            itemFee.setStaff(staff);
+        }
+
+        itemFee.setEditer(user);
+        itemFee.setEditedAt(Calendar.getInstance().getTime());
+        itemFeeFacade.edit(itemFee);
+
+        if (itemFee.getItem() != null) {
+            recalculateItemTotal(itemFee.getItem());
+        }
+
+        return buildDTO(itemFee);
+    }
+
+    // =========================================================================
+    // Retire single fee
+    // =========================================================================
+
+    /**
+     * Soft-retire a single collecting centre fee by ID.
+     */
+    public CollectingCentreFeeDTO retireFee(Long feeId, String retireComments, WebUser user) throws Exception {
+        ItemFee itemFee = loadAndValidateFee(feeId);
+
+        itemFee.setRetired(true);
+        itemFee.setRetirer(user);
+        itemFee.setRetiredAt(Calendar.getInstance().getTime());
+        itemFee.setRetireComments(retireComments != null ? retireComments : "");
+        itemFeeFacade.edit(itemFee);
+
+        if (itemFee.getItem() != null) {
+            recalculateItemTotal(itemFee.getItem());
+        }
+
+        return buildDTO(itemFee);
+    }
+
+    // =========================================================================
+    // Retire all fees for a collecting centre
+    // =========================================================================
+
+    /**
+     * Soft-retire ALL active fees for the given collecting centre.
+     * Returns the count of fees retired.
+     */
+    public int retireAllFeesForCollectingCentre(Long institutionId, String retireComments, WebUser user) throws Exception {
+        Institution cc = loadAndValidateCollectingCentre(institutionId);
+
+        String jpql = "SELECT f FROM ItemFee f "
+                + "WHERE f.retired = false "
+                + "AND f.forInstitution = :cc "
+                + "AND f.forCategory IS NULL";
+        Map<String, Object> params = new HashMap<>();
+        params.put("cc", cc);
+
+        List<ItemFee> fees = itemFeeFacade.findByJpql(jpql, params);
+        if (fees == null || fees.isEmpty()) {
+            return 0;
+        }
+
+        Set<Item> affectedItems = new HashSet<>();
+        String comment = retireComments != null ? retireComments : "";
+
+        for (ItemFee fee : fees) {
+            fee.setRetired(true);
+            fee.setRetirer(user);
+            fee.setRetiredAt(Calendar.getInstance().getTime());
+            fee.setRetireComments(comment);
+            itemFeeFacade.edit(fee);
+            if (fee.getItem() != null) {
+                affectedItems.add(fee.getItem());
+            }
+        }
+
+        for (Item item : affectedItems) {
+            recalculateItemTotal(item);
+        }
+
+        return fees.size();
+    }
+
+    // =========================================================================
+    // Recalculate item totals
+    // =========================================================================
+
+    /**
+     * Recalculate the total and totalForForeigner for all items that have
+     * at least one fee (active or retired) linked to the given collecting centre.
+     * This is useful after a bulk retirement to refresh item totals.
+     * Returns the number of items recalculated.
+     */
+    public int recalculateItemTotalsForCollectingCentre(Long institutionId) throws Exception {
+        Institution cc = loadAndValidateCollectingCentre(institutionId);
+
+        // Fetch distinct items that ever had a fee for this CC (including retired fees)
+        String jpql = "SELECT DISTINCT f.item FROM ItemFee f "
+                + "WHERE f.forInstitution = :cc "
+                + "AND f.forCategory IS NULL "
+                + "AND f.item IS NOT NULL";
+        Map<String, Object> params = new HashMap<>();
+        params.put("cc", cc);
+
+        List<Item> items = itemFacade.findByJpql(jpql, params);
+        if (items == null || items.isEmpty()) {
+            return 0;
+        }
+
+        for (Item item : items) {
+            recalculateItemTotal(item);
+        }
+
+        return items.size();
+    }
+
+    // =========================================================================
+    // Helpers
+    // =========================================================================
+
+    private Institution loadAndValidateCollectingCentre(Long institutionId) throws Exception {
+        if (institutionId == null) {
+            throw new Exception("institutionId is required");
+        }
+        Institution cc = institutionFacade.find(institutionId);
+        if (cc == null) {
+            throw new Exception("Institution not found with ID: " + institutionId);
+        }
+        if (cc.getInstitutionType() != InstitutionType.CollectingCentre) {
+            throw new Exception("Institution with ID " + institutionId + " is not a collecting centre");
+        }
+        return cc;
+    }
+
+    private ItemFee loadAndValidateFee(Long feeId) throws Exception {
+        if (feeId == null) {
+            throw new Exception("feeId is required");
+        }
+        ItemFee fee = itemFeeFacade.find(feeId);
+        if (fee == null) {
+            throw new Exception("Fee not found with ID: " + feeId);
+        }
+        if (fee.isRetired()) {
+            throw new Exception("Fee with ID " + feeId + " is already retired");
+        }
+        return fee;
+    }
+
+    /**
+     * Recalculate an item's total and totalForForeigner by summing its active fees.
+     * Mirrors ItemFeeManager.updateFee() logic.
+     */
+    private void recalculateItemTotal(Item item) {
+        String jpql = "SELECT f FROM ItemFee f WHERE f.item = :item AND f.retired = false";
+        Map<String, Object> params = new HashMap<>();
+        params.put("item", item);
+
+        List<ItemFee> activeFees = itemFeeFacade.findByJpql(jpql, params);
+        double total = 0.0;
+        double totalForForeigner = 0.0;
+        for (ItemFee fee : activeFees) {
+            total += fee.getFee();
+            totalForForeigner += fee.getFfee();
+        }
+        item.setTotal(total);
+        item.setTotalForForeigner(totalForForeigner);
+        itemFacade.edit(item);
+    }
+
+    private CollectingCentreFeeDTO buildDTO(ItemFee fee) {
+        CollectingCentreFeeDTO dto = new CollectingCentreFeeDTO();
+        dto.setId(fee.getId());
+        dto.setName(fee.getName());
+        dto.setFeeType(fee.getFeeType() != null ? fee.getFeeType().name() : null);
+        dto.setFee(fee.getFee());
+        dto.setFfee(fee.getFfee());
+        dto.setDiscountAllowed(fee.isDiscountAllowed());
+        dto.setRetired(fee.isRetired());
+
+        if (fee.getForInstitution() != null) {
+            dto.setCollectingCentreId(fee.getForInstitution().getId());
+            dto.setCollectingCentreName(fee.getForInstitution().getName());
+            dto.setCollectingCentreCode(fee.getForInstitution().getCode());
+        }
+        if (fee.getItem() != null) {
+            dto.setItemId(fee.getItem().getId());
+            dto.setItemName(fee.getItem().getName());
+            dto.setItemCode(fee.getItem().getCode());
+        }
+        if (fee.getInstitution() != null) {
+            dto.setInstitutionId(fee.getInstitution().getId());
+            dto.setInstitutionName(fee.getInstitution().getName());
+        }
+        if (fee.getDepartment() != null) {
+            dto.setDepartmentId(fee.getDepartment().getId());
+            dto.setDepartmentName(fee.getDepartment().getName());
+        }
+        if (fee.getSpeciality() != null) {
+            dto.setSpecialityId(fee.getSpeciality().getId());
+            dto.setSpecialityName(fee.getSpeciality().getName());
+        }
+        if (fee.getStaff() != null) {
+            dto.setStaffId(fee.getStaff().getId());
+            dto.setStaffName(fee.getStaff().getName());
+        }
+        return dto;
+    }
+}

--- a/src/main/java/com/divudi/ws/common/ApplicationConfig.java
+++ b/src/main/java/com/divudi/ws/common/ApplicationConfig.java
@@ -69,6 +69,7 @@ public class ApplicationConfig extends Application {
         resources.add(com.divudi.ws.pharmacy.PharmacyGrnBifdBackfillApi.class);
         resources.add(com.divudi.ws.pharmacy.PharmacySearchApi.class);
         resources.add(com.divudi.ws.pharmacy.StockHistoryApi.class);
+        resources.add(com.divudi.ws.pricing.CollectingCentreFeesApi.class);
         resources.add(com.divudi.ws.service.ServiceApi.class);
     }
     

--- a/src/main/java/com/divudi/ws/common/CapabilityStatementResource.java
+++ b/src/main/java/com/divudi/ws/common/CapabilityStatementResource.java
@@ -191,6 +191,16 @@ public class CapabilityStatementResource {
                         "OPD and Inward service management including fees and categories",
                         "API Key",
                         "GET", "POST", "PUT", "PATCH", "DELETE"))
+                .add(resource("Collecting Centre Fees", "/api/pricing/collecting_centre_fees",
+                        "Manage item fees for collecting centres. "
+                        + "GET ?institutionId=X lists all active fees for that centre. "
+                        + "POST creates a new fee (body: collectingCentreId, itemId, name, feeType, fee, ffee, departmentId). "
+                        + "PUT /{feeId} updates a fee. "
+                        + "DELETE /{feeId} soft-retires a single fee. "
+                        + "DELETE ?institutionId=X soft-retires ALL active fees for that centre. "
+                        + "POST /recalculate?institutionId=X recalculates item totals for all items with CC fees.",
+                        "API Key",
+                        "GET", "POST", "PUT", "DELETE"))
                 .add(resource("FHIR Patient", "/api/fhir/Patient",
                         "FHIR R5 Patient search, read, create, update",
                         "API Key (use FHIR header, not Finance)",

--- a/src/main/java/com/divudi/ws/pricing/CollectingCentreFeesApi.java
+++ b/src/main/java/com/divudi/ws/pricing/CollectingCentreFeesApi.java
@@ -1,0 +1,412 @@
+/*
+ * Open Hospital Management Information System
+ * Dr M H B Ariyaratne
+ * buddhika.ari@gmail.com
+ */
+package com.divudi.ws.pricing;
+
+import com.divudi.bean.common.ApiKeyController;
+import com.divudi.core.data.dto.pricing.CollectingCentreFeeCreateRequestDTO;
+import com.divudi.core.data.dto.pricing.CollectingCentreFeeDTO;
+import com.divudi.core.data.dto.service.ItemFeeUpdateRequestDTO;
+import com.divudi.core.entity.WebUser;
+import com.divudi.service.pricing.CollectingCentreFeesApiService;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonSyntaxException;
+
+import javax.enterprise.context.RequestScoped;
+import javax.inject.Inject;
+import javax.servlet.http.HttpServletRequest;
+import javax.ws.rs.*;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.UriInfo;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * REST API for Collecting Centre Item Fees management.
+ *
+ * Provides a collecting-centre-centric view of ItemFee records:
+ * all fees where forInstitution is a CollectingCentre and forCategory is null.
+ *
+ * Complementary to ServiceApi (/api/services/{id}/fees) which is item-centric.
+ *
+ * All operations require a valid Finance API key header.
+ */
+@Path("pricing/collecting_centre_fees")
+@RequestScoped
+public class CollectingCentreFeesApi {
+
+    @Context
+    private HttpServletRequest requestContext;
+
+    @Context
+    private UriInfo uriInfo;
+
+    @Inject
+    private ApiKeyController apiKeyController;
+
+    @Inject
+    private CollectingCentreFeesApiService feesApiService;
+
+    private static final Gson gson = new GsonBuilder()
+            .setDateFormat("yyyy-MM-dd HH:mm:ss")
+            .create();
+
+    // =========================================================================
+    // GET /api/pricing/collecting_centre_fees?institutionId=X[&query=text&limit=50]
+    // =========================================================================
+
+    /**
+     * List all active fees for a collecting centre.
+     * Optionally filter by item name or code.
+     *
+     * @param institutionId required — ID of the collecting centre institution
+     * @param query         optional — filter by item name or code (case-insensitive)
+     * @param limit         optional — max results, default 100, max 500
+     */
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response listFees() {
+        try {
+            String key = requestContext.getHeader("Finance");
+            WebUser user = validateApiKey(key);
+            if (user == null) {
+                return errorResponse("Not a valid key", 401);
+            }
+
+            String institutionIdStr = uriInfo.getQueryParameters().getFirst("institutionId");
+            String query = uriInfo.getQueryParameters().getFirst("query");
+            String limitStr = uriInfo.getQueryParameters().getFirst("limit");
+
+            if (institutionIdStr == null || institutionIdStr.trim().isEmpty()) {
+                return errorResponse("institutionId parameter is required", 400);
+            }
+
+            Long institutionId;
+            try {
+                institutionId = Long.parseLong(institutionIdStr.trim());
+            } catch (NumberFormatException e) {
+                return errorResponse("Invalid institutionId format", 400);
+            }
+
+            int limit = 100;
+            if (limitStr != null && !limitStr.trim().isEmpty()) {
+                try {
+                    int parsed = Integer.parseInt(limitStr.trim());
+                    limit = Math.min(Math.max(parsed, 1), 500);
+                } catch (NumberFormatException e) {
+                    return errorResponse("Invalid limit format", 400);
+                }
+            }
+
+            List<CollectingCentreFeeDTO> fees = feesApiService.listFeesForCollectingCentre(
+                    institutionId, query, limit);
+            return successResponse(fees);
+
+        } catch (Exception e) {
+            String msg = e.getMessage();
+            if (msg != null && msg.contains("not found")) {
+                return errorResponse(msg, 404);
+            }
+            if (msg != null && msg.contains("not a collecting centre")) {
+                return errorResponse(msg, 400);
+            }
+            return errorResponse("An error occurred: " + (msg != null ? msg : "Unknown error"), 500);
+        }
+    }
+
+    // =========================================================================
+    // POST /api/pricing/collecting_centre_fees
+    // =========================================================================
+
+    /**
+     * Add a new fee for a collecting centre and item.
+     *
+     * Body: {
+     *   "collectingCentreId": 5,
+     *   "itemId": 12,
+     *   "name": "Collection Fee",
+     *   "feeType": "OwnInstitution",
+     *   "fee": 150.00,
+     *   "ffee": 200.00,
+     *   "departmentId": 3,
+     *   "discountAllowed": false
+     * }
+     */
+    @POST
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response addFee(String requestBody) {
+        try {
+            String key = requestContext.getHeader("Finance");
+            WebUser user = validateApiKey(key);
+            if (user == null) {
+                return errorResponse("Not a valid key", 401);
+            }
+
+            CollectingCentreFeeCreateRequestDTO request;
+            try {
+                request = gson.fromJson(requestBody, CollectingCentreFeeCreateRequestDTO.class);
+            } catch (JsonSyntaxException e) {
+                return errorResponse("Invalid JSON format: " + e.getMessage(), 400);
+            }
+
+            if (request == null) {
+                return errorResponse("Request body is required", 400);
+            }
+
+            CollectingCentreFeeDTO result = feesApiService.addFee(request, user);
+            return Response.status(201).entity(gson.toJson(successData(result))).build();
+
+        } catch (Exception e) {
+            String msg = e.getMessage();
+            if (msg != null && msg.contains("not found")) {
+                return errorResponse(msg, 404);
+            }
+            return errorResponse("An error occurred: " + (msg != null ? msg : "Unknown error"), 500);
+        }
+    }
+
+    // =========================================================================
+    // PUT /api/pricing/collecting_centre_fees/{feeId}
+    // =========================================================================
+
+    /**
+     * Update an existing collecting centre fee.
+     * Only non-null fields in the request body are applied.
+     */
+    @PUT
+    @Path("/{feeId}")
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response updateFee(@PathParam("feeId") Long feeId, String requestBody) {
+        try {
+            String key = requestContext.getHeader("Finance");
+            WebUser user = validateApiKey(key);
+            if (user == null) {
+                return errorResponse("Not a valid key", 401);
+            }
+
+            ItemFeeUpdateRequestDTO request;
+            try {
+                request = gson.fromJson(requestBody, ItemFeeUpdateRequestDTO.class);
+            } catch (JsonSyntaxException e) {
+                return errorResponse("Invalid JSON format: " + e.getMessage(), 400);
+            }
+
+            if (request == null) {
+                return errorResponse("Request body is required", 400);
+            }
+
+            CollectingCentreFeeDTO result = feesApiService.updateFee(feeId, request, user);
+            return successResponse(result);
+
+        } catch (Exception e) {
+            String msg = e.getMessage();
+            if (msg != null && msg.contains("not found")) {
+                return errorResponse(msg, 404);
+            }
+            if (msg != null && msg.contains("already retired")) {
+                return errorResponse(msg, 409);
+            }
+            return errorResponse("An error occurred: " + (msg != null ? msg : "Unknown error"), 500);
+        }
+    }
+
+    // =========================================================================
+    // DELETE /api/pricing/collecting_centre_fees/{feeId}
+    // =========================================================================
+
+    /**
+     * Soft-retire a single collecting centre fee.
+     *
+     * @param feeId          required path param — the fee to retire
+     * @param retireComments optional query param — reason for retirement
+     */
+    @DELETE
+    @Path("/{feeId}")
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response retireFee(@PathParam("feeId") Long feeId) {
+        try {
+            String key = requestContext.getHeader("Finance");
+            WebUser user = validateApiKey(key);
+            if (user == null) {
+                return errorResponse("Not a valid key", 401);
+            }
+
+            String retireComments = uriInfo.getQueryParameters().getFirst("retireComments");
+            CollectingCentreFeeDTO result = feesApiService.retireFee(feeId, retireComments, user);
+            return successResponse(result);
+
+        } catch (Exception e) {
+            String msg = e.getMessage();
+            if (msg != null && msg.contains("not found")) {
+                return errorResponse(msg, 404);
+            }
+            if (msg != null && msg.contains("already retired")) {
+                return errorResponse(msg, 409);
+            }
+            return errorResponse("An error occurred: " + (msg != null ? msg : "Unknown error"), 500);
+        }
+    }
+
+    // =========================================================================
+    // DELETE /api/pricing/collecting_centre_fees?institutionId=X
+    // =========================================================================
+
+    /**
+     * Soft-retire ALL active fees for the given collecting centre.
+     * Returns a count of how many fees were retired.
+     *
+     * @param institutionId  required — ID of the collecting centre
+     * @param retireComments optional — reason for retirement
+     */
+    @DELETE
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response retireAllFees() {
+        try {
+            String key = requestContext.getHeader("Finance");
+            WebUser user = validateApiKey(key);
+            if (user == null) {
+                return errorResponse("Not a valid key", 401);
+            }
+
+            String institutionIdStr = uriInfo.getQueryParameters().getFirst("institutionId");
+            String retireComments = uriInfo.getQueryParameters().getFirst("retireComments");
+
+            if (institutionIdStr == null || institutionIdStr.trim().isEmpty()) {
+                return errorResponse("institutionId parameter is required", 400);
+            }
+
+            Long institutionId;
+            try {
+                institutionId = Long.parseLong(institutionIdStr.trim());
+            } catch (NumberFormatException e) {
+                return errorResponse("Invalid institutionId format", 400);
+            }
+
+            int count = feesApiService.retireAllFeesForCollectingCentre(institutionId, retireComments, user);
+            Map<String, Object> result = new HashMap<>();
+            result.put("retiredCount", count);
+            result.put("institutionId", institutionId);
+            return successResponse(result);
+
+        } catch (Exception e) {
+            String msg = e.getMessage();
+            if (msg != null && msg.contains("not found")) {
+                return errorResponse(msg, 404);
+            }
+            if (msg != null && msg.contains("not a collecting centre")) {
+                return errorResponse(msg, 400);
+            }
+            return errorResponse("An error occurred: " + (msg != null ? msg : "Unknown error"), 500);
+        }
+    }
+
+    // =========================================================================
+    // POST /api/pricing/collecting_centre_fees/recalculate?institutionId=X
+    // =========================================================================
+
+    /**
+     * Recalculate the total and totalForForeigner for all items that have
+     * fees (active or retired) linked to the given collecting centre.
+     * Call this after a bulk retirement to refresh item price totals.
+     *
+     * @param institutionId required — ID of the collecting centre
+     */
+    @POST
+    @Path("/recalculate")
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response recalculate() {
+        try {
+            String key = requestContext.getHeader("Finance");
+            WebUser user = validateApiKey(key);
+            if (user == null) {
+                return errorResponse("Not a valid key", 401);
+            }
+
+            String institutionIdStr = uriInfo.getQueryParameters().getFirst("institutionId");
+
+            if (institutionIdStr == null || institutionIdStr.trim().isEmpty()) {
+                return errorResponse("institutionId parameter is required", 400);
+            }
+
+            Long institutionId;
+            try {
+                institutionId = Long.parseLong(institutionIdStr.trim());
+            } catch (NumberFormatException e) {
+                return errorResponse("Invalid institutionId format", 400);
+            }
+
+            int count = feesApiService.recalculateItemTotalsForCollectingCentre(institutionId);
+            Map<String, Object> result = new HashMap<>();
+            result.put("itemsRecalculated", count);
+            result.put("institutionId", institutionId);
+            return successResponse(result);
+
+        } catch (Exception e) {
+            String msg = e.getMessage();
+            if (msg != null && msg.contains("not found")) {
+                return errorResponse(msg, 404);
+            }
+            if (msg != null && msg.contains("not a collecting centre")) {
+                return errorResponse(msg, 400);
+            }
+            return errorResponse("An error occurred: " + (msg != null ? msg : "Unknown error"), 500);
+        }
+    }
+
+    // =========================================================================
+    // Helpers (copied verbatim from DepartmentApi)
+    // =========================================================================
+
+    private WebUser validateApiKey(String key) {
+        if (key == null || key.trim().isEmpty()) {
+            return null;
+        }
+        com.divudi.core.entity.ApiKey apiKey = apiKeyController.findApiKey(key);
+        if (apiKey == null) {
+            return null;
+        }
+        WebUser user = apiKey.getWebUser();
+        if (user == null) {
+            return null;
+        }
+        if (user.isRetired()) {
+            return null;
+        }
+        if (!user.isActivated()) {
+            return null;
+        }
+        if (apiKey.getDateOfExpiary() == null || apiKey.getDateOfExpiary().before(new Date())) {
+            return null;
+        }
+        return user;
+    }
+
+    private Response errorResponse(String message, int code) {
+        Map<String, Object> response = new HashMap<>();
+        response.put("status", "error");
+        response.put("code", code);
+        response.put("message", message);
+        return Response.status(code).entity(gson.toJson(response)).build();
+    }
+
+    private Response successResponse(Object data) {
+        return Response.status(200).entity(gson.toJson(successData(data))).build();
+    }
+
+    private Map<String, Object> successData(Object data) {
+        Map<String, Object> response = new HashMap<>();
+        response.put("status", "success");
+        response.put("code", 200);
+        response.put("data", data);
+        return response;
+    }
+}


### PR DESCRIPTION
## Summary

- Add `GET/POST/PUT/DELETE /api/pricing/collecting_centre_fees` endpoints for managing `ItemFee` records from the **collecting-centre perspective** (complementary to the existing item-centric `ServiceApi`)
- Add `POST /api/pricing/collecting_centre_fees/recalculate?institutionId=X` for manually recalculating item totals after bulk retirement
- Expose to AI Chat module via new `manage_collecting_centre_fees` tool in `AnthropicApiService`

## Endpoints

| Method | Path | Purpose |
|--------|------|---------|
| `GET` | `?institutionId=X[&query&limit]` | List all active fees for a collecting centre |
| `POST` | `/` | Add a new fee (`collectingCentreId`, `itemId`, `name`, `feeType`, `fee` required) |
| `PUT` | `/{feeId}` | Update a fee (partial update, non-null fields only) |
| `DELETE` | `/{feeId}?retireComments=` | Soft-retire a single fee |
| `DELETE` | `?institutionId=X&retireComments=` | Retire ALL active fees for a collecting centre |
| `POST` | `/recalculate?institutionId=X` | Recalculate item totals for all items with CC fees |

## New files
- `core/data/dto/pricing/CollectingCentreFeeDTO.java`
- `core/data/dto/pricing/CollectingCentreFeeCreateRequestDTO.java`
- `service/pricing/CollectingCentreFeesApiService.java`
- `ws/pricing/CollectingCentreFeesApi.java`

## Modified files
- `ApplicationConfig.java` — registers `CollectingCentreFeesApi`
- `CapabilityStatementResource.java` — adds capability entry
- `AnthropicApiService.java` — adds `appendModule` to system prompt + `manage_collecting_centre_fees` tool

## Test plan
- [ ] `GET ?institutionId=X` returns active fees for a valid collecting centre
- [ ] `GET ?institutionId=X` returns 400 for a non-collecting-centre institution
- [ ] `POST` creates a fee and item total is recalculated
- [ ] `POST` with `OwnInstitution` feeType without `departmentId` returns 400
- [ ] `PUT /{feeId}` updates only provided fields
- [ ] `DELETE /{feeId}` retires the fee and updates item total
- [ ] `DELETE ?institutionId=X` retires all active fees for the CC, returns `retiredCount`
- [ ] `POST /recalculate?institutionId=X` returns `itemsRecalculated` count
- [ ] `GET /api/capabilities` shows new Collecting Centre Fees entry

Closes #20015

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * REST API to list, create, update, and retire collecting-centre fees
  * Endpoint to recalculate item fee totals for a collecting centre
  * API-key (Finance header) authentication required for all endpoints

* **Documentation**
  * System capabilities updated to advertise the collecting-centre fees API and its operations
<!-- end of auto-generated comment: release notes by coderabbit.ai -->