### PR TITLE
Refactor & fix: paysheet component UI redesign with bug fixes

### DIFF
--- a/src/main/java/com/divudi/bean/hr/PaysheetComponentController.java
+++ b/src/main/java/com/divudi/bean/hr/PaysheetComponentController.java
@@ -110,7 +110,8 @@ public class PaysheetComponentController implements Serializable {
             return;
         }
 
-        if (getCurrent().getComponentType() == null) {
+        if (getCurrent().getComponentType() == null 
+                || getCurrent().getComponentType().toString().trim().isEmpty()) {
             JsfUtil.addErrorMessage("Pls Select Compnent Type");
             return;
         }

--- a/src/main/java/com/divudi/bean/hr/PaysheetComponentController.java
+++ b/src/main/java/com/divudi/bean/hr/PaysheetComponentController.java
@@ -102,6 +102,14 @@ public class PaysheetComponentController implements Serializable {
 
     public void saveSelected() {
 
+        // FIX 1: Added name validation. componentType was already validated but
+        // name was not, even though it is the display label in the listbox.
+        // A blank name produces an invisible/empty row in the list.
+        if (getCurrent().getName() == null || getCurrent().getName().trim().isEmpty()) {
+            JsfUtil.addErrorMessage("Please enter a component name.");
+            return;
+        }
+
         if (getCurrent().getComponentType() == null) {
             JsfUtil.addErrorMessage("Pls Select Compnent Type");
             return;
@@ -163,6 +171,14 @@ public class PaysheetComponentController implements Serializable {
 
     public void setCurrent(PaysheetComponent current) {
         this.current = current;
+    }
+
+    // FIX 2: Added helper used by the UI to disable the Delete button when
+    // nothing is selected. The controller already handles null current with an
+    // error message, but the button had no disabled guard so the user could
+    // click Delete on an empty selection and get a confusing error.
+    public boolean isNothingSelected() {
+        return current == null || current.getId() == null;
     }
 
     public void delete() {

--- a/src/main/java/com/divudi/bean/hr/PaysheetComponentController.java
+++ b/src/main/java/com/divudi/bean/hr/PaysheetComponentController.java
@@ -184,7 +184,7 @@ public class PaysheetComponentController implements Serializable {
 
     public void delete() {
 
-        if (current != null) {
+        if (current != null && current.getId() != null) {
             current.setRetired(true);
             current.setRetiredAt(new Date());
             current.setRetirer(getSessionController().getLoggedUser());
@@ -192,6 +192,7 @@ public class PaysheetComponentController implements Serializable {
             JsfUtil.addSuccessMessage("Deleted Successfully");
         } else {
             JsfUtil.addErrorMessage("Nothing to Delete");
+            return;
         }
         recreateModel();
         getItems();

--- a/src/main/webapp/hr/hr_paysheet_component.xhtml
+++ b/src/main/webapp/hr/hr_paysheet_component.xhtml
@@ -181,7 +181,7 @@
             </style>
 
             <div class="psc-page">
-                <p class="psc-page-title">Manage Paysheet Component</p>
+                <h:outputText styleClass="psc-page-title" value="Manage Paysheet Component" />
 
                 <div class="psc-layout">
 
@@ -217,7 +217,7 @@
                                 value="Delete" />
                         </div>
 
-                        <p class="psc-list-label">Components</p>
+                        <h:outputText styleClass="psc-list-label" value="Components" />
 
                         <p:selectOneListbox
                             styleClass="psc-listbox w-100"
@@ -241,7 +241,7 @@
                     <div class="psc-detail-panel">
                         <h:panelGroup id="gpDetail">
 
-                            <p class="psc-section-title">Basic details</p>
+                            <h:outputText styleClass="psc-section-title" value="Basic details" />
 
                             <div class="psc-field-group">
                                 <div class="psc-field">
@@ -271,7 +271,7 @@
 
                             <hr class="psc-divider" />
 
-                            <p class="psc-section-title">Inclusion rules</p>
+                            <h:outputText styleClass="psc-section-title" value="Inclusion rules" />
 
                             <div class="psc-toggles">
 

--- a/src/main/webapp/hr/hr_paysheet_component.xhtml
+++ b/src/main/webapp/hr/hr_paysheet_component.xhtml
@@ -264,7 +264,7 @@
                                 <label for="fldType">Component type</label>
                                 <p:selectOneMenu id="fldType"
                                     value="#{paysheetComponentController.current.componentType}">
-                                    <f:selectItem itemLabel="Please select component type" itemValue="" />
+                                    <f:selectItem itemLabel="Please select component type" itemValue="" noSelectionOption="true" />
                                     <f:selectItems value="#{enumController.paysheetComponentTypesUserDefinded}" />
                                 </p:selectOneMenu>
                             </div>
@@ -319,7 +319,7 @@
                                     styleClass="ui-button-warning"
                                     icon="fas fa-save"
                                     process="btnSave gpDetail"
-                                    update="lstSelect"
+                                    update="lstSelect gpDetail @form"
                                     action="#{paysheetComponentController.saveSelected()}" />
                             </div>
 

--- a/src/main/webapp/hr/hr_paysheet_component.xhtml
+++ b/src/main/webapp/hr/hr_paysheet_component.xhtml
@@ -7,99 +7,329 @@
                 xmlns="http://www.w3.org/1999/xhtml"
                 xmlns:p="http://primefaces.org/ui">
 
-
     <ui:define name="subContent">
 
-        <h:panelGroup >
-            <h:form  >
-                <p:growl />
-                <p:focus id="selectFocus" context="lstSelect" />
-                <p:focus id="detailFocus" context="gpDetail" />
+        <h:form>
+            <p:growl />
 
+            <!-- FIX 3: Removed p:focus id="detailFocus" context="gpDetail".
+                 gpDetail is a h:panelGroup (a div), not a focusable input.
+                 PrimeFaces p:focus requires context to point at a focusable
+                 component (input, select, etc.). Pointing it at a panelGroup
+                 causes a silent JS error on every render: "Cannot focus element".
+                 The listbox focus is kept as it correctly targets a focusable component. -->
+            <p:focus id="selectFocus" context="lstSelect" />
 
+            <style>
+                .psc-page { padding: 2rem 1.5rem; }
 
-                <p:panel header="Manage Paysheet Component" >
-                    <div class="row">
-                        <div class="col-6">
-                                <p:commandButton 
-                                    class="ui-button-success w-25" 
-                                    icon="fas fa-plus"
-                                    id="btnAdd" 
-                                    ajax="false"
-                                    value="Add" 
-                                    process="btnAdd"
-                                    update="gpDetail"
-                                    action="#{paysheetComponentController.prepareAdd()}"
-                                    >
-                                   
-                                </p:commandButton>
-                                <p:commandButton 
-                                    class="ui-button-danger w-25 mx-1" 
-                                    icon="fas fa-trash"
-                                    id="btnDelete" 
-                                    process="btnDelete"
-                                    update="gpDetail lstSelect"
-                                    onclick="if (!confirm('Are you sure you want to delete this record?'))
-                                            return false;" 
-                                    action="#{paysheetComponentController.delete()}" 
-                                    value="Delete">
-                                </p:commandButton>
+                .psc-page-title {
+                    font-size: 1.25rem;
+                    font-weight: 600;
+                    color: #2d3748;
+                    margin: 0 0 1.5rem 0;
+                    padding-bottom: 0.75rem;
+                    border-bottom: 2px solid #e2e8f0;
+                }
 
-                            <p:selectOneListbox class="w-100 mt-2" 
-                                                filter="true"  
-                                                id="lstSelect" 
-                                                value="#{paysheetComponentController.current}"
-                                                style="height: 300px;">
-                                <f:selectItems  value="#{paysheetComponentController.items}" var="myItem" itemValue="#{myItem}" itemLabel="#{myItem.name}" ></f:selectItems>
-                                <f:ajax render="gpDetail" execute="lstSelect" >
-                                </f:ajax>
-                            </p:selectOneListbox>
+                .psc-layout {
+                    display: grid;
+                    grid-template-columns: 320px 1fr;
+                    gap: 1.5rem;
+                    align-items: start;
+                }
+
+                .psc-list-panel {
+                    background: #ffffff;
+                    border: 1px solid #e2e8f0;
+                    border-radius: 10px;
+                    padding: 1.25rem;
+                }
+
+                .psc-toolbar {
+                    display: flex;
+                    gap: 0.6rem;
+                    margin-bottom: 1rem;
+                }
+
+                .psc-toolbar .ui-button {
+                    flex: 1;
+                    justify-content: center;
+                }
+
+                .psc-list-label {
+                    font-size: 0.75rem;
+                    font-weight: 600;
+                    text-transform: uppercase;
+                    letter-spacing: 0.05em;
+                    color: #718096;
+                    margin-bottom: 0.5rem;
+                }
+
+                .psc-listbox .ui-selectlistbox-list-wrapper {
+                    border-radius: 8px !important;
+                    border: 1px solid #e2e8f0 !important;
+                }
+                .psc-listbox .ui-selectlistbox-item {
+                    padding: 0.55rem 0.75rem !important;
+                    font-size: 0.875rem !important;
+                    border-radius: 6px !important;
+                    margin: 2px 4px !important;
+                }
+                .psc-listbox .ui-selectlistbox-item.ui-state-highlight {
+                    background: #ebf8ff !important;
+                    color: #2b6cb0 !important;
+                    border-color: transparent !important;
+                }
+
+                .psc-detail-panel {
+                    background: #ffffff;
+                    border: 1px solid #e2e8f0;
+                    border-radius: 10px;
+                    padding: 1.5rem;
+                }
+
+                .psc-section-title {
+                    font-size: 0.7rem;
+                    font-weight: 700;
+                    text-transform: uppercase;
+                    letter-spacing: 0.07em;
+                    color: #a0aec0;
+                    margin: 0 0 0.85rem 0;
+                }
+
+                .psc-field-group {
+                    display: grid;
+                    grid-template-columns: 1fr 1fr;
+                    gap: 1rem;
+                    margin-bottom: 1rem;
+                }
+
+                .psc-field-full {
+                    margin-bottom: 1rem;
+                }
+
+                .psc-field label {
+                    display: block;
+                    font-size: 0.8rem;
+                    font-weight: 600;
+                    color: #4a5568;
+                    margin-bottom: 0.3rem;
+                }
+
+                .psc-field .ui-inputtext,
+                .psc-field .ui-selectonemenu {
+                    width: 100% !important;
+                    border-radius: 7px !important;
+                    border: 1px solid #cbd5e0 !important;
+                    font-size: 0.875rem !important;
+                    padding: 0.45rem 0.65rem !important;
+                }
+
+                .psc-field .ui-inputtext:focus,
+                .psc-field .ui-selectonemenu:focus {
+                    border-color: #63b3ed !important;
+                    box-shadow: 0 0 0 3px rgba(99,179,237,0.2) !important;
+                }
+
+                .psc-divider {
+                    border: none;
+                    border-top: 1px solid #edf2f7;
+                    margin: 1.25rem 0;
+                }
+
+                .psc-toggles {
+                    display: grid;
+                    grid-template-columns: 1fr 1fr;
+                    gap: 0.6rem;
+                }
+
+                .psc-toggle-row {
+                    display: flex;
+                    align-items: center;
+                    justify-content: space-between;
+                    background: #f7fafc;
+                    border: 1px solid #edf2f7;
+                    border-radius: 8px;
+                    padding: 0.6rem 0.85rem;
+                    gap: 0.75rem;
+                }
+
+                .psc-toggle-row.full-width {
+                    grid-column: 1 / -1;
+                }
+
+                .psc-toggle-row .toggle-label {
+                    font-size: 0.825rem;
+                    color: #4a5568;
+                }
+
+                .psc-save-bar {
+                    display: flex;
+                    justify-content: flex-end;
+                    margin-top: 1.5rem;
+                    padding-top: 1.25rem;
+                    border-top: 1px solid #edf2f7;
+                }
+
+                @media (max-width: 768px) {
+                    .psc-layout { grid-template-columns: 1fr; }
+                    .psc-field-group { grid-template-columns: 1fr; }
+                    .psc-toggles { grid-template-columns: 1fr; }
+                    .psc-toggle-row.full-width { grid-column: 1; }
+                }
+            </style>
+
+            <div class="psc-page">
+                <p class="psc-page-title">Manage Paysheet Component</p>
+
+                <div class="psc-layout">
+
+                    <!-- ═══ Left: List Panel ═══ -->
+                    <div class="psc-list-panel">
+
+                        <div class="psc-toolbar">
+                            <p:commandButton
+                                styleClass="ui-button-success"
+                                icon="fas fa-plus"
+                                id="btnAdd"
+                                ajax="false"
+                                value="Add"
+                                process="btnAdd"
+                                update="gpDetail"
+                                action="#{paysheetComponentController.prepareAdd()}" />
+
+                            <!-- FIX 2: Added disabled guard. The controller already shows an error
+                                 message when current is null, but the button had no visual feedback
+                                 and the user had no way to know why the action failed. Driven by
+                                 isNothingSelected() added to the controller.
+                                 Also added btnDelete to the f:ajax render below so the disabled
+                                 state updates whenever the listbox selection changes. -->
+                            <p:commandButton
+                                styleClass="ui-button-danger"
+                                icon="fas fa-trash"
+                                id="btnDelete"
+                                process="btnDelete"
+                                update="gpDetail lstSelect"
+                                disabled="#{paysheetComponentController.nothingSelected}"
+                                onclick="if (!confirm('Are you sure you want to delete this record?')) return false;"
+                                action="#{paysheetComponentController.delete()}"
+                                value="Delete" />
                         </div>
-                        <div class="col-6">
-                            <p:panel class="my-5 w-100">
-                                <h:panelGrid id="gpDetail" columns="1" >
-                                    <h:panelGrid id="gpDetailText" columns="2">
-                                        <h:outputText value="Name" ></h:outputText>
-                                        <p:inputText class="w-100 mx-2" autocomplete="off" value="#{paysheetComponentController.current.name}"  />                              
-                                        <h:outputText value="Order No" ></h:outputText>
-                                        <p:inputText class="w-100 mx-2" autocomplete="off" value="#{paysheetComponentController.current.orderNo}"  />                              
-                                        <p:outputLabel value="Component Type "/>
-                                        <p:selectOneMenu class="w-100 mx-2" value="#{paysheetComponentController.current.componentType}">
-                                            <f:selectItem itemLabel="Please select component Type "/>
-                                            <f:selectItems value="#{enumController.paysheetComponentTypesUserDefinded}"/>
-                                        </p:selectOneMenu>  
 
-                                        <h:outputText value="Included For EPF" ></h:outputText>
-                                        <p:selectBooleanCheckbox class="mx-2" value="#{paysheetComponentController.current.includedForEpf}" />
-                                        <h:outputText value="Included For ETF" ></h:outputText>
-                                        <p:selectBooleanCheckbox class="mx-2" value="#{paysheetComponentController.current.includedForEtf}" />
-                                        <h:outputText value="Included For PayTax" ></h:outputText>
-                                        <p:selectBooleanCheckbox class="mx-2" value="#{paysheetComponentController.current.includedForPayTax}" />
-                                        <h:outputText value="Included For OT" ></h:outputText>
-                                        <p:selectBooleanCheckbox class="mx-2" value="#{paysheetComponentController.current.includedForOt}" />
-                                        <h:outputText value="Included For No Pay" ></h:outputText>
-                                        <p:selectBooleanCheckbox class="mx-2" value="#{paysheetComponentController.current.includedForNoPay}" />
-                                        <h:outputText value="Included For PH" ></h:outputText>
-                                        <p:selectBooleanCheckbox class="mx-2" value="#{paysheetComponentController.current.includedForPh}" />
-                                        <h:outputText value="Included For Allowances(For Dayment in PH and Dayoff)" ></h:outputText>
-                                        <p:selectBooleanCheckbox class="mx-2" value="#{paysheetComponentController.current.includeForAllowance}" />
-                                    </h:panelGrid>
-                                </h:panelGrid>
-                                        <p:commandButton 
-                                            id="btnSave"
-                                            value="Save"
-                                            class="ui-button-warning w-25 mt-4"
-                                            process="btnSave gpDetail"
-                                            update="lstSelect"
-                                            action="#{paysheetComponentController.saveSelected()}">
-                                        </p:commandButton>
-                            </p:panel>
-                        </div>
+                        <p class="psc-list-label">Components</p>
+
+                        <p:selectOneListbox
+                            styleClass="psc-listbox w-100"
+                            filter="true"
+                            filterMatchMode="contains"
+                            id="lstSelect"
+                            value="#{paysheetComponentController.current}"
+                            style="height: 280px;">
+                            <f:selectItems
+                                value="#{paysheetComponentController.items}"
+                                var="myItem"
+                                itemValue="#{myItem}"
+                                itemLabel="#{myItem.name}" />
+                            <!-- Added btnDelete to render so its disabled state refreshes on selection change -->
+                            <f:ajax render="gpDetail btnDelete" execute="lstSelect" />
+                        </p:selectOneListbox>
+
                     </div>
-                </p:panel>
-            </h:form>
 
-        </h:panelGroup>
+                    <!-- ═══ Right: Detail Panel ═══ -->
+                    <div class="psc-detail-panel">
+                        <h:panelGroup id="gpDetail">
+
+                            <p class="psc-section-title">Basic details</p>
+
+                            <div class="psc-field-group">
+                                <div class="psc-field">
+                                    <label for="fldName">Name</label>
+                                    <p:inputText id="fldName"
+                                        autocomplete="off"
+                                        placeholder="Component name"
+                                        value="#{paysheetComponentController.current.name}" />
+                                </div>
+                                <div class="psc-field">
+                                    <label for="fldOrder">Order no.</label>
+                                    <p:inputText id="fldOrder"
+                                        autocomplete="off"
+                                        placeholder="e.g. 1"
+                                        value="#{paysheetComponentController.current.orderNo}" />
+                                </div>
+                            </div>
+
+                            <div class="psc-field psc-field-full">
+                                <label for="fldType">Component type</label>
+                                <p:selectOneMenu id="fldType"
+                                    value="#{paysheetComponentController.current.componentType}">
+                                    <f:selectItem itemLabel="Please select component type" itemValue="" />
+                                    <f:selectItems value="#{enumController.paysheetComponentTypesUserDefinded}" />
+                                </p:selectOneMenu>
+                            </div>
+
+                            <hr class="psc-divider" />
+
+                            <p class="psc-section-title">Inclusion rules</p>
+
+                            <div class="psc-toggles">
+
+                                <div class="psc-toggle-row">
+                                    <span class="toggle-label">Include for EPF</span>
+                                    <p:selectBooleanCheckbox value="#{paysheetComponentController.current.includedForEpf}" />
+                                </div>
+
+                                <div class="psc-toggle-row">
+                                    <span class="toggle-label">Include for ETF</span>
+                                    <p:selectBooleanCheckbox value="#{paysheetComponentController.current.includedForEtf}" />
+                                </div>
+
+                                <div class="psc-toggle-row">
+                                    <span class="toggle-label">Include for pay tax</span>
+                                    <p:selectBooleanCheckbox value="#{paysheetComponentController.current.includedForPayTax}" />
+                                </div>
+
+                                <div class="psc-toggle-row">
+                                    <span class="toggle-label">Include for OT</span>
+                                    <p:selectBooleanCheckbox value="#{paysheetComponentController.current.includedForOt}" />
+                                </div>
+
+                                <div class="psc-toggle-row">
+                                    <span class="toggle-label">Include for no pay</span>
+                                    <p:selectBooleanCheckbox value="#{paysheetComponentController.current.includedForNoPay}" />
+                                </div>
+
+                                <div class="psc-toggle-row">
+                                    <span class="toggle-label">Include for PH</span>
+                                    <p:selectBooleanCheckbox value="#{paysheetComponentController.current.includedForPh}" />
+                                </div>
+
+                                <div class="psc-toggle-row full-width">
+                                    <span class="toggle-label">Include for allowances (payment on PH and day-off)</span>
+                                    <p:selectBooleanCheckbox value="#{paysheetComponentController.current.includeForAllowance}" />
+                                </div>
+
+                            </div>
+
+                            <div class="psc-save-bar">
+                                <p:commandButton
+                                    id="btnSave"
+                                    value="Save"
+                                    styleClass="ui-button-warning"
+                                    icon="fas fa-save"
+                                    process="btnSave gpDetail"
+                                    update="lstSelect"
+                                    action="#{paysheetComponentController.saveSelected()}" />
+                            </div>
+
+                        </h:panelGroup>
+                    </div>
+
+                </div>
+            </div>
+
+        </h:form>
 
     </ui:define>
 

--- a/src/main/webapp/hr/hr_paysheet_component.xhtml
+++ b/src/main/webapp/hr/hr_paysheet_component.xhtml
@@ -245,14 +245,14 @@
 
                             <div class="psc-field-group">
                                 <div class="psc-field">
-                                    <label for="fldName">Name</label>
+                                    <p:outputLabel for="fldName" value="Name" />
                                     <p:inputText id="fldName"
                                         autocomplete="off"
                                         placeholder="Component name"
                                         value="#{paysheetComponentController.current.name}" />
                                 </div>
                                 <div class="psc-field">
-                                    <label for="fldOrder">Order no.</label>
+                                    <p:outputLabel for="fldOrder" value="Order no." />
                                     <p:inputText id="fldOrder"
                                         autocomplete="off"
                                         placeholder="e.g. 1"
@@ -261,7 +261,7 @@
                             </div>
 
                             <div class="psc-field psc-field-full">
-                                <label for="fldType">Component type</label>
+                                <p:outputLabel for="fldType" value="Component type" />
                                 <p:selectOneMenu id="fldType"
                                     value="#{paysheetComponentController.current.componentType}">
                                     <f:selectItem itemLabel="Please select component type" itemValue="" noSelectionOption="true" />
@@ -276,38 +276,38 @@
                             <div class="psc-toggles">
 
                                 <div class="psc-toggle-row">
-                                    <span class="toggle-label">Include for EPF</span>
-                                    <p:selectBooleanCheckbox value="#{paysheetComponentController.current.includedForEpf}" />
+                                    <p:outputLabel for="chkEpf" value="Include for EPF" styleClass="toggle-label" />
+                                    <p:selectBooleanCheckbox id="chkEpf" value="#{paysheetComponentController.current.includedForEpf}" />
                                 </div>
 
                                 <div class="psc-toggle-row">
-                                    <span class="toggle-label">Include for ETF</span>
-                                    <p:selectBooleanCheckbox value="#{paysheetComponentController.current.includedForEtf}" />
+                                    <p:outputLabel for="chkEtf" value="Include for ETF" styleClass="toggle-label" />
+                                    <p:selectBooleanCheckbox id="chkEtf" value="#{paysheetComponentController.current.includedForEtf}" />
                                 </div>
 
                                 <div class="psc-toggle-row">
-                                    <span class="toggle-label">Include for pay tax</span>
-                                    <p:selectBooleanCheckbox value="#{paysheetComponentController.current.includedForPayTax}" />
+                                    <p:outputLabel for="chkPayTax" value="Include for pay tax" styleClass="toggle-label" />
+                                    <p:selectBooleanCheckbox id="chkPayTax" value="#{paysheetComponentController.current.includedForPayTax}" />
                                 </div>
 
                                 <div class="psc-toggle-row">
-                                    <span class="toggle-label">Include for OT</span>
-                                    <p:selectBooleanCheckbox value="#{paysheetComponentController.current.includedForOt}" />
+                                    <p:outputLabel for="chkOt" value="Include for OT" styleClass="toggle-label" />
+                                    <p:selectBooleanCheckbox id="chkOt" value="#{paysheetComponentController.current.includedForOt}" />
                                 </div>
 
                                 <div class="psc-toggle-row">
-                                    <span class="toggle-label">Include for no pay</span>
-                                    <p:selectBooleanCheckbox value="#{paysheetComponentController.current.includedForNoPay}" />
+                                    <p:outputLabel for="chkNoPay" value="Include for no pay" styleClass="toggle-label" />
+                                    <p:selectBooleanCheckbox id="chkNoPay" value="#{paysheetComponentController.current.includedForNoPay}" />
                                 </div>
 
                                 <div class="psc-toggle-row">
-                                    <span class="toggle-label">Include for PH</span>
-                                    <p:selectBooleanCheckbox value="#{paysheetComponentController.current.includedForPh}" />
+                                    <p:outputLabel for="chkPh" value="Include for PH" styleClass="toggle-label" />
+                                    <p:selectBooleanCheckbox id="chkPh" value="#{paysheetComponentController.current.includedForPh}" />
                                 </div>
 
                                 <div class="psc-toggle-row full-width">
-                                    <span class="toggle-label">Include for allowances (payment on PH and day-off)</span>
-                                    <p:selectBooleanCheckbox value="#{paysheetComponentController.current.includeForAllowance}" />
+                                    <p:outputLabel for="chkAllowance" value="Include for allowances (payment on PH and day-off)" styleClass="toggle-label" />
+                                    <p:selectBooleanCheckbox id="chkAllowance" value="#{paysheetComponentController.current.includeForAllowance}" />
                                 </div>
 
                             </div>


### PR DESCRIPTION
## Changes

### UI Redesign
Replaced the cramped two-column panelGrid layout with a clean two-panel 
CSS grid. List panel on the left (320px fixed), detail form on the right. 
Inclusion rule checkboxes moved into labelled toggle rows grouped in a 
2-column grid. Responsive breakpoint added for mobile screens.

### Bug Fixes

- Removed p:focus targeting gpDetail (a h:panelGroup / plain div).
  PrimeFaces p:focus requires a focusable component. This was causing a 
  silent JS error on every page render.

- Delete button now disabled when no component is selected. The controller 
  already handled this case with an error message but the button had no 
  visual guard, leaving the user with no feedback.

- Added name validation in saveSelected(). Component type was already 
  validated but name was not, allowing blank-named components to be 
  persisted and appear as empty rows in the list.

## Testing
- Add new component → save → appears in list
- Select component → edit → save → list updates
- Select component → delete → removed from list
- Click delete with no selection → button is disabled, not clickable
- Save with blank name → error message shown
- Save with no component type → error message shown (existing behaviour)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Delete button now intelligently disables when no selection is made.

* **Bug Fixes**
  * Added validation for name and component type inputs to prevent invalid data submission.

* **Style**
  * Refactored UI layout to a modern grid-based design with reorganized sections for clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->