### PR TITLE
fix(inward-payment): clear stale state when navigating to payment page from admission profile

### DIFF
--- a/src/main/java/com/divudi/bean/inward/InwardSearch.java
+++ b/src/main/java/com/divudi/bean/inward/InwardSearch.java
@@ -118,6 +118,8 @@ public class InwardSearch implements Serializable {
     ConfigOptionApplicationController configOptionApplicationController;
     @Inject
     LabTestHistoryController labTestHistoryController;
+    @Inject
+    InwardPaymentController inwardPaymentController;
 
     /**
      * Properties
@@ -439,6 +441,9 @@ public class InwardSearch implements Serializable {
     }
 
     public String navigateDoctorPayment() {
+        PatientEncounter pe = inwardPaymentController.getCurrent().getPatientEncounter();
+        inwardPaymentController.makeNull();
+        inwardPaymentController.getCurrent().setPatientEncounter(pe);
         if (sessionController.getPaymentManagementAfterShiftStart()) {
             financialTransactionController.findNonClosedShiftStartFundBillIsAvailable();
             if (financialTransactionController.getNonClosedShiftStartFundBill() != null) {


### PR DESCRIPTION
## Summary

- `InwardPaymentController` is `@SessionScoped`; after a successful payment `printPreview` is set to `true`
- Clicking **Payments** from the inpatient dashboard called `inwardSearch.navigateDoctorPayment()` which redirected without resetting the controller, so the previous payment's print appeared instead of a fresh form
- Fix: inject `InwardPaymentController` into `InwardSearch`, save the patient encounter (already set by `f:setPropertyActionListener`), call `makeNull()` to clear all stale state, then restore the encounter before redirecting

## Test plan

- [ ] Open an inpatient admission → click **Payments** → verify a blank payment form appears
- [ ] Complete a payment (verify success message and print panel appear)
- [ ] Navigate back to the inpatient dashboard → click **Payments** again for any admission → verify the **payment form** appears (not the previous print)
- [ ] Verify shift-start check still works: if shift management is enabled, test with and without an open shift

Closes #20268

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where patient encounter information was not properly preserved when navigating between doctor payment workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->