### PR TITLE
Persist DDL version when migration is marked complete (#20090)

### DIFF
--- a/src/main/java/com/divudi/bean/common/DataAdministrationController.java
+++ b/src/main/java/com/divudi/bean/common/DataAdministrationController.java
@@ -2253,11 +2253,25 @@ public class DataAdministrationController implements Serializable {
     }
 
     public void markMigrationComplete() {
+        String version = fetchWikiDdlVersion();
+        if (version != null) {
+            configOptionApplicationController.saveShortTextOption(CONFIG_KEY_DDL_VERSION, version);
+            wikiDdlVersion = version;
+        } else {
+            JsfUtil.addErrorMessage("Could not reach wiki to save DDL version. Banner cleared for this session only — it may return after restart.");
+        }
         databaseMigrationService.markMigrationComplete();
         JsfUtil.addSuccessMessage("Migration marked as complete. The migration page is now restricted to administrators.");
     }
 
     public void markMigrationNotNecessary() {
+        String version = fetchWikiDdlVersion();
+        if (version != null) {
+            configOptionApplicationController.saveShortTextOption(CONFIG_KEY_DDL_VERSION, version);
+            wikiDdlVersion = version;
+        } else {
+            JsfUtil.addErrorMessage("Could not reach wiki to save DDL version. Banner cleared for this session only — it may return after restart.");
+        }
         databaseMigrationService.markMigrationNotNecessary();
         JsfUtil.addSuccessMessage("Migration marked as not necessary. The migration page is now restricted to administrators.");
     }
@@ -2324,6 +2338,7 @@ public class DataAdministrationController implements Serializable {
         if (wikiDdlVersion != null) {
             String storedVersion = configOptionApplicationController.getShortTextValueByKey(CONFIG_KEY_DDL_VERSION);
             if (wikiDdlVersion.equals(storedVersion) && !"UNCHECKED".equals(storedVersion)) {
+                databaseMigrationService.markMigrationComplete();
                 errors = "Schema is up to date (Wiki DDL version: " + wikiDdlVersion + "). No missing fields expected.";
                 return;
             }


### PR DESCRIPTION
## Summary
- `markMigrationComplete` and `markMigrationNotNecessary` now fetch the current wiki DDL version and save it to the `DATABASE_DDL_VERSION` config option before clearing the in-memory flag, so `DatabaseMigrationService.init()` can confirm on the next restart that no migration is pending.
- `checkMissingFields` now also clears the in-memory flag when the stored version already matches the wiki version, so the footer banner disappears immediately in the current JVM without requiring a restart.
- If the wiki is unreachable, both "mark" actions still clear the flag for the current session but warn the user that the banner may return after restart.

Closes #20090

## Test plan
- [ ] With banner showing, click **Mark Migration as Complete** → banner clears; restart server → banner stays cleared (assuming wiki unchanged).
- [ ] With banner showing, click **Mark as Not Necessary** → same behaviour as above.
- [ ] With banner showing and stored version already matching wiki, click **Check Missing Fields** → banner clears immediately (no restart needed).
- [ ] With wiki unreachable, click **Mark Migration as Complete** → warning message shown; banner clears for this JVM; after restart banner reappears (expected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)