### PR TITLE
refactor: apply consistent grid layout to staff paysheet component individual view

### DIFF
--- a/src/main/webapp/hr/hr_staff_paysheet_component_individual.xhtml
+++ b/src/main/webapp/hr/hr_staff_paysheet_component_individual.xhtml
@@ -5,283 +5,353 @@
                 xmlns:hr="http://xmlns.jcp.org/jsf/composite/autocomplete"
                 xmlns:h="http://xmlns.jcp.org/jsf/html"
                 xmlns:p="http://primefaces.org/ui"
-
                 xmlns:f="http://xmlns.jcp.org/jsf/core">
 
-
     <ui:define name="subContent">
+        <h:panelGroup>
+            <h:form>
 
-        <h:panelGroup >
-            <h:form  >
-                <div class="row">
-                    <div class="col-6">
-                        <p:panel >
-                            <f:facet name="header">
-                                <h:outputText value="Staff Details"/>
-                            </f:facet>
-                            <h:panelGrid columns="2" >
-                                <h:outputLabel value="Staff Name"/>
-                                <p:autoComplete class="w-100 mx-4" inputStyleClass="w-100" forceSelection="true" value="#{staffPaySheetComponentController.current.staff}"
-                                                completeMethod="#{staffController.completeStaffCode}" var="mys" itemLabel="#{mys.person.nameWithTitle}" itemValue="#{mys}"
-                                                >   
-                                    <f:ajax event="itemSelect" execute="@this" render="tb6 stfCode stfCode2"  />
-                                    <p:column headerText="Name">
-                                        #{mys.person.name}
-                                    </p:column>
-                                    <p:column headerText="Code">
-                                        #{mys.code}
-                                    </p:column>
-                                </p:autoComplete>
-                                <p:outputLabel value="Emp Code"></p:outputLabel>
-                                <p:outputLabel  class="w-100 mx-4" id="stfCode" value="#{staffPaySheetComponentController.current.staff.code}"></p:outputLabel>
-                                <p:outputLabel value="EPF Code"></p:outputLabel>
-                                <p:outputLabel  class="w-100 mx-4" id="stfCode2" value="#{staffPaySheetComponentController.current.staff.epfNo}"></p:outputLabel>
-                                <h:outputLabel value="Component Name"/>
-                                <p:selectOneMenu  class="w-100 mx-4" value="#{staffPaySheetComponentController.current.paysheetComponent}">                        
-                                    <f:selectItems value="#{staffPaySheetComponentController.compnent}"
-                                                   var="i"  itemLabel="#{i.name}" itemValue="#{i}"/>
-                                </p:selectOneMenu>
+                <p:panel header="Paysheet Component">
+                    <div style="display: grid; grid-template-columns: 1fr 1fr; gap: 1.25rem; align-items: start;">
 
-                                <h:outputLabel value="From"/>
-                                <p:calendar class="w-100 mx-4" inputStyleClass="w-100" navigator="true" value="#{staffPaySheetComponentController.current.fromDate}" pattern="#{sessionController.applicationPreference.shortDateFormat}">                            
-                                </p:calendar>
-                                <h:outputLabel value="To"/>
-                                <p:calendar class="w-100 mx-4" inputStyleClass="w-100" navigator="true" value="#{staffPaySheetComponentController.current.toDate}" pattern="#{sessionController.applicationPreference.shortDateFormat}">                            
-                                </p:calendar>                    
-                                <h:outputLabel value="Value"/>
-                                <p:inputText class="w-100 mx-4" autocomplete="off" value="#{staffPaySheetComponentController.current.staffPaySheetComponentValue}"/>
-                            </h:panelGrid>
-                            <div class="d-flex my-2">
+                        <!-- LEFT: Detail -->
+                        <p:panel header="Detail">
+                            <div style="display: flex; flex-direction: column; gap: 1rem;">
 
