### PR TITLE
fix: add @PermitAll to DatabaseMigrationService so login page can render (#20025)

### DIFF
--- a/src/main/java/com/divudi/service/DatabaseMigrationService.java
+++ b/src/main/java/com/divudi/service/DatabaseMigrationService.java
@@ -14,6 +14,7 @@ import java.util.logging.Logger;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import javax.annotation.PostConstruct;
+import javax.annotation.security.PermitAll;
 import javax.ejb.EJB;
 import javax.ejb.Singleton;
 import javax.ejb.Startup;
@@ -34,6 +35,7 @@ import javax.ejb.TransactionAttributeType;
  */
 @Singleton
 @Startup
+@PermitAll
 public class DatabaseMigrationService {
 
     private static final Logger LOGGER = Logger.getLogger(DatabaseMigrationService.class.getName());


### PR DESCRIPTION
## Summary
- Login page and error page both fail to render because `footer.xhtml` calls `DatabaseMigrationService.isMigrationPending()` from an unauthenticated context, and Payara throws `AccessLocalException: Client not authorized for this invocation`.
- Add class-level `@PermitAll` (matching the pattern already used by `ConfigOptionFacade`) so the read-only migration-status check is reachable from unauthenticated rendering contexts.

Closes #20025

## Test plan
- [ ] Deploy a clean build and hit the login page — no `AccessLocalException` in `server.log`.
- [ ] Confirm the migration banner still appears when migration is pending (login page + authenticated pages).
- [ ] Confirm the banner does not appear after the admin marks migration complete / not necessary.
- [ ] Trigger an app error and verify `generalError.xhtml` renders without cascading EJB security failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)