### PR TITLE
Fixed - Stale handover create bills blocking shift end

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,6 +78,7 @@
 ### When Reviewing a PR
 - [PR Review Workflow](developer_docs/git/pr-review-workflow.md) - Full checklist for handling CodeRabbit/Codex comments: fetch → investigate → discuss → batch-fix → persistence check → push → reply → re-request review → cleanup
 - Use `/review-pr <pr-url>` skill to automate investigation and fix steps
+- **🚨 AFTER APPLYING ANY CODERABBIT/CODEX FIX**: Always verify method names exist on the actual entity before pushing. Automated tools frequently generate wrong getter names (e.g., `getCompleted()` instead of `isCompleted()` for primitive `boolean` fields). See [PR Review Workflow §4a](developer_docs/git/pr-review-workflow.md).
 
 ### When Committing Code
 - [Commit Conventions](developer_docs/git/commit-conventions.md) - Message format

--- a/developer_docs/git/pr-review-workflow.md
+++ b/developer_docs/git/pr-review-workflow.md
@@ -52,6 +52,18 @@ Always fetch first — Codex may have auto-pushed fixes you don't have locally.
 - Do NOT make one commit per comment — keep history clean
 - Use imperative mood in commit message, include `Closes #N` if this resolves the issue
 
+### 4a. Code Review After Applying CodeRabbit Fixes — MANDATORY
+
+**After applying any CodeRabbit (or other automated reviewer) suggestion, always review the changed code with the `java-health-code-reviewer` agent before pushing.** Automated tools frequently generate suggestions with wrong method names, incorrect types, or API calls that do not exist in this codebase, causing compilation errors.
+
+Specifically verify:
+- All method names exist on the actual entity class (e.g., `isCompleted()` not `getCompleted()` for primitive `boolean` fields in JPA entities)
+- All referenced fields/variables are in scope
+- Generated `diff` hunks integrate cleanly with surrounding code (no missing lines, no off-by-one context)
+- The fix does not introduce a regression (e.g., null-safety, logic inversion)
+
+> **Why:** CodeRabbit has broken builds multiple times in this project by generating method calls that don't exist (`getCompleted()` on a `boolean` field, wrong constructor signatures, etc.). Never apply a suggestion blindly.
+
 ### 5. Pre-Push Checklist
 
 - **persistence.xml** — must use `${JDBC_DATASOURCE}` and `${JDBC_AUDIT_DATASOURCE}`, not hardcoded JNDI names. See [Persistence Configuration Guide](../deployment/persistence-verification.md)

