### PR TITLE
20145 manage booking to doctor payment navigation always blocked by validations

### DIFF
--- a/src/main/java/com/divudi/bean/channel/BookingControllerViewScope.java
+++ b/src/main/java/com/divudi/bean/channel/BookingControllerViewScope.java
@@ -6145,16 +6145,31 @@ public class BookingControllerViewScope implements Serializable, ControllerWithP
     }
 
     public String paySelectedDoctor() {
-        if (getSpeciality() == null) {
-            JsfUtil.addErrorMessage("Please Select Specility And Staff");
+        // if (getSpeciality() == null) {
+        //     JsfUtil.addErrorMessage("Please Select Specility And Staff");
+        //     return "";
+        // }
+        // if (getStaff() == null) {
+        //     JsfUtil.addErrorMessage("Please Select Staff");
+        //     return "";
+        // }
+
+        if (selectedBillSession == null || selectedBillSession.getSessionInstance() == null) {
+            JsfUtil.addErrorMessage("Bill Session or Session Instance is not selected");
             return "";
         }
-        if (getStaff() == null) {
+        if (selectedBillSession.getStaff() == null) {
             JsfUtil.addErrorMessage("Please Select Staff");
             return "";
+        } else {
+            if (selectedBillSession.getStaff().getSpeciality() == null) {
+                JsfUtil.addErrorMessage("Please Select Speciality");
+                return "";
+            }
         }
-        channelStaffPaymentBillController.setSpeciality(getSpeciality());
-        channelStaffPaymentBillController.setCurrentStaff(getStaff());
+        channelStaffPaymentBillController.makenull();
+        channelStaffPaymentBillController.setSpeciality(selectedBillSession.getStaff().getSpeciality());
+        channelStaffPaymentBillController.setCurrentStaff(selectedBillSession.getStaff());
         channelStaffPaymentBillController.setConsiderDate(true);
         channelStaffPaymentBillController.calculateDueFees();
 

--- a/src/main/java/com/divudi/bean/channel/BookingControllerViewScopeMonth.java
+++ b/src/main/java/com/divudi/bean/channel/BookingControllerViewScopeMonth.java
@@ -2052,7 +2052,7 @@ public class BookingControllerViewScopeMonth implements Serializable {
         return false;
     }
 
-    private boolean checkPaid() {
+    public boolean checkPaid() {
         String sql = "SELECT bf FROM BillFee bf where bf.retired=false and bf.bill.id=" + getBillSession().getBill().getId();
         List<BillFee> tempFe = getBillFeeFacade().findByJpql(sql);
 
@@ -4740,16 +4740,22 @@ public class BookingControllerViewScopeMonth implements Serializable {
     }
 
     public String paySelectedDoctor() {
-        if (getSpeciality() == null) {
-            JsfUtil.addErrorMessage("Please Select Specility And Staff");
+        if (selectedBillSession == null || selectedBillSession.getSessionInstance() == null) {
+            JsfUtil.addErrorMessage("Bill Session or Session Instance is not selected");
             return "";
         }
-        if (getStaff() == null) {
+        if (selectedBillSession.getStaff() == null) {
             JsfUtil.addErrorMessage("Please Select Staff");
             return "";
+        } else {
+            if (selectedBillSession.getStaff().getSpeciality() == null) {
+                JsfUtil.addErrorMessage("Please Select Speciality");
+                return "";
+            }
         }
-        channelStaffPaymentBillController.setSpeciality(getSpeciality());
-        channelStaffPaymentBillController.setCurrentStaff(getStaff());
+        channelStaffPaymentBillController.makenull();
+        channelStaffPaymentBillController.setSpeciality(selectedBillSession.getStaff().getSpeciality());
+        channelStaffPaymentBillController.setCurrentStaff(selectedBillSession.getStaff());
         channelStaffPaymentBillController.setConsiderDate(true);
         channelStaffPaymentBillController.calculateDueFees();
 

--- a/src/main/java/com/divudi/bean/channel/ChannelStaffPaymentBillController.java
+++ b/src/main/java/com/divudi/bean/channel/ChannelStaffPaymentBillController.java
@@ -1621,6 +1621,10 @@ public class ChannelStaffPaymentBillController implements Serializable {
         this.paymentFacade = paymentFacade;
     }
 
+    public void newPayment() {
+        makenull();
+    }
+
     /**
      *
      */

--- a/src/main/java/com/divudi/bean/channel/ChannelStaffPaymentBillController.java
+++ b/src/main/java/com/divudi/bean/channel/ChannelStaffPaymentBillController.java
@@ -471,7 +471,10 @@ public class ChannelStaffPaymentBillController implements Serializable {
             hm.put("ss", getSelectedServiceSession());
         }
 
-        sql += " and b.bill.singleBillSession.completed=true";
+        if (configOptionApplicationController.getBooleanValueByKey("Only Show Completed Channel Bookings On Doctor Payments")) {
+            sql += " and b.bill.singleBillSession.completed=:com ";
+            hm.put("com", true);
+        }
 
 //        sql += " and b.bill.singleBillSession.absent=false "
 //                + " order by b.bill.singleBillSession.serviceSession.sessionDate,"

--- a/src/main/java/com/divudi/bean/channel/ChannelStaffPaymentBillController.java
+++ b/src/main/java/com/divudi/bean/channel/ChannelStaffPaymentBillController.java
@@ -471,10 +471,7 @@ public class ChannelStaffPaymentBillController implements Serializable {
             hm.put("ss", getSelectedServiceSession());
         }
 
-        if (configOptionApplicationController.getBooleanValueByKey("Only Show Completed Channel Bookings On Doctor Payments")) {
-            sql += " and b.bill.singleBillSession.completed=:com ";
-            hm.put("com", true);
-        }
+        sql += " and b.bill.singleBillSession.completed=true";
 
 //        sql += " and b.bill.singleBillSession.absent=false "
 //                + " order by b.bill.singleBillSession.serviceSession.sessionDate,"

--- a/src/main/webapp/channel/manage_booking_by_date.xhtml
+++ b/src/main/webapp/channel/manage_booking_by_date.xhtml
@@ -1625,14 +1625,11 @@
 
                                 <p:selectBooleanButton onLabel="Absent" offLabel="Absent" disabled="#{bookingControllerViewScope.selectedBillSession.bill.refunded==true
                                                                                                     or bookingControllerViewScope.selectedBillSession.bill.cancelled==true or bookingControllerViewScope.checkPaid()}"  value="#{bookingControllerViewScope.absent}" >
-                                    <p:ajax process="@this" update="statusTab" listener="#{bookingControllerViewScope.updatePresentStatusOfPatient(bookingControllerViewScope.absent)}" ></p:ajax>
+                                    <p:ajax process="@this" listener="#{bookingControllerViewScope.updatePresentStatusOfPatient(bookingControllerViewScope.absent)}" ></p:ajax>
                                 </p:selectBooleanButton>
 
-                                <p:outputLabel class="mx-3" value="Can't change the status. Staff pay already done for this appoinment." rendered="#{true}" style="color: red; font-weight: bold"/>
+                                <p:outputLabel class="mx-3" value="Can't change the status. Staff pay already done for this appointment." rendered="#{bookingControllerViewScopeMonth.checkPaid()}" style="color: red; font-weight: bold"/>
                             </div>
-
-                            
-
                         </p:tab>
 
                         <p:tab title="Search" rendered="false">

--- a/src/main/webapp/channel/manage_booking_by_date.xhtml
+++ b/src/main/webapp/channel/manage_booking_by_date.xhtml
@@ -1620,14 +1620,18 @@
                         </p:tab>
 
                         <p:tab title="Status" id="statusTab">
-                            <p:outputLabel value="Mark As Present / Absent"/>
+                            <div class="d-flex gap-2 align-items-center">
+                                <p:outputLabel value="Mark As Present / Absent "/>
 
-                            <p:selectBooleanButton onLabel="Absent" offLabel="Absent" disabled="#{bookingControllerViewScope.selectedBillSession.bill.refunded==true
-                                                                                                  or bookingControllerViewScope.selectedBillSession.bill.cancelled==true or bookingControllerViewScope.checkPaid()}"  value="#{bookingControllerViewScope.absent}" >
-                                <p:ajax process="@this" update="statusTab" listener="#{bookingControllerViewScope.updatePresentStatusOfPatient(bookingControllerViewScope.absent)}" ></p:ajax>
-                            </p:selectBooleanButton>
+                                <p:selectBooleanButton onLabel="Absent" offLabel="Absent" disabled="#{bookingControllerViewScope.selectedBillSession.bill.refunded==true
+                                                                                                    or bookingControllerViewScope.selectedBillSession.bill.cancelled==true or bookingControllerViewScope.checkPaid()}"  value="#{bookingControllerViewScope.absent}" >
+                                    <p:ajax process="@this" update="statusTab" listener="#{bookingControllerViewScope.updatePresentStatusOfPatient(bookingControllerViewScope.absent)}" ></p:ajax>
+                                </p:selectBooleanButton>
 
-                            <p:outputLabel class="mx-3" value="Can't change the status. Staff pay already done for this appoinment." rendered="#{bookingControllerViewScope.checkPaid()}" style="color: red; font-weight: bold"/>
+                                <p:outputLabel class="mx-3" value="Can't change the status. Staff pay already done for this appoinment." rendered="#{true}" style="color: red; font-weight: bold"/>
+                            </div>
+
+                            
 
                         </p:tab>
 
@@ -1774,33 +1778,37 @@
 
 
                         <p:tab title="Views">
-                            <h:panelGrid columns="2">
-                                <p:panel header="Selected Session">
-                                    <h:panelGrid columns="1">
-                                        <p:commandButton value="Nurse View " 
-                                                         action="#{bookingControllerViewScope.navigateToNurseView}" 
-                                                         onclick="onSubmitButton();" >                                       
-                                        </p:commandButton>
-                                        <p:commandButton value="Doctor View " action="#{bookingControllerViewScope.navigateToDoctorView}" ajax="false" onclick="onSubmitButton();">                                        
-                                        </p:commandButton>
-                                        <p:commandButton value="Session View " action="#{bookingControllerViewScope.navigateToSessionView}" ajax="false" onclick="onSubmitButton();">                                        
-                                        </p:commandButton>
-                                        <p:commandButton value="Phone View " action="#{bookingControllerViewScope.navigateToPhoneView}" ajax="false" onclick="onSubmitButton();">                                        
-                                        </p:commandButton>
-                                        <p:commandButton value="User View " action="#{bookingControllerViewScope.navigateToUserView}" ajax="false" onclick="onSubmitButton();">                                        
-                                        </p:commandButton>
-                                    </h:panelGrid>
 
-                                </p:panel>
-                                <p:panel header="Today's">
-                                    <h:panelGrid columns="1">
-                                        <p:commandButton value="All Patient" action="channel_patient_view_today" ajax="false" onclick="onSubmitButton();">                                        
-                                        </p:commandButton>
-                                        <p:commandButton value="All Doctor" action="channel_doctor_view_today" ajax="false" onclick="onSubmitButton();">                                        
-                                        </p:commandButton>
-                                    </h:panelGrid>                                    
-                                </p:panel>
-                            </h:panelGrid>
+                            <div class="row">
+                                <div class="col-2">
+                                    <p:panel header="Selected Session">
+                                        <div class="d-flex flex-column gap-2">
+                                            <p:commandButton value="Nurse View " 
+                                                            action="#{bookingControllerViewScope.navigateToNurseView}" 
+                                                            onclick="onSubmitButton();" >                                       
+                                            </p:commandButton>
+                                            <p:commandButton value="Doctor View " action="#{bookingControllerViewScope.navigateToDoctorView}" ajax="false" onclick="onSubmitButton();">                                        
+                                            </p:commandButton>
+                                            <p:commandButton value="Session View " action="#{bookingControllerViewScope.navigateToSessionView}" ajax="false" onclick="onSubmitButton();">                                        
+                                            </p:commandButton>
+                                            <p:commandButton value="Phone View " action="#{bookingControllerViewScope.navigateToPhoneView}" ajax="false" onclick="onSubmitButton();">                                        
+                                            </p:commandButton>
+                                            <p:commandButton value="User View " action="#{bookingControllerViewScope.navigateToUserView}" ajax="false" onclick="onSubmitButton();">                                        
+                                            </p:commandButton>
+                                        </div>
+                                    </p:panel>
+                                </div>
+                                <div class="col-2">
+                                    <p:panel header="Today's">
+                                        <div class="d-flex flex-column gap-2">
+                                            <p:commandButton value="All Patient" action="channel_patient_view_today" ajax="false" onclick="onSubmitButton();">                                        
+                                            </p:commandButton>
+                                            <p:commandButton value="All Doctor" action="channel_doctor_view_today" ajax="false" onclick="onSubmitButton();">                                        
+                                            </p:commandButton>
+                                        </div>
+                                    </p:panel>
+                                </div>
+                            </div>
 
                         </p:tab>
                         <p:tab title="Doctor Payment">

--- a/src/main/webapp/channel/manage_booking_by_month.xhtml
+++ b/src/main/webapp/channel/manage_booking_by_month.xhtml
@@ -1583,7 +1583,7 @@
                                     <p:ajax process="@this" listener="#{bookingControllerViewScopeMonth.updateSelectedBillSessionPatient()}" ></p:ajax>
                                 </p:selectBooleanButton>
 
-                                <p:outputLabel class="mx-3" value="Can't change the status. Staff pay already done for this appoinment." rendered="#{bookingControllerViewScopeMonth.checkPaid()}" style="color: red; font-weight: bold"/>
+                                <p:outputLabel class="mx-3" value="Can't change the status. Staff pay already done for this appointment." rendered="#{bookingControllerViewScopeMonth.checkPaid()}" style="color: red; font-weight: bold"/>
                             </div> 
 
                         </p:tab>

--- a/src/main/webapp/channel/manage_booking_by_month.xhtml
+++ b/src/main/webapp/channel/manage_booking_by_month.xhtml
@@ -1575,11 +1575,16 @@
                         </p:tab>
 
                         <p:tab title="Status" >
-                            <p:outputLabel value="Mark As Present / Absent"/>
-                            <p:selectBooleanButton onLabel="Absent" offLabel="Absent" disabled="#{bookingControllerViewScopeMonth.selectedBillSession.bill.refunded==true
-                                                                                                  or bookingControllerViewScopeMonth.selectedBillSession.bill.cancelled==true}"  value="#{bookingControllerViewScopeMonth.selectedBillSession.absent}" >
-                                <p:ajax process="@this" listener="#{bookingControllerViewScopeMonth.updateSelectedBillSessionPatient()}" ></p:ajax>
-                            </p:selectBooleanButton>
+                            
+                            <div class="d-flex gap-2 align-items-center">
+                               <p:outputLabel value="Mark As Present / Absent"/>
+                                <p:selectBooleanButton onLabel="Absent" offLabel="Absent" disabled="#{bookingControllerViewScopeMonth.selectedBillSession.bill.refunded==true
+                                                                                                    or bookingControllerViewScopeMonth.selectedBillSession.bill.cancelled==true}"  value="#{bookingControllerViewScopeMonth.selectedBillSession.absent}" >
+                                    <p:ajax process="@this" listener="#{bookingControllerViewScopeMonth.updateSelectedBillSessionPatient()}" ></p:ajax>
+                                </p:selectBooleanButton>
+
+                                <p:outputLabel class="mx-3" value="Can't change the status. Staff pay already done for this appoinment." rendered="#{bookingControllerViewScopeMonth.checkPaid()}" style="color: red; font-weight: bold"/>
+                            </div> 
 
                         </p:tab>
 
@@ -1726,33 +1731,36 @@
 
 
                         <p:tab title="Views">
-                            <h:panelGrid columns="2">
-                                <p:panel header="Selected Session">
-                                    <h:panelGrid columns="1">
-                                        <p:commandButton value="Nurse View " 
-                                                         action="#{bookingControllerViewScopeMonth.navigateToNurseView}" 
-                                                         onclick="onSubmitButton();" >                                       
-                                        </p:commandButton>
-                                        <p:commandButton value="Doctor View " action="#{bookingControllerViewScopeMonth.navigateToDoctorView}" ajax="false" onclick="onSubmitButton();">                                        
-                                        </p:commandButton>
-                                        <p:commandButton value="Session View " action="#{bookingControllerViewScopeMonth.navigateToSessionView}" ajax="false" onclick="onSubmitButton();">                                        
-                                        </p:commandButton>
-                                        <p:commandButton value="Phone View " action="#{bookingControllerViewScopeMonth.navigateToPhoneView}" ajax="false" onclick="onSubmitButton();">                                        
-                                        </p:commandButton>
-                                        <p:commandButton value="User View " action="#{bookingControllerViewScopeMonth.navigateToUserView}" ajax="false" onclick="onSubmitButton();">                                        
-                                        </p:commandButton>
-                                    </h:panelGrid>
-
-                                </p:panel>
-                                <p:panel header="Today's">
-                                    <h:panelGrid columns="1">
-                                        <p:commandButton value="All Patient" action="channel_patient_view_today" ajax="false" onclick="onSubmitButton();">                                        
-                                        </p:commandButton>
-                                        <p:commandButton value="All Doctor" action="channel_doctor_view_today" ajax="false" onclick="onSubmitButton();">                                        
-                                        </p:commandButton>
-                                    </h:panelGrid>                                    
-                                </p:panel>
-                            </h:panelGrid>
+                            <div class="row">
+                                <div class="col-2">
+                                    <p:panel header="Selected Session">
+                                        <div class="d-flex flex-column gap-2">
+                                            <p:commandButton value="Nurse View " 
+                                                            action="#{bookingControllerViewScopeMonth.navigateToNurseView}" 
+                                                            onclick="onSubmitButton();" >                                       
+                                            </p:commandButton>
+                                            <p:commandButton value="Doctor View " action="#{bookingControllerViewScopeMonth.navigateToDoctorView}" ajax="false" onclick="onSubmitButton();">                                        
+                                            </p:commandButton>
+                                            <p:commandButton value="Session View " action="#{bookingControllerViewScopeMonth.navigateToSessionView}" ajax="false" onclick="onSubmitButton();">                                        
+                                            </p:commandButton>
+                                            <p:commandButton value="Phone View " action="#{bookingControllerViewScopeMonth.navigateToPhoneView}" ajax="false" onclick="onSubmitButton();">                                        
+                                            </p:commandButton>
+                                            <p:commandButton value="User View " action="#{bookingControllerViewScopeMonth.navigateToUserView}" ajax="false" onclick="onSubmitButton();">                                        
+                                            </p:commandButton>
+                                        </div>
+                                    </p:panel>
+                                </div>
+                                <div class="col-2">
+                                    <p:panel header="Today's">
+                                        <div class="d-flex flex-column gap-2">
+                                            <p:commandButton value="All Patient" action="channel_patient_view_today" ajax="false" onclick="onSubmitButton();">                                        
+                                            </p:commandButton>
+                                            <p:commandButton value="All Doctor" action="channel_doctor_view_today" ajax="false" onclick="onSubmitButton();">                                        
+                                            </p:commandButton>
+                                        </div>
+                                    </p:panel>
+                                </div>
+                            </div>
 
                         </p:tab>
                         <p:tab title="Doctor Payment">

--- a/src/main/webapp/channel/session_instance.xhtml
+++ b/src/main/webapp/channel/session_instance.xhtml
@@ -947,7 +947,7 @@
                                                         <p:inputText class="w-100" disabled="true"  value="Saturday" rendered="#{bookingControllerViewScope.selectedSessionInstance.sessionWeekday eq 7 and bookingControllerViewScope.selectedSessionInstance.sessionWeekday ne null}"/>
                                                     </h:panelGroup>
                                                     <h:panelGroup rendered="#{bookingControllerViewScope.selectedSessionInstance.sessionDate ne null}" >
-                                                        <p:datePicker value="#{bookingControllerViewScope.selectedSessionInstance.sessionDate}"/>
+                                                        <p:datePicker value="#{bookingControllerViewScope.selectedSessionInstance.sessionDate}" disabled="true"/>
 
                                                     </h:panelGroup>
 

--- a/src/main/webapp/channel/session_instance_by_month.xhtml
+++ b/src/main/webapp/channel/session_instance_by_month.xhtml
@@ -244,7 +244,7 @@
                                                         <p:inputText class="w-100" disabled="true"  value="Saturday" rendered="#{bookingControllerViewScopeMonth.selectedSessionInstance.sessionWeekday eq 7 and bookingControllerViewScopeMonth.selectedSessionInstance.sessionWeekday ne null}"/>
                                                     </h:panelGroup>
                                                     <h:panelGroup rendered="#{bookingControllerViewScopeMonth.selectedSessionInstance.sessionDate ne null}" >
-                                                        <p:datePicker value="#{bookingControllerViewScopeMonth.selectedSessionInstance.sessionDate}"/>
+                                                        <p:datePicker value="#{bookingControllerViewScopeMonth.selectedSessionInstance.sessionDate}" disabled="true"/>
 
                                                     </h:panelGroup>
 


### PR DESCRIPTION
Issue: #20145 

Files changed:
- bookingControllerViewScope
- bookingContorllerViewScopeMonth
- channelStaffPaymentBillController
- manage_booking_by_date
- manage_booking_by_month
- session_instance
- session_instance_by_month

**ChannelStaffPaymentBillController**, `staff` and `speciality` set by the `selectedBillSession`.

UI improvements for `Views` tab

**Disable** date edit on `session_instance` and `session_instance_by_month`. Otherwise new session instances will be created when date is updated.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added configuration option to control visibility of completed channel bookings in doctor payment views.

* **Bug Fixes & Improvements**
  * Enhanced validation with clearer error messages when selecting doctors for payments.
  * Session date fields are now read-only to prevent unintended modifications.
  * Status changes are now properly blocked when associated payments exist.

* **UI Enhancements**
  * Redesigned booking management interface with improved layout structure.
  * Better organized navigation and status controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->