### PR TITLE
fix(cashier): handover print, preview, and accept page fixes

### DIFF
--- a/src/main/java/com/divudi/bean/cashTransaction/FinancialTransactionController.java
+++ b/src/main/java/com/divudi/bean/cashTransaction/FinancialTransactionController.java
@@ -1964,6 +1964,39 @@ public class FinancialTransactionController implements Serializable {
         // Restore totalOut so "Handingover Value" is correct on the print.
         bundle.setTotalOut(selectedBill.getNetTotal());
 
+        // Fetch individual float transfer payments for this shift so the preview can
+        // display them as detail rows. Float payments were marked handingOverStarted=true
+        // during settleHandoverStartBill(). Scope: bill ID range between shift start and
+        // handover bill, for this user as creator or recipient.
+        Bill shiftStartBill = selectedBill.getReferenceBill();
+        if (shiftStartBill != null && shiftStartBill.getId() != null) {
+            List<BillTypeAtomic> floatBtas = new ArrayList<>();
+            floatBtas.add(BillTypeAtomic.FUND_TRANSFER_BILL);
+            floatBtas.add(BillTypeAtomic.FUND_TRANSFER_RECEIVED_BILL);
+            Map<String, Object> floatParams = new HashMap<>();
+            String floatJpql = "SELECT p FROM Payment p JOIN p.bill b "
+                    + "WHERE (p.creater = :cu OR p.floatRecipient = :cu) "
+                    + "AND p.retired = false "
+                    + "AND p.cancelled = false "
+                    + "AND p.handingOverStarted = true "
+                    + "AND b.billTypeAtomic IN :btas "
+                    + "AND b.id > :sid "
+                    + "AND b.id <= :hid "
+                    + "ORDER BY b.id";
+            floatParams.put("cu", selectedBill.getFromWebUser());
+            floatParams.put("btas", floatBtas);
+            floatParams.put("sid", shiftStartBill.getId());
+            floatParams.put("hid", selectedBill.getId());
+            List<Payment> floatPayments = paymentFacade.findByJpql(floatJpql, floatParams);
+            if (floatPayments != null) {
+                for (Payment fp : floatPayments) {
+                    ReportTemplateRow row = new ReportTemplateRow();
+                    row.setPayment(fp);
+                    bundle.getReportTemplateRows().add(row);
+                }
+            }
+        }
+
         return "/cashier/handover_preview?faces-redirect=true";
     }
 

