### PR TITLE
HR Staff Basic: UI cleanup and paysheet component null-safety fix

### DIFF
--- a/src/main/java/com/divudi/bean/hr/StaffBasicController.java
+++ b/src/main/java/com/divudi/bean/hr/StaffBasicController.java
@@ -232,7 +232,7 @@ public class StaffBasicController implements Serializable {
 
         if (getFromDate() != null) {
             sql += " and ((ss.fromDate <=:fd "
-                    + " and ss.toDate >=:fd) or ss.fromDate >=:fd) ";
+                    + " and (ss.toDate >=:fd or ss.toDate is null)) or ss.fromDate >=:fd) ";
             hm.put("fd", getFromDate());
         }
 
@@ -277,7 +277,6 @@ public class StaffBasicController implements Serializable {
                 for (StaffPaysheetComponent err : getRepeatedComponent()) {
                     if (sp.getId().equals(err.getId())) {
                         sp.setExist(true);
-                        //////// // System.out.println("settin");
                     }
                 }
             }
@@ -450,6 +449,8 @@ public class StaffBasicController implements Serializable {
     public StaffPaysheetComponent getCurrent() {
         if (current == null) {
             current = new StaffPaysheetComponent();
+        }
+        if (current.getPaysheetComponent() == null) {
             current.setPaysheetComponent(getBasicCompnent());
         }
         return current;

--- a/src/main/webapp/hr/hr_staff_basic_individual.xhtml
+++ b/src/main/webapp/hr/hr_staff_basic_individual.xhtml
@@ -208,7 +208,8 @@
                             </f:facet>
 
                             <!-- Row selector (print hidden) -->
-                            <p:column styleClass="noPrintButton" style="width: 2.5rem;" />
+                            <p:column selectionMode="multiple" exportable="false"
+                                styleClass="noPrintButton" style="width: 2.5rem;" />
 
                             <!-- No -->
                             <p:column headerText="#" style="width: 3rem; text-align: center;">

--- a/src/main/webapp/hr/hr_staff_basic_individual.xhtml
+++ b/src/main/webapp/hr/hr_staff_basic_individual.xhtml
@@ -5,282 +5,313 @@
                 xmlns:hr="http://xmlns.jcp.org/jsf/composite/autocomplete"
                 xmlns:h="http://xmlns.jcp.org/jsf/html"
                 xmlns:p="http://primefaces.org/ui"
-
                 xmlns:f="http://xmlns.jcp.org/jsf/core">
 
-
     <ui:define name="subContent">
-
-        <h:panelGroup >
+        <h:panelGroup>
             <h:form>
-                <p:panel header="Shift Basic">
-                    <div class="row">
-                        <div class="col-6">
-                            <p:panel header="Detail" >
-                                <h:panelGrid columns="2"  >
 
-                                    <h:outputLabel value="Staff Name"/>
-                                    <p:autoComplete class="w-100 mx-4" inputStyleClass="w-100" forceSelection="true" 
-                                                    value="#{staffBasicController.current.staff}"
-                                                    completeMethod="#{staffController.completeStaffCode}" var="mys" itemLabel="#{mys.person.nameWithTitle}" itemValue="#{mys}"
-                                                    >   
-                                        <f:ajax event="itemSelect" execute="@this" render="tb7 stfCode stfCode2" listener="#{staffBasicController.makeItemNul}" />
+                <p:panel header="Shift Basic">
+                    <div style="display: grid; grid-template-columns: 1fr 1fr; gap: 1.25rem; align-items: start;">
+
+                        <!-- LEFT: Detail -->
+                        <p:panel header="Detail">
+                            <div style="display: flex; flex-direction: column; gap: 1rem;">
+
+                                <div>
+                                    <h:outputLabel value="Staff Name" style="display: block; margin-bottom: 4px;" />
+                                    <p:autoComplete
+                                        inputStyleClass="w-100"
+                                        style="width: 100%;"
+                                        forceSelection="true"
+                                        value="#{staffBasicController.current.staff}"
+                                        completeMethod="#{staffController.completeStaffCode}"
+                                        var="mys"
+                                        itemLabel="#{mys.person.nameWithTitle}"
+                                        itemValue="#{mys}">
+                                        <f:ajax event="itemSelect" execute="@this"
+                                                render="tb7 stfCode stfCode2"
+                                                listener="#{staffBasicController.makeItemNul}" />
                                         <p:column headerText="Staff Name">
-                                            <h:outputLabel value="#{mys.person.name}"/>
+                                            <h:outputLabel value="#{mys.person.name}" />
                                         </p:column>
                                         <p:column headerText="Code">
-                                            <h:outputLabel value="#{mys.code}"/>
+                                            <h:outputLabel value="#{mys.code}" />
                                         </p:column>
-
                                     </p:autoComplete>
+                                </div>
 
-                                    <p:outputLabel value="Emp Code" class="my-1"></p:outputLabel>
-                                    <p:outputLabel id="stfCode" value="#{staffBasicController.current.staff.code}"></p:outputLabel>
-                                    <p:outputLabel value="EPF Code" class="my-1"></p:outputLabel>
-                                    <p:outputLabel id="stfCode2" value="#{staffBasicController.current.staff.epfNo}"></p:outputLabel>
-                                    <h:outputLabel value="From"/>
-                                    <p:calendar id="frm" class="w-100 mx-4" inputStyleClass="w-100" navigator="true" value="#{staffBasicController.current.fromDate}" pattern="#{sessionController.applicationPreference.shortDateFormat}" >                                
-                                    </p:calendar>
-                                    <h:outputLabel value="To"/>
-                                    <p:calendar class="w-100 mx-4" inputStyleClass="w-100" id="to" navigator="true"  value="#{staffBasicController.current.toDate}" pattern="#{sessionController.applicationPreference.shortDateFormat}">                                      
-                                    </p:calendar>                    
-                                    <h:outputLabel value="Salary"/>
-                                    <p:inputText class="w-100 mx-4" autocomplete="off"  value="#{staffBasicController.current.staffPaySheetComponentValue}"/>
+                                <div style="display: grid; grid-template-columns: 1fr 1fr; gap: 1rem;">
+                                    <div>
+                                        <h:outputLabel value="Emp Code" style="display: block; margin-bottom: 4px;" />
+                                        <p:outputLabel id="stfCode" value="#{staffBasicController.current.staff.code}" />
+                                    </div>
+                                    <div>
+                                        <h:outputLabel value="EPF Code" style="display: block; margin-bottom: 4px;" />
+                                        <p:outputLabel id="stfCode2" value="#{staffBasicController.current.staff.epfNo}" />
+                                    </div>
+                                </div>
 
-                                    <h:outputLabel value="BR Value"/>
-                                    <p:inputText class="w-100 mx-4" autocomplete="off"  value="#{staffBasicController.current.dblValue}"/>
+                                <div style="display: grid; grid-template-columns: 1fr 1fr; gap: 1rem;">
+                                    <div>
+                                        <h:outputLabel value="From" style="display: block; margin-bottom: 4px;" />
+                                        <p:calendar id="frm" inputStyleClass="w-100" style="width: 100%;"
+                                                    navigator="true"
+                                                    value="#{staffBasicController.current.fromDate}"
+                                                    pattern="#{sessionController.applicationPreference.shortDateFormat}" />
+                                    </div>
+                                    <div>
+                                        <h:outputLabel value="To" style="display: block; margin-bottom: 4px;" />
+                                        <p:calendar id="to" inputStyleClass="w-100" style="width: 100%;"
+                                                    navigator="true"
+                                                    value="#{staffBasicController.current.toDate}"
+                                                    pattern="#{sessionController.applicationPreference.shortDateFormat}" />
+                                    </div>
+                                </div>
 
-                                </h:panelGrid>
-                                <div class="mt-2">
+                                <div style="display: grid; grid-template-columns: 1fr 1fr; gap: 1rem;">
+                                    <div>
+                                        <h:outputLabel value="Salary" style="display: block; margin-bottom: 4px;" />
+                                        <p:inputText style="width: 100%;" autocomplete="off"
+                                                     value="#{staffBasicController.current.staffPaySheetComponentValue}" />
+                                    </div>
+                                    <div>
+                                        <h:outputLabel value="BR Value" style="display: block; margin-bottom: 4px;" />
+                                        <p:inputText style="width: 100%;" autocomplete="off"
+                                                     value="#{staffBasicController.current.dblValue}" />
+                                    </div>
+                                </div>
+
+                                <div style="display: flex; gap: 0.5rem; padding-top: 0.25rem;">
                                     <p:commandButton
-                                        class="ui-button-warning w-25"
-                                        id="btnAdd" 
+                                        id="btnAdd"
                                         value="Save"
+                                        styleClass="ui-button-warning"
+                                        style="flex: 1;"
                                         action="#{staffBasicController.save}"
                                         ajax="false" />
-                                    <p:commandButton 
-                                        class="w-25 ui-button-secondary mx-1"
-                                        value="Clear" 
-                                        action="#{staffBasicController.makeNull}" 
-                                        ajax="false"  />
+                                    <p:commandButton
+                                        value="Clear"
+                                        styleClass="ui-button-secondary"
+                                        style="flex: 1;"
+                                        action="#{staffBasicController.makeNull}"
+                                        ajax="false" />
                                 </div>
-                            </p:panel>
-                        </div>
-                        <div class="col-6">
-                            <p:panel header="Basic Detail">
-                                <h:panelGrid columns="2" >
-                                    <h:outputLabel value="From  " />
-                                    <p:calendar class="mx-4 w-100" inputStyleClass="w-100" value="#{staffBasicController.fromDate}"
-                                                navigator="true"
-                                                pattern="#{sessionController.applicationPreference.longDateTimeFormat}"  />                                          
-                                    <h:outputLabel value="Employee  "/>
-                                    <hr:completeStaff  value="#{staffBasicController.reportKeyWord.staff}"/>
-                                    <h:outputLabel value="Department  "/>
-                                    <hr:department value="#{staffBasicController.reportKeyWord.department}"/>
-                                    <h:outputLabel value="Institution  "/>
-                                    <hr:institution value="#{staffBasicController.reportKeyWord.institution}"/>
-                                    <h:outputLabel value="Staff Category  "/>
-                                    <hr:completeStaffCategory value="#{staffBasicController.reportKeyWord.staffCategory}"/>
-                                    <h:outputLabel value="Designation "/>
-                                    <hr:completeDesignation value="#{staffBasicController.reportKeyWord.designation}"/>
-                                    <h:outputLabel value="Roster  "/>
-                                    <hr:completeRoster value="#{staffBasicController.reportKeyWord.roster}"/> 
 
-                                </h:panelGrid>
-                                <div class="mt-4">
-                                    <p:commandButton 
+                            </div>
+                        </p:panel>
+
+                        <!-- RIGHT: Basic Detail -->
+                        <p:panel header="Basic Detail">
+                            <div style="display: flex; flex-direction: column; gap: 1rem;">
+
+                                <div>
+                                    <h:outputLabel value="From" style="display: block; margin-bottom: 4px;" />
+                                    <p:calendar inputStyleClass="w-100" style="width: 100%;"
+                                                value="#{staffBasicController.fromDate}"
+                                                navigator="true"
+                                                pattern="#{sessionController.applicationPreference.longDateTimeFormat}" />
+                                </div>
+
+                                <div style="display: grid; grid-template-columns: 1fr 1fr; gap: 1rem;">
+                                    <div>
+                                        <h:outputLabel value="Employee" style="display: block; margin-bottom: 4px;" />
+                                        <hr:completeStaff value="#{staffBasicController.reportKeyWord.staff}" />
+                                    </div>
+                                    <div>
+                                        <h:outputLabel value="Department" style="display: block; margin-bottom: 4px;" />
+                                        <hr:department value="#{staffBasicController.reportKeyWord.department}" />
+                                    </div>
+                                </div>
+
+                                <div style="display: grid; grid-template-columns: 1fr 1fr; gap: 1rem;">
+                                    <div>
+                                        <h:outputLabel value="Institution" style="display: block; margin-bottom: 4px;" />
+                                        <hr:institution value="#{staffBasicController.reportKeyWord.institution}" />
+                                    </div>
+                                    <div>
+                                        <h:outputLabel value="Staff Category" style="display: block; margin-bottom: 4px;" />
+                                        <hr:completeStaffCategory value="#{staffBasicController.reportKeyWord.staffCategory}" />
+                                    </div>
+                                </div>
+
+                                <div style="display: grid; grid-template-columns: 1fr 1fr; gap: 1rem;">
+                                    <div>
+                                        <h:outputLabel value="Designation" style="display: block; margin-bottom: 4px;" />
+                                        <hr:completeDesignation value="#{staffBasicController.reportKeyWord.designation}" />
+                                    </div>
+                                    <div>
+                                        <h:outputLabel value="Roster" style="display: block; margin-bottom: 4px;" />
+                                        <hr:completeRoster value="#{staffBasicController.reportKeyWord.roster}" />
+                                    </div>
+                                </div>
+
+                                <div style="display: flex; gap: 0.5rem; padding-top: 0.25rem;">
+                                    <p:commandButton
                                         ajax="false"
-                                        value="Fill" 
-                                        icon="fas fa-fill"
-                                        class="ui-button-warning w-25"
+                                        value="Fill"
+                                        styleClass="ui-button-warning"
+                                        style="flex: 1;"
                                         action="#{staffBasicController.createBasicTable}" />
                                     <p:commandButton
                                         ajax="false"
-                                        icon="fas fa-file-excel"
-                                        class="ui-button-success w-25 mx-1"
-                                        value="Excel"
-                                        >
-                                        <p:dataExporter type="xlsx" target="tb7" fileName="hr_staff_basic_individual"  />
+                                        styleClass="ui-button-success"
+                                        style="flex: 1;"
+                                        value="Excel">
+                                        <p:dataExporter type="xlsx" target="tb7" fileName="hr_staff_basic_individual" />
                                     </p:commandButton>
-                                    <p:commandButton 
-                                        value="Print" 
-                                        class="ui-button-info w-25"
-                                        icon="fas fa-print"
-                                        ajax="false" 
-                                        action="#" >
-                                        <p:printer target="staffbasic" ></p:printer>
+                                    <p:commandButton
+                                        value="Print"
+                                        styleClass="ui-button-info"
+                                        style="flex: 1;"
+                                        ajax="false"
+                                        action="#">
+                                        <p:printer target="staffbasic" />
                                     </p:commandButton>
                                 </div>
-                            </p:panel>
-                        </div>
+
+                            </div>
+                        </p:panel>
+
                     </div>
                 </p:panel>
 
-                <p:spacer height="30" />
+                <p:spacer height="20" />
 
                 <p:panel>
                     <f:facet name="header">
-                        <div class="d-flex justify-content-between align-items-center">
-                            <h:outputLabel value="Basic List"/>
-                            <div>
-                                <p:commandButton 
-                                    value="Process"
-                                    action="#{staffBasicController.makeItemNul}" 
-                                    ajax="false" 
-                                    />
-                            </div>
+                        <div style="display: flex; justify-content: space-between; align-items: center;">
+                            <span>Basic List</span>
+                            <p:commandButton
+                                value="Process"
+                                action="#{staffBasicController.makeItemNul}"
+                                ajax="false" />
                         </div>
-
                     </f:facet>
 
-                    <p:panel id="staffbasic" styleClass="noBorder summeryBorder" >
-                        <p:dataTable id="tb7"  value="#{staffBasicController.items}" 
-                                     filteredValue="#{staffBasicController.filteredStaffPaysheet}"
-                                     var="i"  selection="#{staffBasicController.selectedStaffComponent}" 
-                                     rowKey="#{i.id}" rowIndexVar="a"
-                                     selectionMode="multiple">
+                    <p:panel id="staffbasic" styleClass="noBorder summeryBorder">
+                        <p:dataTable
+                            id="tb7"
+                            value="#{staffBasicController.items}"
+                            filteredValue="#{staffBasicController.filteredStaffPaysheet}"
+                            var="i"
+                            selection="#{staffBasicController.selectedStaffComponent}"
+                            rowKey="#{i.id}"
+                            rowIndexVar="a"
+                            selectionMode="multiple"
+                            scrollable="true"
+                            scrollWidth="100%"
+                            style="table-layout: fixed; width: 100%;">
+
                             <f:facet name="header">
-                                <h:outputLabel value="Employee Basic"/>
+                                <h:outputLabel value="Employee Basic" />
                             </f:facet>
-                            <p:column  styleClass="noPrintButton">                            
+
+                            <!-- Row selector (print hidden) -->
+                            <p:column styleClass="noPrintButton" style="width: 2.5rem;" />
+
+                            <!-- No -->
+                            <p:column headerText="#" style="width: 3rem; text-align: center;">
+                                <h:outputLabel value="#{a+1}" />
                             </p:column>
-                            <p:column headerText="No">
-                                <f:facet name="header">
-                                    <h:outputLabel value="No"/>
-                                </f:facet>
-                                <h:outputLabel value="#{a+1}" >
+
+                            <!-- EMP Code -->
+                            <p:column headerText="Emp Code" sortBy="#{i.staff.codeInterger}" style="width: 6rem;">
+                                <h:outputLabel value="#{i.staff.code}" />
+                            </p:column>
+
+                            <!-- Staff Name -->
+                            <p:column headerText="Staff" sortBy="#{i.staff.person.nameWithTitle}" style="width: 14rem;">
+                                <h:outputLabel value="#{i.staff.person.nameWithTitle}" />
+                            </p:column>
+
+                            <!-- Institution -->
+                            <p:column headerText="Institution" sortBy="#{i.staff.workingDepartment.institution.name}" style="width: 10rem;">
+                                <h:outputLabel value="#{i.staff.workingDepartment.institution.name}" />
+                            </p:column>
+
+                            <!-- Department -->
+                            <p:column headerText="Department" sortBy="#{i.staff.workingDepartment.name}" style="width: 10rem;">
+                                <h:outputLabel value="#{i.staff.workingDepartment.name}" />
+                            </p:column>
+
+                            <!-- Category + Designation grouped visually -->
+                            <p:column headerText="Category" style="width: 8rem;">
+                                <h:outputLabel value="#{i.staff.staffCategory.name}" />
+                            </p:column>
+
+                            <p:column headerText="Designation" style="width: 9rem;">
+                                <h:outputLabel value="#{i.staff.designation.name}" />
+                            </p:column>
+
+                            <!-- Roster -->
+                            <p:column headerText="Roster" style="width: 7rem;">
+                                <h:outputLabel value="#{i.staff.roster.name}" />
+                            </p:column>
+
+                            <!-- Grade -->
+                            <p:column headerText="Grade" style="width: 5rem;">
+                                <h:outputLabel value="#{i.staff.grade.name}" />
+                            </p:column>
+
+                            <!-- From Date -->
+                            <p:column headerText="From" style="width: 7rem;">
+                                <h:outputLabel value="#{i.fromDate}">
+                                    <f:convertDateTime pattern="#{sessionController.applicationPreference.shortDateFormat}" />
                                 </h:outputLabel>
                             </p:column>
 
-                            <p:column headerText="Institution" sortBy="#{i.staff.workingDepartment.institution.name}"  >
-                                <f:facet name="header" >
-                                    <h:outputLabel value="Institution"  />
-                                </f:facet>
-                                <h:outputLabel value="#{i.staff.workingDepartment.institution.name}" ></h:outputLabel>
-                            </p:column>
-                            <p:column headerText="Department" sortBy="#{i.staff.workingDepartment.name}" >
-                                <f:facet name="header" >
-                                    <h:outputLabel value="Department"  />
-                                </f:facet>
-
-                                <h:outputLabel value="#{i.staff.workingDepartment.name}" ></h:outputLabel>
-                            </p:column>
-                            <p:column headerText="Roster"  >
-                                <f:facet name="header">
-                                    <h:outputLabel value="Roster"  />
-                                </f:facet>
-                                <h:outputLabel value="#{i.staff.roster.name}" ></h:outputLabel>
-                            </p:column>
-                            <p:column headerText="EMP Code" sortBy="#{i.staff.codeInterger}" >
-                                <f:facet name="header">
-                                    <h:outputLabel value="EMP Code"  />
-                                </f:facet>
-                                <h:outputLabel value="#{i.staff.code}" ></h:outputLabel>
-                            </p:column>
-                            <p:column headerText="DOJ"  >
-                                <f:facet name="header">
-                                    <h:outputLabel value="DOJ"  />
-                                </f:facet>
-                                <h:outputLabel value="#{i.staff.dateJoined}" >
-                                    <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateFormat}"/>
-                                </h:outputLabel>
-                            </p:column>
-                            <p:column headerText="From"  >
-                                <f:facet name="header">
-                                    <h:outputLabel value="From"  />
-                                </f:facet>
-                                <h:outputLabel value="#{i.fromDate}" >
-                                    <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateFormat}"/>
-                                </h:outputLabel>
-                            </p:column>
-                            <p:column headerText="To" >
-                                <f:facet name="header">
-                                    <h:outputLabel value="To"  />
-                                </f:facet>
-                                <p:cellEditor>  
+                            <!-- To Date (editable) -->
+                            <p:column headerText="To" style="width: 7rem;">
+                                <p:cellEditor>
                                     <f:facet name="output">
                                         <h:outputLabel value="#{i.toDate}">
-                                            <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateFormat}"/>
+                                            <f:convertDateTime pattern="#{sessionController.applicationPreference.shortDateFormat}" />
                                         </h:outputLabel>
                                     </f:facet>
                                     <f:facet name="input">
