### PR TITLE
refactor(hr): update time period validation to use minutes for accuracy

### DIFF
--- a/src/main/java/com/divudi/bean/hr/StaffAdditionalFormController.java
+++ b/src/main/java/com/divudi/bean/hr/StaffAdditionalFormController.java
@@ -803,8 +803,9 @@ public class StaffAdditionalFormController implements Serializable {
             return true;
         }
 
-        Long timePeriod = CommonFunctions.calTimePeriod(currentAdditionalForm.getFromTime(), currentAdditionalForm.getToTime());
-        if (timePeriod < 0 || (timePeriod / 24) > 1) {
+        double timePeriodMinutes = CommonFunctions.dateDifferenceInMinutes(
+                currentAdditionalForm.getFromTime(), currentAdditionalForm.getToTime());
+        if (timePeriodMinutes < 0 || timePeriodMinutes > 1440) {
             JsfUtil.addErrorMessage("Please Check  From Time and To Time Range");
             return true;
         }
@@ -892,8 +893,9 @@ public class StaffAdditionalFormController implements Serializable {
             JsfUtil.addErrorMessage("Please Select From Time");
             return true;
         }
-        Long timePeriod = CommonFunctions.calTimePeriod(currentAdditionalForm.getFromTime(), currentAdditionalForm.getToTime());
-        if (timePeriod <= 0 || (timePeriod / 24) > 1) {
+        double timePeriodMinutes = CommonFunctions.dateDifferenceInMinutes(
+                currentAdditionalForm.getFromTime(), currentAdditionalForm.getToTime());
+        if (timePeriodMinutes <= 0 || timePeriodMinutes > 1440) {
             JsfUtil.addErrorMessage("Please Check  From Time and To Time Range");
             return true;
         }
@@ -973,8 +975,9 @@ public class StaffAdditionalFormController implements Serializable {
             JsfUtil.addErrorMessage("Please Select From Time");
             return true;
         }
-        Long timePeriod = CommonFunctions.calTimePeriod(currentAdditionalForm.getFromTime(), currentAdditionalForm.getToTime());
-        if (timePeriod <= 0 || (timePeriod / 24) > 1) {
+        double timePeriodMinutes = CommonFunctions.dateDifferenceInMinutes(
+                currentAdditionalForm.getFromTime(), currentAdditionalForm.getToTime());
+        if (timePeriodMinutes <= 0 || timePeriodMinutes > 1440) {
             JsfUtil.addErrorMessage("Please Check  From Time and To Time Range");
             return true;
         }


### PR DESCRIPTION
Replaced calTimePeriod() (returns hours as Long) with dateDifferenceInMinutes() (returns double minutes) for shift duration validation in three methods:

errorCheckExtra()
errorCheckShiftDayOff()
errorCheckShift()

**What changed:**
The boundary check was updated from (timePeriod / 24) > 1 to timePeriodMinutes > 1440, enforcing the same 24-hour maximum but with minute-level precision.

**Why:**
calTimePeriod() returned a Long in hours, losing sub-hour precision. dateDifferenceInMinutes() returns a double, making the validation more accurate and consistent with how time differences are calculated elsewhere in the codebase.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced accuracy of duration validation for staff shift assignments, extra shift requests, and employee time-off entries by refining the time calculation methodology. The updates ensure more precise and consistent time period measurements across all scheduling-related validation checks while maintaining the same error handling and user-facing messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->