### PR TITLE
Fix Staff Welfare balance not restored on Multi payment cancellation

### DIFF
--- a/src/main/java/com/divudi/bean/common/BillSearch.java
+++ b/src/main/java/com/divudi/bean/common/BillSearch.java
@@ -2914,6 +2914,18 @@ public class BillSearch implements Serializable, ControllerWithMultiplePayments 
 
         // Create payments using PaymentService
         List<Payment> ps = paymentService.createPayment(cancellationBill, paymentMethodData);
+
+        // For Multi payment methods, restore non-drawer balances (Staff Welfare,
+        // Patient Deposit, Staff Credit, Company Credit) per component. The 5-arg
+        // createPayment overload only writes Payment rows + drawer/cashbook; it does
+        // not touch these balances. The post-create Staff_Welfare/Credit/PatientDeposit
+        // blocks below only fire when the cancellation bill's top-level method matches,
+        // so Multi(Cash + Staff Welfare) would otherwise leave the welfare balance
+        // un-refunded. Mirrors OpdBatchBillCancellationController.cancelOpdBatchBill.
+        if (cancellationBill.getPaymentMethod() == PaymentMethod.MultiplePaymentMethods) {
+            paymentService.updateBalances(ps);
+        }
+
         List<BillItem> list = cancelBillItems(getBill(), cancellationBill, ps);
 
         try {

--- a/src/main/java/com/divudi/bean/common/OpdBillCancellationController.java
+++ b/src/main/java/com/divudi/bean/common/OpdBillCancellationController.java
@@ -800,6 +800,18 @@ public class OpdBillCancellationController implements Serializable, ControllerWi
 
         // Create payments using PaymentService
         List<Payment> ps = paymentService.createPayment(cancellationBill, paymentMethodData);
+
+        // For Multi payment methods, restore non-drawer balances (Staff Welfare,
+        // Patient Deposit, Staff Credit, Company Credit) per component. The 5-arg
+        // createPayment overload only writes Payment rows + drawer/cashbook; it does
+        // not touch these balances. The post-create Staff_Welfare/Credit/PatientDeposit
+        // blocks below only fire when the cancellation bill's top-level method matches,
+        // so Multi(Cash + Staff Welfare) would otherwise leave the welfare balance
+        // un-refunded. Mirrors OpdBatchBillCancellationController.cancelOpdBatchBill.
+        if (cancellationBill.getPaymentMethod() == PaymentMethod.MultiplePaymentMethods) {
+            paymentService.updateBalances(ps);
+        }
+
         List<BillItem> list = cancelBillItems(getBill(), cancellationBill, ps);
 
         try {


### PR DESCRIPTION
## Summary
- Fix individual OPD bill cancellation so Multi(Cash + Staff Welfare) refunds actually restore the welfare balance.
- Mirrors the pattern already used in `OpdBatchBillCancellationController.cancelOpdBatchBill` (line 2866).

## Root cause
`PaymentService.createPayment(Bill, PaymentMethodData)` (5-arg overload) creates Payment rows and updates drawer/cashbook, but does **not** update non-drawer balances (Staff Welfare, Patient Deposit, Staff Credit, Company Credit). Each caller must invoke `paymentService.updateBalances(payments)` afterwards to get per-component balance updates.

`BillSearch.cancelBill` and `OpdBillCancellationController.cancelBill` skipped that second call. The post-create `if (cancellationBill.getPaymentMethod() == PaymentMethod.Staff_Welfare)` block only fires when the bill's top-level method is `Staff_Welfare` — so `MultiplePaymentMethods` bills fell through and the welfare component's balance was never refunded.

## Fix
After `paymentService.createPayment(...)`, when `paymentMethod == MultiplePaymentMethods`, call `paymentService.updateBalances(ps)`. Two files, same pattern each.

```java
if (cancellationBill.getPaymentMethod() == PaymentMethod.MultiplePaymentMethods) {
    paymentService.updateBalances(ps);
}
```

## Test plan
- [ ] Create an OPD bill paid with Multi(Cash + Staff Welfare). Note staff's current welfare balance.
- [ ] Cancel the bill via individual cancellation (bill_cancel.xhtml).
- [ ] Verify staff welfare balance increases by the welfare component amount.
- [ ] Repeat via batch bill cancellation (batch_bill_cancel.xhtml) — should continue to work as before.
- [ ] Sanity-check a plain Staff_Welfare-only bill cancel — still refunded via the existing top-level block.
- [ ] Sanity-check a plain Cash bill cancel — drawer updated, no other balance change.

## Related
- Closes #20115
- Follow-up cleanup to unify `createPayment` + `updateBalances` into one service method: #20114

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Resolved an issue where outpatient bill cancellations using multiple payment methods did not properly restore all associated balance components, including staff welfare, patient deposits, staff credits, and company credits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->