-                                        <p:calendar  navigator="true" value="#{i.toDate}"  pattern="#{sessionController.applicationPreference.longDateFormat}" />
+                                        <p:calendar navigator="true" value="#{i.toDate}"
+                                                    pattern="#{sessionController.applicationPreference.shortDateFormat}" />
                                     </f:facet>
                                 </p:cellEditor>
-
                             </p:column>
 
-                            <p:column headerText="Grade" >
-                                <f:facet name="header">
-                                    <h:outputLabel value="Grade"  />
-                                </f:facet>
-                                <h:outputLabel value="#{i.staff.grade.name}"/>                           
-                            </p:column>
-
-                            <p:column headerText="Category" >
-                                <f:facet name="header">
-                                    <h:outputLabel value="Category"  />
-                                </f:facet>
-                                <h:outputLabel value="#{i.staff.staffCategory.name}"/>
-                            </p:column>
-
-                            <p:column headerText="Designtion" >
-                                <f:facet name="header">
-                                    <h:outputLabel value="Designtion"  />
-                                </f:facet>
-                                <h:outputLabel value="#{i.staff.designation.name}"/>
-                            </p:column>
-                            <p:column headerText="Resign Date" >
-                                <f:facet name="header">
-                                    <h:outputLabel value="Resign Date"  />
-                                </f:facet>
-                                <h:outputLabel value="#{i.staff.dateLeft}">
-                                    <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateFormat}"/>
-                                </h:outputLabel>
-                            </p:column>
-                            <p:column headerText="Staff" >
-                                <f:facet name="header">
-                                    <h:outputLabel value="Staff"  />
-                                </f:facet>
-                                <h:outputLabel value="#{i.staff.person.nameWithTitle}"/>
-                            </p:column>
-                            <p:column headerText="Basic" sortBy="#{i.staffPaySheetComponentValue}" >
-                                <f:facet name="header">
-                                    <h:outputLabel value="Basic"  />
-                                </f:facet>
+                            <!-- Basic Salary -->
+                            <p:column headerText="Basic" sortBy="#{i.staffPaySheetComponentValue}"
+                                      style="width: 7rem; text-align: right;">
                                 <h:outputLabel value="#{i.staffPaySheetComponentValue}">
                                     <f:convertNumber pattern="#,##0.00" />
                                 </h:outputLabel>
