### PR TITLE
Apply Inward Discount Matrix to inpatient service/investigation billing

### DIFF
--- a/src/main/java/com/divudi/bean/common/PriceMatrixController.java
+++ b/src/main/java/com/divudi/bean/common/PriceMatrixController.java
@@ -990,6 +990,127 @@ public class PriceMatrixController implements Serializable {
 
     }
 
+    // -------------------------------------------------------------------------
+    // Inward Discount Matrix lookup (used by inpatient service/investigation
+    // billing and surgery service add flows)
+    // -------------------------------------------------------------------------
+
+    /**
+     * Walk the InwardDiscountMatrix for a discount percent applicable to the
+     * given bill context. Order: Item → Category → Parent Category → Department.
+     * At each level the matching scheme is preferred; if not found, a row with
+     * a null paymentScheme is accepted as a plain per-BHT/admission-type rule.
+     *
+     * Returns 0.0 when no matching row exists — the caller can treat that as
+     * "no discount" without any feature toggle.
+     */
+    public double getInwardDiscountPercent(PaymentMethod bhtType, PaymentScheme scheme,
+            AdmissionType admissionType, Department department, Item item) {
+        if (bhtType == null || admissionType == null) {
+            return 0.0;
+        }
+
+        Category category = null;
+        if (item != null) {
+            category = item.getCategory();
+        }
+
+        Double pct = fetchInwardDiscountPercentForItem(bhtType, scheme, admissionType, item);
+        if (pct == null || pct == 0.0) {
+            pct = fetchInwardDiscountPercentForCategory(bhtType, scheme, admissionType, department, category);
+        }
+        if ((pct == null || pct == 0.0) && category != null) {
+            pct = fetchInwardDiscountPercentForCategory(bhtType, scheme, admissionType, department, category.getParentCategory());
+        }
+        if (pct == null || pct == 0.0) {
+            pct = fetchInwardDiscountPercentForDepartment(bhtType, scheme, admissionType, department);
+        }
+        return pct != null ? pct : 0.0;
+    }
+
+    private Double fetchInwardDiscountPercentForItem(PaymentMethod bhtType, PaymentScheme scheme,
+            AdmissionType admissionType, Item item) {
+        if (item == null) {
+            return null;
+        }
+        Double pct = fetchInwardDiscountMatrixPercent(bhtType, scheme, admissionType, null, null, item);
+        if ((pct == null || pct == 0.0) && scheme != null) {
+            pct = fetchInwardDiscountMatrixPercent(bhtType, null, admissionType, null, null, item);
+        }
+        return pct;
+    }
+
+    private Double fetchInwardDiscountPercentForCategory(PaymentMethod bhtType, PaymentScheme scheme,
+            AdmissionType admissionType, Department department, Category category) {
+        if (category == null) {
+            return null;
+        }
+        Double pct = fetchInwardDiscountMatrixPercent(bhtType, scheme, admissionType, department, category, null);
+        if ((pct == null || pct == 0.0) && scheme != null) {
+            pct = fetchInwardDiscountMatrixPercent(bhtType, null, admissionType, department, category, null);
+        }
+        return pct;
+    }
+
+    private Double fetchInwardDiscountPercentForDepartment(PaymentMethod bhtType, PaymentScheme scheme,
+            AdmissionType admissionType, Department department) {
+        if (department == null) {
+            return null;
+        }
+        Double pct = fetchInwardDiscountMatrixPercent(bhtType, scheme, admissionType, department, null, null);
+        if ((pct == null || pct == 0.0) && scheme != null) {
+            pct = fetchInwardDiscountMatrixPercent(bhtType, null, admissionType, department, null, null);
+        }
+        return pct;
+    }
+
+    /**
+     * Single-row matrix fetch. Each argument except bhtType and admissionType
+     * may be null; a null argument is translated to an IS NULL filter so the
+     * row-matching semantics are exact.
+     */
+    private Double fetchInwardDiscountMatrixPercent(PaymentMethod bhtType, PaymentScheme scheme,
+            AdmissionType admissionType, Department department, Category category, Item item) {
+        StringBuilder jpql = new StringBuilder(
+                "select a.discountPercent from InwardDiscountMatrix a"
+                + " where a.retired = false"
+                + " and a.paymentMethod = :pm"
+                + " and a.admissionType = :admTp");
+        HashMap<String, Object> params = new HashMap<>();
+        params.put("pm", bhtType);
+        params.put("admTp", admissionType);
+
+        if (scheme != null) {
+            jpql.append(" and a.paymentScheme = :sch");
+            params.put("sch", scheme);
+        } else {
+            jpql.append(" and a.paymentScheme is null");
+        }
+        if (department != null) {
+            jpql.append(" and a.department = :dep");
+            params.put("dep", department);
+        } else {
+            jpql.append(" and a.department is null");
+        }
+        if (category != null) {
+            jpql.append(" and a.category = :cat");
+            params.put("cat", category);
+        } else {
+            jpql.append(" and a.category is null");
+        }
+        if (item != null) {
+            jpql.append(" and a.item = :itm");
+            params.put("itm", item);
+        } else {
+            jpql.append(" and a.item is null");
+        }
+        try {
+            return getPriceMatrixFacade().findDoubleByJpql(jpql.toString(), params);
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
     // Add business logic below. (Right-click in editor and choose
     // "Insert Code > Add Business Method")
     public PriceMatrixFacade getPriceMatrixFacade() {

--- a/src/main/java/com/divudi/bean/common/PriceMatrixController.java
+++ b/src/main/java/com/divudi/bean/common/PriceMatrixController.java
@@ -1016,13 +1016,13 @@ public class PriceMatrixController implements Serializable {
         }
 
         Double pct = fetchInwardDiscountPercentForItem(bhtType, scheme, admissionType, item);
-        if (pct == null || pct == 0.0) {
+        if (pct == null) {
             pct = fetchInwardDiscountPercentForCategory(bhtType, scheme, admissionType, department, category);
         }
-        if ((pct == null || pct == 0.0) && category != null) {
+        if (pct == null && category != null) {
             pct = fetchInwardDiscountPercentForCategory(bhtType, scheme, admissionType, department, category.getParentCategory());
         }
-        if (pct == null || pct == 0.0) {
+        if (pct == null) {
             pct = fetchInwardDiscountPercentForDepartment(bhtType, scheme, admissionType, department);
         }
         return pct != null ? pct : 0.0;
@@ -1034,7 +1034,7 @@ public class PriceMatrixController implements Serializable {
             return null;
         }
         Double pct = fetchInwardDiscountMatrixPercent(bhtType, scheme, admissionType, null, null, item);
-        if ((pct == null || pct == 0.0) && scheme != null) {
+        if (pct == null && scheme != null) {
             pct = fetchInwardDiscountMatrixPercent(bhtType, null, admissionType, null, null, item);
         }
         return pct;
@@ -1046,7 +1046,7 @@ public class PriceMatrixController implements Serializable {
             return null;
         }
         Double pct = fetchInwardDiscountMatrixPercent(bhtType, scheme, admissionType, department, category, null);
-        if ((pct == null || pct == 0.0) && scheme != null) {
+        if (pct == null && scheme != null) {
             pct = fetchInwardDiscountMatrixPercent(bhtType, null, admissionType, department, category, null);
         }
         return pct;
@@ -1058,7 +1058,7 @@ public class PriceMatrixController implements Serializable {
             return null;
         }
         Double pct = fetchInwardDiscountMatrixPercent(bhtType, scheme, admissionType, department, null, null);
-        if ((pct == null || pct == 0.0) && scheme != null) {
+        if (pct == null && scheme != null) {
             pct = fetchInwardDiscountMatrixPercent(bhtType, null, admissionType, department, null, null);
         }
         return pct;
@@ -1105,7 +1105,18 @@ public class PriceMatrixController implements Serializable {
             jpql.append(" and a.item is null");
         }
         try {
-            return getPriceMatrixFacade().findDoubleByJpql(jpql.toString(), params);
+            List<Object> rs = getPriceMatrixFacade().findObjects(jpql.toString(), params);
+            if (rs == null || rs.isEmpty()) {
+                return null;
+            }
+            Object v = rs.get(0);
+            if (v == null) {
+                return null;
+            }
+            if (v instanceof Number) {
+                return ((Number) v).doubleValue();
+            }
+            return null;
         } catch (Exception e) {
             return null;
         }

--- a/src/main/java/com/divudi/bean/inward/AdmissionController.java
+++ b/src/main/java/com/divudi/bean/inward/AdmissionController.java
@@ -1958,6 +1958,7 @@ public class AdmissionController implements Serializable, ControllerWithPatient 
         if (getInwardBean().getLastGeneratedBhtLong() != null) {
             getCurrent().setBhtLong(getInwardBean().getLastGeneratedBhtLong());
         }
+        getCurrent().setPaymentScheme(paymentScheme);
 
         if (getCurrent().getId() != null && getCurrent().getId() > 0) {
             getFacade().edit(getCurrent());
@@ -2091,6 +2092,7 @@ public class AdmissionController implements Serializable, ControllerWithPatient 
         if (getInwardBean().getLastGeneratedBhtLong() != null) {
             getCurrent().setBhtLong(getInwardBean().getLastGeneratedBhtLong());
         }
+        getCurrent().setPaymentScheme(paymentScheme);
 
         if (getCurrent().getId() != null && getCurrent().getId() > 0) {
             getFacade().edit(getCurrent());
@@ -2234,6 +2236,9 @@ public class AdmissionController implements Serializable, ControllerWithPatient 
 
     public void setCurrent(Admission current) {
         this.current = current;
+        if (current != null && current.getPaymentScheme() != null) {
+            this.paymentScheme = current.getPaymentScheme();
+        }
     }
 
     /**

--- a/src/main/java/com/divudi/bean/inward/AdmissionController.java
+++ b/src/main/java/com/divudi/bean/inward/AdmissionController.java
@@ -2238,6 +2238,12 @@ public class AdmissionController implements Serializable, ControllerWithPatient 
         this.current = current;
         if (current != null && current.getPaymentScheme() != null) {
             this.paymentScheme = current.getPaymentScheme();
+        } else if (current != null && current.getPatient() != null
+                && current.getPatient().getPerson() != null
+                && current.getPatient().getPerson().getMembershipScheme() != null) {
+            this.paymentScheme = current.getPatient().getPerson().getMembershipScheme().getPaymentScheme();
+        } else {
+            this.paymentScheme = null;
         }
     }
 

--- a/src/main/java/com/divudi/bean/inward/BhtEditController.java
+++ b/src/main/java/com/divudi/bean/inward/BhtEditController.java
@@ -484,6 +484,8 @@ public class BhtEditController implements Serializable, ControllerWithPatient {
             }
         }
 
+        current.setPaymentScheme(paymentScheme);
+
         // Save Admission with immediate flush (flushes ALL entities without clear)
         if (current.getId() == null) {
             getEjbFacade().createAndFlush(current);  // SINGLE flush for ALL entities
@@ -727,7 +729,9 @@ public class BhtEditController implements Serializable, ControllerWithPatient {
 
     public void setCurrent(Admission current) {
         this.current = current;
-        if (current != null && current.getPatient() != null
+        if (current != null && current.getPaymentScheme() != null) {
+            paymentScheme = current.getPaymentScheme();
+        } else if (current != null && current.getPatient() != null
                 && current.getPatient().getPerson() != null
                 && current.getPatient().getPerson().getMembershipScheme() != null) {
             paymentScheme = current.getPatient().getPerson().getMembershipScheme().getPaymentScheme();

--- a/src/main/java/com/divudi/bean/inward/InwardBeanController.java
+++ b/src/main/java/com/divudi/bean/inward/InwardBeanController.java
@@ -118,6 +118,8 @@ public class InwardBeanController implements Serializable {
     SessionController sessionController;
     @Inject
     ConfigOptionApplicationController configOptionApplicationController;
+    @Inject
+    com.divudi.bean.common.PriceMatrixController priceMatrixController;
 
     private Long lastGeneratedBhtLong;
 
@@ -2316,9 +2318,49 @@ public class InwardBeanController implements Serializable {
             }
         }
 
+        applyInwardDiscountToBillFee(billFee, item, patientEncounter);
+
         double net = (billFee.getFeeGrossValue() + margin) - billFee.getFeeDiscount();
 
         billFee.setFeeValue(net);
+    }
+
+    /**
+     * Apply the Inward Discount Matrix discount to a BillFee.
+     *
+     * Runs on hospital-portion fees only (skips Staff fees, mirrors the margin
+     * rule) and requires the item to allow discount. The discount scheme is
+     * taken from the admission/encounter itself (set at admission time).
+     * BHT type is the encounter's paymentMethod. When no matrix row matches
+     * the discount is 0, so existing behaviour is preserved for sites that
+     * have not configured the matrix.
+     */
+    public void applyInwardDiscountToBillFee(BillFee billFee, Item item, PatientEncounter patientEncounter) {
+        if (billFee == null || item == null || patientEncounter == null) {
+            return;
+        }
+        if (!item.isDiscountAllowed()) {
+            return;
+        }
+        if (billFee.getFee() == null || billFee.getFee().getFeeType() == FeeType.Staff) {
+            return;
+        }
+        Department matrixDept = item.getDepartment();
+        if (matrixDept == null && billFee.getBillItem() != null && billFee.getBillItem().getBill() != null) {
+            matrixDept = billFee.getBillItem().getBill().getDepartment();
+        }
+        double pct = priceMatrixController.getInwardDiscountPercent(
+                patientEncounter.getPaymentMethod(),
+                patientEncounter.getPaymentScheme(),
+                patientEncounter.getAdmissionType(),
+                matrixDept,
+                item);
+        if (pct <= 0.0) {
+            return;
+        }
+        double gross = billFee.getFeeGrossValue();
+        double discount = (gross * pct) / 100.0;
+        billFee.setFeeDiscount(discount);
     }
 
     public void updateBillItemMargin(BillItem billItem, double serviceValue, PatientEncounter patientEncounter, Department matrixDepartment, PriceMatrix priceMatrix) {
@@ -2326,7 +2368,11 @@ public class InwardBeanController implements Serializable {
         List<BillFee> billFees = getBillBean().getBillFee(billItem);
 
         for (BillFee billFee : billFees) {
-            setBillFeeMargin(billFee, billItem.getItem(), priceMatrix);
+            if (patientEncounter != null && patientEncounter.getAdmissionType() != null) {
+                setBillFeeMargin(billFee, billItem.getItem(), priceMatrix, patientEncounter);
+            } else {
+                setBillFeeMargin(billFee, billItem.getItem(), priceMatrix);
+            }
 
             if (billFee.getId() != null) {
                 getBillFeeFacade().edit(billFee);
@@ -2337,7 +2383,11 @@ public class InwardBeanController implements Serializable {
 
     public void updateBillItemMargin(BillFee billFee, double serviceValue, PatientEncounter patientEncounter, Department matrixDepartment, PriceMatrix priceMatrix) {
 
-        setBillFeeMargin(billFee, billFee.getBillItem().getItem(), priceMatrix);
+        if (patientEncounter != null && patientEncounter.getAdmissionType() != null) {
+            setBillFeeMargin(billFee, billFee.getBillItem().getItem(), priceMatrix, patientEncounter);
+        } else {
+            setBillFeeMargin(billFee, billFee.getBillItem().getItem(), priceMatrix);
+        }
 
         if (billFee.getId() != null) {
             getBillFeeFacade().edit(billFee);

--- a/src/main/java/com/divudi/bean/inward/InwardBeanController.java
+++ b/src/main/java/com/divudi/bean/inward/InwardBeanController.java
@@ -2339,10 +2339,10 @@ public class InwardBeanController implements Serializable {
         if (billFee == null || item == null || patientEncounter == null) {
             return;
         }
-        if (!item.isDiscountAllowed()) {
-            return;
-        }
-        if (billFee.getFee() == null || billFee.getFee().getFeeType() == FeeType.Staff) {
+        if (!item.isDiscountAllowed()
+                || billFee.getFee() == null
+                || billFee.getFee().getFeeType() == FeeType.Staff) {
+            billFee.setFeeDiscount(0.0);
             return;
         }
         Department matrixDept = item.getDepartment();
@@ -2355,11 +2355,8 @@ public class InwardBeanController implements Serializable {
                 patientEncounter.getAdmissionType(),
                 matrixDept,
                 item);
-        if (pct <= 0.0) {
-            return;
-        }
         double gross = billFee.getFeeGrossValue();
-        double discount = (gross * pct) / 100.0;
+        double discount = pct > 0.0 ? (gross * pct) / 100.0 : 0.0;
         billFee.setFeeDiscount(discount);
     }
 

--- a/src/main/java/com/divudi/core/entity/PatientEncounter.java
+++ b/src/main/java/com/divudi/core/entity/PatientEncounter.java
@@ -86,6 +86,8 @@ public class PatientEncounter implements Serializable, RetirableEntity {
     @Enumerated(EnumType.STRING)
     PaymentMethod paymentMethod;
     @ManyToOne
+    private PaymentScheme paymentScheme;
+    @ManyToOne
     Institution creditCompany;
     @ManyToOne
     private Staff referringDoctor;
@@ -683,6 +685,14 @@ public class PatientEncounter implements Serializable, RetirableEntity {
 
     public void setPaymentMethod(PaymentMethod paymentMethod) {
         this.paymentMethod = paymentMethod;
+    }
+
+    public PaymentScheme getPaymentScheme() {
+        return paymentScheme;
+    }
+
+    public void setPaymentScheme(PaymentScheme paymentScheme) {
+        this.paymentScheme = paymentScheme;
     }
 
     public double getCreditLimit() {


### PR DESCRIPTION
## Summary
- Wires the existing Inward Discount Matrix (PR #20055) into the fee calculation used when adding **services and investigations to inpatient bills**, and the same path when adding **services to surgery** (both flows share `BillBhtController`).
- Persists the chosen `paymentScheme` on `PatientEncounter` so every downstream billing flow can read it; the controller-only state added in PR #20057 survived one screen but was lost afterwards.
- New `PriceMatrixController.getInwardDiscountPercent(...)` walks the matrix in the order Item → Category → Parent Category → Department, with a scheme-null fallback at each level. Returns 0 when no row matches, so sites without a configured matrix see no change.
- New `InwardBeanController.applyInwardDiscountToBillFee(...)` applies the lookup to `BillFee.feeDiscount`; the existing `net = gross + margin − discount` formula in `setBillFeeMargin` then produces the right net. Staff fees and items with `discountAllowed = false` are skipped, matching the margin rule.

## Out of scope (separate issues per user direction)
- Direct medicine issue for inpatients
- Direct medicine issue for surgeries

## Schema
No migration file added — follows PR #20055's precedent. The new `paymentscheme_id` column on `patientencounter` will be created via `DataAdministrationController.checkMissingFields`.

## Test plan
- [x] Maven build passes (`mvn compile`)
- [ ] Configure one `InwardDiscountMatrix` row (e.g. department + category + admission type + BHT type + scheme + 10%)
- [ ] Admit a patient, select the matching payment scheme, add a service → verify `feeDiscount` on the BillFee reflects the 10%
- [ ] Repeat for a surgery add-service via `theater/inward_bill_surgery_service.xhtml`
- [ ] Verify non-matching admission/scheme combinations stay at 0% discount
- [ ] Verify Staff fees and `discountAllowed=false` items are not discounted
- [ ] Re-open an edited admission — discount scheme persists across the session

Closes #19306

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced inward discount functionality for admission billing. The system now automatically calculates and applies discounts to bill items based on payment scheme and item hierarchy (item → category → department). Discount percentages are determined by lookup rules and applied during fee calculations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->