### PR TITLE
19664-grn-direct-purchase-reports-unable-to-download-excel-sheet

### DIFF
--- a/src/main/java/com/divudi/bean/pharmacy/PharmacyController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacyController.java
@@ -9845,55 +9845,34 @@ public class PharmacyController implements Serializable {
 
     SimpleDateFormat sdf = new SimpleDateFormat(sessionController.getApplicationPreference().getLongDateTimeFormat());
 
+    Map<String,Object> filters = getFiltersForGRNDetailReport();
+    
     try (XSSFWorkbook workbook = new XSSFWorkbook(); OutputStream out = response.getOutputStream()) {
 
         XSSFSheet sheet = workbook.createSheet("GRN Detail Report");
         int rowIndex = 0;
 
-        // =====================
-        // 1️⃣ Title Row (Row 0) - GRN Header with gray background
-        // =====================
-        XSSFRow titleRow = sheet.createRow(rowIndex++);
-        titleRow.setHeightInPoints(40);
-        XSSFCell titleCell = titleRow.createCell(0);
-        titleCell.setCellValue(GRNHeader());
+        if (filters != null && !filters.isEmpty()){
+            rowIndex = addMetaDataToExcelSheet(workbook, sheet, rowIndex, "GRN and Direct Purchase Report", filters);
+        }
+        // I want to add current data and time as generated 
+        // Add "Generated On" row with current date and time
+        Row generatedOnRow = sheet.createRow(rowIndex++);
+        CellStyle generatedOnStyle = workbook.createCellStyle();
+        XSSFFont generatedOnFont = workbook.createFont();
+        generatedOnFont.setBold(true);
+        generatedOnStyle.setFont(generatedOnFont);
 
-        XSSFCellStyle titleStyle = workbook.createCellStyle();
-        XSSFFont titleFont = workbook.createFont();
-        titleFont.setBold(true);
-        titleFont.setFontHeightInPoints((short) 12);
-        titleFont.setColor(IndexedColors.BLACK.getIndex());
-        titleStyle.setFont(titleFont);
-        titleStyle.setWrapText(true);
-        titleStyle.setVerticalAlignment(VerticalAlignment.CENTER);
-        titleStyle.setAlignment(HorizontalAlignment.CENTER);
-        titleStyle.setFillForegroundColor(IndexedColors.GREY_25_PERCENT.getIndex());
-        titleStyle.setFillPattern(FillPatternType.SOLID_FOREGROUND);
-        titleCell.setCellStyle(titleStyle);
+        Cell generatedLabelCell = generatedOnRow.createCell(0);
+        generatedLabelCell.setCellValue("Generated On:");
+        generatedLabelCell.setCellStyle(generatedOnStyle);
 
-        // =====================
-        // 2️⃣ Subtitle Row (Row 1) - Generated date italic
-        // =====================
-        XSSFRow subRow = sheet.createRow(rowIndex++);
-        subRow.setHeightInPoints(20);
-        XSSFCell subCell = subRow.createCell(0);
-        subCell.setCellValue("Generated on: " + new java.util.Date());
+        Cell generatedValueCell = generatedOnRow.createCell(1);
+        generatedValueCell.setCellValue(sdf.format(new Date()));
 
-        XSSFCellStyle subStyle = workbook.createCellStyle();
-        XSSFFont subFont = workbook.createFont();
-        subFont.setItalic(true);
-        subFont.setFontHeightInPoints((short) 12);
-        subStyle.setFont(subFont);
-        subStyle.setAlignment(HorizontalAlignment.CENTER);
-        subCell.setCellStyle(subStyle);
+        // Add an empty row as spacing before the header
+        sheet.createRow(rowIndex++);
 
-        // Merge title and subtitle across all 21 columns (0–20)
-        sheet.addMergedRegion(new CellRangeAddress(0, 0, 0, 20));
-        sheet.addMergedRegion(new CellRangeAddress(1, 1, 0, 20));
-
-        // =====================
-        // 3️⃣ Header Row (Row 2)
-        // =====================
         Row headerRow = sheet.createRow(rowIndex++);
         headerRow.createCell(0).setCellValue("S. No");
         headerRow.createCell(1).setCellValue("GRN No");
@@ -9918,12 +9897,11 @@ public class PharmacyController implements Serializable {
         headerRow.createCell(20).setCellValue("GRN Sub Total");
 
         int count = 0;
-
         for (Bill bill : bills) {
             Row emptyRow = sheet.createRow(rowIndex++);
             emptyRow.createCell(0).setCellValue("-");
             emptyRow.createCell(1).setCellValue(bill.getDeptId());
-            emptyRow.createCell(2).setCellValue(bill.getReferenceBill().getDeptId());
+            emptyRow.createCell(2).setCellValue(bill.getReferenceBill()!= null ? bill.getReferenceBill().getDeptId():"-");
             emptyRow.createCell(3).setCellValue(
                     bill.getInvoiceNumber() != null ? bill.getInvoiceNumber()
                     : (bill.getReferenceBill() != null && bill.getReferenceBill().getInvoiceNumber() != null
@@ -9950,7 +9928,7 @@ public class PharmacyController implements Serializable {
             emptyRow.createCell(18).setCellValue("-");
             emptyRow.createCell(19).setCellValue(bill.getBillTypeAtomic().equals(BillTypeAtomic.PHARMACY_GRN_CANCELLED)
                     || bill.getBillTypeAtomic().equals(BillTypeAtomic.PHARMACY_GRN_RETURN)
-                    ? -1 * bill.getReferenceBill().getNetTotal() : bill.getReferenceBill().getNetTotal());
+                    ? -1 *(bill.getReferenceBill() != null ? bill.getReferenceBill().getNetTotal() : 0 )  : (bill.getReferenceBill() != null ? bill.getReferenceBill().getNetTotal() : 0 ));
             emptyRow.createCell(20).setCellValue(bill.getNetTotal());
 
             for (BillItem billItem : bill.getBillItems()) {
@@ -10019,7 +9997,6 @@ public class PharmacyController implements Serializable {
         footerRow.getCell(0).setCellValue("TOTAL");
         footerRow.createCell(19).setCellValue(Math.round(calculateTotalPOAmount() * 100.0) / 100.0);
         footerRow.createCell(20).setCellValue(Math.round(calculateTotalGrnAmount() * 100.0) / 100.0);
-
         workbook.write(out);
         context.responseComplete();
 
@@ -10112,7 +10089,8 @@ public class PharmacyController implements Serializable {
         com.itextpdf.text.Font headerFont = FontFactory.getFont(FontFactory.HELVETICA_BOLD, 7);
         com.itextpdf.text.Font bodyFont   = FontFactory.getFont(FontFactory.HELVETICA, 6);
         com.itextpdf.text.Font footerFont = FontFactory.getFont(FontFactory.HELVETICA_BOLD, 8);
-
+        String institutionName = sessionController.getInstitution() != null ? sessionController.getInstitution().getName() : "";
+        
         try (OutputStream out = response.getOutputStream()) {
 
             // ✅ landscape + small margins (important for 21 columns)
@@ -10120,11 +10098,21 @@ public class PharmacyController implements Serializable {
             PdfWriter.getInstance(document, out);
             document.open();
 
-            String headerName = GRNHeader();
-            document.add(new Paragraph(fileName, titleFont));
-            document.add(new Paragraph(headerName, FontFactory.getFont(FontFactory.HELVETICA, 7)));
-            document.add(new Paragraph("Date: " + sdf.format(new Date()), FontFactory.getFont(FontFactory.HELVETICA, 7)));
+            if (!institutionName.isEmpty()) {
+                document.add(new Paragraph(institutionName,
+                        FontFactory.getFont(FontFactory.HELVETICA_BOLD, 18)));
+            }
+            document.add(new Paragraph("GRN and Direct Purchase Report",
+                    FontFactory.getFont(FontFactory.HELVETICA_BOLD, 16)));
+            document.add(new Paragraph("Generated On: " + sdf.format(new Date()),
+                    FontFactory.getFont(FontFactory.HELVETICA, 12)));
             document.add(new Paragraph(" "));
+            
+            Map<String, Object> filters = getFiltersForGRNDetailReport();
+            PdfPTable infoTable = createInfoTablePdfExport(sdf, filters);
+            if (infoTable != null) {
+                document.add(infoTable);
+            }
 
             PdfPTable table = new PdfPTable(21);
             table.setWidthPercentage(100);

--- a/src/main/java/com/divudi/bean/pharmacy/PharmacyController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacyController.java
@@ -10309,7 +10309,7 @@ public class PharmacyController implements Serializable {
         SimpleDateFormat sdf = new SimpleDateFormat(sessionController.getApplicationPreference().getLongDateTimeFormat());
         com.itextpdf.text.Font bodyFontSmall =
                 com.itextpdf.text.FontFactory.getFont(com.itextpdf.text.FontFactory.HELVETICA, 7);
-
+        String institutionName = sessionController.getInstitution() != null ? sessionController.getInstitution().getName() : "";
         com.itextpdf.text.Document document = null;
         OutputStream out = null;
 
@@ -10324,13 +10324,21 @@ public class PharmacyController implements Serializable {
             com.itextpdf.text.pdf.PdfWriter.getInstance(document, out);
             document.open();
 
-            document.add(new com.itextpdf.text.Paragraph(fileName,
-                    com.itextpdf.text.FontFactory.getFont(com.itextpdf.text.FontFactory.HELVETICA, 8)));
-            document.add(new com.itextpdf.text.Paragraph(GRNHeader(),
-                    com.itextpdf.text.FontFactory.getFont(com.itextpdf.text.FontFactory.HELVETICA, 8)));
-            document.add(new com.itextpdf.text.Paragraph("Generated On: " + sdf.format(new Date()),
-                    com.itextpdf.text.FontFactory.getFont(com.itextpdf.text.FontFactory.HELVETICA, 8)));
-            document.add(new com.itextpdf.text.Paragraph(" "));
+           if (!institutionName.isEmpty()) {
+                document.add(new Paragraph(institutionName,
+                        FontFactory.getFont(FontFactory.HELVETICA_BOLD, 18)));
+            }
+            document.add(new Paragraph("GRN and Direct Purchase Summary report",
+                    FontFactory.getFont(FontFactory.HELVETICA_BOLD, 16)));
+            document.add(new Paragraph("Generated On: " + sdf.format(new Date()),
+                    FontFactory.getFont(FontFactory.HELVETICA, 12)));
+            document.add(new Paragraph(" "));
+            
+            Map<String, Object> filters = getFiltersForGRNDetailReport();
+            PdfPTable infoTable = createInfoTablePdfExport(sdf, filters);
+            if (infoTable != null) {
+                document.add(infoTable);
+            }
 
             com.itextpdf.text.pdf.PdfPTable table = new com.itextpdf.text.pdf.PdfPTable(8);
             table.setWidthPercentage(100);
@@ -10350,18 +10358,18 @@ public class PharmacyController implements Serializable {
                 cell.setBackgroundColor(com.itextpdf.text.BaseColor.LIGHT_GRAY);
                 table.addCell(cell);
             }
-
+            
             int index = 1;
             for (Bill f : rows) {
                 table.addCell(numCell(index++, bodyFontSmall));
                 table.addCell(textCell(f.getDeptId(), bodyFontSmall));
-                table.addCell(textCell(f.getReferenceBill().getDeptId(), bodyFontSmall));
-                table.addCell(textCell(f.getInvoiceNumber() == null ? f.getReferenceBill().getInvoiceNumber() : f.getInvoiceNumber() , bodyFontSmall));
+                table.addCell(textCell(f.getReferenceBill() != null ? f.getReferenceBill().getDeptId() : "-", bodyFontSmall));
+                table.addCell(textCell(f.getInvoiceNumber() == null ? (f.getReferenceBill() != null ? f.getReferenceBill().getInvoiceNumber() : "-") : f.getInvoiceNumber() , bodyFontSmall));
                 table.addCell(textCell(
                         f.getCreatedAt() != null ? sdf.format(f.getCreatedAt()) : "-",
                         bodyFontSmall));
-                table.addCell(textCell(f.getBillTypeAtomic() == BillTypeAtomic.PHARMACY_GRN_RETURN ? f.getToInstitution().getName() : f.getFromInstitution().getName(), bodyFontSmall));
-                table.addCell(numCell(f.getBillTypeAtomic()==BillTypeAtomic.PHARMACY_GRN_RETURN || f.getBillTypeAtomic()==BillTypeAtomic.PHARMACY_GRN_CANCELLED ? -1*f.getReferenceBill().getNetTotal() : f.getReferenceBill().getNetTotal() , bodyFontSmall));
+                table.addCell(textCell(f.getBillTypeAtomic() == BillTypeAtomic.PHARMACY_GRN_RETURN ? (f.getToInstitution()!= null ? f.getToInstitution().getName() : "-") : (f.getFromInstitution() != null ? f.getFromInstitution().getName() : "-"), bodyFontSmall));
+                table.addCell(numCell(f.getBillTypeAtomic()==BillTypeAtomic.PHARMACY_GRN_RETURN || f.getBillTypeAtomic()==BillTypeAtomic.PHARMACY_GRN_CANCELLED ? -1*(f.getReferenceBill() != null ? f.getReferenceBill().getNetTotal() : 0) : (f.getReferenceBill() != null ? f.getReferenceBill().getNetTotal() : 0) , bodyFontSmall));
                 table.addCell(numCell(f.getNetTotal(), bodyFontSmall));
             }
 

--- a/src/main/java/com/divudi/bean/pharmacy/PharmacyController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacyController.java
@@ -9855,7 +9855,7 @@ public class PharmacyController implements Serializable {
         if (filters != null && !filters.isEmpty()){
             rowIndex = addMetaDataToExcelSheet(workbook, sheet, rowIndex, "GRN and Direct Purchase Report", filters);
         }
-        // I want to add current data and time as generated 
+        
         // Add "Generated On" row with current date and time
         Row generatedOnRow = sheet.createRow(rowIndex++);
         CellStyle generatedOnStyle = workbook.createCellStyle();
@@ -10397,60 +10397,50 @@ public class PharmacyController implements Serializable {
             context.responseComplete();
         }
     }
+    
+    // PostProcessor for grn and direct purchase summary report excel export
+    public void postProcessGRNAndDirectPurchaseReportExcel(Object document) {
+        if (document == null) {
+            Logger.getLogger(PharmacyController.class.getName()).log(Level.SEVERE, "Document is null in postProcessBillWiseItemMovementReportExcel");
+            return;
+        }
+        if (!(document instanceof XSSFWorkbook)) {
+            Logger.getLogger(PharmacyController.class.getName()).log(Level.SEVERE, "Expected document to be an instance of XSSFWorkbook, but got: {0}", document.getClass().getName());
+            return;
+        }
+        XSSFWorkbook workbook = (XSSFWorkbook) document;
+        XSSFSheet sheet = workbook.getSheetAt(0);
+        if (sheet == null) {
+            return;
+        }
 
+        workbook.setSheetName(0, "GRN and Direct Purchase Report");
+        sheet.shiftRows(0, sheet.getLastRowNum(), 7);
 
-   public void postProcessExcel(Object document) {
-    XSSFWorkbook workbook = (XSSFWorkbook) document;
-    XSSFSheet sheet = workbook.getSheetAt(0);
+        Map<String, Object> filters = getFiltersForGRNDetailReport();
 
-    int titleRows = 2;
-    sheet.shiftRows(0, sheet.getLastRowNum(), titleRows);
+        if (filters != null && !filters.isEmpty()) {
+            addMetaDataToExcelSheet(workbook, sheet, 0, "GRN and Direct Purchase Report", filters);
+        }
+        int rowIndex = 5;
+        SimpleDateFormat sdf = new SimpleDateFormat(sessionController.getApplicationPreference().getLongDateTimeFormat());
+        // Add "Generated On" row with current date and time
+        Row generatedOnRow = sheet.createRow(rowIndex++);
+        CellStyle generatedOnStyle = workbook.createCellStyle();
+        XSSFFont generatedOnFont = workbook.createFont();
+        generatedOnFont.setBold(true);
+        generatedOnStyle.setFont(generatedOnFont);
 
-    // --- ✅ Calculate actual max columns AFTER shifting ---
-    int lastCol = 0;
-    for (Row row : sheet) {
-        if (row.getRowNum() < titleRows) continue; // skip the empty title rows we just created
-        short cellNum = row.getLastCellNum();
-        if (cellNum > lastCol) lastCol = cellNum;
+        Cell generatedLabelCell = generatedOnRow.createCell(0);
+        generatedLabelCell.setCellValue("Generated On:");
+        generatedLabelCell.setCellStyle(generatedOnStyle);
+
+        Cell generatedValueCell = generatedOnRow.createCell(1);
+        generatedValueCell.setCellValue(sdf.format(new Date()));
+
+        // Add an empty row as spacing before the header
+        sheet.createRow(rowIndex++);
     }
-    lastCol = lastCol - 1; // convert from count to 0-based index
-    if (lastCol < 1) lastCol = 9; // fallback only if sheet is truly empty
-
-    // --- Row 0: Main Title ---
-    XSSFRow titleRow = sheet.createRow(0);
-    titleRow.setHeightInPoints(40);
-    XSSFCell titleCell = titleRow.createCell(0);
-    titleCell.setCellValue(GRNHeader());
-    XSSFCellStyle titleStyle = workbook.createCellStyle();
-    XSSFFont titleFont = workbook.createFont();
-    titleFont.setBold(true);
-    titleFont.setFontHeightInPoints((short) 12);
-    titleFont.setColor(IndexedColors.BLACK.getIndex());
-    titleStyle.setFont(titleFont);
-    titleStyle.setWrapText(true);
-    titleStyle.setVerticalAlignment(VerticalAlignment.CENTER);
-    titleStyle.setAlignment(HorizontalAlignment.CENTER);
-    titleStyle.setFillForegroundColor(IndexedColors.GREY_25_PERCENT.getIndex());
-    titleStyle.setFillPattern(FillPatternType.SOLID_FOREGROUND);
-    titleCell.setCellStyle(titleStyle);
-
-    // --- Row 1: Subtitle ---
-    XSSFRow subRow = sheet.createRow(1);
-    subRow.setHeightInPoints(20);
-    XSSFCell subCell = subRow.createCell(0);
-    subCell.setCellValue("Generated on: " + new java.util.Date());
-    XSSFCellStyle subStyle = workbook.createCellStyle();
-    XSSFFont subFont = workbook.createFont();
-    subFont.setItalic(true);
-    subFont.setFontHeightInPoints((short) 12);
-    subStyle.setFont(subFont);
-    subStyle.setAlignment(HorizontalAlignment.CENTER);
-    subCell.setCellStyle(subStyle);
-
-    // --- ✅ Merge using actual column count ---
-    sheet.addMergedRegion(new CellRangeAddress(0, 0, 0, lastCol));
-    sheet.addMergedRegion(new CellRangeAddress(1, 1, 0, lastCol));
-}
     public SessionController getSessionController() {
         return sessionController;
     }

--- a/src/main/webapp/reports/inventoryReports/grn.xhtml
+++ b/src/main/webapp/reports/inventoryReports/grn.xhtml
@@ -315,7 +315,7 @@
                             <p:dataExporter type="xlsx"
                                             target="tbl1"
                                             fileName="GRN_Summary_report_#{pharmacyController.fromDateFormatted()}_to_#{pharmacyController.toDateFormatted()}"
-                                            postProcessor="#{pharmacyController.postProcessExcel}"/>
+                                            postProcessor="#{pharmacyController.postProcessGRNAndDirectPurchaseReportExcel}"/>
                         </p:commandButton>
                         <p:commandButton class="ui-button-success mx-1"
                                          icon="fas fa-file-excel"
@@ -378,6 +378,11 @@
                             <p:column headerText="Supplier" width="5em">
                                 <h:outputText
                                         value="#{bill.billTypeAtomic eq 'PHARMACY_GRN_RETURN' ? bill.toInstitution.name : bill.fromInstitution.name}"/>
+                                <f:facet name="footer">
+                                    <h:outputText value="Total"
+                                                  style="font-weight: bold;">
+                                    </h:outputText>
+                                </f:facet>
                             </p:column>
                             <p:column headerText="PO Sub Total" width="5em" styleClass="text-end">
                                 <h:outputText rendered="#{bill.billTypeAtomic eq 'PHARMACY_GRN_CANCELLED' or


### PR DESCRIPTION
#19664 
Resolved the Excel download issue while adding null safety on Excel generation. Also had an issue with not showing the table on the summary report PDF, that is resolved by adding null safety on PDF generation. 
Modified the summary report post-processor method while including the generated date and time.
Changed files,
01) grn.xhtml (add total for the table)
02) pharmacyController.java (added null safety on PDF and Excel generation methods and modified the post-processor to get better insight from the report)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * GRN and Direct Purchase exports now display "Generated On" timestamp with date-time formatting.
  * Exports now include filters and metadata information for better context.
  * Supplier column footer now displays "Total" label in GRN summary.

* **Bug Fixes**
  * Improved handling of missing reference bill data in exports, preventing errors and displaying fallback values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->