### PR TITLE
Inward Discount Matrix — admin configuration UI for service/investigation and pharmacy discounts

### DIFF
--- a/src/main/java/com/divudi/bean/inward/InwardDiscountMatrixController.java
+++ b/src/main/java/com/divudi/bean/inward/InwardDiscountMatrixController.java
@@ -1,0 +1,275 @@
+/*
+ * Open Hospital Management Information System
+ *
+ * Dr M H B Ariyaratne
+ * buddhika.ari@gmail.com
+ */
+package com.divudi.bean.inward;
+
+import com.divudi.bean.common.SessionController;
+import com.divudi.core.util.JsfUtil;
+import com.divudi.core.data.PaymentMethod;
+import com.divudi.core.entity.Category;
+import com.divudi.core.entity.Department;
+import com.divudi.core.entity.PaymentScheme;
+import com.divudi.core.entity.PriceMatrix;
+import com.divudi.core.entity.inward.AdmissionType;
+import com.divudi.core.entity.inward.InwardDiscountMatrix;
+import com.divudi.core.entity.lab.InvestigationCategory;
+import com.divudi.core.entity.pharmacy.PharmaceuticalItemCategory;
+import com.divudi.core.entity.ServiceCategory;
+import com.divudi.core.entity.ServiceSubCategory;
+import com.divudi.core.facade.PriceMatrixFacade;
+import java.io.Serializable;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import javax.ejb.EJB;
+import javax.enterprise.context.SessionScoped;
+import javax.inject.Inject;
+import javax.inject.Named;
+
+/**
+ * Controller for the Inward Discount Matrix configuration pages.
+ *
+ * Manages discount percentage entries keyed by department, category,
+ * BHT type (paymentMethod), admission type, and discount scheme (paymentScheme).
+ *
+ * @author Dr M H B Ariyaratne
+ */
+@Named
+@SessionScoped
+public class InwardDiscountMatrixController implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    @Inject
+    SessionController sessionController;
+
+    @EJB
+    private PriceMatrixFacade ejbFacade;
+
+    private PriceMatrix current;
+    private List<PriceMatrix> items;
+    private List<PriceMatrix> filterItems;
+
+    private Department department;
+    private Category category;
+    private AdmissionType admissionType;
+    private PaymentMethod paymentMethod;
+    private PaymentScheme paymentScheme;
+    private double discountPercent;
+
+    // -------------------------------------------------------------------------
+    // Navigation
+    // -------------------------------------------------------------------------
+
+    public String navigateToDiscountMatrixServiceInvestigation() {
+        prepareAdd();
+        return "/inward/inward_discount_matrix_service_investigation?faces-redirect=true";
+    }
+
+    public String navigateToDiscountMatrixPharmacy() {
+        prepareAdd();
+        return "/inward/inward_discount_matrix_pharmacy?faces-redirect=true";
+    }
+
+    // -------------------------------------------------------------------------
+    // Lifecycle
+    // -------------------------------------------------------------------------
+
+    public void prepareAdd() {
+        department = null;
+        category = null;
+        admissionType = null;
+        paymentMethod = null;
+        paymentScheme = null;
+        discountPercent = 0.0;
+        items = null;
+        filterItems = null;
+    }
+
+    // -------------------------------------------------------------------------
+    // Save
+    // -------------------------------------------------------------------------
+
+    public void saveForServiceInvestigation() {
+        if (paymentScheme == null) {
+            JsfUtil.addErrorMessage("Please select a Discount Scheme");
+            return;
+        }
+        InwardDiscountMatrix entry = buildEntry();
+        ejbFacade.create(entry);
+        JsfUtil.addSuccessMessage("Saved Successfully");
+        loadServiceInvestigation();
+        clearInputFields();
+    }
+
+    public void saveForPharmacy() {
+        if (paymentScheme == null) {
+            JsfUtil.addErrorMessage("Please select a Discount Scheme");
+            return;
+        }
+        InwardDiscountMatrix entry = buildEntry();
+        ejbFacade.create(entry);
+        JsfUtil.addSuccessMessage("Saved Successfully");
+        loadPharmacy();
+        clearInputFields();
+    }
+
+    private InwardDiscountMatrix buildEntry() {
+        InwardDiscountMatrix entry = new InwardDiscountMatrix();
+        entry.setDepartment(department);
+        entry.setCategory(category);
+        entry.setAdmissionType(admissionType);
+        entry.setPaymentMethod(paymentMethod);
+        entry.setPaymentScheme(paymentScheme);
+        entry.setDiscountPercent(discountPercent);
+        if (department != null) {
+            entry.setInstitution(department.getInstitution());
+        }
+        entry.setCreatedAt(new Date());
+        entry.setCreater(sessionController.getLoggedUser());
+        return entry;
+    }
+
+    private void clearInputFields() {
+        department = null;
+        category = null;
+        admissionType = null;
+        paymentMethod = null;
+        paymentScheme = null;
+        discountPercent = 0.0;
+    }
+
+    // -------------------------------------------------------------------------
+    // Load / Fill
+    // -------------------------------------------------------------------------
+
+    public void loadServiceInvestigation() {
+        filterItems = null;
+        HashMap<String, Object> hm = new HashMap<>();
+        String sql = "select a from InwardDiscountMatrix a"
+                + " where a.retired = false"
+                + " and (type(a.category) = :svc"
+                + "   or type(a.category) = :sub"
+                + "   or type(a.category) = :inv"
+                + "   or a.category is null)"
+                + " order by a.paymentScheme.name, a.department.name, a.category.name";
+        hm.put("svc", ServiceCategory.class);
+        hm.put("sub", ServiceSubCategory.class);
+        hm.put("inv", InvestigationCategory.class);
+        items = ejbFacade.findByJpql(sql, hm);
+    }
+
+    public void loadPharmacy() {
+        filterItems = null;
+        HashMap<String, Object> hm = new HashMap<>();
+        String sql = "select a from InwardDiscountMatrix a"
+                + " where a.retired = false"
+                + " and (type(a.category) = :pharm"
+                + "   or a.category is null)"
+                + " order by a.paymentScheme.name, a.department.name, a.category.name";
+        hm.put("pharm", PharmaceuticalItemCategory.class);
+        items = ejbFacade.findByJpql(sql, hm);
+    }
+
+    // -------------------------------------------------------------------------
+    // Edit / Delete
+    // -------------------------------------------------------------------------
+
+    public void onEdit(PriceMatrix entry) {
+        ejbFacade.edit(entry);
+        JsfUtil.addSuccessMessage("Updated Successfully");
+    }
+
+    public void delete() {
+        if (current == null) {
+            JsfUtil.addErrorMessage("Nothing to delete");
+            return;
+        }
+        current.setRetired(true);
+        current.setRetiredAt(new Date());
+        current.setRetirer(sessionController.getLoggedUser());
+        ejbFacade.edit(current);
+        JsfUtil.addSuccessMessage("Deleted Successfully");
+        items = null;
+        current = null;
+    }
+
+    // -------------------------------------------------------------------------
+    // Getters / Setters
+    // -------------------------------------------------------------------------
+
+    public PriceMatrix getCurrent() {
+        return current;
+    }
+
+    public void setCurrent(PriceMatrix current) {
+        this.current = current;
+    }
+
+    public List<PriceMatrix> getItems() {
+        return items;
+    }
+
+    public void setItems(List<PriceMatrix> items) {
+        this.items = items;
+    }
+
+    public List<PriceMatrix> getFilterItems() {
+        return filterItems;
+    }
+
+    public void setFilterItems(List<PriceMatrix> filterItems) {
+        this.filterItems = filterItems;
+    }
+
+    public Department getDepartment() {
+        return department;
+    }
+
+    public void setDepartment(Department department) {
+        this.department = department;
+    }
+
+    public Category getCategory() {
+        return category;
+    }
+
+    public void setCategory(Category category) {
+        this.category = category;
+    }
+
+    public AdmissionType getAdmissionType() {
+        return admissionType;
+    }
+
+    public void setAdmissionType(AdmissionType admissionType) {
+        this.admissionType = admissionType;
+    }
+
+    public PaymentMethod getPaymentMethod() {
+        return paymentMethod;
+    }
+
+    public void setPaymentMethod(PaymentMethod paymentMethod) {
+        this.paymentMethod = paymentMethod;
+    }
+
+    public PaymentScheme getPaymentScheme() {
+        return paymentScheme;
+    }
+
+    public void setPaymentScheme(PaymentScheme paymentScheme) {
+        this.paymentScheme = paymentScheme;
+    }
+
+    public double getDiscountPercent() {
+        return discountPercent;
+    }
+
+    public void setDiscountPercent(double discountPercent) {
+        this.discountPercent = discountPercent;
+    }
+}

