### PR TITLE
Synchronize billfee values manage booking

### DIFF
--- a/src/main/java/com/divudi/bean/channel/BookingControllerViewScope.java
+++ b/src/main/java/com/divudi/bean/channel/BookingControllerViewScope.java
@@ -8001,29 +8001,31 @@ public class BookingControllerViewScope implements Serializable, ControllerWithP
         }
 
         Bill b = savePaidBill();
+        BillItem billItemForPaidSession = savePaidBillItem(b);
         
         // savePaidBillFee(b, bi);
         PriceMatrix priceMatrix = priceMatrixController.fetchChannellingMemberShipDiscount(settlePaymentMethod, paymentScheme, selectedSessionInstance.getOriginatingSession().getCategory());
 
         if (selectedBillSession.getBill().getBillItems() != null && !selectedBillSession.getBill().getBillItems().isEmpty()) {
             for (BillItem abi : selectedBillSession.getBill().getBillItems()) {
-                createBillFeesForPaidBill(b, abi, priceMatrix);
+                createBillFeesForPaidBill(b, abi, priceMatrix, billItemForPaidSession);
             }
         }
 
         BillItem bi = selectedBillSession.getBillItem();
         Bill creditBill = getBillSession().getBill();
-        bi.setHospitalFee(billBeanController.calFeeValue(FeeType.OwnInstitution, bi, creditBill));
-        bi.setStaffFee(billBeanController.calFeeValue(FeeType.Staff, bi, creditBill));
+        bi.setHospitalFee(billBeanController.calFeeValue(FeeType.OwnInstitution, bi));
+        bi.setStaffFee(billBeanController.calFeeValue(FeeType.Staff, bi));
         getBillItemFacade().edit(bi);
+        billItemForPaidSession.setHospitalFee(bi.getHospitalFee());
+        billItemForPaidSession.setStaffFee(bi.getStaffFee());
+        getBillItemFacade().edit(billItemForPaidSession);
 
         creditBill.setHospitalFee(billBeanController.calFeeValue(FeeType.OwnInstitution, creditBill));
         creditBill.setStaffFee(billBeanController.calFeeValue(FeeType.Staff, creditBill));
         getBillFacade().edit(creditBill);
         b.setHospitalFee(creditBill.getHospitalFee());
         b.setStaffFee(creditBill.getStaffFee());
-
-        BillItem billItemForPaidSession = savePaidBillItem(b);
 
         BillSession bs = savePaidBillSession(b, billItemForPaidSession);
 
@@ -8134,7 +8136,7 @@ public class BookingControllerViewScope implements Serializable, ControllerWithP
         }
     }
 
-    private void createBillFeesForPaidBill(Bill b, BillItem billItem, PriceMatrix priceMatrix) {
+    private void createBillFeesForPaidBill(Bill b, BillItem billItem, PriceMatrix priceMatrix, BillItem paidBillItem) {
         if (selectedBillSession.getBill() == null || selectedBillSession.getBill().getBillFees() == null || selectedBillSession.getBill().getBillFees().isEmpty()) {
             return;
         }
@@ -8151,7 +8153,7 @@ public class BookingControllerViewScope implements Serializable, ControllerWithP
                 newBillFee.setCreatedAt(Calendar.getInstance().getTime());
                 newBillFee.setCreater(getSessionController().getLoggedUser());
                 newBillFee.setBill(b);
-                newBillFee.setBillItem(billItem);
+                newBillFee.setBillItem(paidBillItem);
                 getBillFeeFacade().create(newBillFee);
 
                 double d = 0;
@@ -8180,6 +8182,13 @@ public class BookingControllerViewScope implements Serializable, ControllerWithP
         billItem.setNetValue(tmpTotal);
         billItem.setDiscount(tmpDiscount);
         getBillItemFacade().edit(billItem);
+
+        if (paidBillItem.getItem().equals(billItem.getItem())) {
+            paidBillItem.setGrossValue(tmpGrossTotal);
+            paidBillItem.setNetValue(tmpTotal);
+            paidBillItem.setDiscount(tmpDiscount);
+            getBillItemFacade().edit(paidBillItem);
+        }
     }
 
     private boolean errorChecksettle() {

--- a/src/main/java/com/divudi/bean/channel/BookingControllerViewScope.java
+++ b/src/main/java/com/divudi/bean/channel/BookingControllerViewScope.java
@@ -8000,17 +8000,31 @@ public class BookingControllerViewScope implements Serializable, ControllerWithP
         }
 
         Bill b = savePaidBill();
-        BillItem bi = savePaidBillItem(b);
+        
         // savePaidBillFee(b, bi);
         PriceMatrix priceMatrix = priceMatrixController.fetchChannellingMemberShipDiscount(settlePaymentMethod, paymentScheme, selectedSessionInstance.getOriginatingSession().getCategory());
 
         if (selectedBillSession.getBill().getBillItems() != null && !selectedBillSession.getBill().getBillItems().isEmpty()) {
             for (BillItem abi : selectedBillSession.getBill().getBillItems()) {
-                createBillFeesForPaidBill(b, abi, priceMatrix, bi);
+                createBillFeesForPaidBill(b, abi, priceMatrix);
             }
         }
 
-        BillSession bs = savePaidBillSession(b, bi);
+        BillItem bi = selectedBillSession.getBillItem();
+        Bill creditBill = getBillSession().getBill();
+        bi.setHospitalFee(billBeanController.calFeeValue(FeeType.OwnInstitution, bi));
+        bi.setStaffFee(billBeanController.calFeeValue(FeeType.Staff, bi));
+        getBillItemFacade().edit(bi);
+
+        creditBill.setHospitalFee(billBeanController.calFeeValue(FeeType.OwnInstitution, creditBill));
+        creditBill.setStaffFee(billBeanController.calFeeValue(FeeType.Staff, creditBill));
+        getBillFacade().edit(creditBill);
+        b.setHospitalFee(creditBill.getHospitalFee());
+        b.setStaffFee(creditBill.getStaffFee());
+
+        BillItem billItemForPaidSession = savePaidBillItem(b);
+
+        BillSession bs = savePaidBillSession(b, billItemForPaidSession);
 
         getBillSession().setPaidBillSession(bs);
         getBillSessionFacade().edit(bs);
@@ -8022,7 +8036,7 @@ public class BookingControllerViewScope implements Serializable, ControllerWithP
 
         getBillFacade().edit(getBillSession().getBill());
 
-        b.setSingleBillItem(bi);
+        b.setSingleBillItem(billItemForPaidSession);
         b.setSingleBillSession(bs);
         getBillFacade().editAndCommit(b);
 
@@ -8119,7 +8133,7 @@ public class BookingControllerViewScope implements Serializable, ControllerWithP
         }
     }
 
