### PR TITLE
feat: Inward patient co-payment due reports and management summary (#20039)

### DIFF
--- a/src/main/java/com/divudi/bean/common/CreditCompanyDueController.java
+++ b/src/main/java/com/divudi/bean/common/CreditCompanyDueController.java
@@ -3950,4 +3950,226 @@ public class CreditCompanyDueController implements Serializable {
         this.billType = billType;
     }
 
+    // =========================================================================
+    // Inward Patient Co-payment Due Reports
+    // =========================================================================
+
+    /**
+     * Populates {@code patientEncounters} with all finalized inward admissions
+     * (with or without CC coverage) where the patient still has an outstanding
+     * co-payment balance.
+     *
+     * Patient due = max(0, finalBill.netTotal - creditUsedAmount) - finalBill.paidAmount
+     *
+     * Also resets {@code billed}, {@code paidByPatient}, {@code paidByCompany}
+     * and {@code payableByPatient} to the matching totals.
+     */
+    public void createInwardPatientCopaymentDueSearch() {
+        String dateField = "admissionDate".equals(dateBasis) ? "b.dateOfAdmission" : "b.dateOfDischarge";
+        HashMap m = new HashMap();
+        String sql = "SELECT b FROM PatientEncounter b"
+                + " JOIN b.finalBill fb"
+                + " WHERE b.retired = false"
+                + " AND b.paymentFinalized = true"
+                + " AND " + dateField + " BETWEEN :fd AND :td"
+                + " AND (abs(fb.netTotal) - abs(b.creditUsedAmount) - abs(fb.paidAmount)) > 0.01";
+        if (admissionType != null) {
+            sql += " AND b.admissionType = :ad";
+            m.put("ad", admissionType);
+        }
+        if (site != null) {
+            sql += " AND fb.department.site = :site";
+            m.put("site", site);
+        }
+        if (department != null) {
+            sql += " AND fb.department = :dep";
+            m.put("dep", department);
+        }
+        sql += " ORDER BY " + dateField;
+        m.put("fd", fromDate);
+        m.put("td", toDate);
+        patientEncounters = patientEncounterFacade.findByJpql(sql, m, TemporalType.TIMESTAMP);
+
+        billed = 0;
+        paidByPatient = 0;
+        paidByCompany = 0;
+        payableByPatient = 0;
+        if (patientEncounters != null) {
+            for (PatientEncounter pe : patientEncounters) {
+                if (pe.getFinalBill() == null) {
+                    continue;
+                }
+                billed += pe.getFinalBill().getNetTotal();
+                paidByPatient += pe.getFinalBill().getPaidAmount();
+                paidByCompany += Math.abs(pe.getCreditPaidAmount());
+                double portion = Math.max(0.0, pe.getFinalBill().getNetTotal() - pe.getCreditUsedAmount());
+                payableByPatient += Math.max(0.0, portion - pe.getFinalBill().getPaidAmount());
+            }
+        }
+    }
+
+    /**
+     * Populates {@code creditCompanyAge} with one {@link String1Value5} row per
+     * patient where the outstanding co-payment amount is placed in the age bucket
+     * that corresponds to days since discharge.
+     * Buckets: value1 = 0–30 days, value2 = 31–60, value3 = 61–90, value4 = 91+.
+     */
+    public void createInwardPatientCopaymentDueAge() {
+        createInwardPatientCopaymentDueSearch();
+        creditCompanyAge = new ArrayList<>();
+        if (patientEncounters == null) {
+            return;
+        }
+        Date today = new Date();
+        for (PatientEncounter pe : patientEncounters) {
+            if (pe.getFinalBill() == null) {
+                continue;
+            }
+            double due = Math.max(0.0,
+                    pe.getFinalBill().getNetTotal() - pe.getCreditUsedAmount() - pe.getFinalBill().getPaidAmount());
+            if (due <= 0.01) {
+                continue;
+            }
+            int days = 0;
+            if (pe.getDateOfDischarge() != null) {
+                days = (int) ((today.getTime() - pe.getDateOfDischarge().getTime()) / (1000L * 60 * 60 * 24));
+            }
+            String1Value5 row = new String1Value5();
+            String patientName = (pe.getPatient() != null && pe.getPatient().getPerson() != null)
+                    ? pe.getPatient().getPerson().getNameWithTitle() : "";
+            row.setString((pe.getBhtNo() != null ? pe.getBhtNo() : "") + " – " + patientName);
+            if (days <= 30) {
+                row.setValue1(due);
+            } else if (days <= 60) {
+                row.setValue2(due);
+            } else if (days <= 90) {
+                row.setValue3(due);
+            } else {
+                row.setValue4(due);
+            }
+            creditCompanyAge.add(row);
+        }
+    }
+
+    /**
+     * Populates {@code creditCompanyAge} with three aggregate summary rows:
+     * <ol>
+     *   <li>CC Receivable – total CC outstanding by age bucket</li>
+     *   <li>Patient Co-payment – total patient outstanding by age bucket</li>
+     *   <li>Both Outstanding – total where BOTH CC and patient owe, by age bucket</li>
+     * </ol>
+     * Designed as a management/CFO view of all inward receivables.
+     */
+    public void createInwardOutstandingSummary() {
+        String dateField = "admissionDate".equals(dateBasis) ? "b.dateOfAdmission" : "b.dateOfDischarge";
+        HashMap m = new HashMap();
+        String sql = "SELECT b FROM PatientEncounter b"
+                + " JOIN b.finalBill fb"
+                + " WHERE b.retired = false"
+                + " AND b.paymentFinalized = true"
+                + " AND " + dateField + " BETWEEN :fd AND :td";
+        if (admissionType != null) {
+            sql += " AND b.admissionType = :ad";
+            m.put("ad", admissionType);
+        }
+        if (site != null) {
+            sql += " AND fb.department.site = :site";
+            m.put("site", site);
+        }
+        if (department != null) {
+            sql += " AND fb.department = :dep";
+            m.put("dep", department);
+        }
+        sql += " ORDER BY " + dateField;
+        m.put("fd", fromDate);
+        m.put("td", toDate);
+        List<PatientEncounter> allAdmissions = patientEncounterFacade.findByJpql(sql, m, TemporalType.TIMESTAMP);
+
+        String1Value5 ccRow = new String1Value5();
+        ccRow.setString("CC Receivable");
+        String1Value5 patientRow = new String1Value5();
+        patientRow.setString("Patient Co-payment");
+        String1Value5 bothRow = new String1Value5();
+        bothRow.setString("Both Outstanding");
+
+        Date today = new Date();
+        if (allAdmissions != null) {
+            for (PatientEncounter pe : allAdmissions) {
+                if (pe.getFinalBill() == null) {
+                    continue;
+                }
+                double ccDue = Math.max(0.0, pe.getCreditUsedAmount() - Math.abs(pe.getCreditPaidAmount()));
+                double patientDue = Math.max(0.0,
+                        pe.getFinalBill().getNetTotal() - pe.getCreditUsedAmount() - pe.getFinalBill().getPaidAmount());
+                if (ccDue <= 0.01 && patientDue <= 0.01) {
+                    continue;
+                }
+                int days = 0;
+                if (pe.getDateOfDischarge() != null) {
+                    days = (int) ((today.getTime() - pe.getDateOfDischarge().getTime()) / (1000L * 60 * 60 * 24));
+                }
+                if (ccDue > 0.01) {
+                    addToAgeBucket(ccRow, ccDue, days);
+                }
+                if (patientDue > 0.01) {
+                    addToAgeBucket(patientRow, patientDue, days);
+                }
+                if (ccDue > 0.01 && patientDue > 0.01) {
+                    addToAgeBucket(bothRow, ccDue + patientDue, days);
+                }
+            }
+        }
+
+        creditCompanyAge = new ArrayList<>();
+        creditCompanyAge.add(ccRow);
+        creditCompanyAge.add(patientRow);
+        creditCompanyAge.add(bothRow);
+    }
+
+    /** Adds {@code amount} to the correct age bucket of {@code row}. */
+    private void addToAgeBucket(String1Value5 row, double amount, int days) {
+        if (days <= 30) {
+            row.setValue1(row.getValue1() + amount);
+        } else if (days <= 60) {
+            row.setValue2(row.getValue2() + amount);
+        } else if (days <= 90) {
+            row.setValue3(row.getValue3() + amount);
+        } else {
+            row.setValue4(row.getValue4() + amount);
+        }
+    }
+
+    /**
+     * Returns the CC adjudication status for a patient encounter.
+     * PENDING  – CC has committed but paid nothing
+     * PARTIAL  – CC has paid some but not all
+     * SETTLED  – CC has paid in full (or more)
+     * N/A      – no CC coverage on this encounter
+     */
+    public String getPatientCcStatus(PatientEncounter pe) {
+        if (pe.getCreditUsedAmount() <= 0.01) {
+            return "N/A";
+        }
+        double ccPaid = Math.abs(pe.getCreditPaidAmount());
+        if (ccPaid >= pe.getCreditUsedAmount() - 0.01) {
+            return "SETTLED";
+        }
+        if (ccPaid > 0.01) {
+            return "PARTIAL";
+        }
+        return "PENDING";
+    }
+
+    /**
+     * Returns the outstanding patient co-payment for a given encounter.
+     * Formula: max(0, finalBill.netTotal − creditUsedAmount) − finalBill.paidAmount
+     */
+    public double getPatientCopaymentDue(PatientEncounter pe) {
+        if (pe.getFinalBill() == null) {
+            return 0.0;
+        }
+        double portion = Math.max(0.0, pe.getFinalBill().getNetTotal() - pe.getCreditUsedAmount());
+        return Math.max(0.0, portion - pe.getFinalBill().getPaidAmount());
+    }
+
 }