--- a/src/main/java/com/divudi/core/entity/inward/InwardDiscountMatrix.java
+++ b/src/main/java/com/divudi/core/entity/inward/InwardDiscountMatrix.java
@@ -1,0 +1,31 @@
+/*
+ * Open Hospital Management Information System
+ *
+ * Dr M H B Ariyaratne
+ * buddhika.ari@gmail.com
+ */
+package com.divudi.core.entity.inward;
+
+import com.divudi.core.entity.PriceMatrix;
+import java.io.Serializable;
+import javax.persistence.Entity;
+
+/**
+ * Inward Discount Matrix entry.
+ *
+ * Stores the discount percentage applicable for a combination of:
+ * department, category, BHT type (paymentMethod), admission type, and
+ * discount scheme (paymentScheme).
+ *
+ * All fields are inherited from PriceMatrix. The discriminator is the
+ * concrete entity type, which keeps these records separate from
+ * InwardPriceAdjustment (margin) records.
+ *
+ * @author Dr M H B Ariyaratne
+ */
+@Entity
+public class InwardDiscountMatrix extends PriceMatrix implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+}

--- a/src/main/webapp/inward/inward_administration.xhtml
+++ b/src/main/webapp/inward/inward_administration.xhtml
@@ -70,6 +70,13 @@
                                         </div>
                                     </p:tab>
 