-    private void createBillFeesForPaidBill(Bill b, BillItem billItem, PriceMatrix priceMatrix, BillItem singleBillItem) {
+    private void createBillFeesForPaidBill(Bill b, BillItem billItem, PriceMatrix priceMatrix) {
         if (selectedBillSession.getBill() == null || selectedBillSession.getBill().getBillFees() == null || selectedBillSession.getBill().getBillFees().isEmpty()) {
             return;
         }
@@ -8165,13 +8179,6 @@ public class BookingControllerViewScope implements Serializable, ControllerWithP
         billItem.setNetValue(tmpTotal);
         billItem.setDiscount(tmpDiscount);
         getBillItemFacade().edit(billItem);
-
-        if (billItem.getItem().equals(singleBillItem.getItem())) {
-            singleBillItem.setGrossValue(tmpGrossTotal);
-            singleBillItem.setNetValue(tmpTotal);
-            singleBillItem.setDiscount(tmpDiscount);
-            getBillItemFacade().edit(singleBillItem);
-        }
     }
 
     private boolean errorChecksettle() {

--- a/src/main/java/com/divudi/bean/channel/BookingControllerViewScope.java
+++ b/src/main/java/com/divudi/bean/channel/BookingControllerViewScope.java
@@ -6677,6 +6677,7 @@ public class BookingControllerViewScope implements Serializable, ControllerWithP
             billFeeList.add(bf);
         }
 
+        billItem.setGrossValue(tmpGrossTotal);
         billItem.setDiscount(tmpDiscount);
         billItem.setNetValue(tmpTotal);
         getBillItemFacade().edit(billItem);
@@ -8012,8 +8013,8 @@ public class BookingControllerViewScope implements Serializable, ControllerWithP
 
         BillItem bi = selectedBillSession.getBillItem();
         Bill creditBill = getBillSession().getBill();
-        bi.setHospitalFee(billBeanController.calFeeValue(FeeType.OwnInstitution, bi));
-        bi.setStaffFee(billBeanController.calFeeValue(FeeType.Staff, bi));
+        bi.setHospitalFee(billBeanController.calFeeValue(FeeType.OwnInstitution, bi, creditBill));
+        bi.setStaffFee(billBeanController.calFeeValue(FeeType.Staff, bi, creditBill));
         getBillItemFacade().edit(bi);
 
         creditBill.setHospitalFee(billBeanController.calFeeValue(FeeType.OwnInstitution, creditBill));

--- a/src/main/java/com/divudi/bean/channel/BookingControllerViewScope.java
+++ b/src/main/java/com/divudi/bean/channel/BookingControllerViewScope.java
@@ -9176,27 +9176,39 @@ public class BookingControllerViewScope implements Serializable, ControllerWithP
             return;
         }
 
