### PR TITLE
Fix: Set departmentType on bill from first item in transfer issue controllers

### DIFF
--- a/src/main/java/com/divudi/bean/pharmacy/TransferIssueController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/TransferIssueController.java
@@ -1526,6 +1526,11 @@ public class TransferIssueController implements Serializable {
         billItem.getBillItemFinanceDetails().setValueAtPurchaseRate(purchaseRate.multiply(billItem.getBillItemFinanceDetails().getQuantity()));
 
         billItem.setSearialNo(getBillItems().size() + 1);
+
+        if (getIssuedBill().getDepartmentType() == null && billItem.getItem() != null) {
+            getIssuedBill().setDepartmentType(billItem.getItem().getDepartmentType());
+        }
+
         getBillItems().add(billItem);
 
         qty = null;

--- a/src/main/java/com/divudi/bean/pharmacy/TransferIssueController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/TransferIssueController.java
@@ -12,6 +12,7 @@ import com.divudi.core.data.BillClassType;
 import com.divudi.core.data.BillNumberSuffix;
 import com.divudi.core.data.BillType;
 import com.divudi.core.data.BillTypeAtomic;
+import com.divudi.core.data.DepartmentType;
 import com.divudi.core.data.dto.StockDTO;
 import com.divudi.ejb.BillNumberGenerator;
 
@@ -1527,8 +1528,16 @@ public class TransferIssueController implements Serializable {
 
         billItem.setSearialNo(getBillItems().size() + 1);
 
-        if (getIssuedBill().getDepartmentType() == null && billItem.getItem() != null) {
-            getIssuedBill().setDepartmentType(billItem.getItem().getDepartmentType());
+        if (billItem.getItem() != null) {
+            DepartmentType itemDeptType = billItem.getItem().getDepartmentType();
+            if (getIssuedBill().getDepartmentType() == null) {
+                getIssuedBill().setDepartmentType(itemDeptType);
+            } else if (itemDeptType != null && !itemDeptType.equals(getIssuedBill().getDepartmentType())) {
+                JsfUtil.addErrorMessage("Cannot add items from different department types. "
+                        + "Bill is set for " + getIssuedBill().getDepartmentType().getLabel()
+                        + " items, but you are trying to add a " + itemDeptType.getLabel() + " item.");
+                return;
+            }
         }
 
         getBillItems().add(billItem);

--- a/src/main/java/com/divudi/bean/pharmacy/TransferIssueDirectController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/TransferIssueDirectController.java
@@ -177,6 +177,10 @@ public class TransferIssueDirectController implements Serializable {
 
         billItem.setSearialNo(getBillItems().size());
 
+        if (issuedBill.getDepartmentType() == null && billItem.getItem() != null) {
+            issuedBill.setDepartmentType(billItem.getItem().getDepartmentType());
+        }
+
         // Set the transfer rate based on configuration
         BigDecimal itemTransferRate = determineTransferRate(getTmpStock().getItemBatch());
         BigDecimal lineGrossRate = itemTransferRate.multiply(billItem.getBillItemFinanceDetails().getUnitsPerPack());

--- a/src/main/java/com/divudi/bean/pharmacy/TransferIssueDirectController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/TransferIssueDirectController.java
@@ -177,8 +177,16 @@ public class TransferIssueDirectController implements Serializable {
 
         billItem.setSearialNo(getBillItems().size());
 
-        if (issuedBill.getDepartmentType() == null && billItem.getItem() != null) {
-            issuedBill.setDepartmentType(billItem.getItem().getDepartmentType());
+        if (billItem.getItem() != null) {
+            DepartmentType itemDeptType = billItem.getItem().getDepartmentType();
+            if (issuedBill.getDepartmentType() == null) {
+                issuedBill.setDepartmentType(itemDeptType);
+            } else if (itemDeptType != null && !itemDeptType.equals(issuedBill.getDepartmentType())) {
+                JsfUtil.addErrorMessage("Cannot add items from different department types. "
+                        + "Bill is set for " + issuedBill.getDepartmentType().getLabel()
+                        + " items, but you are trying to add a " + itemDeptType.getLabel() + " item.");
+                return;
+            }
         }
 
         // Set the transfer rate based on configuration

--- a/src/main/java/com/divudi/bean/pharmacy/TransferIssueForRequestsController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/TransferIssueForRequestsController.java
@@ -457,9 +457,8 @@ public class TransferIssueForRequestsController implements Serializable {
             return;
         }
 
-        if (getIssuedBill().getDepartmentType() == null && !getBillItems().isEmpty()
-                && getBillItems().get(0).getItem() != null) {
-            getIssuedBill().setDepartmentType(getBillItems().get(0).getItem().getDepartmentType());
+        if (getIssuedBill().getDepartmentType() == null && getRequestedBill() != null) {
+            getIssuedBill().setDepartmentType(getRequestedBill().getDepartmentType());
         }
 
         saveBill();

--- a/src/main/java/com/divudi/bean/pharmacy/TransferIssueForRequestsController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/TransferIssueForRequestsController.java
@@ -457,6 +457,11 @@ public class TransferIssueForRequestsController implements Serializable {
             return;
         }
 
+        if (getIssuedBill().getDepartmentType() == null && !getBillItems().isEmpty()
+                && getBillItems().get(0).getItem() != null) {
+            getIssuedBill().setDepartmentType(getBillItems().get(0).getItem().getDepartmentType());
+        }
+
         saveBill();
         for (BillItem billItemsInIssue : getBillItems()) {
             BillItem originalOrderItem = billItemsInIssue.getReferanceBillItem();


### PR DESCRIPTION
## Summary
- `TransferIssueController`, `TransferIssueDirectController`, and `TransferIssueForRequestsController` never set `bill.departmentType` when items were added, leaving it NULL on every transfer issue/receive bill
- This caused transfer issue bills to be excluded from the Stock Ledger DTO report when filtering by Department Type, because NULL fails the `IN` clause filter
- Added the same pattern already used in `PharmacyIssueController`: on the first item added to the bill, copy the item's `departmentType` to the bill if not already set

## Root Cause
`PharmacyIssueController` (retail/OPD) correctly sets `bill.departmentType` from the first item's type. The three transfer issue controllers were missing this logic entirely — a gap in the original implementation.

## Test Plan
- [ ] Create a pharmacy transfer issue via each of the three pages (`pharmacy_transfer_issue.xhtml`, `pharmacy_transfer_issue_direct.xhtml`, `pharmacy_transfer_issue_direct_department.xhtml`)
- [ ] Confirm the resulting bill has `departmentType` set (matches the item's department type)
- [ ] Open Stock Ledger DTO report and apply a Department Type filter — transfer issue records should now appear correctly

Closes #19168

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed department type initialization in pharmacy transfer workflows to ensure proper data consistency when processing multiple items. The system now correctly propagates department information during item transfers and settlement operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->