+                                    <p:tab title="Discount Matrix">
+                                        <div class="d-grid gap-2">
+                                            <p:commandButton ajax="false" value="Inward Discount Matrix - Services and Investigations" class="w-100" action="#{inwardDiscountMatrixController.navigateToDiscountMatrixServiceInvestigation()}"></p:commandButton>
+                                            <p:commandButton ajax="false" value="Inward Discount Matrix - Pharmacy" class="w-100" action="#{inwardDiscountMatrixController.navigateToDiscountMatrixPharmacy()}"></p:commandButton>
+                                        </div>
+                                    </p:tab>
+
                                     <p:tab title="Analytics">
                                         <div class="d-grid gap-2">
                                             <p:commandButton ajax="false" value="Inward Prices" class="w-100" action="/inward/?faces-redirect=true" ></p:commandButton>

--- a/src/main/webapp/inward/inward_discount_matrix_pharmacy.xhtml
+++ b/src/main/webapp/inward/inward_discount_matrix_pharmacy.xhtml
@@ -1,0 +1,247 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
+      xmlns:p="http://primefaces.org/ui"
+      xmlns:h="http://xmlns.jcp.org/jsf/html"
+      xmlns:f="http://xmlns.jcp.org/jsf/core">
+
+    <h:body>
+        <ui:composition template="/inward/inward_administration.xhtml">
+            <ui:define name="subcontent">
+                <h:form>
+                    <p:panel header="Inward Discount Matrix - Pharmacy" id="reportPrint" class="row w-100">
+
+                        <!-- Add new entry -->
+                        <p:panel>
+                            <f:facet name="header">
+                                <h:outputLabel value="Add New Discount Entry" class="mt-2"/>
+                                <p:commandButton
+                                    value="Add"
+                                    class="ui-button-success"
+                                    icon="fa fa-plus"
+                                    style="float: right;"
+                                    ajax="false"
+                                    action="#{inwardDiscountMatrixController.saveForPharmacy}">
+                                </p:commandButton>
+                            </f:facet>
+
+                            <div class="row w-100 d-flex ml-2">
+
+                                <div class="row mt-1">
+                                    <div class="col-2">
+                                        <h:outputLabel value="Discount Scheme" class="mt-2"/>
+                                    </div>
+                                    <div class="col-10">
+                                        <p:autoComplete
+                                            value="#{inwardDiscountMatrixController.paymentScheme}"
+                                            forceSelection="true"
+                                            completeMethod="#{paymentSchemeController.completePaymentScheme}"
+                                            var="ps"
+                                            inputStyleClass="form-control"
+                                            class="w-100"
+                                            itemLabel="#{ps.name}"
+                                            itemValue="#{ps}">
+                                        </p:autoComplete>
+                                    </div>
+                                </div>
+
+                                <div class="row mt-1">
+                                    <div class="col-2">
+                                        <h:outputLabel value="Department" class="mt-2"/>
+                                    </div>
+                                    <div class="col-10">
+                                        <p:autoComplete
+                                            value="#{inwardDiscountMatrixController.department}"
+                                            forceSelection="true"
+                                            completeMethod="#{departmentController.completeDept}"
+                                            var="dep"
+                                            inputStyleClass="form-control"
+                                            class="w-100"
+                                            itemLabel="#{dep.name}"
+                                            itemValue="#{dep}">
+                                            <p:column>
+                                                <h:outputLabel value="#{dep.name}"/>
+                                            </p:column>
+                                            <p:column>
+                                                <h:outputLabel value="#{dep.institution.name}"/>
+                                            </p:column>
+                                        </p:autoComplete>
+                                    </div>
+                                </div>
+
+                                <div class="row mt-1">
+                                    <div class="col-2">
+                                        <h:outputLabel value="Pharmaceutical Category" class="mt-2"/>
+                                    </div>
+                                    <div class="col-10">
+                                        <p:selectOneMenu
+                                            class="w-100"
+                                            value="#{inwardDiscountMatrixController.category}">
+                                            <f:selectItem itemLabel="All Categories" itemValue="#{null}"/>
+                                            <f:selectItems value="#{pharmaceuticalItemCategoryController.items}"
+                                                           var="c"
+                                                           itemLabel="#{c.name}"
+                                                           itemValue="#{c}"/>
+                                        </p:selectOneMenu>
+                                    </div>
+                                </div>
+
+                                <div class="row mt-1">
+                                    <div class="col-2">
+                                        <h:outputLabel value="Admission Type" class="mt-2"/>
+                                    </div>
+                                    <div class="col-4">
+                                        <p:selectOneMenu
+                                            class="w-100"
+                                            value="#{inwardDiscountMatrixController.admissionType}">
+                                            <f:selectItem itemLabel="All Admission Types" itemValue="#{null}"/>
+                                            <f:selectItems value="#{admissionTypeController.items}"
+                                                           var="at"
+                                                           itemValue="#{at}"
+                                                           itemLabel="#{at.name}"/>
+                                        </p:selectOneMenu>
+                                    </div>
+                                </div>
+
+                                <div class="row mt-1">
+                                    <div class="col-2">
+                                        <h:outputLabel value="BHT Type" class="mt-2"/>
+                                    </div>
+                                    <div class="col-4">
+                                        <p:selectOneMenu
+                                            class="w-100"
+                                            value="#{inwardDiscountMatrixController.paymentMethod}">
+                                            <f:selectItem itemLabel="All BHT Types"/>
+                                            <f:selectItems value="#{enumController.paymentMethodForAdmission}"/>
+                                        </p:selectOneMenu>
+                                    </div>
+                                </div>
+
+                                <div class="row mt-1">
+                                    <div class="col-2">
+                                        <h:outputLabel value="Discount %" class="mt-2"/>
+                                    </div>
+                                    <div class="col-4">
+                                        <p:inputText
+                                            class="w-100"
+                                            autocomplete="off"
+                                            value="#{inwardDiscountMatrixController.discountPercent}"/>
+                                    </div>
+                                </div>
+
+                            </div>
+                        </p:panel>
+
+                        <!-- Data table -->
+                        <p:panel class="mt-2" id="discountMatrixPreview">
+                            <f:facet name="header">
+                                <h:outputLabel value="Discount Matrix" class="mt-2"/>
+                                <div class="d-flex" style="float: right">
+                                    <p:commandButton
+                                        ajax="false"
+                                        icon="fa fa-fill"
+                                        class="ui-button-warning"
+                                        value="Fill"
+                                        action="#{inwardDiscountMatrixController.loadPharmacy}">
+                                    </p:commandButton>
+                                    <p:commandButton
+                                        class="ui-button-success mx-2"
+                                        actionListener="#{inwardDiscountMatrixController.loadPharmacy}"
+                                        ajax="false"
+                                        value="Excel"
+                                        icon="fa-solid fa-file-excel">
+                                        <p:dataExporter
+                                            type="xlsx"
+                                            target="discountTbl"
+                                            fileName="inward_discount_matrix_pharmacy"/>
+                                    </p:commandButton>
+                                    <p:commandButton
+                                        class="ui-button-info"
+                                        ajax="false"
+                                        icon="fa fa-print"
+                                        value="Print">
+                                        <p:printer target="discountMatrixPreview"/>
+                                    </p:commandButton>
+                                </div>
+                            </f:facet>
+
+                            <p:dataTable
+                                id="discountTbl"
+                                value="#{inwardDiscountMatrixController.items}"
+                                filteredValue="#{inwardDiscountMatrixController.filterItems}"
+                                var="a"
+                                scrollable="true">
+
+                                <p:column headerText="ID" style="width: 3em;">
+                                    #{a.id}
+                                </p:column>
+
+                                <p:column
+                                    headerText="Discount Scheme"
+                                    filterBy="#{a.paymentScheme.name}"
+                                    filterMatchMode="contains">
+                                    <h:outputText value="#{a.paymentScheme.name}"/>
+                                </p:column>
+
+                                <p:column
+                                    headerText="Department"
+                                    filterBy="#{a.department.name}"
+                                    filterMatchMode="contains">
+                                    <h:outputText value="#{a.department.name}"/>
+                                </p:column>
+
+                                <p:column
+                                    headerText="Pharmaceutical Category"
+                                    filterBy="#{a.category.name}"
+                                    filterMatchMode="contains">
+                                    <h:outputText value="#{a.category.name}"/>
+                                </p:column>
+
+                                <p:column headerText="Admission Type">
+                                    <h:outputText value="#{a.admissionType.name}"/>
+                                </p:column>
+
+                                <p:column headerText="BHT Type">
+                                    <h:outputText value="#{a.paymentMethod}"/>
+                                </p:column>
+
+                                <p:column headerText="Discount %" style="width: 8em;">
+                                    <h:inputText
+                                        autocomplete="off"
+                                        value="#{a.discountPercent}"
+                                        style="width: 5em;">
+                                        <f:convertNumber pattern="#,##0.00"/>
+                                    </h:inputText>
+                                </p:column>
+
+                                <p:column headerText="Action" style="width: 10em;">
+                                    <div class="d-flex">
+                                        <p:commandButton
+                                            id="btnEdit"
+                                            ajax="false"
+                                            icon="fa fa-pencil"
+                                            class="ui-button-success mx-1"
+                                            action="#{inwardDiscountMatrixController.onEdit(a)}">
+                                        </p:commandButton>
+                                        <p:commandButton
+                                            id="btnDelete"
+                                            class="ui-button-danger"
+                                            icon="fa-solid fa-trash"
+                                            action="#{inwardDiscountMatrixController.delete}">
+                                            <f:setPropertyActionListener value="#{a}" target="#{inwardDiscountMatrixController.current}"/>
+                                        </p:commandButton>
+                                    </div>
+                                    <p:tooltip for="btnEdit" value="Update" showDelay="0" hideDelay="0"/>
+                                    <p:tooltip for="btnDelete" value="Delete" showDelay="0" hideDelay="0"/>
+                                </p:column>
+
+                            </p:dataTable>
+                        </p:panel>
+
+                    </p:panel>
+                </h:form>
+            </ui:define>
+        </ui:composition>
+    </h:body>
+</html>

