### PR TITLE
feat: select existing non-cash payments for deposit (#20030)

### DIFF
--- a/src/main/java/com/divudi/bean/cashTransaction/FinancialTransactionController.java
+++ b/src/main/java/com/divudi/bean/cashTransaction/FinancialTransactionController.java
@@ -274,6 +274,7 @@ public class FinancialTransactionController implements Serializable {
     boolean floatTransferStarted = false;
 
     private List<Payment> fundTransferAvailablePayments;
+    private List<Payment> depositableNonCashPayments;
 
     // Float Out Cancellation Properties
     private List<Bill> myFundTransferBillsOut;
@@ -1336,6 +1337,7 @@ public class FinancialTransactionController implements Serializable {
     public String navigateToFundDepositBill() {
         resetClassVariables();
         prepareToAddNewFundDepositBill();
+        loadDepositableNonCashPayments();
         return "/cashier/deposit_funds?faces-redirect=true";
     }
 
@@ -2808,6 +2810,14 @@ public class FinancialTransactionController implements Serializable {
 
     public void setFundTransferAvailablePayments(List<Payment> fundTransferAvailablePayments) {
         this.fundTransferAvailablePayments = fundTransferAvailablePayments;
+    }
+
+    public List<Payment> getDepositableNonCashPayments() {
+        return depositableNonCashPayments;
+    }
+
+    public void setDepositableNonCashPayments(List<Payment> depositableNonCashPayments) {
+        this.depositableNonCashPayments = depositableNonCashPayments;
     }
 
     public void addPaymentToShiftEndFundBill() {
@@ -7321,6 +7331,62 @@ public class FinancialTransactionController implements Serializable {
 //    }
     // </editor-fold>
     // <editor-fold defaultstate="collapsed" desc="DepositFundBill">
+
+    public void loadDepositableNonCashPayments() {
+        WebUser loggedUser = sessionController.getLoggedUser();
+        if (loggedUser == null) {
+            depositableNonCashPayments = new ArrayList<>();
+            return;
+        }
+        String jpql = "SELECT p FROM Payment p JOIN p.bill b "
+                + "WHERE p.retired = false "
+                + "AND p.cancelled = false "
+                + "AND p.deposited = false "
+                + "AND p.handingOverStarted = false "
+                + "AND p.currentHolder = :holder "
+                + "AND p.paymentMethod <> :cash "
+                + "AND p.paidValue > 0 "
+                + "ORDER BY p.createdAt DESC";
+        Map<String, Object> params = new HashMap<>();
+        params.put("holder", loggedUser);
+        params.put("cash", com.divudi.core.data.PaymentMethod.Cash);
+        depositableNonCashPayments = paymentFacade.findByJpql(jpql, params);
+    }
+
+    public void addNonCashPaymentToDepositBill(Payment original) {
+        if (original == null) {
+            return;
+        }
+        if (currentBillPayments == null) {
+            currentBillPayments = new ArrayList<>();
+        }
+        for (Payment p : currentBillPayments) {
+            if (original.equals(p.getReferancePayment())) {
+                JsfUtil.addErrorMessage("This payment is already added to the deposit.");
+                return;
+            }
+        }
+        Payment depositPayment = original.clonePaymentForNewBill();
+        depositPayment.setReferancePayment(original);
+        currentBillPayments.add(depositPayment);
+        if (depositableNonCashPayments != null) {
+            depositableNonCashPayments.remove(original);
+        }
+        calculateFundDepositBillTotal();
+    }
+
+    public void removeNonCashPaymentFromDepositBill(Payment depositPayment) {
+        if (currentBillPayments == null) {
+            return;
+        }
+        currentBillPayments.remove(depositPayment);
+        Payment original = depositPayment.getReferancePayment();
+        if (original != null && depositableNonCashPayments != null) {
+            depositableNonCashPayments.add(0, original);
+        }
+        calculateFundDepositBillTotal();
+    }
+
     //Lawan
     public void addPaymentToFundDepositBill() {
         if (currentBill == null) {
@@ -7608,6 +7674,11 @@ public class FinancialTransactionController implements Serializable {
             p.setPaidValue(0 - Math.abs(p.getPaidValue()));
             paymentController.save(p);
             drawerController.updateDrawerForOuts(p);
+            Payment original = p.getReferancePayment();
+            if (original != null) {
+                original.setDeposited(true);
+                paymentFacade.edit(original);
+            }
         }
         return "/cashier/deposit_funds_print?faces-redirect=true";
     }

--- a/src/main/java/com/divudi/core/entity/Payment.java
+++ b/src/main/java/com/divudi/core/entity/Payment.java
@@ -155,6 +155,8 @@ public class Payment implements Serializable, RetirableEntity {
     @ManyToOne
     private CashBook cashbook;
 
+    private boolean deposited;
+
     private boolean cancelled;
     @ManyToOne
     private WebUser cancelledBy;
@@ -769,6 +771,14 @@ public class Payment implements Serializable, RetirableEntity {
 
     public void setFloatRecipient(WebUser floatRecipient) {
         this.floatRecipient = floatRecipient;
+    }
+
+    public boolean isDeposited() {
+        return deposited;
+    }
+
+    public void setDeposited(boolean deposited) {
+        this.deposited = deposited;
     }
 
     public boolean isCancelled() {

--- a/src/main/webapp/cashier/deposit_funds.xhtml
+++ b/src/main/webapp/cashier/deposit_funds.xhtml
@@ -4,7 +4,6 @@
       xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
       xmlns:h="http://xmlns.jcp.org/jsf/html"
       xmlns:p="http://primefaces.org/ui"
-      xmlns:prints="http://xmlns.jcp.org/jsf/composite/ezcomp/prints"
       xmlns:f="http://xmlns.jcp.org/jsf/core">
 
     <h:body>
@@ -12,221 +11,255 @@
         <ui:composition template="/cashier/index.xhtml">
 
             <ui:define name="subcontent">
-                <h:form>
-                    <p:panel class="m-1" >
+                <h:form id="depositForm">
+                    <p:panel class="m-1">
                         <f:facet name="header">
                             <i class="fas fa-piggy-bank mt-2"/>
-                            <p:outputLabel value="Deposit Funds" class="mx-2 mt-2"></p:outputLabel>
+                            <p:outputLabel value="Deposit Funds" class="mx-2 mt-2"/>
                         </f:facet>
 
-                        <div class="row" >
-                            <div class="col-8" >
+                        <div class="row">
+
+                            <!-- Left: input panels -->
+                            <div class="col-8">
+
+                                <!-- Cash (free entry) -->
                                 <p:panel class="m-1 w-100">
                                     <f:facet name="header">
-                                        <h:outputText value="Add Deposits" ></h:outputText>
+                                        <h:outputText value="Cash Deposit"/>
                                         <p:commandButton
-                                            id="btnAdd"
+                                            id="btnAddCash"
                                             style="float: right;"
-                                            value="Add"
+                                            value="Add Cash"
                                             icon="fa fa-plus"
                                             class="ui-button-success float-end"
-                                            process="btnAdd cmdPayment paymentDetails"
-                                            update="tblPayments totals cmdPayment paymentDetails txtTotalDepositValue"
-                                            action="#{financialTransactionController.addPaymentToFundDepositBill()}" >
-                                        </p:commandButton>
+                                            process="btnAddCash cmdPayment paymentDetails"
+                                            update="tblPayments txtTotalDepositValue"
+                                            action="#{financialTransactionController.addPaymentToFundDepositBill()}"/>
                                     </f:facet>
 
                                     <div class="row">
                                         <div class="col-md-3">
-                                            <p:outputLabel value="Payment Method" ></p:outputLabel>
-                                            <p:selectOneMenu 
+                                            <p:outputLabel value="Payment Method"/>
+                                            <p:selectOneMenu
                                                 class="w-100"
-                                                id="cmdPayment" 
-                                                value="#{financialTransactionController.currentPayment.paymentMethod}" >
-                                                <f:selectItem itemLabel="Select Payment Method" ></f:selectItem>
-                                                <f:selectItems value="#{enumController.paymentMethods}" ></f:selectItems>
-                                                <p:ajax process="cmdPayment" update="paymentDetails" ></p:ajax>
+                                                id="cmdPayment"
+                                                value="#{financialTransactionController.currentPayment.paymentMethod}">
+                                                <f:selectItem itemLabel="Select Payment Method"/>
+                                                <f:selectItems value="#{enumController.paymentMethods}"/>
+                                                <p:ajax process="cmdPayment" update="paymentDetails"/>
                                             </p:selectOneMenu>
                                         </div>
-                                        <div class="col-md-4" >
-                                            <h:panelGroup id="paymentDetails" >
-                                                <h:panelGrid 
-                                                    columns="6" 
-                                                    id="cheque" 
-                                                    rendered="#{financialTransactionController.currentPayment.paymentMethod eq 'Cheque'}" >
-                                                    <p:inputText 
-                                                        id="txtChqValue" 
+                                        <div class="col-md-4">
+                                            <h:panelGroup id="paymentDetails">
+                                                <h:panelGrid
+                                                    columns="6"
+                                                    id="cheque"
+                                                    rendered="#{financialTransactionController.currentPayment.paymentMethod eq 'Cheque'}">
+                                                    <p:inputText
+                                                        id="txtChqValue"
                                                         onfocus="this.select()"
-                                                        value="#{financialTransactionController.currentPayment.paidValue}" >
-                                                    </p:inputText>
-                                                    <p:inputText class="mx-2" autocomplete="off"  value="#{financialTransactionController.currentPayment.chequeRefNo}" id="chequNo">
-                                                        <p:ajax process="@this" ></p:ajax>
+                                                        value="#{financialTransactionController.currentPayment.paidValue}"/>
+                                                    <p:inputText class="mx-2" autocomplete="off" value="#{financialTransactionController.currentPayment.chequeRefNo}" id="chequNo">
+                                                        <p:ajax process="@this"/>
                                                     </p:inputText>
                                                     <p:datePicker value="#{financialTransactionController.currentPayment.chequeDate}" id="ChequeDate">
-                                                        <p:ajax process="@this" ></p:ajax>
+                                                        <p:ajax process="@this"/>
                                                     </p:datePicker>
-
-                                                    <p:selectOneMenu  value="#{financialTransactionController.currentPayment.bank}">
+                                                    <p:selectOneMenu value="#{financialTransactionController.currentPayment.bank}">
                                                         <f:selectItem itemLabel="Select Bank"/>
                                                         <f:selectItems value="#{institutionController.banks}" var="inst" itemLabel="#{inst.name}" itemValue="#{inst}"/>
-                                                        <p:ajax process="@this" ></p:ajax>
+                                                        <p:ajax process="@this"/>
                                                     </p:selectOneMenu>
                                                 </h:panelGrid>
                                                 <h:panelGrid
                                                     class="w-100"
                                                     columns="2"
-                                                    id="cash"  
-                                                    rendered="#{financialTransactionController.currentPayment.paymentMethod eq 'Cash'}" >
-                                                    <h:panelGroup >
-                                                        <p:outputLabel value="Referance" ></p:outputLabel>
-                                                        <p:inputText 
+                                                    id="cash"
+                                                    rendered="#{financialTransactionController.currentPayment.paymentMethod eq 'Cash'}">
+                                                    <h:panelGroup>
+                                                        <p:outputLabel value="Reference"/>
+                                                        <p:inputText
                                                             class="w-100"
-                                                            id="txtCashRefNo" 
+                                                            id="txtCashRefNo"
                                                             onfocus="this.select()"
                                                             placeholder="Reference Number"
-                                                            value="#{financialTransactionController.currentPayment.chequeRefNo}" >
-                                                        </p:inputText>
+                                                            value="#{financialTransactionController.currentPayment.chequeRefNo}"/>
                                                     </h:panelGroup>
-                                                    <h:panelGroup >
-                                                        <p:outputLabel value="Value" ></p:outputLabel><br/>
-                                                        <p:inputText 
+                                                    <h:panelGroup>
+                                                        <p:outputLabel value="Value"/><br/>
+                                                        <p:inputText
                                                             class="w-100 text-end"
-                                                            id="txtCashValue" 
+                                                            id="txtCashValue"
                                                             onfocus="this.select()"
-                                                            value="#{financialTransactionController.currentPayment.paidValue}" >
-                                                        </p:inputText>
+                                                            value="#{financialTransactionController.currentPayment.paidValue}"/>
                                                     </h:panelGroup>
                                                 </h:panelGrid>
-
                                                 <h:panelGrid
                                                     columns="6"
                                                     class="row my-1"
-                                                    id="card"  rendered="#{financialTransactionController.currentPayment.paymentMethod eq 'Card'}" >
-                                                    <p:outputLabel value="Value" ></p:outputLabel>
-                                                    <p:inputText 
+                                                    id="card"
+                                                    rendered="#{financialTransactionController.currentPayment.paymentMethod eq 'Card'}">
+                                                    <p:outputLabel value="Value"/>
+                                                    <p:inputText
                                                         class="mx-2"
-                                                        id="txtCardValue" 
-                                                        value="#{financialTransactionController.currentPayment.paidValue}" >
-                                                    </p:inputText>
-                                                    <p:inputText 
+                                                        id="txtCardValue"
+                                                        value="#{financialTransactionController.currentPayment.paidValue}"/>
+                                                    <p:inputText
                                                         class="mx-2"
-                                                        id="txtCardRefNo" 
+                                                        id="txtCardRefNo"
                                                         onfocus="this.select()"
-                                                        value="#{financialTransactionController.currentPayment.creditCardRefNo}" >
-                                                    </p:inputText>
-                                                    <p:selectOneMenu  value="#{financialTransactionController.currentPayment.bank}" class="mx-2" id="cardBank">
+                                                        value="#{financialTransactionController.currentPayment.creditCardRefNo}"/>
+                                                    <p:selectOneMenu value="#{financialTransactionController.currentPayment.bank}" class="mx-2" id="cardBank">
                                                         <f:selectItem itemLabel="Select Bank"/>
                                                         <f:selectItems value="#{institutionController.banks}" var="inst" itemLabel="#{inst.name}" itemValue="#{inst}"/>
-                                                        <p:ajax process="@this" ></p:ajax>
+                                                        <p:ajax process="@this"/>
                                                     </p:selectOneMenu>
                                                 </h:panelGrid>
                                                 <h:panelGrid
                                                     columns="2"
                                                     class="row my-1"
-                                                    id="other"  rendered="#{financialTransactionController.currentPayment.paymentMethod ne 'Cheque' 
-                                                                            and financialTransactionController.currentPayment.paymentMethod ne 'Cash' 
-                                                                            and financialTransactionController.currentPayment.paymentMethod ne 'Card'
-                                                                            and financialTransactionController.currentPayment.paymentMethod ne null}" >
-                                                    <p:outputLabel value="Value" ></p:outputLabel>
-                                                    <p:inputText 
+                                                    id="other"
+                                                    rendered="#{financialTransactionController.currentPayment.paymentMethod ne 'Cheque'
+                                                                and financialTransactionController.currentPayment.paymentMethod ne 'Cash'
+                                                                and financialTransactionController.currentPayment.paymentMethod ne 'Card'
+                                                                and financialTransactionController.currentPayment.paymentMethod ne null}">
+                                                    <p:outputLabel value="Value"/>
+                                                    <p:inputText
                                                         class="mx-2"
-                                                        id="txtOtherValue" 
-                                                        value="#{financialTransactionController.currentPayment.paidValue}" >
-                                                    </p:inputText>
+                                                        id="txtOtherValue"
+                                                        value="#{financialTransactionController.currentPayment.paidValue}"/>
                                                 </h:panelGrid>
                                             </h:panelGroup>
                                         </div>
-                                        <div class="col-md-4">
-
-                                        </div>
                                     </div>
-
                                 </p:panel>
-                                <p:panel  
-                                    class="m-1 w-100"
-                                    header="Already Added Deposits" >
+
+                                <!-- Non-Cash: selectable list from held payments -->
+                                <p:panel class="m-1 w-100">
                                     <f:facet name="header">
-                                        <h:outputText value="Deposits List" ></h:outputText>
+                                        <h:outputText value="Non-Cash Payments in Hold (Card / Cheque / Slip / Other)"/>
                                     </f:facet>
 
-                                    <p:dataTable 
+                                    <p:dataTable
+                                        id="tblNonCash"
+                                        value="#{financialTransactionController.depositableNonCashPayments}"
+                                        var="np"
+                                        emptyMessage="No non-cash payments in your hold">
+                                        <p:column headerText="Date">
+                                            <h:outputText value="#{np.createdAt}">
+                                                <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateTimeFormat}"/>
+                                            </h:outputText>
+                                        </p:column>
+                                        <p:column headerText="Method">
+                                            <h:outputText value="#{np.paymentMethod}"/>
+                                        </p:column>
+                                        <p:column headerText="Reference No">
+                                            <h:outputText value="#{np.referenceNo}"/>
+                                        </p:column>
+                                        <p:column headerText="Bank">
+                                            <h:outputText value="#{np.bank.name}"/>
+                                        </p:column>
+                                        <p:column headerText="Amount" class="text-end">
+                                            <h:outputText value="#{np.paidValue}">
+                                                <f:convertNumber pattern="#,##0.00"/>
+                                            </h:outputText>
+                                        </p:column>
+                                        <p:column headerText="Action" class="text-center" width="6em">
+                                            <p:commandButton
+                                                icon="fa fa-plus"
+                                                class="ui-button-success"
+                                                title="Add to Deposit"
+                                                process="@this"
+                                                update="tblPayments tblNonCash txtTotalDepositValue"
+                                                action="#{financialTransactionController.addNonCashPaymentToDepositBill(np)}"/>
+                                        </p:column>
+                                    </p:dataTable>
+                                </p:panel>
+
+                                <!-- Already-added deposits list -->
+                                <p:panel class="m-1 w-100">
+                                    <f:facet name="header">
+                                        <h:outputText value="Deposits to Submit"/>
+                                    </f:facet>
+
+                                    <p:dataTable
                                         id="tblPayments"
-                                        value="#{financialTransactionController.currentBillPayments}" 
+                                        value="#{financialTransactionController.currentBillPayments}"
                                         var="bp"
                                         emptyMessage="No Deposits Added Yet">
-                                        <p:column headerText="Payment Method" >
-                                            <h:outputText value="#{bp.paymentMethod}" ></h:outputText>
+                                        <p:column headerText="Payment Method">
+                                            <h:outputText value="#{bp.paymentMethod}"/>
                                         </p:column>
-                                        <p:column headerText="Details" >
+                                        <p:column headerText="Details">
                                             <h:panelGroup rendered="#{bp.paymentMethod eq 'Cheque'}">
-                                                <div class="row ">
-                                                    <h:outputLabel value="Bank Name : #{bp.bank.name}" ></h:outputLabel>
+                                                <div class="row">
+                                                    <h:outputLabel value="Bank : #{bp.bank.name}"/>
                                                 </div>
-                                                <div class="row ">
-                                                    <h:outputLabel value="Cheque No : #{bp.chequeRefNo}" ></h:outputLabel>
+                                                <div class="row">
+                                                    <h:outputLabel value="Cheque No : #{bp.referenceNo}"/>
                                                 </div>
-                                                <div class="row ">
-                                                    <h:outputLabel value="Cheque Date : #{bp.chequeDate}" >
-                                                        <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateFormat}"  ></f:convertDateTime>
+                                                <div class="row">
+                                                    <h:outputLabel value="Cheque Date : #{bp.chequeDate}">
+                                                        <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateFormat}"/>
                                                     </h:outputLabel>
                                                 </div>
                                             </h:panelGroup>
                                             <h:panelGroup rendered="#{bp.paymentMethod eq 'Cash'}">
-                                                <h:outputLabel value="Reference No : #{bp.chequeRefNo}" ></h:outputLabel>
+                                                <h:outputLabel value="Reference : #{bp.referenceNo}"/>
                                             </h:panelGroup>
                                             <h:panelGroup rendered="#{bp.paymentMethod eq 'Card'}">
-                                                <div class="row ">
-                                                    <h:outputLabel value="Bank Name : #{bp.bank.name}" ></h:outputLabel>
+                                                <div class="row">
+                                                    <h:outputLabel value="Bank : #{bp.bank.name}"/>
                                                 </div>
-                                                <div class="row ">
-                                                    <h:outputLabel value="Card Reference No : #{bp.creditCardRefNo}" ></h:outputLabel>
+                                                <div class="row">
+                                                    <h:outputLabel value="Card Ref : #{bp.referenceNo}"/>
                                                 </div>
+                                            </h:panelGroup>
+                                            <h:panelGroup rendered="#{bp.referancePayment ne null}">
+                                                <span class="badge bg-info text-dark ms-1">Linked</span>
                                             </h:panelGroup>
                                         </p:column>
                                         <p:column headerText="Value" class="text-end">
-                                            <h:outputText value="#{bp.paidValue}" >
-                                                <f:convertNumber pattern="#,##0.00" ></f:convertNumber>
+                                            <h:outputText value="#{bp.paidValue}">
+                                                <f:convertNumber pattern="#,##0.00"/>
                                             </h:outputText>
                                         </p:column>
-                                        <p:column 
-                                            headerText="Action" 
-                                            class="text-center"
-                                            width="7em">
-                                            <p:commandButton 
+                                        <p:column headerText="Action" class="text-center" width="7em">
+                                            <p:commandButton
                                                 class="ui-button-danger"
-                                                icon=" fa-solid fa-trash"
+                                                icon="fa-solid fa-trash"
                                                 id="btnRemove"
-                                                title="Remove" 
-                                                action="#{financialTransactionController.removePayment}" 
-                                                process="btnRemove tblPayments"
-                                                update=":#{p:resolveFirstComponentWithId('tblPayments',view).clientId} :#{p:resolveFirstComponentWithId('totals',view).clientId}"
-                                                >
-                                                <f:setPropertyActionListener value="#{bp}" target="#{financialTransactionController.removingPayment}" ></f:setPropertyActionListener>
+                                                title="Remove"
+                                                process="@this"
+                                                update="tblPayments tblNonCash txtTotalDepositValue"
+                                                action="#{financialTransactionController.removeNonCashPaymentFromDepositBill(bp)}">
                                             </p:commandButton>
                                         </p:column>
                                     </p:dataTable>
                                 </p:panel>
+
                             </div>
-                            <div class="col-4" >
-                                <p:panelGrid 
-                                    columns="2" 
+
+                            <!-- Right: deposit target and submit -->
+                            <div class="col-4">
+                                <p:panelGrid
+                                    columns="2"
                                     class="w-100 m-1"
                                     layout="tabular"
                                     columnClasses="custom-col-28, custom-col-68">
-                                    <f:facet name="header" >
-                                        <h:outputLabel value="Deposit To" ></h:outputLabel>
-                                        <p:commandButton 
+                                    <f:facet name="header">
+                                        <h:outputLabel value="Deposit To"/>
+                                        <p:commandButton
                                             icon="fa-solid fa-check"
                                             class="ui-button-success float-end"
                                             style="float: right;"
-                                            value="Deposit" 
-                                            ajax="false" 
-                                            action="#{financialTransactionController.settleFundDepositBill()}" >
-                                        </p:commandButton>
+                                            value="Deposit"
+                                            ajax="false"
+                                            action="#{financialTransactionController.settleFundDepositBill()}"/>
                                     </f:facet>
-                                    <p:outputLabel 
-                                        value="Deposit To " ></p:outputLabel>
-                                    <p:autoComplete 
+                                    <p:outputLabel value="Deposit To"/>
+                                    <p:autoComplete
                                         class="w-100"
                                         inputStyleClass="w-100"
                                         completeMethod="#{bankAccountController.completeBankAccount}"
@@ -234,28 +267,24 @@
                                         var="account"
                                         forceSelection="true"
                                         itemLabel="#{account.accountName}"
-                                        itemValue="#{account}"
-                                        ></p:autoComplete>
+                                        itemValue="#{account}"/>
 
-                                    <p:outputLabel value="Deposit Comments" ></p:outputLabel>
-                                    <p:inputTextarea 
+                                    <p:outputLabel value="Comments"/>
+                                    <p:inputTextarea
                                         class="w-100"
                                         rows="3"
-                                        value="#{financialTransactionController.currentBill.comments}">
-                                    </p:inputTextarea>
+                                        value="#{financialTransactionController.currentBill.comments}"/>
 
-                                    <p:outputLabel value="Total Deposit Value" ></p:outputLabel>
-                                    <p:inputText 
+                                    <p:outputLabel value="Total Deposit Value"/>
+                                    <p:inputText
                                         id="txtTotalDepositValue"
                                         class="w-100 text-end"
                                         readonly="true"
-                                        value="#{financialTransactionController.currentBill.netTotal}" >
-                                    </p:inputText>
+                                        value="#{financialTransactionController.currentBill.netTotal}"/>
                                 </p:panelGrid>
                             </div>
+
                         </div>
-
-
 
                     </p:panel>
                 </h:form>


### PR DESCRIPTION
## Summary

- Adds `deposited` boolean field to `Payment` entity — set `true` on the original payment when it is included in a deposit bill, preventing it from appearing in the selectable list again
- `deposit_funds.xhtml` now shows two sections: Cash (free-entry, unchanged) and a selectable table of non-cash payments currently in the user's hold (Card, Cheque, Slip, etc.)
- Non-cash filter: `currentHolder = logged-in user`, `deposited = false`, `paidValue > 0` (excludes the negative deposit payments themselves), `retired/cancelled/handingOverStarted = false`, `paymentMethod != Cash`
- Each selected payment is cloned into a deposit payment with `referancePayment` pointing to the original; on settle the original is marked `deposited = true` via `paymentFacade.edit()`
- Removing an entry from the queue restores it to the selectable list without persisting anything
- Cash payments remain free-form entry; both cash and non-cash can be combined in a single deposit bill

## Test plan

- [ ] Navigate to Deposit Funds — non-cash panel shows payments in user's hold (Card/Cheque/Slip)
- [ ] Adding a non-cash payment moves it from the top table to the submit list
- [ ] Removing it from the submit list returns it to the selectable table
- [ ] Settling a deposit: negative payment records are created with `referancePayment` set; originals have `deposited = true` in DB
- [ ] Previously deposited payments no longer appear in the non-cash selectable list
- [ ] Cash free-entry still works as before
- [ ] Mixed deposit (cash + non-cash) totals correctly

Closes #20030

🤖 Generated with [Claude Code](https://claude.com/claude-code)