### PR TITLE
Fix handover ignoring net cash float on create, listing, and accept (#20111)

### DIFF
--- a/developer_docs/billing/handover-float-propagation.md
+++ b/developer_docs/billing/handover-float-propagation.md
@@ -1,0 +1,125 @@
+# Handover Float Propagation
+
+How net cash floats carry from one user to the next across shift handovers.
+Reference: issue #20111.
+
+## Core concept
+
+A shift handover moves **two things** to the receiving user:
+
+1. **Collected payments** — each has a `department`, each was created from a bill.
+2. **Net float** — cash-only, `department = null`, user-to-user transfer with
+   no bill context.
+
+The handover bill total = `sum(collected payments) + netFloat`.
+
+`netFloat = cashFloatInTotal − cashFloatOutTotal` on the shift bundle
+(`ReportTemplateRowBundle.getCashFloatNetTotal()`).
+
+## The `department = null` marker
+
+`Payment.department == null` is the canonical marker of a float payment.
+All real collections are attached to a department (via the bill). Queries
+that aggregate "my floats" rely on this and on `creater` / `floatRecipient`
+(see `FinancialTransactionController.fetchShiftFloatsFromShiftStartToEnd`).
+
+When constructing a float payment always set:
+
+```java
+p.setDepartment(null);
+p.setInstitution(null);
+```
+
+Setting only `department=null` but leaving `institution` populated produces
+a "half-float" that slips past some aggregates. Always null both.
+
+## `currentHolder` vs `creater` vs `floatRecipient`
+
+| Field | What it means | When accept rewrites it |
+|---|---|---|
+| `creater` | Original author of the payment | Never changes |
+| `floatRecipient` | Original recipient of a float transfer | Never changes |
+| `currentHolder` | The user whose drawer / shift this payment belongs to **right now** | Rewritten on handover accept for collected payments |
+
+Collected (non-float) payments move between shifts **purely by rewriting
+`currentHolder`**. No new payment rows are created on accept for those.
+
+Float payments are **not** transferred by rewriting `currentHolder`. The
+sender's float records stay attributed to the sender. Instead, on accept
+a **new** float payment is created on the receiver side.
+
+## What accept does (FUND_SHIFT_HANDOVER_ACCEPT)
+
+See `FinancialTransactionController.acceptHandoverBillAndWriteToCashbook()`.
+
+For each incoming payment in the handover bundle:
+
+1. If `isFundTransferPayment(p)` (i.e. a float payment) → **skip**, keep the
+   sender's record as-is.
+2. Otherwise → rewrite `currentHolder = receiver`, mark handover-completed,
+   update receiver's drawer.
+
+After the loop, if `bundle.getCashFloatNetTotal() != 0`:
+
+1. Create a new `Bill` with `billTypeAtomic = FUND_TRANSFER_RECEIVED_BILL`,
+   `referenceBill = <the accept bill>`.
+2. Create a new `Payment` on that bill with:
+   - `paymentMethod = Cash`
+   - `paidValue = netFloat`
+   - `creater = sender` (the original handover creator)
+   - `floatRecipient = receiver` (the accepting user)
+   - `currentHolder = receiver`
+   - `department = null`, `institution = null`
+3. Update the receiver's cash drawer via `drawerController.updateDrawerForIns`.
+
+This receiver-side float is what makes the net float appear on the receiver's
+**own** shift handover screen alongside their collections.
+
+## Why the create bill stores a float-inclusive total
+
+`settleHandoverStartBill()` writes
+`currentBill.setTotal(bundle.getTotal() + bundle.getCashFloatNetTotal())`.
+
+The payment-based subtotal is recomputed from persisted payments on accept.
+Net float is not carried on any Payment of the handover bill itself — it
+lives only on the shift's separate float payments. Storing the
+float-inclusive total lets `navigateToReceiveNewHandoverBill()` restore
+`cashFloatNetTotal` by subtraction:
+
+```java
+floatNet = selectedBill.getTotal() − rebuiltPaymentTotal
+```
+
+This is why the create bill total and the sum-of-payments diverge by exactly
+the net float — don't "fix" them to match.
+
+## Cancellation
+
+Handovers cannot be cancelled once accepted (only rejected before accept).
+The receiver-side float payment therefore has no cancel path today.
+If a future requirement arises, cancel should:
+
+- Retire the `FUND_TRANSFER_RECEIVED_BILL` and its float payment.
+- Reverse the receiver's cash drawer update.
+- Clear `currentHolder` rewrites for all collected payments (restore to sender).
+
+## Cash-only
+
+By concept, floats are **cash only**. The code doesn't yet enforce this at
+the creation boundary (tracked separately). The accept-side float propagation
+creates only a `PaymentMethod.Cash` float, matching the convention used
+across the rest of the float flow.
+
+## Key methods
+
+- `FinancialTransactionController.settleHandoverStartBill()` — persists
+  float-inclusive total on CREATE.
+- `FinancialTransactionController.navigateToReceiveNewHandoverBill()` —
+  restores `cashFloatNetTotal` on the bundle by subtraction.
+- `FinancialTransactionController.acceptHandoverBillAndWriteToCashbook()` —
+  rewrites `currentHolder` for collections, creates receiver float on accept.
+- `FinancialTransactionController.fetchShiftFloatsFromShiftStartToEnd()` —
+  aggregates floats for a user's shift (by `creater OR floatRecipient`,
+  filtered by `currentHolder`).
+- `ReportTemplateRowBundle.getCashFloatNetTotal()` —
+  `cashFloatInTotal − cashFloatOutTotal`.