--- a/src/main/webapp/inward/inward_discount_matrix_service_investigation.xhtml
+++ b/src/main/webapp/inward/inward_discount_matrix_service_investigation.xhtml
@@ -1,0 +1,254 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
+      xmlns:p="http://primefaces.org/ui"
+      xmlns:h="http://xmlns.jcp.org/jsf/html"
+      xmlns:f="http://xmlns.jcp.org/jsf/core">
+
+    <h:body>
+        <ui:composition template="/inward/inward_administration.xhtml">
+            <ui:define name="subcontent">
+                <h:form>
+                    <p:panel header="Inward Discount Matrix - Services and Investigations" id="reportPrint" class="row w-100">
+
+                        <!-- Add new entry -->
+                        <p:panel>
+                            <f:facet name="header">
+                                <h:outputLabel value="Add New Discount Entry" class="mt-2"/>
+                                <p:commandButton
+                                    value="Add"
+                                    class="ui-button-success"
+                                    icon="fa fa-plus"
+                                    style="float: right;"
+                                    ajax="false"
+                                    action="#{inwardDiscountMatrixController.saveForServiceInvestigation}">
+                                </p:commandButton>
+                            </f:facet>
+
+                            <div class="row w-100 d-flex ml-2">
+
+                                <div class="row mt-1">
+                                    <div class="col-2">
+                                        <h:outputLabel value="Discount Scheme" class="mt-2"/>
+                                    </div>
+                                    <div class="col-10">
+                                        <p:autoComplete
+                                            value="#{inwardDiscountMatrixController.paymentScheme}"
+                                            forceSelection="true"
+                                            completeMethod="#{paymentSchemeController.completePaymentScheme}"
+                                            var="ps"
+                                            inputStyleClass="form-control"
+                                            class="w-100"
+                                            itemLabel="#{ps.name}"
+                                            itemValue="#{ps}">
+                                        </p:autoComplete>
+                                    </div>
+                                </div>
+
+                                <div class="row mt-1">
+                                    <div class="col-2">
+                                        <h:outputLabel value="Department" class="mt-2"/>
+                                    </div>
+                                    <div class="col-10">
+                                        <p:autoComplete
+                                            value="#{inwardDiscountMatrixController.department}"
+                                            forceSelection="true"
+                                            completeMethod="#{departmentController.completeDept}"
+                                            var="dep"
+                                            inputStyleClass="form-control"
+                                            class="w-100"
+                                            itemLabel="#{dep.name}"
+                                            itemValue="#{dep}">
+                                            <p:column>
+                                                <h:outputLabel value="#{dep.name}"/>
+                                            </p:column>
+                                            <p:column>
+                                                <h:outputLabel value="#{dep.institution.name}"/>
+                                            </p:column>
+                                        </p:autoComplete>
+                                    </div>
+                                </div>
+
+                                <div class="row mt-1">
+                                    <div class="col-2">
+                                        <h:outputLabel value="Category / Subcategory" class="mt-2"/>
+                                    </div>
+                                    <div class="col-10">
+                                        <p:autoComplete
+                                            value="#{inwardDiscountMatrixController.category}"
+                                            forceSelection="true"
+                                            completeMethod="#{categoryController.completeCategoryService}"
+                                            var="cat"
+                                            inputStyleClass="form-control"
+                                            class="w-100"
+                                            itemLabel="#{cat.name} #{cat.parentCategory}"
+                                            itemValue="#{cat}">
+                                            <p:column headerText="Category">
+                                                <h:outputLabel value="#{cat.name}"/>
+                                            </p:column>
+                                            <p:column headerText="Parent Category">
+                                                <h:outputLabel value="#{cat.parentCategory.name}"/>
+                                            </p:column>
+                                        </p:autoComplete>
+                                    </div>
+                                </div>
+
+                                <div class="row mt-1">
+                                    <div class="col-2">
+                                        <h:outputLabel value="Admission Type" class="mt-2"/>
+                                    </div>
+                                    <div class="col-4">
+                                        <p:selectOneMenu
+                                            class="w-100"
+                                            value="#{inwardDiscountMatrixController.admissionType}">
+                                            <f:selectItem itemLabel="All Admission Types" itemValue="#{null}"/>
+                                            <f:selectItems value="#{admissionTypeController.items}"
+                                                           var="at"
+                                                           itemValue="#{at}"
+                                                           itemLabel="#{at.name}"/>
+                                        </p:selectOneMenu>
+                                    </div>
+                                </div>
+
+                                <div class="row mt-1">
+                                    <div class="col-2">
+                                        <h:outputLabel value="BHT Type" class="mt-2"/>
+                                    </div>
+                                    <div class="col-4">
+                                        <p:selectOneMenu
+                                            class="w-100"
+                                            value="#{inwardDiscountMatrixController.paymentMethod}">
+                                            <f:selectItem itemLabel="All BHT Types"/>
+                                            <f:selectItems value="#{enumController.paymentMethodForAdmission}"/>
+                                        </p:selectOneMenu>
+                                    </div>
+                                </div>
+
+                                <div class="row mt-1">
+                                    <div class="col-2">
+                                        <h:outputLabel value="Discount %" class="mt-2"/>
+                                    </div>
+                                    <div class="col-4">
+                                        <p:inputText
+                                            class="w-100"
+                                            autocomplete="off"
+                                            value="#{inwardDiscountMatrixController.discountPercent}"/>
+                                    </div>
+                                </div>
+
+                            </div>
+                        </p:panel>
+
+                        <!-- Data table -->
+                        <p:panel class="mt-2" id="discountMatrixPreview">
+                            <f:facet name="header">
+                                <h:outputLabel value="Discount Matrix" class="mt-2"/>
+                                <div class="d-flex" style="float: right">
+                                    <p:commandButton
+                                        ajax="false"
+                                        icon="fa fa-fill"
+                                        class="ui-button-warning"
+                                        value="Fill"
+                                        action="#{inwardDiscountMatrixController.loadServiceInvestigation}">
+                                    </p:commandButton>
+                                    <p:commandButton
+                                        class="ui-button-success mx-2"
+                                        actionListener="#{inwardDiscountMatrixController.loadServiceInvestigation}"
+                                        ajax="false"
+                                        value="Excel"
+                                        icon="fa-solid fa-file-excel">
+                                        <p:dataExporter
+                                            type="xlsx"
+                                            target="discountTbl"
+                                            fileName="inward_discount_matrix_service_investigation"/>
+                                    </p:commandButton>
+                                    <p:commandButton
+                                        class="ui-button-info"
+                                        ajax="false"
+                                        icon="fa fa-print"
+                                        value="Print">
+                                        <p:printer target="discountMatrixPreview"/>
+                                    </p:commandButton>
+                                </div>
+                            </f:facet>
+
+                            <p:dataTable
+                                id="discountTbl"
+                                value="#{inwardDiscountMatrixController.items}"
+                                filteredValue="#{inwardDiscountMatrixController.filterItems}"
+                                var="a"
+                                scrollable="true">
+
+                                <p:column headerText="ID" style="width: 3em;">
+                                    #{a.id}
+                                </p:column>
+
+                                <p:column
+                                    headerText="Discount Scheme"
+                                    filterBy="#{a.paymentScheme.name}"
+                                    filterMatchMode="contains">
+                                    <h:outputText value="#{a.paymentScheme.name}"/>
+                                </p:column>
+
+                                <p:column
+                                    headerText="Department"
+                                    filterBy="#{a.department.name}"
+                                    filterMatchMode="contains">
+                                    <h:outputText value="#{a.department.name}"/>
+                                </p:column>
+
+                                <p:column
+                                    headerText="Category"
+                                    filterBy="#{a.category.name}"
+                                    filterMatchMode="contains">
+                                    <h:outputText value="#{a.category.name}"/>
+                                </p:column>
+
+                                <p:column headerText="Admission Type">
+                                    <h:outputText value="#{a.admissionType.name}"/>
+                                </p:column>
+
+                                <p:column headerText="BHT Type">
+                                    <h:outputText value="#{a.paymentMethod}"/>
+                                </p:column>
+
+                                <p:column headerText="Discount %" style="width: 8em;">
+                                    <h:inputText
+                                        autocomplete="off"
+                                        value="#{a.discountPercent}"
+                                        style="width: 5em;">
+                                        <f:convertNumber pattern="#,##0.00"/>
+                                    </h:inputText>
+                                </p:column>
+
+                                <p:column headerText="Action" style="width: 10em;">
+                                    <div class="d-flex">
+                                        <p:commandButton
+                                            id="btnEdit"
+                                            ajax="false"
+                                            icon="fa fa-pencil"
+                                            class="ui-button-success mx-1"
+                                            action="#{inwardDiscountMatrixController.onEdit(a)}">
+                                        </p:commandButton>
+                                        <p:commandButton
+                                            id="btnDelete"
+                                            class="ui-button-danger"
+                                            icon="fa-solid fa-trash"
+                                            action="#{inwardDiscountMatrixController.delete}">
+                                            <f:setPropertyActionListener value="#{a}" target="#{inwardDiscountMatrixController.current}"/>
+                                        </p:commandButton>
+                                    </div>
+                                    <p:tooltip for="btnEdit" value="Update" showDelay="0" hideDelay="0"/>
+                                    <p:tooltip for="btnDelete" value="Delete" showDelay="0" hideDelay="0"/>
+                                </p:column>
+
+                            </p:dataTable>
+                        </p:panel>
+
+                    </p:panel>
+                </h:form>
+            </ui:define>
+        </ui:composition>
+    </h:body>
+</html>