-                                <p:commandButton class="w-25 mx-2 ui-button-success" icon="fas fa-plus"  value="Add" action="#{staffPaySheetComponentController.save}" ajax="false" />
-                                <p:commandButton class="w-25 ui-button-warning" icon="fas fa-eraser"  value="Clear" action="#{staffPaySheetComponentController.makeItemNull}" ajax="false" />
+                                <div>
+                                    <h:outputLabel value="Staff Name" style="display: block; margin-bottom: 4px;" />
+                                    <p:autoComplete
+                                        inputStyleClass="w-100"
+                                        style="width: 100%;"
+                                        forceSelection="true"
+                                        value="#{staffPaySheetComponentController.current.staff}"
+                                        completeMethod="#{staffController.completeStaffCode}"
+                                        var="mys"
+                                        itemLabel="#{mys.person.nameWithTitle}"
+                                        itemValue="#{mys}">
+                                        <f:ajax event="itemSelect" execute="@this" render="tb6 stfCode stfCode2" />
+                                        <p:column headerText="Name">
+                                            <h:outputLabel value="#{mys.person.name}" />
+                                        </p:column>
+                                        <p:column headerText="Code">
+                                            <h:outputLabel value="#{mys.code}" />
+                                        </p:column>
+                                    </p:autoComplete>
+                                </div>
 
-                            </div>
-                        </p:panel>
-                    </div>
-                    <div class="col-6">
-                        <p:panel>
-                            <f:facet name="header" >   
-                                <h:outputLabel value="Paysheet Component individual" style="text-transform:capitalize;" />
+                                <div style="display: grid; grid-template-columns: 1fr 1fr; gap: 1rem;">
+                                    <div>
+                                        <h:outputLabel value="Emp Code" style="display: block; margin-bottom: 4px;" />
+                                        <p:outputLabel id="stfCode" value="#{staffPaySheetComponentController.current.staff.code}" />
+                                    </div>
+                                    <div>
+                                        <h:outputLabel value="EPF Code" style="display: block; margin-bottom: 4px;" />
+                                        <p:outputLabel id="stfCode2" value="#{staffPaySheetComponentController.current.staff.epfNo}" />
+                                    </div>
+                                </div>
 
