### PR TITLE
F15 drill-down: Excel export + print page for Level 2

### DIFF
--- a/src/main/java/com/divudi/bean/pharmacy/PharmacyDailyStockDrillDownLevel2Controller.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacyDailyStockDrillDownLevel2Controller.java
@@ -12,16 +12,33 @@ import com.divudi.core.util.CommonFunctions;
 import com.divudi.core.util.JsfUtil;
 import com.divudi.ejb.PharmacyService;
 
+import java.io.OutputStream;
 import java.io.Serializable;
 import java.math.BigDecimal;
+import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.Date;
 import java.util.List;
 import javax.ejb.EJB;
 import javax.enterprise.context.SessionScoped;
+import javax.faces.context.FacesContext;
 import javax.inject.Inject;
 import javax.inject.Named;
+import javax.servlet.http.HttpServletResponse;
+import org.apache.poi.ss.usermodel.Cell;
+import org.apache.poi.ss.usermodel.CellStyle;
+import org.apache.poi.ss.usermodel.FillPatternType;
+import org.apache.poi.ss.usermodel.Font;
+import org.apache.poi.ss.usermodel.HorizontalAlignment;
+import org.apache.poi.ss.usermodel.IndexedColors;
+import org.apache.poi.ss.usermodel.Row;
+import org.apache.poi.ss.usermodel.Sheet;
+import org.apache.poi.ss.usermodel.Workbook;
+import org.apache.poi.ss.util.CellRangeAddress;
+import org.apache.poi.xssf.usermodel.XSSFCellStyle;
+import org.apache.poi.xssf.usermodel.XSSFColor;
+import org.apache.poi.xssf.usermodel.XSSFWorkbook;
 
 /**
  * F15 drill-down Level 2 controller — lists the individual bills behind a single
@@ -192,6 +209,219 @@ public class PharmacyDailyStockDrillDownLevel2Controller implements Serializable
             return null;
         }
         return billSearch.navigateToViewBillByAtomicBillTypeByBillId(bill.getId());
+    }
+
+    /**
+     * Navigate to the Level 2 print page — issue #20245. The print page reads
+     * the bill list and selection context straight from this @SessionScoped
+     * controller, so no data hand-off is needed.
+     */
+    public String navigateToPrintPage() {
+        if (bills == null || bills.isEmpty()) {
+            JsfUtil.addErrorMessage("Please drill into a Level 1 row first before printing");
+            return null;
+        }
+        return "/pharmacy/reports/summary_reports/daily_stock_values_drill_down_level2_print?faces-redirect=true";
+    }
+
+    /**
+     * Download the Level 2 bill list as an .xlsx file — issue #20244.
+     * Header band carries the L2 selection context, followed by a 9-column bill
+     * table and a bold totals row matching the on-screen view.
+     */
+    public void downloadExcel() {
+        if (bills == null || bills.isEmpty()) {
+            JsfUtil.addErrorMessage("Please drill into a Level 1 row first before downloading");
+            return;
+        }
+        try {
+            FacesContext context = FacesContext.getCurrentInstance();
+            HttpServletResponse response = (HttpServletResponse) context.getExternalContext().getResponse();
+
+            SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd");
+            String atomicLabel = billTypeAtomic != null ? billTypeAtomic.name() : "AllAtomics";
+            String fileName = "Pharmacy_BillList_"
+                    + atomicLabel + "_"
+                    + dateFormat.format(fromDate) + "_to_"
+                    + dateFormat.format(toDate) + ".xlsx";
+
+            response.reset();
+            response.setContentType("application/vnd.openxmlformats-officedocument.spreadsheetml.sheet");
+            response.setHeader("Content-Disposition", "attachment; filename=\"" + fileName + "\"");
+
+            Workbook workbook = createExcelReport();
+            OutputStream out = response.getOutputStream();
+            workbook.write(out);
+            workbook.close();
+            out.flush();
+            out.close();
+
+            context.responseComplete();
+        } catch (Exception e) {
+            e.printStackTrace();
+            JsfUtil.addErrorMessage("Error generating Excel report: " + e.getMessage());
+        }
+    }
+
+    private Workbook createExcelReport() {
+        XSSFWorkbook workbook = new XSSFWorkbook();
+        Sheet sheet = workbook.createSheet("L2 Bill List");
+
+        short numFmt = workbook.createDataFormat().getFormat("#,##0.00");
+        short dateFmt = workbook.createDataFormat().getFormat("yyyy-mm-dd hh:mm");
+
+        CellStyle titleStyle = workbook.createCellStyle();
+        Font titleFont = workbook.createFont();
+        titleFont.setBold(true);
+        titleFont.setFontHeightInPoints((short) 14);
+        titleStyle.setFont(titleFont);
+        titleStyle.setAlignment(HorizontalAlignment.CENTER);
+
+        CellStyle labelStyle = workbook.createCellStyle();
+        Font labelFont = workbook.createFont();
+        labelFont.setBold(true);
+        labelStyle.setFont(labelFont);
+
+        CellStyle numStyle = workbook.createCellStyle();
+        numStyle.setDataFormat(numFmt);
+        numStyle.setAlignment(HorizontalAlignment.RIGHT);
+
+        CellStyle dateStyle = workbook.createCellStyle();
+        dateStyle.setDataFormat(dateFmt);
+
+        SimpleDateFormat dateFormat = new SimpleDateFormat("dd-MM-yyyy");
+
+        int rowNum = 0;
+        int totalCols = 9;
+
+        Row titleRow = sheet.createRow(rowNum++);
+        Cell titleCell = titleRow.createCell(0);
+        titleCell.setCellValue("F15 Drill-Down — Level 2 (Bill List)");
+        titleCell.setCellStyle(titleStyle);
+        sheet.addMergedRegion(new CellRangeAddress(rowNum - 1, rowNum - 1, 0, totalCols - 1));
+
+        rowNum++; // blank
+
+        rowNum = writeKeyValueRow(sheet, rowNum, "From Date", dateFormat.format(fromDate), labelStyle);
+        rowNum = writeKeyValueRow(sheet, rowNum, "To Date", dateFormat.format(toDate), labelStyle);
+        rowNum = writeKeyValueRow(sheet, rowNum, "Institution", institution != null ? institution.getName() : "", labelStyle);
+        rowNum = writeKeyValueRow(sheet, rowNum, "Site", site != null ? site.getName() : "", labelStyle);
+        rowNum = writeKeyValueRow(sheet, rowNum, "Department", department != null ? department.getName() : "", labelStyle);
+        rowNum = writeKeyValueRow(sheet, rowNum, "Transaction Type", transactionType != null ? transactionType.name() : "", labelStyle);
+        rowNum = writeKeyValueRow(sheet, rowNum, "Bill Type Atomic", billTypeAtomic != null ? billTypeAtomic.getLabel() : "", labelStyle);
+        if (transactionType == TransactionType.SALES) {
+            rowNum = writeKeyValueRow(sheet, rowNum, "Admission Type", admissionType != null ? admissionType.getName() : "", labelStyle);
+            rowNum = writeKeyValueRow(sheet, rowNum, "Payment Scheme", paymentScheme != null ? paymentScheme.getName() : "", labelStyle);
+        }
+
+        rowNum++; // blank
+
+        // Section header (single coloured band, blue, since L2 has no per-section colour like L1)
+        byte[] blue = {(byte) 0x0D, (byte) 0x6E, (byte) 0xFD};
+        String[] cols = {"Date / Time", "Bill Type Atomic", "Gross Total", "Discount", "Service Charge",
+                         "Net Total", "Retail Value", "Purchase Value", "Cost Value"};
+        rowNum = writeSectionHeader(sheet, workbook, rowNum, "Bills (" + bills.size() + ")", cols, blue, totalCols);
+
+        for (BillLight b : bills) {
+            Row r = sheet.createRow(rowNum++);
+            if (b.getBillDate() != null) {
+                Cell dc = r.createCell(0);
+                dc.setCellValue(b.getBillDate());
+                dc.setCellStyle(dateStyle);
+            } else {
+                r.createCell(0).setCellValue("");
+            }
+            r.createCell(1).setCellValue(b.getBillTypeAtomic() != null ? b.getBillTypeAtomic().getLabel() : "");
+            setCellNum(r, 2, b.getTotal() != null ? b.getTotal() : 0.0, numStyle);
+            setCellNum(r, 3, b.getDiscount() != null ? b.getDiscount() : 0.0, numStyle);
+            setCellNum(r, 4, b.getServiceCharge() != null ? b.getServiceCharge() : 0.0, numStyle);
+            setCellNum(r, 5, b.getNetTotal() != null ? b.getNetTotal() : 0.0, numStyle);
+            setCellNum(r, 6, b.getTotalRetailSaleValue() != null ? b.getTotalRetailSaleValue().doubleValue() : 0.0, numStyle);
+            setCellNum(r, 7, b.getTotalPurchaseValue() != null ? b.getTotalPurchaseValue().doubleValue() : 0.0, numStyle);
+            setCellNum(r, 8, b.getTotalCostValue() != null ? b.getTotalCostValue().doubleValue() : 0.0, numStyle);
+        }
+
+        // Total row
+        CellStyle totalStyle = makeSolidStyle(workbook, blue, numFmt, true, true);
+        Row totalRow = sheet.createRow(rowNum++);
+        Cell totalLabel = totalRow.createCell(0);
+        totalLabel.setCellValue("Total");
+        totalLabel.setCellStyle(totalStyle);
+        Cell emptyAtomic = totalRow.createCell(1);
+        emptyAtomic.setCellStyle(totalStyle);
+        setCellNum(totalRow, 2, totalGross, totalStyle);
+        setCellNum(totalRow, 3, totalDiscount, totalStyle);
+        setCellNum(totalRow, 4, totalServiceCharge, totalStyle);
+        setCellNum(totalRow, 5, totalNet, totalStyle);
+        setCellNum(totalRow, 6, totalRetail.doubleValue(), totalStyle);
+        setCellNum(totalRow, 7, totalPurchase.doubleValue(), totalStyle);
+        setCellNum(totalRow, 8, totalCost.doubleValue(), totalStyle);
+
+        for (int c = 0; c < totalCols; c++) {
+            sheet.autoSizeColumn(c);
+        }
+        return workbook;
+    }
+
+    private int writeKeyValueRow(Sheet sheet, int rowNum, String key, String value, CellStyle keyStyle) {
+        Row r = sheet.createRow(rowNum++);
+        Cell k = r.createCell(0);
+        k.setCellValue(key);
+        k.setCellStyle(keyStyle);
+        r.createCell(1).setCellValue(value != null ? value : "");
+        return rowNum;
+    }
+
+    private int writeSectionHeader(Sheet sheet, XSSFWorkbook wb, int rowNum,
+                                   String sectionTitle, String[] colHeaders, byte[] rgb, int totalCols) {
+        CellStyle sectionStyle = makeSolidStyle(wb, rgb, (short) 0, true, true);
+        Row sectionRow = sheet.createRow(rowNum++);
+        Cell sectionCell = sectionRow.createCell(0);
+        sectionCell.setCellValue(sectionTitle);
+        sectionCell.setCellStyle(sectionStyle);
+        sheet.addMergedRegion(new CellRangeAddress(rowNum - 1, rowNum - 1, 0, totalCols - 1));
+
+        byte[] lightRgb = lighten(rgb);
+        CellStyle colStyle = makeSolidStyle(wb, lightRgb, (short) 0, true, false);
+        Row colRow = sheet.createRow(rowNum++);
+        for (int i = 0; i < colHeaders.length; i++) {
+            Cell c = colRow.createCell(i);
+            c.setCellValue(colHeaders[i]);
+            c.setCellStyle(colStyle);
+        }
+        return rowNum;
+    }
+
+    private void setCellNum(Row row, int col, double value, CellStyle style) {
+        Cell c = row.createCell(col);
+        c.setCellValue(value);
+        c.setCellStyle(style);
+    }
+
+    private XSSFCellStyle makeSolidStyle(XSSFWorkbook wb, byte[] rgb, short numFmt, boolean bold, boolean whiteText) {
+        XSSFCellStyle style = wb.createCellStyle();
+        style.setFillPattern(FillPatternType.SOLID_FOREGROUND);
+        style.setFillForegroundColor(new XSSFColor(rgb, null));
+        if (numFmt != 0) {
+            style.setDataFormat(numFmt);
+        }
+        style.setAlignment(HorizontalAlignment.LEFT);
+        Font font = wb.createFont();
+        font.setBold(bold);
+        if (whiteText) {
+            font.setColor(IndexedColors.WHITE.getIndex());
+        }
+        style.setFont(font);
+        return style;
+    }
+
+    private byte[] lighten(byte[] rgb) {
+        byte[] out = new byte[3];
+        for (int i = 0; i < 3; i++) {
+            int v = (rgb[i] & 0xFF);
+            out[i] = (byte) Math.min(255, v + 80);
+        }
+        return out;
     }
 
     public Date getFromDate() {

--- a/src/main/webapp/pharmacy/reports/summary_reports/daily_stock_values_drill_down_level2.xhtml
+++ b/src/main/webapp/pharmacy/reports/summary_reports/daily_stock_values_drill_down_level2.xhtml
@@ -33,15 +33,31 @@
 
                 <h:form id="drillDownLevel2Form">
 
-                    <!-- Header / Back button -->
+                    <!-- Header / Back button + Export buttons -->
                     <div class="d-flex justify-content-between align-items-center mb-3">
                         <h4 class="mb-0">F15 Drill-Down — Level 2 (Bill List)</h4>
-                        <p:commandButton
-                            value="Back to Level 1"
-                            icon="fa fa-arrow-left"
-                            ajax="false"
-                            styleClass="ui-button-secondary"
-                            action="#{pharmacyDailyStockDrillDownLevel2Controller.navigateBackToLevel1()}"/>
+                        <div class="d-flex gap-2">
+                            <p:commandButton
+                                value="Download Excel"
+                                icon="fa fa-file-excel-o"
+                                ajax="false"
+                                styleClass="ui-button-help"
+                                action="#{pharmacyDailyStockDrillDownLevel2Controller.downloadExcel()}"
+                                rendered="#{not empty pharmacyDailyStockDrillDownLevel2Controller.bills}"/>
+                            <p:commandButton
+                                value="Print"
+                                icon="fa fa-print"
+                                ajax="false"
+                                styleClass="ui-button-info"
+                                action="#{pharmacyDailyStockDrillDownLevel2Controller.navigateToPrintPage()}"
+                                rendered="#{not empty pharmacyDailyStockDrillDownLevel2Controller.bills}"/>
+                            <p:commandButton
+                                value="Back to Level 1"
+                                icon="fa fa-arrow-left"
+                                ajax="false"
+                                styleClass="ui-button-secondary"
+                                action="#{pharmacyDailyStockDrillDownLevel2Controller.navigateBackToLevel1()}"/>
+                        </div>
                     </div>
 
                     <!-- Selection Context -->

--- a/src/main/webapp/pharmacy/reports/summary_reports/daily_stock_values_drill_down_level2_print.xhtml
+++ b/src/main/webapp/pharmacy/reports/summary_reports/daily_stock_values_drill_down_level2_print.xhtml
@@ -1,0 +1,437 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
+      xmlns:h="http://xmlns.jcp.org/jsf/html"
+      xmlns:f="http://xmlns.jcp.org/jsf/core"
+      xmlns:p="http://primefaces.org/ui">
+
+    <h:body>
+        <ui:composition template="/pharmacy/pharmacy_analytics.xhtml">
+            <ui:define name="subcontent">
+
+                <style>
+                    .screen-only { display: block; }
+                    .print-only { display: none; }
+
+                    @media print {
+                        @page { size: A4 landscape; margin: 10mm; }
+
+                        .screen-only { display: none !important; }
+                        .print-only { display: block !important; }
+
+                        .ui-panel-titlebar,
+                        .card-header,
+                        .sidebar,
+                        nav,
+                        footer,
+                        .navbar,
+                        .btn,
+                        .ui-button,
+                        .p-button,
+                        .no-print,
+                        .col-md-2,
+                        .p-panel,
+                        .p-accordionpanel,
+                        .row > .col-md-2,
+                        .ui-panel-content:has(.p-accordionpanel),
+                        .p-accordion,
+                        .p-tab,
+                        .d-grid {
+                            display: none !important;
+                        }
+
+                        .col-md-10,
+                        .report-container {
+                            width: 100% !important;
+                            max-width: 100% !important;
+                            margin: 0 !important;
+                            padding: 0 !important;
+                        }
+
+                        .ui-panel,
+                        .ui-panel-content {
+                            border: none !important;
+                            background: transparent !important;
+                            box-shadow: none !important;
+                        }
+
+                        body * { visibility: hidden; }
+                        .report-container, .report-container * { visibility: visible; }
+
+                        .report-container {
+                            position: absolute !important;
+                            left: 0 !important;
+                            top: 0 !important;
+                            width: 100% !important;
+                        }
+
+                        .print-table {
+                            border-collapse: collapse;
+                            width: 100%;
+                            font-size: 9px;
+                            margin: 0;
+                            page-break-inside: auto;
+                        }
+
+                        .print-table th,
+                        .print-table td {
+                            border: 1px solid #000;
+                            padding: 3px;
+                            font-size: 9px;
+                            line-height: 1.2;
+                        }
+
+                        .print-table th {
+                            background-color: #f0f0f0 !important;
+                            font-weight: bold;
+                            text-align: center;
+                        }
+
+                        .print-table .text-end { text-align: right; }
+
+                        .section-header {
+                            background-color: #e0e0e0 !important;
+                            font-weight: bold;
+                            text-align: center;
+                            page-break-after: avoid;
+                        }
+
+                        .total-row {
+                            background-color: #f8f8f8 !important;
+                            font-weight: bold;
+                            border-top: 2px solid #000;
+                        }
+
+                        .print-title {
+                            text-align: center;
+                            font-size: 14px;
+                            font-weight: bold;
+                            margin-bottom: 8px;
+                            color: #000;
+                        }
+
+                        .print-info {
+                            margin-bottom: 8px;
+                            font-size: 10px;
+                        }
+
+                        .print-info .info-row {
+                            margin-bottom: 2px;
+                        }
+
+                        body, * {
+                            color: #000 !important;
+                            background: white !important;
+                        }
+                    }
+
+                    @media screen {
+                        .report-container {
+                            max-width: 100%;
+                            margin: 20px auto;
+                            background: white;
+                            padding: 20px;
+                            box-shadow: 0 0 10px rgba(0,0,0,0.1);
+                        }
+
+                        .screen-table {
+                            border-collapse: collapse;
+                            width: 100%;
+                            margin-bottom: 20px;
+                            font-size: 12px;
+                        }
+
+                        .screen-table th,
+                        .screen-table td {
+                            border: 1px solid #dee2e6;
+                            padding: 8px;
+                            text-align: left;
+                        }
+
+                        .screen-table th {
+                            background-color: #f8f9fa;
+                            font-weight: bold;
+                            color: #495057;
+                        }
+
+                        .screen-table .text-end { text-align: right; }
+
+                        .section-title {
+                            background-color: #e3f2fd;
+                            font-weight: bold;
+                            text-align: center;
+                            color: #1976d2;
+                        }
+
+                        .total-row {
+                            background-color: #f5f5f5;
+                            font-weight: bold;
+                        }
+
+                        .report-title {
+                            text-align: center;
+                            font-size: 24px;
+                            font-weight: bold;
+                            color: #2c3e50;
+                            margin-bottom: 20px;
+                        }
+
+                        .report-info {
+                            background-color: #f8f9fa;
+                            padding: 15px;
+                            border-radius: 5px;
+                            margin-bottom: 20px;
+                        }
+
+                        .info-label {
+                            font-weight: bold;
+                            color: #495057;
+                        }
+                    }
+                </style>
+
+                <h:form id="drillDownLevel2PrintForm">
+
+                    <!-- Screen-only control buttons -->
+                    <div class="card mb-4 screen-only">
+                        <div class="card-header bg-info text-white">
+                            <h:outputText value="&#xf02f;" styleClass="fa me-2"/>
+                            <h:outputText value="Print Controls" styleClass="fw-bold"/>
+                        </div>
+                        <div class="card-body">
+                            <div class="d-flex gap-2">
+                                <p:commandButton
+                                    value="Print Report"
+                                    onclick="window.print(); return false;"
+                                    styleClass="ui-button-success"
+                                    icon="fa fa-print"
+                                    title="Print this report"/>
+                                <p:button
+                                    value="Back to Level 2"
+                                    outcome="/pharmacy/reports/summary_reports/daily_stock_values_drill_down_level2"
+                                    styleClass="ui-button-secondary"
+                                    icon="fa fa-arrow-left"
+                                    title="Return to Level 2"/>
+                            </div>
+                        </div>
+                    </div>
+
+                    <!-- Report container -->
+                    <div class="report-container">
+
+                        <!-- Print-only header -->
+                        <div class="print-only">
+                            <div class="print-title">F15 Drill-Down — Level 2 (Bill List)</div>
+                            <div class="print-info">
+                                <div class="info-row">
+                                    <strong>From:</strong>
+                                    <h:outputText value="#{pharmacyDailyStockDrillDownLevel2Controller.fromDate}">
+                                        <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateFormat}"/>
+                                    </h:outputText>
+                                    &nbsp;&nbsp;
+                                    <strong>To:</strong>
+                                    <h:outputText value="#{pharmacyDailyStockDrillDownLevel2Controller.toDate}">
+                                        <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateFormat}"/>
+                                    </h:outputText>
+                                </div>
+                                <div class="info-row">
+                                    <strong>Institution:</strong>
+                                    <h:outputText value="#{pharmacyDailyStockDrillDownLevel2Controller.institution.name}"/>
+                                    &nbsp;&nbsp;
+                                    <strong>Site:</strong>
+                                    <h:outputText value="#{pharmacyDailyStockDrillDownLevel2Controller.site.name}"/>
+                                    &nbsp;&nbsp;
+                                    <strong>Department:</strong>
+                                    <h:outputText value="#{pharmacyDailyStockDrillDownLevel2Controller.department.name}"/>
+                                </div>
+                                <div class="info-row">
+                                    <strong>Transaction Type:</strong>
+                                    <h:outputText value="#{pharmacyDailyStockDrillDownLevel2Controller.transactionType}"/>
+                                    &nbsp;&nbsp;
+                                    <strong>Bill Type:</strong>
+                                    <h:outputText value="#{pharmacyDailyStockDrillDownLevel2Controller.billTypeAtomic.label}"/>
+                                </div>
+                                <h:panelGroup
+                                    layout="block"
+                                    styleClass="info-row"
+                                    rendered="#{pharmacyDailyStockDrillDownLevel2Controller.transactionType eq 'SALES'}">
+                                    <strong>Admission Type:</strong>
+                                    <h:outputText value="#{pharmacyDailyStockDrillDownLevel2Controller.admissionType.name}"/>
+                                    &nbsp;&nbsp;
+                                    <strong>Payment Scheme:</strong>
+                                    <h:outputText value="#{pharmacyDailyStockDrillDownLevel2Controller.paymentScheme.name}"/>
+                                </h:panelGroup>
+                            </div>
+                        </div>
+
+                        <!-- Screen-only header -->
+                        <div class="screen-only">
+                            <div class="report-title">F15 Drill-Down — Level 2 (Bill List)</div>
+                            <div class="report-info">
+                                <div class="row">
+                                    <div class="col-md-6">
+                                        <span class="info-label">From:</span>
+                                        <h:outputText value="#{pharmacyDailyStockDrillDownLevel2Controller.fromDate}">
+                                            <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateFormat}"/>
+                                        </h:outputText>
+                                    </div>
+                                    <div class="col-md-6">
+                                        <span class="info-label">To:</span>
+                                        <h:outputText value="#{pharmacyDailyStockDrillDownLevel2Controller.toDate}">
+                                            <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateFormat}"/>
+                                        </h:outputText>
+                                    </div>
+                                    <div class="col-md-4">
+                                        <span class="info-label">Institution:</span>
+                                        <h:outputText value="#{pharmacyDailyStockDrillDownLevel2Controller.institution.name}"/>
+                                    </div>
+                                    <div class="col-md-4">
+                                        <span class="info-label">Site:</span>
+                                        <h:outputText value="#{pharmacyDailyStockDrillDownLevel2Controller.site.name}"/>
+                                    </div>
+                                    <div class="col-md-4">
+                                        <span class="info-label">Department:</span>
+                                        <h:outputText value="#{pharmacyDailyStockDrillDownLevel2Controller.department.name}"/>
+                                    </div>
+                                    <div class="col-md-6 mt-2">
+                                        <span class="info-label">Transaction Type:</span>
+                                        <h:outputText value="#{pharmacyDailyStockDrillDownLevel2Controller.transactionType}"/>
+                                    </div>
+                                    <div class="col-md-6 mt-2">
+                                        <span class="info-label">Bill Type:</span>
+                                        <h:outputText value="#{pharmacyDailyStockDrillDownLevel2Controller.billTypeAtomic.label}"/>
+                                    </div>
+                                    <h:panelGroup
+                                        layout="block"
+                                        styleClass="col-md-6 mt-2"
+                                        rendered="#{pharmacyDailyStockDrillDownLevel2Controller.transactionType eq 'SALES'}">
+                                        <span class="info-label">Admission Type:</span>
+                                        <h:outputText value="#{pharmacyDailyStockDrillDownLevel2Controller.admissionType.name}"/>
+                                    </h:panelGroup>
+                                    <h:panelGroup
+                                        layout="block"
+                                        styleClass="col-md-6 mt-2"
+                                        rendered="#{pharmacyDailyStockDrillDownLevel2Controller.transactionType eq 'SALES'}">
+                                        <span class="info-label">Payment Scheme:</span>
+                                        <h:outputText value="#{pharmacyDailyStockDrillDownLevel2Controller.paymentScheme.name}"/>
+                                    </h:panelGroup>
+                                </div>
+                            </div>
+                        </div>
+
+                        <!-- Bill table -->
+                        <table class="screen-table print-table">
+                            <thead>
+                                <tr>
+                                    <th colspan="9" class="section-title section-header">
+                                        Bills (<h:outputText value="#{pharmacyDailyStockDrillDownLevel2Controller.bills.size()}"/>)
+                                    </th>
+                                </tr>
+                                <tr>
+                                    <th>Date / Time</th>
+                                    <th>Bill Type Atomic</th>
+                                    <th class="text-end">Gross Total</th>
+                                    <th class="text-end">Discount</th>
+                                    <th class="text-end">Service Charge</th>
+                                    <th class="text-end">Net Total</th>
+                                    <th class="text-end">Retail Value</th>
+                                    <th class="text-end">Purchase Value</th>
+                                    <th class="text-end">Cost Value</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <ui:repeat value="#{pharmacyDailyStockDrillDownLevel2Controller.bills}" var="bill">
+                                    <tr>
+                                        <td>
+                                            <h:outputText value="#{bill.billDate}">
+                                                <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateTimeFormat}"/>
+                                            </h:outputText>
+                                        </td>
+                                        <td><h:outputText value="#{bill.billTypeAtomic.label}"/></td>
+                                        <td class="text-end">
+                                            <h:outputText value="#{bill.total}">
+                                                <f:convertNumber pattern="#,##0.00"/>
+                                            </h:outputText>
+                                        </td>
+                                        <td class="text-end">
+                                            <h:outputText value="#{bill.discount}">
+                                                <f:convertNumber pattern="#,##0.00"/>
+                                            </h:outputText>
+                                        </td>
+                                        <td class="text-end">
+                                            <h:outputText value="#{bill.serviceCharge}">
+                                                <f:convertNumber pattern="#,##0.00"/>
+                                            </h:outputText>
+                                        </td>
+                                        <td class="text-end">
+                                            <h:outputText value="#{bill.netTotal}">
+                                                <f:convertNumber pattern="#,##0.00"/>
+                                            </h:outputText>
+                                        </td>
+                                        <td class="text-end">
+                                            <h:outputText value="#{bill.totalRetailSaleValue}">
+                                                <f:convertNumber pattern="#,##0.00"/>
+                                            </h:outputText>
+                                        </td>
+                                        <td class="text-end">
+                                            <h:outputText value="#{bill.totalPurchaseValue}">
+                                                <f:convertNumber pattern="#,##0.00"/>
+                                            </h:outputText>
+                                        </td>
+                                        <td class="text-end">
+                                            <h:outputText value="#{bill.totalCostValue}">
+                                                <f:convertNumber pattern="#,##0.00"/>
+                                            </h:outputText>
+                                        </td>
+                                    </tr>
+                                </ui:repeat>
+                                <tr class="total-row">
+                                    <td><strong>Total</strong></td>
+                                    <td></td>
+                                    <td class="text-end">
+                                        <h:outputText value="#{pharmacyDailyStockDrillDownLevel2Controller.totalGross}">
+                                            <f:convertNumber pattern="#,##0.00"/>
+                                        </h:outputText>
+                                    </td>
+                                    <td class="text-end">
+                                        <h:outputText value="#{pharmacyDailyStockDrillDownLevel2Controller.totalDiscount}">
+                                            <f:convertNumber pattern="#,##0.00"/>
+                                        </h:outputText>
+                                    </td>
+                                    <td class="text-end">
+                                        <h:outputText value="#{pharmacyDailyStockDrillDownLevel2Controller.totalServiceCharge}">
+                                            <f:convertNumber pattern="#,##0.00"/>
+                                        </h:outputText>
+                                    </td>
+                                    <td class="text-end">
+                                        <h:outputText value="#{pharmacyDailyStockDrillDownLevel2Controller.totalNet}">
+                                            <f:convertNumber pattern="#,##0.00"/>
+                                        </h:outputText>
+                                    </td>
+                                    <td class="text-end">
+                                        <h:outputText value="#{pharmacyDailyStockDrillDownLevel2Controller.totalRetail}">
+                                            <f:convertNumber pattern="#,##0.00"/>
+                                        </h:outputText>
+                                    </td>
+                                    <td class="text-end">
+                                        <h:outputText value="#{pharmacyDailyStockDrillDownLevel2Controller.totalPurchase}">
+                                            <f:convertNumber pattern="#,##0.00"/>
+                                        </h:outputText>
+                                    </td>
+                                    <td class="text-end">
+                                        <h:outputText value="#{pharmacyDailyStockDrillDownLevel2Controller.totalCost}">
+                                            <f:convertNumber pattern="#,##0.00"/>
+                                        </h:outputText>
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </div>
+
+                </h:form>
+
+            </ui:define>
+        </ui:composition>
+    </h:body>
+</html>