--- a/src/main/webapp/inward/inward_discount_matrix_service_investigation.xhtml
+++ b/src/main/webapp/inward/inward_discount_matrix_service_investigation.xhtml
@@ -72,24 +72,18 @@
 
                                 <div class="row mt-1">
                                     <div class="col-2">
-                                        <h:outputLabel value="Category / Subcategory" class="mt-2"/>
+                                        <h:outputLabel value="Category" class="mt-2"/>
                                     </div>
                                     <div class="col-10">
                                         <p:autoComplete
                                             value="#{inwardDiscountMatrixController.category}"
                                             forceSelection="true"
-                                            completeMethod="#{categoryController.completeCategoryService}"
+                                            completeMethod="#{categoryController.completeServiceInvestigationCategory}"
                                             var="cat"
                                             inputStyleClass="form-control"
                                             class="w-100"
-                                            itemLabel="#{cat.name} #{cat.parentCategory}"
+                                            itemLabel="#{cat.name}"
                                             itemValue="#{cat}">
-                                            <p:column headerText="Category">
-                                                <h:outputLabel value="#{cat.name}"/>
-                                            </p:column>
-                                            <p:column headerText="Parent Category">
-                                                <h:outputLabel value="#{cat.parentCategory.name}"/>
-                                            </p:column>
                                         </p:autoComplete>
                                     </div>
                                 </div>


