### PR TITLE
fix(api): return generated id from POST institutions/departments

### DIFF
--- a/src/main/java/com/divudi/service/institution/DepartmentApiService.java
+++ b/src/main/java/com/divudi/service/institution/DepartmentApiService.java
@@ -49,19 +49,26 @@ public class DepartmentApiService implements Serializable {
      * Uses DTO constructor queries for optimal performance
      */
     public List<DepartmentDTO> searchDepartments(String query, DepartmentType type, Long institutionId, Integer limit) throws Exception {
-        if (query == null || query.trim().isEmpty()) {
-            throw new Exception("Department search query is required");
+        boolean hasQuery = query != null && !query.trim().isEmpty();
+
+        // At least one filter (query or institutionId) must be provided so we
+        // don't return the entire department table. Either alone is sufficient.
+        if (!hasQuery && institutionId == null) {
+            throw new Exception("Either query or institutionId is required");
         }
 
         Map<String, Object> params = new HashMap<>();
-        params.put("query", "%" + query.toUpperCase() + "%");
 
         StringBuilder jpql = new StringBuilder();
         jpql.append("SELECT new com.divudi.core.data.dto.search.DepartmentDTO(")
             .append("d.id, d.name, d.code) ")
             .append("FROM Department d ")
-            .append("WHERE d.retired = false ")
-            .append("AND (upper(d.name) LIKE :query OR upper(d.code) LIKE :query) ");
+            .append("WHERE d.retired = false ");
+
+        if (hasQuery) {
+            jpql.append("AND (upper(d.name) LIKE :query OR upper(d.code) LIKE :query) ");
+            params.put("query", "%" + query.toUpperCase() + "%");
+        }
 
         // Add type filter if provided
         if (type != null) {
@@ -163,8 +170,9 @@ public class DepartmentApiService implements Serializable {
         department.setCreatedAt(Calendar.getInstance().getTime());
         department.setRetired(false);
 
-        // Save department
-        departmentFacade.create(department);
+        // Save department and flush so the IDENTITY-generated id is populated
+        // before we build the response DTO (issue #20276)
+        departmentFacade.createAndFlush(department);
 
         return buildDepartmentResponseDTO(department, "Department created successfully");
     }
@@ -237,8 +245,8 @@ public class DepartmentApiService implements Serializable {
             department.setPharmacyMarginFromPurchaseRate(request.getPharmacyMarginFromPurchaseRate());
         }
 
-        // Save updated department
-        departmentFacade.edit(department);
+        // Save updated department and flush so response reflects persisted state
+        departmentFacade.editAndFlush(department);
 
         return buildDepartmentResponseDTO(department, "Department updated successfully");
     }
@@ -268,8 +276,8 @@ public class DepartmentApiService implements Serializable {
         department.setRetiredAt(Calendar.getInstance().getTime());
         department.setRetireComments(retireComments);
 
-        // Save retired department
-        departmentFacade.edit(department);
+        // Save retired department and flush so response reflects persisted state
+        departmentFacade.editAndFlush(department);
 
         return buildDepartmentResponseDTO(department, "Department retired successfully");
     }
@@ -321,8 +329,8 @@ public class DepartmentApiService implements Serializable {
             department.setSuperDepartment(superDepartment);
         }
 
-        // Save updated department
-        departmentFacade.edit(department);
+        // Save updated department and flush so response reflects persisted state
+        departmentFacade.editAndFlush(department);
 
         return buildDepartmentResponseDTO(department, "Department relationships updated successfully");
     }

--- a/src/main/java/com/divudi/service/institution/InstitutionApiService.java
+++ b/src/main/java/com/divudi/service/institution/InstitutionApiService.java
@@ -134,8 +134,9 @@ public class InstitutionApiService implements Serializable {
         institution.setCreatedAt(Calendar.getInstance().getTime());
         institution.setRetired(false);
 
-        // Save institution
-        institutionFacade.create(institution);
+        // Save institution and flush so the IDENTITY-generated id is populated
+        // before we build the response DTO (issue #20276)
+        institutionFacade.createAndFlush(institution);
 
         return buildInstitutionResponseDTO(institution, "Institution created successfully");
     }
@@ -208,8 +209,8 @@ public class InstitutionApiService implements Serializable {
             institution.setOwnerEmail(request.getOwnerEmail());
         }
 
-        // Save updated institution
-        institutionFacade.edit(institution);
+        // Save updated institution and flush so response reflects persisted state
+        institutionFacade.editAndFlush(institution);
 
         return buildInstitutionResponseDTO(institution, "Institution updated successfully");
     }
@@ -239,8 +240,8 @@ public class InstitutionApiService implements Serializable {
         institution.setRetiredAt(Calendar.getInstance().getTime());
         institution.setRetireComments(retireComments);
 
-        // Save retired institution
-        institutionFacade.edit(institution);
+        // Save retired institution and flush so response reflects persisted state
+        institutionFacade.editAndFlush(institution);
 
         return buildInstitutionResponseDTO(institution, "Institution retired successfully");
     }
@@ -274,8 +275,8 @@ public class InstitutionApiService implements Serializable {
             institution.setInstitution(null);
         }
 
-        // Save updated institution
-        institutionFacade.edit(institution);
+        // Save updated institution and flush so response reflects persisted state
+        institutionFacade.editAndFlush(institution);
 
         return buildInstitutionResponseDTO(institution, "Institution parent relationship updated successfully");
     }

