### PR TITLE
Fix Card cancellation on Package Batch Bill cancel page (#18565)

### DIFF
--- a/src/main/webapp/opd/opd_package_batch_bill_cancel.xhtml
+++ b/src/main/webapp/opd/opd_package_batch_bill_cancel.xhtml
@@ -232,7 +232,7 @@
                                                     class="row my-1"
                                                     layout="block"  
                                                     id="creditCard" rendered="#{billPackageController.paymentMethod eq 'Card'}" >
-                                                    <pa:creditCard paymentMethodData="#{billPackageController.paymentMethodData}"/>
+                                                    <pa:creditCardDetailsAsOnlyPayment paymentMethodData="#{billPackageController.paymentMethodData}" valueRequired="false"/>
                                                 </h:panelGroup>
                                                 <h:panelGroup
                                                     class="row my-1"


### PR DESCRIPTION
## Summary
- Replaces `pa:creditCard` with `pa:creditCardDetailsAsOnlyPayment valueRequired=\"false\"` in `opd/opd_package_batch_bill_cancel.xhtml` to match other cancel pages.
- Fixes three symptoms on Package Batch Bill cancellation when original settlement was by Card:
  1. Cancellation blocked by `Bank is required` / `Comments are required` validation even though the bank was selected at settlement.
  2. Pre-populated bank not visible on the cancel form (no labels, compact flex layout).
  3. Switching away and back to Card did not re-show bank details.

## Root cause
`resources/paymentMethod/creditCard.xhtml` hardcodes `required=\"true\"` on the Bank dropdown, Card number and Comment fields and does not honour a `valueRequired` attribute. The other cancel pages (`opd/bill_cancel.xhtml`, `opd/batch_bill_cancel.xhtml`, `opd/opd_package_bill_cancel.xhtml`) use `pa:creditCardDetailsAsOnlyPayment`, which respects `valueRequired` and renders a label/field grid so the pre-populated bank is visible.

The Java-side pre-population in `BillPackageController.initializeCancellationPaymentFromOriginalPayments(...)` was already correct; only the JSF composite needed to be aligned.

## Test plan
- [ ] Settle a Package Batch Bill using Card mode (select a bank).
- [ ] Navigate to `opd/opd_package_batch_bill_cancel` for that bill.
- [ ] Verify Card is pre-selected, bank name is visible with labels, card ref no and comment are pre-populated.
- [ ] Click `Cancel Package Bill` — cancellation completes without `Bank is required` / `Comments are required` validation errors.
- [ ] Switch payment method to Cash, then back to Card — bank still displays.
- [ ] Cancellation print shows as expected.

Closes #18565

🤖 Generated with [Claude Code](https://claude.com/claude-code)