### PR TITLE
fix(cogs-report): include Stock Verification Adjustment Bills in COGS stock adjustment rows

### DIFF
--- a/src/main/java/com/divudi/bean/report/PharmacyReportController.java
+++ b/src/main/java/com/divudi/bean/report/PharmacyReportController.java
@@ -5343,6 +5343,7 @@ public class PharmacyReportController implements Serializable {
             List<BillType> billTypes = new ArrayList<>();
             billTypes.add(BillType.PharmacyAdjustmentDepartmentSingleStock);
             billTypes.add(BillType.PharmacyAdjustmentDepartmentStock);
+            billTypes.add(BillType.PharmacyStockAdjustmentBill);
             billItemsDtos = new ArrayList<>();
             netTotal = 0.0;
 
@@ -13318,6 +13319,7 @@ public class PharmacyReportController implements Serializable {
             List<BillType> billTypes = new ArrayList<>();
             billTypes.add(BillType.PharmacyAdjustmentDepartmentSingleStock);
             billTypes.add(BillType.PharmacyAdjustmentDepartmentStock);
+            billTypes.add(BillType.PharmacyStockAdjustmentBill);
 
             // Query for Stock Adjustment Issues (negative quantities)
             Map<String, Object> paramsIssue = new HashMap<>();


### PR DESCRIPTION
## Summary

- Added `BillType.PharmacyStockAdjustmentBill` to `calculateStockAdjustment()` so that stock verification (physical count) adjustment transactions are counted in the **Stock Adjustment Receive** and **Stock Adjustment Issue** rows of the Cost of Goods Sold report.
- Added the same bill type to `retrieveStockAdjustmentBillItems()` so the drill-down report accessed by clicking those rows also includes verification adjustment transactions.

Fixes #20313

## Root cause

`PharmacyStockAdjustmentBill` is created whenever a stock take / physical count is approved. Both methods only queried `PharmacyAdjustmentDepartmentSingleStock` and `PharmacyAdjustmentDepartmentStock`, leaving verification adjustments invisible. The actual Closing Stock (from `StockHistory`) already reflected the adjustments, so the omission produced a variance equal to the adjustment total.

## Test plan

- [ ] Run the COGS report for a period that contains a stock take approval
- [ ] Confirm the **Stock Adjustment Issue** / **Stock Adjustment Receive** rows now include the verification adjustment amounts
- [ ] Confirm the **Variance** row is now 0 (or reduced to any legitimate rounding difference)
- [ ] Click the **Stock Adjustment Issue** / **Receive** drill-down link; confirm the detail rows show the verification adjustment bill items

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Pharmacy stock adjustment calculations now properly include all relevant bill types, ensuring complete and accurate inventory tracking with correct financial totals.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->