--- a/src/main/java/com/divudi/bean/cashTransaction/FinancialTransactionController.java
+++ b/src/main/java/com/divudi/bean/cashTransaction/FinancialTransactionController.java
@@ -1864,21 +1864,51 @@ public class FinancialTransactionController implements Serializable {
         bundle.aggregateTotalsFromAllChildBundles();
         bundle.collectDepartments();
 
-        // Restore cash float net for display. The denomination bill holds the
-        // physical cash the sender counted at handover; bundle.cashValue is the
-        // cash portion collected during the shift (float-exclusive). Their
-        // difference is the net cash float carried into the handover. Using
-        // the denomination bill (instead of selectedBill.total) is independent
-        // of how total was persisted, so legacy handovers created before the
-        // total-persistence fix also restore correctly.
+        // Restore cash handover value and float net after aggregate (aggregate
+        // overwrites cashHandoverValue with sum of child values = collected cash).
+        // The denomination bill holds the physical cash the sender counted.
         if (denoBill != null) {
             double physicalCash = denoBill.getNetTotal();
+            bundle.setCashHandoverValue(physicalCash);
+            bundle.setDenominatorValue(physicalCash);
             double rebuiltCash = bundle.getCashValue();
             double floatNet = physicalCash - rebuiltCash;
             if (floatNet > 0.001) {
                 bundle.setCashFloatInTotal(floatNet);
             } else if (floatNet < -0.001) {
                 bundle.setCashFloatOutTotal(-floatNet);
+            }
+        }
+        bundle.setTotalOut(selectedBill.getNetTotal());
+
+        // Fetch float transfer payments for this shift so the accept page can
+        // display them. Same query as navigateToViewHandoverBill.
+        Bill shiftStartBill = selectedBill.getReferenceBill();
+        if (shiftStartBill != null && shiftStartBill.getId() != null) {
+            List<BillTypeAtomic> floatBtas = new ArrayList<>();
+            floatBtas.add(BillTypeAtomic.FUND_TRANSFER_BILL);
+            floatBtas.add(BillTypeAtomic.FUND_TRANSFER_RECEIVED_BILL);
+            Map<String, Object> floatParams = new HashMap<>();
+            String floatJpql = "SELECT p FROM Payment p JOIN p.bill b "
+                    + "WHERE (p.creater = :cu OR p.floatRecipient = :cu) "
+                    + "AND p.retired = false "
+                    + "AND p.cancelled = false "
+                    + "AND p.handingOverStarted = true "
+                    + "AND b.billTypeAtomic IN :btas "
+                    + "AND b.id > :sid "
+                    + "AND b.id <= :hid "
+                    + "ORDER BY b.id";
+            floatParams.put("cu", selectedBill.getFromWebUser());
+            floatParams.put("btas", floatBtas);
+            floatParams.put("sid", shiftStartBill.getId());
+            floatParams.put("hid", selectedBill.getId());
+            List<Payment> floatPayments = paymentFacade.findByJpql(floatJpql, floatParams);
+            if (floatPayments != null) {
+                for (Payment fp : floatPayments) {
+                    ReportTemplateRow floatRow = new ReportTemplateRow();
+                    floatRow.setPayment(fp);
+                    bundle.getReportTemplateRows().add(floatRow);
+                }
             }
         }
 

--- a/src/main/java/com/divudi/bean/cashTransaction/FinancialTransactionController.java
+++ b/src/main/java/com/divudi/bean/cashTransaction/FinancialTransactionController.java
@@ -5865,6 +5865,9 @@ public class FinancialTransactionController implements Serializable {
             for (Payment ftp : floatPaymentsToMark) {
                 ftp.setHandingOverStarted(true);
                 paymentController.save(ftp);
+                ReportTemplateRow floatRow = new ReportTemplateRow();
+                floatRow.setPayment(ftp);
+                bundle.getReportTemplateRows().add(floatRow);
             }
         }
 

--- a/src/main/java/com/divudi/bean/cashTransaction/FinancialTransactionController.java
+++ b/src/main/java/com/divudi/bean/cashTransaction/FinancialTransactionController.java
@@ -1945,10 +1945,13 @@ public class FinancialTransactionController implements Serializable {
         bundle.collectDepartments();
         bundle.setHandoverBill(selectedBill);
 
-        // Restore denominatorValue and cash float net so the print shows correct
-        // "Handing Over" and "Net Float (Cash)" values from the saved denomination bill.
+        // Restore cash handover, denominatorValue, and cash float net from the saved
+        // denomination bill. aggregateTotalsFromAllChildBundles() overwrites cashHandoverValue
+        // with the sum of child values (= collected cash), so we must set the correct
+        // physical-cash value after the aggregate call, not before.
         if (denoBill != null) {
             double physicalCash = denoBill.getNetTotal();
+            bundle.setCashHandoverValue(physicalCash);
             bundle.setDenominatorValue(physicalCash);
             double rebuiltCash = bundle.getCashValue();
             double floatNet = physicalCash - rebuiltCash;

--- a/src/main/webapp/cashier/handover_accept.xhtml
+++ b/src/main/webapp/cashier/handover_accept.xhtml
@@ -151,7 +151,7 @@
                                                     <tr>
                                                         <td>Cash</td>
                                                         <td class="text-end">
-                                                            <h:outputText value="#{financialTransactionController.bundle.cashValue + financialTransactionController.bundle.cashFloatNetTotal}">
+                                                            <h:outputText value="#{financialTransactionController.bundle.cashValue}">
                                                                 <f:convertNumber pattern="#,##0.00" />
                                                             </h:outputText>
                                                         </td>
@@ -161,10 +161,24 @@
                                                             </h:outputText>
                                                         </td>
                                                         <td class="text-end">
-                                                            <h:outputText value="#{financialTransactionController.bundle.cashValue + financialTransactionController.bundle.cashFloatNetTotal - financialTransactionController.bundle.cashHandoverValue}">
+                                                            <h:outputText value="#{financialTransactionController.bundle.cashValue - financialTransactionController.bundle.cashHandoverValue}">
                                                                 <f:convertNumber pattern="#,##0.00" />
                                                             </h:outputText>
                                                         </td>
+                                                    </tr>
+                                                </ui:fragment>
+
+                                                <!-- Net Float (Cash) row — only when there is a net float -->
+                                                <ui:fragment rendered="#{financialTransactionController.bundle.cashFloatNetTotal != 0}">
+                                                    <tr>
+                                                        <td><em>Net Float (Cash)</em></td>
+                                                        <td class="text-end">
+                                                            <h:outputText value="#{financialTransactionController.bundle.cashFloatNetTotal}">
+                                                                <f:convertNumber pattern="#,##0.00" />
+                                                            </h:outputText>
+                                                        </td>
+                                                        <td></td>
+                                                        <td></td>
                                                     </tr>
                                                 </ui:fragment>
 
@@ -243,7 +257,7 @@
                                                             </h:outputText>
                                                         </td>
                                                         <td class="text-end">
-                                                            <h:outputText value="#{financialTransactionController.bundle.ewalletValue}">
+                                                            <h:outputText value="#{financialTransactionController.bundle.ewalletHandoverValue}">
                                                                 <f:convertNumber pattern="#,##0.00" />
                                                             </h:outputText>
                                                         </td>
@@ -774,10 +788,10 @@
                                             </f:facet>
                                         </p:column>
 
-                                        <p:column 
-                                            headerText="Online Settlement" 
+                                        <p:column
+                                            headerText="Online Settlement"
                                             class="text-end"
-                                            rendered="#{financialTransactionController.bundle.hasOnCallTransaction}" >
+                                            rendered="#{financialTransactionController.bundle.hasOnlineSettlementTransaction}" >
                                             <h:outputText value="#{summary.onlineSettlementValue}" >
                                                 <f:convertNumber pattern="#,##0.00" ></f:convertNumber>
                                             </h:outputText>
@@ -815,6 +829,79 @@
                                         </p:column>
 
                                     </p:dataTable>
+
+                                    <!-- Float Transfers section -->
+                                    <h:panelGroup layout="block" styleClass="row mt-2"
+                                         rendered="#{financialTransactionController.bundle.cashFloatNetTotal != 0
+                                                     or not empty financialTransactionController.bundle.reportTemplateRows}">
+                                        <p:panel>
+                                            <f:facet name="header">
+                                                <p:outputLabel value="Float Transfers" />
+                                            </f:facet>
+                                            <p:dataTable
+                                                value="#{financialTransactionController.bundle.reportTemplateRows}"
+                                                var="floatRow"
+                                                rendered="#{not empty financialTransactionController.bundle.reportTemplateRows}"
+                                                emptyMessage="No float transfers">
+                                                <p:column headerText="Date">
+                                                    <h:outputText value="#{floatRow.payment.createdAt}">
+                                                        <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateTimeFormat}" />
+                                                    </h:outputText>
+                                                </p:column>
+                                                <p:column headerText="Type">
+                                                    <h:outputText value="Float Out"
+                                                        rendered="#{floatRow.payment.bill.billTypeAtomic.name() eq 'FUND_TRANSFER_BILL'}" />
+                                                    <h:outputText value="Float In"
+                                                        rendered="#{floatRow.payment.bill.billTypeAtomic.name() eq 'FUND_TRANSFER_RECEIVED_BILL'}" />
+                                                </p:column>
+                                                <p:column headerText="From">
+                                                    <h:outputText value="#{floatRow.payment.creater.webUserPerson.nameWithTitle}" />
+                                                </p:column>
+                                                <p:column headerText="To">
+                                                    <h:outputText value="#{floatRow.payment.floatRecipient.webUserPerson.nameWithTitle}" />
+                                                </p:column>
+                                                <p:column headerText="Method">
+                                                    <h:outputText value="#{floatRow.payment.paymentMethod}" />
+                                                </p:column>
+                                                <p:column headerText="Amount" styleClass="text-end">
+                                                    <h:outputText value="#{floatRow.payment.paidValue}">
+                                                        <f:convertNumber pattern="#,##0.00" />
+                                                    </h:outputText>
+                                                </p:column>
+                                            </p:dataTable>
+                                            <table class="table table-bordered mt-2 w-50">
+                                                <ui:fragment rendered="#{financialTransactionController.bundle.cashFloatInTotal gt 0}">
+                                                    <tr>
+                                                        <td>Float Received (Cash)</td>
+                                                        <td class="text-end">
+                                                            <h:outputText value="#{financialTransactionController.bundle.cashFloatInTotal}">
+                                                                <f:convertNumber pattern="#,##0.00" />
+                                                            </h:outputText>
+                                                        </td>
+                                                    </tr>
+                                                </ui:fragment>
+                                                <ui:fragment rendered="#{financialTransactionController.bundle.cashFloatOutTotal gt 0}">
+                                                    <tr>
+                                                        <td>Float Sent (Cash)</td>
+                                                        <td class="text-end">
+                                                            <h:outputText value="#{financialTransactionController.bundle.cashFloatOutTotal}">
+                                                                <f:convertNumber pattern="#,##0.00" />
+                                                            </h:outputText>
+                                                        </td>
+                                                    </tr>
+                                                </ui:fragment>
+                                                <tr>
+                                                    <td><strong>Net Float (Cash)</strong></td>
+                                                    <td class="text-end">
+                                                        <h:outputText value="#{financialTransactionController.bundle.cashFloatNetTotal}">
+                                                            <f:convertNumber pattern="#,##0.00" />
+                                                        </h:outputText>
+                                                    </td>
+                                                </tr>
+                                            </table>
+                                        </p:panel>
+                                    </h:panelGroup>
+
                                 </div>
                             </div>
                         </h:panelGroup>

--- a/src/main/webapp/cashier/handover_preview.xhtml
+++ b/src/main/webapp/cashier/handover_preview.xhtml
@@ -788,6 +788,96 @@
                             </p:dataTable>
                         </div>
 
+                        <div class="row mt-2"
+                             rendered="#{financialTransactionController.bundle.cashFloatNetTotal != 0
+                                        or not empty financialTransactionController.bundle.reportTemplateRows}">
+                            <p:panel>
+                                <f:facet name="header">
+                                    <p:outputLabel value="Float Transfers" class="font-weight-bold" />
+                                </f:facet>
+
+                                <p:dataTable
+                                    value="#{financialTransactionController.bundle.reportTemplateRows}"
+                                    var="floatRow"
+                                    rendered="#{not empty financialTransactionController.bundle.reportTemplateRows}"
+                                    emptyMessage="No float transfer records">
+
+                                    <p:column headerText="Date">
+                                        <h:outputText value="#{floatRow.payment.createdAt}">
+                                            <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateTimeFormat}" />
+                                        </h:outputText>
+                                    </p:column>
+
+                                    <p:column headerText="Type">
+                                        <h:outputText value="Float Out"
+                                            rendered="#{floatRow.payment.bill.billTypeAtomic.name() eq 'FUND_TRANSFER_BILL'}" />
+                                        <h:outputText value="Float In"
+                                            rendered="#{floatRow.payment.bill.billTypeAtomic.name() eq 'FUND_TRANSFER_RECEIVED_BILL'}" />
+                                    </p:column>
+
+                                    <p:column headerText="From">
+                                        <h:outputText value="#{floatRow.payment.creater.webUserPerson.nameWithTitle}" />
+                                    </p:column>
+
+                                    <p:column headerText="To">
+                                        <h:outputText value="#{floatRow.payment.floatRecipient.webUserPerson.nameWithTitle}" />
+                                    </p:column>
+
+                                    <p:column headerText="Method">
+                                        <h:outputText value="#{floatRow.payment.paymentMethod}" />
+                                    </p:column>
+
+                                    <p:column headerText="Amount" class="text-end">
+                                        <h:outputText value="#{floatRow.payment.paidValue}">
+                                            <f:convertNumber pattern="#,##0.00" />
+                                        </h:outputText>
+                                    </p:column>
+
+                                </p:dataTable>
+
+                                <table class="table table-bordered mt-2 w-50">
+                                    <thead>
+                                        <tr>
+                                            <th>Float Summary</th>
+                                            <th class="text-end">Amount</th>
+                                        </tr>
+                                    </thead>
+                                    <tbody>
+                                        <ui:fragment rendered="#{financialTransactionController.bundle.cashFloatInTotal gt 0}">
+                                            <tr>
+                                                <td>Float Received (Cash)</td>
+                                                <td class="text-end">
+                                                    <h:outputText value="#{financialTransactionController.bundle.cashFloatInTotal}">
+                                                        <f:convertNumber pattern="#,##0.00" />
+                                                    </h:outputText>
+                                                </td>
+                                            </tr>
+                                        </ui:fragment>
+                                        <ui:fragment rendered="#{financialTransactionController.bundle.cashFloatOutTotal gt 0}">
+                                            <tr>
+                                                <td>Float Sent (Cash)</td>
+                                                <td class="text-end">
+                                                    <h:outputText value="#{financialTransactionController.bundle.cashFloatOutTotal}">
+                                                        <f:convertNumber pattern="#,##0.00" />
+                                                    </h:outputText>
+                                                </td>
+                                            </tr>
+                                        </ui:fragment>
+                                        <ui:fragment rendered="#{financialTransactionController.bundle.cashFloatNetTotal != 0}">
+                                            <tr class="table-active fw-bold">
+                                                <td>Net Float (Cash)</td>
+                                                <td class="text-end">
+                                                    <h:outputText value="#{financialTransactionController.bundle.cashFloatNetTotal}">
+                                                        <f:convertNumber pattern="#,##0.00" />
+                                                    </h:outputText>
+                                                </td>
+                                            </tr>
+                                        </ui:fragment>
+                                    </tbody>
+                                </table>
+
+                            </p:panel>
+                        </div>
 
                     </p:panel>
 

