### PR TITLE
Fix: Database migration SQL comment semicolons and failed migrations hidden from pending panel

### DIFF
--- a/src/main/java/com/divudi/bean/common/DatabaseMigrationController.java
+++ b/src/main/java/com/divudi/bean/common/DatabaseMigrationController.java
@@ -95,14 +95,10 @@ public class DatabaseMigrationController implements Serializable {
      */
     public List<MigrationInfo> getPendingMigrations() {
         List<MigrationInfo> pending = new ArrayList<>();
-        String lastExecutedVersion = getLastExecutedVersion();
 
         for (MigrationInfo info : availableMigrations) {
             if (!isMigrationExecuted(info.getVersion())) {
-                // Also check if this version is newer than last executed
-                if (lastExecutedVersion == null || compareVersions(info.getVersion(), lastExecutedVersion) > 0) {
-                    pending.add(info);
-                }
+                pending.add(info);
             }
         }
 
@@ -554,19 +550,20 @@ public class DatabaseMigrationController implements Serializable {
             List<String> statements = splitSqlStatements(sql);
 
             for (String stmt : statements) {
-                String trimmedStmt = stmt.trim();
-                if (trimmedStmt.isEmpty() || trimmedStmt.startsWith("--")) {
+                // Strip leading comment/blank lines to get to the executable SQL
+                String executableStmt = stripLeadingComments(stmt);
+                if (executableStmt.isEmpty()) {
                     continue;
                 }
-                logBuilder.append("Executing: ").append(trimmedStmt.substring(0, Math.min(100, trimmedStmt.length()))).append("...\n");
+                logBuilder.append("Executing: ").append(executableStmt.substring(0, Math.min(100, executableStmt.length()))).append("...\n");
                 try {
-                    if (isDdlStatement(trimmedStmt)) {
-                        migrationFacade.executeDdlNative(trimmedStmt);
+                    if (isDdlStatement(executableStmt)) {
+                        migrationFacade.executeDdlNative(executableStmt);
                     } else {
-                        migrationFacade.executeNativeSql(trimmedStmt);
+                        migrationFacade.executeNativeSql(executableStmt);
                     }
                 } catch (Exception e) {
-                    if (isCreateIndexStatement(trimmedStmt) && isDuplicateIndexError(e)) {
+                    if (isCreateIndexStatement(executableStmt) && isDuplicateIndexError(e)) {
                         logBuilder.append("Index already exists, skipping...\n");
                     } else {
                         throw e;
@@ -580,6 +577,30 @@ public class DatabaseMigrationController implements Serializable {
             logBuilder.append("Error executing SQL: ").append(e.getMessage()).append("\n");
             throw e;
         }
+    }
+
+    /**
+     * Strips leading comment lines (--) and blank lines from a SQL statement block,
+     * returning only the executable portion. This handles the common pattern of
+     * comment blocks accumulated with the following SQL statement by splitSqlStatements.
+     */
+    private String stripLeadingComments(String sql) {
+        if (sql == null) {
+            return "";
+        }
+        StringBuilder result = new StringBuilder();
+        boolean foundExecutable = false;
+        for (String line : sql.split("\n")) {
+            String trimmed = line.trim();
+            if (!foundExecutable) {
+                if (trimmed.isEmpty() || trimmed.startsWith("--")) {
+                    continue;
+                }
+                foundExecutable = true;
+            }
+            result.append(line).append("\n");
+        }
+        return result.toString().trim();
     }
 
     /**

--- a/src/main/java/com/divudi/core/entity/DatabaseMigration.java
+++ b/src/main/java/com/divudi/core/entity/DatabaseMigration.java
@@ -276,17 +276,26 @@ public class DatabaseMigration implements Serializable, Comparable<DatabaseMigra
             return 1;
         }
 
-        String[] parts1 = version1.split("\\.");
-        String[] parts2 = version2.split("\\.");
+        String v1 = version1.startsWith("v") ? version1.substring(1) : version1;
+        String v2 = version2.startsWith("v") ? version2.substring(1) : version2;
+
+        String[] parts1 = v1.split("\\.");
+        String[] parts2 = v2.split("\\.");
 
         int maxLength = Math.max(parts1.length, parts2.length);
 
         for (int i = 0; i < maxLength; i++) {
-            int num1 = i < parts1.length ? Integer.parseInt(parts1[i]) : 0;
-            int num2 = i < parts2.length ? Integer.parseInt(parts2[i]) : 0;
-
-            if (num1 != num2) {
-                return Integer.compare(num1, num2);
+            try {
+                int num1 = i < parts1.length ? Integer.parseInt(parts1[i]) : 0;
+                int num2 = i < parts2.length ? Integer.parseInt(parts2[i]) : 0;
+                if (num1 != num2) {
+                    return Integer.compare(num1, num2);
+                }
+            } catch (NumberFormatException e) {
+                String s1 = i < parts1.length ? parts1[i] : "";
+                String s2 = i < parts2.length ? parts2[i] : "";
+                int cmp = s1.compareTo(s2);
+                if (cmp != 0) return cmp;
             }
         }
 


### PR DESCRIPTION
## Summary
- Fixed `executeSqlScript` to strip leading comment lines from statement blocks before execution, preventing comment text (e.g. `duplicate index errors are handled by DatabaseMigrationController`) from being sent to MySQL as invalid SQL
- Fixed `getPendingMigrations()` to show all unexecuted migrations as pending — previously, a FAILED migration older than the last successful version was silently hidden
- Fixed `DatabaseMigration.compareVersions()` to safely handle `v`-prefixed version strings like `v2.1.10`

## Test plan
- [ ] Navigate to `/admin/database_migration.xhtml`
- [ ] Confirm v2.1.10 (or any previously failed migration) now appears in the Pending Migrations panel
- [ ] Execute the migration and confirm it completes without the `SQLSyntaxErrorException: duplicate index errors are handled by...` error
- [ ] Confirm the migration is marked as SUCCESS afterwards
- [ ] Confirm that a migration older than the current version still appears as pending if it hasn't been run

Closes #20027

🤖 Generated with [Claude Code](https://claude.com/claude-code)