### PR TITLE
Opd Bill Print empty pages issue (ruhunu-prod hotfix)

### DIFF
--- a/src/main/webapp/resources/css/opd_five_five.css
+++ b/src/main/webapp/resources/css/opd_five_five.css
@@ -22,7 +22,6 @@
         font-size: 9px!important;
         font-size: 80%;
         text-transform: capitalize!important;
-        page-break-before: always!important;
     }
 
     .channelRecipt_24_2x9_3{

--- a/src/main/webapp/resources/css/opd_five_five.css
+++ b/src/main/webapp/resources/css/opd_five_five.css
@@ -22,6 +22,7 @@
         font-size: 9px!important;
         font-size: 80%;
         text-transform: capitalize!important;
+        page-break-before: always!important;
     }
 
     .channelRecipt_24_2x9_3{

--- a/src/main/webapp/resources/css/opd_pos_bill.css
+++ b/src/main/webapp/resources/css/opd_pos_bill.css
@@ -64,7 +64,7 @@
         /*        font:*/
         font-size: 11px!important; 
         /*        text-transform: uppercase!important;*/
-        page-break-after:always!important;
+        page-break-before:always!important;
 
     }
 

--- a/src/main/webapp/resources/css/pharmacypos.css
+++ b/src/main/webapp/resources/css/pharmacypos.css
@@ -26,6 +26,7 @@
         background-size: 100% auto !important;
         font-size: 130%;
         text-transform: capitalize !important;
+        page-break-before: always!important;
     }
 
     /* Add this new rule to hide the header specifically for inward service bills */
@@ -68,8 +69,8 @@
         /*        font:*/
         font-size: 11px!important;
         /*        text-transform: uppercase!important;*/
-        page-break-after:always!important;
-
+        page-break-before: always!important;
+        page-break-after:avoid!important;
     }
 
     /*    .billDetails{
@@ -79,7 +80,8 @@
         }*/
 
     .a4bill{
-        page-break-after:always!important;
+        page-break-after:avoid!important;
+        page-break-before: always!important;
         font-family: sans-serif!important;
         font-size: 11px!important;
         position: relative!important;

--- a/src/main/webapp/resources/ezcomp/prints/five_five_paper_coustom_1.xhtml
+++ b/src/main/webapp/resources/ezcomp/prints/five_five_paper_coustom_1.xhtml
@@ -32,7 +32,7 @@
             }
         </style>
 
-        <div class="fiveinchbill" style="page-break-after: always" >
+        <div class="fiveinchbill" style="page-break-before: always" >
 
             <div class="institutionName">
                 <h:outputLabel style="font-size: 14pt" value="#{cc.attrs.bill.department.printingName}" />

--- a/src/main/webapp/resources/ezcomp/prints/five_five_paper_coustom_1_OPD_Batch_Bill.xhtml
+++ b/src/main/webapp/resources/ezcomp/prints/five_five_paper_coustom_1_OPD_Batch_Bill.xhtml
@@ -20,7 +20,7 @@
     <cc:implementation>
 
         <h:outputStylesheet library="css" name="opd_five_five.css" ></h:outputStylesheet>
-        <div class="fiveinchbill" style="page-break-after: always" >
+        <div class="fiveinchbill" style="page-break-before: always" >
 
             <div class="institutionName">
                 <h:outputLabel style="font-size: 14pt" value="#{cc.attrs.bill.department.printingName}" />

--- a/src/main/webapp/resources/ezcomp/prints/five_five_paper_with_headings.xhtml
+++ b/src/main/webapp/resources/ezcomp/prints/five_five_paper_with_headings.xhtml
@@ -22,7 +22,7 @@
 
 
         <h:outputStylesheet library="css" name="opd_five_five.css" ></h:outputStylesheet>
-        <div class="fiveinchbill">
+        <div class="fiveinchbill" style="page-break-before: always!important;">
 
             <div class="institutionName">
                 <h:outputLabel value="#{cc.attrs.bill.department.printingName}" />

--- a/src/main/webapp/resources/ezcomp/prints/five_five_paper_with_headings.xhtml
+++ b/src/main/webapp/resources/ezcomp/prints/five_five_paper_with_headings.xhtml
@@ -22,7 +22,7 @@
 
 
         <h:outputStylesheet library="css" name="opd_five_five.css" ></h:outputStylesheet>
-        <div class="fiveinchbill" style="page-break-after: always" >
+        <div class="fiveinchbill">
 
             <div class="institutionName">
                 <h:outputLabel value="#{cc.attrs.bill.department.printingName}" />

--- a/src/main/webapp/resources/ezcomp/prints/five_five_paper_with_headings_badge_bill.xhtml
+++ b/src/main/webapp/resources/ezcomp/prints/five_five_paper_with_headings_badge_bill.xhtml
@@ -17,7 +17,7 @@
     <!-- IMPLEMENTATION -->
     <cc:implementation>
         <h:outputStylesheet library="css" name="pharmacypos.css" ></h:outputStylesheet>
