### PR TITLE
Improve database migration handling when wiki is unreachable

### DIFF
--- a/src/main/java/com/divudi/bean/common/DataAdministrationController.java
+++ b/src/main/java/com/divudi/bean/common/DataAdministrationController.java
@@ -2258,7 +2258,8 @@ public class DataAdministrationController implements Serializable {
             configOptionApplicationController.saveShortTextOption(CONFIG_KEY_DDL_VERSION, version);
             wikiDdlVersion = version;
         } else {
-            JsfUtil.addErrorMessage("Could not reach wiki to save DDL version. Banner cleared for this session only — it may return after restart.");
+            configOptionApplicationController.saveShortTextOption(CONFIG_KEY_DDL_VERSION, "CONFIRMED");
+            JsfUtil.addInfoMessage("Wiki unreachable. Schema confirmation saved locally — banner will not return after restart.");
         }
         databaseMigrationService.markMigrationComplete();
         JsfUtil.addSuccessMessage("Migration marked as complete. The migration page is now restricted to administrators.");
@@ -2270,7 +2271,8 @@ public class DataAdministrationController implements Serializable {
             configOptionApplicationController.saveShortTextOption(CONFIG_KEY_DDL_VERSION, version);
             wikiDdlVersion = version;
         } else {
-            JsfUtil.addErrorMessage("Could not reach wiki to save DDL version. Banner cleared for this session only — it may return after restart.");
+            configOptionApplicationController.saveShortTextOption(CONFIG_KEY_DDL_VERSION, "CONFIRMED");
+            JsfUtil.addInfoMessage("Wiki unreachable. Schema confirmation saved locally — banner will not return after restart.");
         }
         databaseMigrationService.markMigrationNotNecessary();
         JsfUtil.addSuccessMessage("Migration marked as not necessary. The migration page is now restricted to administrators.");

--- a/src/main/java/com/divudi/service/DatabaseMigrationService.java
+++ b/src/main/java/com/divudi/service/DatabaseMigrationService.java
@@ -54,11 +54,18 @@ public class DatabaseMigrationService {
             String storedVersion = readStoredDdlVersion();
             if (storedVersion != null && !storedVersion.isEmpty() && !"UNCHECKED".equals(storedVersion)) {
                 String wikiVersion = fetchWikiDdlVersion();
-                if (wikiVersion != null && wikiVersion.equals(storedVersion)) {
+                if (wikiVersion == null) {
+                    // Wiki unreachable — trust the admin's stored confirmation rather than falsely alarming
                     migrationPending = false;
-                    LOGGER.info("DatabaseMigrationService: Wiki DDL version matches stored version (" + storedVersion + "). No migration pending.");
+                    LOGGER.info("DatabaseMigrationService: Wiki unreachable at startup; trusting stored confirmation (" + storedVersion + "). No migration pending.");
                     return;
                 }
+                if (wikiVersion.equals(storedVersion) || "CONFIRMED".equals(storedVersion)) {
+                    migrationPending = false;
+                    LOGGER.info("DatabaseMigrationService: Schema confirmed (wiki=" + wikiVersion + ", stored=" + storedVersion + "). No migration pending.");
+                    return;
+                }
+                LOGGER.info("DatabaseMigrationService: DDL version mismatch (wiki=" + wikiVersion + ", stored=" + storedVersion + "). Migration may be pending.");
             }
         } catch (Exception e) {
             LOGGER.log(Level.WARNING, "DatabaseMigrationService: Could not auto-check DDL version at startup.", e);


### PR DESCRIPTION
## Summary
This PR improves the database migration service to gracefully handle scenarios where the wiki is unreachable, while still allowing administrators to confirm schema changes locally.

## Key Changes

- **DatabaseMigrationService**: Refactored version checking logic to distinguish between three states:
  - Wiki unreachable: Trust the stored confirmation and skip migration checks
  - Versions match or "CONFIRMED" flag set: No migration pending
  - Version mismatch: Log that migration may be pending

- **DataAdministrationController**: Updated `markMigrationComplete()` and `markMigrationNotNecessary()` methods to:
  - Save a "CONFIRMED" flag locally when wiki is unreachable instead of just clearing the banner for the session
  - Change error message to info message, since the operation now succeeds even without wiki connectivity
  - Ensure the migration banner doesn't reappear after restart when admin has confirmed the schema

## Implementation Details

The changes introduce a "CONFIRMED" sentinel value that persists the administrator's schema confirmation decision locally. This allows the system to:
1. Gracefully degrade when wiki connectivity is lost
2. Prevent false alarms about pending migrations after restart
3. Still require explicit admin action to confirm schema state
4. Maintain audit trail through the stored confirmation flag

https://claude.ai/code/session_01FXktWJbuNNRkL7Vn4Y16WM