--- a/src/main/java/com/divudi/bean/cashTransaction/FinancialTransactionController.java
+++ b/src/main/java/com/divudi/bean/cashTransaction/FinancialTransactionController.java
@@ -1864,29 +1864,19 @@ public class FinancialTransactionController implements Serializable {
         bundle.aggregateTotalsFromAllChildBundles();
         bundle.collectDepartments();
 
-        // Create and configure the current bill
-//        currentBill = new Bill();
-//        currentBill.setBillType(BillType.CashHandoverAcceptBill);
-//        currentBill.setBillTypeAtomic(BillTypeAtomic.FUND_SHIFT_HANDOVER_ACCEPT);
-//        currentBill.setBillClassType(BillClassType.Bill);
-//        currentBill.setReferenceBill(selectedBill);
-//        currentBill.setFromDepartment(selectedBill.getFromDepartment());
-//        currentBill.setFromDate(selectedBill.getFromDate());
-//        currentBill.setDepartment(sessionController.getDepartment());
-//        currentBill.setInstitution(sessionController.getInstitution());
-//        currentBill.setStaff(sessionController.getLoggedUser().getStaff());
-//        currentBill.setWebUser(sessionController.getLoggedUser());
-//        currentBill.setToWebUser(sessionController.getLoggedUser());
-//        currentBill.setFromWebUser(selectedBill.getCreater());
-//        currentBill.setCreatedAt(new Date());
-//        currentBill.setCreater(sessionController.getLoggedUser());
-//        currentBill.setBillDate(new Date());
-//        currentBill.setBillTime(new Date());
-//        currentBill.setTotal(bundle.getTotal());
-//        currentBill.setNetTotal(bundle.getTotal());
-//
-//        // Save the current bill
-//        billController.save(currentBill);
+        // Restore cash float net from the stored handover bill: at creation time
+        // we persisted selectedBill.total = (payment-based total) + cashFloatNetTotal.
+        // The rebuild above recomputes the payment-based total from persisted payments,
+        // so the difference is the float net that was physically in hand at handover.
+        double storedTotal = selectedBill.getTotal();
+        double rebuiltTotal = bundle.getTotal() != null ? bundle.getTotal() : 0.0;
+        double floatNet = storedTotal - rebuiltTotal;
+        if (floatNet > 0) {
+            bundle.setCashFloatInTotal(floatNet);
+        } else if (floatNet < 0) {
+            bundle.setCashFloatOutTotal(-floatNet);
+        }
+
         return "/cashier/handover_accept?faces-redirect=true";
     }
 