-        <div class="fiveinchbill" style="page-break-after: always">
+        <div class="fiveinchbill" style="page-break-before: always">
             <div class="institutionName">
                 <h:outputLabel value="#{cc.attrs.billController.batchBill.department.printingName}" />
             </div>

--- a/src/main/webapp/resources/ezcomp/prints/five_five_paper_without_headings.xhtml
+++ b/src/main/webapp/resources/ezcomp/prints/five_five_paper_without_headings.xhtml
@@ -20,7 +20,7 @@
     <cc:implementation>
 
         <h:outputStylesheet library="css" name="opd_five_five.css" ></h:outputStylesheet>
-        <div class="fiveinchbill " style="page-break-after: always" >
+        <div class="fiveinchbill " >
 
             <div style="font-weight: bold;text-align: left;font-size: 10pt" class="row mt-2 d-flex align-items-center">
                 <div class="col-5">

--- a/src/main/webapp/resources/ezcomp/prints/five_five_paper_without_headings.xhtml
+++ b/src/main/webapp/resources/ezcomp/prints/five_five_paper_without_headings.xhtml
@@ -20,7 +20,7 @@
     <cc:implementation>
 
         <h:outputStylesheet library="css" name="opd_five_five.css" ></h:outputStylesheet>
-        <div class="fiveinchbill " >
+        <div class="fiveinchbill "  style="page-break-before: always!important;">
 
             <div style="font-weight: bold;text-align: left;font-size: 10pt" class="row mt-2 d-flex align-items-center">
                 <div class="col-5">

--- a/src/main/webapp/resources/ezcomp/prints/posOpdBill.xhtml
+++ b/src/main/webapp/resources/ezcomp/prints/posOpdBill.xhtml
@@ -17,7 +17,7 @@
     <cc:implementation>
 
         <h:outputStylesheet library="css" name="pharmacypos.css" ></h:outputStylesheet>
-        <div class="posbillBreak" style="page-break-after: always">
+        <div class="posbillBreak" style="page-break-after: avoid!important;">
 
 
             <div class="institutionName" style="text-align: center!important;

--- a/src/main/webapp/resources/ezcomp/prints/posOpdBillWithoutLogo.xhtml
+++ b/src/main/webapp/resources/ezcomp/prints/posOpdBillWithoutLogo.xhtml
@@ -17,7 +17,7 @@
     <cc:implementation>
 
         <h:outputStylesheet library="css" name="opd_pos_bill.css" ></h:outputStylesheet>
-        <div class="posbillBreak">            
+        <div class="posbillBreak" style="page-break-after: avoid!important;">            
 
 
             <!--            <div class="institutionName" style="text-align: center!important;

--- a/src/main/webapp/resources/ezcomp/prints/pos_opd_bill_batch.xhtml
+++ b/src/main/webapp/resources/ezcomp/prints/pos_opd_bill_batch.xhtml
@@ -19,7 +19,7 @@
         <h:outputStylesheet library="css" name="pharmacypos.css" ></h:outputStylesheet>
         
         <ui:repeat value="#{cc.attrs.billController.bills}" var="ffb">
-            <div class="posbillBreak" style="page-break-after: always">
+            <div class="posbillBreak">
 
 
                 <div class="institutionName" style="text-align: center!important;

--- a/src/main/webapp/resources/ezcomp/prints/pos_opd_bill_without_logo_batch.xhtml
+++ b/src/main/webapp/resources/ezcomp/prints/pos_opd_bill_without_logo_batch.xhtml
@@ -18,7 +18,7 @@
 
         <h:outputStylesheet library="css" name="pharmacypos.css" ></h:outputStylesheet>
         <ui:repeat value="#{cc.attrs.billController.bills}" var="ffb">
-            <div class="posbillBreak" style="page-break-after: always">
+            <div class="posbillBreak" >
 
                 <div class="headingBill">
                     <h:outputLabel value="INVOICE"   />    


### PR DESCRIPTION
Hotfix port of #20265 onto `ruhunu-prod`.

Cherry-picks the two commits from PR #20265 (currently open against `development`):
- `3ea3af9` — switch print components from `page-break-after: always` to `page-break-before: always`
- `7e50f0f` — follow-up adjustments to `five_five_paper_with_headings.xhtml`, `five_five_paper_without_headings.xhtml`

## Why

With `page-break-after: always` an empty page was being created after the last bill. Using `page-break-before: always` to start each component on a new page eliminates the trailing blank page.

## Scope

CSS / XHTML only — 11 files, no Java changes. Per CLAUDE.md rule #12, JSF-only changes do not require recompilation.

## Test plan

- [ ] Print an OPD POS bill — confirm no trailing blank page
- [ ] Print a batch OPD bill — confirm each bill starts on a new page, no blank page after the last
- [ ] Print 5x5 receipts (with/without headings, badge bill, custom_1) — verify pagination
- [ ] Print pharmacy POS receipts — verify pagination

🤖 Generated with [Claude Code](https://claude.com/claude-code)