### PR TITLE
fix(cashier): correct back button label and navigation on handover accept select page

### DIFF
--- a/src/main/webapp/cashier/handover_accept_select.xhtml
+++ b/src/main/webapp/cashier/handover_accept_select.xhtml
@@ -22,11 +22,11 @@
                                     <p:outputLabel value="Handover Accept" />
                                 </div>
                                 <div class="col float-right">
-                                    <p:commandButton 
-                                        value="Back to Shift Accept" 
+                                    <p:commandButton
+                                        value="Back to Accept Handovers"
                                         class="m-1 ui-button-success"
-                                        icon="pi pi-arrow-left" 
-                                        action="#{financialTransactionController.navigateBackToPaymentHandoverAccept()}"
+                                        icon="pi pi-arrow-left"
+                                        action="#{financialTransactionController.navigateToReceiveHandoverBillsForMe()}"
                                         ajax="false">
                                     </p:commandButton>
 


### PR DESCRIPTION
## Summary

- Renames the button label from **"Back to Shift Accept"** to **"Back to Accept Handovers"**
- Changes the button action from `navigateBackToPaymentHandoverAccept()` (which threw an NPE because `bundle` is null in this flow) to `navigateToReceiveHandoverBillsForMe()` (which safely initialises the list and navigates to the correct page)

Fixes #20285

## Test plan

- [ ] Navigate to Cashier → Shift Handovers to Accept
- [ ] Open any handover entry (a payment-method row leading to `handover_accept_select.xhtml`)
- [ ] Verify the button is now labelled **"Back to Accept Handovers"**
- [ ] Click the button and confirm it returns to the **Shift Handovers to Accept** list without any error

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved navigation flow in the cashier handover accept interface. The back button label has been updated to "Back to Accept Handovers" and now directs users to the appropriate screen within the handover workflow. This improves the user experience by clarifying the navigation path.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->