--- a/src/main/webapp/credit/inward_outstanding_summary.xhtml
+++ b/src/main/webapp/credit/inward_outstanding_summary.xhtml
@@ -80,7 +80,7 @@
                             </p:column>
                             <p:columnGroup type="footer">
                                 <p:row>
-                                    <p:column footerText="Note: 'Both Outstanding' row shows accounts where CC and patient amounts are simultaneously due. It is not additive with the rows above."/>
+                                    <p:column colspan="5" footerText="Note: 'Both Outstanding' row shows accounts where CC and patient amounts are simultaneously due. It is not additive with the rows above."/>
                                 </p:row>
                             </p:columnGroup>
                         </p:dataTable>

--- a/src/main/webapp/credit/inward_outstanding_summary.xhtml
+++ b/src/main/webapp/credit/inward_outstanding_summary.xhtml
@@ -1,0 +1,92 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
+      xmlns:p="http://primefaces.org/ui"
+      xmlns:h="http://xmlns.jcp.org/jsf/html"
+      xmlns:f="http://xmlns.jcp.org/jsf/core">
+
+    <h:body>
+        <ui:composition template="/payments/credit_company_pay_index.xhtml">
+            <ui:define name="admin">
+                <h:form>
+                    <p:panel class="my-2">
+                        <f:facet name="header">
+                            <h:outputLabel value="INWARD OUTSTANDING SUMMARY"/>
+                        </f:facet>
+                        <p:outputPanel styleClass="mb-2">
+                            <h:outputText value="Management view: CC receivables vs patient co-payment receivables by age bucket, with overlap row showing accounts where both are outstanding."/>
+                        </p:outputPanel>
+                        <h:panelGrid columns="2" class="my-2">
+                            <h:outputLabel value="From"/>
+                            <p:calendar value="#{creditCompanyDueController.fromDate}"
+                                        pattern="#{sessionController.applicationPreference.longDateTimeFormat}"/>
+                            <h:outputLabel value="To"/>
+                            <p:calendar value="#{creditCompanyDueController.toDate}"
+                                        pattern="#{sessionController.applicationPreference.longDateTimeFormat}"/>
+                            <h:outputLabel value="Date Basis"/>
+                            <p:selectOneMenu value="#{creditCompanyDueController.dateBasis}">
+                                <f:selectItem itemValue="dischargeDate" itemLabel="Discharge Date"/>
+                                <f:selectItem itemValue="admissionDate" itemLabel="Admission Date"/>
+                            </p:selectOneMenu>
+                            <h:outputLabel value="Admission Type"/>
+                            <p:selectOneMenu value="#{creditCompanyDueController.admissionType}">
+                                <f:selectItem itemLabel="All Admission Types" itemValue="#{null}"/>
+                                <f:selectItems value="#{admissionTypeController.items}" var="at" itemValue="#{at}" itemLabel="#{at.name}"/>
+                            </p:selectOneMenu>
+                            <h:outputLabel value="Site"/>
+                            <p:selectOneMenu value="#{creditCompanyDueController.site}" filter="true">
+                                <f:selectItem itemLabel="All Sites" itemValue="#{null}"/>
+                                <f:selectItems value="#{institutionController.sites}" var="dueSite" itemLabel="#{dueSite.name}" itemValue="#{dueSite}"/>
+                            </p:selectOneMenu>
+                            <h:outputLabel value="Department"/>
+                            <p:selectOneMenu value="#{creditCompanyDueController.department}" filter="true" filterMatchMode="contains">
+                                <f:selectItem itemLabel="All Departments" itemValue="#{null}"/>
+                                <f:selectItems value="#{departmentController.getDepartmentsOfInstitutionAndSite()}" var="d" itemLabel="#{d.name}" itemValue="#{d}"/>
+                            </p:selectOneMenu>
+                        </h:panelGrid>
+                        <p:commandButton id="btnSearch" class="ui-button-warning" icon="fas fa-cogs" ajax="false"
+                                         value="Process Summary"
+                                         action="#{creditCompanyDueController.createInwardOutstandingSummary()}"/>
+                        <p:defaultCommand target="btnSearch"/>
+
+                        <p:dataTable id="lst" value="#{creditCompanyDueController.creditCompanyAge}" var="row"
+                                     emptyMessage="No records found" class="mt-3">
+                            <f:facet name="header">
+                                <h:outputLabel value="Inward Outstanding Summary (aged from discharge date)"/>
+                            </f:facet>
+                            <p:column headerText="Category">
+                                <h:outputLabel value="#{row.string}" style="font-weight:bold"/>
+                            </p:column>
+                            <p:column headerText="0–30 Days" style="text-align:right">
+                                <h:outputLabel value="#{row.value1}">
+                                    <f:convertNumber pattern="#,##0.00"/>
+                                </h:outputLabel>
+                            </p:column>
+                            <p:column headerText="31–60 Days" style="text-align:right">
+                                <h:outputLabel value="#{row.value2}">
+                                    <f:convertNumber pattern="#,##0.00"/>
+                                </h:outputLabel>
+                            </p:column>
+                            <p:column headerText="61–90 Days" style="text-align:right">
+                                <h:outputLabel value="#{row.value3}">
+                                    <f:convertNumber pattern="#,##0.00"/>
+                                </h:outputLabel>
+                            </p:column>
+                            <p:column headerText="91+ Days" style="text-align:right">
+                                <h:outputLabel value="#{row.value4}">
+                                    <f:convertNumber pattern="#,##0.00"/>
+                                </h:outputLabel>
+                            </p:column>
+                            <p:columnGroup type="footer">
+                                <p:row>
+                                    <p:column footerText="Note: 'Both Outstanding' row shows accounts where CC and patient amounts are simultaneously due. It is not additive with the rows above."/>
+                                </p:row>
+                            </p:columnGroup>
+                        </p:dataTable>
+                    </p:panel>
+                </h:form>
+            </ui:define>
+        </ui:composition>
+    </h:body>
+</html>

