### PR TITLE
Add PharmacyService methods accepting custom List<BillTypeAtomic> (F15 drill-down L1 prep)

### DIFF
--- a/src/main/java/com/divudi/ejb/PharmacyService.java
+++ b/src/main/java/com/divudi/ejb/PharmacyService.java
@@ -357,6 +357,29 @@ public class PharmacyService {
         return bundle;
     }
 
+    /**
+     * F15 drill-down (Level 1) variant of fetchPharmacyIncomeByBillTypeAndDiscountTypeAndAdmissionTypeDto.
+     * Accepts a caller-supplied list of BillTypeAtomic so Level 1 can summarise a user-chosen
+     * subset of sales atomics without affecting F15. Falls back to getPharmacyIncomeBillTypes()
+     * when the list is null or empty. F15 itself does NOT call this method.
+     */
+    public PharmacyBundle fetchPharmacyIncomeByBillTypeAndDiscountTypeAndAdmissionTypeDtoForAtomics(Date fromDate, Date toDate, Institution institution, Institution site, Department department, WebUser webUser, AdmissionType admissionType, PaymentScheme paymentScheme, List<BillTypeAtomic> billTypeAtomics) {
+
+        PharmacyBundle bundle;
+
+        List<BillTypeAtomic> effectiveAtomics = (billTypeAtomics == null || billTypeAtomics.isEmpty())
+                ? getPharmacyIncomeBillTypes()
+                : billTypeAtomics;
+
+        List<BillLight> pharmacyIncomeBillLights = billService.fetchBillLightsWithFinanceDetailsAndPaymentScheme(fromDate, toDate, institution, site, department, webUser, effectiveAtomics, admissionType, paymentScheme);
+
+        bundle = new PharmacyBundle(pharmacyIncomeBillLights);
+
+        bundle.generatePaymentDetailsGroupedByBillTypeAndDiscountSchemeAndAdmissionTypeDto();
+
+        return bundle;
+    }
+
     public PharmacyBundle fetchPharmacyStockPurchaseValueByBillType(Date fromDate, Date toDate, Institution institution, Institution site, Department department, WebUser webUser, AdmissionType admissionType, PaymentScheme paymentScheme) {
         PharmacyBundle bundle;
         List<BillTypeAtomic> billTypeAtomics = getPharmacyPurchaseBillTypes();
@@ -388,6 +411,23 @@ public class PharmacyService {
         return bundle;
     }
 
+    /**
+     * F15 drill-down (Level 1) variant of fetchPharmacyStockPurchaseValueByBillTypeDtoCompleted.
+     * Accepts a caller-supplied list of BillTypeAtomic so Level 1 can summarise a user-chosen
+     * subset of purchase atomics without affecting F15. Falls back to getPharmacyPurchaseBillTypes()
+     * when the list is null or empty. F15 itself does NOT call this method.
+     */
+    public PharmacyBundle fetchPharmacyStockPurchaseValueByBillTypeDtoCompletedForAtomics(Date fromDate, Date toDate, Institution institution, Institution site, Department department, WebUser webUser, AdmissionType admissionType, PaymentScheme paymentScheme, List<BillTypeAtomic> billTypeAtomics) {
+        PharmacyBundle bundle;
+        List<BillTypeAtomic> effectiveAtomics = (billTypeAtomics == null || billTypeAtomics.isEmpty())
+                ? getPharmacyPurchaseBillTypes()
+                : billTypeAtomics;
+        List<BillLight> pharmacyIncomeBillLights = billService.fetchBillLightsWithFinanceDetailsCompleted(fromDate, toDate, institution, site, department, webUser, effectiveAtomics, admissionType, paymentScheme);
+        bundle = new PharmacyBundle(pharmacyIncomeBillLights);
+        bundle.generatePharmacyPurchaseGroupedByBillTypeDtos();
+        return bundle;
+    }
+
     public PharmacyBundle fetchPharmacyTransferValueByBillType(Date fromDate, Date toDate, Institution institution, Institution site, Department department, WebUser webUser, AdmissionType admissionType, PaymentScheme paymentScheme) {
         PharmacyBundle bundle;
         List<BillTypeAtomic> billTypeAtomics = getPharmacyInternalTransferBillTypes();
@@ -401,6 +441,24 @@ public class PharmacyService {
         PharmacyBundle bundle;
         List<BillTypeAtomic> billTypeAtomics = getPharmacyInternalTransferBillTypes();
         List<BillLight> pharmacyIncomeBillLights = billService.fetchBillLightsWithFinanceDetails(fromDate, toDate, institution, site, department, webUser, billTypeAtomics, admissionType, paymentScheme);
+        bundle = new PharmacyBundle(pharmacyIncomeBillLights);
+        bundle.generatePharmacyPurchaseGroupedByBillTypeDtos();
+        return bundle;
+    }
+
+    /**
+     * F15 drill-down (Level 1) variant of fetchPharmacyTransferValueByBillTypeDto.
+     * Accepts a caller-supplied list of BillTypeAtomic so Level 1 can summarise a user-chosen
+     * subset of transfer atomics without affecting F15. Falls back to
+     * getPharmacyInternalTransferBillTypes() when the list is null or empty.
+     * F15 itself does NOT call this method.
+     */
+    public PharmacyBundle fetchPharmacyTransferValueByBillTypeDtoForAtomics(Date fromDate, Date toDate, Institution institution, Institution site, Department department, WebUser webUser, AdmissionType admissionType, PaymentScheme paymentScheme, List<BillTypeAtomic> billTypeAtomics) {
+        PharmacyBundle bundle;
+        List<BillTypeAtomic> effectiveAtomics = (billTypeAtomics == null || billTypeAtomics.isEmpty())
+                ? getPharmacyInternalTransferBillTypes()
+                : billTypeAtomics;
+        List<BillLight> pharmacyIncomeBillLights = billService.fetchBillLightsWithFinanceDetails(fromDate, toDate, institution, site, department, webUser, effectiveAtomics, admissionType, paymentScheme);
         bundle = new PharmacyBundle(pharmacyIncomeBillLights);
         bundle.generatePharmacyPurchaseGroupedByBillTypeDtos();
         return bundle;
@@ -421,6 +479,26 @@ public class PharmacyService {
         // Use the adjustment-specific fetch that prefers bfd.grossTotal/netTotal over bill.total/netTotal
         // because some adjustment bills (e.g. retail rate adjustment) have bill.total=0 but correct BFD values
         List<BillLight> pharmacyIncomeBillLights = billService.fetchBillLightsForAdjustmentsWithFinanceDetails(fromDate, toDate, institution, site, department, webUser, billTypeAtomics, admissionType, paymentScheme);
+        bundle = new PharmacyBundle(pharmacyIncomeBillLights);
+        bundle.generatePharmacyPurchaseGroupedByBillTypeDtos();
+        return bundle;
+    }
+
+    /**
+     * F15 drill-down (Level 1) variant of fetchPharmacyAdjustmentValueByBillTypeDto.
+     * Accepts a caller-supplied list of BillTypeAtomic so Level 1 can summarise a user-chosen
+     * subset of adjustment atomics without affecting F15. Falls back to
+     * getPharmacyAdjustmentBillTypes() when the list is null or empty.
+     * F15 itself does NOT call this method.
+     */
+    public PharmacyBundle fetchPharmacyAdjustmentValueByBillTypeDtoForAtomics(Date fromDate, Date toDate, Institution institution, Institution site, Department department, WebUser webUser, AdmissionType admissionType, PaymentScheme paymentScheme, List<BillTypeAtomic> billTypeAtomics) {
+        PharmacyBundle bundle;
+        List<BillTypeAtomic> effectiveAtomics = (billTypeAtomics == null || billTypeAtomics.isEmpty())
+                ? getPharmacyAdjustmentBillTypes()
+                : billTypeAtomics;
+        // Use the adjustment-specific fetch that prefers bfd.grossTotal/netTotal over bill.total/netTotal
+        // because some adjustment bills (e.g. retail rate adjustment) have bill.total=0 but correct BFD values
+        List<BillLight> pharmacyIncomeBillLights = billService.fetchBillLightsForAdjustmentsWithFinanceDetails(fromDate, toDate, institution, site, department, webUser, effectiveAtomics, admissionType, paymentScheme);
         bundle = new PharmacyBundle(pharmacyIncomeBillLights);
         bundle.generatePharmacyPurchaseGroupedByBillTypeDtos();
         return bundle;


### PR DESCRIPTION
## Summary

Adds four new methods in `PharmacyService` that accept a caller-supplied `List<BillTypeAtomic>`, enabling the upcoming **F15 drill-down (Level 1)** date-range summary (parent epic #20236) to pull the same data shape as F15 but for a user-chosen subset of atomics.

New methods:
- `fetchPharmacyIncomeByBillTypeAndDiscountTypeAndAdmissionTypeDtoForAtomics` (Sales)
- `fetchPharmacyStockPurchaseValueByBillTypeDtoCompletedForAtomics` (Purchases)
- `fetchPharmacyTransferValueByBillTypeDtoForAtomics` (Transfers)
- `fetchPharmacyAdjustmentValueByBillTypeDtoForAtomics` (Adjustments)

## Design choices

- **Separately named methods, not overloads.** Per discussion, the existing F15 methods are the most critical report path and must remain byte-for-byte untouched. Diff is purely additive (`+78, -0`).
- **Defensive fallback.** Each new method falls back to its corresponding hardcoded `getPharmacy*BillTypes()` getter when the supplied `billTypeAtomics` is `null` or empty.
- **Sales grouping preserved.** The Sales variant still calls `generatePaymentDetailsGroupedByBillTypeAndDiscountSchemeAndAdmissionTypeDto()` so totals tie back to F15 (BillTypeAtomic + AdmissionType + PaymentScheme grouping). The other three call `generatePharmacyPurchaseGroupedByBillTypeDtos()` exactly as today.
- **No `BillService` query changes.** Only the atomic list passes through.

## Acceptance criteria (from #20237)

- [x] F15 produces identical numbers before and after this change — existing F15 methods untouched.
- [x] New methods are public and callable from the upcoming Level 1 controller.
- [x] No changes to `BillService` queries — only the atomic list passes through.

## Test plan

- [ ] Run F15 (`pharmacy/reports/summary_reports/daily_stock_values_report_optimized.xhtml`) for a known date and confirm Opening / Closing / Sales / Purchases / Transfers / Adjustments numbers are identical to a baseline run on `development`.
- [ ] Smoke-build / smoke-deploy verifies the new method signatures compile.
- Functional testing of the new methods will land with the Level 1 controller (#20238).

Closes #20237
Parent: #20236

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced pharmacy income reporting with customizable bill-type filtering and analysis.
  * Added detailed stock purchase tracking with bill-type categorization capabilities.
  * Introduced pharmacy transfer value reporting with granular bill-type filtering.
  * Added adjustment tracking with bill-type-based breakdown and analysis.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->