### PR TITLE
feat(inward): apply inpatient discount matrix to service billing page

### DIFF
--- a/src/main/java/com/divudi/bean/common/PriceMatrixController.java
+++ b/src/main/java/com/divudi/bean/common/PriceMatrixController.java
@@ -1122,6 +1122,13 @@ public class PriceMatrixController implements Serializable {
         } else {
             jpql.append(" and a.item is null");
         }
+        // Prefer specific rows over wildcards: non-null fields rank higher
+        jpql.append(" order by"
+                + " case when a.paymentMethod is null then 1 else 0 end asc,"
+                + " case when a.admissionType is null then 1 else 0 end asc,"
+                + " case when a.department is null then 1 else 0 end asc,"
+                + " case when a.category is null then 1 else 0 end asc,"
+                + " case when a.item is null then 1 else 0 end asc");
         try {
             List<Object> rs = getPriceMatrixFacade().findObjects(jpql.toString(), params);
             if (rs == null || rs.isEmpty()) {

--- a/src/main/java/com/divudi/bean/common/PriceMatrixController.java
+++ b/src/main/java/com/divudi/bean/common/PriceMatrixController.java
@@ -1025,6 +1025,13 @@ public class PriceMatrixController implements Serializable {
         if (pct == null) {
             pct = fetchInwardDiscountPercentForDepartment(bhtType, scheme, admissionType, department);
         }
+        // Global wildcard: rows with null dept/category/item apply to everything
+        if (pct == null) {
+            pct = fetchInwardDiscountMatrixPercent(bhtType, scheme, admissionType, null, null, null);
+            if (pct == null && scheme != null) {
+                pct = fetchInwardDiscountMatrixPercent(bhtType, null, admissionType, null, null, null);
+            }
+        }
         return pct != null ? pct : 0.0;
     }
 
@@ -1073,12 +1080,23 @@ public class PriceMatrixController implements Serializable {
             AdmissionType admissionType, Department department, Category category, Item item) {
         StringBuilder jpql = new StringBuilder(
                 "select a.discountPercent from InwardDiscountMatrix a"
-                + " where a.retired = false"
-                + " and a.paymentMethod = :pm"
-                + " and a.admissionType = :admTp");
+                + " where a.retired = false");
         HashMap<String, Object> params = new HashMap<>();
-        params.put("pm", bhtType);
-        params.put("admTp", admissionType);
+
+        // NULL in the matrix means "all BHT types" — match exact value or wildcard row
+        if (bhtType != null) {
+            jpql.append(" and (a.paymentMethod = :pm or a.paymentMethod is null)");
+            params.put("pm", bhtType);
+        } else {
+            jpql.append(" and a.paymentMethod is null");
+        }
+        // NULL in the matrix means "all admission types" — match exact value or wildcard row
+        if (admissionType != null) {
+            jpql.append(" and (a.admissionType = :admTp or a.admissionType is null)");
+            params.put("admTp", admissionType);
+        } else {
+            jpql.append(" and a.admissionType is null");
+        }
 
         if (scheme != null) {
             jpql.append(" and a.paymentScheme = :sch");

--- a/src/main/java/com/divudi/bean/inward/BillBhtController.java
+++ b/src/main/java/com/divudi/bean/inward/BillBhtController.java
@@ -924,22 +924,6 @@ public class BillBhtController implements Serializable {
 
             getInwardBean().setBillFeeMargin(billFee, billItem.getItem(), priceMatrix, patientEncounter);
 
-            if (billFee.getFee() != null && billFee.getFee().getFeeType() != FeeType.Staff
-                    && billFee.getFeeGrossValue() != null && billFee.getFeeGrossValue() > 0
-                    && patientEncounter != null) {
-                double discountPct = priceMatrixController.getInwardDiscountPercent(
-                        paymentMethod,
-                        patientEncounter.getPaymentScheme(),
-                        patientEncounter.getAdmissionType(),
-                        matrixDepartment,
-                        billItem.getItem());
-                if (discountPct > 0) {
-                    double feeDiscountAmt = billFee.getFeeGrossValue() * discountPct / 100.0;
-                    billFee.setFeeDiscount(feeDiscountAmt);
-                    billFee.setFeeValue(billFee.getFeeValue() - feeDiscountAmt);
-                }
-            }
-
             billFeeList.add(billFee);
         }
 
@@ -1015,12 +999,12 @@ public class BillBhtController implements Serializable {
                 margin += bf.getFeeMargin();
             }
 
-            bi.setDiscount(bi.getGrossValue() - bi.getNetValue());
+            bi.setDiscount(bi.getGrossValue() + bi.getMarginValue() - bi.getNetValue());
         }
 
         setTotal(tot);
-        setDiscount(tot - net);
         setMarginTotal(margin);
+        setDiscount(tot + margin - net);
         setNetTotal(net);
     }
 

--- a/src/main/java/com/divudi/bean/inward/BillBhtController.java
+++ b/src/main/java/com/divudi/bean/inward/BillBhtController.java
@@ -924,6 +924,22 @@ public class BillBhtController implements Serializable {
 
             getInwardBean().setBillFeeMargin(billFee, billItem.getItem(), priceMatrix, patientEncounter);
 
+            if (billFee.getFee() != null && billFee.getFee().getFeeType() != FeeType.Staff
+                    && billFee.getFeeGrossValue() != null && billFee.getFeeGrossValue() > 0
+                    && patientEncounter != null) {
+                double discountPct = priceMatrixController.getInwardDiscountPercent(
+                        paymentMethod,
+                        patientEncounter.getPaymentScheme(),
+                        patientEncounter.getAdmissionType(),
+                        matrixDepartment,
+                        billItem.getItem());
+                if (discountPct > 0) {
+                    double feeDiscountAmt = billFee.getFeeGrossValue() * discountPct / 100.0;
+                    billFee.setFeeDiscount(feeDiscountAmt);
+                    billFee.setFeeValue(billFee.getFeeValue() - feeDiscountAmt);
+                }
+            }
+
             billFeeList.add(billFee);
         }
 
@@ -995,14 +1011,15 @@ public class BillBhtController implements Serializable {
                 tot += bf.getFeeGrossValue();
                 net += bf.getFeeValue();
                 bf.getBillItem().setNetValue(bf.getBillItem().getNetValue() + bf.getFeeValue());
-                //    bf.getBillItem().setNetValue(bf.getBillItem().getNetValue());
                 bf.getBillItem().setGrossValue(bf.getBillItem().getGrossValue() + bf.getFeeGrossValue());
                 margin += bf.getFeeMargin();
-                
             }
+
+            bi.setDiscount(bi.getGrossValue() - bi.getNetValue());
         }
 
         setTotal(tot);
