### PR TITLE
Show gross fees with Discount and Service Charge columns in Inpatient Invoice Journal

### DIFF
--- a/src/main/java/com/divudi/bean/inward/InwardInvoiceJournalController.java
+++ b/src/main/java/com/divudi/bean/inward/InwardInvoiceJournalController.java
@@ -89,6 +89,9 @@ public class InwardInvoiceJournalController implements Serializable {
     /** Column totals keyed by InwardChargeType. */
     private Map<InwardChargeType, Double> columnTotals = new EnumMap<>(InwardChargeType.class);
 
+    private double grandTotalGross;
+    private double grandTotalDiscount;
+    private double grandTotalServiceCharge;
     private double grandTotalCharges;
     private double grandTotalDeposits;
     private double grandTotalCreditSettlement;
@@ -101,6 +104,9 @@ public class InwardInvoiceJournalController implements Serializable {
         reportRows               = new ArrayList<>();
         columnTotals             = new EnumMap<>(InwardChargeType.class);
         activeChargeTypes        = EnumSet.noneOf(InwardChargeType.class);
+        grandTotalGross          = 0;
+        grandTotalDiscount       = 0;
+        grandTotalServiceCharge  = 0;
         grandTotalCharges        = 0;
         grandTotalDeposits       = 0;
         grandTotalCreditSettlement = 0;
@@ -110,8 +116,11 @@ public class InwardInvoiceJournalController implements Serializable {
             return;
         }
 
-        // --- bulk fetch charge totals for all encounters at once ---
+        // --- bulk fetch gross charges per InwardChargeType for all encounters ---
         Map<Long, Map<InwardChargeType, Double>> chargeMap = fetchChargesByEncounter(encounters);
+
+        // --- bulk fetch discount / service-charge totals per encounter ---
+        Map<Long, double[]> discountMarginMap = fetchDiscountAndMarginByEncounter(encounters);
 
         // --- bulk fetch deposit totals for all encounters at once ---
         Map<Long, Double> depositMap = fetchDepositTotalsByEncounter(encounters);
@@ -121,7 +130,7 @@ public class InwardInvoiceJournalController implements Serializable {
 
         // --- build one row per encounter ---
         for (PatientEncounter enc : encounters) {
-            InwardInvoiceJournalRowDto row = buildRow(enc, chargeMap, depositMap, creditMap);
+            InwardInvoiceJournalRowDto row = buildRow(enc, chargeMap, discountMarginMap, depositMap, creditMap);
             reportRows.add(row);
 
             // accumulate column totals and active types
@@ -132,6 +141,9 @@ public class InwardInvoiceJournalController implements Serializable {
                     columnTotals.merge(ct, v, Double::sum);
                 }
             }
+            grandTotalGross            += row.getGrossTotal();
+            grandTotalDiscount         += row.getTotalDiscount();
+            grandTotalServiceCharge    += row.getTotalServiceCharge();
             grandTotalCharges          += row.getGrandTotal();
             grandTotalDeposits         += row.getTotalDeposits();
             grandTotalCreditSettlement += row.getCreditSettlementTotal();
@@ -212,16 +224,20 @@ public class InwardInvoiceJournalController implements Serializable {
     }
 
     /**
-     * Single bulk query: sum(netValue) grouped by (patientEncounter, inwardChargeType)
+     * Single bulk query: sum(grossValue) grouped by (patientEncounter, inwardChargeType)
      * for all encounters in the set, covering all non-cancelled bill items.
      * Returns Map< encounterId, Map<InwardChargeType, total> >.
+     *
+     * Uses BillItem.grossValue (hospital fee before discount / margin). Discount
+     * and service-charge totals are fetched separately from BillFee because
+     * BillItem.discount is not rolled up for inpatient bills (see BillBhtController.calTotals).
      */
     private Map<Long, Map<InwardChargeType, Double>> fetchChargesByEncounter(
             List<PatientEncounter> encounters) {
 
         Map<Long, Map<InwardChargeType, Double>> result = new HashMap<>();
 
-        String jpql = "select bi.bill.patientEncounter.id, bi.inwardChargeType, sum(bi.netValue)"
+        String jpql = "select bi.bill.patientEncounter.id, bi.inwardChargeType, sum(bi.grossValue)"
                 + " from BillItem bi"
                 + " where bi.retired = false"
                 + " and bi.bill.retired = false"
@@ -243,6 +259,42 @@ public class InwardInvoiceJournalController implements Serializable {
                 Double           total = ((Number) r[2]).doubleValue();
                 result.computeIfAbsent(encId, k -> new EnumMap<>(InwardChargeType.class))
                       .put(type, total);
+            }
+        }
+        return result;
+    }
+
+    /**
+     * Single bulk query: sum(feeDiscount) and sum(feeMargin) from BillFee
+     * grouped by encounter, matching the same filter used for gross charges.
+     * Returns Map< encounterId, double[]{ discount, serviceCharge } >.
+     *
+     * Reads from BillFee (not BillItem) because BillItem.discount is not
+     * populated for inpatient bills — discount lives per-fee.
+     */
+    private Map<Long, double[]> fetchDiscountAndMarginByEncounter(List<PatientEncounter> encounters) {
+        Map<Long, double[]> result = new HashMap<>();
+
+        String jpql = "select bf.bill.patientEncounter.id, sum(bf.feeDiscount), sum(bf.feeMargin)"
+                + " from BillFee bf"
+                + " where bf.retired = false"
+                + " and bf.bill.retired = false"
+                + " and bf.bill.cancelled = false"
+                + " and bf.bill.billTypeAtomic != :originalFinalBillType"
+                + " and bf.bill.patientEncounter in :encs"
+                + " group by bf.bill.patientEncounter.id";
+
+        Map<String, Object> params = new HashMap<>();
+        params.put("encs", encounters);
+        params.put("originalFinalBillType", BillTypeAtomic.INWARD_ORIGINAL_FINAL_BILL);
+
+        List<Object[]> rows = patientEncounterFacade.findObjectArrayByJpql(jpql, params, TemporalType.TIMESTAMP);
+        if (rows != null) {
+            for (Object[] r : rows) {
+                Long encId = (Long) r[0];
+                double disc = r[1] == null ? 0.0 : ((Number) r[1]).doubleValue();
+                double marg = r[2] == null ? 0.0 : ((Number) r[2]).doubleValue();
+                result.put(encId, new double[]{disc, marg});
             }
         }
         return result;
@@ -313,6 +365,7 @@ public class InwardInvoiceJournalController implements Serializable {
     private InwardInvoiceJournalRowDto buildRow(
             PatientEncounter enc,
             Map<Long, Map<InwardChargeType, Double>> chargeMap,
+            Map<Long, double[]> discountMarginMap,
             Map<Long, Double> depositMap,
             Map<Long, double[]> creditMap) {
 
@@ -329,10 +382,17 @@ public class InwardInvoiceJournalController implements Serializable {
             row.setFinalBillNo(enc.getFinalBill().getIdStr());
         }
 
-        // charges
+        // charges (gross per InwardChargeType)
         Map<InwardChargeType, Double> charges = chargeMap.get(enc.getId());
         if (charges != null) {
             charges.forEach(row::addCharge);
+        }
+
+        // discount & service-charge totals
+        double[] dm = discountMarginMap.get(enc.getId());
+        if (dm != null) {
+            row.setTotalDiscount(dm[0]);
+            row.setTotalServiceCharge(dm[1]);
         }
 
         // deposits
@@ -393,6 +453,7 @@ public class InwardInvoiceJournalController implements Serializable {
         reportRows       = null;
         columnTotals     = new EnumMap<>(InwardChargeType.class);
         activeChargeTypes = EnumSet.noneOf(InwardChargeType.class);
+        grandTotalGross = grandTotalDiscount = grandTotalServiceCharge = 0;
         grandTotalCharges = grandTotalDeposits = grandTotalCreditSettlement = 0;
     }
 
@@ -443,6 +504,9 @@ public class InwardInvoiceJournalController implements Serializable {
 
     public Map<InwardChargeType, Double> getColumnTotals() { return columnTotals; }
 
+    public double getGrandTotalGross() { return grandTotalGross; }
+    public double getGrandTotalDiscount() { return grandTotalDiscount; }
+    public double getGrandTotalServiceCharge() { return grandTotalServiceCharge; }
     public double getGrandTotalCharges() { return grandTotalCharges; }
     public double getGrandTotalDeposits() { return grandTotalDeposits; }
     public double getGrandTotalCreditSettlement() { return grandTotalCreditSettlement; }

--- a/src/main/java/com/divudi/core/data/dto/InwardInvoiceJournalRowDto.java
+++ b/src/main/java/com/divudi/core/data/dto/InwardInvoiceJournalRowDto.java
@@ -35,6 +35,12 @@ public class InwardInvoiceJournalRowDto implements Serializable {
             new EnumMap<>(InwardChargeType.class);
 
     // -------------------------------------------------------------------------
+    // Discount / service charge totals (per encounter, across all fees)
+    // -------------------------------------------------------------------------
+    private double totalDiscount;
+    private double totalServiceCharge;
+
+    // -------------------------------------------------------------------------
     // Deposit / settlement summary
     // -------------------------------------------------------------------------
     private double totalDeposits;
@@ -56,8 +62,12 @@ public class InwardInvoiceJournalRowDto implements Serializable {
         chargesByType.merge(type, amount, Double::sum);
     }
 
-    public double getGrandTotal() {
+    public double getGrossTotal() {
         return chargesByType.values().stream().mapToDouble(Double::doubleValue).sum();
+    }
+
+    public double getGrandTotal() {
+        return getGrossTotal() - totalDiscount + totalServiceCharge;
     }
 
     // -------------------------------------------------------------------------
@@ -86,6 +96,12 @@ public class InwardInvoiceJournalRowDto implements Serializable {
     public void setAdmissionType(AdmissionType admissionType) { this.admissionType = admissionType; }
 
     public Map<InwardChargeType, Double> getChargesByType() { return chargesByType; }
+
+    public double getTotalDiscount() { return totalDiscount; }
+    public void setTotalDiscount(double totalDiscount) { this.totalDiscount = totalDiscount; }
+
+    public double getTotalServiceCharge() { return totalServiceCharge; }
+    public void setTotalServiceCharge(double totalServiceCharge) { this.totalServiceCharge = totalServiceCharge; }
 
     public double getTotalDeposits() { return totalDeposits; }
     public void setTotalDeposits(double totalDeposits) { this.totalDeposits = totalDeposits; }

--- a/src/main/webapp/inward/inward_report_invoice_journal.xhtml
+++ b/src/main/webapp/inward/inward_report_invoice_journal.xhtml
@@ -280,8 +280,47 @@
                                 </f:facet>
                             </p:columns>
 
-                            <!-- ===== Grand total of charges ===== -->
-                            <p:column headerText="Total Charges"
+                            <!-- ===== Discount ===== -->
+                            <p:column headerText="Discount"
+                                      style="text-align:right; white-space:nowrap;">
+                                <h:outputText value="#{row.totalDiscount}">
+                                    <f:convertNumber minFractionDigits="2" maxFractionDigits="2" />
+                                </h:outputText>
+                                <f:facet name="footer">
+                                    <h:outputText value="#{inwardInvoiceJournalController.grandTotalDiscount}">
+                                        <f:convertNumber minFractionDigits="2" maxFractionDigits="2" />
+                                    </h:outputText>
+                                </f:facet>
+                            </p:column>
+
+                            <!-- ===== Service Charge (margin) ===== -->
+                            <p:column headerText="Service Charge"
+                                      style="text-align:right; white-space:nowrap;">
+                                <h:outputText value="#{row.totalServiceCharge}">
+                                    <f:convertNumber minFractionDigits="2" maxFractionDigits="2" />
+                                </h:outputText>
+                                <f:facet name="footer">
+                                    <h:outputText value="#{inwardInvoiceJournalController.grandTotalServiceCharge}">
+                                        <f:convertNumber minFractionDigits="2" maxFractionDigits="2" />
+                                    </h:outputText>
+                                </f:facet>
+                            </p:column>
+
+                            <!-- ===== Gross total of charges ===== -->
+                            <p:column headerText="Gross Total"
+                                      style="text-align:right; white-space:nowrap; font-weight:bold;">
+                                <h:outputText value="#{row.grossTotal}">
+                                    <f:convertNumber minFractionDigits="2" maxFractionDigits="2" />
+                                </h:outputText>
+                                <f:facet name="footer">
+                                    <h:outputText value="#{inwardInvoiceJournalController.grandTotalGross}">
+                                        <f:convertNumber minFractionDigits="2" maxFractionDigits="2" />
+                                    </h:outputText>
+                                </f:facet>
+                            </p:column>
+
+                            <!-- ===== Net total of charges (gross - discount + service charge) ===== -->
+                            <p:column headerText="Net Total"
                                       style="text-align:right; white-space:nowrap; font-weight:bold;">
                                 <h:outputText value="#{row.grandTotal}">
                                     <f:convertNumber minFractionDigits="2" maxFractionDigits="2" />
@@ -325,7 +364,22 @@
 
                             <f:facet name="footer">
                                 <div class="text-end">
-                                    <strong>Grand Total Charges: </strong>
+                                    <strong>Grand Total Gross: </strong>
+                                    <h:outputText value="#{inwardInvoiceJournalController.grandTotalGross}">
+                                        <f:convertNumber minFractionDigits="2" maxFractionDigits="2" />
+                                    </h:outputText>
+                                    &#160;&#160;&#160;
+                                    <strong>Grand Total Discount: </strong>
+                                    <h:outputText value="#{inwardInvoiceJournalController.grandTotalDiscount}">
+                                        <f:convertNumber minFractionDigits="2" maxFractionDigits="2" />
+                                    </h:outputText>
+                                    &#160;&#160;&#160;
+                                    <strong>Grand Total Service Charge: </strong>
+                                    <h:outputText value="#{inwardInvoiceJournalController.grandTotalServiceCharge}">
+                                        <f:convertNumber minFractionDigits="2" maxFractionDigits="2" />
+                                    </h:outputText>
+                                    &#160;&#160;&#160;
+                                    <strong>Grand Total Net Charges: </strong>
                                     <h:outputText value="#{inwardInvoiceJournalController.grandTotalCharges}">
                                         <f:convertNumber minFractionDigits="2" maxFractionDigits="2" />
                                     </h:outputText>

--- a/src/main/webapp/inward/inward_reports.xhtml
+++ b/src/main/webapp/inward/inward_reports.xhtml
@@ -50,6 +50,13 @@
                                         <p:commandButton ajax="false" value="BHT VAT Report" icon="fa fa-fw fa-receipt" action="inward_report_bht_inward_vat?faces-redirect=true" />
                                         <p:commandButton ajax="false" value="BHT Break Down (TAB Format)" icon="fa fa-fw fa-table" action="inward_bill_intrim_finalized?faces-redirect=true" actionListener="#{bhtSummeryFinalizedController.makeNull()}" />
                                         <p:commandButton ajax="false" value="BHT Break Down (Table Format)" icon="fa fa-fw fa-list-alt" action="inward_bill_final_break_down?faces-redirect=true" />
+                                        <p:commandButton
+                                            value="Inpatient Invoice Journal"
+                                            icon="fa fa-fw fa-book"
+                                            action="inward_report_invoice_journal?faces-redirect=true"
+                                            actionListener="#{inwardInvoiceJournalController.makeNull()}"
+                                            class="ui-button-success"
+                                            ajax="false" />
                                         <p:commandButton ajax="false" value="BHT Sevice Errror Diduction" icon="fa fa-fw fa-exclamation-triangle" action="inward_bill_final_break_down_error?faces-redirect=true" rendered="false" />
                                         <p:commandButton ajax="false" value="BHT Interim Error Correction" icon="fa fa-fw fa-wrench" action="inward_bill_intrim_finalized_error_correction?faces-redirect=true" />
                                         <p:commandButton ajax="false" value="Error" icon="fa fa-fw fa-bug" action="#{bhtSummeryFinalizedController.errorCheck}" rendered="false"/>
@@ -91,13 +98,6 @@
                                             icon="fa fa-fw fa-receipt"
                                             action="inward_report_bht_deposit_detail?faces-redirect=true"
                                             actionListener="#{bhtDepositDetailReportController.makeNull()}"
-                                            class="ui-button-success"
-                                            ajax="false" />
-                                        <p:commandButton
-                                            value="Inpatient Invoice Journal"
-                                            icon="fa fa-fw fa-book"
-                                            action="inward_report_invoice_journal?faces-redirect=true"
-                                            actionListener="#{inwardInvoiceJournalController.makeNull()}"
                                             class="ui-button-success"
                                             ajax="false" />
                                         <p:commandButton


### PR DESCRIPTION
## Summary
- Per-InwardChargeType columns now show **gross hospital fee** (before discount / margin) instead of net.
- New **Discount** and **Service Charge** columns added before the totals, plus both **Gross Total** and **Net Total** columns — so the reconciliation against Deposits / Credit Settlement still works.
- Moved the **Inpatient Invoice Journal** button from the Payment Reports tab into the **BHT Summary Reports** tab (where it belongs next to the other BHT-level breakdown reports).

Closes #20085

## Why
With the Inward Discount Matrix (#19306 / #20055) now applying discounts to inpatient service/investigation billing, the existing net-only view hid both the discount and the long-standing service charge (margin). Splitting them out lets staff audit the effect per BHT.

## Implementation notes
- `InwardInvoiceJournalRowDto`: added `totalDiscount`, `totalServiceCharge`, `getGrossTotal()`. `getGrandTotal()` is now `gross − discount + service charge`.
- `InwardInvoiceJournalController`:
  - Per-charge-type bulk query switched from `sum(bi.netValue)` to `sum(bi.grossValue)`.
  - New bulk query `fetchDiscountAndMarginByEncounter` sums `BillFee.feeDiscount` and `BillFee.feeMargin` per encounter. Reads from `BillFee` — not `BillItem` — because `BillItem.discount` is not rolled up for inpatient bills (see `BillBhtController.calTotals`).
  - Grand totals and `makeNull()` updated.
- `inward_report_invoice_journal.xhtml`: new columns with footer totals; summary strip extended; Excel export automatically picks them up via the existing `tblReport` target.
- `inward_reports.xhtml`: button relocated.

## Test plan
- [ ] Open `inward/inward_report_invoice_journal.xhtml`; verify the button lives under **BHT Summary Reports**.
- [ ] Generate the report on a period with discounted inpatient bills; confirm per-charge-type columns show **gross** and new **Discount** / **Service Charge** columns show non-zero totals.
- [ ] Confirm `Net Total = Gross Total − Discount + Service Charge`, and reconciles with `Total Deposits` + `Credit Settlement`.
- [ ] Print and Excel export both include the new columns.
- [ ] Sanity-check a period without any discount matrix configured — Discount column is 0 everywhere; Net Total equals Gross Total + Service Charge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced invoice journal reports with new columns displaying discount and service charge amounts per encounter.
  * Added summary totals breaking down gross charges, discounts, and service charges in report footer.

* **Chores**
  * Removed Inpatient Invoice Journal button from BHT Summary Reports navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->