### PR TITLE
Add discount scheme selection to inward admission and BHT edit (#20056)

### DIFF
--- a/src/main/java/com/divudi/bean/inward/AdmissionController.java
+++ b/src/main/java/com/divudi/bean/inward/AdmissionController.java
@@ -61,6 +61,7 @@ import com.divudi.core.entity.Department;
 import com.divudi.core.entity.Staff;
 import com.divudi.core.entity.clinical.ClinicalFindingValue;
 import com.divudi.core.entity.inward.AdmissionType;
+import com.divudi.core.entity.PaymentScheme;
 import com.divudi.core.entity.inward.Reservation;
 import com.divudi.core.facade.ClinicalFindingValueFacade;
 import com.divudi.core.facade.ReservationFacade;
@@ -191,6 +192,7 @@ public class AdmissionController implements Serializable, ControllerWithPatient 
     private Institution site;
 
     private PaymentMethod paymentMethod;
+    private PaymentScheme paymentScheme;
     private boolean admittingProcessStarted;
     private Reservation latestfoundReservation;
 
@@ -2394,6 +2396,19 @@ public class AdmissionController implements Serializable, ControllerWithPatient 
             current.setPatient(patient);
             patientAllergies = clinicalFindingValueController.findClinicalFindingValues(patient, ClinicalFindingValueType.PatientAllergy);
         }
+        selectPaymentSchemeAsPerPatientMembership();
+    }
+
+    private void selectPaymentSchemeAsPerPatientMembership() {
+        if (patient == null) {
+            paymentScheme = null;
+            return;
+        }
+        if (patient.getPerson() == null || patient.getPerson().getMembershipScheme() == null) {
+            paymentScheme = null;
+        } else {
+            paymentScheme = patient.getPerson().getMembershipScheme().getPaymentScheme();
+        }
     }
 
     public YearMonthDay getYearMonthDay() {
@@ -2670,6 +2685,14 @@ public class AdmissionController implements Serializable, ControllerWithPatient 
     @Override
     public void listnerForPaymentMethodChange() {
         // ToDo: Add Logic
+    }
+
+    public PaymentScheme getPaymentScheme() {
+        return paymentScheme;
+    }
+
+    public void setPaymentScheme(PaymentScheme paymentScheme) {
+        this.paymentScheme = paymentScheme;
     }
 
     public Department getLoggedDepartment() {

--- a/src/main/java/com/divudi/bean/inward/AdmissionController.java
+++ b/src/main/java/com/divudi/bean/inward/AdmissionController.java
@@ -2397,7 +2397,6 @@ public class AdmissionController implements Serializable, ControllerWithPatient 
             patientAllergies = clinicalFindingValueController.findClinicalFindingValues(patient, ClinicalFindingValueType.PatientAllergy);
         }
         selectPaymentSchemeAsPerPatientMembership();
-        PrimeFaces.current().ajax().update("pg1");
     }
 
     private void selectPaymentSchemeAsPerPatientMembership() {

--- a/src/main/java/com/divudi/bean/inward/AdmissionController.java
+++ b/src/main/java/com/divudi/bean/inward/AdmissionController.java
@@ -2397,6 +2397,7 @@ public class AdmissionController implements Serializable, ControllerWithPatient 
             patientAllergies = clinicalFindingValueController.findClinicalFindingValues(patient, ClinicalFindingValueType.PatientAllergy);
         }
         selectPaymentSchemeAsPerPatientMembership();
