### PR TITLE
20008 endered amount not updating balance in on call channel bill causing error

### DIFF
--- a/src/main/java/com/divudi/bean/channel/BookingControllerViewScope.java
+++ b/src/main/java/com/divudi/bean/channel/BookingControllerViewScope.java
@@ -7411,11 +7411,13 @@ public class BookingControllerViewScope implements Serializable, ControllerWithP
     public void markAsForeigner() {
         setForiegn(true);
         calculateSelectedBillSessionTotal();
+        calculateCashBalance();
     }
 
     public void markAsLocal() {
         setForiegn(false);
         calculateSelectedBillSessionTotal();
+        calculateCashBalance();
     }
 
     public void markAsForeignerWithBillUpdate() {
@@ -7981,7 +7983,13 @@ public class BookingControllerViewScope implements Serializable, ControllerWithP
                     JsfUtil.addErrorMessage("Please Enter Tenderd Amount");
                     return;
                 }
-                Double tend = Double.valueOf(strTenderedValue);
+                Double tend;
+                try {
+                    tend = Double.parseDouble(strTenderedValue);
+                } catch (NumberFormatException e) {
+                    JsfUtil.addErrorMessage("Please Enter valid Tenderd Amount");
+                    return;
+                }
                 if (getSelectedBillSession().getBillItem().getBill().getNetTotal() > tend) {
                     JsfUtil.addErrorMessage("Please Enter correct Tenderd Amount");
                     return;
@@ -9041,21 +9049,16 @@ public class BookingControllerViewScope implements Serializable, ControllerWithP
 
         for (BillFee billFee : billFees) {
             BillItem billItem = billFee.getBillItem();
-            System.out.println("billItem = " + billItem.getItem().getName());
 
             if (isForiegn()) {
-                System.out.println("billFee.getFee().getFfee() = " + billFee.getFee().getFfee());
                 if (billFee.getFee().getFeeType().equals(FeeType.Staff)) {
-                    System.out.println("billFee.getFee().getProfessionalFfee() = " + billFee.getFee().getProfessionalFfee());
                     billItem.setStaffFee(billFee.getFee().getProfessionalFfee());
                 } else if (billFee.getFee().getFeeType().equals(FeeType.OwnInstitution)) {
-                    System.out.println("billFee.getFee().getHospitalFfee() = " + billFee.getFee().getHospitalFfee());
                     billItem.setHospitalFee(billFee.getFee().getHospitalFfee());
                 }
 
                 billItem.setNetValue(billFee.getFee().getFfee());
             } else {
-                System.out.println("local");
                 if (billFee.getFee().getFeeType().equals(FeeType.Staff)) {
                     billItem.setStaffFee(billFee.getFee().getProfessionalFee());
                 } else if (billFee.getFee().getFeeType().equals(FeeType.OwnInstitution)) {

--- a/src/main/java/com/divudi/bean/channel/BookingControllerViewScope.java
+++ b/src/main/java/com/divudi/bean/channel/BookingControllerViewScope.java
@@ -3655,7 +3655,8 @@ public class BookingControllerViewScope implements Serializable, ControllerWithP
             selectedBillSession.getBillItem().getBill().getBillFees().removeAll(billFeesToRemove);
         }
         selectedBillSession.getBillItem().getBill().getBillItems().remove(selectedBillItem);
-        calculateBillTotalsFromBillFees(selectedBillSession.getBillItem().getBill());
+        // calculateBillTotalsFromBillFees(selectedBillSession.getBillItem().getBill());
+        calculateSelectedBillSessionTotalForSettling();
         calculateCashBalance();
     }
 
@@ -3723,8 +3724,9 @@ public class BookingControllerViewScope implements Serializable, ControllerWithP
             newBillItem.setBillFees(billFeesToAdd);
         }
 
-        calculateBillTotalsFromBillFees(selectedBillSession.getBillItem().getBill());
+        // calculateBillTotalsFromBillFees(selectedBillSession.getBillItem().getBill());
 //        fillBaseFees();  
+        calculateSelectedBillSessionTotalForSettling();
         calculateCashBalance();
 
         itemToAddToBooking = null;
@@ -9113,6 +9115,7 @@ public class BookingControllerViewScope implements Serializable, ControllerWithP
 //        System.out.println("feeNetTotalForSelectedBill 4 = " + feeNetTotalForSelectedBill);
         getBillSession().getBill().setNetTotal(feeNetTotalForSelectedBill);
         getBillSession().getBill().setDiscount(feeDiscountForSelectedBill);
+        getBillSession().getBill().setTotal(feeTotalForSelectedBill);
 
         // for paymentMethod.CARD set the value after total calculation
         if (settlePaymentMethod == PaymentMethod.Card) {
@@ -9546,6 +9549,13 @@ public class BookingControllerViewScope implements Serializable, ControllerWithP
 
     public void setStrTenderedValue(String strTenderedValue) {
         this.strTenderedValue = strTenderedValue;
+        
+        // Null check and set cash paid to 0 if the input is null or empty
+        if (strTenderedValue == null || strTenderedValue.trim().isEmpty()) {
+            cashPaid = 0.0;
+            return;
+        }
+
         try {
             cashPaid = Double.parseDouble(strTenderedValue);
         } catch (NumberFormatException e) {

--- a/src/main/java/com/divudi/bean/channel/BookingControllerViewScope.java
+++ b/src/main/java/com/divudi/bean/channel/BookingControllerViewScope.java
@@ -3658,6 +3658,7 @@ public class BookingControllerViewScope implements Serializable, ControllerWithP
         selectedBillSession.getBillItem().getBill().getBillItems().remove(selectedBillItem);
         // calculateBillTotalsFromBillFees(selectedBillSession.getBillItem().getBill());
         calculateSelectedBillSessionTotalForSettlingByBillFees();
+        getBillFacade().edit(selectedBillSession.getBillItem().getBill());
         calculateCashBalance();
     }
 
@@ -3728,6 +3729,7 @@ public class BookingControllerViewScope implements Serializable, ControllerWithP
         // calculateBillTotalsFromBillFees(selectedBillSession.getBillItem().getBill());
 //        fillBaseFees();  
         calculateSelectedBillSessionTotalForSettlingByBillFees();
+        getBillFacade().edit(selectedBillSession.getBillItem().getBill());
         calculateCashBalance();
 
         itemToAddToBooking = null;

--- a/src/main/java/com/divudi/bean/channel/BookingControllerViewScope.java
+++ b/src/main/java/com/divudi/bean/channel/BookingControllerViewScope.java
@@ -2235,7 +2235,8 @@ public class BookingControllerViewScope implements Serializable, ControllerWithP
 
         if (viewScopeDataTransferController.getNeedToFillFeeTotalsByBillFees() != null && viewScopeDataTransferController.getNeedToFillFeeTotalsByBillFees()) {
             if (getBillSession() != null) {
-                calculateSelectedBillSessionTotalForSettling();
+                // calculateSelectedBillSessionTotalForSettling();
+                calculateSelectedBillSessionTotalForSettlingByBillFees();
             }
             viewScopeDataTransferController.setNeedToFillFeeTotalsByBillFees(false);
         }
@@ -3656,7 +3657,7 @@ public class BookingControllerViewScope implements Serializable, ControllerWithP
         }
         selectedBillSession.getBillItem().getBill().getBillItems().remove(selectedBillItem);
         // calculateBillTotalsFromBillFees(selectedBillSession.getBillItem().getBill());
-        calculateSelectedBillSessionTotalForSettling();
+        calculateSelectedBillSessionTotalForSettlingByBillFees();
         calculateCashBalance();
     }
 
@@ -3726,7 +3727,7 @@ public class BookingControllerViewScope implements Serializable, ControllerWithP
 
         // calculateBillTotalsFromBillFees(selectedBillSession.getBillItem().getBill());
 //        fillBaseFees();  
-        calculateSelectedBillSessionTotalForSettling();
+        calculateSelectedBillSessionTotalForSettlingByBillFees();
         calculateCashBalance();
 
         itemToAddToBooking = null;
@@ -4219,7 +4220,7 @@ public class BookingControllerViewScope implements Serializable, ControllerWithP
 
         if (configOptionApplicationController.getBooleanValueByKey("Allow Tenderd amount for channel booking")) {
             if (paymentMethod == PaymentMethod.Cash) {
-                if (strTenderedValue.isEmpty()) {
+                if (strTenderedValue == null || strTenderedValue.isEmpty()) {
                     JsfUtil.addErrorMessage("Please Enter Tenderd Amount");
                     return;
                 }
@@ -7968,24 +7969,24 @@ public class BookingControllerViewScope implements Serializable, ControllerWithP
                 }
             }
 
-            if (configOptionApplicationController.getBooleanValueByKey("Allow Tenderd amount for channel booking")) {
-                if (settlePaymentMethod == PaymentMethod.Cash) {
-                    if (strTenderedValue == null || strTenderedValue.isEmpty()) {
-                        JsfUtil.addErrorMessage("Please Enter Tenderd Amount");
-                        return;
-                    }
-                    Double tend = Double.valueOf(strTenderedValue);
-                    if (getSelectedBillSession().getBillItem().getBill().getNetTotal() > tend) {
-                        JsfUtil.addErrorMessage("Please Enter correct Tenderd Amount");
-                        return;
-                    }
-                }
-            }
-
             if (errorChecksettle()) {
                 return;
             }
 
+        }
+
+        if (configOptionApplicationController.getBooleanValueByKey("Allow Tenderd amount for channel booking")) {
+            if (settlePaymentMethod == PaymentMethod.Cash) {
+                if (strTenderedValue == null || strTenderedValue.isEmpty()) {
+                    JsfUtil.addErrorMessage("Please Enter Tenderd Amount");
+                    return;
+                }
+                Double tend = Double.valueOf(strTenderedValue);
+                if (getSelectedBillSession().getBillItem().getBill().getNetTotal() > tend) {
+                    JsfUtil.addErrorMessage("Please Enter correct Tenderd Amount");
+                    return;
+                }
+            }
         }
 
         Bill b = savePaidBill();
@@ -8992,8 +8993,15 @@ public class BookingControllerViewScope implements Serializable, ControllerWithP
         feeTotalForSelectedBill = 0.0;
         feeDiscountForSelectedBill = 0.0;
         feeNetTotalForSelectedBill = 0.0;
+
+        List<BillFee> billFees = getBillSession().getBill().getBillFees();
+        if (billFees == null) {
+            billFees = billBeanController.getBillFee(getBillSession().getBill());
+        }
+
         if (paymentSchemeDiscount != null) {
-            for (ItemFee itmf : getSelectedItemFees()) {
+            for (BillFee bf : billFees) {
+                ItemFee itmf = (ItemFee) bf.getFee();
                 if (foriegn) {
                     feeTotalForSelectedBill += itmf.getFfee();
                     if (itmf.isDiscountAllowed()) {
@@ -9007,7 +9015,8 @@ public class BookingControllerViewScope implements Serializable, ControllerWithP
                 }
             }
         } else {
-            for (ItemFee itmf : getSelectedItemFees()) {
+            for (BillFee bf : billFees) {
+                ItemFee itmf = (ItemFee) bf.getFee();
                 if (foriegn) {
                     feeTotalForSelectedBill += itmf.getFfee();
                 } else {
@@ -9032,16 +9041,21 @@ public class BookingControllerViewScope implements Serializable, ControllerWithP
 
         for (BillFee billFee : billFees) {
             BillItem billItem = billFee.getBillItem();
+            System.out.println("billItem = " + billItem.getItem().getName());
 
             if (isForiegn()) {
+                System.out.println("billFee.getFee().getFfee() = " + billFee.getFee().getFfee());
                 if (billFee.getFee().getFeeType().equals(FeeType.Staff)) {
+                    System.out.println("billFee.getFee().getProfessionalFfee() = " + billFee.getFee().getProfessionalFfee());
                     billItem.setStaffFee(billFee.getFee().getProfessionalFfee());
                 } else if (billFee.getFee().getFeeType().equals(FeeType.OwnInstitution)) {
+                    System.out.println("billFee.getFee().getHospitalFfee() = " + billFee.getFee().getHospitalFfee());
                     billItem.setHospitalFee(billFee.getFee().getHospitalFfee());
                 }
 
                 billItem.setNetValue(billFee.getFee().getFfee());
             } else {
+                System.out.println("local");
                 if (billFee.getFee().getFeeType().equals(FeeType.Staff)) {
                     billItem.setStaffFee(billFee.getFee().getProfessionalFee());
                 } else if (billFee.getFee().getFeeType().equals(FeeType.OwnInstitution)) {
@@ -9113,6 +9127,44 @@ public class BookingControllerViewScope implements Serializable, ControllerWithP
 //        System.out.println("feeNetTotalForSelectedBill 3 = " + feeNetTotalForSelectedBill);
         feeNetTotalForSelectedBill = feeTotalForSelectedBill - feeDiscountForSelectedBill;
 //        System.out.println("feeNetTotalForSelectedBill 4 = " + feeNetTotalForSelectedBill);
+        getBillSession().getBill().setNetTotal(feeNetTotalForSelectedBill);
+        getBillSession().getBill().setDiscount(feeDiscountForSelectedBill);
+        getBillSession().getBill().setTotal(feeTotalForSelectedBill);
+
+        // for paymentMethod.CARD set the value after total calculation
+        if (settlePaymentMethod == PaymentMethod.Card) {
+            getPaymentMethodData().getCreditCard().setTotalValue(getBillSession().getBill().getNetTotal());
+        }
+    }
+
+    public void calculateSelectedBillSessionTotalForSettlingByBillFees() {
+        Category cat = getBillSession().getSessionInstance().getOriginatingSession().getCategory();
+        PaymentSchemeDiscount paymentSchemeDiscount = priceMatrixController.fetchChannellingMemberShipDiscount(settlePaymentMethod, paymentScheme, cat);
+        feeTotalForSelectedBill = 0.0;
+        feeDiscountForSelectedBill = 0.0;
+        feeNetTotalForSelectedBill = 0.0;
+
+        List<BillFee> billFees = getBillSession().getBill().getBillFees();
+        if (billFees == null) {
+            billFees = billBeanController.getBillFee(getBillSession().getBill());
+        }
+        if (paymentSchemeDiscount != null) {
+            for (BillFee bf : billFees) {
+                feeTotalForSelectedBill += bf.getFeeGrossValue();
+
+                ItemFee itmf = (ItemFee) bf.getFee();
+                if (itmf.isDiscountAllowed()) {
+                    feeDiscountForSelectedBill += bf.getFeeGrossValue() * (paymentSchemeDiscount.getDiscountPercent() / 100);
+                }
+            }
+        } else {
+            for (BillFee bf : billFees) {
+                feeTotalForSelectedBill += bf.getFeeGrossValue();
+            }
+
+        }
+
+        feeNetTotalForSelectedBill = feeTotalForSelectedBill - feeDiscountForSelectedBill;
         getBillSession().getBill().setNetTotal(feeNetTotalForSelectedBill);
         getBillSession().getBill().setDiscount(feeDiscountForSelectedBill);
         getBillSession().getBill().setTotal(feeTotalForSelectedBill);

--- a/src/main/java/com/divudi/bean/channel/BookingControllerViewScope.java
+++ b/src/main/java/com/divudi/bean/channel/BookingControllerViewScope.java
@@ -9163,6 +9163,8 @@ public class BookingControllerViewScope implements Serializable, ControllerWithP
         } else {
             for (BillFee bf : billFees) {
                 feeTotalForSelectedBill += bf.getFeeGrossValue();
+                feeNetTotalForSelectedBill += bf.getFeeValue();
+                feeDiscountForSelectedBill += bf.getFeeDiscount();
             }
 
         }
@@ -9172,7 +9174,6 @@ public class BookingControllerViewScope implements Serializable, ControllerWithP
         getBillSession().getBill().setDiscount(feeDiscountForSelectedBill);
         getBillSession().getBill().setTotal(feeTotalForSelectedBill);
 
-        // for paymentMethod.CARD set the value after total calculation
         if (settlePaymentMethod == PaymentMethod.Card) {
             getPaymentMethodData().getCreditCard().setTotalValue(getBillSession().getBill().getNetTotal());
         }

--- a/src/main/java/com/divudi/bean/channel/BookingControllerViewScopeMonth.java
+++ b/src/main/java/com/divudi/bean/channel/BookingControllerViewScopeMonth.java
@@ -691,7 +691,9 @@ public class BookingControllerViewScopeMonth implements Serializable {
             selectedBillSession.getBillItem().getBill().getPaidBill().setPrinted(true);
             selectedBillSession.getBillItem().getBill().getPaidBill().setPrintedAt(new Date());
             selectedBillSession.getBillItem().getBill().getPaidBill().setPrintedUser(sessionController.getLoggedUser());
-            billFacade.edit(selectedBillSession.getBillItem().getBill().getPaidBill());
+            // billFacade.edit(selectedBillSession.getBillItem().getBill().getPaidBill());
+            Bill manageBill = billFacade.find(selectedBillSession.getBillItem().getBill().getPaidBill().getId());
+            billFacade.edit(manageBill);
         } else {
         }
     }
@@ -2483,8 +2485,20 @@ public class BookingControllerViewScopeMonth implements Serializable {
             }
         }
         getItemsAddedToBooking().add(itemToAddToBooking);
+
+        String sql;
+        Map<String, Object> m = new HashMap<>();
+        sql = "Select f from ItemFee f where f.retired=false and f.item=:item order by f.id";
+        m.put("item", itemToAddToBooking);
+        List<ItemFee> feesOfNewItem = itemFeeFacade.findByJpql(sql, m);
+        if (feesOfNewItem != null) {
+            addedItemFees.addAll(feesOfNewItem);
+            selectedItemFees.addAll(feesOfNewItem);
+        }
+        calculateSelectedBillSessionTotal();
         itemToAddToBooking = null;
-        fillFees();
+        // fillFees();
+
     }
 
     public void removeAddedAditionalItem() {
@@ -2500,7 +2514,8 @@ public class BookingControllerViewScopeMonth implements Serializable {
             selectedBillSession.getBillItem().getBill().getBillFees().removeAll(billFeesToRemove);
         }
         selectedBillSession.getBillItem().getBill().getBillItems().remove(selectedBillItem);
-        calculateBillTotalsFromBillFees(selectedBillSession.getBillItem().getBill());
+        // calculateBillTotalsFromBillFees(selectedBillSession.getBillItem().getBill());
+        calculateSelectedBillSessionTotalForSettling();
     }
 
     public void addItemToBookingAtSettling() {
@@ -2566,8 +2581,8 @@ public class BookingControllerViewScopeMonth implements Serializable {
             newBillItem.setBillFees(billFeesToAdd);
         }
 
-        calculateBillTotalsFromBillFees(selectedBillSession.getBillItem().getBill());
-
+        // calculateBillTotalsFromBillFees(selectedBillSession.getBillItem().getBill());
+        calculateSelectedBillSessionTotalForSettling();
         itemToAddToBooking = null;
 //        fillFees();
     }
@@ -4783,6 +4798,12 @@ public class BookingControllerViewScopeMonth implements Serializable {
         savingBill.setBillFees(savingBillFees);
         savingBill.setCashPaid(cashPaid);
         savingBill.setCashBalance(cashBalance);
+
+        // additional items are added to bill -> billItems
+        if (additionalBillItems != null && !additionalBillItems.isEmpty()) {
+            savingBill.getBillItems().addAll(additionalBillItems);
+        }
+
         if (savingBill.getBillType() == BillType.ChannelAgent) {
             updateBallance(savingBill.getCreditCompany(), 0 - savingBill.getNetTotal(), HistoryType.ChannelBooking, savingBill, savingBillItem, savingBillSession, savingBillItem.getAgentRefNo());
             savingBill.setBalance(0.0);
@@ -5357,6 +5378,61 @@ public class BookingControllerViewScopeMonth implements Serializable {
         billToCaclculate.setNetTotal(calculatingNetBillTotal);
         billToCaclculate.setTotal(calculatingGrossBillTotal);
         getBillFacade().edit(billToCaclculate);
+        feeTotalForSelectedBill = calculatingGrossBillTotal;
+        feeNetTotalForSelectedBill = calculatingNetBillTotal;
+    }
+
+    public void calculateSelectedBillSessionTotalForSettling() {
+        if (getBillSession() == null || getBillSession().getBill() == null) {
+            return;
+        }
+
+        PaymentSchemeDiscount paymentSchemeDiscount = priceMatrixController.fetchChannellingMemberShipDiscount(settlePaymentMethod, paymentScheme, getBillSession().getSessionInstance().getOriginatingSession().getCategory());
+        feeTotalForSelectedBill = 0.0;
+        feeDiscountForSelectedBill = 0.0;
+        feeNetTotalForSelectedBill = 0.0;
+
+        List<BillFee> billFees = getBillSession().getBill().getBillFees();
+        if (billFees == null) {
+            billFees = billBeanController.getBillFee(getBillSession().getBill());
+        }
+        if (paymentSchemeDiscount != null) {
+            for (BillFee bf : billFees) {
+
+                ItemFee itmf = (ItemFee) bf.getFee();
+
+                if (foriegn) {
+                    feeTotalForSelectedBill += itmf.getFfee();
+                    if (itmf.isDiscountAllowed()) {
+                        feeDiscountForSelectedBill += itmf.getFfee() * (paymentSchemeDiscount.getDiscountPercent() / 100);
+                    }
+                } else {
+                    feeTotalForSelectedBill += itmf.getFee();
+                    if (itmf.isDiscountAllowed()) {
+                        feeDiscountForSelectedBill += itmf.getFee() * (paymentSchemeDiscount.getDiscountPercent() / 100);
+                    }
+                }
+            }
+        } else {
+            for (BillFee bf : billFees) {
+                ItemFee itmf = (ItemFee) bf.getFee();
+                if (foriegn) {
+                    feeTotalForSelectedBill += itmf.getFfee();
+                } else {
+                    feeTotalForSelectedBill += itmf.getFee();
+                }
+            }
+
+        }
+
+        feeNetTotalForSelectedBill = feeTotalForSelectedBill - feeDiscountForSelectedBill;
+        getBillSession().getBill().setNetTotal(feeNetTotalForSelectedBill);
+        getBillSession().getBill().setDiscount(feeDiscountForSelectedBill);
+        getBillSession().getBill().setTotal(feeTotalForSelectedBill);
+
+        if (settlePaymentMethod == PaymentMethod.Card) {
+            getPaymentMethodData().getCreditCard().setTotalValue(getBillSession().getBill().getNetTotal());
+        }
     }
 
     public void prepareBillSessionForReportLink() {
@@ -7200,6 +7276,10 @@ public class BookingControllerViewScopeMonth implements Serializable {
 
         System.out.println("feeTotalForSelectedBill = " + feeTotalForSelectedBill);
         feeNetTotalForSelectedBill = feeTotalForSelectedBill - feeDiscountForSelectedBill;
+        
+        if (settlePaymentMethod == PaymentMethod.Card) {
+            getPaymentMethodData().getCreditCard().setTotalValue(getBillSession().getBill().getNetTotal());
+        }
     }
 
     public SmsFacade getSmsFacade() {
@@ -7583,6 +7663,13 @@ public class BookingControllerViewScopeMonth implements Serializable {
     public void setStrTenderedValue(String strTenderedValue) {
 
         this.strTenderedValue = strTenderedValue;
+
+        // Null check and set cash paid to 0 if the input is null or empty
+        if (strTenderedValue == null || strTenderedValue.trim().isEmpty()) {
+            cashPaid = 0.0;
+            return;
+        }
+
         try {
             cashPaid = Double.parseDouble(strTenderedValue);
         } catch (NumberFormatException e) {

--- a/src/main/java/com/divudi/bean/channel/BookingControllerViewScopeMonth.java
+++ b/src/main/java/com/divudi/bean/channel/BookingControllerViewScopeMonth.java
@@ -3006,7 +3006,13 @@ public class BookingControllerViewScopeMonth implements Serializable {
                     JsfUtil.addErrorMessage("Please Enter Tenderd Amount");
                     return;
                 }
-                Double tend = Double.valueOf(strTenderedValue);
+                Double tend;
+                try {
+                    tend = Double.parseDouble(strTenderedValue);
+                } catch (NumberFormatException e) {
+                    JsfUtil.addErrorMessage("Please Enter valid Tenderd Amount");
+                    return;
+                }
                 if (feeNetTotalForSelectedBill > tend) {
                     JsfUtil.addErrorMessage("Please Enter Tenderd Amount");
                     return;

--- a/src/main/java/com/divudi/bean/channel/BookingControllerViewScopeMonth.java
+++ b/src/main/java/com/divudi/bean/channel/BookingControllerViewScopeMonth.java
@@ -4,6 +4,7 @@
  */
 package com.divudi.bean.channel;
 
+import com.divudi.bean.cashTransaction.DrawerController;
 import com.divudi.bean.cashTransaction.FinancialTransactionController;
 import com.divudi.bean.common.BillBeanController;
 import com.divudi.bean.common.BillController;
@@ -76,6 +77,7 @@ import com.divudi.service.StaffService;
 import com.divudi.core.entity.Doctor;
 import com.divudi.core.entity.Payment;
 import com.divudi.core.entity.UserPreference;
+import com.divudi.core.entity.cashTransaction.Drawer;
 import com.divudi.core.entity.channel.AgentReferenceBook;
 import com.divudi.core.entity.channel.AppointmentActivity;
 import com.divudi.core.entity.channel.SessionInstanceActivity;
@@ -212,6 +214,8 @@ public class BookingControllerViewScopeMonth implements Serializable {
     ChannelScheduleController channelScheduleController;
     @Inject
     SecurityController securityController;
+    @Inject
+    DrawerController drawerController;
     /**
      * Properties
      */
@@ -641,7 +645,18 @@ public class BookingControllerViewScopeMonth implements Serializable {
 
     public void removeAddedAditionalItems(Item item) {
         itemsAddedToBooking.remove(item);
-        fillFees();
+        List<ItemFee> feesToRemove = new ArrayList<>();
+        for (ItemFee itemFee : getAddedItemFees()) {
+            if (itemFee.getItem() == null) {
+                continue;
+            }
+            if (itemFee.getItem().equals(item)) {
+                feesToRemove.add(itemFee);
+            }
+        }
+        addedItemFees.removeAll(feesToRemove);
+        selectedItemFees.removeAll(feesToRemove);
+        calculateSelectedBillSessionTotal();
     }
 
     public void closePrinting() {
@@ -2515,7 +2530,7 @@ public class BookingControllerViewScopeMonth implements Serializable {
         }
         selectedBillSession.getBillItem().getBill().getBillItems().remove(selectedBillItem);
         // calculateBillTotalsFromBillFees(selectedBillSession.getBillItem().getBill());
-        calculateSelectedBillSessionTotalForSettling();
+        calculateSelectedBillSessionTotalForSettlingByBillFees();
     }
 
     public void addItemToBookingAtSettling() {
@@ -2582,7 +2597,7 @@ public class BookingControllerViewScopeMonth implements Serializable {
         }
 
         // calculateBillTotalsFromBillFees(selectedBillSession.getBillItem().getBill());
-        calculateSelectedBillSessionTotalForSettling();
+        calculateSelectedBillSessionTotalForSettlingByBillFees();
         itemToAddToBooking = null;
 //        fillFees();
     }
@@ -2987,7 +3002,12 @@ public class BookingControllerViewScopeMonth implements Serializable {
 
         if (configOptionApplicationController.getBooleanValueByKey("Allow Tenderd amount for channel booking")) {
             if (paymentMethod == PaymentMethod.Cash) {
-                if (strTenderedValue == "" || strTenderedValue.isEmpty()) {
+                if (strTenderedValue == null || strTenderedValue.isEmpty()) {
+                    JsfUtil.addErrorMessage("Please Enter Tenderd Amount");
+                    return;
+                }
+                Double tend = Double.valueOf(strTenderedValue);
+                if (feeNetTotalForSelectedBill > tend) {
                     JsfUtil.addErrorMessage("Please Enter Tenderd Amount");
                     return;
                 }
@@ -3002,7 +3022,11 @@ public class BookingControllerViewScopeMonth implements Serializable {
         saveSelected(patient);
         printingBill = saveBilledBill(reservedBooking);
         if (printingBill.getBillTypeAtomic().getBillFinanceType() == BillFinanceType.CASH_IN) {
-            createPayment(printingBill, paymentMethod);
+            List<Payment> p = createPayment(printingBill, paymentMethod);
+
+            if (printingBill.getBillType() != BillType.ChannelAgent) {
+                drawerController.updateDrawerForIns(p);
+            }
         }
         sendSmsAfterBooking();
         if (selectedSessionInstance.isStarted()) {
@@ -5382,11 +5406,10 @@ public class BookingControllerViewScopeMonth implements Serializable {
         feeNetTotalForSelectedBill = calculatingNetBillTotal;
     }
 
-    public void calculateSelectedBillSessionTotalForSettling() {
+    public void calculateSelectedBillSessionTotalForSettlingByBillFees() {
         if (getBillSession() == null || getBillSession().getBill() == null) {
             return;
         }
-
         PaymentSchemeDiscount paymentSchemeDiscount = priceMatrixController.fetchChannellingMemberShipDiscount(settlePaymentMethod, paymentScheme, getBillSession().getSessionInstance().getOriginatingSession().getCategory());
         feeTotalForSelectedBill = 0.0;
         feeDiscountForSelectedBill = 0.0;
@@ -5398,29 +5421,16 @@ public class BookingControllerViewScopeMonth implements Serializable {
         }
         if (paymentSchemeDiscount != null) {
             for (BillFee bf : billFees) {
+                feeTotalForSelectedBill += bf.getFeeGrossValue();
 
                 ItemFee itmf = (ItemFee) bf.getFee();
-
-                if (foriegn) {
-                    feeTotalForSelectedBill += itmf.getFfee();
-                    if (itmf.isDiscountAllowed()) {
-                        feeDiscountForSelectedBill += itmf.getFfee() * (paymentSchemeDiscount.getDiscountPercent() / 100);
-                    }
-                } else {
-                    feeTotalForSelectedBill += itmf.getFee();
-                    if (itmf.isDiscountAllowed()) {
-                        feeDiscountForSelectedBill += itmf.getFee() * (paymentSchemeDiscount.getDiscountPercent() / 100);
-                    }
+                if (itmf.isDiscountAllowed()) {
+                    feeDiscountForSelectedBill += bf.getFeeGrossValue() * (paymentSchemeDiscount.getDiscountPercent() / 100);
                 }
             }
         } else {
             for (BillFee bf : billFees) {
-                ItemFee itmf = (ItemFee) bf.getFee();
-                if (foriegn) {
-                    feeTotalForSelectedBill += itmf.getFfee();
-                } else {
-                    feeTotalForSelectedBill += itmf.getFee();
-                }
+                feeTotalForSelectedBill += bf.getFeeGrossValue();
             }
 
         }
@@ -5430,6 +5440,7 @@ public class BookingControllerViewScopeMonth implements Serializable {
         getBillSession().getBill().setDiscount(feeDiscountForSelectedBill);
         getBillSession().getBill().setTotal(feeTotalForSelectedBill);
 
+        // for paymentMethod.CARD set the value after total calculation
         if (settlePaymentMethod == PaymentMethod.Card) {
             getPaymentMethodData().getCreditCard().setTotalValue(getBillSession().getBill().getNetTotal());
         }
@@ -6368,6 +6379,19 @@ public class BookingControllerViewScopeMonth implements Serializable {
             }
 
         }
+        if (configOptionApplicationController.getBooleanValueByKey("Allow Tenderd amount for channel booking")) {
+            if (settlePaymentMethod == PaymentMethod.Cash) {
+                if (strTenderedValue == null || strTenderedValue.isEmpty()) {
+                    JsfUtil.addErrorMessage("Please Enter Tenderd Amount");
+                    return;
+                }
+                Double tend = Double.valueOf(strTenderedValue);
+                if (getSelectedBillSession().getBillItem().getBill().getNetTotal() > tend) {
+                    JsfUtil.addErrorMessage("Please Enter correct Tenderd Amount");
+                    return;
+                }
+            }
+        }
 
         Bill b = savePaidBill();
         BillItem bi = savePaidBillItem(b);
@@ -6387,7 +6411,8 @@ public class BookingControllerViewScopeMonth implements Serializable {
         b.setSingleBillSession(bs);
         getBillFacade().editAndCommit(b);
 
-        createPayment(b, settlePaymentMethod);
+        List<Payment> p = createPayment(b, settlePaymentMethod);
+        drawerController.updateDrawerForIns(p);
 
         if (toStaff != null && settlePaymentMethod == PaymentMethod.Staff_Welfare) {
             staffBean.updateStaffWelfare(toStaff, getBillSession().getBill().getTotal());
@@ -7945,5 +7970,110 @@ public class BookingControllerViewScopeMonth implements Serializable {
             }
         }
         return false;
+    }
+
+    public void markAsForeigner() {
+        setForiegn(true);
+        calculateSelectedBillSessionTotal();
+    }
+
+    public void markAsLocal() {
+        setForiegn(false);
+        calculateSelectedBillSessionTotal();
+    }
+
+    public void markAsForeignerWithBillUpdate() {
+        if (selectedBillSession.getBill().getBillFeesWIthoutZeroValue().size() > 0 && selectedSessionInstance.getOriginatingSession().getCategory().getName().equalsIgnoreCase("Scanning")) {
+            JsfUtil.addErrorMessage("First Remove the added item.");
+            return;
+        }
+        setForiegn(true);
+        calculateSelectedBillSessionTotalWithBillUpdate();
+    }
+
+    public void markAsLocalWithBillUpdate() {
+        if (selectedBillSession.getBill().getBillFeesWIthoutZeroValue().size() > 0 && selectedSessionInstance.getOriginatingSession().getCategory().getName().equalsIgnoreCase("Scanning")) {
+            JsfUtil.addErrorMessage("First Remove the added item.");
+            return;
+        }
+        setForiegn(false);
+        calculateSelectedBillSessionTotalWithBillUpdate();
+    }
+
+    public void calculateSelectedBillSessionTotalWithBillUpdate() {
+        PaymentSchemeDiscount paymentSchemeDiscount = priceMatrixController.fetchChannellingMemberShipDiscount(paymentMethod, paymentScheme, getSelectedSessionInstance().getOriginatingSession().getCategory());
+        feeTotalForSelectedBill = 0.0;
+        feeDiscountForSelectedBill = 0.0;
+        feeNetTotalForSelectedBill = 0.0;
+
+        List<BillFee> billFees = getBillSession().getBill().getBillFees();
+        if (billFees == null) {
+            billFees = billBeanController.getBillFee(getBillSession().getBill());
+        }
+
+        if (paymentSchemeDiscount != null) {
+            for (BillFee bf : billFees) {
+                ItemFee itmf = (ItemFee) bf.getFee();
+                if (foriegn) {
+                    feeTotalForSelectedBill += itmf.getFfee();
+                    if (itmf.isDiscountAllowed()) {
+                        feeDiscountForSelectedBill += itmf.getFfee() * (paymentSchemeDiscount.getDiscountPercent() / 100);
+                    }
+                } else {
+                    feeTotalForSelectedBill += itmf.getFee();
+                    if (itmf.isDiscountAllowed()) {
+                        feeDiscountForSelectedBill += itmf.getFee() * (paymentSchemeDiscount.getDiscountPercent() / 100);
+                    }
+                }
+            }
+        } else {
+            for (BillFee bf : billFees) {
+                ItemFee itmf = (ItemFee) bf.getFee();
+                if (foriegn) {
+                    feeTotalForSelectedBill += itmf.getFfee();
+                } else {
+                    feeTotalForSelectedBill += itmf.getFee();
+                }
+            }
+
+        }
+        feeNetTotalForSelectedBill = feeTotalForSelectedBill - feeDiscountForSelectedBill;
+
+        selectedBillSession.getBill().setNetTotal(feeNetTotalForSelectedBill);
+        selectedBillSession.getBill().setTotal(feeTotalForSelectedBill);
+        selectedBillSession.getBill().setDiscount(feeDiscountForSelectedBill);
+
+        updateBillItemValuesForForeign();
+    }
+
+    private void updateBillItemValuesForForeign() {
+        List<BillFee> billFees = selectedBillSession.getBill().getBillFeesWIthoutZeroValue();
+        List<BillItem> billItems = selectedBillSession.getBill().getBillItems();
+
+        for (BillFee billFee : billFees) {
+            BillItem billItem = billFee.getBillItem();
+
+            if (isForiegn()) {
+                if (billFee.getFee().getFeeType().equals(FeeType.Staff)) {
+                    billItem.setStaffFee(billFee.getFee().getProfessionalFfee());
+                } else if (billFee.getFee().getFeeType().equals(FeeType.OwnInstitution)) {
+                    billItem.setHospitalFee(billFee.getFee().getHospitalFfee());
+                }
+
+                billItem.setNetValue(billFee.getFee().getFfee());
+            } else {
+                if (billFee.getFee().getFeeType().equals(FeeType.Staff)) {
+                    billItem.setStaffFee(billFee.getFee().getProfessionalFee());
+                } else if (billFee.getFee().getFeeType().equals(FeeType.OwnInstitution)) {
+                    billItem.setHospitalFee(billFee.getFee().getHospitalFee());
+                }
+
+                billItem.setNetValue(billFee.getFee().getFee());
+            }
+
+            billItems.get(billItems.indexOf(billItem)).setNetValue(billItem.getNetValue());
+            billItems.get(billItems.indexOf(billItem)).setStaffFee(billItem.getStaffFee());
+            billItems.get(billItems.indexOf(billItem)).setHospitalFee(billItem.getHospitalFee());
+        }
     }
 }

--- a/src/main/java/com/divudi/bean/channel/BookingControllerViewScopeMonth.java
+++ b/src/main/java/com/divudi/bean/channel/BookingControllerViewScopeMonth.java
@@ -7938,4 +7938,12 @@ public class BookingControllerViewScopeMonth implements Serializable {
         this.listAll = listAll;
     }
 
+    public boolean checkItemIsSessionInstance(BillItem bi) {
+        if (bi.getItem() != null) {
+            if (bi.getItem() instanceof ServiceSession) {
+                return true;
+            }
+        }
+        return false;
+    }
 }

--- a/src/main/java/com/divudi/bean/channel/BookingControllerViewScopeMonth.java
+++ b/src/main/java/com/divudi/bean/channel/BookingControllerViewScopeMonth.java
@@ -2531,6 +2531,7 @@ public class BookingControllerViewScopeMonth implements Serializable {
         selectedBillSession.getBillItem().getBill().getBillItems().remove(selectedBillItem);
         // calculateBillTotalsFromBillFees(selectedBillSession.getBillItem().getBill());
         calculateSelectedBillSessionTotalForSettlingByBillFees();
+        getBillFacade().edit(selectedBillSession.getBillItem().getBill());
     }
 
     public void addItemToBookingAtSettling() {
@@ -2598,6 +2599,7 @@ public class BookingControllerViewScopeMonth implements Serializable {
 
         // calculateBillTotalsFromBillFees(selectedBillSession.getBillItem().getBill());
         calculateSelectedBillSessionTotalForSettlingByBillFees();
+        getBillFacade().edit(selectedBillSession.getBillItem().getBill());
         itemToAddToBooking = null;
 //        fillFees();
     }

--- a/src/main/java/com/divudi/bean/channel/BookingControllerViewScopeMonth.java
+++ b/src/main/java/com/divudi/bean/channel/BookingControllerViewScopeMonth.java
@@ -5437,6 +5437,8 @@ public class BookingControllerViewScopeMonth implements Serializable {
         } else {
             for (BillFee bf : billFees) {
                 feeTotalForSelectedBill += bf.getFeeGrossValue();
+                feeNetTotalForSelectedBill += bf.getFeeValue();
+                feeDiscountForSelectedBill += bf.getFeeDiscount();
             }
 
         }

--- a/src/main/webapp/channel/channel_booking_by_date.xhtml
+++ b/src/main/webapp/channel/channel_booking_by_date.xhtml
@@ -535,7 +535,7 @@
                                                             action="#{bookingControllerViewScope.markAsForeigner}" 
                                                             rendered="#{!bookingControllerViewScope.foriegn}" 
                                                             process="@this" 
-                                                            update="gpLocalForeign totalsPanel panelBookingDetails lstAddedItems" 
+                                                            update="gpLocalForeign totalsPanel panelBookingDetails lstAddedItems paymentDetails" 
                                                             >
                                                         </p:commandButton>
                                                         <p:commandButton 
@@ -544,7 +544,7 @@
                                                             action="#{bookingControllerViewScope.markAsLocal}" 
                                                             rendered="#{bookingControllerViewScope.foriegn}" 
                                                             process="@this" 
-                                                            update="gpLocalForeign totalsPanel panelBookingDetails lstAddedItems" 
+                                                            update="gpLocalForeign totalsPanel panelBookingDetails lstAddedItems paymentDetails" 
                                                             >
                                                         </p:commandButton>
 

--- a/src/main/webapp/channel/channel_booking_by_date.xhtml
+++ b/src/main/webapp/channel/channel_booking_by_date.xhtml
@@ -393,7 +393,8 @@
                                                         <p:selectOneMenu class="w-75 mx-1" autoWidth="false" id="lstItems" value="#{bookingControllerViewScope.itemToAddToBooking}" >
                                                             <f:selectItem itemLabel="Select" ></f:selectItem>
                                                             <f:selectItems  value="#{bookingControllerViewScope.itemsAvailableToAddToBooking}" var="iata" itemValue="#{iata}"  itemLabel="#{iata.name}" ></f:selectItems>
-                                                            <p:ajax event="change" process="lstItems" update="totalsPanel :#{p:resolveFirstComponentWithId('gpFeeTotal',view).clientId}" listener="#{bookingControllerViewScope.fillBaseFees}" ></p:ajax>
+                                                            <!-- <p:ajax event="change" process="lstItems" update="totalsPanel :#{p:resolveFirstComponentWithId('gpFeeTotal',view).clientId}" listener="#{bookingControllerViewScope.fillBaseFees}" ></p:ajax> -->
+                                                            <p:ajax event="change" process="lstItems" update="totalsPanel :#{p:resolveFirstComponentWithId('gpFeeTotal',view).clientId}" ></p:ajax>
                                                         </p:selectOneMenu>
                                                     </p:column>
                                                     <p:column >
@@ -534,7 +535,7 @@
                                                             action="#{bookingControllerViewScope.markAsForeigner}" 
                                                             rendered="#{!bookingControllerViewScope.foriegn}" 
                                                             process="@this" 
-                                                            update="gpLocalForeign totalsPanel panelBookingDetails" 
+                                                            update="gpLocalForeign totalsPanel panelBookingDetails lstAddedItems" 
                                                             >
                                                         </p:commandButton>
                                                         <p:commandButton 
@@ -543,7 +544,7 @@
                                                             action="#{bookingControllerViewScope.markAsLocal}" 
                                                             rendered="#{bookingControllerViewScope.foriegn}" 
                                                             process="@this" 
-                                                            update="gpLocalForeign totalsPanel panelBookingDetails" 
+                                                            update="gpLocalForeign totalsPanel panelBookingDetails lstAddedItems" 
                                                             >
                                                         </p:commandButton>
 

--- a/src/main/webapp/channel/channel_booking_by_month.xhtml
+++ b/src/main/webapp/channel/channel_booking_by_month.xhtml
@@ -655,7 +655,8 @@
                                                         <p:selectOneMenu class="w-75 mx-1" autoWidth="false" id="lstItems" value="#{bookingControllerViewScopeMonth.itemToAddToBooking}" >
                                                             <f:selectItem itemLabel="Select" ></f:selectItem>
                                                             <f:selectItems  value="#{bookingControllerViewScopeMonth.itemsAvailableToAddToBooking}" var="iata" itemValue="#{iata}"  itemLabel="#{iata.name}" ></f:selectItems>
-                                                            <p:ajax event="change" process="lstItems" update="totalsPanel :#{p:resolveFirstComponentWithId('gpFeeTotal',view).clientId}" listener="#{bookingControllerViewScopeMonth.fillFees}" ></p:ajax>
+                                                            <!-- <p:ajax event="change" process="lstItems" update="totalsPanel :#{p:resolveFirstComponentWithId('gpFeeTotal',view).clientId}" listener="#{bookingControllerViewScopeMonth.fillFees}" ></p:ajax> -->
+                                                             <p:ajax event="change" process="lstItems" update="totalsPanel :#{p:resolveFirstComponentWithId('gpFeeTotal',view).clientId}"></p:ajax>
                                                         </p:selectOneMenu>
                                                     </p:column>
                                                     <p:column >
@@ -666,7 +667,7 @@
                                                             icon="fas fa-plus"
                                                             class="ui-button-success"
                                                             action="#{bookingControllerViewScopeMonth.addItemToBooking}"
-                                                            update="totalsPanel paymentDetails :#{p:resolveFirstComponentWithId('gpFeeTotal',view).clientId} :#{p:resolveFirstComponentWithId('lstAddedItems',view).clientId} lstItems panelBookingDetails"
+                                                            update="totalsPanel gdManageBookings paymentDetails :#{p:resolveFirstComponentWithId('gpFeeTotal',view).clientId} :#{p:resolveFirstComponentWithId('lstAddedItems',view).clientId} lstItems panelBookingDetails"
                                                             ></p:commandButton>
                                                     </p:column>
                                                 </p:row>
@@ -683,7 +684,7 @@
                                                                     class="ui-button-danger" 
                                                                     action="#{bookingControllerViewScopeMonth.removeAddedAditionalItems(item)}" 
                                                                     process="btnRemoveAdditem" 
-                                                                    update=":#{p:resolveFirstComponentWithId('lstAddedItems',view).clientId} :#{p:resolveFirstComponentWithId('paymentDetails',view).clientId} :#{p:resolveFirstComponentWithId('gpFeeTotal',view).clientId} :#{p:resolveFirstComponentWithId('panelBookingDetails',view).clientId}"/>
+                                                                    update=":#{p:resolveFirstComponentWithId('lstAddedItems',view).clientId} :#{p:resolveFirstComponentWithId('paymentDetails',view).clientId} :#{p:resolveFirstComponentWithId('gpFeeTotal',view).clientId} :#{p:resolveFirstComponentWithId('panelBookingDetails',view).clientId} gdManageBookings"/>
                                                             </div>
                                                         </div>
                                                     </ui:repeat>
@@ -773,9 +774,24 @@
                                                 </h:panelGroup>
 
                                                 <h:outputLabel value="Foriegner"/>
-                                                <p:selectBooleanCheckbox class="w-75" id="f" value="#{bookingControllerViewScopeMonth.foriegn}">
-                                                    <f:ajax event="change" execute="@this" render="totalsPanel panelBookingDetails"/>
-                                                </p:selectBooleanCheckbox>
+                                                <h:panelGroup id="gpLocalForeign"  class="col-md-6" rendered="#{!configOptionApplicationController.getBooleanValueByKey('Save the Patient with Patient Status')}">
+                                                    <p:commandButton 
+                                                        value="Mark Foreigner" 
+                                                        action="#{bookingControllerViewScopeMonth.markAsForeigner}" 
+                                                        rendered="#{!bookingControllerViewScopeMonth.foriegn}" 
+                                                        process="@this" 
+                                                        update="gpLocalForeign totalsPanel panelBookingDetails gdManageBookings" 
+                                                        >
+                                                    </p:commandButton>
+                                                    <p:commandButton 
+                                                        value="Mark Local" 
+                                                        action="#{bookingControllerViewScopeMonth.markAsLocal}" 
+                                                        rendered="#{bookingControllerViewScopeMonth.foriegn}" 
+                                                        process="@this" 
+                                                        update="gpLocalForeign totalsPanel panelBookingDetails gdManageBookings" 
+                                                    >
+                                                    </p:commandButton>
+                                                </h:panelGroup>
 
 
                                                 <p:outputLabel value="Payment Method"/>

--- a/src/main/webapp/channel/channel_booking_by_month.xhtml
+++ b/src/main/webapp/channel/channel_booking_by_month.xhtml
@@ -759,7 +759,7 @@
                                                 </h:panelGroup>
                                             </h:panelGroup>
 
-                                            <h:panelGrid id="gdManageBookings" class="w-100 m-2" columns="2"  >
+                                            <h:panelGrid id="gdManageBookings" class="w-100 m-2 ui-fluid" columns="2"  style="table-layout: fixed;">
                                                 <p:outputLabel value="Tenderd Amount" rendered="#{bookingControllerViewScopeMonth.paymentMethod eq 'Cash'}"/>
                                                 <h:panelGroup class="w-100 my-2" style="font-weight: bolder" rendered="#{bookingControllerViewScopeMonth.paymentMethod eq 'Cash'}">
                                                     <p:inputText id="paid" value="#{bookingControllerViewScopeMonth.strTenderedValue}">
@@ -786,6 +786,7 @@
                                                         id="cmbPs"
                                                         filter="true"
                                                         filterMatchMode="contains"
+                                                        styleClass="form-control"
                                                         value="#{bookingControllerViewScopeMonth.paymentMethod}">
                                                         <f:selectItem itemLabel="Select Payment Method" ></f:selectItem>
                                                         <f:selectItems value="#{enumController.paymentMethodsForChanneling}"/>
@@ -812,6 +813,7 @@
                                                 <p:outputLabel value="Discount Scheme"/>
                                                 <p:selectOneMenu 
                                                     class="w-75" 
+                                                    styleClass="form-control"
                                                     autoWidth="false" 
                                                     id="cmbPs2" 
                                                     value="#{bookingControllerViewScopeMonth.paymentScheme}">

--- a/src/main/webapp/channel/channel_booking_by_month.xhtml
+++ b/src/main/webapp/channel/channel_booking_by_month.xhtml
@@ -1141,104 +1141,98 @@
                                             </h:panelGrid>
                                         </p:panel>
 
-                                        <p:panelGrid id="panelBookingDetails" class="w-100 mt-1">
-                                            <f:facet name="header">
-                                                <p:row>
-                                                    <p:column colspan="2" class="w-100" style="text-align: left" >
+                                        <h:panelGroup id="panelBookingDetails">
+                                            <p:panelGrid columns="2" layout="tabular"  class="w-100 mt-1">
+                                                    <f:facet name="header">
                                                         <h:outputText styleClass="fa-solid fa-calendar-plus"/>
                                                         <h:outputText class="mx-4" value="Booking Details"/>
-                                                    </p:column>
-                                                </p:row>
+                                                    </f:facet>
 
-                                            </f:facet>
-                                            <p:row>
-                                                <p:column><p:outputLabel value="Speciality" /></p:column>
-                                                <p:column><p:outputLabel value="#{bookingControllerViewScopeMonth.speciality.name}" /></p:column>
-                                            </p:row>
-                                            <p:row>
-                                                <p:column><p:outputLabel value="Consultant" /></p:column>
-                                                <p:column><p:outputLabel value="#{bookingControllerViewScopeMonth.staff.person.nameWithTitle}" /></p:column>
-                                            </p:row>
-                                            <p:row>
-                                                <p:column><p:outputLabel value="Session" /></p:column>
-                                                <p:column><p:outputLabel value="#{bookingControllerViewScopeMonth.selectedSessionInstance.name}" /></p:column>
-                                            </p:row>
-                                            <p:row>
-                                                <p:column><p:outputLabel value="Date" /></p:column>
-                                                <p:column>
+                                                    <p:outputLabel value="Speciality" />
+                                                    <p:outputLabel value="#{bookingControllerViewScopeMonth.selectedSessionInstance.staff.speciality.name}" />
+
+
+                                                    <p:outputLabel value="Consultant" />
+                                                    <p:outputLabel value="#{bookingControllerViewScopeMonth.selectedSessionInstance.staff.person.nameWithTitle}" />
+
+
+                                                    <p:outputLabel value="Session" />
+                                                    <p:outputLabel value="#{bookingControllerViewScopeMonth.selectedSessionInstance.name}" />
+
+
+                                                    <p:outputLabel value="Date" />
+
                                                     <p:outputLabel value="#{bookingControllerViewScopeMonth.selectedSessionInstance.sessionDate}">
                                                         <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateFormat}" />
                                                     </p:outputLabel>
-                                                </p:column>
-                                            </p:row>
-                                            <p:row>
-                                                <p:column><p:outputLabel value="Time" /></p:column>
-                                                <p:column>
+
+
+
+                                                    <p:outputLabel value="Time" />
+
                                                     <p:outputLabel value="#{bookingControllerViewScopeMonth.selectedSessionInstance.originatingSession.startingTime}">
                                                         <f:convertDateTime pattern="#{sessionController.applicationPreference.longTimeFormat}" />
                                                     </p:outputLabel>
-                                                </p:column>
-                                            </p:row>
-                                            <p:row>
-                                                <p:column><p:outputLabel value="Reserved Numbers" /></p:column>
-                                                <p:column>
+
+
+
+                                                    <p:outputLabel value="Reserved Numbers" />
+
                                                     <p:outputLabel value="#{bookingControllerViewScopeMonth.selectedSessionInstance.originatingSession.reserveNumbers}">
                                                     </p:outputLabel>
-                                                </p:column>
-                                            </p:row>
-                                            <p:row>
-                                                <p:column><p:outputLabel value="Total Fee" /></p:column>
-                                                <p:column >
+
+
+
+                                                    <p:outputLabel value="Total Fee" />
+
                                                     <h:panelGroup id="gpFeeTotal">
                                                         <p:outputLabel  rendered="#{!bookingControllerViewScopeMonth.foriegn}"
                                                                         value="#{bookingControllerViewScopeMonth.feeTotalForSelectedBill}">
                                                             <f:convertNumber pattern="#,##0.00" />
                                                         </p:outputLabel>
                                                         <p:outputLabel rendered="#{bookingControllerViewScopeMonth.foriegn}"
-                                                                       value="#{bookingControllerViewScopeMonth.feeTotalForSelectedBill}">
+                                                                    value="#{bookingControllerViewScopeMonth.feeTotalForSelectedBill}">
                                                             <f:convertNumber pattern="#,##0.00" />
                                                         </p:outputLabel>
                                                     </h:panelGroup>
-                                                </p:column>
-                                            </p:row>
-                                            <p:row>
-                                                <p:column colspan="2">
-                                                    <p:dataTable value="#{bookingControllerViewScopeMonth.selectedItemFeesWithouZeros}" var="i" >
-                                                        <p:column headerText="Name">
-                                                            <h:outputLabel value="#{i.item.name}"/> 
-                                                            <h:outputLabel class="mr-4" value="("/> 
-                                                            <h:outputLabel value="#{i.feeType.label}"/> 
-                                                            <h:outputLabel value=")"/> 
-                                                        </p:column>
-                                                        <p:column headerText="Fee for">
-                                                            <h:panelGroup rendered="#{i.feeType eq 'Staff'}" >
-                                                                <h:outputLabel rendered="#{i.staff.person.name ne null}"  value=" #{i.staff.person.name}"></h:outputLabel>
-                                                                <h:outputLabel  rendered="#{i.speciality.name ne null}" class="mr-4" value="("/> 
-                                                                <h:outputLabel rendered="#{i.speciality.name ne null}"  value="#{i.speciality.name}"/> 
-                                                                <h:outputLabel  rendered="#{i.speciality.name ne null}" value=")"/> 
-                                                            </h:panelGroup>
-                                                            <h:panelGroup rendered="#{i.feeType eq 'OwnInstitution' or i.feeType eq 'OtherInstitution' }" >
-                                                                <h:outputLabel rendered="#{i.institution.name ne null}"  value="#{i.institution.name}"></h:outputLabel>
-                                                                <h:outputLabel  rendered="#{i.department.name ne null}" class="mr-4" value="("/> 
-                                                                <h:outputLabel rendered="#{i.department.name ne null}"  value=" #{i.department.name}"></h:outputLabel>
-                                                                <h:outputLabel  rendered="#{i.department.name ne null}" value=")"/> 
-                                                            </h:panelGroup>
-                                                        </p:column>
-                                                        <p:column headerText="Fee" rendered="#{!bookingControllerViewScopeMonth.foriegn}">
-                                                            <h:outputText value="#{i.fee}" >
-                                                                <f:convertNumber pattern="#,##0.00" ></f:convertNumber>
-                                                            </h:outputText>
-                                                        </p:column>
-                                                        <p:column headerText="Fee" rendered="#{bookingControllerViewScopeMonth.foriegn}">
-                                                            <h:outputText value="#{i.ffee}" >
-                                                                <f:convertNumber pattern="#,##0.00" ></f:convertNumber>
-                                                            </h:outputText>
-                                                        </p:column>
-                                                    </p:dataTable>
-                                                </p:column>
+                                            </p:panelGrid>
+                                                <p:dataTable value="#{bookingControllerViewScopeMonth.selectedItemFeesWithouZeros}" var="i" >
+                                                    <p:column headerText="Name">
+                                                        <h:outputLabel value="#{i.item.name}"/> 
+                                                        <h:outputLabel class="mr-4" value="("/> 
+                                                        <h:outputLabel value="#{i.feeType.label}"/> 
+                                                        <h:outputLabel value=")"/> 
+                                                    </p:column>
 
-                                            </p:row>
-                                        </p:panelGrid>
+                                                    <p:column headerText="Fee for">
+                                                        <h:panelGroup rendered="#{i.feeType eq 'Staff'}" >
+                                                            <h:outputLabel rendered="#{i.staff.person.name ne null}"  value=" #{i.staff.person.name}"></h:outputLabel>
+                                                            <h:outputLabel  rendered="#{i.speciality.name ne null}" class="mr-4" value="("/> 
+                                                            <h:outputLabel rendered="#{i.speciality.name ne null}"  value="#{i.speciality.name}"/> 
+                                                            <h:outputLabel  rendered="#{i.speciality.name ne null}" value=")"/> 
+                                                        </h:panelGroup>
+                                                        <h:panelGroup rendered="#{i.feeType eq 'OwnInstitution' or i.feeType eq 'OtherInstitution' }" >
+                                                            <h:outputLabel rendered="#{i.institution.name ne null}"  value="#{i.institution.name}"></h:outputLabel>
+                                                            <h:outputLabel  rendered="#{i.department.name ne null}" class="mr-4" value="("/> 
+                                                            <h:outputLabel rendered="#{i.department.name ne null}"  value=" #{i.department.name}"></h:outputLabel>
+                                                            <h:outputLabel  rendered="#{i.department.name ne null}" value=")"/> 
+                                                        </h:panelGroup>
+                                                    </p:column>
+
+                                                    <p:column headerText="Fee" rendered="#{!bookingControllerViewScopeMonth.foriegn}">
+                                                        <h:outputText value="#{i.fee}" >
+                                                            <f:convertNumber pattern="#,##0.00" ></f:convertNumber>
+                                                        </h:outputText>
+                                                    </p:column>
+
+                                                    <p:column headerText="Fee" rendered="#{bookingControllerViewScopeMonth.foriegn}">
+                                                        <h:outputText value="#{i.ffee}" >
+                                                            <f:convertNumber pattern="#,##0.00" ></f:convertNumber>
+                                                        </h:outputText>
+                                                    </p:column>
+
+                                                </p:dataTable>
+                                        </h:panelGroup>
 
 
                                     </div>

--- a/src/main/webapp/channel/manage_booking_by_date.xhtml
+++ b/src/main/webapp/channel/manage_booking_by_date.xhtml
@@ -807,7 +807,7 @@
                                                 icon="fas fa-plus"
                                                 class="ui-button-success"
                                                 action="#{bookingControllerViewScope.addItemToBookingAtSettling()}"
-                                                update="lstItems tblBillItemsForAddingNewItem tblBillFeesForAddingNewItem totalsPanel gdManageBookings balance :#{p:resolveFirstComponentWithId('balance',view).clientId} "
+                                                update="paymentDetails lstItems tblBillItemsForAddingNewItem tblBillFeesForAddingNewItem totalsPanel gdManageBookings balance :#{p:resolveFirstComponentWithId('balance',view).clientId} "
                                                 ></p:commandButton>
 
                                             <p:dataTable id="tblBillItemsForAddingNewItem" 
@@ -822,10 +822,11 @@
                                                 <p:column >
                                                     <p:commandButton 
                                                         id="btnRemove"
-                                                        ajax="false"
                                                         icon="fas fa-trash"
                                                         disabled="#{bookingControllerViewScope.checkItemIsSessionInstance(bi)}"
                                                         class="ui-button-danger"
+                                                        update="@form"
+                                                        process="@this"
                                                         action="#{bookingControllerViewScope.removeAddedAditionalItem()}"
                                                         >
                                                         <f:setPropertyActionListener target="#{bookingControllerViewScope.selectedBillItem}" value="#{bi}"/>

--- a/src/main/webapp/channel/manage_booking_by_date.xhtml
+++ b/src/main/webapp/channel/manage_booking_by_date.xhtml
@@ -496,7 +496,7 @@
                                                     <p:ajax process="@this" 
                                                             update="gdManageBookings :#{p:resolveFirstComponentWithId('totalsPanel',view).clientId} paymentDetails"
                                                             event="change"
-                                                            listener="#{bookingControllerViewScope.calculateSelectedBillSessionTotalForSettling()}"/>
+                                                            listener="#{bookingControllerViewScope.calculateSelectedBillSessionTotalForSettlingByBillFees()}"/>
                                                 </p:selectOneMenu>
 
                                                 <p:outputLabel value="Discount Scheme"/>
@@ -515,7 +515,7 @@
                                                         process="@this "
                                                         update="gdManageBookings :#{p:resolveFirstComponentWithId('totalsPanel',view).clientId} paymentDetails lstItems"
                                                         event="change"
-                                                        listener="#{bookingControllerViewScope.calculateSelectedBillSessionTotalForSettling()}"/>
+                                                        listener="#{bookingControllerViewScope.calculateSelectedBillSessionTotalForSettlingByBillFees()}"/>
                                                 </p:selectOneMenu>
 
                                                 <p:outputLabel value="Citizenship" ></p:outputLabel>

--- a/src/main/webapp/channel/manage_booking_by_month.xhtml
+++ b/src/main/webapp/channel/manage_booking_by_month.xhtml
@@ -760,6 +760,7 @@
                                                         class="ui-button-danger"
                                                         update="@form"
                                                         process="@this"
+                                                        disabled="#{bookingControllerViewScopeMonth.checkItemIsSessionInstance(bi)}"
                                                         action="#{bookingControllerViewScopeMonth.removeAddedAditionalItem()}"
                                                         >
                                                         <f:setPropertyActionListener target="#{bookingControllerViewScopeMonth.selectedBillItem}" value="#{bi}"/>

--- a/src/main/webapp/channel/manage_booking_by_month.xhtml
+++ b/src/main/webapp/channel/manage_booking_by_month.xhtml
@@ -396,7 +396,7 @@
                                                             process="@this"
                                                             update="gdManageBookings :#{p:resolveFirstComponentWithId('totalsPanel',view).clientId} paymentDetails lstItems panelBillDetailsForSettling"
                                                             event="change"
-                                                            listener="#{bookingControllerViewScopeMonth.calculateSelectedBillSessionTotalForSettling()}"/>
+                                                            listener="#{bookingControllerViewScopeMonth.calculateSelectedBillSessionTotalForSettlingByBillFees()}"/>
                                                     </p:selectOneMenu>
                                                 </div>
 
@@ -685,7 +685,7 @@
                                             <h:panelGroup id="gdManageBookings">
                                                 <div class="row w-100 m-2 ui-fluid" style="table-layout: fixed;">
                                                     <div class="col-4 align-self-center">
-                                                        <p:outputLabel value="Tendered Amount" />
+                                                        <p:outputLabel for="paid" value="Tendered Amount" />
                                                     </div>
                                                     <div class="col-8">
                                                         <p:inputText id="paid" style="font-weight: bolder; width: 65%;" value="#{bookingControllerViewScopeMonth.strTenderedValue}" styleClass="form-control">
@@ -704,9 +704,29 @@
                                                         <h:outputLabel value="Foriegner"/>
                                                     </div>
                                                     <div class="col-8">
-                                                        <p:selectBooleanCheckbox class="w-75" id="f" value="#{bookingControllerViewScopeMonth.foriegn}">
-                                                            <f:ajax event="change" execute="@this" render="totalsPanel panelBookingDetails"/>
-                                                        </p:selectBooleanCheckbox>
+                                                        <h:panelGroup id="gpLocalForeign" rendered="#{!configOptionApplicationController.getBooleanValueByKey('Save the Patient with Patient Status')}">
+                                                            <p:commandButton
+                                                                value="Mark Foreigner"
+                                                                style="width: 65%; margin-bottom: 10px;"
+                                                                disabled="#{bookingControllerViewScopeMonth.selectedSessionInstance.originatingSession.category ne 'Scanning'}"
+                                                                action="#{bookingControllerViewScopeMonth.markAsForeignerWithBillUpdate()}"
+                                                                rendered="#{!bookingControllerViewScopeMonth.foriegn}"
+                                                                process="@this"
+                                                                update="gpLocalForeign totalsPanel paymentDetails tblBillFeesForAddingNewItem tblBillItemsForAddingNewItem gdManageBookings msg"
+                                                                >
+                                                            </p:commandButton>
+                                                            <p:commandButton
+                                                                value="Mark Local"
+                                                                style="width: 65%;"
+                                                                disabled="#{bookingControllerViewScopeMonth.selectedSessionInstance.originatingSession.category ne 'Scanning'}"
+                                                                action="#{bookingControllerViewScopeMonth.markAsLocalWithBillUpdate()}"
+                                                                rendered="#{bookingControllerViewScopeMonth.foriegn}"
+                                                                process="@this"
+                                                                update="gpLocalForeign totalsPanel paymentDetails tblBillFeesForAddingNewItem tblBillItemsForAddingNewItem gdManageBookings msg"
+                                                                >
+                                                            </p:commandButton>
+
+                                                        </h:panelGroup>
                                                     </div>
 
                                                     <div class="col-4 align-self-center">
@@ -714,7 +734,8 @@
                                                     </div>
                                                     <div class="col-8">
                                                         <p:selectOneMenu 
-                                                            class="w-75" 
+                                                            styleClass="form-control"
+                                                            style="width: 65%;"
                                                             autoWidth="false" 
                                                             id="cmbPs2" 
                                                             value="#{bookingControllerViewScopeMonth.paymentScheme}">
@@ -728,7 +749,7 @@
                                                                 process="@this"
                                                                 update="gdManageBookings :#{p:resolveFirstComponentWithId('totalsPanel',view).clientId} paymentDetails lstItems panelBillDetailsForSettling"
                                                                 event="change"
-                                                                listener="#{bookingControllerViewScopeMonth.calculateSelectedBillSessionTotalForSettling()}"/>
+                                                                listener="#{bookingControllerViewScopeMonth.calculateSelectedBillSessionTotalForSettlingByBillFees()}"/>
                                                         </p:selectOneMenu>
                                                     </div>
                                                 </div>
@@ -788,6 +809,7 @@
                                                 </p:column>
                                             </p:dataTable>
 
+                                            <p:growl id="msg" life="2000"></p:growl>
                                             <p:dataTable 
                                                 id="tblBillFeesForAddingNewItem" 
                                                 value="#{bookingControllerViewScopeMonth.selectedBillSession.billItem.bill.billFeesWIthoutZeroValue}" 

--- a/src/main/webapp/channel/manage_booking_by_month.xhtml
+++ b/src/main/webapp/channel/manage_booking_by_month.xhtml
@@ -682,43 +682,63 @@
                                                 </h:panelGroup>
                                             </h:panelGroup>
 
-                                            <h:panelGrid id="gdManageBookings" class="w-100 m-2" columns="2"  >
-                                                <p:outputLabel value="Tendered Amount" />
-                                                <h:panelGroup class="w-100 my-2" style="font-weight: bolder" >
-                                                    <p:inputText id="paid" value="#{bookingControllerViewScopeMonth.strTenderedValue}">
-                                                        <p:ajax event="keyup" process="paid" update="balance"/>
-                                                    </p:inputText>
-                                                </h:panelGroup>
+                                            <h:panelGroup id="gdManageBookings">
+                                                <div class="row w-100 m-2 ui-fluid" style="table-layout: fixed;">
+                                                    <div class="col-4 align-self-center">
+                                                        <p:outputLabel value="Tendered Amount" />
+                                                    </div>
+                                                    <div class="col-8">
+                                                        <p:inputText id="paid" style="font-weight: bolder; width: 65%;" value="#{bookingControllerViewScopeMonth.strTenderedValue}" styleClass="form-control">
+                                                            <p:ajax event="keyup" process="paid" update="balance"/>
+                                                        </p:inputText>
+                                                    </div>
 
-                                                <p:outputLabel value="Balance" />
-                                                <h:panelGroup id="balance" class="w-100 my-2" style="font-weight: bolder" >
-                                                    <p:outputLabel value="#{-bookingControllerViewScopeMonth.cashBalance}"/>
-                                                </h:panelGroup>
+                                                    <div class="col-4 align-self-center">
+                                                        <p:outputLabel value="Balance" />
+                                                    </div>
+                                                    <div class="col-8">
+                                                        <p:outputLabel id="balance" class="w-100" style="font-weight: bolder" value="#{-bookingControllerViewScopeMonth.cashBalance}"/>
+                                                    </div>
 
-                                                <h:outputLabel value="Foriegner"/>
-                                                <p:selectBooleanCheckbox class="w-75" id="f" value="#{bookingControllerViewScopeMonth.foriegn}">
-                                                    <f:ajax event="change" execute="@this" render="totalsPanel panelBookingDetails"/>
-                                                </p:selectBooleanCheckbox>
+                                                    <div class="col-4 align-self-center">
+                                                        <h:outputLabel value="Foriegner"/>
+                                                    </div>
+                                                    <div class="col-8">
+                                                        <p:selectBooleanCheckbox class="w-75" id="f" value="#{bookingControllerViewScopeMonth.foriegn}">
+                                                            <f:ajax event="change" execute="@this" render="totalsPanel panelBookingDetails"/>
+                                                        </p:selectBooleanCheckbox>
+                                                    </div>
 
-                                                <p:outputLabel value="Discount Scheme"/>
-                                                <p:selectOneMenu 
-                                                    class="w-75" 
-                                                    autoWidth="false" 
-                                                    id="cmbPs2" 
-                                                    value="#{bookingControllerViewScopeMonth.paymentScheme}">
-                                                    <f:selectItem itemLabel="Select Discount Scheme"/>
-                                                    <f:selectItems 
-                                                        value="#{paymentSchemeController.paymentSchemesForChannel}"
-                                                        var="paysch" 
-                                                        itemLabel="#{paysch.name}" 
-                                                        itemValue="#{paysch}"  />
-                                                    <p:ajax 
-                                                        process="@this"
-                                                        update="gdManageBookings :#{p:resolveFirstComponentWithId('totalsPanel',view).clientId} paymentDetails lstItems panelBillDetailsForSettling"
-                                                        event="change"
-                                                        listener="#{bookingControllerViewScopeMonth.calculateSelectedBillSessionTotalForSettling()}"/>
-                                                </p:selectOneMenu>
-                                            </h:panelGrid>
+                                                    <div class="col-4 align-self-center">
+                                                        <p:outputLabel value="Discount Scheme"/>
+                                                    </div>
+                                                    <div class="col-8">
+                                                        <p:selectOneMenu 
+                                                            class="w-75" 
+                                                            autoWidth="false" 
+                                                            id="cmbPs2" 
+                                                            value="#{bookingControllerViewScopeMonth.paymentScheme}">
+                                                            <f:selectItem itemLabel="Select Discount Scheme"/>
+                                                            <f:selectItems 
+                                                                value="#{paymentSchemeController.paymentSchemesForChannel}"
+                                                                var="paysch" 
+                                                                itemLabel="#{paysch.name}" 
+                                                                itemValue="#{paysch}"  />
+                                                            <p:ajax 
+                                                                process="@this"
+                                                                update="gdManageBookings :#{p:resolveFirstComponentWithId('totalsPanel',view).clientId} paymentDetails lstItems panelBillDetailsForSettling"
+                                                                event="change"
+                                                                listener="#{bookingControllerViewScopeMonth.calculateSelectedBillSessionTotalForSettling()}"/>
+                                                        </p:selectOneMenu>
+                                                    </div>
+                                                </div>
+                                            </h:panelGroup>
+                                            
+                                            <div class="row">
+                                                <div class="col-1">
+
+                                                </div>
+                                            </div>
                                         </p:panel>
 
                                         <p:panel header="Additional Items" >

--- a/src/main/webapp/channel/manage_booking_by_month.xhtml
+++ b/src/main/webapp/channel/manage_booking_by_month.xhtml
@@ -392,10 +392,11 @@
                                                             var="pm"
                                                             itemLabel="#{pm.label}"
                                                             itemValue="#{pm}"/>
-                                                        <p:ajax process="@this" 
-                                                                update="paymentDetails"
-                                                                event="change"
-                                                                listener="#{bookingControllerViewScopeMonth.listnerForPaymentMethodChangeOnCreditSettle()}"/>
+                                                        <p:ajax 
+                                                            process="@this"
+                                                            update="gdManageBookings :#{p:resolveFirstComponentWithId('totalsPanel',view).clientId} paymentDetails lstItems panelBillDetailsForSettling"
+                                                            event="change"
+                                                            listener="#{bookingControllerViewScopeMonth.calculateSelectedBillSessionTotalForSettling()}"/>
                                                     </p:selectOneMenu>
                                                 </div>
 
@@ -407,7 +408,6 @@
                                                             ajax="false"
                                                             icon="fa fa-check"
                                                             action="#{bookingControllerViewScopeMonth.settleCredit()}"
-                                                            immediate="true"
                                                             disabled="#{bookingControllerViewScopeMonth.selectedBillSession.bill.billType.parent ne 'ChannelCreditFlow'
                                                                         or bookingControllerViewScopeMonth.selectedBillSession.bill.cancelled==true
                                                                         or  bookingControllerViewScopeMonth.selectedBillSession.bill.paidAmount ne 0 or bookingControllerViewScopeMonth.selectedSessionInstance.completed}"
@@ -683,10 +683,10 @@
                                             </h:panelGroup>
 
                                             <h:panelGrid id="gdManageBookings" class="w-100 m-2" columns="2"  >
-                                                <p:outputLabel value="Tenderd Amount" />
+                                                <p:outputLabel value="Tendered Amount" />
                                                 <h:panelGroup class="w-100 my-2" style="font-weight: bolder" >
                                                     <p:inputText id="paid" value="#{bookingControllerViewScopeMonth.strTenderedValue}">
-                                                        <p:ajax event="keyup" process=" paid" update="@this"/>
+                                                        <p:ajax event="keyup" process="paid" update="balance"/>
                                                     </p:inputText>
                                                 </h:panelGroup>
 
@@ -714,9 +714,9 @@
                                                         itemValue="#{paysch}"  />
                                                     <p:ajax 
                                                         process="@this"
-                                                        update="gdManageBookings :#{p:resolveFirstComponentWithId('totalsPanel',view).clientId} paymentDetails lstItems"
+                                                        update="gdManageBookings :#{p:resolveFirstComponentWithId('totalsPanel',view).clientId} paymentDetails lstItems panelBillDetailsForSettling"
                                                         event="change"
-                                                        listener="#{bookingControllerViewScopeMonth.calculateSelectedBillSessionTotal()}"/>
+                                                        listener="#{bookingControllerViewScopeMonth.calculateSelectedBillSessionTotalForSettling()}"/>
                                                 </p:selectOneMenu>
                                             </h:panelGrid>
                                         </p:panel>
@@ -740,7 +740,7 @@
                                                 icon="fas fa-plus"
                                                 class="ui-button-success"
                                                 action="#{bookingControllerViewScopeMonth.addItemToBookingAtSettling()}"
-                                                update="lstItems tblBillItemsForAddingNewItem tblBillFeesForAddingNewItem panelBillDetailsForSettling"
+                                                update="@form"
                                                 ></p:commandButton>
 
 
@@ -756,9 +756,10 @@
                                                 <p:column >
                                                     <p:commandButton 
                                                         id="btnRemove"
-                                                        ajax="false"
                                                         icon="fas fa-trash"
                                                         class="ui-button-danger"
+                                                        update="@form"
+                                                        process="@this"
                                                         action="#{bookingControllerViewScopeMonth.removeAddedAditionalItem()}"
                                                         >
                                                         <f:setPropertyActionListener target="#{bookingControllerViewScopeMonth.selectedBillItem}" value="#{bi}"/>


### PR DESCRIPTION
Issue: #20008 

Files changed:
- BookingControllerViewScope
- BookingControllerViewScopeMonth
- manage_booking_by_month
- manage_booking_by_date
- channel_booking_by_month

**calculateSelectedBillSessionTotalForSettlingByBillFees()**, method used in places where totals should be calculated using bill fees , Manage_booking pages. Uses BillFee `FeeGrossValue` to calculate the totals.

BillItems not added to bill solved for `channel_booking_by_month`

**Balance** not properly calculated when tendered amount removed fixed.

Required fields validation when removing additional items issue fixed.

UI improvements for `manage_booking_by_month` and `channel_booking_by_month`

In manage_booking_by_month, channel_booking_by_month foreign flag was not used for calculations, fixed it referencing the by_date pages.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened cash/credit tender validation with clear errors for empty, null or non-numeric input; blank tenders set safely to zero.

* **UI/UX Improvements**
  * Reworked booking-details layout and responsive grid; replaced checkbox with explicit "Mark Foreigner"/"Mark Local" buttons.
  * Expanded AJAX partial updates for smoother interactions and added in-page messages for feedback.

* **Billing Improvements**
  * More accurate bill/fee/discount totals during booking and settlement, including card total updates and refreshed cash-balance calculations.

* **Operational**
  * Payment actions now update the cash/register state and improve persistence of printed paid bills.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->