### PR TITLE
fix(inward): filter allergy list by PatientAllergy type

### DIFF
--- a/src/main/java/com/divudi/bean/inward/AdmissionController.java
+++ b/src/main/java/com/divudi/bean/inward/AdmissionController.java
@@ -343,8 +343,9 @@ public class AdmissionController implements Serializable, ControllerWithPatient 
         }
         patientAllergies = new ArrayList<>();
         Map params = new HashMap<>();
-        String s = "SELECT c FROM ClinicalFindingValue c WHERE c.retired = false AND c.patient = :pt";
+        String s = "SELECT c FROM ClinicalFindingValue c WHERE c.retired = false AND c.patient = :pt AND c.clinicalFindingValueType = :type";
         params.put("pt", pt);
+        params.put("type", ClinicalFindingValueType.PatientAllergy);
         patientAllergies = clinicalFindingValueFacade.findByJpql(s, params);
     }
 

--- a/src/main/java/com/divudi/bean/inward/AdmissionPatientChangeController.java
+++ b/src/main/java/com/divudi/bean/inward/AdmissionPatientChangeController.java
@@ -183,8 +183,9 @@ public class AdmissionPatientChangeController implements Serializable, Controlle
         }
         patientAllergies = new ArrayList<>();
         Map params = new HashMap<>();
-        String s = "SELECT c FROM ClinicalFindingValue c WHERE c.retired = false AND c.patient = :pt";
+        String s = "SELECT c FROM ClinicalFindingValue c WHERE c.retired = false AND c.patient = :pt AND c.clinicalFindingValueType = :type";
         params.put("pt", pt);
+        params.put("type", ClinicalFindingValueType.PatientAllergy);
         patientAllergies = clinicalFindingValueFacade.findByJpql(s, params);
     }
 


### PR DESCRIPTION
## Summary

- `AdmissionController.fillCurrentPatientAllergies()` and `AdmissionPatientChangeController.fillCurrentPatientAllergies()` were querying all `ClinicalFindingValue` rows for a patient with no type filter, so diagnoses, past surgical history, and investigations appeared in the allergy section on `inward_admission.xhtml`
- Added `AND c.clinicalFindingValueType = :type` (bound to `ClinicalFindingValueType.PatientAllergy`) to both queries — matching the pattern already correct in `BhtEditController`

Closes #20320

## Test plan

- [ ] Select a patient who has both allergies and other clinical findings (diagnoses, past history) on `inward_admission.xhtml`
- [ ] Verify only allergy entries appear in the **Add Patient Allergies** list
- [ ] Verify the same is correct on the patient change flow (`AdmissionPatientChangeController`)
- [ ] Confirm `BhtEditController` allergy display is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)