### PR TITLE
19600-need-to-improve-laboratory-workload-report-pdf

### DIFF
--- a/src/main/java/com/divudi/bean/common/ReportsController.java
+++ b/src/main/java/com/divudi/bean/common/ReportsController.java
@@ -5154,10 +5154,10 @@ public class ReportsController implements Serializable {
 
             if (isVisitCC){
                 headers = new String[]{"Sample ID", "Invoice No.", "MRN", "Name", "Age","Gender","Investigation","Lab Department", "CC", "CC Route","Invoiced Date","Invoiced By","Received Date","Received By","Remarks","Patient Source","Patient Type","Referring Doctor","Item Value"};
-                columnWidths = new float[]{1f, 2f, 1f, 2f, 0.5f, 0.5f, 2f, 1f,1f,1f,1f,1f,1f,1f,1f,0.5f,0.5f,2f,1f};
+                columnWidths = new float[]{1f, 2f, 1f, 2f, 1f, 0.5f, 2f, 1f,1f,1f,1f,1f,1f,1f,1f,0.5f,1f,2f,1f};
             } else{
                 headers = new String[]{"Sample ID", "Invoice No.", "MRN", "Name", "Age","Gender","Investigation","Lab Department","Invoiced Date","Invoiced By","Received Date","Received By","Remarks","Patient Source","Patient Type","Referring Doctor","Item Value"};
-                columnWidths = new float[]{1f, 2f, 1f, 2f, 0.5f, 0.5f, 2f, 1f,1f,1f,1f,1f,1f,0.5f,0.5f,2f,1f};
+                columnWidths = new float[]{1f, 2f, 1f, 2f, 1f, 0.5f, 2f, 1f,1f,1f,1f,1f,1f,0.5f,1f,2f,1f};
             }
             table.setWidths(columnWidths);
 
@@ -5180,8 +5180,9 @@ public class ReportsController implements Serializable {
                 table.addCell(textCell(row.getBillItem().getItem().getDepartment().getName(),bodyFontSmall));
                 
                 if (isVisitCC){
-                   table.addCell(textCell(row.getBillItem().getBill().getCollectingCentre().getName(),bodyFontSmall)); 
-                   table.addCell(textCell( row.getBillItem().getBill().getCollectingCentre().getRoute().getName(),bodyFontSmall)); 
+                   Institution cc =  row.getBillItem().getBill().getCollectingCentre();
+                   table.addCell(textCell(cc != null ? cc.getName() : "-",bodyFontSmall)); 
+                   table.addCell(textCell( cc != null && cc.getRoute()!=null ? cc.getRoute().getName() : "-",bodyFontSmall)); 
                 }
  
                 table.addCell(textCell(row.getBillItem().getPatientEncounter() != null ? sdf.format(row.getBillItem().getPatientEncounter().getFinalBill().getCreatedAt()) : sdf.format(row.getBillItem().getBill().getCreatedAt()),bodyFontSmall));


### PR DESCRIPTION
closes #19600
Added null safety to column data when generating the PDF in the laboratory workload report.
changed file,
01) reportsController.java (before, there is no null safety on CC and CC route column)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved laboratory workload detail PDF report layout with adjusted column proportions for better readability.
  * Enhanced null-safety handling in reports to display placeholder values instead of errors when collecting centre or route data is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->