-                            </f:facet>
-                            <h:panelGrid columns="2" >
-                                <h:outputLabel value="From : " />
-                                <p:calendar class="w-100 mx-4" inputStyleClass="w-100" navigator="true" value="#{staffPaySheetComponentController.fromDate}" pattern="#{sessionController.applicationPreference.longDateTimeFormat}"  />
-
-                                <h:outputLabel value="Paysheet Component"/>
-                                <p:selectOneMenu class="w-100 mx-4" value="#{staffPaySheetComponentController.paysheetComponent}">                        
-                                    <f:selectItems value="#{staffPaySheetComponentController.compnent}"
-                                                   var="i"  itemLabel="#{i.name}" itemValue="#{i}"/>
-                                </p:selectOneMenu>
-                                <h:outputLabel value="Employee : "/>
-                                <hr:completeStaff value="#{staffPaySheetComponentController.reportKeyWord.staff}"/>
-                                <h:outputLabel value="Department : "/>
-                                <hr:department value="#{staffPaySheetComponentController.reportKeyWord.department}"/>
-                                <h:outputLabel value="institution : "/>
-                                <hr:institution value="#{staffPaySheetComponentController.reportKeyWord.institution}"/>
-                                <h:outputLabel value="Staff Category : "/>
-                                <hr:completeStaffCategory value="#{staffPaySheetComponentController.reportKeyWord.staffCategory}"/>
-                                <h:outputLabel value="Designation : "/>
-                                <hr:completeDesignation value="#{staffPaySheetComponentController.reportKeyWord.designation}"/>
-                                <h:outputLabel value="Roster : "/>
-                                <hr:completeRoster value="#{staffPaySheetComponentController.reportKeyWord.roster}"/> 
-
-
-                            </h:panelGrid>
-                            <div class="d-flex my-2">
-
-                                <p:commandButton class="w-25 ui-button-warning" icon="fas fa-fill"  ajax="false" value="Fill" action="#{staffPaySheetComponentController.createTable()}" />
-                                <p:commandButton class="w-25 mx-1 ui-button-success" icon="fas fa-file-excel" ajax="false" value="Excel" >
-                                    <p:dataExporter type="xlsx" target="tb6" fileName="hr_staff_paysheet_component_individual"  />
-                                </p:commandButton>
-                                <p:commandButton class="w-25 ui-button-info" icon="fas fa-print" value="Print" ajax="false" action="#" >
-                                    <p:printer target="individualpanel" ></p:printer>
-                                </p:commandButton> 
-                            </div>
-                        </p:panel>
-                    </div>
-                </div>
-
-
-
-                <p:spacer height="30" />
-
-                <p:panel  id="individualpanel" styleClass="noBorder summeryBorder">
-                    <f:facet name="header">
-                        <h:outputText value="Basic List"></h:outputText>
-                    </f:facet>
-                    <p:dataTable id="tb6" value="#{staffPaySheetComponentController.items}" 
-                                 filteredValue="#{staffPaySheetComponentController.filteredStaff}"
-                                 var="i" editable="true" rowIndexVar="a" >
-
-                        <f:facet name="header">
-                            <h:outputLabel value="#{staffPaySheetComponentController.paysheetComponent.name}"/>
-                        </f:facet>
-
-                        <p:ajax event="rowEdit" listener="#{staffPaySheetComponentController.onEdit}" />  
-
-
-                        <p:column headerText="No">
-                            <f:facet name="header">
-                                <h:outputLabel value="No"/>
-                            </f:facet>
-                            <h:outputLabel value="#{a+1}" >
-                            </h:outputLabel>
-                        </p:column>
-
-                        <p:column headerText="Institution" sortBy="#{i.staff.workingDepartment.institution.name}"  >
-                            <f:facet name="header" >
-                                <h:outputLabel value="Institution"  />
-                            </f:facet>
-                            <h:outputLabel value="#{i.staff.workingDepartment.institution.name}" ></h:outputLabel>
-                        </p:column>
-                        <p:column headerText="Department" sortBy="#{i.staff.workingDepartment.name}" >
-                            <f:facet name="header" >
-                                <h:outputLabel value="Department"  />
-                            </f:facet>
-
-                            <h:outputLabel value="#{i.staff.workingDepartment.name}" ></h:outputLabel>
-                        </p:column>
-                        <p:column headerText="Roster"  >
-                            <f:facet name="header">
-                                <h:outputLabel value="Roster"  />
-                            </f:facet>
-                            <h:outputLabel value="#{i.staff.roster.name}" ></h:outputLabel>
-                        </p:column>
-                        <p:column headerText="EMP Code" sortBy="#{i.staff.codeInterger}" >
-                            <f:facet name="header">
-                                <h:outputLabel value="EMP Code"  />
-                            </f:facet>
-                            <h:outputLabel value="#{i.staff.code}" ></h:outputLabel>
-                        </p:column>
-                        <p:column headerText="From" >
-                            <f:facet name="header">
-                                <h:outputLabel value="From"  />
-                            </f:facet>
-
-                            <p:cellEditor>  
-                                <f:facet name="output">
-                                    <h:outputLabel value="#{i.fromDate}" >
-                                        <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateFormat}"/>
-                                    </h:outputLabel>
-                                </f:facet>
-                                <f:facet name="input">
-                                    <p:calendar navigator="true" autocomplete="off" value="#{i.fromDate}">
-
-                                    </p:calendar>
-                                </f:facet>
-                            </p:cellEditor>
-                        </p:column>
-
-                        <p:column headerText="To" >
-                            <f:facet name="header">
-                                <h:outputLabel value="To"  />
-                            </f:facet>
-                            <p:cellEditor>  
-                                <f:facet name="output">
-                                    <h:outputLabel value="#{i.toDate}">
-                                        <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateFormat}"/>
-                                    </h:outputLabel>
-                                </f:facet>
-                                <f:facet name="input">
-                                    <p:calendar navigator="true" autocomplete="off" value="#{i.toDate}">
-
-                                    </p:calendar>
-                                </f:facet>
-                            </p:cellEditor>
-                        </p:column>
-                        <p:column headerText="Grade" >
-                            <f:facet name="header">
-                                <h:outputLabel value="Grade"  />
-                            </f:facet>
-                            <h:outputLabel value="#{i.staff.grade.name}"/>                           
-                        </p:column>
-
-                        <p:column headerText="Category" >
-                            <f:facet name="header">
-                                <h:outputLabel value="Category"  />
-                            </f:facet>
-                            <h:outputLabel value="#{i.staff.staffCategory.name}"/>
-                        </p:column>
-
-                        <p:column headerText="Designtion" >
-                            <f:facet name="header">
-                                <h:outputLabel value="Designtion"  />
-                            </f:facet>
-                            <h:outputLabel value="#{i.staff.designation.name}"/>
-                        </p:column>
-                        <p:column headerText="Resign Date" >
-                            <f:facet name="header">
-                                <h:outputLabel value="Resign Date"  />
-                            </f:facet>
-                            <h:outputLabel value="#{i.staff.dateLeft}">
-                                <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateFormat}"/>
-                            </h:outputLabel>
-                        </p:column>
-                        <p:column headerText="Staff" >
-                            <f:facet name="header">
-                                <h:outputLabel value="Staff"  />
-                            </f:facet>
-                            <h:outputLabel value="#{i.staff.person.nameWithTitle}"/>
-                        </p:column>
-
-                        <p:column headerText="Component" rendered="false" >
-                            <f:facet name="header">
-                                <h:outputLabel value="Component"  />
-                            </f:facet>
-                            <p:cellEditor>  
-                                <f:facet name="output">
-                                    <h:outputLabel value="#{i.paysheetComponent.name}">
-                                        <f:convertNumber pattern="#,##0.00" />
-                                    </h:outputLabel>
-                                </f:facet>
-                                <f:facet name="input">
-                                    <p:selectOneMenu value="#{i.paysheetComponent}">                        
+                                <div>
+                                    <h:outputLabel value="Component Name" style="display: block; margin-bottom: 4px;" />
+                                    <p:selectOneMenu style="width: 100%;" value="#{staffPaySheetComponentController.current.paysheetComponent}">
                                         <f:selectItems value="#{staffPaySheetComponentController.compnent}"