--- a/src/main/webapp/resources/ezcomp/prints/five_five_paper_with_headings_for_handover.xhtml
+++ b/src/main/webapp/resources/ezcomp/prints/five_five_paper_with_headings_for_handover.xhtml
@@ -843,6 +843,86 @@
 
                 </p:dataTable>
 
+                <h:panelGroup rendered="#{not empty cc.attrs.bundle.reportTemplateRows
+                                         or cc.attrs.bundle.cashFloatNetTotal != 0}">
+                    <hr/>
+                    <div class="my-2" style="font-weight: bold;">Float Transfers</div>
+
+                    <p:dataTable
+                        style="padding: 0px!important; margin: 0px!important; font-size: #{pharmacySummaryReportController.fontSizeForPrinting}!important;"
+                        styleClass="ui-datatable-borderless ui-datatable-sm compact-datatable"
+                        rendered="#{not empty cc.attrs.bundle.reportTemplateRows}"
+                        value="#{cc.attrs.bundle.reportTemplateRows}"
+                        var="floatRow">
+
+                        <p:column headerText="Date" style="font-weight: normal">
+                            <h:outputText value="#{floatRow.payment.createdAt}">
+                                <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateFormat}" />
+                            </h:outputText>
+                        </p:column>
+
+                        <p:column headerText="Type" style="font-weight: normal">
+                            <h:outputText value="Float Out"
+                                rendered="#{floatRow.payment.bill.billTypeAtomic.name() eq 'FUND_TRANSFER_BILL'}" />
+                            <h:outputText value="Float In"
+                                rendered="#{floatRow.payment.bill.billTypeAtomic.name() eq 'FUND_TRANSFER_RECEIVED_BILL'}" />
+                        </p:column>
+
+                        <p:column headerText="From" style="font-weight: normal">
+                            <h:outputText value="#{floatRow.payment.creater.webUserPerson.nameWithTitle}" />
+                        </p:column>
+
+                        <p:column headerText="To" style="font-weight: normal">
+                            <h:outputText value="#{floatRow.payment.floatRecipient.webUserPerson.nameWithTitle}" />
+                        </p:column>
+
+                        <p:column headerText="Method" style="font-weight: normal">
+                            <h:outputText value="#{floatRow.payment.paymentMethod}" />
+                        </p:column>
+
+                        <p:column headerText="Amount" class="text-end" style="font-weight: normal">
+                            <h:outputText value="#{floatRow.payment.paidValue}">
+                                <f:convertNumber pattern="#,##0.00" />
+                            </h:outputText>
+                        </p:column>
+
+                    </p:dataTable>
+
+                    <table class="table table-bordered mt-1" style="width: 40%;">
+                        <tbody>
+                            <h:panelGroup rendered="#{cc.attrs.bundle.cashFloatInTotal gt 0}">
+                                <tr>
+                                    <td>Float Received (Cash)</td>
+                                    <td class="text-end">
+                                        <h:outputText value="#{cc.attrs.bundle.cashFloatInTotal}">
+                                            <f:convertNumber pattern="#,##0.00" />
+                                        </h:outputText>
+                                    </td>
+                                </tr>
+                            </h:panelGroup>
+                            <h:panelGroup rendered="#{cc.attrs.bundle.cashFloatOutTotal gt 0}">
+                                <tr>
+                                    <td>Float Sent (Cash)</td>
+                                    <td class="text-end">
+                                        <h:outputText value="#{cc.attrs.bundle.cashFloatOutTotal}">
+                                            <f:convertNumber pattern="#,##0.00" />
+                                        </h:outputText>
+                                    </td>
+                                </tr>
+                            </h:panelGroup>
+                            <h:panelGroup rendered="#{cc.attrs.bundle.cashFloatNetTotal != 0}">
+                                <tr style="font-weight: bold;">
+                                    <td>Net Float (Cash)</td>
+                                    <td class="text-end">
+                                        <h:outputText value="#{cc.attrs.bundle.cashFloatNetTotal}">
+                                            <f:convertNumber pattern="#,##0.00" />
+                                        </h:outputText>
+                                    </td>
+                                </tr>
+                            </h:panelGroup>
+                        </tbody>
+                    </table>
+                </h:panelGroup>
 
             </div>
 


