### PR TITLE
fix(cashier): handover accept drill-down, totals, cash value, back button

### DIFF
--- a/src/main/webapp/cashier/handover_accept.xhtml
+++ b/src/main/webapp/cashier/handover_accept.xhtml
@@ -608,11 +608,11 @@
                                             <h:outputText value="#{summary.cardValue}" >
                                                 <f:convertNumber pattern="#,##0.00" ></f:convertNumber>
                                             </h:outputText>
-                                            <p:commandButton 
-                                                icon="pi pi-refresh" 
-                                                title="Change Handover Value" 
-                                                ajax="false" 
-                                                styleClass="ui-button-warning m-1 mx-2" 
+                                            <p:commandButton
+                                                icon="pi pi-search"
+                                                title="View Payments"
+                                                ajax="false"
+                                                styleClass="ui-button-info m-1 mx-2"
                                                 action="#{financialTransactionController.navigateToSelectPaymentsForHandoverAccept(summary, 'Card')}" >
                                             </p:commandButton>
                                             <f:facet name="footer">
@@ -634,12 +634,19 @@
                                             </f:facet>
                                         </p:column>
 
-                                        <p:column headerText="Credit" 
+                                        <p:column headerText="Credit"
                                                   class="text-end"
                                                   rendered="#{financialTransactionController.bundle.hasCreditTransaction}" >
                                             <h:outputText value="#{summary.creditValue}" >
                                                 <f:convertNumber pattern="#,##0.00" ></f:convertNumber>
                                             </h:outputText>
+                                            <p:commandButton
+                                                icon="pi pi-search"
+                                                title="View Payments"
+                                                ajax="false"
+                                                styleClass="ui-button-info m-1 mx-2"
+                                                action="#{financialTransactionController.navigateToSelectPaymentsForHandoverAccept(summary, 'Credit')}" >
+                                            </p:commandButton>
                                             <f:facet name="footer">
                                                 <h:outputText value="#{financialTransactionController.bundle.creditValue}">
                                                     <f:convertNumber pattern="#,##0.00" />
@@ -648,13 +655,20 @@
                                         </p:column>
 
                                         <!-- Continuing from Credit -->
-                                        <p:column 
-                                            headerText="Staff Welfare" 
+                                        <p:column
+                                            headerText="Staff Welfare"
                                             class="text-end"
                                             rendered="#{financialTransactionController.bundle.hasStaffWelfareTransaction}" >
                                             <h:outputText value="#{summary.staffWelfareValue}" >
                                                 <f:convertNumber pattern="#,##0.00" ></f:convertNumber>
                                             </h:outputText>
+                                            <p:commandButton
+                                                icon="pi pi-search"
+                                                title="View Payments"
+                                                ajax="false"
+                                                styleClass="ui-button-info m-1 mx-2"
+                                                action="#{financialTransactionController.navigateToSelectPaymentsForHandoverAccept(summary, 'StaffWelfare')}" >
+                                            </p:commandButton>
                                             <f:facet name="footer">
                                                 <h:outputText value="#{financialTransactionController.bundle.staffWelfareValue}">
                                                     <f:convertNumber pattern="#,##0.00" />
@@ -662,13 +676,20 @@
                                             </f:facet>
                                         </p:column>
 
-                                        <p:column 
-                                            headerText="Staff" 
+                                        <p:column
+                                            headerText="Staff"
                                             class="text-end"
                                             rendered="#{financialTransactionController.bundle.hasStaffTransaction}" >
                                             <h:outputText value="#{summary.staffValue}" >
                                                 <f:convertNumber pattern="#,##0.00" ></f:convertNumber>
                                             </h:outputText>
+                                            <p:commandButton
+                                                icon="pi pi-search"
+                                                title="View Payments"
+                                                ajax="false"
+                                                styleClass="ui-button-info m-1 mx-2"
+                                                action="#{financialTransactionController.navigateToSelectPaymentsForHandoverAccept(summary, 'Staff')}" >
+                                            </p:commandButton>
                                             <f:facet name="footer">
                                                 <h:outputText value="#{financialTransactionController.bundle.staffValue}">
                                                     <f:convertNumber pattern="#,##0.00" />