-
                             </p:column>
-                            <p:column headerText="BR Value"  >
-                                <f:facet name="header">
-                                    <h:outputLabel value="BR Value"  />
-                                </f:facet>
+
+                            <!-- BR Value -->
+                            <p:column headerText="BR Value" style="width: 7rem; text-align: right;">
                                 <h:outputLabel value="#{i.dblValue}">
                                     <f:convertNumber pattern="#,##0.00" />
                                 </h:outputLabel>
-
                             </p:column>
 
-                            <p:column style="width:6%" exportable="false" styleClass="noPrintButton">  
-                                <p:commandButton ajax="false" value="Remove" action="#{staffBasicController.remove}" >
-                                    <f:setPropertyActionListener target="#{staffBasicController.current}" value="#{i}" />
-                                </p:commandButton>
-                            </p:column>  
+                            <!-- Actions (hidden from print/export) -->
+                            <p:column style="width: 9rem;" exportable="false" styleClass="noPrintButton">
+                                <div style="display: flex; gap: 0.4rem;">
+                                    <p:commandButton ajax="false" value="View" styleClass="ui-button-info"
+                                                     style="flex: 1; padding: 0.25rem 0.4rem; font-size: 0.82rem;">
+                                        <f:setPropertyActionListener target="#{staffBasicController.current}" value="#{i}" />
+                                    </p:commandButton>
+                                    <p:commandButton ajax="false" value="Remove" styleClass="ui-button-danger"
+                                                     style="flex: 1; padding: 0.25rem 0.4rem; font-size: 0.82rem;"
+                                                     action="#{staffBasicController.remove}">
+                                        <f:setPropertyActionListener target="#{staffBasicController.current}" value="#{i}" />
+                                    </p:commandButton>
+                                </div>
+                            </p:column>
 