-                                                       var="ii"  itemLabel="#{ii.name}" itemValue="#{ii}"/>
-                                    </p:selectOneMenu>                                  
-                                </f:facet>
-                            </p:cellEditor>
+                                                       var="i" itemLabel="#{i.name}" itemValue="#{i}"/>
+                                    </p:selectOneMenu>
+                                </div>
 
-                        </p:column>
+                                <div style="display: grid; grid-template-columns: 1fr 1fr; gap: 1rem;">
+                                    <div>
+                                        <h:outputLabel value="From" style="display: block; margin-bottom: 4px;" />
+                                        <p:calendar inputStyleClass="w-100" style="width: 100%;"
+                                                    navigator="true"
+                                                    value="#{staffPaySheetComponentController.current.fromDate}"
+                                                    pattern="#{sessionController.applicationPreference.shortDateFormat}" />
+                                    </div>
+                                    <div>
+                                        <h:outputLabel value="To" style="display: block; margin-bottom: 4px;" />
+                                        <p:calendar inputStyleClass="w-100" style="width: 100%;"
+                                                    navigator="true"
+                                                    value="#{staffPaySheetComponentController.current.toDate}"
+                                                    pattern="#{sessionController.applicationPreference.shortDateFormat}" />
+                                    </div>
+                                </div>
 
+                                <div>
+                                    <h:outputLabel value="Value" style="display: block; margin-bottom: 4px;" />
+                                    <p:inputText style="width: 100%;" autocomplete="off"
+                                                 value="#{staffPaySheetComponentController.current.staffPaySheetComponentValue}" />
+                                </div>
 
