### PR TITLE
fix(inward): include estimated professional fees in estimated interim bill total (#20158)

### DIFF
--- a/src/main/java/com/divudi/bean/inward/BhtSummeryController.java
+++ b/src/main/java/com/divudi/bean/inward/BhtSummeryController.java
@@ -181,6 +181,7 @@ public class BhtSummeryController implements Serializable {
     private boolean patientEncounterHasProvisionalBill = false;
     private List<PatientEncounter> childPatientEncouters;
     private Institution institution;
+    private boolean estimatedBillView = false;
 
     public String navigateToIntrimBillEstimate() {
         institution = sessionController.getInstitution();
@@ -2287,6 +2288,7 @@ public class BhtSummeryController implements Serializable {
         Date toDate = null;
 
         makeNull();
+        estimatedBillView = true;
 
         if (patientEncounter == null) {
             return;
@@ -2384,6 +2386,7 @@ public class BhtSummeryController implements Serializable {
         toTime = null;
         patientRooms = null;
         creditCompanyAllocations = null;
+        estimatedBillView = false;
     }
 
     public void onInstitutionChange() {
@@ -3010,7 +3013,7 @@ public class BhtSummeryController implements Serializable {
                     i.setTotal(getInwardBean().calNetCostOfIssue(getPatientEncounter(), BillType.StoreBhtPre, childPatientEncouters));
                     break;
                 case ProfessionalCharge:
-                    i.setTotal(getInwardBean().calculateProfessionalCharges(getPatientEncounter(), childPatientEncouters, false));
+                    i.setTotal(getInwardBean().calculateProfessionalCharges(getPatientEncounter(), childPatientEncouters, estimatedBillView));
                     break;
                 case DoctorAndNurses:
                     i.setTotal(getInwardBean().calculateDoctorAndNurseCharges(getPatientEncounter(), childPatientEncouters));


### PR DESCRIPTION
## Summary
- The estimated interim bill page (`inward_bill_intrim_estimate.xhtml`) listed estimated professional fees in the **Professional Fee** tab but did not include them in the **Charges** panel total or the Summary **Total Charges** — so `grantTotal`, `Due`, and the printed bill were short by the estimate amount.
- Root cause: `setKnownChargeTot()` always called `calculateProfessionalCharges(..., false)`, which only sums `BillType.InwardProfessional` and ignores `BillType.InwardProfessionalEstimates`.
- Fix: introduce an `estimatedBillView` flag set `true` only by `createTablesWithEstimatedProfessionalFees()` (cleared in `makeNull()`), and pass it through to `calculateProfessionalCharges`. On the estimated view the total now includes both `InwardProfessional` + `InwardProfessionalEstimates`. Regular interim bill and final bill paths keep `estimatedBillView=false` and are unchanged — no behavior change there.

Closes #20158

## Notes
- A follow-up enhancement is needed to allow staff to **list and remove previously saved estimated professional fees** on the *Add Estimated Professional Fees* page, so that obsolete estimates can be removed once the consultant adds the actual fee. Filed as a separate issue.

## Test plan
- [ ] Open *Inward Payment Bill – Estimated Professional Fees* (`inward_bill_intrim_estimate.xhtml`), select a BHT that has saved `InwardProfessionalEstimates`. Verify the **Professional Fee** tab still lists them, the right-side **Charges** panel **Professional Charge** row now equals the sum of estimates (plus any actual professional fees), and the middle **Summary → Total Charges** matches the sum of all rows.
- [ ] On the regular **Interim Bill** (`inward_bill_intrim.xhtml`) and on the **Final Bill** flow, confirm the Professional Charge total and Total Charges are unchanged (still based on `InwardProfessional` only).
- [ ] Verify Discharge / Settle / Print Bill on the estimated page now reflect the new `grantTotal`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added estimated billing view capability for professional charges in inward bill summaries, enabling users to preview costs using special calculation logic.

* **Bug Fixes**
  * Fixed professional charge recalculation logic to properly reset between billing view transitions, ensuring accurate results when switching between estimated and standard calculation modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->