-        for (BillItem billItem : selectedBillSession.getBill().getBillItems()) {
-            double netValue = 0.0;
-            for (BillFee billFee : billItem.getBillFees()) {
-                if (isForiegn()) {
-                    if (billFee.getFee().getFeeType().equals(FeeType.Staff)) {
-                        billItem.setStaffFee(billFee.getFee().getProfessionalFfee());
-                    } else if (billFee.getFee().getFeeType().equals(FeeType.OwnInstitution)) {
-                        billItem.setHospitalFee(billFee.getFee().getHospitalFfee());
-                    }
-                    netValue += billFee.getFee().getFfee();
-                } else {
-                    if (billFee.getFee().getFeeType().equals(FeeType.Staff)) {
-                        billItem.setStaffFee(billFee.getFee().getProfessionalFee());
-                    } else if (billFee.getFee().getFeeType().equals(FeeType.OwnInstitution)) {
-                        billItem.setHospitalFee(billFee.getFee().getHospitalFee());
-                    }
+        List<BillFee> billFees = getBillSession().getBill().getBillFees();
+        if (billFees == null) {
+            billFees = billBeanController.getBillFee(getBillSession().getBill());
+        }
 
-                    netValue += billFee.getFee().getFee();
-                }
+        for (BillItem billItem : selectedBillSession.getBill().getBillItems()) {
+            double totalGross = 0.0;
+            double totalDiscount = 0.0;
+            double totalNet = 0.0;
+            double hosFee = 0.0;
+            double staffFee = 0.0;
+
+            for (BillFee billFee : billFees) {
+                ItemFee f = (ItemFee) billFee.getFee();
+
+                if (f.getItem().equals(billItem.getItem())) {
+                    totalGross += billFee.getFeeGrossValue();
+                    totalDiscount += billFee.getFeeDiscount();
+                    totalNet += billFee.getFeeValue();
+
+                    if (f.getFeeType().equals(FeeType.Staff)) {
+                        staffFee += billFee.getFeeValue();
+                    }
+                    if (f.getFeeType().equals(FeeType.OwnInstitution)) {
+                        hosFee += billFee.getFeeValue();
+                    }
+                }                
             }
-            billItem.setNetValue(netValue);
+            billItem.setGrossValue(totalGross);
+            billItem.setDiscount(totalDiscount);
+            billItem.setNetValue(totalNet);
+            billItem.setStaffFee(staffFee);
+            billItem.setHospitalFee(hosFee);
         }
     }
 

--- a/src/main/java/com/divudi/bean/channel/BookingControllerViewScope.java
+++ b/src/main/java/com/divudi/bean/channel/BookingControllerViewScope.java
@@ -8001,7 +8001,15 @@ public class BookingControllerViewScope implements Serializable, ControllerWithP
 
         Bill b = savePaidBill();
         BillItem bi = savePaidBillItem(b);
-        savePaidBillFee(b, bi);
+        // savePaidBillFee(b, bi);
+        PriceMatrix priceMatrix = priceMatrixController.fetchChannellingMemberShipDiscount(settlePaymentMethod, paymentScheme, selectedSessionInstance.getOriginatingSession().getCategory());
+
+        if (selectedBillSession.getBill().getBillItems() != null && !selectedBillSession.getBill().getBillItems().isEmpty()) {
+            for (BillItem abi : selectedBillSession.getBill().getBillItems()) {
+                createBillFeesForPaidBill(b, abi, priceMatrix, bi);
+            }
+        }
+
         BillSession bs = savePaidBillSession(b, bi);
 
         getBillSession().setPaidBillSession(bs);
@@ -8108,6 +8116,61 @@ public class BookingControllerViewScope implements Serializable, ControllerWithP
             bf.setBill(b);
             bf.setBillItem(bi);
             getBillFeeFacade().create(bf);
+        }
+    }
+
+    private void createBillFeesForPaidBill(Bill b, BillItem billItem, PriceMatrix priceMatrix, BillItem singleBillItem) {
+        if (selectedBillSession.getBill() == null || selectedBillSession.getBill().getBillFees() == null || selectedBillSession.getBill().getBillFees().isEmpty()) {
+            return;
+        }
+        double tmpTotal = 0;
+        double tmpDiscount = 0;
+        double tmpGrossTotal = 0.0;
+        
+        for (BillFee bf : selectedBillSession.getBill().getBillFees()) {
+            ItemFee f = (ItemFee) bf.getFee();
+
+            if (f.getItem().equals(billItem.getItem())) {
+                BillFee newBillFee = new BillFee();
+                newBillFee.copy(bf);
+                newBillFee.setCreatedAt(Calendar.getInstance().getTime());
+                newBillFee.setCreater(getSessionController().getLoggedUser());
+                newBillFee.setBill(b);
+                newBillFee.setBillItem(billItem);
+                getBillFeeFacade().create(newBillFee);
+
+                double d = 0;
+
+                if (priceMatrix != null) {
+                    if (f.isDiscountAllowed()) {
+                        d = bf.getFeeValue() * (priceMatrix.getDiscountPercent() / 100);
+                        bf.setFeeDiscount(d);
+                        bf.setFeeGrossValue(bf.getFeeValue());
+                        newBillFee.setFeeGrossValue(bf.getFeeGrossValue());
+                        newBillFee.setFeeDiscount(d);
+                    }
+
+                    bf.setFeeValue(bf.getFeeGrossValue() - bf.getFeeDiscount());
+                    newBillFee.setFeeValue(bf.getFeeValue());
+                    tmpDiscount += d;
+                }
+                tmpGrossTotal += bf.getFeeGrossValue();
+                tmpTotal += bf.getFeeValue();
+                // BillFees of both bills are updated
+                getBillFeeFacade().edit(bf);
+                getBillFeeFacade().edit(newBillFee);
+            }            
+        }
+        billItem.setGrossValue(tmpGrossTotal);
+        billItem.setNetValue(tmpTotal);
+        billItem.setDiscount(tmpDiscount);
+        getBillItemFacade().edit(billItem);
+
+        if (billItem.getItem().equals(singleBillItem.getItem())) {
+            singleBillItem.setGrossValue(tmpGrossTotal);
+            singleBillItem.setNetValue(tmpTotal);
+            singleBillItem.setDiscount(tmpDiscount);
+            getBillItemFacade().edit(singleBillItem);
         }
     }
 
@@ -8999,7 +9062,7 @@ public class BookingControllerViewScope implements Serializable, ControllerWithP
     }
 
     public void calculateSelectedBillSessionTotalWithBillUpdate() {
-        PaymentSchemeDiscount paymentSchemeDiscount = priceMatrixController.fetchChannellingMemberShipDiscount(paymentMethod, paymentScheme, getSelectedSessionInstance().getOriginatingSession().getCategory());
+        PaymentSchemeDiscount paymentSchemeDiscount = priceMatrixController.fetchChannellingMemberShipDiscount(settlePaymentMethod, paymentScheme, getSelectedSessionInstance().getOriginatingSession().getCategory());
         feeTotalForSelectedBill = 0.0;
         feeDiscountForSelectedBill = 0.0;
         feeNetTotalForSelectedBill = 0.0;
@@ -9010,28 +9073,43 @@ public class BookingControllerViewScope implements Serializable, ControllerWithP
         }
 
         if (paymentSchemeDiscount != null) {
+            double d = 0.0;
             for (BillFee bf : billFees) {
+                d = 0.0;
                 ItemFee itmf = (ItemFee) bf.getFee();
                 if (foriegn) {
                     feeTotalForSelectedBill += itmf.getFfee();
+                    bf.setFeeGrossValue(itmf.getFfee());
+
                     if (itmf.isDiscountAllowed()) {
-                        feeDiscountForSelectedBill += itmf.getFfee() * (paymentSchemeDiscount.getDiscountPercent() / 100);
+                        d = itmf.getFfee() * (paymentSchemeDiscount.getDiscountPercent() / 100);
+                        feeDiscountForSelectedBill += d;     
                     }
+
                 } else {
                     feeTotalForSelectedBill += itmf.getFee();
+                    bf.setFeeGrossValue(itmf.getFee());
+                    
                     if (itmf.isDiscountAllowed()) {
-                        feeDiscountForSelectedBill += itmf.getFee() * (paymentSchemeDiscount.getDiscountPercent() / 100);
+                        d = itmf.getFee() * (paymentSchemeDiscount.getDiscountPercent() / 100);
+                        feeDiscountForSelectedBill += d; 
                     }
                 }
+                bf.setFeeDiscount(d);
+                bf.setFeeValue(bf.getFeeGrossValue() - d);
             }
         } else {
             for (BillFee bf : billFees) {
                 ItemFee itmf = (ItemFee) bf.getFee();
                 if (foriegn) {
                     feeTotalForSelectedBill += itmf.getFfee();
+                    bf.setFeeGrossValue(itmf.getFfee());
                 } else {
                     feeTotalForSelectedBill += itmf.getFee();
+                    bf.setFeeGrossValue(itmf.getFee());
                 }
+                bf.setFeeValue(bf.getFeeGrossValue());
+                bf.setFeeDiscount(0.0);
             }
 
         }
@@ -9045,34 +9123,63 @@ public class BookingControllerViewScope implements Serializable, ControllerWithP
         calculateCashBalance();
     }
 