### PR DESCRIPTION
## Summary

- Fix handover print composite (`five_five_paper_with_headings_for_handover.xhtml`): add Staff Welfare columns, missing footer facets on all handover columns, Net Float (Cash) row, and correct reprint values
- Fix handover preview (`handover_preview.xhtml`): restore `cashHandoverValue` from denomination bill after aggregate overwrites it; add Float Transfers detail section
- Fix handover accept (`handover_accept.xhtml`): same `cashHandoverValue` restore fix; correct Cash Collected column (removed spurious `+cashFloatNetTotal`); fix eWallet Handed Over column (was showing collected not handover value); fix Online Settlement column `rendered` condition (was using wrong `hasOnCallTransaction` flag); add Net Float (Cash) row; add Float Transfers detail section
- All three pages now display individual float transfer rows with From/To/Amount details and a Net Float summary

Closes #18907

## Test plan

- [ ] Create a shift handover with a cash float in/out — verify print shows Net Float (Cash) row and float detail table
- [ ] View handover preview — verify Handed Over column matches denomination total, float rows appear
- [ ] Open a pending handover on accept page — verify Cash Collected = shift cash only, Handed Over = denomination total, Net Float row present, Online Settlement column renders correctly when applicable, float detail section visible
- [ ] Reprint a completed handover — verify values correct and float rows present

🤖 Generated with [Claude Code](https://claude.com/claude-code)