@@ -676,13 +697,20 @@
                                             </f:facet>
                                         </p:column>
 
-                                        <p:column 
-                                            headerText="Voucher" 
+                                        <p:column
+                                            headerText="Voucher"
                                             class="text-end"
                                             rendered="#{financialTransactionController.bundle.hasVoucherTransaction}" >
                                             <h:outputText value="#{summary.voucherValue}" >
                                                 <f:convertNumber pattern="#,##0.00" ></f:convertNumber>
                                             </h:outputText>
+                                            <p:commandButton
+                                                icon="pi pi-search"
+                                                title="View Payments"
+                                                ajax="false"
+                                                styleClass="ui-button-info m-1 mx-2"
+                                                action="#{financialTransactionController.navigateToSelectPaymentsForHandoverAccept(summary, 'Voucher')}" >
+                                            </p:commandButton>
                                             <f:facet name="footer">
                                                 <h:outputText value="#{financialTransactionController.bundle.voucherValue}">
                                                     <f:convertNumber pattern="#,##0.00" />
@@ -690,13 +718,20 @@
                                             </f:facet>
                                         </p:column>
 
-                                        <p:column 
-                                            headerText="IOU" 
+                                        <p:column
+                                            headerText="IOU"
                                             class="text-end"
                                             rendered="#{financialTransactionController.bundle.hasIouTransaction}" >
                                             <h:outputText value="#{summary.iouValue}" >
                                                 <f:convertNumber pattern="#,##0.00" ></f:convertNumber>
                                             </h:outputText>
+                                            <p:commandButton
+                                                icon="pi pi-search"
+                                                title="View Payments"
+                                                ajax="false"
+                                                styleClass="ui-button-info m-1 mx-2"
+                                                action="#{financialTransactionController.navigateToSelectPaymentsForHandoverAccept(summary, 'IOU')}" >
+                                            </p:commandButton>
                                             <f:facet name="footer">
                                                 <h:outputText value="#{financialTransactionController.bundle.iouValue}">
                                                     <f:convertNumber pattern="#,##0.00" />
@@ -704,13 +739,20 @@
                                             </f:facet>
                                         </p:column>
 
-                                        <p:column 
+                                        <p:column
                                             headerText="Agent"
                                             class="text-end"
                                             rendered="#{financialTransactionController.bundle.hasAgentTransaction}" >
                                             <h:outputText value="#{summary.agentValue}" >
                                                 <f:convertNumber pattern="#,##0.00" ></f:convertNumber>
                                             </h:outputText>
+                                            <p:commandButton
+                                                icon="pi pi-search"
+                                                title="View Payments"
+                                                ajax="false"
+                                                styleClass="ui-button-info m-1 mx-2"
+                                                action="#{financialTransactionController.navigateToSelectPaymentsForHandoverAccept(summary, 'Agent')}" >
+                                            </p:commandButton>
                                             <f:facet name="footer">
                                                 <h:outputText value="#{financialTransactionController.bundle.agentValue}">
                                                     <f:convertNumber pattern="#,##0.00" />
@@ -718,13 +760,20 @@
                                             </f:facet>
                                         </p:column>
 
-                                        <p:column 
-                                            headerText="Cheque" 
+                                        <p:column
+                                            headerText="Cheque"
                                             class="text-end"
                                             rendered="#{financialTransactionController.bundle.hasChequeTransaction}" >
                                             <h:outputText value="#{summary.chequeValue}" >
                                                 <f:convertNumber pattern="#,##0.00" ></f:convertNumber>
                                             </h:outputText>
+                                            <p:commandButton
+                                                icon="pi pi-search"
+                                                title="View Payments"
+                                                ajax="false"
+                                                styleClass="ui-button-info m-1 mx-2"
+                                                action="#{financialTransactionController.navigateToSelectPaymentsForHandoverAccept(summary, 'Cheque')}" >
+                                            </p:commandButton>
                                             <f:facet name="footer">
                                                 <h:outputText value="#{financialTransactionController.bundle.chequeValue}">
                                                     <f:convertNumber pattern="#,##0.00" />
@@ -732,13 +781,20 @@
                                             </f:facet>
                                         </p:column>
 
