### PR TITLE
F15 drill-down: Level 2 page + controller (bill list)

### DIFF
--- a/src/main/java/com/divudi/bean/pharmacy/PharmacyDailyStockDrillDownLevel1Controller.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacyDailyStockDrillDownLevel1Controller.java
@@ -189,11 +189,24 @@ public class PharmacyDailyStockDrillDownLevel1Controller implements Serializable
         return "/pharmacy/reports/summary_reports/daily_stock_values_report_optimized?faces-redirect=true";
     }
 
+    @Inject
+    private PharmacyDailyStockDrillDownLevel2Controller drillDownLevel2Controller;
+
     /**
-     * Stub for Level 2 drill-down (issue #20240). Replaced when L2 lands.
+     * Drill from a Level 1 row into Level 2 (per-bill list) — issue #20240.
+     * Carries the L1 filters (date range, institution/site/department) plus the
+     * row's selection key (BillTypeAtomic, AdmissionType, PaymentScheme — the
+     * latter two only meaningful for SALES rows) into the L2 controller.
      */
-    public void drillToLevel2(PharmacyRow row) {
-        JsfUtil.addInfoMessage("Level 2 drill-down (bill list) is coming in a future update");
+    public String drillToLevel2(PharmacyRow row) {
+        if (row == null || row.getBillTypeAtomic() == null) {
+            JsfUtil.addErrorMessage("Cannot drill — row has no bill type");
+            return null;
+        }
+        return drillDownLevel2Controller.navigateToLevel2FromLevel1(
+                fromDate, toDate, institution, site, department,
+                transactionType, row.getBillTypeAtomic(),
+                row.getAdmissionType(), row.getPaymentScheme());
     }
 
     public Date getFromDate() {

--- a/src/main/java/com/divudi/bean/pharmacy/PharmacyDailyStockDrillDownLevel2Controller.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacyDailyStockDrillDownLevel2Controller.java
@@ -1,0 +1,286 @@
+package com.divudi.bean.pharmacy;
+
+import com.divudi.bean.pharmacy.PharmacyDailyStockDrillDownLevel1Controller.TransactionType;
+import com.divudi.core.data.BillTypeAtomic;
+import com.divudi.core.entity.Department;
+import com.divudi.core.entity.Institution;
+import com.divudi.core.entity.PaymentScheme;
+import com.divudi.core.entity.inward.AdmissionType;
+import com.divudi.core.light.common.BillLight;
+import com.divudi.core.util.CommonFunctions;
+import com.divudi.core.util.JsfUtil;
+import com.divudi.ejb.PharmacyService;
+
+import java.io.Serializable;
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.Date;
+import java.util.List;
+import javax.ejb.EJB;
+import javax.enterprise.context.SessionScoped;
+import javax.inject.Named;
+
+/**
+ * F15 drill-down Level 2 controller — lists the individual bills behind a single
+ * Level 1 row.
+ *
+ * For SALES rows the L1 grouping key is BillTypeAtomic + AdmissionType + PaymentScheme;
+ * for the other transaction types it is BillTypeAtomic only. Filters (date range,
+ * institution, site, department) are inherited from L1.
+ *
+ * Parent epic: #20236. This controller: #20240.
+ */
+@Named
+@SessionScoped
+public class PharmacyDailyStockDrillDownLevel2Controller implements Serializable {
+
+    @EJB
+    private PharmacyService pharmacyService;
+
+    private Date fromDate;
+    private Date toDate;
+    private Institution institution;
+    private Institution site;
+    private Department department;
+
+    private TransactionType transactionType;
+    private BillTypeAtomic billTypeAtomic;
+    private AdmissionType admissionType;
+    private PaymentScheme paymentScheme;
+
+    private List<BillLight> bills = new ArrayList<>();
+
+    private double totalGross;
+    private double totalDiscount;
+    private double totalServiceCharge;
+    private double totalNet;
+    private BigDecimal totalRetail = BigDecimal.ZERO;
+    private BigDecimal totalPurchase = BigDecimal.ZERO;
+    private BigDecimal totalCost = BigDecimal.ZERO;
+
+    public PharmacyDailyStockDrillDownLevel2Controller() {
+    }
+
+    /**
+     * Entry point invoked by Level 1's row-drill action. Copies the L1 row's
+     * filter context (date range, institution/site/department, transaction type
+     * and the row's selection key — atomic + admissionType + paymentScheme),
+     * runs the fetch, then redirects to the L2 page.
+     */
+    public String navigateToLevel2FromLevel1(Date fromDate, Date toDate,
+                                             Institution institution, Institution site, Department department,
+                                             TransactionType transactionType, BillTypeAtomic billTypeAtomic,
+                                             AdmissionType admissionType, PaymentScheme paymentScheme) {
+        this.fromDate = fromDate;
+        this.toDate = toDate;
+        this.institution = institution;
+        this.site = site;
+        this.department = department;
+        this.transactionType = transactionType;
+        this.billTypeAtomic = billTypeAtomic;
+        this.admissionType = admissionType;
+        this.paymentScheme = paymentScheme;
+        loadBills();
+        return "/pharmacy/reports/summary_reports/daily_stock_values_drill_down_level2?faces-redirect=true";
+    }
+
+    private void loadBills() {
+        bills = new ArrayList<>();
+        resetTotals();
+
+        if (transactionType == null || billTypeAtomic == null) {
+            JsfUtil.addErrorMessage("Missing transaction type or bill type — cannot load Level 2 bill list");
+            return;
+        }
+
+        Date startOfDay = CommonFunctions.getStartOfDay(fromDate);
+        Date endOfDay = CommonFunctions.getEndOfDay(toDate);
+
+        switch (transactionType) {
+            case SALES:
+                bills = pharmacyService.fetchPharmacyIncomeBillLightsForLevel2(
+                        startOfDay, endOfDay, institution, site, department, null,
+                        admissionType, paymentScheme, billTypeAtomic);
+                break;
+            case PURCHASES:
+                bills = pharmacyService.fetchPharmacyPurchaseBillLightsForLevel2(
+                        startOfDay, endOfDay, institution, site, department, null,
+                        admissionType, paymentScheme, billTypeAtomic);
+                break;
+            case TRANSFERS:
+                bills = pharmacyService.fetchPharmacyTransferBillLightsForLevel2(
+                        startOfDay, endOfDay, institution, site, department, null,
+                        admissionType, paymentScheme, billTypeAtomic);
+                break;
+            case ADJUSTMENTS:
+                bills = pharmacyService.fetchPharmacyAdjustmentBillLightsForLevel2(
+                        startOfDay, endOfDay, institution, site, department, null,
+                        admissionType, paymentScheme, billTypeAtomic);
+                break;
+        }
+
+        if (bills == null) {
+            bills = new ArrayList<>();
+        }
+
+        // Sort bills oldest first by bill date (per #20240 acceptance criteria).
+        bills.sort(Comparator.comparing(
+                BillLight::getBillDate,
+                Comparator.nullsLast(Comparator.naturalOrder())));
+
+        computeTotals();
+    }
+
+    private void resetTotals() {
+        totalGross = 0;
+        totalDiscount = 0;
+        totalServiceCharge = 0;
+        totalNet = 0;
+        totalRetail = BigDecimal.ZERO;
+        totalPurchase = BigDecimal.ZERO;
+        totalCost = BigDecimal.ZERO;
+    }
+
+    private void computeTotals() {
+        for (BillLight b : bills) {
+            if (b.getTotal() != null) {
+                totalGross += b.getTotal();
+            }
+            if (b.getDiscount() != null) {
+                totalDiscount += b.getDiscount();
+            }
+            if (b.getServiceCharge() != null) {
+                totalServiceCharge += b.getServiceCharge();
+            }
+            if (b.getNetTotal() != null) {
+                totalNet += b.getNetTotal();
+            }
+            if (b.getTotalRetailSaleValue() != null) {
+                totalRetail = totalRetail.add(b.getTotalRetailSaleValue());
+            }
+            if (b.getTotalPurchaseValue() != null) {
+                totalPurchase = totalPurchase.add(b.getTotalPurchaseValue());
+            }
+            if (b.getTotalCostValue() != null) {
+                totalCost = totalCost.add(b.getTotalCostValue());
+            }
+        }
+    }
+
+    /**
+     * Back-to-Level-1 navigation. Level 1 is @SessionScoped so its previously
+     * selected filters persist automatically — no explicit hand-back needed.
+     */
+    public String navigateBackToLevel1() {
+        return "/pharmacy/reports/summary_reports/daily_stock_values_drill_down_level1?faces-redirect=true";
+    }
+
+    public Date getFromDate() {
+        return fromDate;
+    }
+
+    public void setFromDate(Date fromDate) {
+        this.fromDate = fromDate;
+    }
+
+    public Date getToDate() {
+        return toDate;
+    }
+
+    public void setToDate(Date toDate) {
+        this.toDate = toDate;
+    }
+
+    public Institution getInstitution() {
+        return institution;
+    }
+
+    public void setInstitution(Institution institution) {
+        this.institution = institution;
+    }
+
+    public Institution getSite() {
+        return site;
+    }
+
+    public void setSite(Institution site) {
+        this.site = site;
+    }
+
+    public Department getDepartment() {
+        return department;
+    }
+
+    public void setDepartment(Department department) {
+        this.department = department;
+    }
+
+    public TransactionType getTransactionType() {
+        return transactionType;
+    }
+
+    public void setTransactionType(TransactionType transactionType) {
+        this.transactionType = transactionType;
+    }
+
+    public BillTypeAtomic getBillTypeAtomic() {
+        return billTypeAtomic;
+    }
+
+    public void setBillTypeAtomic(BillTypeAtomic billTypeAtomic) {
+        this.billTypeAtomic = billTypeAtomic;
+    }
+
+    public AdmissionType getAdmissionType() {
+        return admissionType;
+    }
+
+    public void setAdmissionType(AdmissionType admissionType) {
+        this.admissionType = admissionType;
+    }
+
+    public PaymentScheme getPaymentScheme() {
+        return paymentScheme;
+    }
+
+    public void setPaymentScheme(PaymentScheme paymentScheme) {
+        this.paymentScheme = paymentScheme;
+    }
+
+    public List<BillLight> getBills() {
+        return bills;
+    }
+
+    public void setBills(List<BillLight> bills) {
+        this.bills = bills;
+    }
+
+    public double getTotalGross() {
+        return totalGross;
+    }
+
+    public double getTotalDiscount() {
+        return totalDiscount;
+    }
+
+    public double getTotalServiceCharge() {
+        return totalServiceCharge;
+    }
+
+    public double getTotalNet() {
+        return totalNet;
+    }
+
+    public BigDecimal getTotalRetail() {
+        return totalRetail;
+    }
+
+    public BigDecimal getTotalPurchase() {
+        return totalPurchase;
+    }
+
+    public BigDecimal getTotalCost() {
+        return totalCost;
+    }
+}

--- a/src/main/java/com/divudi/ejb/PharmacyService.java
+++ b/src/main/java/com/divudi/ejb/PharmacyService.java
@@ -504,6 +504,67 @@ public class PharmacyService {
         return bundle;
     }
 
+    /**
+     * F15 drill-down (Level 2) — fetch the individual sales BillLights behind a single
+     * Level 1 sales row. Returns the raw, ungrouped BillLight list so the L2 page can
+     * render one row per bill. AdmissionType + PaymentScheme are required because L1
+     * groups sales by BillTypeAtomic + AdmissionType + PaymentScheme.
+     * F15 itself does NOT call this method.
+     *
+     * Issue: #20240. Parent epic: #20236.
+     */
+    public List<BillLight> fetchPharmacyIncomeBillLightsForLevel2(Date fromDate, Date toDate, Institution institution, Institution site, Department department, WebUser webUser, AdmissionType admissionType, PaymentScheme paymentScheme, BillTypeAtomic billTypeAtomic) {
+        if (billTypeAtomic == null) {
+            return new ArrayList<>();
+        }
+        return billService.fetchBillLightsWithFinanceDetailsAndPaymentScheme(fromDate, toDate, institution, site, department, webUser, Arrays.asList(billTypeAtomic), admissionType, paymentScheme);
+    }
+
+    /**
+     * F15 drill-down (Level 2) — fetch the individual purchase BillLights behind a single
+     * Level 1 purchase row. Returns the raw, ungrouped BillLight list. Mirrors
+     * fetchPharmacyStockPurchaseValueByBillTypeDtoCompletedForAtomics so the L2 figures
+     * tally with L1 (completed bills only).
+     * F15 itself does NOT call this method.
+     *
+     * Issue: #20240. Parent epic: #20236.
+     */
+    public List<BillLight> fetchPharmacyPurchaseBillLightsForLevel2(Date fromDate, Date toDate, Institution institution, Institution site, Department department, WebUser webUser, AdmissionType admissionType, PaymentScheme paymentScheme, BillTypeAtomic billTypeAtomic) {
+        if (billTypeAtomic == null) {
+            return new ArrayList<>();
+        }
+        return billService.fetchBillLightsWithFinanceDetailsCompleted(fromDate, toDate, institution, site, department, webUser, Arrays.asList(billTypeAtomic), admissionType, paymentScheme);
+    }
+
+    /**
+     * F15 drill-down (Level 2) — fetch the individual transfer BillLights behind a single
+     * Level 1 transfer row. Returns the raw, ungrouped BillLight list.
+     * F15 itself does NOT call this method.
+     *
+     * Issue: #20240. Parent epic: #20236.
+     */
+    public List<BillLight> fetchPharmacyTransferBillLightsForLevel2(Date fromDate, Date toDate, Institution institution, Institution site, Department department, WebUser webUser, AdmissionType admissionType, PaymentScheme paymentScheme, BillTypeAtomic billTypeAtomic) {
+        if (billTypeAtomic == null) {
+            return new ArrayList<>();
+        }
+        return billService.fetchBillLightsWithFinanceDetails(fromDate, toDate, institution, site, department, webUser, Arrays.asList(billTypeAtomic), admissionType, paymentScheme);
+    }
+
+    /**
+     * F15 drill-down (Level 2) — fetch the individual adjustment BillLights behind a single
+     * Level 1 adjustment row. Returns the raw, ungrouped BillLight list. Uses the
+     * adjustment-specific fetch (BFD-aware) so the L2 figures tally with L1.
+     * F15 itself does NOT call this method.
+     *
+     * Issue: #20240. Parent epic: #20236.
+     */
+    public List<BillLight> fetchPharmacyAdjustmentBillLightsForLevel2(Date fromDate, Date toDate, Institution institution, Institution site, Department department, WebUser webUser, AdmissionType admissionType, PaymentScheme paymentScheme, BillTypeAtomic billTypeAtomic) {
+        if (billTypeAtomic == null) {
+            return new ArrayList<>();
+        }
+        return billService.fetchBillLightsForAdjustmentsWithFinanceDetails(fromDate, toDate, institution, site, department, webUser, Arrays.asList(billTypeAtomic), admissionType, paymentScheme);
+    }
+
     public List<BillTypeAtomic> getPharmacyIncomeBillTypes() {
         return Arrays.asList(
                 BillTypeAtomic.PHARMACY_RETAIL_SALE,

--- a/src/main/webapp/pharmacy/reports/summary_reports/daily_stock_values_drill_down_level1.xhtml
+++ b/src/main/webapp/pharmacy/reports/summary_reports/daily_stock_values_drill_down_level1.xhtml
@@ -219,8 +219,8 @@
                                                     <p:commandLink
                                                         value="#{row.rowType}"
                                                         action="#{pharmacyDailyStockDrillDownLevel1Controller.drillToLevel2(row)}"
-                                                        title="Drill down to bill list (coming soon)"
-                                                        update="@form"/>
+                                                        title="Drill down to bill list"
+                                                        ajax="false"/>
                                                 </td>
                                                 <td class="text-end value-column">
                                                     <h:outputText value="#{row.grossTotal}">

--- a/src/main/webapp/pharmacy/reports/summary_reports/daily_stock_values_drill_down_level2.xhtml
+++ b/src/main/webapp/pharmacy/reports/summary_reports/daily_stock_values_drill_down_level2.xhtml
@@ -1,0 +1,216 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
+      xmlns:h="http://xmlns.jcp.org/jsf/html"
+      xmlns:f="http://xmlns.jcp.org/jsf/core"
+      xmlns:p="http://primefaces.org/ui">
+
+    <h:body>
+        <ui:composition template="/pharmacy/pharmacy_analytics.xhtml">
+            <ui:define name="subcontent">
+
+                <style>
+                    .value-column {
+                        width: 110px;
+                        min-width: 110px;
+                        max-width: 110px;
+                    }
+                    .date-column {
+                        width: 160px;
+                        min-width: 160px;
+                    }
+                    .atomic-column {
+                        width: auto;
+                    }
+                </style>
+
+                <h:form id="drillDownLevel2Form">
+
+                    <!-- Header / Back button -->
+                    <div class="d-flex justify-content-between align-items-center mb-3">
+                        <h4 class="mb-0">F15 Drill-Down — Level 2 (Bill List)</h4>
+                        <p:commandButton
+                            value="Back to Level 1"
+                            icon="fa fa-arrow-left"
+                            ajax="false"
+                            styleClass="ui-button-secondary"
+                            action="#{pharmacyDailyStockDrillDownLevel2Controller.navigateBackToLevel1()}"/>
+                    </div>
+
+                    <!-- Selection Context -->
+                    <div class="card mb-4">
+                        <div class="card-header bg-info text-white">
+                            <h:outputText value="&#xf05a;" styleClass="fa me-2"/>
+                            <h:outputText value="Selection Context" styleClass="fw-bold"/>
+                        </div>
+                        <div class="card-body">
+                            <div class="row g-3">
+                                <div class="col-md-3">
+                                    <div class="fw-bold">Transaction Type</div>
+                                    <div><h:outputText value="#{pharmacyDailyStockDrillDownLevel2Controller.transactionType}"/></div>
+                                </div>
+                                <div class="col-md-3">
+                                    <div class="fw-bold">Bill Type</div>
+                                    <div><h:outputText value="#{pharmacyDailyStockDrillDownLevel2Controller.billTypeAtomic.label}"/></div>
+                                </div>
+                                <div class="col-md-3">
+                                    <div class="fw-bold">From — To</div>
+                                    <div>
+                                        <h:outputText value="#{pharmacyDailyStockDrillDownLevel2Controller.fromDate}">
+                                            <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateFormat}"/>
+                                        </h:outputText>
+                                        <h:outputText value=" — "/>
+                                        <h:outputText value="#{pharmacyDailyStockDrillDownLevel2Controller.toDate}">
+                                            <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateFormat}"/>
+                                        </h:outputText>
+                                    </div>
+                                </div>
+                                <div class="col-md-3">
+                                    <div class="fw-bold">Institution / Site / Department</div>
+                                    <div>
+                                        <h:outputText value="#{pharmacyDailyStockDrillDownLevel2Controller.institution.name}"/>
+                                        <h:outputText value=" / " rendered="#{pharmacyDailyStockDrillDownLevel2Controller.site != null}"/>
+                                        <h:outputText value="#{pharmacyDailyStockDrillDownLevel2Controller.site.name}"/>
+                                        <h:outputText value=" / " rendered="#{pharmacyDailyStockDrillDownLevel2Controller.department != null}"/>
+                                        <h:outputText value="#{pharmacyDailyStockDrillDownLevel2Controller.department.name}"/>
+                                    </div>
+                                </div>
+                                <h:panelGroup
+                                    layout="block"
+                                    styleClass="col-md-3"
+                                    rendered="#{pharmacyDailyStockDrillDownLevel2Controller.transactionType eq 'SALES'}">
+                                    <div class="fw-bold">Admission Type</div>
+                                    <div><h:outputText value="#{pharmacyDailyStockDrillDownLevel2Controller.admissionType.name}"/></div>
+                                </h:panelGroup>
+                                <h:panelGroup
+                                    layout="block"
+                                    styleClass="col-md-3"
+                                    rendered="#{pharmacyDailyStockDrillDownLevel2Controller.transactionType eq 'SALES'}">
+                                    <div class="fw-bold">Payment Scheme</div>
+                                    <div><h:outputText value="#{pharmacyDailyStockDrillDownLevel2Controller.paymentScheme.name}"/></div>
+                                </h:panelGroup>
+                            </div>
+                        </div>
+                    </div>
+
+                    <!-- Result Section -->
+                    <div class="card">
+                        <div class="card-header bg-success text-white fw-bold">
+                            <h:outputText value="Bills (#{pharmacyDailyStockDrillDownLevel2Controller.bills.size()})"/>
+                        </div>
+                        <div class="card-body p-0">
+                            <table class="table table-bordered table-hover mb-0">
+                                <thead class="bg-light">
+                                    <tr>
+                                        <th class="date-column">Date / Time</th>
+                                        <th class="atomic-column">Bill Type Atomic</th>
+                                        <th class="text-end value-column">Gross Total</th>
+                                        <th class="text-end value-column">Discount</th>
+                                        <th class="text-end value-column">Service Charge</th>
+                                        <th class="text-end value-column">Net Total</th>
+                                        <th class="text-end value-column">Retail Value</th>
+                                        <th class="text-end value-column">Purchase Value</th>
+                                        <th class="text-end value-column">Cost Value</th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    <ui:repeat value="#{pharmacyDailyStockDrillDownLevel2Controller.bills}" var="bill">
+                                        <tr>
+                                            <td class="date-column">
+                                                <h:outputText value="#{bill.billDate}">
+                                                    <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateTimeFormat}"/>
+                                                </h:outputText>
+                                            </td>
+                                            <td class="atomic-column">
+                                                <h:outputText value="#{bill.billTypeAtomic.label}"/>
+                                            </td>
+                                            <td class="text-end value-column">
+                                                <h:outputText value="#{bill.total}">
+                                                    <f:convertNumber pattern="#,##0.00"/>
+                                                </h:outputText>
+                                            </td>
+                                            <td class="text-end value-column">
+                                                <h:outputText value="#{bill.discount}">
+                                                    <f:convertNumber pattern="#,##0.00"/>
+                                                </h:outputText>
+                                            </td>
+                                            <td class="text-end value-column">
+                                                <h:outputText value="#{bill.serviceCharge}">
+                                                    <f:convertNumber pattern="#,##0.00"/>
+                                                </h:outputText>
+                                            </td>
+                                            <td class="text-end value-column">
+                                                <h:outputText value="#{bill.netTotal}">
+                                                    <f:convertNumber pattern="#,##0.00"/>
+                                                </h:outputText>
+                                            </td>
+                                            <td class="text-end value-column">
+                                                <h:outputText value="#{bill.totalRetailSaleValue}">
+                                                    <f:convertNumber pattern="#,##0.00"/>
+                                                </h:outputText>
+                                            </td>
+                                            <td class="text-end value-column">
+                                                <h:outputText value="#{bill.totalPurchaseValue}">
+                                                    <f:convertNumber pattern="#,##0.00"/>
+                                                </h:outputText>
+                                            </td>
+                                            <td class="text-end value-column">
+                                                <h:outputText value="#{bill.totalCostValue}">
+                                                    <f:convertNumber pattern="#,##0.00"/>
+                                                </h:outputText>
+                                            </td>
+                                        </tr>
+                                    </ui:repeat>
+                                </tbody>
+                                <tfoot class="bg-success text-white fw-bold">
+                                    <tr>
+                                        <td class="date-column">Total</td>
+                                        <td class="atomic-column"></td>
+                                        <td class="text-end value-column">
+                                            <h:outputText value="#{pharmacyDailyStockDrillDownLevel2Controller.totalGross}">
+                                                <f:convertNumber pattern="#,##0.00"/>
+                                            </h:outputText>
+                                        </td>
+                                        <td class="text-end value-column">
+                                            <h:outputText value="#{pharmacyDailyStockDrillDownLevel2Controller.totalDiscount}">
+                                                <f:convertNumber pattern="#,##0.00"/>
+                                            </h:outputText>
+                                        </td>
+                                        <td class="text-end value-column">
+                                            <h:outputText value="#{pharmacyDailyStockDrillDownLevel2Controller.totalServiceCharge}">
+                                                <f:convertNumber pattern="#,##0.00"/>
+                                            </h:outputText>
+                                        </td>
+                                        <td class="text-end value-column">
+                                            <h:outputText value="#{pharmacyDailyStockDrillDownLevel2Controller.totalNet}">
+                                                <f:convertNumber pattern="#,##0.00"/>
+                                            </h:outputText>
+                                        </td>
+                                        <td class="text-end value-column">
+                                            <h:outputText value="#{pharmacyDailyStockDrillDownLevel2Controller.totalRetail}">
+                                                <f:convertNumber pattern="#,##0.00"/>
+                                            </h:outputText>
+                                        </td>
+                                        <td class="text-end value-column">
+                                            <h:outputText value="#{pharmacyDailyStockDrillDownLevel2Controller.totalPurchase}">
+                                                <f:convertNumber pattern="#,##0.00"/>
+                                            </h:outputText>
+                                        </td>
+                                        <td class="text-end value-column">
+                                            <h:outputText value="#{pharmacyDailyStockDrillDownLevel2Controller.totalCost}">
+                                                <f:convertNumber pattern="#,##0.00"/>
+                                            </h:outputText>
+                                        </td>
+                                    </tr>
+                                </tfoot>
+                            </table>
+                        </div>
+                    </div>
+
+                </h:form>
+
+            </ui:define>
+        </ui:composition>
+    </h:body>
+</html>


### PR DESCRIPTION
## Summary

Adds the Level 2 drill-down page — the per-bill list that appears when a Level 1 row is clicked. Closes the third sub-issue of epic #20236.

- New page `/pharmacy/reports/summary_reports/daily_stock_values_drill_down_level2.xhtml` with the 9 columns from the spec (Date/Time, Bill Type Atomic, Gross, Discount, Service Charge, Net, Retail, Purchase, Cost) plus a totals footer.
- New `@SessionScoped` controller `PharmacyDailyStockDrillDownLevel2Controller`. Carries L1 filters (date range, institution/site/department) plus the row's selection key (BillTypeAtomic + AdmissionType + PaymentScheme for SALES; BillTypeAtomic only for the others).
- Bills are sorted by bill date ascending.
- Row click is intentionally non-clickable for now — the row → bill view wire-up is a separate sub-issue (#20241).
- Back-to-Level-1 navigates to L1; L1 is `@SessionScoped` so its filters and result set persist automatically (same pattern as L1 → F15).
- L1's existing `drillToLevel2(PharmacyRow)` stub is now wired to actually navigate to L2.
- 4 new pure-additive methods on `PharmacyService` (`fetchPharmacy*BillLightsForLevel2`) return raw, ungrouped `BillLight` lists per transaction type. F15 does NOT call these — additive only.

## Test plan

- [ ] Open F15 → click any section's "Drill Down" → arrive at L1.
- [ ] Click any L1 row → arrive at L2 with the matching bill list.
- [ ] Verify L2 totals across the 9 numeric columns equal the L1 row's totals.
- [ ] For a SALES L1 row: confirm the L2 list contains only bills matching that BillTypeAtomic + AdmissionType + PaymentScheme.
- [ ] For a PURCHASES / TRANSFERS / ADJUSTMENTS L1 row: confirm the list contains only bills with that BillTypeAtomic.
- [ ] Click "Back to Level 1" → L1 still shows the previous filters and bundle.
- [ ] Confirm F15 itself is unaffected (existing methods byte-for-byte unchanged).

Closes #20240

🤖 Generated with [Claude Code](https://claude.com/claude-code)