### PR TITLE
F15 drill-down: Wire Level 2 row click to existing bill view

### DIFF
--- a/src/main/java/com/divudi/bean/pharmacy/PharmacyDailyStockDrillDownLevel2Controller.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacyDailyStockDrillDownLevel2Controller.java
@@ -1,5 +1,6 @@
 package com.divudi.bean.pharmacy;
 
+import com.divudi.bean.common.BillSearch;
 import com.divudi.bean.pharmacy.PharmacyDailyStockDrillDownLevel1Controller.TransactionType;
 import com.divudi.core.data.BillTypeAtomic;
 import com.divudi.core.entity.Department;
@@ -19,6 +20,7 @@ import java.util.Date;
 import java.util.List;
 import javax.ejb.EJB;
 import javax.enterprise.context.SessionScoped;
+import javax.inject.Inject;
 import javax.inject.Named;
 
 /**
@@ -37,6 +39,8 @@ public class PharmacyDailyStockDrillDownLevel2Controller implements Serializable
 
     @EJB
     private PharmacyService pharmacyService;
+    @Inject
+    private BillSearch billSearch;
 
     private Date fromDate;
     private Date toDate;
@@ -174,6 +178,20 @@ public class PharmacyDailyStockDrillDownLevel2Controller implements Serializable
      */
     public String navigateBackToLevel1() {
         return "/pharmacy/reports/summary_reports/daily_stock_values_drill_down_level1?faces-redirect=true";
+    }
+
+    /**
+     * Open the existing per-bill view page for the given Level 2 row — issue #20241.
+     * Delegates to BillSearch which loads the full Bill by id and routes to the
+     * correct view page for the bill's BillTypeAtomic (refund / cancellation /
+     * wholesale / GRN / transfer / etc.).
+     */
+    public String viewBill(BillLight bill) {
+        if (bill == null || bill.getId() == null) {
+            JsfUtil.addErrorMessage("Cannot open bill view — bill is missing or has no id");
+            return null;
+        }
+        return billSearch.navigateToViewBillByAtomicBillTypeByBillId(bill.getId());
     }
 
     public Date getFromDate() {

--- a/src/main/webapp/pharmacy/reports/summary_reports/daily_stock_values_drill_down_level2.xhtml
+++ b/src/main/webapp/pharmacy/reports/summary_reports/daily_stock_values_drill_down_level2.xhtml
@@ -23,6 +23,12 @@
                     .atomic-column {
                         width: auto;
                     }
+                    .view-column {
+                        width: 70px;
+                        min-width: 70px;
+                        max-width: 70px;
+                        text-align: center;
+                    }
                 </style>
 
                 <h:form id="drillDownLevel2Form">
@@ -112,6 +118,7 @@
                                         <th class="text-end value-column">Retail Value</th>
                                         <th class="text-end value-column">Purchase Value</th>
                                         <th class="text-end value-column">Cost Value</th>
+                                        <th class="view-column">View</th>
                                     </tr>
                                 </thead>
                                 <tbody>
@@ -160,6 +167,14 @@
                                                     <f:convertNumber pattern="#,##0.00"/>
                                                 </h:outputText>
                                             </td>
+                                            <td class="view-column">
+                                                <p:commandLink
+                                                    action="#{pharmacyDailyStockDrillDownLevel2Controller.viewBill(bill)}"
+                                                    title="View bill"
+                                                    ajax="false">
+                                                    <h:outputText value="&#xf06e;" styleClass="fa text-primary"/>
+                                                </p:commandLink>
+                                            </td>
                                         </tr>
                                     </ui:repeat>
                                 </tbody>
@@ -202,6 +217,7 @@
                                                 <f:convertNumber pattern="#,##0.00"/>
                                             </h:outputText>
                                         </td>
+                                        <td class="view-column"></td>
                                     </tr>
                                 </tfoot>
                             </table>


### PR DESCRIPTION
## Summary

Adds a "View" icon column at the end of every Level 2 bill row. Clicking the eye icon opens the existing per-bill view page appropriate for the bill's `BillTypeAtomic` — refunds, cancellations, retail/wholesale, GRN, transfers, etc.

- L2 controller injects `BillSearch` and exposes `viewBill(BillLight)`.
- Delegates to the existing `BillSearch.navigateToViewBillByAtomicBillTypeByBillId(Long)` (BillSearch.java:4722), which loads the full `Bill` from the `BillLight` id and dispatches to the correct view via `navigateToViewBillByAtomicBillType()`.
- No new routing — every bill type already reachable from normal bill search is reachable from L2.
- Footer gains an empty `<td>` to keep columns aligned.

## Test plan

- [ ] On the L2 page, every row shows an eye icon in the new "View" column.
- [ ] Clicking the eye on a SALES row (PHARMACY_RETAIL_SALE / WHOLESALE / DIRECT_ISSUE_*) opens the matching bill view page.
- [ ] Clicking the eye on a CANCELLATION / REFUND row opens the matching cancellation/refund view page.
- [ ] Clicking the eye on a PURCHASE / TRANSFER / ADJUSTMENT row opens the matching view page.
- [ ] Back-to-Level-1 button still returns to L1 with state intact (L1 is `@SessionScoped`).

Closes #20241

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a "View" column to the daily stock values drill-down report, enabling users to access detailed bill information directly from the report table.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->