-                        <p:column headerText="Value" >
+                                <div style="display: flex; gap: 0.5rem; padding-top: 0.25rem;">
+                                    <p:commandButton
+                                        value="Add"
+                                        icon="fas fa-plus"
+                                        styleClass="ui-button-success"
+                                        style="flex: 1;"
+                                        action="#{staffPaySheetComponentController.save}"
+                                        ajax="false" />
+                                    <p:commandButton
+                                        value="Clear"
+                                        icon="fas fa-eraser"
+                                        styleClass="ui-button-warning"
+                                        style="flex: 1;"
+                                        action="#{staffPaySheetComponentController.makeItemNull}"
+                                        ajax="false" />
+                                </div>
+
+                            </div>
+                        </p:panel>
+
+                        <!-- RIGHT: Paysheet Component Individual -->
+                        <p:panel header="Paysheet Component Individual">
+                            <div style="display: flex; flex-direction: column; gap: 1rem;">
+
+                                <div>
+                                    <h:outputLabel value="From" style="display: block; margin-bottom: 4px;" />
+                                    <p:calendar inputStyleClass="w-100" style="width: 100%;"
+                                                value="#{staffPaySheetComponentController.fromDate}"
+                                                navigator="true"
+                                                pattern="#{sessionController.applicationPreference.longDateTimeFormat}" />
+                                </div>
+
+                                <div>
+                                    <h:outputLabel value="Paysheet Component" style="display: block; margin-bottom: 4px;" />
+                                    <p:selectOneMenu style="width: 100%;" value="#{staffPaySheetComponentController.paysheetComponent}">
+                                        <f:selectItems value="#{staffPaySheetComponentController.compnent}"
+                                                       var="i" itemLabel="#{i.name}" itemValue="#{i}"/>
+                                    </p:selectOneMenu>
+                                </div>
+
+                                <div style="display: grid; grid-template-columns: 1fr 1fr; gap: 1rem;">
+                                    <div>
+                                        <h:outputLabel value="Employee" style="display: block; margin-bottom: 4px;" />
+                                        <hr:completeStaff value="#{staffPaySheetComponentController.reportKeyWord.staff}" />
+                                    </div>
+                                    <div>
+                                        <h:outputLabel value="Department" style="display: block; margin-bottom: 4px;" />
+                                        <hr:department value="#{staffPaySheetComponentController.reportKeyWord.department}" />
+                                    </div>
+                                </div>
+
+                                <div style="display: grid; grid-template-columns: 1fr 1fr; gap: 1rem;">
+                                    <div>
+                                        <h:outputLabel value="Institution" style="display: block; margin-bottom: 4px;" />
+                                        <hr:institution value="#{staffPaySheetComponentController.reportKeyWord.institution}" />
+                                    </div>
+                                    <div>
+                                        <h:outputLabel value="Staff Category" style="display: block; margin-bottom: 4px;" />
+                                        <hr:completeStaffCategory value="#{staffPaySheetComponentController.reportKeyWord.staffCategory}" />
+                                    </div>
+                                </div>
+
+                                <div style="display: grid; grid-template-columns: 1fr 1fr; gap: 1rem;">
+                                    <div>
+                                        <h:outputLabel value="Designation" style="display: block; margin-bottom: 4px;" />
+                                        <hr:completeDesignation value="#{staffPaySheetComponentController.reportKeyWord.designation}" />
+                                    </div>
+                                    <div>
+                                        <h:outputLabel value="Roster" style="display: block; margin-bottom: 4px;" />
+                                        <hr:completeRoster value="#{staffPaySheetComponentController.reportKeyWord.roster}" />
+                                    </div>
+                                </div>
+
+                                <div style="display: flex; gap: 0.5rem; padding-top: 0.25rem;">
+                                    <p:commandButton
+                                        ajax="false"
+                                        value="Fill"
+                                        icon="fas fa-fill"
+                                        styleClass="ui-button-warning"
+                                        style="flex: 1;"
+                                        action="#{staffPaySheetComponentController.createTable()}" />
+                                    <p:commandButton
+                                        ajax="false"
+                                        value="Excel"
+                                        icon="fas fa-file-excel"
+                                        styleClass="ui-button-success"
+                                        style="flex: 1;">
+                                        <p:dataExporter type="xlsx" target="tb6" fileName="hr_staff_paysheet_component_individual" />
+                                    </p:commandButton>
+                                    <p:commandButton
+                                        value="Print"
+                                        icon="fas fa-print"
+                                        styleClass="ui-button-info"
+                                        style="flex: 1;"
+                                        ajax="false"
+                                        action="#">
+                                        <p:printer target="individualpanel" />
+                                    </p:commandButton>
+                                </div>
+
+                            </div>
+                        </p:panel>
+
+                    </div>
+                </p:panel>
+
+                <p:spacer height="20" />
+
+                <p:panel>
+                    <f:facet name="header">
+                        <div style="display: flex; justify-content: space-between; align-items: center;">
+                            <span>Basic List</span>
+                            <p:commandButton
+                                value="Process"
+                                action="#{staffPaySheetComponentController.makeItemNull}"
+                                ajax="false" />
+                        </div>
+                    </f:facet>
+
+                    <p:panel id="individualpanel" styleClass="noBorder summeryBorder">
+                        <p:dataTable
+                            id="tb6"
+                            value="#{staffPaySheetComponentController.items}"
+                            filteredValue="#{staffPaySheetComponentController.filteredStaff}"
+                            var="i"
+                            editable="true"
+                            rowIndexVar="a"
+                            scrollable="true"
+                            scrollWidth="100%"
+                            style="table-layout: fixed; width: 100%;">
+
                             <f:facet name="header">