-                                        <p:column 
+                                        <p:column
                                             headerText="Slip"
                                             class="text-end"
                                             rendered="#{financialTransactionController.bundle.hasSlipTransaction}" >
                                             <h:outputText value="#{summary.slipValue}" >
                                                 <f:convertNumber pattern="#,##0.00" ></f:convertNumber>
                                             </h:outputText>
+                                            <p:commandButton
+                                                icon="pi pi-search"
+                                                title="View Payments"
+                                                ajax="false"
+                                                styleClass="ui-button-info m-1 mx-2"
+                                                action="#{financialTransactionController.navigateToSelectPaymentsForHandoverAccept(summary, 'Slip')}" >
+                                            </p:commandButton>
                                             <f:facet name="footer">
                                                 <h:outputText value="#{financialTransactionController.bundle.slipValue}">
                                                     <f:convertNumber pattern="#,##0.00" />
@@ -746,13 +802,20 @@
                                             </f:facet>
                                         </p:column>
 
-                                        <p:column 
-                                            headerText="eWallet" 
+                                        <p:column
+                                            headerText="eWallet"
                                             class="text-end"
                                             rendered="#{financialTransactionController.bundle.hasEWalletTransaction}" >
                                             <h:outputText value="#{summary.ewalletValue}" >
                                                 <f:convertNumber pattern="#,##0.00" ></f:convertNumber>
                                             </h:outputText>
+                                            <p:commandButton
+                                                icon="pi pi-search"
+                                                title="View Payments"
+                                                ajax="false"
+                                                styleClass="ui-button-info m-1 mx-2"
+                                                action="#{financialTransactionController.navigateToSelectPaymentsForHandoverAccept(summary, 'ewallet')}" >
+                                            </p:commandButton>
                                             <f:facet name="footer">
                                                 <h:outputText value="#{financialTransactionController.bundle.ewalletValue}">
                                                     <f:convertNumber pattern="#,##0.00" />
@@ -760,13 +823,20 @@
                                             </f:facet>
                                         </p:column>
 
-                                        <p:column 
-                                            headerText="Patient Deposit" 
+                                        <p:column
+                                            headerText="Patient Deposit"
                                             class="text-end"
                                             rendered="#{financialTransactionController.bundle.hasPatientDepositTransaction}" >
                                             <h:outputText value="#{summary.patientDepositValue}" >
                                                 <f:convertNumber pattern="#,##0.00" ></f:convertNumber>
                                             </h:outputText>
+                                            <p:commandButton
+                                                icon="pi pi-search"
+                                                title="View Payments"
+                                                ajax="false"
+                                                styleClass="ui-button-info m-1 mx-2"
+                                                action="#{financialTransactionController.navigateToSelectPaymentsForHandoverAccept(summary, 'PatientDeposit')}" >
+                                            </p:commandButton>
                                             <f:facet name="footer">
                                                 <h:outputText value="#{financialTransactionController.bundle.patientDepositValue}">
                                                     <f:convertNumber pattern="#,##0.00" />
@@ -774,13 +844,20 @@
                                             </f:facet>
                                         </p:column>
 
-                                        <p:column 
-                                            headerText="Patient Points" 
+                                        <p:column
+                                            headerText="Patient Points"
                                             class="text-end"
                                             rendered="#{financialTransactionController.bundle.hasPatientPointsTransaction}" >
                                             <h:outputText value="#{summary.patientPointsValue}" >
                                                 <f:convertNumber pattern="#,##0.00" ></f:convertNumber>
                                             </h:outputText>
+                                            <p:commandButton
+                                                icon="pi pi-search"
+                                                title="View Payments"
+                                                ajax="false"
+                                                styleClass="ui-button-info m-1 mx-2"
+                                                action="#{financialTransactionController.navigateToSelectPaymentsForHandoverAccept(summary, 'PatientPoints')}" >
+                                            </p:commandButton>
                                             <f:facet name="footer">
                                                 <h:outputText value="#{financialTransactionController.bundle.patientPointsValue}">
                                                     <f:convertNumber pattern="#,##0.00" />
@@ -795,6 +872,13 @@
                                             <h:outputText value="#{summary.onlineSettlementValue}" >
                                                 <f:convertNumber pattern="#,##0.00" ></f:convertNumber>
                                             </h:outputText>
