### PR TITLE
fix(inward-room-facility-api): make departmentId mandatory on create/…

### DIFF
--- a/src/main/java/com/divudi/service/AnthropicApiService.java
+++ b/src/main/java/com/divudi/service/AnthropicApiService.java
@@ -510,7 +510,7 @@ public class AnthropicApiService implements Serializable {
                                         .add("description", "Room id. Used for POST_CHARGE/PUT_CHARGE and as filter for LIST_CHARGES."))
                                 .add("departmentId", Json.createObjectBuilder()
                                         .add("type", "string")
-                                        .add("description", "Department id. Optional for POST_CHARGE/PUT_CHARGE."))
+                                        .add("description", "Department id. Required for POST_CHARGE; required (non-null) when supplied on PUT_CHARGE."))
                                 .add("filled", Json.createObjectBuilder()
                                         .add("type", "string")
                                         .add("description", "Whether room is under construction (true/false). Optional for POST_ROOM/PUT_ROOM."))

--- a/src/main/java/com/divudi/ws/common/CapabilityStatementResource.java
+++ b/src/main/java/com/divudi/ws/common/CapabilityStatementResource.java
@@ -152,6 +152,7 @@ public class CapabilityStatementResource {
                 .add(resource("Inward Room Facility Charges", "/api/inward/room-facility-charges",
                         "Manage inward room facility charges / room fees (backs /inward/inward_room_facility.xhtml). "
                         + "Supports optional filters roomId and roomCategoryId. "
+                        + "departmentId is required on POST and may not be set to null on PUT. "
                         + "Charge fields: roomCharge, maintananceCharge, linenCharge, nursingCharge, "
                         + "moCharge, moChargeForAfterDuration, adminstrationCharge, medicalCareCharge. "
                         + "TimedItemFee fields: timedItemFeeDurationHours, timedItemFeeOverShootHours, "

--- a/src/main/java/com/divudi/ws/inward/InwardRoomFacilityChargeApi.java
+++ b/src/main/java/com/divudi/ws/inward/InwardRoomFacilityChargeApi.java
@@ -164,7 +164,7 @@ public class InwardRoomFacilityChargeApi {
     /**
      * Create a new room facility charge.
      * POST /api/inward/room-facility-charges
-     * Body: { "name", "roomId", "roomCategoryId", "departmentId",
+     * Body: { "name" (required), "departmentId" (required), "roomId", "roomCategoryId",
      *         "roomCharge", "maintananceCharge", "linenCharge", "nursingCharge",
      *         "moCharge", "moChargeForAfterDuration", "adminstrationCharge", "medicalCareCharge",
      *         "timedItemFeeDurationHours", "timedItemFeeOverShootHours", "timedItemFeeDurationDaysForMoCharge" }
@@ -213,13 +213,13 @@ public class InwardRoomFacilityChargeApi {
                 }
             }
 
-            Department department = null;
             Long departmentId = asLong(body.get("departmentId"));
-            if (departmentId != null) {
-                department = departmentFacade.find(departmentId);
-                if (department == null || department.isRetired()) {
-                    return errorResponse("Department not found: " + departmentId, 400);
-                }
+            if (departmentId == null) {
+                return errorResponse("departmentId is required", 400);
+            }
+            Department department = departmentFacade.find(departmentId);
+            if (department == null || department.isRetired()) {
+                return errorResponse("Department not found: " + departmentId, 400);
             }
 
             // Parse all charge fields before any DB writes to avoid orphaned TimedItemFee rows
@@ -318,14 +318,13 @@ public class InwardRoomFacilityChargeApi {
             if (body.containsKey("departmentId")) {
                 Long departmentId = asLong(body.get("departmentId"));
                 if (departmentId == null) {
-                    charge.setDepartment(null);
-                } else {
-                    Department department = departmentFacade.find(departmentId);
-                    if (department == null || department.isRetired()) {
-                        return errorResponse("Department not found: " + departmentId, 400);
-                    }
-                    charge.setDepartment(department);
+                    return errorResponse("departmentId cannot be null", 400);
                 }
+                Department department = departmentFacade.find(departmentId);
+                if (department == null || department.isRetired()) {
+                    return errorResponse("Department not found: " + departmentId, 400);
+                }
+                charge.setDepartment(department);
             }
 
             applyChargeFields(body, charge);


### PR DESCRIPTION
…update

Several Room Facility Charges were created via API without a department, breaking inward workflows that group rooms by department. Enforce departmentId on POST and reject explicit null on PUT so callers cannot clear an existing department.

Closes #20272