### PR TITLE
F15 drill-down: F15 → Level 1 navigation (section buttons + per-atomic icons)

### DIFF
--- a/src/main/java/com/divudi/bean/pharmacy/PharmacyDailyStockReportOptimizedController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacyDailyStockReportOptimizedController.java
@@ -3,6 +3,8 @@ package com.divudi.bean.pharmacy;
 import com.divudi.bean.common.*;
 import com.divudi.core.util.JsfUtil;
 import com.divudi.ejb.PharmacyBean;
+import com.divudi.core.data.BillTypeAtomic;
+import com.divudi.core.data.PharmacyRow;
 import com.divudi.core.entity.Department;
 import com.divudi.core.entity.Institution;
 import com.divudi.core.facade.StockHistoryFacade;
@@ -15,8 +17,11 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.io.Serializable;
 import java.text.SimpleDateFormat;
+import java.util.Arrays;
 import java.util.Calendar;
+import java.util.Collections;
 import java.util.Date;
+import java.util.List;
 import javax.ejb.EJB;
 import javax.enterprise.context.SessionScoped;
 import javax.faces.context.FacesContext;
@@ -58,6 +63,8 @@ public class PharmacyDailyStockReportOptimizedController implements Serializable
     private InstitutionController institutionController;
     @Inject
     private DepartmentController departmentController;
+    @Inject
+    private PharmacyDailyStockDrillDownLevel1Controller drillDownLevel1Controller;
 
     // Filter properties
     private Date fromDate;
@@ -84,6 +91,56 @@ public class PharmacyDailyStockReportOptimizedController implements Serializable
             department = sessionController.getDepartment();
         }
         return "/pharmacy/reports/summary_reports/daily_stock_values_report_optimized?faces-redirect=true";
