### PR TITLE
#20044 - fix: searchRequest() fails with EclipseLink error 6044 — null primary key rows in REQUEST table 

### DIFF
--- a/src/main/java/com/divudi/service/RequestService.java
+++ b/src/main/java/com/divudi/service/RequestService.java
@@ -96,6 +96,7 @@ public class RequestService {
 
         String jpql = "Select q from Request q "
                 + " where q.retired =:ret "
+                + " and q.id is not null "
                 + " and q.createdAt between :frm and :to";
 
         if (requestNo != null && !requestNo.trim().equals("")) {


### PR DESCRIPTION
###  Summary

  - The searchRequest() method on view_request.xhtml was throwing a
  TransactionRolledbackLocalException (EclipseLink error 6044) due to rows in the REQUEST table where
  ID IS NULL
  - Added q.id is not null to the JPQL query in RequestService.fillAllRequest() to filter out corrupt
  rows before EclipseLink attempts to map them
  - No business logic changed — the fix is a defensive null-PK guard at the query layer

###   Root Cause

  The REQUEST table contained rows with a null primary key, likely from a direct DB insert or data
  migration that bypassed JPA. EclipseLink cannot map such rows to a Request entity and rolls back the
   transaction with error 6044.

###   Test Plan

  - Navigate to /common/request/view_request.xhtml
  - Search requests with a valid date range — list should load without errors
  - Verify Payara logs show no EclipseLink 6044 warnings for this query
  - Confirm existing request workflows (approve, reject, cancel) are unaffected

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved request query results by excluding entries with missing identifiers, ensuring more accurate data retrieval.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->