--- a/src/main/webapp/credit/inward_patient_copay_due_age.xhtml
+++ b/src/main/webapp/credit/inward_patient_copay_due_age.xhtml
@@ -1,0 +1,85 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
+      xmlns:p="http://primefaces.org/ui"
+      xmlns:h="http://xmlns.jcp.org/jsf/html"
+      xmlns:f="http://xmlns.jcp.org/jsf/core">
+
+    <h:body>
+        <ui:composition template="/payments/credit_company_pay_index.xhtml">
+            <ui:define name="admin">
+                <h:form>
+                    <p:panel class="my-2">
+                        <f:facet name="header">
+                            <h:outputLabel value="INWARD PATIENT CO-PAYMENT DUE AGE"/>
+                        </f:facet>
+                        <h:panelGrid columns="2" class="my-2">
+                            <h:outputLabel value="From"/>
+                            <p:calendar value="#{creditCompanyDueController.fromDate}"
+                                        pattern="#{sessionController.applicationPreference.longDateTimeFormat}"/>
+                            <h:outputLabel value="To"/>
+                            <p:calendar value="#{creditCompanyDueController.toDate}"
+                                        pattern="#{sessionController.applicationPreference.longDateTimeFormat}"/>
+                            <h:outputLabel value="Date Basis"/>
+                            <p:selectOneMenu value="#{creditCompanyDueController.dateBasis}">
+                                <f:selectItem itemValue="dischargeDate" itemLabel="Discharge Date"/>
+                                <f:selectItem itemValue="admissionDate" itemLabel="Admission Date"/>
+                            </p:selectOneMenu>
+                            <h:outputLabel value="Admission Type"/>
+                            <p:selectOneMenu value="#{creditCompanyDueController.admissionType}">
+                                <f:selectItem itemLabel="All Admission Types" itemValue="#{null}"/>
+                                <f:selectItems value="#{admissionTypeController.items}" var="at" itemValue="#{at}" itemLabel="#{at.name}"/>
+                            </p:selectOneMenu>
+                            <h:outputLabel value="Site"/>
+                            <p:selectOneMenu value="#{creditCompanyDueController.site}" filter="true">
+                                <f:selectItem itemLabel="All Sites" itemValue="#{null}"/>
+                                <f:selectItems value="#{institutionController.sites}" var="dueSite" itemLabel="#{dueSite.name}" itemValue="#{dueSite}"/>
+                            </p:selectOneMenu>
+                            <h:outputLabel value="Department"/>
+                            <p:selectOneMenu value="#{creditCompanyDueController.department}" filter="true" filterMatchMode="contains">
+                                <f:selectItem itemLabel="All Departments" itemValue="#{null}"/>
+                                <f:selectItems value="#{departmentController.getDepartmentsOfInstitutionAndSite()}" var="d" itemLabel="#{d.name}" itemValue="#{d}"/>
+                            </p:selectOneMenu>
+                        </h:panelGrid>
+                        <p:commandButton id="btnSearch" class="ui-button-warning" icon="fas fa-cogs" ajax="false"
+                                         value="Process Due Age"
+                                         action="#{creditCompanyDueController.createInwardPatientCopaymentDueAge()}"/>
+                        <p:defaultCommand target="btnSearch"/>
+
+                        <p:dataTable id="lst" value="#{creditCompanyDueController.creditCompanyAge}" var="row"
+                                     filteredValue="#{creditCompanyDueController.filteredList}"
+                                     emptyMessage="No records found">
+                            <f:facet name="header">
+                                <h:outputLabel value="Inward Patient Co-payment Due Age (days since discharge)"/>
+                            </f:facet>
+                            <p:column headerText="BHT – Patient Name" filterBy="#{row.string}" filterMatchMode="contains">
+                                <h:outputLabel value="#{row.string}"/>
+                            </p:column>
+                            <p:column headerText="0–30" style="text-align:right">
+                                <h:outputLabel value="#{row.value1}">
+                                    <f:convertNumber pattern="#,##0.00"/>
+                                </h:outputLabel>
+                            </p:column>
+                            <p:column headerText="31–60" style="text-align:right">
+                                <h:outputLabel value="#{row.value2}">
+                                    <f:convertNumber pattern="#,##0.00"/>
+                                </h:outputLabel>
+                            </p:column>
+                            <p:column headerText="61–90" style="text-align:right">
+                                <h:outputLabel value="#{row.value3}">
+                                    <f:convertNumber pattern="#,##0.00"/>
+                                </h:outputLabel>
+                            </p:column>
+                            <p:column headerText="91+" style="text-align:right">
+                                <h:outputLabel value="#{row.value4}">
+                                    <f:convertNumber pattern="#,##0.00"/>
+                                </h:outputLabel>
+                            </p:column>
+                        </p:dataTable>
+                    </p:panel>
+                </h:form>
+            </ui:define>
+        </ui:composition>
+    </h:body>
+</html>