+    }
+
+    /**
+     * F15 → Level 1 drill-down: section-level entry. Opens Level 1 with the
+     * given transaction type pre-selected and ALL of its atomics ticked.
+     * Single-day range = F15's selected date.
+     *
+     * Issue #20239.
+     */
+    public String drillDownAllForSection(String typeName) {
+        PharmacyDailyStockDrillDownLevel1Controller.TransactionType type =
+                PharmacyDailyStockDrillDownLevel1Controller.TransactionType.valueOf(typeName);
+        return drillDownLevel1Controller.navigateToLevel1FromF15(
+                fromDate, fromDate, institution, site, department, type, atomicsForType(type));
+    }
+
+    /**
+     * F15 → Level 1 drill-down: per-atomic entry. Opens Level 1 with the
+     * given transaction type pre-selected and only the row's BillTypeAtomic
+     * ticked. Falls back to all atomics for the section if the row's atomic
+     * is null. Single-day range = F15's selected date.
+     *
+     * Issue #20239.
+     */
+    public String drillDownSingleAtomic(String typeName, PharmacyRow row) {
+        PharmacyDailyStockDrillDownLevel1Controller.TransactionType type =
+                PharmacyDailyStockDrillDownLevel1Controller.TransactionType.valueOf(typeName);
+        List<BillTypeAtomic> atomics = (row != null && row.getBillTypeAtomic() != null)
+                ? Arrays.asList(row.getBillTypeAtomic())
+                : atomicsForType(type);
+        return drillDownLevel1Controller.navigateToLevel1FromF15(
+                fromDate, fromDate, institution, site, department, type, atomics);
+    }
+
+    private List<BillTypeAtomic> atomicsForType(PharmacyDailyStockDrillDownLevel1Controller.TransactionType type) {
+        if (type == null) {
+            return Collections.emptyList();
+        }
+        switch (type) {
+            case SALES:
+                return pharmacyService.getPharmacyIncomeBillTypes();
+            case PURCHASES:
+                return pharmacyService.getPharmacyPurchaseBillTypes();
+            case TRANSFERS:
+                return pharmacyService.getPharmacyInternalTransferBillTypes();
+            case ADJUSTMENTS:
+                return pharmacyService.getPharmacyAdjustmentBillTypes();
+            default:
+                return Collections.emptyList();
+        }
     }
 
     /**

--- a/src/main/webapp/pharmacy/reports/summary_reports/daily_stock_values_report_optimized.xhtml
+++ b/src/main/webapp/pharmacy/reports/summary_reports/daily_stock_values_report_optimized.xhtml
@@ -309,9 +309,18 @@
 
                                     <!-- Sales Section Card -->
                                     <div class="card mb-3">
-                                        <div class="card-header bg-success text-white">
-                                            <h:outputText value="&#xf788;" styleClass="fas me-2" /> <!-- fa-cash-register icon -->
-                                            <h:outputText value="Sales Transactions" styleClass="fw-bold"/>
+                                        <div class="card-header bg-success text-white d-flex justify-content-between align-items-center">
+                                            <span>
+                                                <h:outputText value="&#xf788;" styleClass="fas me-2" /> <!-- fa-cash-register icon -->
+                                                <h:outputText value="Sales Transactions" styleClass="fw-bold"/>
+                                            </span>
+                                            <p:commandButton
+                                                value="Drill Down"
+                                                icon="fa fa-search-plus"
+                                                ajax="false"
+                                                styleClass="ui-button-info ui-button-sm"
+                                                action="#{pharmacyDailyStockReportOptimizedController.drillDownAllForSection('SALES')}"
+                                                title="Drill down to Level 1 with all sales atomics ticked"/>
                                         </div>
                                         <div class="card-body p-0">
                                             <table class="table table-sm table-hover mb-0">
@@ -325,6 +334,7 @@
                                                         <th class="text-end value-column">Stock Value (Cost)</th>
                                                         <th class="text-end value-column">Stock Value (Purchase)</th>
                                                         <th class="text-end value-column">Stock Value (Retail)</th>
+                                                        <th class="text-center" style="width: 60px;">Drill</th>
                                                     </tr>
                                                 </thead>
                                                 <tbody>
@@ -368,6 +378,14 @@
                                                                     <f:convertNumber pattern="#,##0.00"/>
                                                                 </h:outputText>
                                                             </td>
+                                                            <td class="text-center" style="width: 60px;">
+                                                                <p:commandLink
+                                                                    action="#{pharmacyDailyStockReportOptimizedController.drillDownSingleAtomic('SALES', sale)}"
+                                                                    title="Drill down to Level 1 for this atomic only"
+                                                                    ajax="false">
+                                                                    <h:outputText styleClass="fa fa-search-plus"/>
+                                                                </p:commandLink>
+                                                            </td>
                                                         </tr>
                                                     </ui:repeat>
                                                 </tbody>
@@ -409,6 +427,7 @@
                                                                 <f:convertNumber pattern="#,##0.00"/>
                                                             </h:outputText>
                                                         </td>
+                                                        <td class="text-center" style="width: 60px;"></td>
                                                     </tr>
                                                 </tfoot>
                                             </table>
@@ -417,9 +436,18 @@
 
                                     <!-- Purchases Section Card -->
                                     <div class="card mb-3">
-                                        <div class="card-header bg-warning text-dark">
-                                            <h:outputText value="&#xf07a;" styleClass="fas me-2" /> <!-- fa-shopping-cart icon -->
-                                            <h:outputText value="Purchase Transactions" styleClass="fw-bold"/>
+                                        <div class="card-header bg-warning text-dark d-flex justify-content-between align-items-center">
+                                            <span>
+                                                <h:outputText value="&#xf07a;" styleClass="fas me-2" /> <!-- fa-shopping-cart icon -->
+                                                <h:outputText value="Purchase Transactions" styleClass="fw-bold"/>
+                                            </span>
+                                            <p:commandButton
+                                                value="Drill Down"
+                                                icon="fa fa-search-plus"
+                                                ajax="false"
+                                                styleClass="ui-button-info ui-button-sm"
+                                                action="#{pharmacyDailyStockReportOptimizedController.drillDownAllForSection('PURCHASES')}"
+                                                title="Drill down to Level 1 with all purchase atomics ticked"/>
                                         </div>
                                         <div class="card-body p-0">
                                             <table class="table table-sm table-hover mb-0">
@@ -433,6 +461,7 @@
                                                         <th class="text-end value-column">Stock Value (Cost)</th>
                                                         <th class="text-end value-column">Stock Value (Purchase)</th>
                                                         <th class="text-end value-column">Stock Value (Retail)</th>
+                                                        <th class="text-center" style="width: 60px;">Drill</th>
                                                     </tr>
                                                 </thead>
                                                 <tbody>
@@ -476,6 +505,14 @@
                                                                     <f:convertNumber pattern="#,##0.00"/>
                                                                 </h:outputText>
                                                             </td>
+                                                            <td class="text-center" style="width: 60px;">
+                                                                <p:commandLink
+                                                                    action="#{pharmacyDailyStockReportOptimizedController.drillDownSingleAtomic('PURCHASES', purchase)}"
+                                                                    title="Drill down to Level 1 for this atomic only"
+                                                                    ajax="false">
+                                                                    <h:outputText styleClass="fa fa-search-plus"/>
+                                                                </p:commandLink>
+                                                            </td>
                                                         </tr>
                                                     </ui:repeat>
                                                 </tbody>
@@ -517,6 +554,7 @@
                                                                 <f:convertNumber pattern="#,##0.00"/>
                                                             </h:outputText>
                                                         </td>
+                                                        <td class="text-center" style="width: 60px;"></td>
                                                     </tr>
                                                 </tfoot>
                                             </table>
@@ -525,9 +563,18 @@
 
                                     <!-- Transfers Section Card -->
                                     <div class="card mb-3">
-                                        <div class="card-header bg-info text-white">
-                                            <h:outputText value="&#xf362;" styleClass="fas me-2" /> <!-- fa-exchange-alt icon -->
-                                            <h:outputText value="Transfer Transactions" styleClass="fw-bold"/>
+                                        <div class="card-header bg-info text-white d-flex justify-content-between align-items-center">
+                                            <span>
+                                                <h:outputText value="&#xf362;" styleClass="fas me-2" /> <!-- fa-exchange-alt icon -->
+                                                <h:outputText value="Transfer Transactions" styleClass="fw-bold"/>
+                                            </span>
+                                            <p:commandButton
+                                                value="Drill Down"
+                                                icon="fa fa-search-plus"
+                                                ajax="false"
+                                                styleClass="ui-button-info ui-button-sm"
+                                                action="#{pharmacyDailyStockReportOptimizedController.drillDownAllForSection('TRANSFERS')}"
+                                                title="Drill down to Level 1 with all transfer atomics ticked"/>
                                         </div>
                                         <div class="card-body p-0">
                                             <table class="table table-sm table-hover mb-0">
@@ -541,6 +588,7 @@
                                                         <th class="text-end value-column">Stock Value (Cost)</th>
                                                         <th class="text-end value-column">Stock Value (Purchase)</th>
                                                         <th class="text-end value-column">Stock Value (Retail)</th>
+                                                        <th class="text-center" style="width: 60px;">Drill</th>
                                                     </tr>
                                                 </thead>
                                                 <tbody>
@@ -584,6 +632,14 @@
                                                                     <f:convertNumber pattern="#,##0.00"/>
                                                                 </h:outputText>
                                                             </td>
+                                                            <td class="text-center" style="width: 60px;">
+                                                                <p:commandLink
+                                                                    action="#{pharmacyDailyStockReportOptimizedController.drillDownSingleAtomic('TRANSFERS', transfer)}"
+                                                                    title="Drill down to Level 1 for this atomic only"
+                                                                    ajax="false">
+                                                                    <h:outputText styleClass="fa fa-search-plus"/>
+                                                                </p:commandLink>
+                                                            </td>
                                                         </tr>
                                                     </ui:repeat>
                                                 </tbody>
@@ -625,6 +681,7 @@
                                                                 <f:convertNumber pattern="#,##0.00"/>
                                                             </h:outputText>
                                                         </td>
+                                                        <td class="text-center" style="width: 60px;"></td>
                                                     </tr>
                                                 </tfoot>
                                             </table>
@@ -633,9 +690,18 @@
 
                                     <!-- Adjustments Section Card -->
                                     <div class="card mb-3">
-                                        <div class="card-header bg-danger text-white">
-                                            <h:outputText value="&#xf044;" styleClass="fas me-2" /> <!-- fa-edit icon -->
-                                            <h:outputText value="Adjustment Transactions" styleClass="fw-bold"/>
+                                        <div class="card-header bg-danger text-white d-flex justify-content-between align-items-center">
+                                            <span>
+                                                <h:outputText value="&#xf044;" styleClass="fas me-2" /> <!-- fa-edit icon -->
+                                                <h:outputText value="Adjustment Transactions" styleClass="fw-bold"/>
+                                            </span>
+                                            <p:commandButton
+                                                value="Drill Down"
+                                                icon="fa fa-search-plus"
+                                                ajax="false"
+                                                styleClass="ui-button-info ui-button-sm"
+                                                action="#{pharmacyDailyStockReportOptimizedController.drillDownAllForSection('ADJUSTMENTS')}"
+                                                title="Drill down to Level 1 with all adjustment atomics ticked"/>
                                         </div>
                                         <div class="card-body p-0">
                                             <table class="table table-sm table-hover mb-0">
@@ -649,6 +715,7 @@
                                                         <th class="text-end value-column">Stock Value (Cost)</th>
                                                         <th class="text-end value-column">Stock Value (Purchase)</th>
                                                         <th class="text-end value-column">Stock Value (Retail)</th>
+                                                        <th class="text-center" style="width: 60px;">Drill</th>
                                                     </tr>
                                                 </thead>
                                                 <tbody>
@@ -692,6 +759,14 @@
                                                                     <f:convertNumber pattern="#,##0.00"/>
                                                                 </h:outputText>
                                                             </td>
+                                                            <td class="text-center" style="width: 60px;">
+                                                                <p:commandLink
+                                                                    action="#{pharmacyDailyStockReportOptimizedController.drillDownSingleAtomic('ADJUSTMENTS', adjustment)}"
+                                                                    title="Drill down to Level 1 for this atomic only"
+                                                                    ajax="false">
+                                                                    <h:outputText styleClass="fa fa-search-plus"/>
+                                                                </p:commandLink>
+                                                            </td>
                                                         </tr>
                                                     </ui:repeat>
                                                 </tbody>
@@ -733,6 +808,7 @@
                                                                 <f:convertNumber pattern="#,##0.00"/>
                                                             </h:outputText>
                                                         </td>
+                                                        <td class="text-center" style="width: 60px;"></td>
                                                     </tr>
                                                 </tfoot>
                                             </table>


### PR DESCRIPTION
## Summary

Wires the F15 (Daily Stock Values) report to drill into the Level 1 page introduced in #20238 via two entry points (parent epic #20236).

## Entry points

1. **Section-level button** — small *Drill Down* button (icon `fa fa-search-plus`) on each of the four section card headers (Sales / Purchases / Transfers / Adjustments). Click opens Level 1 with:
   - Transaction-type radio set to that section
   - All atomics for that section ticked
   - From-date and to-date = F15's date (single-day range)
   - Institution / site / department copied from F15

2. **Per-atomic drill icon** — small icon in a new 9th column at the end of each row in every section table. Click opens Level 1 with:
   - Transaction-type radio set to that section
   - Only that row's `BillTypeAtomic` ticked (falls back to all atomics for the section if the row has no atomic)
   - Other filters as above

L1 immediately generates the report — already wired via `navigateToLevel1FromF15(...)` from #20238.

## Implementation notes

- F15 controller injects `PharmacyDailyStockDrillDownLevel1Controller` (session-scoped) and pushes its own state into it before redirecting.
- New methods on `PharmacyDailyStockReportOptimizedController`:
  - `drillDownAllForSection(String typeName)`
  - `drillDownSingleAtomic(String typeName, PharmacyRow row)`
  - `atomicsForType(...)` helper
- Section-button-only at the footer level — the section header button already covers the "all atomics for this section" case, so adding the same link to the footer would be redundant.
- Type names passed as `String` rather than enum literal to avoid EL/enum awkwardness in JSF expressions.

## Acceptance criteria (from #20239)

- [x] Buttons / icons render in line with the existing F15 visual style (Bootstrap utility classes + `ui-button-info ui-button-sm`).
- [x] Clicking either entry point lands on Level 1 with the correct preselection and immediately runnable filters (from/to dates filled, processReport already invoked).

## Out of scope

- Level 2 (bill list) — #20240
- L1 / L2 Excel + Print — #20242 / #20243 / #20244 / #20245

## Test plan

- [ ] Generate F15 for a known date and department.
- [ ] **Sales section header** *Drill Down* → L1 opens, radio = SALES, all sales atomics ticked, dates = F15 date, totals match Sales section.
- [ ] Click the per-row icon on any sales row → L1 opens with only that atomic ticked, totals = that single atomic on that day.
- [ ] Repeat the section + per-row check for **Purchases**, **Transfers**, **Adjustments**.
- [ ] *Back to F15* on L1 returns to F15 with its previous filters intact.
- [ ] F15 numbers themselves unchanged (regression — diff is purely additive on F15's data path).

Closes #20239
Parent: #20236

🤖 Generated with [Claude Code](https://claude.com/claude-code)