+        setDiscount(tot - net);
         setMarginTotal(margin);
         setNetTotal(net);
     }

--- a/src/main/webapp/inward/inward_bill_service.xhtml
+++ b/src/main/webapp/inward/inward_bill_service.xhtml
@@ -553,14 +553,21 @@
                                                         </p:column>
 
                                                         <p:column width="8em" class="text-end">
-                                                            <f:facet name="header">Gross Value</f:facet>
+                                                            <f:facet name="header">Rate</f:facet>
                                                             <h:outputLabel value="#{bi.billItem.grossValue}">
                                                                 <f:convertNumber pattern="#,##0.00" />
                                                             </h:outputLabel>
                                                         </p:column>
 
                                                         <p:column width="8em" class="text-end">
-                                                            <f:facet name="header">Margin Value</f:facet>
+                                                            <f:facet name="header">Discount</f:facet>
+                                                            <h:outputLabel value="#{bi.billItem.discount}">
+                                                                <f:convertNumber pattern="#,##0.00" />
+                                                            </h:outputLabel>
+                                                        </p:column>
+
+                                                        <p:column width="8em" class="text-end">
+                                                            <f:facet name="header">Service Charge</f:facet>
                                                             <h:outputLabel value="#{bi.billItem.marginValue}">
                                                                 <f:convertNumber pattern="#,##0.00" />
                                                             </h:outputLabel>
@@ -681,14 +688,23 @@
                                         <p:panel header="Bill Details" id="details"  >
                                             <div class="card">
                                                 <div class="d-flex justify-content-between p-3 m-2" style="font-size: 18px; font-weight: 700;" >