--- a/src/main/webapp/credit/inward_patient_copay_due_search.xhtml
+++ b/src/main/webapp/credit/inward_patient_copay_due_search.xhtml
@@ -1,0 +1,182 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
+      xmlns:p="http://primefaces.org/ui"
+      xmlns:h="http://xmlns.jcp.org/jsf/html"
+      xmlns:f="http://xmlns.jcp.org/jsf/core">
+
+    <h:body>
+        <ui:composition template="/payments/credit_company_pay_index.xhtml">
+            <ui:define name="admin">
+                <h:form>
+                    <p:panel>
+                        <f:facet name="header">
+                            <h:outputLabel value="INWARD PATIENT CO-PAYMENT DUE SEARCH"/>
+                        </f:facet>
+                        <h:panelGrid columns="2" class="my-2">
+                            <h:outputLabel value="From Date"/>
+                            <p:calendar class="mx-4 w-100" inputStyleClass="w-100" id="fromDate"
+                                        value="#{creditCompanyDueController.fromDate}" navigator="true"
+                                        pattern="#{sessionController.applicationPreference.longDateTimeFormat}">
+                                <f:ajax event="dateSelect" execute="toDate @this" render="lst"/>
+                            </p:calendar>
+                            <h:outputLabel value="To Date &emsp;"/>
+                            <p:calendar class="mx-4 w-100" inputStyleClass="w-100" id="toDate"
+                                        value="#{creditCompanyDueController.toDate}" navigator="true"
+                                        pattern="#{sessionController.applicationPreference.longDateTimeFormat}">
+                                <f:ajax event="dateSelect" execute="@this fromDate" render="lst"/>
+                            </p:calendar>
+                            <h:outputLabel value="Date Basis"/>
+                            <p:selectOneMenu value="#{creditCompanyDueController.dateBasis}">
+                                <f:selectItem itemValue="dischargeDate" itemLabel="Discharge Date"/>
+                                <f:selectItem itemValue="admissionDate" itemLabel="Admission Date"/>
+                            </p:selectOneMenu>
+                            <h:outputLabel value="Admission Type"/>
+                            <p:selectOneMenu value="#{creditCompanyDueController.admissionType}">
+                                <f:selectItem itemLabel="All Admission Types" itemValue="#{null}"/>
+                                <f:selectItems value="#{admissionTypeController.items}" var="at" itemValue="#{at}" itemLabel="#{at.name}"/>
+                            </p:selectOneMenu>
+                            <h:outputLabel value="Site"/>
+                            <p:selectOneMenu value="#{creditCompanyDueController.site}" filter="true">
+                                <f:selectItem itemLabel="All Sites" itemValue="#{null}"/>
+                                <f:selectItems value="#{institutionController.sites}" var="dueSite" itemLabel="#{dueSite.name}" itemValue="#{dueSite}"/>
+                            </p:selectOneMenu>
+                            <h:outputLabel value="Department"/>
+                            <p:selectOneMenu value="#{creditCompanyDueController.department}" filter="true" filterMatchMode="contains">
+                                <f:selectItem itemLabel="All Departments" itemValue="#{null}"/>
+                                <f:selectItems value="#{departmentController.getDepartmentsOfInstitutionAndSite()}" var="d" itemLabel="#{d.name}" itemValue="#{d}"/>
+                            </p:selectOneMenu>
+                        </h:panelGrid>
+                        <h:panelGrid columns="6" class="my-2">
+                            <p:commandButton class="ui-button-warning" icon="fas fa-cogs" ajax="false" value="Process"
+                                             action="#{creditCompanyDueController.createInwardPatientCopaymentDueSearch()}"/>
+                            <p:commandButton class="ui-button-info mx-2" icon="fas fa-print" ajax="false" value="Print">
+                                <p:printer target="lst"/>
+                            </p:commandButton>
+                            <p:commandButton class="ui-button-success" icon="fas fa-file-excel"
+                                             actionListener="#{creditCompanyDueController.createInwardPatientCopaymentDueSearch()}"
+                                             ajax="false" value="Excel">
+                                <p:dataExporter type="xlsx" target="lst" fileName="Inward Patient Copayment Due"/>
+                            </p:commandButton>
+                        </h:panelGrid>
+
+                        <p:dataTable id="lst" value="#{creditCompanyDueController.patientEncounters}" var="pe"
+                                     emptyMessage="No records found">
+                            <f:facet name="header">
+                                <h:outputLabel value="Inward Patient Co-payment Due Search"/>
+                                <br/>
+                                <h:outputLabel value="From : " style="white-space: pre-line"/>
+                                <h:outputLabel value="#{creditCompanyDueController.fromDate}">
+                                    <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateTimeFormat}"/>
+                                </h:outputLabel>
+                                <h:outputLabel value="  To : "/>
+                                <h:outputLabel value="#{creditCompanyDueController.toDate}">
+                                    <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateTimeFormat}"/>
+                                </h:outputLabel>
+                            </f:facet>
+                            <p:columnGroup type="header">
+                                <p:row>
+                                    <p:column headerText="BHT No"/>
+                                    <p:column headerText="Patient Name"/>
+                                    <p:column headerText="Admission Date"/>
+                                    <p:column headerText="Discharge Date"/>
+                                    <p:column headerText="CC Company"/>
+                                    <p:column headerText="Final Bill Total" style="text-align:right"/>
+                                    <p:column headerText="CC Committed" style="text-align:right"/>
+                                    <p:column headerText="CC Paid" style="text-align:right"/>
+                                    <p:column headerText="CC Status"/>
+                                    <p:column headerText="Patient Portion" style="text-align:right"/>
+                                    <p:column headerText="Patient Paid" style="text-align:right"/>
+                                    <p:column headerText="Patient Outstanding" style="text-align:right"/>
+                                </p:row>
+                            </p:columnGroup>
+                            <p:column>
+                                <h:outputLabel value="#{pe.bhtNo}"/>
+                            </p:column>
+                            <p:column>
+                                <h:outputLabel value="#{pe.patient.person.nameWithTitle}"/>
+                            </p:column>
+                            <p:column>
+                                <h:outputLabel value="#{pe.dateOfAdmission}">
+                                    <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateTimeFormat}"/>
+                                </h:outputLabel>
+                            </p:column>
+                            <p:column>
+                                <h:outputLabel value="#{pe.dateOfDischarge}">
+                                    <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateTimeFormat}"/>
+                                </h:outputLabel>
+                            </p:column>
+                            <p:column>
+                                <h:outputLabel value="#{pe.creditCompany != null ? pe.creditCompany.name : 'Self-pay'}"/>
+                            </p:column>
+                            <p:column style="text-align:right">
+                                <h:outputLabel value="#{pe.finalBill.netTotal}">
+                                    <f:convertNumber pattern="#,##0.00"/>
+                                </h:outputLabel>
+                            </p:column>
+                            <p:column style="text-align:right">
+                                <h:outputLabel value="#{pe.creditUsedAmount}">
+                                    <f:convertNumber pattern="#,##0.00"/>
+                                </h:outputLabel>
+                            </p:column>
+                            <p:column style="text-align:right">
+                                <h:outputLabel value="#{pe.paidByCreditCompany}">
+                                    <f:convertNumber pattern="#,##0.00"/>
+                                </h:outputLabel>
+                            </p:column>
+                            <p:column>
+                                <h:outputLabel value="#{creditCompanyDueController.getPatientCcStatus(pe)}"/>
+                            </p:column>
+                            <p:column style="text-align:right">
+                                <h:outputLabel value="#{pe.finalBill.netTotal - pe.creditUsedAmount}">
+                                    <f:convertNumber pattern="#,##0.00"/>
+                                </h:outputLabel>
+                            </p:column>
+                            <p:column style="text-align:right">
+                                <h:outputLabel value="#{pe.finalBill.paidAmount}">
+                                    <f:convertNumber pattern="#,##0.00"/>
+                                </h:outputLabel>
+                            </p:column>
+                            <p:column style="text-align:right">
+                                <h:outputLabel value="#{creditCompanyDueController.getPatientCopaymentDue(pe)}">
+                                    <f:convertNumber pattern="#,##0.00"/>
+                                </h:outputLabel>
+                            </p:column>
+                            <p:columnGroup type="footer">
+                                <p:row>
+                                    <p:column footerText="Grand Total" colspan="5"/>
+                                    <p:column style="text-align:right">
+                                        <f:facet name="footer">
+                                            <h:outputLabel value="#{creditCompanyDueController.billed}">
+                                                <f:convertNumber pattern="#,##0.00"/>
+                                            </h:outputLabel>
+                                        </f:facet>
+                                    </p:column>
+                                    <p:column colspan="4"/>
+                                    <p:column style="text-align:right">
+                                        <f:facet name="footer">
+                                            <h:outputLabel value="#{creditCompanyDueController.paidByPatient}">
+                                                <f:convertNumber pattern="#,##0.00"/>
+                                            </h:outputLabel>
+                                        </f:facet>
+                                    </p:column>
+                                    <p:column style="text-align:right">
+                                        <f:facet name="footer">
+                                            <h:outputLabel value="#{creditCompanyDueController.payableByPatient}">
+                                                <f:convertNumber pattern="#,##0.00"/>
+                                            </h:outputLabel>
+                                        </f:facet>
+                                    </p:column>
+                                </p:row>
+                            </p:columnGroup>
+                            <f:facet name="footer">
+                                <h:outputLabel class="my-2" value="Printed By : #{sessionController.loggedUser.webUserPerson.name}" style="float: right"/>
+                            </f:facet>
+                        </p:dataTable>
+                    </p:panel>
+                </h:form>
+            </ui:define>
+        </ui:composition>
+    </h:body>
+</html>