@@ -5667,8 +5657,8 @@ public class FinancialTransactionController implements Serializable {
 
         currentBill.setBillDate(new Date());
         currentBill.setBillTime(new Date());
-        currentBill.setTotal(bundle.getTotal());
-        currentBill.setNetTotal(bundle.getTotalOut());
+        currentBill.setTotal(bundle.getTotal() + bundle.getCashFloatNetTotal());
+        currentBill.setNetTotal(bundle.getTotal() + bundle.getCashFloatNetTotal());
 
         currentBill.setCreatedAt(new Date());
         currentBill.setCreater(sessionController.getLoggedUser());
@@ -7132,6 +7122,55 @@ public class FinancialTransactionController implements Serializable {
             if (p.getPaymentMethod() != null && p.getPaymentMethod() != PaymentMethod.Cash) {
                 drawerController.updateDrawer(currentBill, p.getPaidValue(), p.getPaymentMethod(), reciver);
             }
+        }
+
+        // Propagate net cash float to the receiver so it appears on their shift handover.
+        // Floats are marked by department=null; accepting a handover that carries a net
+        // float must create a receiver-side float payment (new FUND_TRANSFER_RECEIVED_BILL),
+        // because the sender's float payments stay attributed to the sender (creater=sender,
+        // floatRecipient was never set for shift-handover floats). Without this, the receiver's
+        // Shift Handover Create page shows no float row and a missing "Net To Handover" line.
+        double cashFloatNet = bundle.getCashFloatNetTotal();
+        if (Math.abs(cashFloatNet) > 0.001) {
+            Bill floatReceivedBill = new Bill();
+            floatReceivedBill.setBillType(BillType.FundTransferReceivedBill);
+            floatReceivedBill.setBillTypeAtomic(BillTypeAtomic.FUND_TRANSFER_RECEIVED_BILL);
+            floatReceivedBill.setBillClassType(BillClassType.Bill);
+            floatReceivedBill.setReferenceBill(currentBill);
+            floatReceivedBill.setDepartment(sessionController.getDepartment());
+            floatReceivedBill.setInstitution(sessionController.getInstitution());
+            floatReceivedBill.setFromDepartment(sender != null ? sender.getDepartment() : null);
+            floatReceivedBill.setToDepartment(sessionController.getDepartment());
+            floatReceivedBill.setFromInstitution(sender != null ? sender.getInstitution() : sessionController.getInstitution());
+            floatReceivedBill.setToInstitution(sessionController.getInstitution());
+            floatReceivedBill.setStaff(reciver.getStaff());
+            floatReceivedBill.setToStaff(reciver.getStaff());
+            floatReceivedBill.setFromStaff(sender != null ? sender.getStaff() : null);
+            floatReceivedBill.setFromWebUser(sender);
+            floatReceivedBill.setToWebUser(reciver);
+            floatReceivedBill.setCreater(reciver);
+            floatReceivedBill.setCreatedAt(new Date());
+            floatReceivedBill.setBillDate(new Date());
+            floatReceivedBill.setBillTime(new Date());
+            floatReceivedBill.setTotal(cashFloatNet);
+            floatReceivedBill.setNetTotal(cashFloatNet);
+            String floatDeptId = billNumberGenerator.departmentBillNumberGeneratorYearly(sessionController.getDepartment(), BillTypeAtomic.FUND_TRANSFER_RECEIVED_BILL);
+            floatReceivedBill.setDeptId(floatDeptId);
+            floatReceivedBill.setInsId(floatDeptId);
+            billController.save(floatReceivedBill);
+
+            Payment floatPayment = new Payment();
+            floatPayment.setBill(floatReceivedBill);
+            floatPayment.setPaymentMethod(PaymentMethod.Cash);
+            floatPayment.setPaidValue(cashFloatNet);
+            floatPayment.setCreater(sender);
+            floatPayment.setFloatRecipient(reciver);
+            floatPayment.setCurrentHolder(reciver);
+            floatPayment.setDepartment(null);
+            floatPayment.setInstitution(null);
+            floatPayment.setCreatedAt(new Date());
+            paymentController.save(floatPayment);
+            drawerController.updateDrawerForIns(floatPayment, reciver);
         }
 
         billController.save(currentBill);

--- a/src/main/java/com/divudi/bean/cashTransaction/FinancialTransactionController.java
+++ b/src/main/java/com/divudi/bean/cashTransaction/FinancialTransactionController.java
@@ -1864,17 +1864,22 @@ public class FinancialTransactionController implements Serializable {
         bundle.aggregateTotalsFromAllChildBundles();
         bundle.collectDepartments();
 
-        // Restore cash float net from the stored handover bill: at creation time
-        // we persisted selectedBill.total = (payment-based total) + cashFloatNetTotal.
-        // The rebuild above recomputes the payment-based total from persisted payments,
-        // so the difference is the float net that was physically in hand at handover.
-        double storedTotal = selectedBill.getTotal();
-        double rebuiltTotal = bundle.getTotal() != null ? bundle.getTotal() : 0.0;
-        double floatNet = storedTotal - rebuiltTotal;
-        if (floatNet > 0) {
-            bundle.setCashFloatInTotal(floatNet);
-        } else if (floatNet < 0) {
-            bundle.setCashFloatOutTotal(-floatNet);
+        // Restore cash float net for display. The denomination bill holds the
+        // physical cash the sender counted at handover; bundle.cashValue is the
+        // cash portion collected during the shift (float-exclusive). Their
+        // difference is the net cash float carried into the handover. Using
+        // the denomination bill (instead of selectedBill.total) is independent
+        // of how total was persisted, so legacy handovers created before the
+        // total-persistence fix also restore correctly.
+        if (denoBill != null) {
+            double physicalCash = denoBill.getNetTotal();
+            double rebuiltCash = bundle.getCashValue();
+            double floatNet = physicalCash - rebuiltCash;
+            if (floatNet > 0.001) {
+                bundle.setCashFloatInTotal(floatNet);
+            } else if (floatNet < -0.001) {
+                bundle.setCashFloatOutTotal(-floatNet);
+            }
         }
 
         return "/cashier/handover_accept?faces-redirect=true";
@@ -5657,8 +5662,15 @@ public class FinancialTransactionController implements Serializable {
 
         currentBill.setBillDate(new Date());
         currentBill.setBillTime(new Date());
-        currentBill.setTotal(bundle.getTotal() + bundle.getCashFloatNetTotal());
-        currentBill.setNetTotal(bundle.getTotal() + bundle.getCashFloatNetTotal());
+        // Persist the amount actually handed over (totalOut tracks selected
+        // payment rows) plus the net cash float. Using bundle.getTotal() here
+        // would inflate the bill when the cashier partially selected non-cash
+        // rows, and the accept page would then credit phantom float to the
+        // receiver.
+        double totalOut = bundle.getTotalOut() != null ? bundle.getTotalOut() : 0.0;
+        double handoverBillTotal = totalOut + bundle.getCashFloatNetTotal();
+        currentBill.setTotal(handoverBillTotal);
+        currentBill.setNetTotal(handoverBillTotal);
 
         currentBill.setCreatedAt(new Date());
         currentBill.setCreater(sessionController.getLoggedUser());
@@ -7130,6 +7142,9 @@ public class FinancialTransactionController implements Serializable {
         // because the sender's float payments stay attributed to the sender (creater=sender,
         // floatRecipient was never set for shift-handover floats). Without this, the receiver's
         // Shift Handover Create page shows no float row and a missing "Net To Handover" line.
+        // The payment's paidValue preserves the signed net (positive = receiver gains cash,
+        // negative = receiver transfers cash out); we use updateDrawer (sign-preserving)
+        // instead of updateDrawerForIns (which takes Math.abs).
         double cashFloatNet = bundle.getCashFloatNetTotal();
         if (Math.abs(cashFloatNet) > 0.001) {
             Bill floatReceivedBill = new Bill();
@@ -7170,7 +7185,7 @@ public class FinancialTransactionController implements Serializable {
             floatPayment.setInstitution(null);
             floatPayment.setCreatedAt(new Date());
             paymentController.save(floatPayment);
-            drawerController.updateDrawerForIns(floatPayment, reciver);
+            drawerController.updateDrawer(floatPayment, cashFloatNet, reciver);
         }
 
         billController.save(currentBill);

--- a/src/main/webapp/cashier/handover_accept.xhtml
+++ b/src/main/webapp/cashier/handover_accept.xhtml
@@ -84,7 +84,23 @@
                                             <i class="pi pi-dollar" style="margin-right:5px; color: #17a2b8;"></i>
                                             <p:outputLabel value="Total Handover Value" />
                                         </h:panelGroup>
-                                        <p:outputLabel value="#{financialTransactionController.bundle.total}">
+                                        <p:outputLabel value="#{financialTransactionController.bundle.total + financialTransactionController.bundle.cashFloatNetTotal}">
+                                            <f:convertNumber pattern="#,##0.00" />
+                                        </p:outputLabel>
+
+                                        <h:panelGroup rendered="#{financialTransactionController.bundle.cashFloatInTotal gt 0}">
+                                            <i class="pi pi-arrow-down" style="margin-right:5px; color: #198754;"></i>
+                                            <p:outputLabel value="Float Received (Cash)" />
+                                        </h:panelGroup>
+                                        <p:outputLabel rendered="#{financialTransactionController.bundle.cashFloatInTotal gt 0}" value="#{financialTransactionController.bundle.cashFloatInTotal}">
+                                            <f:convertNumber pattern="#,##0.00" />
+                                        </p:outputLabel>
+
+                                        <h:panelGroup rendered="#{financialTransactionController.bundle.cashFloatOutTotal gt 0}">
+                                            <i class="pi pi-arrow-up" style="margin-right:5px; color: #dc3545;"></i>
+                                            <p:outputLabel value="Float Sent (Cash)" />
+                                        </h:panelGroup>
+                                        <p:outputLabel rendered="#{financialTransactionController.bundle.cashFloatOutTotal gt 0}" value="#{financialTransactionController.bundle.cashFloatOutTotal}">
                                             <f:convertNumber pattern="#,##0.00" />
                                         </p:outputLabel>
                                     </p:panelGrid>
@@ -135,7 +151,7 @@
                                                     <tr>
                                                         <td>Cash</td>
                                                         <td class="text-end">
-                                                            <h:outputText value="#{financialTransactionController.bundle.cashValue}">
+                                                            <h:outputText value="#{financialTransactionController.bundle.cashValue + financialTransactionController.bundle.cashFloatNetTotal}">
                                                                 <f:convertNumber pattern="#,##0.00" />
                                                             </h:outputText>
                                                         </td>
@@ -145,7 +161,7 @@
                                                             </h:outputText>
                                                         </td>
                                                         <td class="text-end">
-                                                            <h:outputText value="#{financialTransactionController.bundle.cashValue - financialTransactionController.bundle.cashHandoverValue}">
+                                                            <h:outputText value="#{financialTransactionController.bundle.cashValue + financialTransactionController.bundle.cashFloatNetTotal - financialTransactionController.bundle.cashHandoverValue}">
                                                                 <f:convertNumber pattern="#,##0.00" />
                                                             </h:outputText>
                                                         </td>
@@ -564,7 +580,7 @@
                                                 <f:convertNumber pattern="#,##0.00" ></f:convertNumber>
                                             </h:outputText>
                                             <f:facet name="footer" >
-                                                <p:outputLabel value="#{financialTransactionController.bundle.cashValue}" >
+                                                <p:outputLabel value="#{financialTransactionController.bundle.cashValue + financialTransactionController.bundle.cashFloatNetTotal}" >
                                                     <f:convertNumber pattern="#,##0.00" ></f:convertNumber>
                                                 </p:outputLabel>
                                             </f:facet>
@@ -778,10 +794,10 @@
                                                 <f:convertNumber pattern="#,##0.00" />
                                             </h:outputText>
                                             <f:facet name="footer">
-                                                <h:outputText value="#{financialTransactionController.bundle.cashValue + financialTransactionController.bundle.cardValue + financialTransactionController.bundle.multiplePaymentMethodsValue + 
-                                                                       financialTransactionController.bundle.creditValue + financialTransactionController.bundle.staffWelfareValue + financialTransactionController.bundle.staffValue + financialTransactionController.bundle.voucherValue + 
-                                                                       financialTransactionController.bundle.iouValue + financialTransactionController.bundle.agentValue + financialTransactionController.bundle.chequeValue + financialTransactionController.bundle.slipValue + 
-                                                                       financialTransactionController.bundle.ewalletValue + financialTransactionController.bundle.patientDepositValue + financialTransactionController.bundle.patientPointsValue + financialTransactionController.bundle.onlineSettlementValue}" 
+                                                <h:outputText value="#{financialTransactionController.bundle.cashValue + financialTransactionController.bundle.cardValue + financialTransactionController.bundle.multiplePaymentMethodsValue +
+                                                                       financialTransactionController.bundle.creditValue + financialTransactionController.bundle.staffWelfareValue + financialTransactionController.bundle.staffValue + financialTransactionController.bundle.voucherValue +
+                                                                       financialTransactionController.bundle.iouValue + financialTransactionController.bundle.agentValue + financialTransactionController.bundle.chequeValue + financialTransactionController.bundle.slipValue +
+                                                                       financialTransactionController.bundle.ewalletValue + financialTransactionController.bundle.patientDepositValue + financialTransactionController.bundle.patientPointsValue + financialTransactionController.bundle.onlineSettlementValue + financialTransactionController.bundle.cashFloatNetTotal}"
                                                               style="text-align: right;">
                                                     <f:convertNumber pattern="#,##0.00" />
                                                 </h:outputText>

--- a/src/main/webapp/cashier/handover_bills_for_me_to_receive.xhtml
+++ b/src/main/webapp/cashier/handover_bills_for_me_to_receive.xhtml
@@ -43,7 +43,7 @@
                         </p:column>
 
                         <p:column headerText="Value">
-                            <h:outputText value="#{bp.netTotal}" >
+                            <h:outputText value="#{bp.total}" >
                                 <f:convertNumber pattern="#,##0.00" ></f:convertNumber>
                             </h:outputText>
                         </p:column>

--- a/src/main/webapp/resources/ezcomp/prints/five_five_paper_with_headings_for_handover.xhtml
+++ b/src/main/webapp/resources/ezcomp/prints/five_five_paper_with_headings_for_handover.xhtml
@@ -206,12 +206,22 @@
                             </h:outputText>
 
                             <h:outputText value="Total Due Handover Value:" styleClass="handover-label" style="font-weight: normal"/>
-                            <h:outputText value="#{cc.attrs.bundle.total}">
+                            <h:outputText value="#{cc.attrs.bundle.total + cc.attrs.bundle.cashFloatNetTotal}">
                                 <f:convertNumber pattern="#,##0.00" />
                             </h:outputText>
 
                             <h:outputText value="Handingover Value:" styleClass="handover-label" style="font-weight: normal"/>
                             <h:outputText value="#{cc.attrs.bundle.totalOut}">
+                                <f:convertNumber pattern="#,##0.00" />
+                            </h:outputText>
+
+                            <h:outputText rendered="#{cc.attrs.bundle.cashFloatInTotal gt 0}" value="Float Received (Cash):" styleClass="handover-label" style="font-weight: normal"/>
+                            <h:outputText rendered="#{cc.attrs.bundle.cashFloatInTotal gt 0}" value="#{cc.attrs.bundle.cashFloatInTotal}">
+                                <f:convertNumber pattern="#,##0.00" />
+                            </h:outputText>
+
+                            <h:outputText rendered="#{cc.attrs.bundle.cashFloatOutTotal gt 0}" value="Float Sent (Cash):" styleClass="handover-label" style="font-weight: normal"/>
+                            <h:outputText rendered="#{cc.attrs.bundle.cashFloatOutTotal gt 0}" value="#{cc.attrs.bundle.cashFloatOutTotal}">
                                 <f:convertNumber pattern="#,##0.00" />
                             </h:outputText>
 
@@ -237,9 +247,9 @@
                                         <h:panelGroup rendered="#{cc.attrs.bundle.hasCashTransaction}">
                                             <tr>
                                                 <td>Cash</td>
-                                                <td class="text-end"><h:outputText value="#{cc.attrs.bundle.cashValue}"><f:convertNumber pattern="#,##0.00"/></h:outputText></td>
+                                                <td class="text-end"><h:outputText value="#{cc.attrs.bundle.cashValue + cc.attrs.bundle.cashFloatNetTotal}"><f:convertNumber pattern="#,##0.00"/></h:outputText></td>
                                                 <td class="text-end"><h:outputText value="#{cc.attrs.bundle.denominatorValue}"><f:convertNumber pattern="#,##0.00"/></h:outputText></td>
-                                                <td class="text-end"><h:outputText value="#{cc.attrs.bundle.cashValue - cc.attrs.bundle.denominatorValue}"><f:convertNumber pattern="#,##0.00"/></h:outputText></td>
+                                                <td class="text-end"><h:outputText value="#{cc.attrs.bundle.cashValue + cc.attrs.bundle.cashFloatNetTotal - cc.attrs.bundle.denominatorValue}"><f:convertNumber pattern="#,##0.00"/></h:outputText></td>
                                             </tr>
                                         </h:panelGroup>
                                         <h:panelGroup rendered="#{cc.attrs.bundle.hasCardTransaction}">


### PR DESCRIPTION
## Summary
- Handover bills now persist `total` and `netTotal` as *payment total + net cash float*, so the "Bills to Receive" list and accept page show the true handover value.
- On accept, a new `FUND_TRANSFER_RECEIVED_BILL` + cash `Payment` is created for the receiver (`department=null`, `institution=null`, `creater=sender`, `floatRecipient=receiver`, `currentHolder=receiver`) so the float carries into the receiver's own shift handover instead of disappearing.
- Create-preview print, accept page, and "Bills to Receive" list now render Float Received / Float Sent rows and float-inclusive totals that reconcile with the per-bundle footer.
- Adds `developer_docs/billing/handover-float-propagation.md` covering the `department=null` float marker, `currentHolder` vs `creater` vs `floatRecipient`, and the accept-side float creation.

Closes #20111

## Test plan
- [ ] Start shift as cashier A, collect OPD bills, receive a float transfer from user B.
- [ ] Handover shift from A → receiver R. Confirm: Shift End preview, Handover Current Shift, and print all show `Collected = payments + net float`, `Net to Handover = payments + net float`.
- [ ] As receiver R, open `handover_bills_for_me_to_receive.xhtml`. The Value column should show `payments + net float` (not payments only).
- [ ] Open the accept page. Top header `Total Handover Value`, `Float Received (Cash)`, the Cash row (Collected / Handing Over / Difference), and the per-bundle table footer all reconcile.
- [ ] Accept the handover. On R's `handover_start_all.xhtml`, verify the received float appears as "Float Received (Cash)" and `Net To Handover` reflects payments + inherited float.
- [ ] R hands over to user S; confirm the same float flows through again on S's accept page.
- [ ] Sender's post-accept Shift End no longer shows pending float payments.
- [ ] Non-cash payment methods (card, cheque) on the handover continue to behave as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Cash float tracking now visible during shift handovers, displaying "Float Received (Cash)" and "Float Sent (Cash)" amounts where applicable.
  * Handover totals and cash calculations now include and reflect cash float adjustments.

* **Documentation**
  * Added developer documentation detailing how net cash float transfers across shift handovers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->