-                            <p:column style="width:6%" exportable="false" styleClass="noPrintButton">  
-                                <p:commandButton ajax="false" value="View" >
-                                    <f:setPropertyActionListener target="#{staffBasicController.current}" value="#{i}" />
-                                </p:commandButton>
-                            </p:column> 
                         </p:dataTable>
                     </p:panel>
                 </p:panel>
+
             </h:form>
-
         </h:panelGroup>
-
     </ui:define>
 
 </ui:composition>


### PR DESCRIPTION
## Summary

Two separate fixes bundled together — a UI overhaul for the staff basic
screen and a backend bug fix in the paysheet component initializer.

## Changes

### Backend — StaffBasicController.java

- **Fix null-safe paysheet component init**: `getBasicComponent()` was
  only called when `current` itself was null. If `current` existed but
  its `parisheetComponent` was null (e.g. after a `makeNull` reset), it
  was never set. Moved the null check for `parisheetComponent` into its
  own guard so it always initializes correctly.

- **Fix date filter for open-ended records**: The `fromDate` query now
  correctly includes records where `toDate IS NULL`, treating them as
  active/indefinite. Previously, records with no end date were excluded
  when filtering by date range.

- Removed a stale commented-out `System.out.println` debug line.

### Frontend — hr_staff_basic_individual.xhtml