+        PrimeFaces.current().ajax().update("pg1");
     }
 
     private void selectPaymentSchemeAsPerPatientMembership() {

--- a/src/main/java/com/divudi/bean/inward/BhtEditController.java
+++ b/src/main/java/com/divudi/bean/inward/BhtEditController.java
@@ -51,6 +51,7 @@ import javax.inject.Inject;
 import javax.inject.Named;
 import com.divudi.core.entity.EncounterCreditCompany;
 import com.divudi.core.entity.Institution;
+import com.divudi.core.entity.PaymentScheme;
 import com.divudi.core.entity.clinical.ClinicalFindingValue;
 import com.divudi.core.facade.ClinicalFindingValueFacade;
 import com.divudi.core.facade.EmailFacade;
@@ -135,6 +136,7 @@ public class BhtEditController implements Serializable, ControllerWithPatient {
 
     YearMonthDay yearMonthDay;
     private PaymentMethod paymentMethod;
+    private PaymentScheme paymentScheme;
 
     private Speciality referringSpeciality;
     private Speciality opdSpeciality;
@@ -725,7 +727,13 @@ public class BhtEditController implements Serializable, ControllerWithPatient {
 
     public void setCurrent(Admission current) {
         this.current = current;
-
+        if (current != null && current.getPatient() != null
+                && current.getPatient().getPerson() != null
+                && current.getPatient().getPerson().getMembershipScheme() != null) {
+            paymentScheme = current.getPatient().getPerson().getMembershipScheme().getPaymentScheme();
+        } else {
+            paymentScheme = null;
+        }
     }
 
     private AdmissionFacade getFacade() {
@@ -975,7 +983,15 @@ public class BhtEditController implements Serializable, ControllerWithPatient {
     public void listnerForPaymentMethodChange() {
         // ToDo: Add Logic
     }
-    
+
+    public PaymentScheme getPaymentScheme() {
+        return paymentScheme;
+    }
+
+    public void setPaymentScheme(PaymentScheme paymentScheme) {
+        this.paymentScheme = paymentScheme;
+    }
+
     // Admission edit: prepare data to log audit event
     public void admissionToAuditMap(Map<String, Object> m, Admission o) {
         if (o == null || m == null) {

--- a/src/main/java/com/divudi/bean/membership/PaymentSchemeController.java
+++ b/src/main/java/com/divudi/bean/membership/PaymentSchemeController.java
@@ -430,6 +430,22 @@ public class PaymentSchemeController implements Serializable {
         return createPaymentSchemes(false, true, false);
     }
 
+    public List<PaymentScheme> getPaymentSchemesForInward() {
+        StringBuilder jpql = new StringBuilder("SELECT i FROM PaymentScheme i WHERE i.retired = false AND i.validForInpatientBills = true");
+        Map<String, Object> parameters = new HashMap<>();
+        if (sessionController.getDepartment() != null) {
+            boolean departmentSpecific = configOptionApplicationController.getBooleanValueByKey(
+                    "Department Specific Discount Schemes for " + sessionController.getDepartment().getName(), false
+            );
+            if (departmentSpecific) {
+                jpql.append(" AND i.department = :dep");
+                parameters.put("dep", sessionController.getDepartment());
+            }
+        }
+        jpql.append(" ORDER BY i.orderNo, i.name");
+        return getFacade().findByJpql(jpql.toString(), parameters);
+    }
+
     public List<PaymentScheme> createPaymentSchemes(boolean includeOpd, boolean includePharmacy, boolean includeChannel) {
         StringBuilder jpql = new StringBuilder("SELECT i FROM PaymentScheme i WHERE i.retired = false");
         Map<String, Object> parameters = new HashMap<>();

--- a/src/main/webapp/admin/pricing/payment_scheme.xhtml
+++ b/src/main/webapp/admin/pricing/payment_scheme.xhtml
@@ -122,6 +122,8 @@
                                                 <p:selectBooleanCheckbox value="#{paymentSchemeController.current.validForBilledBills}" />
                                                 <h:outputLabel value="Valid for Channeling" />
                                                 <p:selectBooleanCheckbox value="#{paymentSchemeController.current.validForChanneling}" />
+                                                <h:outputLabel value="Valid for Inward" />
+                                                <p:selectBooleanCheckbox value="#{paymentSchemeController.current.validForInpatientBills}" />
                                                 <h:outputLabel value="Department" />
                                                 <p:autoComplete 
                                                     value="#{paymentSchemeController.current.department}"

--- a/src/main/webapp/inward/inward_admission.xhtml
+++ b/src/main/webapp/inward/inward_admission.xhtml
@@ -427,6 +427,14 @@
                                                 <p:ajax process="@this" update="crd pg1" event="change" listener="#{admissionController.findLastUsedCreditCompanies()}" />
                                             </p:selectOneMenu>
                                         </div>
+                                        <div class="mb-1 mt-2">
+                                            <p:outputLabel value="Discount Scheme" styleClass="d-block"/>
+                                            <p:selectOneMenu class="w-100" styleClass="form-control w-100" value="#{admissionController.paymentScheme}">
+                                                <f:selectItem itemLabel="No Discount Scheme" itemValue="#{null}"/>
+                                                <f:selectItems value="#{paymentSchemeController.paymentSchemesForInward}"
+                                                               var="ps" itemLabel="#{ps.name}" itemValue="#{ps}"/>
+                                            </p:selectOneMenu>
+                                        </div>
                                     </h:panelGroup>
                                 </div>
                                 <!-- Right: credit company form + table (always visible) -->

--- a/src/main/webapp/inward/inward_admission.xhtml
+++ b/src/main/webapp/inward/inward_admission.xhtml
@@ -128,7 +128,8 @@
                     <div class="row">
                         <div class="col-5">
                             <h:panelGroup id="ptd">
-                                <common:patient_details_for_addmission editable="true" controller="#{admissionController}"/>
+                                <common:patient_details_for_addmission editable="true" controller="#{admissionController}"
+                                                                       extraUpdateIds=":#{p:resolveFirstComponentWithId('pg1',view).clientId}"/>
                             </h:panelGroup>
                         </div>
 

--- a/src/main/webapp/inward/inward_edit_bht.xhtml
+++ b/src/main/webapp/inward/inward_edit_bht.xhtml
@@ -449,9 +449,16 @@
                                         <h:outputLabel class="mx-2" value="#{bhtEditController.current.admissionType.name}"/>                               
 
                                         <h:outputLabel value="Select Payment Method"/>
-                                        <p:selectOneMenu  class="mx-2 w-100" id="cmbPs" value="#{bhtEditController.current.paymentMethod}">                       
+                                        <p:selectOneMenu  class="mx-2 w-100" id="cmbPs" value="#{bhtEditController.current.paymentMethod}">
                                             <f:selectItems value="#{enumController.paymentMethodForAdmission}" />
                                             <p:ajax process="@this" update="crd" event="change" />
+                                        </p:selectOneMenu>
+
+                                        <h:outputLabel value="Discount Scheme"/>
+                                        <p:selectOneMenu class="mx-2 w-100" value="#{bhtEditController.paymentScheme}">
+                                            <f:selectItem itemLabel="No Discount Scheme" itemValue="#{null}"/>
+                                            <f:selectItems value="#{paymentSchemeController.paymentSchemesForInward}"
+                                                           var="ps" itemLabel="#{ps.name}" itemValue="#{ps}"/>
                                         </p:selectOneMenu>
 
                                     </h:panelGrid>

--- a/src/main/webapp/resources/ezcomp/common/patient_details_for_addmission.xhtml
+++ b/src/main/webapp/resources/ezcomp/common/patient_details_for_addmission.xhtml
@@ -13,6 +13,7 @@
         <cc:attribute name="editable" type="java.lang.Boolean"  />
         <cc:attribute name="searchable" type="java.lang.Boolean" default="true" />
         <cc:attribute name="controller" type="com.divudi.bean.common.ControllerWithPatient"/>
+        <cc:attribute name="extraUpdateIds" default="" />
     </cc:interface>
 
     <!-- IMPLEMENTATION -->
@@ -106,11 +107,11 @@
                             #{ps.person.phone}
                         </p:column>
                         <p:column>
-                            <p:commandButton 
-                                action="#{patientController.selectQuickOneFromQuickSearchPatient(cc.attrs.controller)}" 
+                            <p:commandButton
+                                action="#{patientController.selectQuickOneFromQuickSearchPatient(cc.attrs.controller)}"
                                 id="btnSelectPt"
                                 process="btnSelectPt tblPatients"
-                                update=":#{p:resolveFirstComponentWithId('ptImp',view).clientId}"
+                                update=":#{p:resolveFirstComponentWithId('ptImp',view).clientId} #{cc.attrs.extraUpdateIds}"
                                 value="select">
                                 <f:setPropertyActionListener value="#{ps}" target="#{patientController.current}" />
                             </p:commandButton>


### PR DESCRIPTION
## Summary

- **`AdmissionController`**: Added `paymentScheme` field. `setPatient()` now calls `selectPaymentSchemeAsPerPatientMembership()` which auto-populates the scheme from the patient's membership scheme (same pattern as OPD billing).
- **`BhtEditController`**: Added `paymentScheme` field. `setCurrent()` auto-populates from the admission's patient membership.
- **`PaymentSchemeController`**: Added `getPaymentSchemesForInward()` — returns schemes where `validForInpatientBills = true`, with department-specific filtering.
- **`inward_admission.xhtml`**: Added "Discount Scheme" `p:selectOneMenu` in the Payment Details panel.
- **`inward_edit_bht.xhtml`**: Added "Discount Scheme" `p:selectOneMenu` in the BHT edit panel.

## Test plan

- [ ] Admit a patient who is a member — verify Discount Scheme auto-populates with their membership scheme
- [ ] Admit a patient with no membership — verify Discount Scheme shows "No Discount Scheme"
- [ ] Manually change the Discount Scheme dropdown and confirm selection is retained
- [ ] Open an existing BHT via Edit BHT — verify scheme auto-populates for member patients
- [ ] Verify only schemes with `validForInpatientBills = true` appear in the dropdown

## Related
- Closes #20056
- Admin config: #20054 (Inward Discount Matrix)
- Billing engine: #19306 (apply discounts to bills)

🤖 Generated with [Claude Code](https://claude.com/claude-code)