--- a/src/main/java/com/divudi/ws/institution/DepartmentApi.java
+++ b/src/main/java/com/divudi/ws/institution/DepartmentApi.java
@@ -91,10 +91,6 @@ public class DepartmentApi {
             String institutionIdStr = uriInfo.getQueryParameters().getFirst("institutionId");
             String limitStr = uriInfo.getQueryParameters().getFirst("limit");
 
-            if (query == null || query.trim().isEmpty()) {
-                return errorResponse("Query parameter is required", 400);
-            }
-
             // Parse department type if provided
             DepartmentType type = null;
             if (typeStr != null && !typeStr.trim().isEmpty()) {
@@ -115,6 +111,12 @@ public class DepartmentApi {
                 }
             }
 
+            // Either query or institutionId must be provided so we don't list
+            // the entire department table (issue #20276)
+            if ((query == null || query.trim().isEmpty()) && institutionId == null) {
+                return errorResponse("Either query or institutionId is required", 400);
+            }
+
             // Parse limit if provided
             Integer limit = null;
             if (limitStr != null && !limitStr.trim().isEmpty()) {
@@ -126,7 +128,8 @@ public class DepartmentApi {
             }
 
             // Perform search
-            List<DepartmentDTO> results = departmentService.searchDepartments(query.trim(), type, institutionId, limit);
+            String trimmedQuery = (query != null) ? query.trim() : null;
+            List<DepartmentDTO> results = departmentService.searchDepartments(trimmedQuery, type, institutionId, limit);
 
             return successResponse(results);
 


### PR DESCRIPTION
## Summary
- POST `/api/institutions` and `/api/departments` previously called `em.persist(...)` only, so the IDENTITY-generated `id` was not assigned before the response DTO was built — clients had to follow up with a search call to discover the new id.
- Switch the create paths to `createAndFlush(...)` so the id is populated before the response is built. Switch update/retire/relationship-change paths to `editAndFlush(...)` for consistency.
- Relax `GET /api/departments/search` to accept `institutionId` without `query`, so callers can list departments by institution in a single round-trip. Either filter is now required (sending neither still returns 400).

Closes #20276

## Test plan
- [ ] `POST /api/institutions` with a valid payload — response `data.id` is populated and matches the row in DB.
- [ ] `POST /api/departments` with a valid payload — response `data.id` is populated and matches the row in DB.
- [ ] `PUT /api/institutions/{id}` and `PUT /api/departments/{id}` — response reflects updated values.
- [ ] `DELETE /api/institutions/{id}` and `DELETE /api/departments/{id}` — response shows `active: false`.
- [ ] `GET /api/departments/search?institutionId=<id>` (no `query`) — returns the institution's non-retired departments.
- [ ] `GET /api/departments/search` (no `query`, no `institutionId`) — still returns 400 with "Either query or institutionId is required".
- [ ] `GET /api/departments/search?query=...` (existing behaviour) — still works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)