- Replaced Bootstrap grid (`row`/`col-*`) and `h:panelGrid` layout with
  CSS Grid and Flexbox for more predictable, responsive alignment.
- Replaced redundant inline `<f:facet name="header">` blocks inside each
  `p:column` with the standard `headerText` attribute.
- Set explicit `style="width: Xrem;"` on all table columns to prevent
  PrimeFaces from distributing widths unpredictably.
- Added `scrollable="true"` and `scrollWidth="100%"` to allow horizontal
  scroll instead of overflowing the page.
- Switched date display in the table from `longDateFormat` to
  `shortDateFormat` to reduce column width.
- Merged the two separate `View` and `Remove` action columns into one
  compact Actions column.
- Removed `DOJ` (Date of Joined) and `Resign Date` columns from the
  list table — these belong on the staff profile, not a paysheet summary.
- Color-coded action buttons: View → info (blue), Remove → danger (red).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved date filtering to treat open-ended ranges as overlapping.
  * Ensured paysheet component is initialized when missing.

* **Style / UI Changes**
  * Redesigned "Shift Basic" form with CSS grid/flex grouping and tighter spacing.
  * Updated button sizing and layout.
  * Reworked Basic List table: scrollable fixed layout, new row numbering, consolidated Actions column with View/Remove, removed obsolete columns, and standardized short date format.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->