-                                <h:outputLabel value="Value"  />
+                                <h:outputLabel value="#{staffPaySheetComponentController.paysheetComponent.name}" />
                             </f:facet>
-                            <p:cellEditor>  
-                                <f:facet name="output">
-                                    <h:outputLabel value="#{i.staffPaySheetComponentValue}">
-                                        <f:convertNumber pattern="#,##0.00" />
-                                    </h:outputLabel>
-                                </f:facet>
-                                <f:facet name="input">
-                                    <p:inputText autocomplete="off" value="#{i.staffPaySheetComponentValue}"/>
-                                </f:facet>
-                            </p:cellEditor>
 
-                        </p:column>
+                            <p:ajax event="rowEdit" listener="#{staffPaySheetComponentController.onEdit}" />
 
-                        <p:column style="width:6%"  exportable="false" styleClass="noPrintButton">  
-                            <p:rowEditor />  
-                        </p:column>  
+                            <!-- Row selector (print hidden) -->
+                            <p:column exportable="false" styleClass="noPrintButton" style="width: 2.5rem;" />
 
-                        <p:column style="width:6%" exportable="false" styleClass="noPrintButton">  
-                            <p:commandButton ajax="false" value="Remove" action="#{staffPaySheetComponentController.remove}" >
-                                <f:setPropertyActionListener target="#{staffPaySheetComponentController.removingEntry}" value="#{i}" />
-                            </p:commandButton>
-                        </p:column>  
+                            <!-- No -->
+                            <p:column headerText="#" style="width: 3rem; text-align: center;">
+                                <h:outputLabel value="#{a+1}" />
+                            </p:column>
 
+                            <!-- EMP Code -->
+                            <p:column headerText="EMP Code" sortBy="#{i.staff.codeInterger}" style="width: 6rem;">
+                                <h:outputLabel value="#{i.staff.code}" />
+                            </p:column>
 