### PR DESCRIPTION
## Summary

- New `InwardDiscountMatrix` entity (extends `PriceMatrix`) — clean separation from existing price margin records
- New `InwardDiscountMatrixController` (@SessionScoped) with save/load/delete for both page types
- Two new XHTML pages under `/inward/`: one for services + investigations, one for pharmacy
- New **Discount Matrix** tab added to `inward_administration.xhtml` with two navigation buttons

## Criteria per discount entry

| Field | Notes |
|---|---|
| Discount Scheme | `paymentScheme` — patient's membership/discount scheme |
| Department | optional narrowing |
| Category | service/investigation or pharmaceutical item category |
| Admission Type | e.g. Private, General |
| BHT Type | `paymentMethod` — Cash, Credit, etc. |
| Discount % | `discountPercent` |

## No schema changes required

`PriceMatrix` already has all required fields (`paymentScheme`, `admissionType`, `discountPercent`). The new entity is a JPA single-table/joined discriminator subclass — EclipseLink will add the `DTYPE` column row automatically. `exclude-unlisted-classes=false` means no persistence.xml update needed.

## Related

- Closes #20054
- Prerequisite for #19306 (applying inward discounts in billing engine)

## Test plan

- [ ] Navigate to Inward Administration → Discount Matrix tab
- [ ] Open "Services and Investigations" page — add an entry with all 5 criteria and verify it saves
- [ ] Open "Pharmacy" page — add an entry and verify it saves
- [ ] Edit discount % inline and click Update — verify persisted
- [ ] Delete an entry — verify soft-deleted (retired=true)
- [ ] Fill button loads the correct category-filtered records
- [ ] Excel export works

🤖 Generated with [Claude Code](https://claude.com/claude-code)