--- a/src/main/webapp/credit/inward_patient_copay_due_search.xhtml
+++ b/src/main/webapp/credit/inward_patient_copay_due_search.xhtml
@@ -19,13 +19,13 @@
                             <p:calendar class="mx-4 w-100" inputStyleClass="w-100" id="fromDate"
                                         value="#{creditCompanyDueController.fromDate}" navigator="true"
                                         pattern="#{sessionController.applicationPreference.longDateTimeFormat}">
-                                <f:ajax event="dateSelect" execute="toDate @this" render="lst"/>
+                                <f:ajax event="dateSelect" execute="toDate @this"/>
                             </p:calendar>
                             <h:outputLabel value="To Date &emsp;"/>
                             <p:calendar class="mx-4 w-100" inputStyleClass="w-100" id="toDate"
                                         value="#{creditCompanyDueController.toDate}" navigator="true"
                                         pattern="#{sessionController.applicationPreference.longDateTimeFormat}">
-                                <f:ajax event="dateSelect" execute="@this fromDate" render="lst"/>
+                                <f:ajax event="dateSelect" execute="@this fromDate"/>
                             </p:calendar>
                             <h:outputLabel value="Date Basis"/>
                             <p:selectOneMenu value="#{creditCompanyDueController.dateBasis}">
