### PR TITLE
Fix uploaded consultants not appearing in Staff List & Consultant page (#20152)

### DIFF
--- a/src/main/java/com/divudi/bean/emr/DataUploadController.java
+++ b/src/main/java/com/divudi/bean/emr/DataUploadController.java
@@ -3507,53 +3507,14 @@ public class DataUploadController implements Serializable {
             Sex sex;
             Title title;
 
-            String code = null;
-            String name = null;
-            String titleString = "";
-
-            String registration = "";
-            String description = "";
-            String sexString = null;
-            String mobileNumber = "";
-
-            String specialityString = null;
-
-            Cell codeCell = row.getCell(0);
-            if (codeCell != null && codeCell.getCellType() == CellType.STRING) {
-                code = codeCell.getStringCellValue();
-            }
-
-            Cell titleCell = row.getCell(1);
-            if (titleCell != null && titleCell.getCellType() == CellType.STRING) {
-                titleString = titleCell.getStringCellValue();
-            }
-
-            Cell nameCell = row.getCell(2);
-            if (nameCell != null && nameCell.getCellType() == CellType.STRING) {
-                name = nameCell.getStringCellValue();
-
-            }
-
-            Cell registrationCell = row.getCell(3);
-            if (registrationCell != null && registrationCell.getCellType() == CellType.STRING) {
-                registration = registrationCell.getStringCellValue();
-            }
-
-            Cell descriptionCell = row.getCell(4);
-            if (descriptionCell != null && descriptionCell.getCellType() == CellType.STRING) {
-                description = descriptionCell.getStringCellValue();
-            }
-
-            Cell sexCell = row.getCell(5);
-            sexString = readCellAsString(sexCell);
-
-            Cell mobileCell = row.getCell(6);
-            mobileNumber = readCellAsString(mobileCell);
-
-            Cell specialityCell = row.getCell(7);
-            if (specialityCell != null && specialityCell.getCellType() == CellType.STRING) {
-                specialityString = specialityCell.getStringCellValue();
-            }
+            String code = readCellAsString(row.getCell(0));
+            String titleString = readCellAsString(row.getCell(1));
+            String name = readCellAsString(row.getCell(2));
+            String registration = readCellAsString(row.getCell(3));
+            String description = readCellAsString(row.getCell(4));
+            String sexString = readCellAsString(row.getCell(5));
+            String mobileNumber = readCellAsString(row.getCell(6));
+            String specialityString = readCellAsString(row.getCell(7));
 
             if (name == null || name.trim().equals("")) {
                 continue;
@@ -3619,53 +3580,14 @@ public class DataUploadController implements Serializable {
             Sex sex;
             Title title;
 
-            String code = null;
-            String name = null;
-            String titleString = "";
-
-            String registration = "";
-            String description = "";
-            String sexString = null;
-            String mobileNumber = "";
-
-            String specialityString = null;
-
-            Cell codeCell = row.getCell(0);
-            if (codeCell != null && codeCell.getCellType() == CellType.STRING) {
-                code = codeCell.getStringCellValue();
-            }
-
-            Cell titleCell = row.getCell(1);
-            if (titleCell != null && titleCell.getCellType() == CellType.STRING) {
-                titleString = titleCell.getStringCellValue();
-            }
-
-            Cell nameCell = row.getCell(2);
-            if (nameCell != null && nameCell.getCellType() == CellType.STRING) {
-                name = nameCell.getStringCellValue();
-
-            }
-
-            Cell registrationCell = row.getCell(3);
-            if (registrationCell != null && registrationCell.getCellType() == CellType.STRING) {
-                registration = registrationCell.getStringCellValue();
-            }
-
-            Cell descriptionCell = row.getCell(4);
-            if (descriptionCell != null && descriptionCell.getCellType() == CellType.STRING) {
-                description = descriptionCell.getStringCellValue();
-            }
-
-            Cell sexCell = row.getCell(5);
-            sexString = readCellAsString(sexCell);
-
-            Cell mobileCell = row.getCell(6);
-            mobileNumber = readCellAsString(mobileCell);
-
-            Cell specialityCell = row.getCell(7);
-            if (specialityCell != null && specialityCell.getCellType() == CellType.STRING) {
-                specialityString = specialityCell.getStringCellValue();
-            }
+            String code = readCellAsString(row.getCell(0));
+            String titleString = readCellAsString(row.getCell(1));
+            String name = readCellAsString(row.getCell(2));
+            String registration = readCellAsString(row.getCell(3));
+            String description = readCellAsString(row.getCell(4));
+            String sexString = readCellAsString(row.getCell(5));
+            String mobileNumber = readCellAsString(row.getCell(6));
+            String specialityString = readCellAsString(row.getCell(7));
 
             System.out.println("name = " + name);
             if (name == null || name.trim().equals("")) {

--- a/src/main/java/com/divudi/bean/hr/StaffController.java
+++ b/src/main/java/com/divudi/bean/hr/StaffController.java
@@ -198,6 +198,7 @@ public class StaffController implements Serializable {
     }
 
     public String navigateToListStaff() {
+        staff = null;
         fillItems();
         return "/admin/staff/staff_list?faces-redirect=true";
     }


### PR DESCRIPTION
## Summary
After a Consultant Excel upload, users reported that uploaded consultants did not appear on either the **Staff List** or the **Consultant** page. Investigation surfaced two independent causes, both fixed here:

**1. Silent row-skipping in `readConsultantsFromExcel` / `readDoctorsFromExcel`**
Every cell (Code, Title, Name, Registration, Description, Speciality) was read under a `cell.getCellType() == CellType.STRING` guard. When Excel stores a cell as `FORMULA`, `NUMERIC`, or `BLANK` (typical when the sheet uses data-validation dropdowns, pasted formula values, or auto-typed cells), the field stayed null/empty, and the row was silently dropped by the `name` / `specialityString` emptiness checks a few lines later. This is the same class of bug fixed for Sex/Mobile in #20148 — this PR extends the existing `readCellAsString` helper to every cell so rows aren't dropped because of a cell-type mismatch.

**2. Stale `StaffController.staff` session cache**
`StaffController` is `@SessionScoped` and `getStaff()` lazy-caches the list; nothing in the codebase ever reset it. A user who viewed Staff List once in the session, then uploaded, then returned, would see the pre-upload list forever (until logout). Added `staff = null;` at the top of `navigateToListStaff()` so each click on the Staff List button re-queries. The Consultant page is already OK — `ConsultantController.getSelectedItems()` re-queries on every call.

Closes #20152

## Test plan
- [ ] Upload a Consultant Excel file where some cells are plain text and others are numeric / formula-result / dropdown-validated. After Save, verify **all** rows (not just some) appear on the Consultant page.
- [ ] Same upload, then click **Staff List** — verify all newly uploaded consultants appear, without needing logout/login.
- [ ] Open Staff List first (populating the cache), then upload a new consultant, then return to Staff List — verify the new row is visible.
- [ ] Repeat the same flow against the Doctor upload page — same schema, same code path.
- [ ] Regression: with an all-text Excel sheet, verify preview + save + Staff List still behave correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)