### PR TITLE
feat: REST API for collecting centre item fees management

### DIFF
--- a/src/main/java/com/divudi/ws/pricing/CollectingCentreFeesApi.java
+++ b/src/main/java/com/divudi/ws/pricing/CollectingCentreFeesApi.java
@@ -169,6 +169,9 @@ public class CollectingCentreFeesApi {
             if (msg != null && msg.contains("not found")) {
                 return errorResponse(msg, 404);
             }
+            if (msg != null && (msg.contains("required") || msg.contains("Invalid") || msg.contains("is not a collecting centre fee") || msg.contains("is retired"))) {
+                return errorResponse(msg, 400);
+            }
             return errorResponse("An error occurred: " + (msg != null ? msg : "Unknown error"), 500);
         }
     }
@@ -215,6 +218,9 @@ public class CollectingCentreFeesApi {
             if (msg != null && msg.contains("already retired")) {
                 return errorResponse(msg, 409);
             }
+            if (msg != null && (msg.contains("required") || msg.contains("Invalid") || msg.contains("is not a collecting centre fee"))) {
+                return errorResponse(msg, 400);
+            }
             return errorResponse("An error occurred: " + (msg != null ? msg : "Unknown error"), 500);
         }
     }
@@ -251,6 +257,9 @@ public class CollectingCentreFeesApi {
             }
             if (msg != null && msg.contains("already retired")) {
                 return errorResponse(msg, 409);
+            }
+            if (msg != null && (msg.contains("required") || msg.contains("Invalid") || msg.contains("is not a collecting centre fee"))) {
+                return errorResponse(msg, 400);
             }
             return errorResponse("An error occurred: " + (msg != null ? msg : "Unknown error"), 500);
         }


### PR DESCRIPTION
## Summary

- Adds `GET/POST/PUT/DELETE /api/pricing/collecting_centre_fees` endpoints for managing ItemFee records scoped to a collecting centre
- Supports bulk soft-retirement of all fees for a given collecting centre
- Adds `POST /api/pricing/collecting_centre_fees/recalculate?institutionId=X` to refresh item price totals after bulk retirement
- Registered in `ApplicationConfig`, `CapabilityStatementResource`, and `AnthropicApiService` (system prompt + tool)
- Validation errors (missing required fields, invalid feeType, scope violations) return HTTP 400; already-retired conflicts return 409

## Test plan

- [ ] `GET ?institutionId=X` returns active fees for the collecting centre
- [ ] `POST` with valid body creates a new fee and returns 201
- [ ] `POST` missing required fields returns 400
- [ ] `PUT /{feeId}` updates fee fields
- [ ] `DELETE /{feeId}` soft-retires a single fee
- [ ] `DELETE /{feeId}` on already-retired fee returns 409
- [ ] `DELETE ?institutionId=X` retires all active fees for the centre, returns count
- [ ] `POST /recalculate?institutionId=X` recalculates item totals, returns count
- [ ] `GET /api/capabilities` includes the new resource entry

Closes #20015

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error handling for collecting centre fees operations with more specific error messages and appropriate HTTP status codes when validation fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->