@@ -129,7 +129,7 @@
                                 <h:outputLabel value="#{creditCompanyDueController.getPatientCcStatus(pe)}"/>
                             </p:column>
                             <p:column style="text-align:right">
-                                <h:outputLabel value="#{pe.finalBill.netTotal - pe.creditUsedAmount}">
+                                <h:outputLabel value="#{(pe.finalBill.netTotal - pe.creditUsedAmount) gt 0 ? pe.finalBill.netTotal - pe.creditUsedAmount : 0}">
                                     <f:convertNumber pattern="#,##0.00"/>
                                 </h:outputLabel>
                             </p:column>

--- a/src/main/webapp/payments/credit_company_pay_index.xhtml
+++ b/src/main/webapp/payments/credit_company_pay_index.xhtml
@@ -95,10 +95,18 @@
 
                                         <p:tab title="Inpatient Credit Management">
                                             <div class="d-grid gap-2">
-                                                <p:commandButton styleClass="w-100 ui-button-info ui-button-outlined" ajax="false" icon="pi pi-list" value="Inward Due Search" title="List outstanding inward dues for credit companies" action="/credit/inward_due_search_credit_company?faces-redirect=true"/>
-                                                <p:commandButton styleClass="w-100 ui-button-info ui-button-outlined" ajax="false" icon="pi pi-calendar-times" value="Inward Due Age" title="View aged inward dues" action="/credit/inward_due_age_credit_company?faces-redirect=true"/>
-                                                <p:commandButton styleClass="w-100 ui-button-success" ajax="false" icon="pi pi-id-card" value="Inward Payment by BHT" title="Process inward payments by BHT" action="/credit/credit_compnay_bill_inward?faces-redirect=true"/>
-                                                <p:commandButton styleClass="w-100 ui-button-success" ajax="false" icon="pi pi-building" value="Inward Payment by Company" title="Process inward payments by company" action="/credit/credit_compnay_bill_payment_inward?faces-redirect=true"/>
+                                                <h:outputLabel value="— CC Reports —" styleClass="text-muted small text-center mt-1"/>
+                                                <p:commandButton styleClass="w-100 ui-button-info ui-button-outlined" ajax="false" icon="pi pi-list" value="Inward CC Due Search" title="List outstanding inward dues owed by credit companies" action="/credit/inward_due_search_credit_company?faces-redirect=true"/>
+                                                <p:commandButton styleClass="w-100 ui-button-info ui-button-outlined" ajax="false" icon="pi pi-calendar-times" value="Inward CC Due Age" title="View aged inward dues owed by credit companies" action="/credit/inward_due_age_credit_company?faces-redirect=true"/>
+                                                <p:commandButton styleClass="w-100 ui-button-success" ajax="false" icon="pi pi-id-card" value="Inward Payment by BHT" title="Process inward CC payments by BHT" action="/credit/credit_compnay_bill_inward?faces-redirect=true"/>
+                                                <p:commandButton styleClass="w-100 ui-button-success" ajax="false" icon="pi pi-building" value="Inward Payment by Company" title="Process inward CC payments by company" action="/credit/credit_compnay_bill_payment_inward?faces-redirect=true"/>
+                                                <h:outputLabel value="— Patient Reports —" styleClass="text-muted small text-center mt-2"/>
+                                                <p:commandButton styleClass="w-100 ui-button-info ui-button-outlined" ajax="false" icon="pi pi-search" value="Inward Patient Due Search" title="List all inward admissions with outstanding patient co-payment balances"
+                                                                 actionListener="#{creditCompanyDueController.makeNull()}"
+                                                                 action="/credit/inward_patient_copay_due_search?faces-redirect=true"/>
+                                                <p:commandButton styleClass="w-100 ui-button-info ui-button-outlined" ajax="false" icon="pi pi-calendar-times" value="Inward Patient Due Age" title="View aged patient co-payment balances (one row per patient)"
+                                                                 actionListener="#{creditCompanyDueController.makeNull()}"
+                                                                 action="/credit/inward_patient_copay_due_age?faces-redirect=true"/>
                                                 <p:commandButton
                                                     styleClass="w-100 ui-button-warning"
                                                     ajax="false"
