### PR TITLE
Fixed - Add navigateToManageInvestigation() navigation method to InvestigationController

### DIFF
--- a/src/main/java/com/divudi/bean/lab/InvestigationController.java
+++ b/src/main/java/com/divudi/bean/lab/InvestigationController.java
@@ -307,6 +307,14 @@ public class InvestigationController implements Serializable {
         
         return "/admin/lims/investigation?faces-redirect=true";
     }
+    
+    public String navigateToManageInvestigation() {
+        if(current == null){
+            JsfUtil.addErrorMessage("Not Found Investigation");
+            return "";
+        }
+        return "/admin/lims/investigation?faces-redirect=true";
+    }
 
     public String navigateToListInvestigationsForAdmin() {
         fillItems();


### PR DESCRIPTION
## Summary
  - Adds a no-argument overload of `navigateToManageInvestigation()` in
    `InvestigationController` for callers where the target investigation is
    already bound to `current`.
  - Avoids the redundant `ejbFacade.findWithoutCache(id)` lookup performed by
    the existing `navigateToManageInvestigation(Long investigationId)` overload
    (line 295).
  - On `current == null`, shows the error "Not Found Investigation" and stays
    on the current page; otherwise redirects to `/admin/lims/investigation`.

  ## Changes
  - `src/main/java/com/divudi/bean/lab/InvestigationController.java`
    - New method `navigateToManageInvestigation()` (no-arg) at line 311.

  ## Test plan
  - [ ] Open a page that binds an investigation to `InvestigationController.current`
        (e.g., a datatable row selection) and trigger a button wired to
        `#{investigationController.navigateToManageInvestigation()}`.
  - [ ] Verify redirect to `/admin/lims/investigation` loads the selected
        investigation.
  - [ ] Clear `current` (or navigate before any selection) and trigger the
        same action; verify "Not Found Investigation" error message is shown
        and the page does not navigate.
  - [ ] Confirm the existing `navigateToManageInvestigation(Long)` overload
        continues to work unchanged.