### PR TITLE
Add loading indicator to Settle Bill button on Inward Interim Bill page

### DIFF
--- a/src/main/webapp/inward/inward_bill_intrim.xhtml
+++ b/src/main/webapp/inward/inward_bill_intrim.xhtml
@@ -205,6 +205,7 @@
                                     value="Settle Bill"
                                     icon="fa fa-check"
                                     class="ui-button-success mx-1"
+                                    onclick="PF('settleBillLoadingDlg').show();"
                                     action="#{bhtSummeryController.toSettle()}"  />
 
                                 <p:commandButton
@@ -1128,6 +1129,20 @@
 
                     </p:panel>
                     <p:messages id="pageMessages" ></p:messages>
+
+                    <p:dialog widgetVar="settleBillLoadingDlg"
+                              modal="true"
+                              closable="false"
+                              showHeader="true"
+                              header="Processing - Please Wait"
+                              style="min-width: 320px; text-align: center;">
+                        <div style="padding: 20px;">
+                            <i class="pi pi-spin pi-spinner" style="font-size: 3rem; color: #4CAF50;"></i>
+                            <p style="margin-top: 15px; font-size: 1rem;">Settling the bill, please wait...</p>
+                            <p style="color: #888; font-size: 0.85rem;">Do not refresh or close this page.</p>
+                        </div>
+                    </p:dialog>
+
                 </h:form>
             </ui:define>
         </ui:composition>


### PR DESCRIPTION
## Summary

- Adds a non-closable modal `p:dialog` loading spinner that appears the moment the **Settle Bill** button is clicked on `/inward/inward_bill_intrim.xhtml`
- Uses `onclick="PF('settleBillLoadingDlg').show();"` on the button — works correctly with `ajax="false"` (full page postback) since the dialog fires immediately before form submission
- Prevents users from double-clicking, refreshing, or assuming the page has frozen during the long-running `bhtSummeryController.toSettle()` operation

Closes #20033

## Context

The `Settle Bill` button triggers a potentially long-running backend process. Because it uses `ajax="false"`, there is zero visual feedback during processing. This is a UX stop-gap until the root-cause performance issue (#17562) is addressed.

## Test plan

- [ ] Open `/inward/inward_bill_intrim.xhtml`
- [ ] Select a patient and load their bill
- [ ] Click **Settle Bill** — verify a modal spinner dialog appears immediately
- [ ] Confirm the dialog blocks all interaction (modal, no close button)
- [ ] Verify the dialog disappears naturally when the page reloads after settling

🤖 Generated with [Claude Code](https://claude.com/claude-code)