### PR TITLE
Fix blank doctor name in Excel export + add Reload button on doctor list pages (#19827)

### DIFF
--- a/src/main/java/com/divudi/bean/common/DoctorController.java
+++ b/src/main/java/com/divudi/bean/common/DoctorController.java
@@ -143,6 +143,14 @@ public class DoctorController implements Serializable {
         selectedItems = getFacade().findByJpql(j, m);
     }
 
+    public void reloadDoctorsIncludingConsultants() {
+        fillDoctorsIncludingConsultants();
+    }
+
+    public void reloadDoctorsExcludingConsultants() {
+        fillDoctorsExcludingConsultants();
+    }
+
     private void fillDoctorsExcludingConsultants() {
         String j;
         j = "select c "
@@ -217,13 +225,15 @@ public class DoctorController implements Serializable {
             int rowNum = 1;
             for (Doctor doctor : items) {
                 Row row = sheet.createRow(rowNum++);
-                row.createCell(0).setCellValue(doctor.getName());
-                row.createCell(1).setCellValue(doctor.getPerson().getPhone());
-                row.createCell(2).setCellValue(doctor.getPerson().getFax());
-                row.createCell(3).setCellValue(doctor.getPerson().getMobile());
-                row.createCell(4).setCellValue(doctor.getPerson().getAddress());
+                Person person = doctor.getPerson();
+                String name = person != null ? person.getNameWithTitle() : doctor.getName();
+                row.createCell(0).setCellValue(name);
+                row.createCell(1).setCellValue(person != null ? person.getPhone() : null);
+                row.createCell(2).setCellValue(person != null ? person.getFax() : null);
+                row.createCell(3).setCellValue(person != null ? person.getMobile() : null);
+                row.createCell(4).setCellValue(person != null ? person.getAddress() : null);
                 row.createCell(5).setCellValue(doctor.getCode());
-                row.createCell(6).setCellValue(doctor.getSpeciality().getName());
+                row.createCell(6).setCellValue(doctor.getSpeciality() != null ? doctor.getSpeciality().getName() : null);
                 row.createCell(7).setCellValue(doctor.getRegistration());
                 row.createCell(8).setCellValue(doctor.getQualification());
                 row.createCell(9).setCellValue(doctor.getCharge());

--- a/src/main/webapp/admin/staff/doctors_excluding_consultants.xhtml
+++ b/src/main/webapp/admin/staff/doctors_excluding_consultants.xhtml
@@ -40,17 +40,25 @@
                                                                  return false;" action="#{doctorController.delete()}"  value="Delete" 
                                 class="m-1 ui-button-danger w-25" >
                             </p:commandButton>
-                            <p:commandButton 
-                                value="Excel" 
+                            <p:commandButton
+                                value="Excel"
                                 icon="fa-solid fa-file-excel"
                                 class="ui-button-success w-25"
                                 ajax="false"
                                 action="#{doctorController.downloadAsExcel()}"
                                 />
+                            <p:commandButton
+                                id="btnReload"
+                                value="Reload"
+                                icon="fa-solid fa-rotate"
+                                class="m-1 ui-button-info w-25"
+                                process="@this"
+                                update="lstSelect"
+                                action="#{doctorController.reloadDoctorsExcludingConsultants()}"/>
 
 
 
-                            <p:selectOneListbox  
+                            <p:selectOneListbox
                                 class="w-100" 
                                 filterMatchMode="contains" 
                                 id="lstSelect" 

--- a/src/main/webapp/admin/staff/doctors_including_consultants.xhtml
+++ b/src/main/webapp/admin/staff/doctors_including_consultants.xhtml
@@ -40,17 +40,25 @@
                                                                  return false;" action="#{doctorController.delete()}"  value="Delete" 
                                 class="m-1 ui-button-danger w-25" >
                             </p:commandButton>
-                            <p:commandButton 
-                                value="Excel" 
+                            <p:commandButton
+                                value="Excel"
                                 icon="fa-solid fa-file-excel"
                                 class="ui-button-success w-25"
                                 ajax="false"
                                 action="#{doctorController.downloadAsExcel()}"
                                 />
+                            <p:commandButton
+                                id="btnReload"
+                                value="Reload"
+                                icon="fa-solid fa-rotate"
+                                class="m-1 ui-button-info w-25"
+                                process="@this"
+                                update="lstSelect"
+                                action="#{doctorController.reloadDoctorsIncludingConsultants()}"/>
 
 
 
-                            <p:selectOneListbox  
+                            <p:selectOneListbox
                                 class="w-100" 
                                 filterMatchMode="contains" 
                                 id="lstSelect" 


### PR DESCRIPTION
## Summary
- Fixes the reported bug: Excel export from `doctors_including_consultants.xhtml` / `doctors_excluding_consultants.xhtml` had a blank Name column because it called `doctor.getName()` (returns the mostly-null `Staff.name` field) instead of the person name. Now uses `Person.getNameWithTitle()` with null-safety on `person` and `speciality` so one incomplete record cannot abort the whole download.
- Adds a **Reload** button to both doctor-list pages. `DoctorController` is `@SessionScoped` and the list is only populated by `navigateToDoctorsIncludingConsultants()` — a direct URL visit or browser refresh previously left the listbox empty. Reload calls new public `reloadDoctorsIncludingConsultants()` / `reloadDoctorsExcludingConsultants()` methods that wrap the existing private fill logic.

Closes #19827

## Test plan
- [ ] Visit `/admin/staff/doctors_including_consultants.xhtml` directly (or refresh) → click **Reload** → doctor list populates.
- [ ] Same for `/admin/staff/doctors_excluding_consultants.xhtml`.
- [ ] Click **Excel** on either page → open file → Name column shows each doctor's name with title (e.g. "Dr. Jane Doe"), not blank.
- [ ] Excel still downloads even when a doctor has no speciality or no person record (previously would throw NPE and abort).

🤖 Generated with [Claude Code](https://claude.com/claude-code)