### PR TITLE
fix(pharmacy): use PreBill for native inpatient direct issue bill header

### DIFF
--- a/src/main/java/com/divudi/bean/pharmacy/InpatientDirectIssueNativeSqlController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/InpatientDirectIssueNativeSqlController.java
@@ -15,6 +15,7 @@ import com.divudi.core.data.dto.PrintBillData;
 import com.divudi.core.data.dto.StockDTO;
 import com.divudi.core.entity.Bill;
 import com.divudi.core.entity.BillItem;
+import com.divudi.core.entity.PreBill;
 import com.divudi.core.entity.Department;
 import com.divudi.core.entity.Item;
 import com.divudi.core.entity.PatientEncounter;
@@ -242,7 +243,7 @@ public class InpatientDirectIssueNativeSqlController implements Serializable {
     }
 
     private Bill buildBillHeader(Department matrixDept) {
-        Bill b = preBill != null ? preBill : new Bill();
+        Bill b = preBill != null ? preBill : new PreBill();
 
         b.setBillType(BillType.PharmacyBhtPre);
         b.setBillTypeAtomic(BillTypeAtomic.DIRECT_ISSUE_INWARD_MEDICINE);
@@ -548,7 +549,7 @@ public class InpatientDirectIssueNativeSqlController implements Serializable {
 
     public Bill getPreBill() {
         if (preBill == null) {
-            preBill = new Bill();
+            preBill = new PreBill();
         }
         return preBill;
     }


### PR DESCRIPTION
## Summary

- `InpatientDirectIssueNativeSqlController` was instantiating the bill header as `new Bill()` instead of `new PreBill()`
- JPA uses the actual Java class to set the `DTYPE` discriminator column, so bills were persisted with `DTYPE='Bill'`
- The interim bill's **Medicine Issue** tab filters rows with `billClass eq 'class com.divudi.core.entity.PreBill'`, so native-method bills were hidden (but still counted in the totals via a separate query)
- Fix: instantiate as `new PreBill()` in both `getPreBill()` and `buildBillHeader()`, consistent with the original `PharmacySaleBhtController`

## Test plan

- [ ] Issue medicines to an inpatient via `pharmacy_bill_issue_bht_native.xhtml`
- [ ] Open the interim bill for that patient (`inward_bill_intrim.xhtml`)
- [ ] Verify the bill appears in the **Medicine Issue** tab
- [ ] Verify the bill total in the Charges panel matches the Medicine Issue tab total

Closes #20308

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized inpatient direct issue bill header initialization to use more appropriate entity types, enhancing internal consistency and data handling in the bill creation process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->