### PR TITLE
Fixed - Doctor Session Number Not Displayed in Session Numbering (Empty Circle Shown) 

### DIFF
--- a/src/main/webapp/resources/ezcomp/prints/five_five_paper_coustom_1.xhtml
+++ b/src/main/webapp/resources/ezcomp/prints/five_five_paper_coustom_1.xhtml
@@ -162,7 +162,7 @@
                                         <h:outputLabel value="#{billItem.item.name}"></h:outputLabel>
                                         <h:outputLabel value=" (N)" rendered="#{billItem.item.speciality}"/>
                                     </div>
-                                    <h:panelGroup rendered="#{billItem.item.printSessionNumber}" style="">
+                                    <h:panelGroup rendered="#{not billItem.sessionId.blank}" style="">
                                         <h:panelGroup rendered="#{configOptionApplicationController.getBooleanValueByKey('Print Individual Bill Item Session Number in OPD Bills')}" >
                                             <h:outputLabel  value="#{billItem.sessionId}" style="border: 1px solid black; border-radius: 50%; width: 22px; height: 22px; display: inline-flex; align-items: center; justify-content: center;"></h:outputLabel>
                                         </h:panelGroup>


### PR DESCRIPTION
Doctor Session Number Not Displayed in Session Numbering (Empty Circle Shown) #19848

closes #19848
Signed-off-by: damithdeshan98 <hkddrajapaksha@gmail.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated session number display logic in OPD bill items to render based on actual session data availability rather than print configuration settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->