+                                            <p:commandButton
+                                                icon="pi pi-search"
+                                                title="View Payments"
+                                                ajax="false"
+                                                styleClass="ui-button-info m-1 mx-2"
+                                                action="#{financialTransactionController.navigateToSelectPaymentsForHandoverAccept(summary, 'OnlineSettlement')}" >
+                                            </p:commandButton>
                                             <f:facet name="footer">
                                                 <h:outputText value="#{financialTransactionController.bundle.onlineSettlementValue}">
                                                     <f:convertNumber pattern="#,##0.00" />
@@ -819,13 +903,13 @@
                                         </p:column>
 
                                         <p:column headerText="Actions" class="text-center">
-                                            <p:commandButton 
-                                                class="m-1 ui-button-success" 
-                                                value="View Details" 
-                                                icon="pi pi-eye"  
+                                            <p:commandButton
+                                                class="m-1 ui-button-success"
+                                                value="View Details"
+                                                icon="pi pi-eye"
                                                 action="#{financialTransactionController.navigateToViewIndividualShiftForHandover}">
                                             </p:commandButton>
-
+                                            <f:facet name="footer"><h:outputText value="" /></f:facet>
                                         </p:column>
 
                                     </p:dataTable>

--- a/src/main/webapp/cashier/handover_accept_select.xhtml
+++ b/src/main/webapp/cashier/handover_accept_select.xhtml
@@ -23,10 +23,10 @@
                                 </div>
                                 <div class="col float-right">
                                     <p:commandButton
-                                        value="Back to Accept Handovers"
+                                        value="Back"
                                         class="m-1 ui-button-success"
                                         icon="pi pi-arrow-left"
-                                        action="#{financialTransactionController.navigateToReceiveHandoverBillsForMe()}"
+                                        action="#{financialTransactionController.navigateBackToPaymentHandoverAccept()}"
                                         ajax="false">
                                     </p:commandButton>
 

--- a/src/main/webapp/resources/ezcomp/prints/five_five_paper_with_headings_for_handover.xhtml
+++ b/src/main/webapp/resources/ezcomp/prints/five_five_paper_with_headings_for_handover.xhtml
@@ -249,7 +249,7 @@
                                                 <td>Cash</td>
                                                 <td class="text-end"><h:outputText value="#{cc.attrs.bundle.cashValue}"><f:convertNumber pattern="#,##0.00"/></h:outputText></td>
                                                 <td class="text-end"><h:outputText value="#{cc.attrs.bundle.cashValue}"><f:convertNumber pattern="#,##0.00"/></h:outputText></td>
-                                                <td class="text-end"><h:outputText value="0.00"><f:convertNumber pattern="#,##0.00"/></h:outputText></td>
+                                                <td class="text-end"><h:outputText value="#{0}"><f:convertNumber pattern="#,##0.00"/></h:outputText></td>
                                             </tr>
                                         </h:panelGroup>
                                         <h:panelGroup rendered="#{cc.attrs.bundle.cashFloatNetTotal != 0}">
@@ -257,7 +257,7 @@
                                                 <td>Net Float (Cash)</td>
                                                 <td class="text-end"><h:outputText value="#{cc.attrs.bundle.cashFloatNetTotal}"><f:convertNumber pattern="#,##0.00"/></h:outputText></td>
                                                 <td class="text-end"><h:outputText value="#{cc.attrs.bundle.cashFloatNetTotal}"><f:convertNumber pattern="#,##0.00"/></h:outputText></td>
-                                                <td class="text-end"><h:outputText value="0.00"><f:convertNumber pattern="#,##0.00"/></h:outputText></td>
+                                                <td class="text-end"><h:outputText value="#{0}"><f:convertNumber pattern="#,##0.00"/></h:outputText></td>
                                             </tr>
                                         </h:panelGroup>
                                         <h:panelGroup rendered="#{cc.attrs.bundle.hasCardTransaction}">