--- a/src/main/java/com/divudi/bean/cashTransaction/FinancialTransactionController.java
+++ b/src/main/java/com/divudi/bean/cashTransaction/FinancialTransactionController.java
@@ -6577,6 +6577,7 @@ public class FinancialTransactionController implements Serializable {
             case FUND_SHIFT_HANDOVER_CREATE:
                 jpql.append("and (s.completed = false or s.completed is null) ");
                 jpql.append("and (s.cancelled = false or s.cancelled is null) ");
+                jpql.append("and (s.referenceBill is null or s.referenceBill.completed = false or s.referenceBill.completed is null) ");
                 break;
             case FUND_TRANSFER_BILL:
                 jpql.append("and s.referenceBill is null ");

--- a/src/main/java/com/divudi/bean/common/DataAdministrationController.java
+++ b/src/main/java/com/divudi/bean/common/DataAdministrationController.java
@@ -1054,10 +1054,10 @@ public class DataAdministrationController implements Serializable {
                 if (bill == null) {
                     continue;
                 }
-                if (Boolean.TRUE.equals(bill.getCompleted()) || Boolean.TRUE.equals(bill.getCancelled())) {
+                if (bill.isCompleted() || bill.isCancelled()) {
                     continue;
                 }
-                if (bill.getReferenceBill() == null || !Boolean.TRUE.equals(bill.getReferenceBill().getCompleted())) {
+                if (bill.getReferenceBill() == null || !bill.getReferenceBill().isCompleted()) {
                     continue;
                 }
                 bill.setCompleted(true);

--- a/src/main/java/com/divudi/bean/common/DataAdministrationController.java
+++ b/src/main/java/com/divudi/bean/common/DataAdministrationController.java
@@ -1048,13 +1048,25 @@ public class DataAdministrationController implements Serializable {
             }
             Date now = new Date();
             WebUser currentUser = sessionController.getLoggedUser();
-            for (Bill bill : staleBills) {
+            int updatedCount = 0;
+            for (Bill stale : staleBills) {
+                Bill bill = billFacade.find(stale.getId());
+                if (bill == null) {
+                    continue;
+                }
+                if (Boolean.TRUE.equals(bill.getCompleted()) || Boolean.TRUE.equals(bill.getCancelled())) {
+                    continue;
+                }
+                if (bill.getReferenceBill() == null || !Boolean.TRUE.equals(bill.getReferenceBill().getCompleted())) {
+                    continue;
+                }
                 bill.setCompleted(true);
                 bill.setCompletedAt(now);
                 bill.setCompletedBy(currentUser);
                 billFacade.edit(bill);
+                updatedCount++;
             }
-            executionFeedback = "Marked " + staleBills.size() + " stale handover create bill(s) as completed.";
+            executionFeedback = "Marked " + updatedCount + " stale handover create bill(s) as completed.";
         } catch (Exception e) {
             executionFeedback = "Error: " + getExceptionMessage(e);
         }

--- a/src/main/java/com/divudi/bean/common/DataAdministrationController.java
+++ b/src/main/java/com/divudi/bean/common/DataAdministrationController.java
@@ -1029,6 +1029,37 @@ public class DataAdministrationController implements Serializable {
         }
     }
 
+    public void markStaleHandoverCreateBillsAsCompleted() {
+        executionFeedback = "";
+        try {
+            String jpql = "SELECT b FROM Bill b "
+                    + "WHERE b.retired = false "
+                    + "AND b.billTypeAtomic = :btype "
+                    + "AND (b.completed = false OR b.completed IS NULL) "
+                    + "AND (b.cancelled = false OR b.cancelled IS NULL) "
+                    + "AND b.referenceBill IS NOT NULL "
+                    + "AND b.referenceBill.completed = true";
+            Map<String, Object> params = new HashMap<>();
+            params.put("btype", BillTypeAtomic.FUND_SHIFT_HANDOVER_CREATE);
+            List<Bill> staleBills = billFacade.findByJpql(jpql, params, TemporalType.TIMESTAMP);
+            if (staleBills == null || staleBills.isEmpty()) {
+                executionFeedback = "No stale handover create bills found. Nothing to update.";
+                return;
+            }
+            Date now = new Date();
+            WebUser currentUser = sessionController.getLoggedUser();
+            for (Bill bill : staleBills) {
+                bill.setCompleted(true);
+                bill.setCompletedAt(now);
+                bill.setCompletedBy(currentUser);
+                billFacade.edit(bill);
+            }
+            executionFeedback = "Marked " + staleBills.size() + " stale handover create bill(s) as completed.";
+        } catch (Exception e) {
+            executionFeedback = "Error: " + getExceptionMessage(e);
+        }
+    }
+
     /**
      * Helper method to correct BillFinanceDetails values to NEGATIVE
      * Returns true if any correction was made

--- a/src/main/java/com/divudi/ws/common/ApplicationConfig.java
+++ b/src/main/java/com/divudi/ws/common/ApplicationConfig.java
@@ -37,6 +37,7 @@ public class ApplicationConfig extends Application {
      */
     private void addRestResourceClasses(Set<Class<?>> resources) {
         resources.add(com.divudi.ws.channel.ChannelApi.class);
+        resources.add(com.divudi.ws.channel.ChannelSpecialityApi.class);
         resources.add(com.divudi.ws.channel.CorsResponseFilter.class);
         resources.add(com.divudi.ws.clinical.ClinicalMetadataApi.class);
         resources.add(com.divudi.ws.clinical.FavouriteMedicineApi.class);
@@ -57,6 +58,10 @@ public class ApplicationConfig extends Application {
         resources.add(com.divudi.ws.institution.InstitutionApi.class);
         resources.add(com.divudi.ws.institution.SiteApi.class);
         resources.add(com.divudi.ws.inward.ApiInward.class);
+        resources.add(com.divudi.ws.inward.InwardDiscountMatrixApi.class);
+        resources.add(com.divudi.ws.inward.InwardRoomApi.class);
+        resources.add(com.divudi.ws.inward.InwardRoomCategoryApi.class);
+        resources.add(com.divudi.ws.inward.InwardRoomFacilityChargeApi.class);
         resources.add(com.divudi.ws.lims.Lims.class);
         resources.add(com.divudi.ws.lims.LimsMiddlewareController.class);
         resources.add(com.divudi.ws.lims.MiddlewareController.class);

--- a/src/main/resources/META-INF/persistence.xml
+++ b/src/main/resources/META-INF/persistence.xml
@@ -2,7 +2,7 @@
 <persistence version="2.2" xmlns="http://java.sun.com/xml/ns/persistence" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/persistence http://xmlns.jcp.org/xml/ns/persistence/persistence_2_2.xsd">
     <persistence-unit name="hmisPU" transaction-type="JTA">
         <provider>org.eclipse.persistence.jpa.PersistenceProvider</provider>
-        <jta-data-source>${JDBC_DATASOURCE}</jta-data-source>
+        <jta-data-source>jdbc/coop</jta-data-source>
         <exclude-unlisted-classes>false</exclude-unlisted-classes>
         <properties>
             <property name="eclipselink.logging.level.sql" value="SEVERE"/>
@@ -51,7 +51,7 @@
         </properties>
     </persistence-unit>
     <persistence-unit name="hmisAuditPU" transaction-type="JTA">
-        <jta-data-source>${JDBC_AUDIT_DATASOURCE}</jta-data-source>
+        <jta-data-source>jdbc/rhAuditDS</jta-data-source>
         <exclude-unlisted-classes>false</exclude-unlisted-classes>
         <properties>
             <property name="eclipselink.logging.level.sql" value="SEVERE"/>

--- a/src/main/resources/META-INF/persistence.xml
+++ b/src/main/resources/META-INF/persistence.xml
@@ -2,7 +2,7 @@
 <persistence version="2.2" xmlns="http://java.sun.com/xml/ns/persistence" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/persistence http://xmlns.jcp.org/xml/ns/persistence/persistence_2_2.xsd">
     <persistence-unit name="hmisPU" transaction-type="JTA">
         <provider>org.eclipse.persistence.jpa.PersistenceProvider</provider>
-        <jta-data-source>jdbc/coop</jta-data-source>
+        <jta-data-source>${JDBC_DATASOURCE}</jta-data-source>
         <exclude-unlisted-classes>false</exclude-unlisted-classes>
         <properties>
             <property name="eclipselink.logging.level.sql" value="SEVERE"/>
@@ -51,7 +51,7 @@
         </properties>
     </persistence-unit>
     <persistence-unit name="hmisAuditPU" transaction-type="JTA">
-        <jta-data-source>jdbc/rhAuditDS</jta-data-source>
+        <jta-data-source>${JDBC_AUDIT_DATASOURCE}</jta-data-source>
         <exclude-unlisted-classes>false</exclude-unlisted-classes>
         <properties>
             <property name="eclipselink.logging.level.sql" value="SEVERE"/>

--- a/src/main/webapp/dataAdmin/admin_functions.xhtml
+++ b/src/main/webapp/dataAdmin/admin_functions.xhtml
@@ -1067,6 +1067,46 @@
                             </table>
                         </p:tab>
 
+                        <p:tab id="tabCashierShifts" title="Cashier / Shifts">
+                            <table class="table table-sm table-bordered w-100">
+                                <thead class="table-light">
+                                    <tr>
+                                        <th style="width: 15%;">Name</th>
+                                        <th style="width: 30%;">Description</th>
+                                        <th style="width: 10%;">Action</th>
+                                        <th style="width: 45%;">Output</th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    <tr>
+                                        <td><strong>Mark Stale Handover Bills Completed</strong></td>
+                                        <td>
+                                            Finds all Shift Handover Create bills that are not yet marked as completed
+                                            but whose shift start bill is already closed (completed = true). These are
+                                            orphaned records from shifts that ended without the recipient accepting the
+                                            handover through the system. Marking them completed removes the false
+                                            "handover awaiting acceptance" block on shift end.
+                                        </td>
+                                        <td>
+                                            <p:commandButton
+                                                id="btnMarkStaleHandoverBills"
+                                                action="#{dataAdministrationController.markStaleHandoverCreateBillsAsCompleted()}"
+                                                ajax="true"
+                                                update="@form"
+                                                value="Mark Completed"
+                                                styleClass="ui-button-warning m-1"
+                                                icon="pi pi-check-circle"
+                                                rendered="#{webUserController.hasPrivilege('Admin')}"
+                                                onclick="return confirm('This will mark all stale handover create bills (from already-closed shifts) as completed. Continue?');" />
+                                        </td>
+                                        <td>
+                                            #{dataAdministrationController.executionFeedback}
+                                        </td>
+                                    </tr>
+                                </tbody>
+                            </table>
+                        </p:tab>
+
                     </p:accordionPanel>
                 </h:form>
 


### PR DESCRIPTION
## Summary

- **Root cause**: `hasAtLeastOneHandoverBillToReceive()` was finding `FUND_SHIFT_HANDOVER_CREATE` bills from *already-closed* shifts (no shift-scope filter), causing a false \"handover awaiting acceptance\" block when a user tried to end their current shift.
- **Code fix** (`FinancialTransactionController.java`): Added `and (s.referenceBill is null or s.referenceBill.completed = false or s.referenceBill.completed is null)` to the JPQL in `hasAtLeastOneToReceived()` — handover create bills whose shift start bill is already completed are now excluded from all pending-handover checks.
- **Admin data fix** (`DataAdministrationController.java`): New method `markStaleHandoverCreateBillsAsCompleted()` backfills the 1,537 existing stale records in production (handover create bills with `completed=false` referencing a closed shift start bill).
- **UI** (`admin_functions.xhtml`): New \"Cashier / Shifts\" accordion tab with an Admin-only button to invoke the backfill.

## Test plan

- [ ] Deploy and open Admin Functions → Cashier / Shifts → click \"Mark Completed\" — confirm output reports the expected count of stale bills marked.
- [ ] Verify affected cashier (Jayarathna) can now end their shift without the false validation error.
- [ ] Confirm a cashier with a *genuinely* pending handover (recipient has not accepted, current shift is still open) is still correctly blocked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Refined handover matching so completed reference bills no longer count toward pending handovers.

* **New Features**
  * Admin UI: action to locate and mark stale shift handover bills as completed (admin-only, shows feedback).
  * Added several new REST endpoints to the API surface.

* **Documentation**
  * Strengthened PR review workflow guidance and added a post-fix verification note for generated code.

* **Chores**
  * Updated persistence datasource configuration names.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->