@@ -106,6 +114,10 @@
                                                     value="Inward Patient Co-payment"
                                                     title="Collect patient co-payment balance after credit company settlement"
                                                     action="#{inwardPaymentController.navigateToInwardPatientCopayment()}"/>
+                                                <h:outputLabel value="— Management —" styleClass="text-muted small text-center mt-2"/>
+                                                <p:commandButton styleClass="w-100 ui-button-help ui-button-outlined" ajax="false" icon="pi pi-chart-bar" value="Inward Outstanding Summary" title="Management view: CC receivables vs patient co-payment receivables by age bucket"
+                                                                 actionListener="#{creditCompanyDueController.makeNull()}"
+                                                                 action="/credit/inward_outstanding_summary?faces-redirect=true"/>
                                             </div>
                                         </p:tab>
 


### PR DESCRIPTION
## Summary

Adds two patient co-payment report sets and a management summary view to the Inpatient Credit Management module, as specified in #20039.

### What's added

**Set 2 – Patient Co-payment Due Reports**
- `inward_patient_copay_due_search.xhtml` — flat list of all finalized inpatients with outstanding patient co-payment balances. Columns: BHT, patient name, dates, final bill total, CC committed, CC paid, **CC Status flag** (PENDING / PARTIAL / SETTLED / N/A), patient portion, patient paid, patient outstanding. Print + Excel export.
- `inward_patient_copay_due_age.xhtml` — one row per patient; outstanding amount placed in the correct age bucket (0–30, 31–60, 61–90, 91+ days since discharge).