--- a/src/main/webapp/resources/ezcomp/prints/five_five_paper_with_headings_for_handover.xhtml
+++ b/src/main/webapp/resources/ezcomp/prints/five_five_paper_with_headings_for_handover.xhtml
@@ -248,8 +248,8 @@
                                             <tr>
                                                 <td>Cash</td>
                                                 <td class="text-end"><h:outputText value="#{cc.attrs.bundle.cashValue}"><f:convertNumber pattern="#,##0.00"/></h:outputText></td>
-                                                <td class="text-end"><h:outputText value="#{cc.attrs.bundle.denominatorValue}"><f:convertNumber pattern="#,##0.00"/></h:outputText></td>
-                                                <td class="text-end"><h:outputText value="#{cc.attrs.bundle.cashValue - cc.attrs.bundle.denominatorValue}"><f:convertNumber pattern="#,##0.00"/></h:outputText></td>
+                                                <td class="text-end"><h:outputText value="#{cc.attrs.bundle.cashValue}"><f:convertNumber pattern="#,##0.00"/></h:outputText></td>
+                                                <td class="text-end"><h:outputText value="0.00"><f:convertNumber pattern="#,##0.00"/></h:outputText></td>
                                             </tr>
                                         </h:panelGroup>
                                         <h:panelGroup rendered="#{cc.attrs.bundle.cashFloatNetTotal != 0}">
@@ -839,7 +839,16 @@
                         </f:facet>
                     </p:column>
 
-
+                    <p:column headerText="Total" class="text-end">
+                        <h:outputText value="#{summary.total}">
+                            <f:convertNumber pattern="#,##0.00" />
+                        </h:outputText>
+                        <f:facet name="footer">
+                            <h:outputText value="#{cc.attrs.bundle.cashValue + cc.attrs.bundle.cardValue + cc.attrs.bundle.creditValue + cc.attrs.bundle.staffWelfareValue + cc.attrs.bundle.staffValue + cc.attrs.bundle.voucherValue + cc.attrs.bundle.iouValue + cc.attrs.bundle.agentValue + cc.attrs.bundle.chequeValue + cc.attrs.bundle.slipValue + cc.attrs.bundle.ewalletValue + cc.attrs.bundle.patientDepositValue + cc.attrs.bundle.patientPointsValue + cc.attrs.bundle.onlineSettlementValue + cc.attrs.bundle.onCallValue}">
+                                <f:convertNumber pattern="#,##0.00" />
+                            </h:outputText>
+                        </f:facet>
+                    </p:column>
 
                 </p:dataTable>
 


### PR DESCRIPTION
## Summary

- **`handover_accept.xhtml`**: Added `pi-search` drill-down buttons to all payment method columns (Credit, Staff Welfare, Staff, Voucher, IOU, Agent, Cheque, Slip, eWallet, Patient Deposit, Patient Points, Online Settlement). Changed Card column icon from `pi-refresh` to `pi-search`. Added empty footer facet to Actions column so the footer totals row renders correctly.
- **`five_five_paper_with_headings_for_handover.xhtml`** (creation & reprint print): Fixed cash "Handing Over" column — now uses `cashValue` instead of `denominatorValue` (denominations represent the breakdown, not a separate handover amount; cash is always fully handed over, difference = 0). Added a Total column with footer sum to the per-department detail table.
- **`handover_accept_select.xhtml`**: Fixed back button — now calls `navigateBackToPaymentHandoverAccept()` to return to the accept/view page, instead of `navigateToReceiveHandoverBillsForMe()` which was wrongly going to the handover list.

## Test plan

- [ ] View a handover on the accept page — all payment method columns should show the search (drill-down) icon
- [ ] Click any drill-down icon — verify it navigates to `handover_accept_select` with correct payment method loaded
- [ ] On `handover_accept_select`, click Back — verify it returns to `handover_accept` (the view page), NOT the handover list
- [ ] View the handover creation bill print — Cash row "Handing Over" should equal "Collected", Difference = 0
- [ ] Verify the per-department detail table at the bottom of the creation/reprint print shows a Total column with footer totals
- [ ] Accept page detail table footer row should show totals for all payment method columns

Closes #20310

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "View Payments" functionality for multiple payment method types in the handover acceptance workflow.
  * Added "Total" column to the handover comparison report.

* **Improvements**
  * Simplified navigation in the handover acceptance process.
  * Updated cash calculations in handover documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->