+    // private void updateBillItemValuesForForeign() {
+    //     List<BillFee> billFees = selectedBillSession.getBill().getBillFeesWIthoutZeroValue();
+    //     List<BillItem> billItems = selectedBillSession.getBill().getBillItems();
+
+    //     for (BillFee billFee : billFees) {
+    //         BillItem billItem = billFee.getBillItem();
+
+    //         if (isForiegn()) {
+    //             if (billFee.getFee().getFeeType().equals(FeeType.Staff)) {
+    //                 billItem.setStaffFee(billFee.getFee().getProfessionalFfee());
+    //             } else if (billFee.getFee().getFeeType().equals(FeeType.OwnInstitution)) {
+    //                 billItem.setHospitalFee(billFee.getFee().getHospitalFfee());
+    //             }
+
+    //             billItem.setNetValue(billFee.getFee().getFfee());
+    //         } else {
+    //             if (billFee.getFee().getFeeType().equals(FeeType.Staff)) {
+    //                 billItem.setStaffFee(billFee.getFee().getProfessionalFee());
+    //             } else if (billFee.getFee().getFeeType().equals(FeeType.OwnInstitution)) {
+    //                 billItem.setHospitalFee(billFee.getFee().getHospitalFee());
+    //             }
+
+    //             billItem.setNetValue(billFee.getFee().getFee());
+    //         }
+
+    //         billItems.get(billItems.indexOf(billItem)).setNetValue(billItem.getNetValue());
+    //         billItems.get(billItems.indexOf(billItem)).setStaffFee(billItem.getStaffFee());
+    //         billItems.get(billItems.indexOf(billItem)).setHospitalFee(billItem.getHospitalFee());
+    //     }
+    // }
+
     private void updateBillItemValuesForForeign() {
-        List<BillFee> billFees = selectedBillSession.getBill().getBillFeesWIthoutZeroValue();
-        List<BillItem> billItems = selectedBillSession.getBill().getBillItems();
+        if (selectedBillSession.getBill().getBillItems() == null || selectedBillSession.getBill().getBillItems().isEmpty()) {
+            return;
+        }
 
-        for (BillFee billFee : billFees) {
-            BillItem billItem = billFee.getBillItem();
+        for (BillItem billItem : selectedBillSession.getBill().getBillItems()) {
+            double netValue = 0.0;
+            for (BillFee billFee : billItem.getBillFees()) {
+                if (isForiegn()) {
+                    if (billFee.getFee().getFeeType().equals(FeeType.Staff)) {
+                        billItem.setStaffFee(billFee.getFee().getProfessionalFfee());
+                    } else if (billFee.getFee().getFeeType().equals(FeeType.OwnInstitution)) {
+                        billItem.setHospitalFee(billFee.getFee().getHospitalFfee());
+                    }
+                    netValue += billFee.getFee().getFfee();
+                } else {
+                    if (billFee.getFee().getFeeType().equals(FeeType.Staff)) {
+                        billItem.setStaffFee(billFee.getFee().getProfessionalFee());
+                    } else if (billFee.getFee().getFeeType().equals(FeeType.OwnInstitution)) {
+                        billItem.setHospitalFee(billFee.getFee().getHospitalFee());
+                    }
 
-            if (isForiegn()) {
-                if (billFee.getFee().getFeeType().equals(FeeType.Staff)) {
-                    billItem.setStaffFee(billFee.getFee().getProfessionalFfee());
-                } else if (billFee.getFee().getFeeType().equals(FeeType.OwnInstitution)) {
-                    billItem.setHospitalFee(billFee.getFee().getHospitalFfee());
+                    netValue += billFee.getFee().getFee();
                 }
-
-                billItem.setNetValue(billFee.getFee().getFfee());
-            } else {
-                if (billFee.getFee().getFeeType().equals(FeeType.Staff)) {
-                    billItem.setStaffFee(billFee.getFee().getProfessionalFee());
-                } else if (billFee.getFee().getFeeType().equals(FeeType.OwnInstitution)) {
-                    billItem.setHospitalFee(billFee.getFee().getHospitalFee());
-                }
-
-                billItem.setNetValue(billFee.getFee().getFee());
             }
-
-            billItems.get(billItems.indexOf(billItem)).setNetValue(billItem.getNetValue());
-            billItems.get(billItems.indexOf(billItem)).setStaffFee(billItem.getStaffFee());
-            billItems.get(billItems.indexOf(billItem)).setHospitalFee(billItem.getHospitalFee());
+            billItem.setNetValue(netValue);
         }
     }
 
@@ -9155,11 +9262,11 @@ public class BookingControllerViewScope implements Serializable, ControllerWithP
         }
         if (paymentSchemeDiscount != null) {
             for (BillFee bf : billFees) {
-                feeTotalForSelectedBill += bf.getFeeGrossValue();
+                feeTotalForSelectedBill += bf.getFeeValue();
 
                 ItemFee itmf = (ItemFee) bf.getFee();
                 if (itmf.isDiscountAllowed()) {
-                    feeDiscountForSelectedBill += bf.getFeeGrossValue() * (paymentSchemeDiscount.getDiscountPercent() / 100);
+                    feeDiscountForSelectedBill += bf.getFeeValue() * (paymentSchemeDiscount.getDiscountPercent() / 100);
                 }
             }
         } else {

--- a/src/main/java/com/divudi/bean/channel/BookingControllerViewScopeMonth.java
+++ b/src/main/java/com/divudi/bean/channel/BookingControllerViewScopeMonth.java
@@ -5264,6 +5264,7 @@ public class BookingControllerViewScopeMonth implements Serializable {
             billFeeList.add(bf);
         }
 
+        billItem.setGrossValue(tmpGrossTotal);
         billItem.setDiscount(tmpDiscount);
         billItem.setNetValue(tmpTotal);
         getBillItemFacade().edit(billItem);
@@ -6416,8 +6417,8 @@ public class BookingControllerViewScopeMonth implements Serializable {
 
         BillItem bi = selectedBillSession.getBillItem();
         Bill creditBill = getBillSession().getBill();
-        bi.setHospitalFee(billBeanController.calFeeValue(FeeType.OwnInstitution, bi));
-        bi.setStaffFee(billBeanController.calFeeValue(FeeType.Staff, bi));
+        bi.setHospitalFee(billBeanController.calFeeValue(FeeType.OwnInstitution, bi, creditBill));
+        bi.setStaffFee(billBeanController.calFeeValue(FeeType.Staff, bi, creditBill));
         getBillItemFacade().edit(bi);
 
         creditBill.setHospitalFee(billBeanController.calFeeValue(FeeType.OwnInstitution, creditBill));

--- a/src/main/java/com/divudi/bean/channel/BookingControllerViewScopeMonth.java
+++ b/src/main/java/com/divudi/bean/channel/BookingControllerViewScopeMonth.java
@@ -8157,27 +8157,39 @@ public class BookingControllerViewScopeMonth implements Serializable {
             return;
         }
 
-        for (BillItem billItem : selectedBillSession.getBill().getBillItems()) {
-            double netValue = 0.0;
-            for (BillFee billFee : billItem.getBillFees()) {
-                if (isForiegn()) {
-                    if (billFee.getFee().getFeeType().equals(FeeType.Staff)) {
-                        billItem.setStaffFee(billFee.getFee().getProfessionalFfee());
-                    } else if (billFee.getFee().getFeeType().equals(FeeType.OwnInstitution)) {
-                        billItem.setHospitalFee(billFee.getFee().getHospitalFfee());
-                    }
-                    netValue += billFee.getFee().getFfee();
-                } else {
-                    if (billFee.getFee().getFeeType().equals(FeeType.Staff)) {
-                        billItem.setStaffFee(billFee.getFee().getProfessionalFee());
-                    } else if (billFee.getFee().getFeeType().equals(FeeType.OwnInstitution)) {
-                        billItem.setHospitalFee(billFee.getFee().getHospitalFee());
-                    }
+        List<BillFee> billFees = getBillSession().getBill().getBillFees();
+        if (billFees == null) {
+            billFees = billBeanController.getBillFee(getBillSession().getBill());
+        }
 
-                    netValue += billFee.getFee().getFee();
-                }
+        for (BillItem billItem : selectedBillSession.getBill().getBillItems()) {
+            double totalGross = 0.0;
+            double totalDiscount = 0.0;
+            double totalNet = 0.0;
+            double hosFee = 0.0;
+            double staffFee = 0.0;
+
+            for (BillFee billFee : billFees) {
+                ItemFee f = (ItemFee) billFee.getFee();
+
+                if (f.getItem().equals(billItem.getItem())) {
+                    totalGross += billFee.getFeeGrossValue();
+                    totalDiscount += billFee.getFeeDiscount();
+                    totalNet += billFee.getFeeValue();
+
+                    if (f.getFeeType().equals(FeeType.Staff)) {
+                        staffFee += billFee.getFeeValue();
+                    }
+                    if (f.getFeeType().equals(FeeType.OwnInstitution)) {
+                        hosFee += billFee.getFeeValue();
+                    }
+                }                
             }
-            billItem.setNetValue(netValue);
+            billItem.setGrossValue(totalGross);
+            billItem.setDiscount(totalDiscount);
+            billItem.setNetValue(totalNet);
+            billItem.setStaffFee(staffFee);
+            billItem.setHospitalFee(hosFee);
         }
     }
 }

--- a/src/main/java/com/divudi/bean/channel/BookingControllerViewScopeMonth.java
+++ b/src/main/java/com/divudi/bean/channel/BookingControllerViewScopeMonth.java
@@ -6403,17 +6403,32 @@ public class BookingControllerViewScopeMonth implements Serializable {
             }
         }
 
-        Bill b = savePaidBill();
-        BillItem bi = savePaidBillItem(b);
+         Bill b = savePaidBill();
+        
         // savePaidBillFee(b, bi);
         PriceMatrix priceMatrix = priceMatrixController.fetchChannellingMemberShipDiscount(settlePaymentMethod, paymentScheme, selectedSessionInstance.getOriginatingSession().getCategory());
 
         if (selectedBillSession.getBill().getBillItems() != null && !selectedBillSession.getBill().getBillItems().isEmpty()) {
             for (BillItem abi : selectedBillSession.getBill().getBillItems()) {
-                createBillFeesForPaidBill(b, abi, priceMatrix, bi);
+                createBillFeesForPaidBill(b, abi, priceMatrix);
             }
         }
-        BillSession bs = savePaidBillSession(b, bi);
+
+        BillItem bi = selectedBillSession.getBillItem();
+        Bill creditBill = getBillSession().getBill();
+        bi.setHospitalFee(billBeanController.calFeeValue(FeeType.OwnInstitution, bi));
+        bi.setStaffFee(billBeanController.calFeeValue(FeeType.Staff, bi));
+        getBillItemFacade().edit(bi);
+
+        creditBill.setHospitalFee(billBeanController.calFeeValue(FeeType.OwnInstitution, creditBill));
+        creditBill.setStaffFee(billBeanController.calFeeValue(FeeType.Staff, creditBill));
+        getBillFacade().edit(creditBill);
+        b.setHospitalFee(creditBill.getHospitalFee());
+        b.setStaffFee(creditBill.getStaffFee());
+
+        BillItem billItemForPaidSession = savePaidBillItem(b);
+
+        BillSession bs = savePaidBillSession(b, billItemForPaidSession);
 
         getBillSession().setPaidBillSession(bs);
         getBillSessionFacade().edit(bs);
@@ -6422,9 +6437,10 @@ public class BookingControllerViewScopeMonth implements Serializable {
         getBillSession().getBill().setPaidAmount(b.getPaidAmount());
         getBillSession().getBill().setBalance(0.0);
         getBillSession().getBill().setPaidBill(b);
+
         getBillFacade().edit(getBillSession().getBill());
 
-        b.setSingleBillItem(bi);
+        b.setSingleBillItem(billItemForPaidSession);
         b.setSingleBillSession(bs);
         getBillFacade().editAndCommit(b);
 
@@ -6457,7 +6473,7 @@ public class BookingControllerViewScopeMonth implements Serializable {
         JsfUtil.addSuccessMessage("On Call Channel Booking Settled");
     }
 
-    private void createBillFeesForPaidBill(Bill b, BillItem billItem, PriceMatrix priceMatrix, BillItem singleBillItem) {
+    private void createBillFeesForPaidBill(Bill b, BillItem billItem, PriceMatrix priceMatrix) {
         if (selectedBillSession.getBill() == null || selectedBillSession.getBill().getBillFees() == null || selectedBillSession.getBill().getBillFees().isEmpty()) {
             return;
         }
@@ -6503,13 +6519,6 @@ public class BookingControllerViewScopeMonth implements Serializable {
         billItem.setNetValue(tmpTotal);
         billItem.setDiscount(tmpDiscount);
         getBillItemFacade().edit(billItem);
-
-        if (billItem.getItem().equals(singleBillItem.getItem())) {
-            singleBillItem.setGrossValue(tmpGrossTotal);
-            singleBillItem.setNetValue(tmpTotal);
-            singleBillItem.setDiscount(tmpDiscount);
-            getBillItemFacade().edit(singleBillItem);
-        }
     }
 
     private BillSession savePaidBillSession(Bill bill, BillItem billItem) {

--- a/src/main/java/com/divudi/bean/channel/BookingControllerViewScopeMonth.java
+++ b/src/main/java/com/divudi/bean/channel/BookingControllerViewScopeMonth.java
@@ -5429,11 +5429,11 @@ public class BookingControllerViewScopeMonth implements Serializable {
         }
         if (paymentSchemeDiscount != null) {
             for (BillFee bf : billFees) {
-                feeTotalForSelectedBill += bf.getFeeGrossValue();
+                feeTotalForSelectedBill += bf.getFeeValue();
 
                 ItemFee itmf = (ItemFee) bf.getFee();
                 if (itmf.isDiscountAllowed()) {
-                    feeDiscountForSelectedBill += bf.getFeeGrossValue() * (paymentSchemeDiscount.getDiscountPercent() / 100);
+                    feeDiscountForSelectedBill += bf.getFeeValue() * (paymentSchemeDiscount.getDiscountPercent() / 100);
                 }
             }
         } else {
@@ -6405,7 +6405,14 @@ public class BookingControllerViewScopeMonth implements Serializable {
 
         Bill b = savePaidBill();
         BillItem bi = savePaidBillItem(b);
-        savePaidBillFee(b, bi);
+        // savePaidBillFee(b, bi);
+        PriceMatrix priceMatrix = priceMatrixController.fetchChannellingMemberShipDiscount(settlePaymentMethod, paymentScheme, selectedSessionInstance.getOriginatingSession().getCategory());
+
+        if (selectedBillSession.getBill().getBillItems() != null && !selectedBillSession.getBill().getBillItems().isEmpty()) {
+            for (BillItem abi : selectedBillSession.getBill().getBillItems()) {
+                createBillFeesForPaidBill(b, abi, priceMatrix, bi);
+            }
+        }
         BillSession bs = savePaidBillSession(b, bi);
 
         getBillSession().setPaidBillSession(bs);
@@ -6448,6 +6455,61 @@ public class BookingControllerViewScopeMonth implements Serializable {
         creditCompany = null;
         toStaff = null;
         JsfUtil.addSuccessMessage("On Call Channel Booking Settled");
+    }
+
+    private void createBillFeesForPaidBill(Bill b, BillItem billItem, PriceMatrix priceMatrix, BillItem singleBillItem) {
+        if (selectedBillSession.getBill() == null || selectedBillSession.getBill().getBillFees() == null || selectedBillSession.getBill().getBillFees().isEmpty()) {
+            return;
+        }
+        double tmpTotal = 0;
+        double tmpDiscount = 0;
+        double tmpGrossTotal = 0.0;
+        
+        for (BillFee bf : selectedBillSession.getBill().getBillFees()) {
+            ItemFee f = (ItemFee) bf.getFee();
+
+            if (f.getItem().equals(billItem.getItem())) {
+                BillFee newBillFee = new BillFee();
+                newBillFee.copy(bf);
+                newBillFee.setCreatedAt(Calendar.getInstance().getTime());
+                newBillFee.setCreater(getSessionController().getLoggedUser());
+                newBillFee.setBill(b);
+                newBillFee.setBillItem(billItem);
+                getBillFeeFacade().create(newBillFee);
+
+                double d = 0;
+
+                if (priceMatrix != null) {
+                    if (f.isDiscountAllowed()) {
+                        d = bf.getFeeValue() * (priceMatrix.getDiscountPercent() / 100);
+                        bf.setFeeDiscount(d);
+                        bf.setFeeGrossValue(bf.getFeeValue());
+                        newBillFee.setFeeGrossValue(bf.getFeeGrossValue());
+                        newBillFee.setFeeDiscount(d);
+                    }
+
+                    bf.setFeeValue(bf.getFeeGrossValue() - bf.getFeeDiscount());
+                    newBillFee.setFeeValue(bf.getFeeValue());
+                    tmpDiscount += d;
+                }
+                tmpGrossTotal += bf.getFeeGrossValue();
+                tmpTotal += bf.getFeeValue();
+                // BillFees of both bills are updated
+                getBillFeeFacade().edit(bf);
+                getBillFeeFacade().edit(newBillFee);
+            }
+        }
+        billItem.setGrossValue(tmpGrossTotal);
+        billItem.setNetValue(tmpTotal);
+        billItem.setDiscount(tmpDiscount);
+        getBillItemFacade().edit(billItem);
+
+        if (billItem.getItem().equals(singleBillItem.getItem())) {
+            singleBillItem.setGrossValue(tmpGrossTotal);
+            singleBillItem.setNetValue(tmpTotal);
+            singleBillItem.setDiscount(tmpDiscount);
+            getBillItemFacade().edit(singleBillItem);
+        }
     }
 
     private BillSession savePaidBillSession(Bill bill, BillItem billItem) {
@@ -8011,7 +8073,7 @@ public class BookingControllerViewScopeMonth implements Serializable {
     }
 
     public void calculateSelectedBillSessionTotalWithBillUpdate() {
-        PaymentSchemeDiscount paymentSchemeDiscount = priceMatrixController.fetchChannellingMemberShipDiscount(paymentMethod, paymentScheme, getSelectedSessionInstance().getOriginatingSession().getCategory());
+        PaymentSchemeDiscount paymentSchemeDiscount = priceMatrixController.fetchChannellingMemberShipDiscount(settlePaymentMethod, paymentScheme, getSelectedSessionInstance().getOriginatingSession().getCategory());
         feeTotalForSelectedBill = 0.0;
         feeDiscountForSelectedBill = 0.0;
         feeNetTotalForSelectedBill = 0.0;
@@ -8022,28 +8084,43 @@ public class BookingControllerViewScopeMonth implements Serializable {
         }
 
         if (paymentSchemeDiscount != null) {
+            double d = 0.0;
             for (BillFee bf : billFees) {
+                d = 0.0;
                 ItemFee itmf = (ItemFee) bf.getFee();
                 if (foriegn) {
                     feeTotalForSelectedBill += itmf.getFfee();
+                    bf.setFeeGrossValue(itmf.getFfee());
+
                     if (itmf.isDiscountAllowed()) {
-                        feeDiscountForSelectedBill += itmf.getFfee() * (paymentSchemeDiscount.getDiscountPercent() / 100);
+                        d = itmf.getFfee() * (paymentSchemeDiscount.getDiscountPercent() / 100);
+                        feeDiscountForSelectedBill += d;     
                     }
+
                 } else {
                     feeTotalForSelectedBill += itmf.getFee();
+                    bf.setFeeGrossValue(itmf.getFee());
+                    
                     if (itmf.isDiscountAllowed()) {
-                        feeDiscountForSelectedBill += itmf.getFee() * (paymentSchemeDiscount.getDiscountPercent() / 100);
+                        d = itmf.getFee() * (paymentSchemeDiscount.getDiscountPercent() / 100);
+                        feeDiscountForSelectedBill += d; 
                     }
                 }
+                bf.setFeeDiscount(d);
+                bf.setFeeValue(bf.getFeeGrossValue() - d);
             }
         } else {
             for (BillFee bf : billFees) {
                 ItemFee itmf = (ItemFee) bf.getFee();
                 if (foriegn) {
                     feeTotalForSelectedBill += itmf.getFfee();
+                    bf.setFeeGrossValue(itmf.getFfee());
                 } else {
                     feeTotalForSelectedBill += itmf.getFee();
+                    bf.setFeeGrossValue(itmf.getFee());
                 }
+                bf.setFeeValue(bf.getFeeGrossValue());
+                bf.setFeeDiscount(0.0);
             }
 
         }
@@ -8057,33 +8134,31 @@ public class BookingControllerViewScopeMonth implements Serializable {
     }
 
     private void updateBillItemValuesForForeign() {
-        List<BillFee> billFees = selectedBillSession.getBill().getBillFeesWIthoutZeroValue();
-        List<BillItem> billItems = selectedBillSession.getBill().getBillItems();
+        if (selectedBillSession.getBill().getBillItems() == null || selectedBillSession.getBill().getBillItems().isEmpty()) {
+            return;
+        }
 
-        for (BillFee billFee : billFees) {
-            BillItem billItem = billFee.getBillItem();
+        for (BillItem billItem : selectedBillSession.getBill().getBillItems()) {
+            double netValue = 0.0;
+            for (BillFee billFee : billItem.getBillFees()) {
+                if (isForiegn()) {
+                    if (billFee.getFee().getFeeType().equals(FeeType.Staff)) {
+                        billItem.setStaffFee(billFee.getFee().getProfessionalFfee());
+                    } else if (billFee.getFee().getFeeType().equals(FeeType.OwnInstitution)) {
+                        billItem.setHospitalFee(billFee.getFee().getHospitalFfee());
+                    }
+                    netValue += billFee.getFee().getFfee();
+                } else {
+                    if (billFee.getFee().getFeeType().equals(FeeType.Staff)) {
+                        billItem.setStaffFee(billFee.getFee().getProfessionalFee());
+                    } else if (billFee.getFee().getFeeType().equals(FeeType.OwnInstitution)) {
+                        billItem.setHospitalFee(billFee.getFee().getHospitalFee());
+                    }
 
-            if (isForiegn()) {
-                if (billFee.getFee().getFeeType().equals(FeeType.Staff)) {
-                    billItem.setStaffFee(billFee.getFee().getProfessionalFfee());
-                } else if (billFee.getFee().getFeeType().equals(FeeType.OwnInstitution)) {
-                    billItem.setHospitalFee(billFee.getFee().getHospitalFfee());
+                    netValue += billFee.getFee().getFee();
                 }
-
-                billItem.setNetValue(billFee.getFee().getFfee());
-            } else {
-                if (billFee.getFee().getFeeType().equals(FeeType.Staff)) {
-                    billItem.setStaffFee(billFee.getFee().getProfessionalFee());
-                } else if (billFee.getFee().getFeeType().equals(FeeType.OwnInstitution)) {
-                    billItem.setHospitalFee(billFee.getFee().getHospitalFee());
-                }
-
-                billItem.setNetValue(billFee.getFee().getFee());
             }
-
-            billItems.get(billItems.indexOf(billItem)).setNetValue(billItem.getNetValue());
-            billItems.get(billItems.indexOf(billItem)).setStaffFee(billItem.getStaffFee());
-            billItems.get(billItems.indexOf(billItem)).setHospitalFee(billItem.getHospitalFee());
+            billItem.setNetValue(netValue);
         }
     }
 }

--- a/src/main/java/com/divudi/bean/channel/BookingControllerViewScopeMonth.java
+++ b/src/main/java/com/divudi/bean/channel/BookingControllerViewScopeMonth.java
@@ -6405,29 +6405,31 @@ public class BookingControllerViewScopeMonth implements Serializable {
         }
 
          Bill b = savePaidBill();
+         BillItem billItemForPaidSession = savePaidBillItem(b);
         
         // savePaidBillFee(b, bi);
         PriceMatrix priceMatrix = priceMatrixController.fetchChannellingMemberShipDiscount(settlePaymentMethod, paymentScheme, selectedSessionInstance.getOriginatingSession().getCategory());
 
         if (selectedBillSession.getBill().getBillItems() != null && !selectedBillSession.getBill().getBillItems().isEmpty()) {
             for (BillItem abi : selectedBillSession.getBill().getBillItems()) {
-                createBillFeesForPaidBill(b, abi, priceMatrix);
+                createBillFeesForPaidBill(b, abi, priceMatrix, billItemForPaidSession);
             }
         }
 
         BillItem bi = selectedBillSession.getBillItem();
         Bill creditBill = getBillSession().getBill();
-        bi.setHospitalFee(billBeanController.calFeeValue(FeeType.OwnInstitution, bi, creditBill));
-        bi.setStaffFee(billBeanController.calFeeValue(FeeType.Staff, bi, creditBill));
+        bi.setHospitalFee(billBeanController.calFeeValue(FeeType.OwnInstitution, bi));
+        bi.setStaffFee(billBeanController.calFeeValue(FeeType.Staff, bi));
         getBillItemFacade().edit(bi);
+        billItemForPaidSession.setHospitalFee(bi.getHospitalFee());
+        billItemForPaidSession.setStaffFee(bi.getStaffFee());
+        getBillItemFacade().edit(billItemForPaidSession);
 
         creditBill.setHospitalFee(billBeanController.calFeeValue(FeeType.OwnInstitution, creditBill));
         creditBill.setStaffFee(billBeanController.calFeeValue(FeeType.Staff, creditBill));
         getBillFacade().edit(creditBill);
         b.setHospitalFee(creditBill.getHospitalFee());
         b.setStaffFee(creditBill.getStaffFee());
-
-        BillItem billItemForPaidSession = savePaidBillItem(b);
 
         BillSession bs = savePaidBillSession(b, billItemForPaidSession);
 
@@ -6474,14 +6476,14 @@ public class BookingControllerViewScopeMonth implements Serializable {
         JsfUtil.addSuccessMessage("On Call Channel Booking Settled");
     }
 
-    private void createBillFeesForPaidBill(Bill b, BillItem billItem, PriceMatrix priceMatrix) {
+    private void createBillFeesForPaidBill(Bill b, BillItem billItem, PriceMatrix priceMatrix, BillItem paidBillItem) {
         if (selectedBillSession.getBill() == null || selectedBillSession.getBill().getBillFees() == null || selectedBillSession.getBill().getBillFees().isEmpty()) {
             return;
         }
         double tmpTotal = 0;
         double tmpDiscount = 0;
         double tmpGrossTotal = 0.0;
-        
+    
         for (BillFee bf : selectedBillSession.getBill().getBillFees()) {
             ItemFee f = (ItemFee) bf.getFee();
 
@@ -6491,7 +6493,7 @@ public class BookingControllerViewScopeMonth implements Serializable {
                 newBillFee.setCreatedAt(Calendar.getInstance().getTime());
                 newBillFee.setCreater(getSessionController().getLoggedUser());
                 newBillFee.setBill(b);
-                newBillFee.setBillItem(billItem);
+                newBillFee.setBillItem(paidBillItem);
                 getBillFeeFacade().create(newBillFee);
 
                 double d = 0;
@@ -6520,6 +6522,13 @@ public class BookingControllerViewScopeMonth implements Serializable {
         billItem.setNetValue(tmpTotal);
         billItem.setDiscount(tmpDiscount);
         getBillItemFacade().edit(billItem);
+
+        if (paidBillItem.getItem().equals(billItem.getItem())) {
+            paidBillItem.setGrossValue(tmpGrossTotal);
+            paidBillItem.setNetValue(tmpTotal);
+            paidBillItem.setDiscount(tmpDiscount);
+            getBillItemFacade().edit(paidBillItem);
+        }
     }
 
     private BillSession savePaidBillSession(Bill bill, BillItem billItem) {

--- a/src/main/java/com/divudi/bean/common/BillBeanController.java
+++ b/src/main/java/com/divudi/bean/common/BillBeanController.java
@@ -341,21 +341,6 @@ public class BillBeanController implements Serializable {
 
     }
 
-    public double calFeeValue(FeeType feeType, BillItem billItem, Bill bill) {
-        String sql = "SELECT sum(bf.feeValue)"
-                + " FROM BillFee bf "
-                + " WHERE bf.fee.feeType=:ftp "
-                + " and bf.billItem=:bt "
-                + " and bf.bill=:b ";
-
-        HashMap temMap = new HashMap();
-        temMap.put("ftp", feeType);
-        temMap.put("bt", billItem);
-        temMap.put("b", bill);
-        return getBillFeeFacade().findDoubleByJpql(sql, temMap, TemporalType.TIMESTAMP);
-
-    }
-
     public double calFeeValueCredit(FeeType feeType, Date fromDate,
             Date toDate, Institution institution) {
         String sql = "SELECT sum(bf.feeValue)"

--- a/src/main/java/com/divudi/bean/common/BillBeanController.java
+++ b/src/main/java/com/divudi/bean/common/BillBeanController.java
@@ -341,6 +341,21 @@ public class BillBeanController implements Serializable {
 
     }
 
+    public double calFeeValue(FeeType feeType, BillItem billItem, Bill bill) {
+        String sql = "SELECT sum(bf.feeValue)"
+                + " FROM BillFee bf "
+                + " WHERE bf.fee.feeType=:ftp "
+                + " and bf.billItem=:bt "
+                + " and bf.bill=:b ";
+
+        HashMap temMap = new HashMap();
+        temMap.put("ftp", feeType);
+        temMap.put("bt", billItem);
+        temMap.put("b", bill);
+        return getBillFeeFacade().findDoubleByJpql(sql, temMap, TemporalType.TIMESTAMP);
+
+    }
+
     public double calFeeValueCredit(FeeType feeType, Date fromDate,
             Date toDate, Institution institution) {
         String sql = "SELECT sum(bf.feeValue)"


### PR DESCRIPTION
Path: `manage_booking_by_date` , `manage_booking_by_month`
Issue:
- When discount schemes or citizenship status update happens, billFees and billItems are not updated with the bill totals.

Moodifications:
- BillFees of **both bills** will be updated.
- BillItems of **both bills** will be updated.  **GrossValue, NetValue, Discount**
- BillSession.BillItem`, **HospitalFee, StaffFee** will be updated. **Both BillSessions**
- **Both bills'** **HospitalFee, StaffFee** will be updated
- **Bill Fee values will be calculated using the onCall billFee.FeeValues**.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved billing settlement and fee calculations to ensure accurate charge computations.

* **Refactor**
  * Refined internal billing logic for credit settlements and membership discount handling to enhance accuracy and maintainability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->