-                    </p:dataTable>
+                            <!-- Staff -->
+                            <p:column headerText="Staff" style="width: 14rem;">
+                                <h:outputLabel value="#{i.staff.person.nameWithTitle}" />
+                            </p:column>
+
+                            <!-- Institution -->
+                            <p:column headerText="Institution" sortBy="#{i.staff.workingDepartment.institution.name}" style="width: 10rem;">
+                                <h:outputLabel value="#{i.staff.workingDepartment.institution.name}" />
+                            </p:column>
+
+                            <!-- Department -->
+                            <p:column headerText="Department" sortBy="#{i.staff.workingDepartment.name}" style="width: 10rem;">
+                                <h:outputLabel value="#{i.staff.workingDepartment.name}" />
+                            </p:column>
+
+                            <!-- Category -->
+                            <p:column headerText="Category" style="width: 8rem;">
+                                <h:outputLabel value="#{i.staff.staffCategory.name}" />
+                            </p:column>
+
+                            <!-- Designation -->
+                            <p:column headerText="Designation" style="width: 9rem;">
+                                <h:outputLabel value="#{i.staff.designation.name}" />
+                            </p:column>
+
+                            <!-- Roster -->
+                            <p:column headerText="Roster" style="width: 7rem;">
+                                <h:outputLabel value="#{i.staff.roster.name}" />
+                            </p:column>
+
+                            <!-- Grade -->
+                            <p:column headerText="Grade" style="width: 5rem;">
+                                <h:outputLabel value="#{i.staff.grade.name}" />
+                            </p:column>
+
+                            <!-- From (editable) -->
+                            <p:column headerText="From" style="width: 7rem;">
+                                <p:cellEditor>
+                                    <f:facet name="output">
+                                        <h:outputLabel value="#{i.fromDate}">
+                                            <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateFormat}" />
+                                        </h:outputLabel>
+                                    </f:facet>
+                                    <f:facet name="input">
+                                        <p:calendar navigator="true" autocomplete="off" value="#{i.fromDate}" />
+                                    </f:facet>
+                                </p:cellEditor>
+                            </p:column>
+
+                            <!-- To (editable) -->
+                            <p:column headerText="To" style="width: 7rem;">
+                                <p:cellEditor>
+                                    <f:facet name="output">
+                                        <h:outputLabel value="#{i.toDate}">
+                                            <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateFormat}" />
+                                        </h:outputLabel>
+                                    </f:facet>
+                                    <f:facet name="input">
+                                        <p:calendar navigator="true" autocomplete="off" value="#{i.toDate}" />
+                                    </f:facet>
+                                </p:cellEditor>
+                            </p:column>
+
+                            <!-- Resign Date -->
+                            <p:column headerText="Resign Date" style="width: 7rem;">
+                                <h:outputLabel value="#{i.staff.dateLeft}">
+                                    <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateFormat}" />
+                                </h:outputLabel>
+                            </p:column>
+
+                            <!-- Component (hidden from render) -->
+                            <p:column headerText="Component" rendered="false" style="width: 8rem;">
+                                <p:cellEditor>
+                                    <f:facet name="output">
+                                        <h:outputLabel value="#{i.paysheetComponent.name}">
+                                            <f:convertNumber pattern="#,##0.00" />
+                                        </h:outputLabel>
+                                    </f:facet>
+                                    <f:facet name="input">
+                                        <p:selectOneMenu value="#{i.paysheetComponent}">
+                                            <f:selectItems value="#{staffPaySheetComponentController.compnent}"
+                                                           var="ii" itemLabel="#{ii.name}" itemValue="#{ii}"/>
+                                        </p:selectOneMenu>
+                                    </f:facet>
+                                </p:cellEditor>
+                            </p:column>
+
+                            <!-- Value (editable) -->
+                            <p:column headerText="Value" style="width: 7rem; text-align: right;">
+                                <p:cellEditor>
+                                    <f:facet name="output">
+                                        <h:outputLabel value="#{i.staffPaySheetComponentValue}">
+                                            <f:convertNumber pattern="#,##0.00" />
+                                        </h:outputLabel>
+                                    </f:facet>
+                                    <f:facet name="input">
+                                        <p:inputText autocomplete="off" value="#{i.staffPaySheetComponentValue}" />
+                                    </f:facet>
+                                </p:cellEditor>
+                            </p:column>
+
+                            <!-- Row editor -->
+                            <p:column style="width: 4rem;" exportable="false" styleClass="noPrintButton">
+                                <p:rowEditor />
+                            </p:column>
+
+                            <!-- Actions -->
+                            <p:column style="width: 6rem;" exportable="false" styleClass="noPrintButton">
+                                <p:commandButton ajax="false" value="Remove" styleClass="ui-button-danger"
+                                                 style="padding: 0.25rem 0.4rem; font-size: 0.82rem;"
+                                                 action="#{staffPaySheetComponentController.remove}">
+                                    <f:setPropertyActionListener target="#{staffPaySheetComponentController.removingEntry}" value="#{i}" />
+                                </p:commandButton>
+                            </p:column>
+
+                        </p:dataTable>
+                    </p:panel>
                 </p:panel>
 
             </h:form>
-
         </h:panelGroup>
-
     </ui:define>
 
 </ui:composition>


### PR DESCRIPTION
Refactored the hr_staff_paysheet_component_individual.xhtml layout to match the
established UI pattern used in hr_staff_basic_individual.xhtml

Changes:
- Replaced h:panelGrid with CSS grid/flex layout for form panels
- Applied inline label styling (display: block, margin-bottom: 4px)
- Grouped related fields into sub-grids (From/To, Emp/EPF codes)
- Standardised button styles using styleClass with flex: 1
- Added scrollable, fixed-width columns to the data table

No functional changes — all bindings, fields, and logic are unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added dedicated "Remove" button for individual paysheet entries.
  * Introduced editable date fields for enhanced date management.

* **Improvements**
  * Reorganized paysheet interface layout for improved clarity with distinct detail sections.
  * Updated data table structure with refined column organization and visibility.
  * Enhanced staff and component input controls with improved styling and layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->