### PR DESCRIPTION
## Summary

Wraps up the last two sub-issues of epic #20236 in a single PR — Excel export and print page for the Level 2 (per-bill) drill-down view.

### Excel export (#20244)

- New `downloadExcel` / `createExcelReport` methods on `PharmacyDailyStockDrillDownLevel2Controller`, same Apache POI pattern as L1 / F15.
- Header band: from-date, to-date, institution, site, department, transaction type, bill type atomic. Plus admission type and payment scheme when transaction type is SALES.
- 9-column bill table: Date/Time, Bill Type Atomic, Gross, Discount, Service Charge, Net, Retail, Purchase, Cost.
- Bold totals row.
- File name: `Pharmacy_BillList_<atomic>_<from>_to_<to>.xlsx`.

### Print page (#20245)

- New `daily_stock_values_drill_down_level2_print.xhtml` mirrors the L2 layout. A4 **landscape** (9 columns of bill data), monochrome borders, navigation/buttons hidden during print, page-break-inside avoided.
- L2 controller exposes `navigateToPrintPage()`; the print page reads the bill list and selection context straight from the `@SessionScoped` L2 controller — no data hand-off needed.
- "Back to Level 2" button on the print page returns to the L2 view.

Both buttons appear in the L2 page header (rendered only when a bill list is loaded).

## Test plan

- [ ] Drill into any L2 view → "Download Excel" downloads `Pharmacy_BillList_<atomic>_<from>_to_<to>.xlsx`.
- [ ] Confirm every bill row in the Excel matches the on-screen L2 list, totals match the on-screen totals.
- [ ] For a SALES atomic, header band shows admission type + payment scheme; for non-SALES it does not.
- [ ] "Print" → opens the print page → "Print Report" → browser print preview shows clean A4 landscape layout with no nav/buttons.
- [ ] Confirm print page shows the same bills and totals as L2.
- [ ] "Back to Level 2" returns to the L2 view with bill list intact.

Closes #20244
Closes #20245

🤖 Generated with [Claude Code](https://claude.com/claude-code)