**Set 3 – Inward Outstanding Summary (Management View)**
- `inward_outstanding_summary.xhtml` — three aggregate rows (CC Receivable / Patient Co-payment / Both Outstanding) × four age buckets. CFO/revenue-cycle director view.

**Navigation (`credit_company_pay_index.xhtml`)**
- Renamed "Inward Due Search" → **"Inward CC Due Search"**
- Renamed "Inward Due Age" → **"Inward CC Due Age"**
- Added buttons: Inward Patient Due Search, Inward Patient Due Age, Inward Outstanding Summary
- Visual section separators: CC Reports / Patient Reports / Management

**`CreditCompanyDueController.java`**
- `createInwardPatientCopaymentDueSearch()` — JPQL on `PatientEncounter` filtering `(finalBill.netTotal − creditUsedAmount − finalBill.paidAmount) > 0.01`; includes all inpatients (with or without CC) who have any patient balance.
- `createInwardPatientCopaymentDueAge()` — delegates to search, then maps each row to the correct `String1Value5` age bucket.
- `createInwardOutstandingSummary()` — scans all finalized admissions in the date range; builds CC, patient, and overlap rows.
- `getPatientCcStatus(pe)` — helper returning PENDING/PARTIAL/SETTLED/N/A.
- `getPatientCopaymentDue(pe)` — helper returning patient outstanding.

## Test plan
- [ ] Navigate to the Inpatient Credit Management tab — verify all section labels and button names render correctly
- [ ] Click "Inward CC Due Search" and "Inward CC Due Age" — confirm existing CC reports still work unchanged
- [ ] Click "Inward Patient Due Search" — set a date range, process; verify only admissions with patient balance > 0 appear
- [ ] Verify CC Status column shows PENDING for unremitted CC, PARTIAL for partial, SETTLED/N/A where appropriate
- [ ] Click "Inward Patient Due Age" — verify one row per patient, amount in correct age bucket
- [ ] Click "Inward Outstanding Summary" — verify three rows (CC Receivable, Patient Co-payment, Both Outstanding) with correct age-bucket totals
- [ ] Test Print and Excel export on the patient due search page

Closes #20039

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added patient co-payment due search to query and filter inpatient encounters by date range and demographics.
  * Added co-payment aging report with day-based aging buckets (0–30, 31–60, 61–90, 91+ days).
  * Added outstanding summary report for tracking credit company and patient co-payment receivables.
  * Enhanced inpatient credit management navigation with new organized report sections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->