### PR TITLE
feat: inward credit co-payment — patient portion tracking and collection

### DIFF
--- a/src/main/java/com/divudi/bean/common/EnumController.java
+++ b/src/main/java/com/divudi/bean/common/EnumController.java
@@ -1041,6 +1041,19 @@ public class EnumController implements Serializable {
         return p;
     }
 
+    /** Payment methods allowed on the inward patient co-payment page.
+     *  Excludes PatientDeposit and MultiplePaymentMethods which have no
+     *  corresponding input panel on that page. */
+    public PaymentMethod[] getPaymentMethodsForCopay() {
+        return new PaymentMethod[]{
+            PaymentMethod.Cash,
+            PaymentMethod.Card,
+            PaymentMethod.Cheque,
+            PaymentMethod.Slip,
+            PaymentMethod.ewallet,
+            PaymentMethod.OnlineSettlement};
+    }
+
     public PaymentMethod[] getPaymentMethodsForIou() {
         PaymentMethod[] p = {PaymentMethod.Cash,
             PaymentMethod.Cheque,

--- a/src/main/java/com/divudi/bean/inward/BhtSummeryController.java
+++ b/src/main/java/com/divudi/bean/inward/BhtSummeryController.java
@@ -1537,6 +1537,13 @@ public class BhtSummeryController implements Serializable {
             if (alloc.isPatientPortion()) {
                 patientAllocation = alloc;
             } else {
+                if (alloc.getEncounterCreditCompany() != null
+                        && alloc.getAllocatedAmount() - alloc.getEncounterCreditCompany().getCreditLimit() > 0.01) {
+                    JsfUtil.addErrorMessage("Allocation for " + alloc.getCompanyName()
+                            + " exceeds its credit limit ("
+                            + String.format("%.2f", alloc.getEncounterCreditCompany().getCreditLimit()) + ")");
+                    return true;
+                }
                 companyAllocated += alloc.getAllocatedAmount();
             }
         }

--- a/src/main/java/com/divudi/bean/inward/BhtSummeryController.java
+++ b/src/main/java/com/divudi/bean/inward/BhtSummeryController.java
@@ -1526,18 +1526,32 @@ public class BhtSummeryController implements Serializable {
             JsfUtil.addErrorMessage("Please allocate the full credit due amount before settlement");
             return true;
         }
-        double totalAllocated = 0.0;
+        // Sum CC company rows and locate the patient row
+        double companyAllocated = 0.0;
+        CreditCompanyAllocation patientAllocation = null;
         for (CreditCompanyAllocation alloc : creditCompanyAllocations) {
             if (alloc.getAllocatedAmount() < 0) {
                 JsfUtil.addErrorMessage("Allocated amounts cannot be negative");
                 return true;
             }
-            totalAllocated += alloc.getAllocatedAmount();
+            if (alloc.isPatientPortion()) {
+                patientAllocation = alloc;
+            } else {
+                companyAllocated += alloc.getAllocatedAmount();
+            }
         }
-        if (Math.abs(totalAllocated - expected) > 0.01) {
-            JsfUtil.addErrorMessage("Credit allocation total (" + String.format("%.2f", totalAllocated)
-                    + ") does not match the net due amount (" + String.format("%.2f", expected) + ")");
+        // CC rows must not exceed the expected total
+        if (companyAllocated - expected > 0.01) {
+            JsfUtil.addErrorMessage("Credit company allocation (" + String.format("%.2f", companyAllocated)
+                    + ") exceeds the net due amount (" + String.format("%.2f", expected) + ")");
             return true;
+        }
+        // Auto-sync the patient row so total always equals expected
+        double patientShare = Math.max(0.0, expected - companyAllocated);
+        if (patientAllocation != null) {
+            patientAllocation.setAllocatedAmount(patientShare);
+        } else if (patientShare > 0.01) {
+            creditCompanyAllocations.add(new CreditCompanyAllocation(patientShare, true));
         }
         return false;
     }

--- a/src/main/java/com/divudi/bean/inward/BhtSummeryController.java
+++ b/src/main/java/com/divudi/bean/inward/BhtSummeryController.java
@@ -1542,6 +1542,35 @@ public class BhtSummeryController implements Serializable {
         return false;
     }
 
+    /**
+     * Recalculates the patient co-payment row so it always equals:
+     *   net due  –  sum of all CC company allocations.
+     * Called via p:ajax whenever a CC company amount is changed by the user.
+     */
+    public void recalculatePatientPortion() {
+        if (creditCompanyAllocations == null || creditCompanyAllocations.isEmpty()) {
+            return;
+        }
+        double expected = Math.max(0.0, (grantTotal - discount) - paidByPatient - paidByCompany);
+        double ccSum = 0.0;
+        for (CreditCompanyAllocation alloc : creditCompanyAllocations) {
+            if (!alloc.isPatientPortion()) {
+                ccSum += alloc.getAllocatedAmount();
+            }
+        }
+        double patientShare = expected - ccSum;
+        for (CreditCompanyAllocation alloc : creditCompanyAllocations) {
+            if (alloc.isPatientPortion()) {
+                alloc.setAllocatedAmount(patientShare < 0 ? 0.0 : patientShare);
+                return;
+            }
+        }
+        // No patient row exists yet; add one if there is a remainder
+        if (patientShare > 0.01) {
+            creditCompanyAllocations.add(new CreditCompanyAllocation(patientShare, true));
+        }
+    }
+
     private void saveCCBillForAllocation(PatientEncounter pe, CreditCompanyAllocation alloc) {
         // Patient co-payment rows are NOT saved as CC commitment bills.
         // The patient settles their share via the normal inward payment flow.

--- a/src/main/java/com/divudi/bean/inward/BhtSummeryController.java
+++ b/src/main/java/com/divudi/bean/inward/BhtSummeryController.java
@@ -136,6 +136,8 @@ public class BhtSummeryController implements Serializable {
     ConfigOptionApplicationController configOptionApplicationController;
     @Inject
     AdmissionController admissionController;
+    @Inject
+    InwardPaymentController inwardPaymentController;
     ////////////////////////
     private List<DepartmentBillItems> departmentBillItems;
     private List<BillFee> profesionallFee;
@@ -1351,6 +1353,26 @@ public class BhtSummeryController implements Serializable {
         showOrginalBill = false;
         printPreview = true;
         originalBill = null;
+    }
+
+    /**
+     * Navigate to the appropriate payment collection page after the final bill
+     * is settled. For Cash/Card/Cheque patients this goes to the standard inward
+     * payment page; for Credit patients who have a patient co-payment portion it
+     * goes to the dedicated co-payment page.
+     */
+    public String navigateToCollectPayment() {
+        if (patientEncounter == null) {
+            JsfUtil.addErrorMessage("No patient encounter selected");
+            return "";
+        }
+        inwardPaymentController.makeNull();
+        inwardPaymentController.getCurrent().setPatientEncounter(patientEncounter);
+        inwardPaymentController.bhtListener();
+        if (patientEncounter.getPaymentMethod() == PaymentMethod.Credit) {
+            return "/credit/inward_patient_copay_payment?faces-redirect=true";
+        }
+        return "/inward/inward_bill_payment?faces-redirect=true";
     }
 
     public String settleProvisionalBill(Bill b) {

--- a/src/main/java/com/divudi/bean/inward/BhtSummeryController.java
+++ b/src/main/java/com/divudi/bean/inward/BhtSummeryController.java
@@ -1482,8 +1482,15 @@ public class BhtSummeryController implements Serializable {
                 creditCompanyAllocations.add(new CreditCompanyAllocation(ecc, alloc));
                 remaining -= alloc;
             }
+            // Any amount not covered by companies is the patient's co-payment share
+            if (remaining > 0.01) {
+                creditCompanyAllocations.add(new CreditCompanyAllocation(remaining, true));
+            }
         } else if (remaining > 0 && patientEncounter.getCreditCompany() != null) {
             creditCompanyAllocations.add(new CreditCompanyAllocation(patientEncounter.getCreditCompany(), remaining));
+        } else if (remaining > 0.01) {
+            // No companies registered at all — full amount falls on the patient
+            creditCompanyAllocations.add(new CreditCompanyAllocation(remaining, true));
         }
     }
 
@@ -1514,6 +1521,11 @@ public class BhtSummeryController implements Serializable {
     }
 
     private void saveCCBillForAllocation(PatientEncounter pe, CreditCompanyAllocation alloc) {
+        // Patient co-payment rows are NOT saved as CC commitment bills.
+        // The patient settles their share via the normal inward payment flow.
+        if (alloc.isPatientPortion()) {
+            return;
+        }
         if (alloc.getEncounterCreditCompany() != null) {
             saveCCBill(pe, alloc.getEncounterCreditCompany(), alloc.getAllocatedAmount());
         } else {

--- a/src/main/java/com/divudi/bean/inward/InwardPaymentController.java
+++ b/src/main/java/com/divudi/bean/inward/InwardPaymentController.java
@@ -197,16 +197,11 @@ public class InwardPaymentController implements Serializable, ControllerWithMult
         if (b == null) {
             return 0;
         }
-
-        return b.getNetTotal() - (b.getPaidAmount() + getCurrent().getPatientEncounter().getCreditPaidAmount());
-
-//        double billValue = Math.abs(b.getNetTotal());
-//        double paidByPatient = Math.abs(b.getPaidAmount());
-//        double creditUsedAmount = Math.abs(getCurrent().getPatientEncounter().getCreditUsedAmount());
-//        double creditPaidAmount = Math.abs(getCurrent().getPatientEncounter().getCreditPaidAmount());
-//        double netCredit = creditUsedAmount - creditPaidAmount;
-//
-//        return billValue - (paidByPatient + netCredit);
+        // Patient portion = bill total minus the CC committed amount (not paid yet).
+        // This correctly shows patient due before the company has actually remitted.
+        PatientEncounter pe = getCurrent().getPatientEncounter();
+        double patientPortion = Math.max(0.0, b.getNetTotal() - pe.getCreditUsedAmount());
+        return Math.max(0.0, patientPortion - b.getPaidAmount());
     }
 
     private boolean errorCheck() {

--- a/src/main/java/com/divudi/bean/inward/InwardPaymentController.java
+++ b/src/main/java/com/divudi/bean/inward/InwardPaymentController.java
@@ -105,7 +105,9 @@ public class InwardPaymentController implements Serializable, ControllerWithMult
     private double total;
     private Patient patient;
     private PaymentMethodData paymentMethodData;
-    
+    /** Net total of the inward final bill; populated by bhtListener for display on the co-payment page. */
+    private double finalBillTotal;
+
     // </editor-fold>
 
     public PaymentMethod[] getPaymentMethods() {
@@ -118,10 +120,56 @@ public class InwardPaymentController implements Serializable, ControllerWithMult
             return;
         }
         due = getFinalBillDue();
+        finalBillTotal = getFinalBillNetTotal();
         patient = current.getPatientEncounter().getPatient();
         paymentMethod = null;
         paymentMethodData = new PaymentMethodData();
 
+    }
+
+    /** Navigate to the inward patient co-payment collection page. */
+    public String navigateToInwardPatientCopayment() {
+        makeNull();
+        return "/credit/inward_patient_copay_payment?faces-redirect=true";
+    }
+
+    /** CC amount committed against this admission (sum of CC commitment bills created at finalization). */
+    public double getCcCommittedAmount() {
+        if (current == null || current.getPatientEncounter() == null) {
+            return 0.0;
+        }
+        return current.getPatientEncounter().getCreditUsedAmount();
+    }
+
+    /** CC amount already received from credit companies for this admission. */
+    public double getCcPaidAmount() {
+        if (current == null || current.getPatientEncounter() == null) {
+            return 0.0;
+        }
+        return current.getPatientEncounter().getCreditPaidAmount();
+    }
+
+    public double getFinalBillTotal() {
+        return finalBillTotal;
+    }
+
+    public void setFinalBillTotal(double finalBillTotal) {
+        this.finalBillTotal = finalBillTotal;
+    }
+
+    /** Fetch only the net total of the final bill (no due calculation). */
+    private double getFinalBillNetTotal() {
+        String sql = "Select b From BilledBill b where"
+                + " b.retired=false "
+                + " and b.cancelled=false "
+                + " and b.billType=:btp "
+                + " and b.patientEncounter=:pe "
+                + " order by b.id desc";
+        HashMap hm = new HashMap();
+        hm.put("btp", BillType.InwardFinalBill);
+        hm.put("pe", getCurrent().getPatientEncounter());
+        Bill b = getBilledBillFacade().findFirstByJpql(sql, hm);
+        return b != null ? b.getNetTotal() : 0.0;
     }
 
     public String navigateToInpationDashbord() {
@@ -782,6 +830,8 @@ public class InwardPaymentController implements Serializable, ControllerWithMult
         comment = null;
         paymentMethod = null;
         total = 0.0;
+        finalBillTotal = 0.0;
+        due = 0.0;
     }
 
     private void saveBill() {

--- a/src/main/java/com/divudi/bean/pharmacy/PharmacyConfigController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacyConfigController.java
@@ -160,6 +160,11 @@ public class PharmacyConfigController implements Serializable {
     private boolean patientDepositA4Paper;
     private boolean patientDepositCustomPaper;
 
+    // Inward Copayment Bill Settings
+    private boolean inwardCopaymentPosPaper;
+    private boolean inwardCopaymentFiveFivePaper;
+    private boolean inwardCopaymentA4Paper;
+
     // Petty Cash Settings
     private boolean pettyCashPosPaper;
     private boolean pettyCashA4Paper;
@@ -327,6 +332,11 @@ public class PharmacyConfigController implements Serializable {
         patientDepositPosPaper = configOptionController.getBooleanValueByKey("Patient Deposit Receipt POS Paper", true);
         patientDepositA4Paper = configOptionController.getBooleanValueByKey("Patient Deposit Receipt A4 Paper", false);
         patientDepositCustomPaper = configOptionController.getBooleanValueByKey("Patient Deposit Receipt Custom Paper", false);
+
+        // Inward Copayment Bill Settings
+        inwardCopaymentPosPaper = configOptionController.getBooleanValueByKey("Inward Copayment Bill POS Paper", true);
+        inwardCopaymentFiveFivePaper = configOptionController.getBooleanValueByKey("Inward Copayment Bill Five Five Paper", false);
+        inwardCopaymentA4Paper = configOptionController.getBooleanValueByKey("Inward Copayment Bill A4 Paper", false);
 
         // Petty Cash Settings
         pettyCashPosPaper = configOptionController.getBooleanValueByKey("Petty Cash Receipt POS Paper", true);
@@ -718,6 +728,21 @@ public class PharmacyConfigController implements Serializable {
 
         } catch (Exception e) {
             JsfUtil.addErrorMessage("Error saving Credit Settlement Cancellation configuration: " + e.getMessage());
+        }
+    }
+
+    /**
+     * Save Inward Copayment Bill configuration changes specifically
+     */
+    public void saveInwardCopaymentConfig() {
+        try {
+            configOptionController.setBooleanValueByKey("Inward Copayment Bill POS Paper", inwardCopaymentPosPaper);
+            configOptionController.setBooleanValueByKey("Inward Copayment Bill Five Five Paper", inwardCopaymentFiveFivePaper);
+            configOptionController.setBooleanValueByKey("Inward Copayment Bill A4 Paper", inwardCopaymentA4Paper);
+            JsfUtil.addSuccessMessage("Inward Copayment Bill configuration saved successfully");
+            loadCurrentConfig();
+        } catch (Exception e) {
+            JsfUtil.addErrorMessage("Error saving Inward Copayment Bill configuration: " + e.getMessage());
         }
     }
 
@@ -1529,6 +1554,31 @@ public class PharmacyConfigController implements Serializable {
 
     public void setRetailSaleReturnRefundBillPosPaperCustom1(boolean retailSaleReturnRefundBillPosPaperCustom1) {
         this.retailSaleReturnRefundBillPosPaperCustom1 = retailSaleReturnRefundBillPosPaperCustom1;
+    }
+
+    // Inward Copayment Bill Getters and Setters
+    public boolean isInwardCopaymentPosPaper() {
+        return inwardCopaymentPosPaper;
+    }
+
+    public void setInwardCopaymentPosPaper(boolean inwardCopaymentPosPaper) {
+        this.inwardCopaymentPosPaper = inwardCopaymentPosPaper;
+    }
+
+    public boolean isInwardCopaymentFiveFivePaper() {
+        return inwardCopaymentFiveFivePaper;
+    }
+
+    public void setInwardCopaymentFiveFivePaper(boolean inwardCopaymentFiveFivePaper) {
+        this.inwardCopaymentFiveFivePaper = inwardCopaymentFiveFivePaper;
+    }
+
+    public boolean isInwardCopaymentA4Paper() {
+        return inwardCopaymentA4Paper;
+    }
+
+    public void setInwardCopaymentA4Paper(boolean inwardCopaymentA4Paper) {
+        this.inwardCopaymentA4Paper = inwardCopaymentA4Paper;
     }
 
     // Patient Deposit Getters and Setters

--- a/src/main/java/com/divudi/core/data/dataStructure/CreditCompanyAllocation.java
+++ b/src/main/java/com/divudi/core/data/dataStructure/CreditCompanyAllocation.java
@@ -19,14 +19,22 @@ public class CreditCompanyAllocation implements Serializable {
 
     private static final long serialVersionUID = 1L;
 
-    /** Source record; null for the single-company fallback row. */
+    /** Source record; null for the single-company fallback row and patient rows. */
     private EncounterCreditCompany encounterCreditCompany;
 
-    /** The credit company institution. */
+    /** The credit company institution; null for patient-portion rows. */
     private Institution creditCompany;
 
-    /** Amount allocated to this company; editable by the cashier. */
+    /** Amount allocated to this company or to the patient; editable by the cashier. */
     private double allocatedAmount;
+
+    /**
+     * True when this row represents the patient's co-payment portion rather than
+     * a credit company commitment. Patient rows are displayed in the allocation
+     * table but are NOT saved as CC commitment bills — the patient settles via the
+     * normal inward payment flow.
+     */
+    private boolean patientPortion;
 
     /**
      * Constructor for normal rows built from an {@link EncounterCreditCompany}.
@@ -45,9 +53,29 @@ public class CreditCompanyAllocation implements Serializable {
         this.allocatedAmount = allocatedAmount;
     }
 
-    /** Display name derived from the institution. */
+    /**
+     * Constructor for a patient co-payment row. The patient is responsible for
+     * the given amount; no CC commitment bill is created for this row.
+     */
+    public CreditCompanyAllocation(double allocatedAmount, boolean patientPortion) {
+        this.allocatedAmount = allocatedAmount;
+        this.patientPortion = patientPortion;
+    }
+
+    /** Display name: "Patient" for patient rows, institution name otherwise. */
     public String getCompanyName() {
+        if (patientPortion) {
+            return "Patient";
+        }
         return creditCompany != null ? creditCompany.getName() : "";
+    }
+
+    public boolean isPatientPortion() {
+        return patientPortion;
+    }
+
+    public void setPatientPortion(boolean patientPortion) {
+        this.patientPortion = patientPortion;
     }
 
     public EncounterCreditCompany getEncounterCreditCompany() {

--- a/src/main/resources/META-INF/persistence_for_pusing_to_development_branch.xml
+++ b/src/main/resources/META-INF/persistence_for_pusing_to_development_branch.xml
@@ -7,6 +7,47 @@
         <properties>
             <property name="eclipselink.logging.level.sql" value="SEVERE"/>
             <property name="eclipselink.logging.level" value="SEVERE"/>
+            <!-- EclipseLink concurrency manager tuning (issue #19397) - Do NOT Remove -->
+            <!-- Reduce cache lock wait from default 900s to 10s to fail fast -->
+            <property name="eclipselink.concurrency.manager.waittime" value="10000"/>
+            <!-- Throw exception instead of silently waiting on cache lock contention -->
+            <property name="eclipselink.concurrency.manager.allow.concurrencyexception" value="true"/>
+            <!-- Log cache contention warnings for early detection -->
+            <property name="eclipselink.concurrency.manager.maxfrequencytodumptinymessage" value="5000"/>
+            <!-- ================================================================ -->
+            <!-- PERFORMANCE TUNING (issue #19985)                             -->
+            <!-- ================================================================ -->
+
+            <!-- JDBC batch writing for UPDATE/DELETE statements.               -->
+            <!-- IDENTITY strategy prevents batching of INSERT statements       -->
+            <!-- (EclipseLink limitation), but batch-writing still improves     -->
+            <!-- UPDATE and DELETE throughput under concurrent load.            -->
+            <!-- IMPORTANT: requires rewriteBatchedStatements=true on the       -->
+            <!-- Payara JDBC pool — without it MySQL silently ignores batching. -->
+            <property name="eclipselink.jdbc.batch-writing" value="JDBC"/>
+            <property name="eclipselink.jdbc.batch-writing.size" value="1000"/>
+
+            <!-- NOTE: eclipselink.jdbc.cache-statements must NOT be set here.   -->
+            <!-- hmisPU uses transaction-type="JTA" with an external Payara     -->
+            <!-- connection pool; EclipseLink's internal statement cache        -->
+            <!-- conflicts with external pooling and can cause premature        -->
+            <!-- statement closure. Configure statement caching on the Payara   -->
+            <!-- pool instead: Admin Console → pool → statement-cache-size=200, -->
+            <!-- or add cachePrepStmts=true to the MySQL Connector/J URL.       -->
+
+            <!-- Increase shared L2 cache default from 100 → 1000 per entity   -->
+            <!-- class. 100 causes constant eviction for reference data         -->
+            <!-- (departments, items, users); 1000 gives breathing room without -->
+            <!-- the heap risk of a blanket 5000 across all 188 entity classes. -->
+            <!-- For the busiest reference entities (Department, Item, WebUser, -->
+            <!-- Fee) add @Cache(size=5000) on those classes individually.      -->
+            <property name="eclipselink.cache.size.default" value="1000"/>
+
+            <!-- Skip re-reading LOB columns (description, filters, columns,   -->
+            <!-- rows, totals on ReportTemplate etc.) when the object is        -->
+            <!-- already in the L2 cache. Avoids fetching large blobs on        -->
+            <!-- every cache hit.                                               -->
+            <property name="eclipselink.jdbc.result-set-access-optimization" value="true"/>
         </properties>
     </persistence-unit>
     <persistence-unit name="hmisAuditPU" transaction-type="JTA">

--- a/src/main/webapp/credit/inward_patient_copay_payment.xhtml
+++ b/src/main/webapp/credit/inward_patient_copay_payment.xhtml
@@ -13,6 +13,7 @@
         xmlns:bill="http://xmlns.jcp.org/jsf/composite/inward/bill/payment">
 
     <ui:define name="admin">
+        <h:panelGroup rendered="#{webUserController.hasPrivilege('InwardBilling')}">
         <h:panelGroup>
             <h:form id="copayForm">
                 <p:growl id="growl" showDetail="true"/>
@@ -77,7 +78,7 @@
                                         class="ui-button-success"
                                         style="width:150px;"
                                         ajax="false"
-                                        disabled="#{inwardPaymentController.due le 0}"
+                                        disabled="#{!inwardPaymentController.current.patientEncounter.paymentFinalized or inwardPaymentController.due le 0}"
                                         action="#{inwardPaymentController.pay()}"/>
                                     <p:commandButton
                                         value="New"
@@ -321,6 +322,7 @@
             </h:form>
         </p:dialog>
 
+        </h:panelGroup><!-- /InwardBilling privilege guard -->
     </ui:define>
 
 </ui:composition>

--- a/src/main/webapp/credit/inward_patient_copay_payment.xhtml
+++ b/src/main/webapp/credit/inward_patient_copay_payment.xhtml
@@ -225,50 +225,43 @@
                 <h:panelGroup rendered="#{inwardPaymentController.printPreview}">
                     <p:panel>
                         <f:facet name="header">
-                            <h:outputLabel value="Inpatient Co-payment Bill" class="mt-2"/>
-                            <div class="d-flex gap-2" style="float:right;">
-                                <p:commandButton
-                                    value="New Payment"
-                                    icon="fa-solid fa-plus"
-                                    class="ui-button-success"
-                                    ajax="false"
-                                    action="#{inwardPaymentController.makeNull}"/>
-                                <p:commandButton
-                                    value="Print"
-                                    ajax="false"
-                                    icon="fa fa-print"
-                                    class="ui-button-info"
-                                    action="#">
-                                    <p:printer target="gpCopayBillPreview"/>
-                                </p:commandButton>
+                            <div class="d-flex align-items-center justify-content-between">
+                                <h:outputLabel value="Inpatient Co-payment Bill" class="mt-2"/>
+                                <div class="d-flex gap-2">
+                                    <p:commandButton
+                                        value="Print"
+                                        ajax="false"
+                                        icon="fa fa-print"
+                                        class="ui-button-info">
+                                        <p:printer target="gpCopayBillPreview"/>
+                                    </p:commandButton>
+                                    <p:commandButton
+                                        rendered="#{webUserController.hasPrivilege('ChangeReceiptPrintingPaperTypes')}"
+                                        value="Settings"
+                                        icon="fas fa-cog"
+                                        class="ui-button-secondary"
+                                        type="button"
+                                        onclick="PF('inwardCopayConfigDialog').show();"/>
+                                    <p:commandButton
+                                        value="New Payment"
+                                        icon="fa-solid fa-plus"
+                                        class="ui-button-success"
+                                        ajax="false"
+                                        action="#{inwardPaymentController.makeNull}"/>
+                                </div>
                             </div>
                         </f:facet>
-                        <div class="row">
-                            <div class="col-6"></div>
-                            <div class="col-6">
-                                <div class="d-flex gap-3" style="float:right;">
-                                    <p:outputLabel value="Paper Type" class="m-2"/>
-                                    <p:selectOneMenu value="#{sessionController.departmentPreference.inwardDepositPaymentBillPaper}"
-                                                     class="m-1" style="width:18em;">
-                                        <f:selectItem itemLabel="Please Select Paper Type"/>
-                                        <f:selectItems value="#{enumController.paperTypes}"/>
-                                    </p:selectOneMenu>
-                                </div>
-                            </div>
-                        </div>
-                        <div class="row">
-                            <h:panelGroup id="gpCopayBillPreview">
-                                <div class="d-flex justify-content-center">
-                                    <h:panelGroup rendered="#{sessionController.departmentPreference.inwardDepositPaymentBillPaper eq 'FiveFivePaper'}">
-                                        <bill:FiveFivePaymentBill bill="#{inwardPaymentController.current}"/>
-                                    </h:panelGroup>
-                                    <h:panelGroup rendered="#{sessionController.departmentPreference.inwardDepositPaymentBillPaper eq 'A4Paper'}">
-                                        <bill:A4PaperPaymentBill bill="#{inwardPaymentController.current}"/>
-                                    </h:panelGroup>
-                                    <h:panelGroup rendered="#{sessionController.departmentPreference.inwardDepositPaymentBillPaper eq 'PosPaper'}">
-                                        <bill:posPaperPaymentBill bill="#{inwardPaymentController.current}"/>
-                                    </h:panelGroup>
-                                </div>
+                        <div class="d-flex justify-content-center my-2">
+                            <h:panelGroup id="gpCopayBillPreview" layout="block">
+                                <h:panelGroup rendered="#{configOptionController.getBooleanValueByKey('Inward Copayment Bill POS Paper', true)}">
+                                    <bill:posPaperPaymentBill bill="#{inwardPaymentController.current}"/>
+                                </h:panelGroup>
+                                <h:panelGroup rendered="#{configOptionController.getBooleanValueByKey('Inward Copayment Bill Five Five Paper', false)}">
+                                    <bill:FiveFivePaymentBill bill="#{inwardPaymentController.current}"/>
+                                </h:panelGroup>
+                                <h:panelGroup rendered="#{configOptionController.getBooleanValueByKey('Inward Copayment Bill A4 Paper', false)}">
+                                    <bill:A4PaperPaymentBill bill="#{inwardPaymentController.current}"/>
+                                </h:panelGroup>
                             </h:panelGroup>
                         </div>
                     </p:panel>
@@ -276,6 +269,58 @@
 
             </h:form>
         </h:panelGroup>
+
+        <!-- Inward Copayment Printer Configuration Dialog -->
+        <p:dialog id="inwardCopayConfigDialog"
+                  header="Inward Co-payment Bill Printer Configuration"
+                  widgetVar="inwardCopayConfigDialog"
+                  modal="true"
+                  width="560"
+                  resizable="false"
+                  closeOnEscape="true">
+            <p:ajax event="open" listener="#{pharmacyConfigController.loadCurrentConfig}" update="inwardCopayConfigForm"/>
+            <h:form id="inwardCopayConfigForm">
+                <div class="card config-section">
+                    <div class="card-header">
+                        <i class="fas fa-file-alt me-2"/>
+                        <h:outputText value="Paper Format Settings"/>
+                    </div>
+                    <div class="card-body">
+                        <div class="mb-3">
+                            <h:selectBooleanCheckbox id="inwardCopayPOS"
+                                                     value="#{pharmacyConfigController.inwardCopaymentPosPaper}"/>
+                            <h:outputLabel for="inwardCopayPOS" value="POS Paper" class="ms-2"/>
+                            <small class="form-text text-muted d-block">Standard thermal/POS roll paper (default)</small>
+                        </div>
+                        <div class="mb-3">
+                            <h:selectBooleanCheckbox id="inwardCopayFiveFive"
+                                                     value="#{pharmacyConfigController.inwardCopaymentFiveFivePaper}"/>
+                            <h:outputLabel for="inwardCopayFiveFive" value="5×5 Paper" class="ms-2"/>
+                            <small class="form-text text-muted d-block">5.5-inch half-page format</small>
+                        </div>
+                        <div class="mb-3">
+                            <h:selectBooleanCheckbox id="inwardCopayA4"
+                                                     value="#{pharmacyConfigController.inwardCopaymentA4Paper}"/>
+                            <h:outputLabel for="inwardCopayA4" value="A4 Paper" class="ms-2"/>
+                            <small class="form-text text-muted d-block">Full A4 size paper</small>
+                        </div>
+                    </div>
+                </div>
+                <div class="d-flex gap-2 mt-3">
+                    <p:commandButton value="Apply &amp; Close"
+                                     icon="fas fa-save"
+                                     class="ui-button-success"
+                                     ajax="false"
+                                     action="#{pharmacyConfigController.saveInwardCopaymentConfig}"/>
+                    <p:commandButton value="Cancel"
+                                     icon="fas fa-times"
+                                     class="ui-button-secondary"
+                                     type="button"
+                                     onclick="PF('inwardCopayConfigDialog').hide(); return false;"/>
+                </div>
+            </h:form>
+        </p:dialog>
+
     </ui:define>
 
 </ui:composition>

--- a/src/main/webapp/credit/inward_patient_copay_payment.xhtml
+++ b/src/main/webapp/credit/inward_patient_copay_payment.xhtml
@@ -77,6 +77,7 @@
                                         class="ui-button-success"
                                         style="width:150px;"
                                         ajax="false"
+                                        disabled="#{inwardPaymentController.due le 0}"
                                         action="#{inwardPaymentController.pay()}"/>
                                     <p:commandButton
                                         value="New"
@@ -138,7 +139,14 @@
                                         </div>
                                     </h:panelGroup>
 
-                                    <h:panelGroup rendered="#{inwardPaymentController.current.patientEncounter.paymentFinalized}">
+                                    <h:panelGroup rendered="#{inwardPaymentController.current.patientEncounter.paymentFinalized and inwardPaymentController.due le 0}">
+                                        <div class="alert alert-success">
+                                            <h:outputText styleClass="pi pi-check-circle me-2"/>
+                                            <h:outputText value="Patient outstanding balance is fully settled. No further payment is required."/>
+                                        </div>
+                                    </h:panelGroup>
+
+                                    <h:panelGroup rendered="#{inwardPaymentController.current.patientEncounter.paymentFinalized and inwardPaymentController.due gt 0}">
                                         <div class="row my-2 align-items-center">
                                             <div class="col-md-4">
                                                 <p:outputLabel value="Payment Mode" style="font-weight:bold;"/>

--- a/src/main/webapp/credit/inward_patient_copay_payment.xhtml
+++ b/src/main/webapp/credit/inward_patient_copay_payment.xhtml
@@ -159,7 +159,7 @@
                                                     value="#{inwardPaymentController.paymentMethod}">
                                                     <f:selectItem itemLabel="Select Payment Method"/>
                                                     <f:selectItems
-                                                        value="#{enumController.paymentMethodsForIwardDeposit}"
+                                                        value="#{enumController.paymentMethodsForCopay}"
                                                         var="pm"
                                                         itemLabel="#{pm.label}"
                                                         itemValue="#{pm}"/>

--- a/src/main/webapp/credit/inward_patient_copay_payment.xhtml
+++ b/src/main/webapp/credit/inward_patient_copay_payment.xhtml
@@ -1,0 +1,273 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<!DOCTYPE composition PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+
+<ui:composition
+        xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
+        template="/payments/credit_company_pay_index.xhtml"
+        xmlns:h="http://xmlns.jcp.org/jsf/html"
+        xmlns:f="http://xmlns.jcp.org/jsf/core"
+        xmlns="http://www.w3.org/1999/xhtml"
+        xmlns:p="http://primefaces.org/ui"
+        xmlns:in="http://xmlns.jcp.org/jsf/composite/inward"
+        xmlns:pa="http://xmlns.jcp.org/jsf/composite/paymentMethod"
+        xmlns:bill="http://xmlns.jcp.org/jsf/composite/inward/bill/payment">
+
+    <ui:define name="admin">
+        <h:panelGroup>
+            <h:form id="copayForm">
+                <p:growl id="growl" showDetail="true"/>
+
+                <!-- BHT Search panel — shown when no encounter is selected -->
+                <h:panelGroup rendered="#{inwardPaymentController.current.patientEncounter eq null}">
+                    <p:panel>
+                        <f:facet name="header">
+                            <h:outputText value="INWARD PATIENT CO-PAYMENT COLLECTION" style="font-size:1.1rem;font-weight:bold;"/>
+                        </f:facet>
+                        <div class="row my-3 align-items-center">
+                            <div class="col-md-3">
+                                <p:outputLabel value="Search by BHT / Patient Name" style="font-weight:bold;"/>
+                            </div>
+                            <div class="col-md-7">
+                                <p:autoComplete
+                                    widgetVar="aBht"
+                                    id="acBht"
+                                    forceSelection="true"
+                                    placeholder="Type BHT number or patient name"
+                                    value="#{inwardPaymentController.current.patientEncounter}"
+                                    completeMethod="#{admissionController.completePatientAll}"
+                                    var="myItem"
+                                    itemValue="#{myItem}"
+                                    itemLabel="#{myItem.bhtNo}"
+                                    class="w-100"
+                                    inputStyleClass="w-100"
+                                    maxResults="20">
+                                    <p:column headerText="BHT No" style="width:8em;">
+                                        <h:outputLabel value="#{myItem.bhtNo}"/>
+                                    </p:column>
+                                    <p:column headerText="Patient" style="width:15em;">
+                                        <h:outputLabel value="#{myItem.patient.person.nameWithTitle}"/>
+                                    </p:column>
+                                    <p:column headerText="Payment" style="width:8em;">
+                                        <h:outputLabel value="#{myItem.paymentMethod}"/>
+                                    </p:column>
+                                </p:autoComplete>
+                            </div>
+                            <div class="col-md-2">
+                                <p:commandButton
+                                    value="Select"
+                                    icon="fa fa-check"
+                                    class="ui-button-success w-100"
+                                    ajax="false"
+                                    action="#{inwardPaymentController.bhtListener}"/>
+                            </div>
+                        </div>
+                    </p:panel>
+                </h:panelGroup>
+
+                <!-- Co-payment form — shown once an encounter is selected -->
+                <h:panelGroup rendered="#{inwardPaymentController.current.patientEncounter ne null and !inwardPaymentController.printPreview}">
+                    <p:panel>
+                        <f:facet name="header">
+                            <div class="d-flex justify-content-between align-items-center">
+                                <h:outputText value="INWARD PATIENT CO-PAYMENT COLLECTION" style="font-size:1.1rem;font-weight:bold;"/>
+                                <div class="d-flex gap-2">
+                                    <p:commandButton
+                                        value="Pay"
+                                        icon="fa fa-check"
+                                        class="ui-button-success"
+                                        style="width:150px;"
+                                        ajax="false"
+                                        action="#{inwardPaymentController.pay()}"/>
+                                    <p:commandButton
+                                        value="New"
+                                        icon="fa fa-plus"
+                                        class="ui-button-warning"
+                                        ajax="false"
+                                        action="#{inwardPaymentController.makeNull}"/>
+                                </div>
+                            </div>
+                        </f:facet>
+
+                        <div class="row g-3">
+                            <!-- Left: BHT details -->
+                            <div class="col-md-5">
+                                <p:panel header="Patient Details">
+                                    <in:bhtDetail admission="#{inwardPaymentController.current.patientEncounter}"/>
+                                </p:panel>
+
+                                <!-- Balance summary -->
+                                <p:panel header="Balance Summary" styleClass="mt-3">
+                                    <p:panelGrid columns="2" styleClass="w-100">
+                                        <h:outputLabel value="Total Bill" style="font-weight:bold;"/>
+                                        <h:outputLabel value="#{inwardPaymentController.finalBillTotal}">
+                                            <f:convertNumber pattern="#,##0.00"/>
+                                        </h:outputLabel>
+
+                                        <h:outputLabel value="CC Committed" style="font-weight:bold;"/>
+                                        <h:outputLabel value="#{inwardPaymentController.ccCommittedAmount}">
+                                            <f:convertNumber pattern="#,##0.00"/>
+                                        </h:outputLabel>
+
+                                        <h:outputLabel value="CC Paid" style="font-weight:bold;"/>
+                                        <h:outputLabel value="#{inwardPaymentController.ccPaidAmount}">
+                                            <f:convertNumber pattern="#,##0.00"/>
+                                        </h:outputLabel>
+
+                                        <h:outputLabel value="Patient Portion" style="font-weight:bold;"/>
+                                        <h:outputLabel value="#{inwardPaymentController.finalBillTotal - inwardPaymentController.ccCommittedAmount}"
+                                                       style="color:#1565c0;font-weight:bold;">
+                                            <f:convertNumber pattern="#,##0.00"/>
+                                        </h:outputLabel>
+
+                                        <h:outputLabel value="Patient Outstanding" style="font-weight:bold;color:#c62828;"/>
+                                        <h:outputLabel value="#{inwardPaymentController.due}"
+                                                       style="font-weight:bold;font-size:1.1em;color:#c62828;">
+                                            <f:convertNumber pattern="#,##0.00"/>
+                                        </h:outputLabel>
+                                    </p:panelGrid>
+                                </p:panel>
+                            </div>
+
+                            <!-- Right: Payment details -->
+                            <div class="col-md-7">
+                                <p:panel header="Payment Details">
+                                    <h:panelGroup rendered="#{!inwardPaymentController.current.patientEncounter.paymentFinalized}">
+                                        <div class="alert alert-warning">
+                                            <h:outputText styleClass="pi pi-exclamation-triangle me-2"/>
+                                            <h:outputText value="The final bill for this admission has not been finalized yet. Patient co-payment cannot be collected until the final bill is processed."/>
+                                        </div>
+                                    </h:panelGroup>
+
+                                    <h:panelGroup rendered="#{inwardPaymentController.current.patientEncounter.paymentFinalized}">
+                                        <div class="row my-2 align-items-center">
+                                            <div class="col-md-4">
+                                                <p:outputLabel value="Payment Mode" style="font-weight:bold;"/>
+                                            </div>
+                                            <div class="col-md-8">
+                                                <p:selectOneMenu
+                                                    class="w-100"
+                                                    id="cmbPs"
+                                                    value="#{inwardPaymentController.paymentMethod}">
+                                                    <f:selectItem itemLabel="Select Payment Method"/>
+                                                    <f:selectItems
+                                                        value="#{enumController.paymentMethodsForIwardDeposit}"
+                                                        var="pm"
+                                                        itemLabel="#{pm.label}"
+                                                        itemValue="#{pm}"/>
+                                                    <p:ajax process="cmbPs" update="paymentDetails" event="change"
+                                                            listener="#{inwardPaymentController.updatePaymentData()}"/>
+                                                </p:selectOneMenu>
+                                            </div>
+                                        </div>
+
+                                        <h:panelGroup id="paymentDetails">
+                                            <h:panelGroup rendered="#{inwardPaymentController.paymentMethod eq 'Cash'}">
+                                                <div class="row my-2 align-items-center">
+                                                    <div class="col-md-4">
+                                                        <p:outputLabel value="Paying Amount" style="font-weight:bold;"/>
+                                                    </div>
+                                                    <div class="col-md-8">
+                                                        <p:inputText class="w-100" autocomplete="off"
+                                                                     value="#{inwardPaymentController.current.total}">
+                                                            <f:convertNumber pattern="#,##0.00"/>
+                                                        </p:inputText>
+                                                    </div>
+                                                </div>
+                                            </h:panelGroup>
+
+                                            <h:panelGroup rendered="#{inwardPaymentController.paymentMethod eq 'Card'}">
+                                                <pa:creditCard paymentMethodData="#{inwardPaymentController.paymentMethodData}"/>
+                                            </h:panelGroup>
+
+                                            <h:panelGroup rendered="#{inwardPaymentController.paymentMethod eq 'Cheque'}">
+                                                <pa:cheque paymentMethodData="#{inwardPaymentController.paymentMethodData}"/>
+                                            </h:panelGroup>
+
+                                            <h:panelGroup rendered="#{inwardPaymentController.paymentMethod eq 'Slip'}">
+                                                <pa:slip paymentMethodData="#{inwardPaymentController.paymentMethodData}"/>
+                                            </h:panelGroup>
+
+                                            <h:panelGroup rendered="#{inwardPaymentController.paymentMethod eq 'ewallet'}">
+                                                <pa:ewallet paymentMethodData="#{inwardPaymentController.paymentMethodData}"/>
+                                            </h:panelGroup>
+
+                                            <h:panelGroup rendered="#{inwardPaymentController.paymentMethod eq 'OnlineSettlement'}">
+                                                <pa:online_settlement paymentMethodData="#{inwardPaymentController.paymentMethodData}"/>
+                                            </h:panelGroup>
+                                        </h:panelGroup>
+
+                                        <div class="row my-2 align-items-center">
+                                            <div class="col-md-4">
+                                                <p:outputLabel value="Comments" style="font-weight:bold;"/>
+                                            </div>
+                                            <div class="col-md-8">
+                                                <p:inputText class="w-100" id="txtComment"
+                                                             value="#{inwardPaymentController.comment}"
+                                                             placeholder="Payment remarks (optional)"/>
+                                            </div>
+                                        </div>
+                                    </h:panelGroup>
+                                </p:panel>
+                            </div>
+                        </div>
+                    </p:panel>
+                </h:panelGroup>
+
+                <!-- Print preview -->
+                <h:panelGroup rendered="#{inwardPaymentController.printPreview}">
+                    <p:panel>
+                        <f:facet name="header">
+                            <h:outputLabel value="Inpatient Co-payment Bill" class="mt-2"/>
+                            <div class="d-flex gap-2" style="float:right;">
+                                <p:commandButton
+                                    value="New Payment"
+                                    icon="fa-solid fa-plus"
+                                    class="ui-button-success"
+                                    ajax="false"
+                                    action="#{inwardPaymentController.makeNull}"/>
+                                <p:commandButton
+                                    value="Print"
+                                    ajax="false"
+                                    icon="fa fa-print"
+                                    class="ui-button-info"
+                                    action="#">
+                                    <p:printer target="gpCopayBillPreview"/>
+                                </p:commandButton>
+                            </div>
+                        </f:facet>
+                        <div class="row">
+                            <div class="col-6"></div>
+                            <div class="col-6">
+                                <div class="d-flex gap-3" style="float:right;">
+                                    <p:outputLabel value="Paper Type" class="m-2"/>
+                                    <p:selectOneMenu value="#{sessionController.departmentPreference.inwardDepositPaymentBillPaper}"
+                                                     class="m-1" style="width:18em;">
+                                        <f:selectItem itemLabel="Please Select Paper Type"/>
+                                        <f:selectItems value="#{enumController.paperTypes}"/>
+                                    </p:selectOneMenu>
+                                </div>
+                            </div>
+                        </div>
+                        <div class="row">
+                            <h:panelGroup id="gpCopayBillPreview">
+                                <div class="d-flex justify-content-center">
+                                    <h:panelGroup rendered="#{sessionController.departmentPreference.inwardDepositPaymentBillPaper eq 'FiveFivePaper'}">
+                                        <bill:FiveFivePaymentBill bill="#{inwardPaymentController.current}"/>
+                                    </h:panelGroup>
+                                    <h:panelGroup rendered="#{sessionController.departmentPreference.inwardDepositPaymentBillPaper eq 'A4Paper'}">
+                                        <bill:A4PaperPaymentBill bill="#{inwardPaymentController.current}"/>
+                                    </h:panelGroup>
+                                    <h:panelGroup rendered="#{sessionController.departmentPreference.inwardDepositPaymentBillPaper eq 'PosPaper'}">
+                                        <bill:posPaperPaymentBill bill="#{inwardPaymentController.current}"/>
+                                    </h:panelGroup>
+                                </div>
+                            </h:panelGroup>
+                        </div>
+                    </p:panel>
+                </h:panelGroup>
+
+            </h:form>
+        </h:panelGroup>
+    </ui:define>
+
+</ui:composition>

--- a/src/main/webapp/inward/inward_admission.xhtml
+++ b/src/main/webapp/inward/inward_admission.xhtml
@@ -481,7 +481,7 @@
                                                         />
                                                 </h:panelGroup>
                                                 <!-- For non-Credit admissions: patient responsibility note -->
-                                                <h:panelGroup rendered="#{admissionController.current.paymentMethod ne 'Credit'}">
+                                                <h:panelGroup rendered="#{not empty admissionController.current.paymentMethod and admissionController.current.paymentMethod ne 'Credit'}">
                                                     <div class="alert alert-info p-2 mt-2" style="font-size:0.9em;">
                                                         <h:outputText styleClass="pi pi-info-circle me-1"/>
                                                         <h:outputText value="Patient is responsible for the full bill amount. No credit company assigned."/>

--- a/src/main/webapp/inward/inward_admission.xhtml
+++ b/src/main/webapp/inward/inward_admission.xhtml
@@ -429,12 +429,14 @@
                                         </div>
                                     </h:panelGroup>
                                 </div>
-                                <!-- Right: credit company form + table (fills remaining space) -->
+                                <!-- Right: credit company form + table (always visible) -->
                                 <div class="col-md-9">
-                                    <h:panelGroup id="crd" style="display: #{admissionController.current.paymentMethod eq 'Credit' ? 'block' : 'none'};">
+                                    <h:panelGroup id="crd">
                                         <div class="row my-2">
+                                            <!-- Add Credit Company form — only for Credit payment method -->
                                             <div class="col-6">
-                                                <h:panelGroup id="gpCreditDetails">
+                                                <h:panelGroup id="gpCreditDetails"
+                                                              rendered="#{admissionController.current.paymentMethod eq 'Credit'}">
                                                     <div class="mb-2">
                                                         <h:outputLabel value="Company Name" styleClass="form-label"/>
                                                         <p:autoComplete class="w-100" inputStyleClass="w-100" id="acCreditCompany" forceSelection="true"
@@ -478,21 +480,32 @@
                                                         action="#{admissionController.addCreditCompnay}"
                                                         />
                                                 </h:panelGroup>
+                                                <!-- For non-Credit admissions: patient responsibility note -->
+                                                <h:panelGroup rendered="#{admissionController.current.paymentMethod ne 'Credit'}">
+                                                    <div class="alert alert-info p-2 mt-2" style="font-size:0.9em;">
+                                                        <h:outputText styleClass="pi pi-info-circle me-1"/>
+                                                        <h:outputText value="Patient is responsible for the full bill amount. No credit company assigned."/>
+                                                    </div>
+                                                </h:panelGroup>
                                             </div>
+                                            <!-- Companies table — always shown -->
                                             <div class="col-6">
                                                 <p:dataTable id="tblCreditCompanies" value="#{admissionController.encounterCreditCompanies}" var="ecc"
-                                                             rowIndexVar="index">
+                                                             rowIndexVar="index"
+                                                             emptyMessage="No credit companies added. Patient is responsible for the full amount.">
                                                     <f:facet name="header">
-                                                        <h:outputText value="Companies"/>
+                                                        <h:outputText value="Payment Responsibility"/>
                                                     </f:facet>
-                                                    <p:column  width="2em">
+                                                    <p:column width="2em">
                                                         <h:outputText value="#{index + 1}" />
                                                     </p:column>
                                                     <p:column style="font-weight:bolder;" width="10em">
                                                         <h:outputText value="#{ecc.institution.name}" />
                                                     </p:column>
                                                     <p:column styleClass="text-end" headerText="Credit Limit" width="5em">
-                                                        <h:outputText value="#{ecc.creditLimit}" />
+                                                        <h:outputText value="#{ecc.creditLimit}">
+                                                            <f:convertNumber pattern="#,##0.00"/>
+                                                        </h:outputText>
                                                     </p:column>
                                                     <p:column headerText="Policy No" width="5em">
                                                         <h:outputText value="#{ecc.policyNo}" />
@@ -500,7 +513,8 @@
                                                     <p:column headerText="Reference No" width="5em">
                                                         <h:outputText value="#{ecc.referanceNo}" />
                                                     </p:column>
-                                                    <p:column style="text-align: right;font-weight: bolder"  width="2em">
+                                                    <p:column style="text-align: right;font-weight: bolder" width="2em"
+                                                              rendered="#{admissionController.current.paymentMethod eq 'Credit'}">
                                                         <p:commandButton
                                                             id="btnRemoveCredit"
                                                             process="@this"
@@ -511,6 +525,13 @@
                                                             />
                                                     </p:column>
                                                 </p:dataTable>
+                                                <!-- Patient balance note -->
+                                                <h:panelGroup rendered="#{admissionController.current.paymentMethod eq 'Credit' and not empty admissionController.encounterCreditCompanies}">
+                                                    <div class="alert alert-warning p-2 mt-2" style="font-size:0.9em;">
+                                                        <h:outputText styleClass="pi pi-exclamation-triangle me-1"/>
+                                                        <h:outputText value="Patient is responsible for any balance above the credit limits. Exact patient portion is determined at discharge."/>
+                                                    </div>
+                                                </h:panelGroup>
                                             </div>
                                         </div>
                                     </h:panelGroup>

--- a/src/main/webapp/inward/inward_admission.xhtml
+++ b/src/main/webapp/inward/inward_admission.xhtml
@@ -490,7 +490,9 @@
                                             </div>
                                             <!-- Companies table — always shown -->
                                             <div class="col-6">
-                                                <p:dataTable id="tblCreditCompanies" value="#{admissionController.encounterCreditCompanies}" var="ecc"
+                                                <p:dataTable id="tblCreditCompanies"
+                                                             rendered="#{admissionController.current.paymentMethod eq 'Credit'}"
+                                                             value="#{admissionController.encounterCreditCompanies}" var="ecc"
                                                              rowIndexVar="index"
                                                              emptyMessage="No credit companies added. Patient is responsible for the full amount.">
                                                     <f:facet name="header">

--- a/src/main/webapp/inward/inward_bill_final.xhtml
+++ b/src/main/webapp/inward/inward_bill_final.xhtml
@@ -276,15 +276,27 @@
                         <f:facet name="header">
                             <h:outputLabel value="Credit Company Allocation" />
                         </f:facet>
-                        <p:dataTable value="#{bhtSummeryController.creditCompanyAllocations}" var="alloc" styleClass="w-100">
-                            <p:column headerText="Company">
-                                <h:outputLabel value="#{alloc.companyName}" />
+                        <p:dataTable value="#{bhtSummeryController.creditCompanyAllocations}" var="alloc" styleClass="w-100"
+                                     rowStyleClass="#{alloc.patientPortion ? 'patient-copay-row' : ''}">
+                            <p:column headerText="Payer">
+                                <h:outputLabel value="#{alloc.companyName}"
+                                               style="#{alloc.patientPortion ? 'font-weight:bold;color:#1565c0;' : ''}"/>
                             </p:column>
                             <p:column headerText="Allocated Amount" style="width: 200px;">
-                                <p:inputText value="#{alloc.allocatedAmount}" style="width: 150px;"
-                                             title="Allocated amount for #{alloc.companyName}">
-                                    <f:convertNumber pattern="#,##0.00"/>
-                                </p:inputText>
+                                <h:panelGroup rendered="#{!alloc.patientPortion}">
+                                    <p:inputText value="#{alloc.allocatedAmount}" style="width: 150px;"
+                                                 title="Allocated amount for #{alloc.companyName}">
+                                        <f:convertNumber pattern="#,##0.00"/>
+                                    </p:inputText>
+                                </h:panelGroup>
+                                <h:panelGroup rendered="#{alloc.patientPortion}">
+                                    <h:outputLabel value="#{alloc.allocatedAmount}"
+                                                   style="font-weight:bold;color:#1565c0;">
+                                        <f:convertNumber pattern="#,##0.00"/>
+                                    </h:outputLabel>
+                                    <h:outputLabel value=" (patient pays via co-payment collection)"
+                                                   style="color:#888;font-size:0.85em;margin-left:6px;"/>
+                                </h:panelGroup>
                             </p:column>
                         </p:dataTable>
                     </p:panel>

--- a/src/main/webapp/inward/inward_bill_final.xhtml
+++ b/src/main/webapp/inward/inward_bill_final.xhtml
@@ -693,6 +693,22 @@
                                         <p:ajax process="@this" update="@all"/>
                                     </p:selectBooleanCheckbox>
 
+                                    <!-- Collect payment button — routes to the right page based on payment method -->
+                                    <p:commandButton
+                                        value="Collect Patient Payment"
+                                        ajax="false"
+                                        icon="fas fa-money-bill-wave"
+                                        class="ui-button-success mx-1"
+                                        rendered="#{bhtSummeryController.patientEncounter.paymentMethod ne 'Credit'}"
+                                        action="#{bhtSummeryController.navigateToCollectPayment()}"/>
+                                    <p:commandButton
+                                        value="Collect Patient Co-payment"
+                                        ajax="false"
+                                        icon="fas fa-user-check"
+                                        class="ui-button-warning mx-1"
+                                        rendered="#{bhtSummeryController.patientEncounter.paymentMethod eq 'Credit'}"
+                                        action="#{bhtSummeryController.navigateToCollectPayment()}"/>
+
                                     <p:commandButton value="Final Bill" ajax="false"
                                                      class="ui-button-info mx-1" icon="fas fa-print">
                                         <p:printer target="finalBillOnly"/>

--- a/src/main/webapp/inward/inward_bill_final.xhtml
+++ b/src/main/webapp/inward/inward_bill_final.xhtml
@@ -282,20 +282,30 @@
                                 <h:outputLabel value="#{alloc.companyName}"
                                                style="#{alloc.patientPortion ? 'font-weight:bold;color:#1565c0;' : ''}"/>
                             </p:column>
-                            <p:column headerText="Allocated Amount" style="width: 200px;">
+                            <p:column headerText="Allocated Amount" style="width:220px;text-align:right;">
+                                <!-- CC company row: editable, auto-recalculates patient row on change -->
                                 <h:panelGroup rendered="#{!alloc.patientPortion}">
-                                    <p:inputText value="#{alloc.allocatedAmount}" style="width: 150px;"
+                                    <p:inputText value="#{alloc.allocatedAmount}"
+                                                 style="width:160px;text-align:right;"
+                                                 onfocus="this.select()"
                                                  title="Allocated amount for #{alloc.companyName}">
                                         <f:convertNumber pattern="#,##0.00"/>
+                                        <p:ajax event="change"
+                                                process="creditAllocationPanel"
+                                                update="creditAllocationPanel"
+                                                listener="#{bhtSummeryController.recalculatePatientPortion()}"/>
                                     </p:inputText>
                                 </h:panelGroup>
+                                <!-- Patient row: editable, shown in blue -->
                                 <h:panelGroup rendered="#{alloc.patientPortion}">
-                                    <h:outputLabel value="#{alloc.allocatedAmount}"
-                                                   style="font-weight:bold;color:#1565c0;">
+                                    <p:inputText value="#{alloc.allocatedAmount}"
+                                                 style="width:160px;text-align:right;font-weight:bold;color:#1565c0;"
+                                                 onfocus="this.select()"
+                                                 title="Patient co-payment portion">
                                         <f:convertNumber pattern="#,##0.00"/>
-                                    </h:outputLabel>
-                                    <h:outputLabel value=" (patient pays via co-payment collection)"
-                                                   style="color:#888;font-size:0.85em;margin-left:6px;"/>
+                                    </p:inputText>
+                                    <h:outputLabel value=" (patient co-payment)"
+                                                   style="color:#888;font-size:0.82em;margin-left:4px;"/>
                                 </h:panelGroup>
                             </p:column>
                         </p:dataTable>

--- a/src/main/webapp/payments/credit_company_pay_index.xhtml
+++ b/src/main/webapp/payments/credit_company_pay_index.xhtml
@@ -99,6 +99,13 @@
                                                 <p:commandButton styleClass="w-100 ui-button-info ui-button-outlined" ajax="false" icon="pi pi-calendar-times" value="Inward Due Age" title="View aged inward dues" action="/credit/inward_due_age_credit_company?faces-redirect=true"/>
                                                 <p:commandButton styleClass="w-100 ui-button-success" ajax="false" icon="pi pi-id-card" value="Inward Payment by BHT" title="Process inward payments by BHT" action="/credit/credit_compnay_bill_inward?faces-redirect=true"/>
                                                 <p:commandButton styleClass="w-100 ui-button-success" ajax="false" icon="pi pi-building" value="Inward Payment by Company" title="Process inward payments by company" action="/credit/credit_compnay_bill_payment_inward?faces-redirect=true"/>
+                                                <p:commandButton
+                                                    styleClass="w-100 ui-button-warning"
+                                                    ajax="false"
+                                                    icon="pi pi-user"
+                                                    value="Inward Patient Co-payment"
+                                                    title="Collect patient co-payment balance after credit company settlement"
+                                                    action="#{inwardPaymentController.navigateToInwardPatientCopayment()}"/>
                                             </div>
                                         </p:tab>
 


### PR DESCRIPTION
## Summary

- **Improvement 1 — Admission page always shows payment responsibility**: The credit company section on `inward_admission.xhtml` is now always visible regardless of payment method. For Cash/Card admissions a note says "Patient is responsible for the full amount." For Credit admissions the Add Company form is shown, and a note below the table confirms the patient pays any balance above credit limits.

- **Improvement 1 — Patient row in final bill credit allocation**: `CreditCompanyAllocation` gets a `patientPortion` flag. `BhtSummeryController.populateCreditCompanyAllocations()` now adds a Patient row for any amount not covered by credit companies (including the case where no companies are registered). `saveCCBillForAllocation()` skips patient rows — the patient settles via the normal inward payment flow. The patient row is shown in blue and read-only on `inward_bill_final.xhtml`.

- **Improvement 2 — New patient co-payment page**: `credit/inward_patient_copay_payment.xhtml` under the credit management template. Shows Total Bill / CC Committed / CC Paid / Patient Portion / Patient Outstanding, accepts all payment methods via `InwardPaymentController.pay()`, and prints using the existing paper-type composites. Accessible from the "Inward Patient Co-payment" button added to `credit_company_pay_index.xhtml`.

## Test plan

- [ ] Admit a Credit patient with Company A limit 1,500,000 and Company B limit 1,000,000; final bill = 3,000,000 — verify allocation table shows A, B, and Patient (500,000) rows
- [ ] Verify Settle succeeds and only two CC commitment bills are created (not a third for the patient)
- [ ] Use "Inward Patient Co-payment" from the Credit Management menu, search BHT, verify Patient Outstanding = 500,000, record cash payment, verify outstanding drops to 0
- [ ] Admit a Cash patient and verify the credit company section on the admission page shows the "Patient is responsible for the full amount" note
- [ ] Admit a Credit patient with a single company that covers the full amount — verify no Patient row appears in the final bill allocation (remaining ≤ 0.01)

Closes #20036

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Patient co-payment collection workflow for inpatient encounters with dedicated payment page, navigation buttons, and printer/format settings.
  * UI updates to billing/credit views to show payer vs. patient portions and a clearer payment responsibility table.
  * New config options for selecting co-payment bill paper types.

* **Bug Fixes**
  * Improved allocation calculations and automatic patient co-payment adjustment to ensure billing totals stay consistent.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->