-                                                    <h:outputLabel value="Bill Total" ></h:outputLabel>
+                                                    <h:outputLabel value="Gross Total" ></h:outputLabel>
                                                     <h:outputLabel value="#{billBhtController.total}" >
                                                         <f:convertNumber pattern="#,##0.00" />
                                                     </h:outputLabel>
                                                 </div>
                                             </div>
                                             <div class="card my-2">
-                                                <div class="d-flex justify-content-between p-3 m-2" style="font-size: 18px; font-weight: 700;" >                                                    <h:outputLabel value="Margin Value" ></h:outputLabel>
+                                                <div class="d-flex justify-content-between p-3 m-2" style="font-size: 18px; font-weight: 700;" >
+                                                    <h:outputLabel value="Discount" ></h:outputLabel>
+                                                    <h:outputLabel value="#{billBhtController.discount}" >
+                                                        <f:convertNumber pattern="#,##0.00" />
+                                                    </h:outputLabel>
+                                                </div>
+                                            </div>
+                                            <div class="card my-2">
+                                                <div class="d-flex justify-content-between p-3 m-2" style="font-size: 18px; font-weight: 700;" >
+                                                    <h:outputLabel value="Service Charge" ></h:outputLabel>
                                                     <h:outputLabel value="#{billBhtController.marginTotal}" >
                                                         <f:convertNumber pattern="#,##0.00" />
                                                     </h:outputLabel>
@@ -696,7 +712,7 @@
                                             </div>
                                             <div class="card">
                                                 <div class="d-flex justify-content-between p-3 m-2" style="font-size: 18px; font-weight: 700;" >
-                                                    <h:outputLabel value="Net Value" ></h:outputLabel>
+                                                    <h:outputLabel value="Net Total" ></h:outputLabel>
                                                     <h:outputLabel value="#{billBhtController.netTotal}" >
                                                         <f:convertNumber pattern="#,##0.00" />
                                                     </h:outputLabel>


### PR DESCRIPTION
## Summary

- Wires up the existing `InwardDiscountMatrix` to the inpatient service billing page (`inward_bill_service.xhtml`) — discount rules were configurable in admin but had never been applied at billing time
- Fixes a bug in the discount matrix lookup where `NULL` `paymentMethod` / `admissionType` rows (meaning "all BHT types / all admission types") were invisible to the JPQL query, causing all lookups to return 0
- Adds Discount column and correct totals labels to the billing UI

## Changes

### `BillBhtController.java`
- `billFeeFromBillItemWithMatrix()`: calls `getInwardDiscountPercent()` using the encounter's `paymentMethod`, `paymentScheme`, and `admissionType`; applies the resulting discount % to each `BillFee` (`feeDiscount` + `feeValue`), skipping `FeeType.Staff`
- `calTotals()`: computes `BillItem.discount` and the controller-level `discount` field so UI totals reflect actual discounts

### `PriceMatrixController.java`
- `fetchInwardDiscountMatrixPercent()`: treats `NULL` `paymentMethod` and `NULL` `admissionType` in the matrix as wildcards (`OR IS NULL`) so globally-applicable rows are found
- `getInwardDiscountPercent()`: adds a global wildcard fallback (null dept / null category / null item) after the department-level lookup so catch-all matrix rows are reachable

### `inward_bill_service.xhtml`
- Bill items table: added **Discount** column; renamed "Margin Value" → **Service Charge**; renamed "Gross Value" → **Rate**
- Bill details panel: renamed "Bill Total" → **Gross Total**; added **Discount** row; renamed "Margin Value" → **Service Charge**; renamed "Net Value" → **Net Total**

## Test plan

- [ ] Add an inpatient BHT whose payment scheme has a matching `InwardDiscountMatrix` entry (null dept/category/item wildcard row)
- [ ] Add a service to the bill — Discount column should show the correct amount, Net Value should be reduced accordingly
- [ ] Verify Gross Total, Discount, Service Charge, Net Total in the Bill Details panel are all correct
- [ ] Add a service for a BHT with no matching matrix entry — all discount fields should remain 0 (no regression)
- [ ] Verify post-settlement bill table shows correct Discount and Net Total columns

Closes #20326

🤖 Generated with [Claude Code](https://claude.com/claude-code)