### PR TITLE
fix(upload): infer sex from title when sex cell is blank

### DIFF
--- a/src/main/java/com/divudi/bean/emr/DataUploadController.java
+++ b/src/main/java/com/divudi/bean/emr/DataUploadController.java
@@ -3468,6 +3468,24 @@ public class DataUploadController implements Serializable {
 //        return itemFees;
 //
 //    }
+    private boolean isFemaleTitle(Title title) {
+        if (title == null) {
+            return false;
+        }
+        switch (title) {
+            case Mrs:
+            case Miss:
+            case Ms:
+            case DrMrs:
+            case DrMs:
+            case DrMiss:
+            case ProfMrs:
+                return true;
+            default:
+                return false;
+        }
+    }
+
     private String readCellAsString(Cell cell) {
         if (cell == null) {
             return "";
@@ -3526,13 +3544,14 @@ public class DataUploadController implements Serializable {
 
             speciality = doctorSpecialityController.findDoctorSpeciality(specialityString, true);
 
+            title = Title.getTitleEnum(titleString);
             if (sexString != null && sexString.toLowerCase().contains("f")) {
                 sex = Sex.Female;
+            } else if (sexString == null || sexString.isEmpty()) {
+                sex = isFemaleTitle(title) ? Sex.Female : Sex.Male;
             } else {
                 sex = Sex.Male;
             }
-
-            title = Title.getTitleEnum(titleString);
 
             consultant = consultantController.getConsultantByName(name);
             if (consultant == null) {
@@ -3600,15 +3619,14 @@ public class DataUploadController implements Serializable {
 
             speciality = doctorSpecialityController.findDoctorSpeciality(specialityString, true);
 
-            System.out.println("sexString = " + sexString);
+            title = Title.getTitleEnum(titleString);
             if (sexString != null && sexString.toLowerCase().contains("f")) {
                 sex = Sex.Female;
+            } else if (sexString == null || sexString.isEmpty()) {
+                sex = isFemaleTitle(title) ? Sex.Female : Sex.Male;
             } else {
                 sex = Sex.Male;
             }
-
-            title = Title.getTitleEnum(titleString);
-            System.out.println("title = " + title);
 
             doctor = doctorController.getDoctorsByName(name);
             System.out.println("doctor = " + doctor);


### PR DESCRIPTION
## Summary

- When the Sex column (F) is empty in the uploaded Excel, the previous code defaulted every consultant/doctor to **Male**
- Real-world files (e.g., the coop consultation list) often leave the sex cell blank but use female-specific titles like Mrs, Miss, Ms, Dr. (Mrs), Dr. (Ms), Dr. (Miss), Prof. (Mrs)
- Added `isFemaleTitle()` helper and fall back to title-based inference in both `readConsultantsFromExcel` and `readDoctorsFromExcel` when `sexString` is empty
- Explicit "F" in the sex cell still takes priority; any other non-blank, non-"f" string still resolves to Male
- Also removed leftover debug `System.out.println` statements

Closes #20148

## Test plan

- [ ] Upload an Excel with sex column blank but female titles (Mrs, Dr. (Mrs), etc.) — consultants should appear as Female in the preview table
- [ ] Upload an Excel with explicit "F" in sex column — should still work as Female
- [ ] Upload an Excel with explicit "M" in sex column — should still work as Male
- [ ] Upload an Excel with male titles (Dr., Mr.) and no sex column — should default to Male

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Excel import handling for consultants and doctors by inferring gender from title when the gender column is missing or blank.

* **Refactor**
  * Optimized data processing order to parse title information earlier in the import workflow.

* **Chores**
  * Removed debug logging output from the import process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->