### PR TITLE
feat(pharmacy): enforce departmentType on adjustment bills

### DIFF
--- a/src/main/java/com/divudi/bean/pharmacy/PharmacyAdjustmentController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacyAdjustmentController.java
@@ -579,6 +579,20 @@ public class PharmacyAdjustmentController implements Serializable {
         return DepartmentType.Pharmacy;
     }
 
+    private boolean applyOrValidateDepartmentType(Item selectedItem) {
+        DepartmentType resolved = resolveDepartmentType(selectedItem);
+        DepartmentType existing = getDeptAdjustmentPreBill().getDepartmentType();
+        if (existing == null) {
+            getDeptAdjustmentPreBill().setDepartmentType(resolved);
+            return true;
+        }
+        if (existing != resolved) {
+            JsfUtil.addErrorMessage("All items in one adjustment bill must have the same Department Type.");
+            return false;
+        }
+        return true;
+    }
+
     private void saveDeptAdjustmentBill() {
         getDeptAdjustmentPreBill().setBillDate(Calendar.getInstance().getTime());
         getDeptAdjustmentPreBill().setBillTime(Calendar.getInstance().getTime());
@@ -595,7 +609,7 @@ public class PharmacyAdjustmentController implements Serializable {
         getDeptAdjustmentPreBill().setFromInstitution(getSessionController().getLoggedUser().getDepartment().getInstitution());
         getDeptAdjustmentPreBill().setComments(comment);
         if (stock != null && stock.getItemBatch() != null) {
-            getDeptAdjustmentPreBill().setDepartmentType(resolveDepartmentType(stock.getItemBatch().getItem()));
+            applyOrValidateDepartmentType(stock.getItemBatch().getItem());
         }
         if (getDeptAdjustmentPreBill().getId() == null) {
             getBillFacade().create(getDeptAdjustmentPreBill());
@@ -619,7 +633,7 @@ public class PharmacyAdjustmentController implements Serializable {
         getDeptAdjustmentPreBill().setFromInstitution(getSessionController().getLoggedUser().getDepartment().getInstitution());
         getDeptAdjustmentPreBill().setComments(comment);
         if (stock != null && stock.getItemBatch() != null) {
-            getDeptAdjustmentPreBill().setDepartmentType(resolveDepartmentType(stock.getItemBatch().getItem()));
+            applyOrValidateDepartmentType(stock.getItemBatch().getItem());
         }
 
         // Generate deptId and insId using configurable bill number generation strategy
@@ -698,7 +712,7 @@ public class PharmacyAdjustmentController implements Serializable {
         getDeptAdjustmentPreBill().setFromInstitution(getSessionController().getLoggedUser().getDepartment().getInstitution());
         getDeptAdjustmentPreBill().setComments(comment);
         if (stock != null && stock.getItemBatch() != null) {
-            getDeptAdjustmentPreBill().setDepartmentType(resolveDepartmentType(stock.getItemBatch().getItem()));
+            applyOrValidateDepartmentType(stock.getItemBatch().getItem());
         }
         if (getDeptAdjustmentPreBill().getId() == null) {
             getBillFacade().create(getDeptAdjustmentPreBill());
@@ -725,7 +739,7 @@ public class PharmacyAdjustmentController implements Serializable {
         getDeptAdjustmentPreBill().setFromInstitution(getSessionController().getLoggedUser().getDepartment().getInstitution());
         getDeptAdjustmentPreBill().setComments(comment);
         if (stock != null && stock.getItemBatch() != null) {
-            getDeptAdjustmentPreBill().setDepartmentType(resolveDepartmentType(stock.getItemBatch().getItem()));
+            applyOrValidateDepartmentType(stock.getItemBatch().getItem());
         }
         if (getDeptAdjustmentPreBill().getId() == null) {
             getBillFacade().create(getDeptAdjustmentPreBill());
@@ -752,11 +766,11 @@ public class PharmacyAdjustmentController implements Serializable {
         getDeptAdjustmentPreBill().setFromInstitution(getSessionController().getLoggedUser().getDepartment().getInstitution());
         getDeptAdjustmentPreBill().setComments(comment);
         if (stock != null && stock.getItemBatch() != null) {
-            getDeptAdjustmentPreBill().setDepartmentType(resolveDepartmentType(stock.getItemBatch().getItem()));
+            applyOrValidateDepartmentType(stock.getItemBatch().getItem());
         } else if (selectedStockDto != null && selectedStockDto.getItemBatchId() != null) {
             ItemBatch ib = itemBatchFacade.find(selectedStockDto.getItemBatchId());
             if (ib != null) {
-                getDeptAdjustmentPreBill().setDepartmentType(resolveDepartmentType(ib.getItem()));
+                applyOrValidateDepartmentType(ib.getItem());
             }
         }
 
@@ -791,9 +805,9 @@ public class PharmacyAdjustmentController implements Serializable {
         getDeptAdjustmentPreBill().setFromInstitution(sessionController.getLoggedUser().getDepartment().getInstitution());
         getDeptAdjustmentPreBill().setComments(comment);
         if (amp != null) {
-            getDeptAdjustmentPreBill().setDepartmentType(resolveDepartmentType(amp));
+            applyOrValidateDepartmentType(amp);
         } else if (stock != null && stock.getItemBatch() != null) {
-            getDeptAdjustmentPreBill().setDepartmentType(resolveDepartmentType(stock.getItemBatch().getItem()));
+            applyOrValidateDepartmentType(stock.getItemBatch().getItem());
         }
 
         if (getDeptAdjustmentPreBill().getBillFinanceDetails() == null) {
@@ -826,9 +840,9 @@ public class PharmacyAdjustmentController implements Serializable {
         getDeptAdjustmentPreBill().setFromInstitution(getSessionController().getLoggedUser().getDepartment().getInstitution());
         getDeptAdjustmentPreBill().setComments(comment);
         if (amp != null) {
-            getDeptAdjustmentPreBill().setDepartmentType(resolveDepartmentType(amp));
+            applyOrValidateDepartmentType(amp);
         } else if (stock != null && stock.getItemBatch() != null) {
-            getDeptAdjustmentPreBill().setDepartmentType(resolveDepartmentType(stock.getItemBatch().getItem()));
+            applyOrValidateDepartmentType(stock.getItemBatch().getItem());
         }
 
         if (getDeptAdjustmentPreBill().getBillFinanceDetails() == null) {
@@ -861,7 +875,7 @@ public class PharmacyAdjustmentController implements Serializable {
         getDeptAdjustmentPreBill().setFromInstitution(getSessionController().getLoggedUser().getDepartment().getInstitution());
         getDeptAdjustmentPreBill().setComments(comment);
         if (stock != null && stock.getItemBatch() != null) {
-            getDeptAdjustmentPreBill().setDepartmentType(resolveDepartmentType(stock.getItemBatch().getItem()));
+            applyOrValidateDepartmentType(stock.getItemBatch().getItem());
         }
         if (getDeptAdjustmentPreBill().getId() == null) {
             getBillFacade().create(getDeptAdjustmentPreBill());
@@ -889,7 +903,7 @@ public class PharmacyAdjustmentController implements Serializable {
         getDeptAdjustmentPreBill().setFromInstitution(getSessionController().getLoggedUser().getDepartment().getInstitution());
         getDeptAdjustmentPreBill().setComments(comment);
         if (stock != null && stock.getItemBatch() != null) {
-            getDeptAdjustmentPreBill().setDepartmentType(resolveDepartmentType(stock.getItemBatch().getItem()));
+            applyOrValidateDepartmentType(stock.getItemBatch().getItem());
         }
         if (getDeptAdjustmentPreBill().getId() == null) {
             getBillFacade().create(getDeptAdjustmentPreBill());
@@ -1917,11 +1931,9 @@ public class PharmacyAdjustmentController implements Serializable {
             return;
         }
         deptAdjustmentPreBill = new PreBill();
-        if (!stocks.isEmpty() && stocks.get(0).getItemBatch() != null) {
-            deptAdjustmentPreBill.setDepartmentType(resolveDepartmentType(stocks.get(0).getItemBatch().getItem()));
-        }
         for (Stock s : stocks) {
             if (s.getStock() != s.getCalculated()) {
+                stock = s;
                 saveDeptSingleStockAdjustmentBill();
                 PharmaceuticalBillItem ph = saveDeptAdjustmentBillItems(s);
                 getPharmacyBean().resetStock(ph, s, s.getCalculated(), getSessionController().getDepartment());

--- a/src/main/java/com/divudi/bean/pharmacy/PharmacyAdjustmentController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacyAdjustmentController.java
@@ -9,6 +9,7 @@ import com.divudi.bean.common.ConfigOptionApplicationController;
 import com.divudi.bean.common.SessionController;
 
 import com.divudi.core.data.BillClassType;
+import com.divudi.core.data.DepartmentType;
 import com.divudi.core.data.BillNumberSuffix;
 import com.divudi.core.data.BillType;
 import com.divudi.core.data.dataStructure.YearMonthDay;
@@ -571,6 +572,13 @@ public class PharmacyAdjustmentController implements Serializable {
         this.expiryDateAdjustmentBillItems = expiryDateAdjustmentBillItems;
     }
 
+    private DepartmentType resolveDepartmentType(Item selectedItem) {
+        if (selectedItem != null && selectedItem.getDepartmentType() != null) {
+            return selectedItem.getDepartmentType();
+        }
+        return DepartmentType.Pharmacy;
+    }
+
     private void saveDeptAdjustmentBill() {
         getDeptAdjustmentPreBill().setBillDate(Calendar.getInstance().getTime());
         getDeptAdjustmentPreBill().setBillTime(Calendar.getInstance().getTime());
@@ -586,6 +594,9 @@ public class PharmacyAdjustmentController implements Serializable {
         getDeptAdjustmentPreBill().setFromDepartment(getSessionController().getLoggedUser().getDepartment());
         getDeptAdjustmentPreBill().setFromInstitution(getSessionController().getLoggedUser().getDepartment().getInstitution());
         getDeptAdjustmentPreBill().setComments(comment);
+        if (stock != null && stock.getItemBatch() != null) {
+            getDeptAdjustmentPreBill().setDepartmentType(resolveDepartmentType(stock.getItemBatch().getItem()));
+        }
         if (getDeptAdjustmentPreBill().getId() == null) {
             getBillFacade().create(getDeptAdjustmentPreBill());
         } else {
@@ -607,6 +618,9 @@ public class PharmacyAdjustmentController implements Serializable {
         getDeptAdjustmentPreBill().setFromDepartment(getSessionController().getLoggedUser().getDepartment());
         getDeptAdjustmentPreBill().setFromInstitution(getSessionController().getLoggedUser().getDepartment().getInstitution());
         getDeptAdjustmentPreBill().setComments(comment);
+        if (stock != null && stock.getItemBatch() != null) {
+            getDeptAdjustmentPreBill().setDepartmentType(resolveDepartmentType(stock.getItemBatch().getItem()));
+        }
 
         // Generate deptId and insId using configurable bill number generation strategy
         Department dept = getSessionController().getDepartment();
@@ -683,6 +697,9 @@ public class PharmacyAdjustmentController implements Serializable {
         getDeptAdjustmentPreBill().setFromDepartment(getSessionController().getLoggedUser().getDepartment());
         getDeptAdjustmentPreBill().setFromInstitution(getSessionController().getLoggedUser().getDepartment().getInstitution());
         getDeptAdjustmentPreBill().setComments(comment);
+        if (stock != null && stock.getItemBatch() != null) {
+            getDeptAdjustmentPreBill().setDepartmentType(resolveDepartmentType(stock.getItemBatch().getItem()));
+        }
         if (getDeptAdjustmentPreBill().getId() == null) {
             getBillFacade().create(getDeptAdjustmentPreBill());
         } else {
@@ -707,6 +724,9 @@ public class PharmacyAdjustmentController implements Serializable {
         getDeptAdjustmentPreBill().setFromDepartment(getSessionController().getLoggedUser().getDepartment());
         getDeptAdjustmentPreBill().setFromInstitution(getSessionController().getLoggedUser().getDepartment().getInstitution());
         getDeptAdjustmentPreBill().setComments(comment);
+        if (stock != null && stock.getItemBatch() != null) {
+            getDeptAdjustmentPreBill().setDepartmentType(resolveDepartmentType(stock.getItemBatch().getItem()));
+        }
         if (getDeptAdjustmentPreBill().getId() == null) {
             getBillFacade().create(getDeptAdjustmentPreBill());
         } else {
@@ -731,6 +751,14 @@ public class PharmacyAdjustmentController implements Serializable {
         getDeptAdjustmentPreBill().setFromDepartment(getSessionController().getLoggedUser().getDepartment());
         getDeptAdjustmentPreBill().setFromInstitution(getSessionController().getLoggedUser().getDepartment().getInstitution());
         getDeptAdjustmentPreBill().setComments(comment);
+        if (stock != null && stock.getItemBatch() != null) {
+            getDeptAdjustmentPreBill().setDepartmentType(resolveDepartmentType(stock.getItemBatch().getItem()));
+        } else if (selectedStockDto != null && selectedStockDto.getItemBatchId() != null) {
+            ItemBatch ib = itemBatchFacade.find(selectedStockDto.getItemBatchId());
+            if (ib != null) {
+                getDeptAdjustmentPreBill().setDepartmentType(resolveDepartmentType(ib.getItem()));
+            }
+        }
 
         // Create BillFinanceDetails for the adjustment
         if (getDeptAdjustmentPreBill().getBillFinanceDetails() == null) {
@@ -762,6 +790,11 @@ public class PharmacyAdjustmentController implements Serializable {
         getDeptAdjustmentPreBill().setFromDepartment(sessionController.getLoggedUser().getDepartment());
         getDeptAdjustmentPreBill().setFromInstitution(sessionController.getLoggedUser().getDepartment().getInstitution());
         getDeptAdjustmentPreBill().setComments(comment);
+        if (amp != null) {
+            getDeptAdjustmentPreBill().setDepartmentType(resolveDepartmentType(amp));
+        } else if (stock != null && stock.getItemBatch() != null) {
+            getDeptAdjustmentPreBill().setDepartmentType(resolveDepartmentType(stock.getItemBatch().getItem()));
+        }
 
         if (getDeptAdjustmentPreBill().getBillFinanceDetails() == null) {
             BillFinanceDetails bfd = new BillFinanceDetails(getDeptAdjustmentPreBill());
@@ -792,6 +825,11 @@ public class PharmacyAdjustmentController implements Serializable {
         getDeptAdjustmentPreBill().setFromDepartment(getSessionController().getLoggedUser().getDepartment());
         getDeptAdjustmentPreBill().setFromInstitution(getSessionController().getLoggedUser().getDepartment().getInstitution());
         getDeptAdjustmentPreBill().setComments(comment);
+        if (amp != null) {
+            getDeptAdjustmentPreBill().setDepartmentType(resolveDepartmentType(amp));
+        } else if (stock != null && stock.getItemBatch() != null) {
+            getDeptAdjustmentPreBill().setDepartmentType(resolveDepartmentType(stock.getItemBatch().getItem()));
+        }
 
         if (getDeptAdjustmentPreBill().getBillFinanceDetails() == null) {
             BillFinanceDetails bfd = new BillFinanceDetails(getDeptAdjustmentPreBill());
@@ -822,6 +860,9 @@ public class PharmacyAdjustmentController implements Serializable {
         getDeptAdjustmentPreBill().setFromDepartment(getSessionController().getLoggedUser().getDepartment());
         getDeptAdjustmentPreBill().setFromInstitution(getSessionController().getLoggedUser().getDepartment().getInstitution());
         getDeptAdjustmentPreBill().setComments(comment);
+        if (stock != null && stock.getItemBatch() != null) {
+            getDeptAdjustmentPreBill().setDepartmentType(resolveDepartmentType(stock.getItemBatch().getItem()));
+        }
         if (getDeptAdjustmentPreBill().getId() == null) {
             getBillFacade().create(getDeptAdjustmentPreBill());
         } else {
@@ -847,6 +888,9 @@ public class PharmacyAdjustmentController implements Serializable {
         getDeptAdjustmentPreBill().setFromDepartment(getSessionController().getLoggedUser().getDepartment());
         getDeptAdjustmentPreBill().setFromInstitution(getSessionController().getLoggedUser().getDepartment().getInstitution());
         getDeptAdjustmentPreBill().setComments(comment);
+        if (stock != null && stock.getItemBatch() != null) {
+            getDeptAdjustmentPreBill().setDepartmentType(resolveDepartmentType(stock.getItemBatch().getItem()));
+        }
         if (getDeptAdjustmentPreBill().getId() == null) {
             getBillFacade().create(getDeptAdjustmentPreBill());
         } else {
@@ -1873,6 +1917,9 @@ public class PharmacyAdjustmentController implements Serializable {
             return;
         }
         deptAdjustmentPreBill = new PreBill();
+        if (!stocks.isEmpty() && stocks.get(0).getItemBatch() != null) {
+            deptAdjustmentPreBill.setDepartmentType(resolveDepartmentType(stocks.get(0).getItemBatch().getItem()));
+        }
         for (Stock s : stocks) {
             if (s.getStock() != s.getCalculated()) {
                 saveDeptSingleStockAdjustmentBill();
@@ -1900,6 +1947,7 @@ public class PharmacyAdjustmentController implements Serializable {
         for (Stock s : stocks) {
             if (s.getStock() != s.getCalculated()) {
                 deptAdjustmentPreBill = null;
+                stock = s;
                 saveDeptAdjustmentBill();
                 PharmaceuticalBillItem ph = saveDeptAdjustmentBillItems(s);
                 bills.add(getBillFacade().find(getDeptAdjustmentPreBill().getId()));

--- a/src/main/java/com/divudi/bean/pharmacy/PharmacyStockTakeController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacyStockTakeController.java
@@ -2411,7 +2411,7 @@ public class PharmacyStockTakeController implements Serializable {
 
         String jpql = "select new com.divudi.core.light.common.PharmacySnapshotBillLight("
                 + "b.id, b.deptId, b.createdAt, ins.name, dept.name, "
-                + "(select count(bi) from BillItem bi where bi.bill = b), b.netTotal, b.completed) "
+                + "(select count(bi) from BillItem bi where bi.bill = b), b.netTotal, b.completed, b.departmentType) "
                 + "from Bill b "
                 + "left join b.institution ins "
                 + "left join b.department dept "
@@ -2426,6 +2426,7 @@ public class PharmacyStockTakeController implements Serializable {
 
         if (results != null && !results.isEmpty()) {
             snapshotBillDisplay = results.get(0);
+            selectedDepartmentType = snapshotBillDisplay.getDepartmentType();
             System.out.println("[ViewSnapshot] Done. Navigating to print page. ms=" + (System.currentTimeMillis() - t0));
             return "/pharmacy/pharmacy_stock_take_print?faces-redirect=true&billId=" + billId;
         } else {
@@ -2450,7 +2451,7 @@ public class PharmacyStockTakeController implements Serializable {
         snapshotItems = null;
         String jpql = "select new com.divudi.core.light.common.PharmacySnapshotBillLight("
                 + "b.id, b.deptId, b.createdAt, ins.name, dept.name, "
-                + "(select count(bi) from BillItem bi where bi.bill = b), b.netTotal, b.completed) "
+                + "(select count(bi) from BillItem bi where bi.bill = b), b.netTotal, b.completed, b.departmentType) "
                 + "from Bill b "
                 + "left join b.institution ins "
                 + "left join b.department dept "
@@ -2461,6 +2462,7 @@ public class PharmacyStockTakeController implements Serializable {
             (List<PharmacySnapshotBillLight>) billFacade.findLightsByJpql(jpql, params);
         if (results != null && !results.isEmpty()) {
             snapshotBillDisplay = results.get(0);
+            selectedDepartmentType = snapshotBillDisplay.getDepartmentType();
         }
     }
 

--- a/src/main/java/com/divudi/bean/pharmacy/PharmacyStockTakeController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacyStockTakeController.java
@@ -235,7 +235,7 @@ public class PharmacyStockTakeController implements Serializable {
         Department dept = department;
 
         // Fetch stocks using DTO projection for performance (avoids N+1 queries)
-        String jpql = "select new com.divudi.core.data.dto.StockDTO("
+        String jpqlBase = "select new com.divudi.core.data.dto.StockDTO("
                 + "s.id, ib.id, i.id, "
                 + "c.name, i.name, ib.batchNo, "
                 + "ib.dateOfExpire, s.stock, ib.costRate, "
@@ -245,12 +245,21 @@ public class PharmacyStockTakeController implements Serializable {
                 + "join ib.item i "
                 + "left join i.category c "
                 + "left join i.dosageForm df "
-                + "where s.department=:d and s.stock>0 "
-                + "order by coalesce(c.name, '') asc, "
-                + "coalesce(i.name, '') asc, "
-                + "coalesce(ib.dateOfExpire, current_date) asc";
+                + "where s.department=:d and s.stock>0";
         HashMap<String, Object> params = new HashMap<>();
         params.put("d", dept);
+        if (selectedDepartmentType != null) {
+            if (selectedDepartmentType == com.divudi.core.data.DepartmentType.Pharmacy) {
+                jpqlBase += " and (i.departmentType = :dt or i.departmentType is null)";
+            } else {
+                jpqlBase += " and i.departmentType = :dt";
+            }
+            params.put("dt", selectedDepartmentType);
+        }
+        String jpql = jpqlBase
+                + " order by coalesce(c.name, '') asc, "
+                + "coalesce(i.name, '') asc, "
+                + "coalesce(ib.dateOfExpire, current_date) asc";
         @SuppressWarnings("unchecked")
         List<StockDTO> stockDTOs = (List<StockDTO>) (List<?>) stockFacade.findByJpql(jpql, params);
 
@@ -327,7 +336,7 @@ public class PharmacyStockTakeController implements Serializable {
         // Handle zero-stock batches if configured
         if (includeZeroStockBatches && zeroStockBatchLimit > 0) {
             // Fetch zero-stock batches using DTO projection, ordered by expiry date descending
-            String zeroStockJpql = "select new com.divudi.core.data.dto.StockDTO("
+            String zeroStockJpqlBase = "select new com.divudi.core.data.dto.StockDTO("
                     + "s.id, ib.id, i.id, "
                     + "c.name, i.name, ib.batchNo, "
                     + "ib.dateOfExpire, s.stock, ib.costRate, "
@@ -337,8 +346,16 @@ public class PharmacyStockTakeController implements Serializable {
                     + "join ib.item i "
                     + "left join i.category c "
                     + "left join i.dosageForm df "
-                    + "where s.department=:d and (s.stock is null or s.stock = 0) "
-                    + "order by coalesce(c.name, '') asc, "
+                    + "where s.department=:d and (s.stock is null or s.stock = 0)";
+            if (selectedDepartmentType != null) {
+                if (selectedDepartmentType == com.divudi.core.data.DepartmentType.Pharmacy) {
+                    zeroStockJpqlBase += " and (i.departmentType = :dt or i.departmentType is null)";
+                } else {
+                    zeroStockJpqlBase += " and i.departmentType = :dt";
+                }
+            }
+            String zeroStockJpql = zeroStockJpqlBase
+                    + " order by coalesce(c.name, '') asc, "
                     + "coalesce(i.name, '') asc, "
                     + "coalesce(ib.dateOfExpire, current_date) desc";
             @SuppressWarnings("unchecked")

--- a/src/main/java/com/divudi/bean/pharmacy/PharmacyStockTakeController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacyStockTakeController.java
@@ -232,6 +232,11 @@ public class PharmacyStockTakeController implements Serializable {
             return null;
         }
 
+        if (selectedDepartmentType == null) {
+            JsfUtil.addErrorMessage("Please select a department type");
+            return null;
+        }
+
         Department dept = department;
 
         // Fetch stocks using DTO projection for performance (avoids N+1 queries)
@@ -274,6 +279,7 @@ public class PharmacyStockTakeController implements Serializable {
         snapshotBill.setBillType(BillType.PharmacySnapshotBill);
         snapshotBill.setBillClassType(BillClassType.BilledBill);
         snapshotBill.setDepartment(dept);
+        snapshotBill.setDepartmentType(selectedDepartmentType);
 
         // Null check for institution
         if (dept.getInstitution() != null) {

--- a/src/main/java/com/divudi/core/light/common/PharmacySnapshotBillLight.java
+++ b/src/main/java/com/divudi/core/light/common/PharmacySnapshotBillLight.java
@@ -1,5 +1,6 @@
 package com.divudi.core.light.common;
 
+import com.divudi.core.data.DepartmentType;
 import java.io.Serializable;
 import java.util.Date;
 
@@ -18,6 +19,7 @@ public class PharmacySnapshotBillLight implements Serializable {
     private Long itemsCount;
     private Double netTotal;
     private Boolean completed;
+    private DepartmentType departmentType;
 
     public PharmacySnapshotBillLight(Long id,
                                      String deptId,
@@ -55,6 +57,19 @@ public class PharmacySnapshotBillLight implements Serializable {
         this.itemsCount = itemsCount;
         this.netTotal = netTotal;
         this.completed = completed;
+    }
+
+    public PharmacySnapshotBillLight(Long id,
+                                     String deptId,
+                                     Date createdAt,
+                                     String institutionName,
+                                     String departmentName,
+                                     Long itemsCount,
+                                     Double netTotal,
+                                     Boolean completed,
+                                     DepartmentType departmentType) {
+        this(id, deptId, createdAt, institutionName, departmentName, itemsCount, netTotal, completed);
+        this.departmentType = departmentType;
     }
 
     /**
@@ -150,6 +165,14 @@ public class PharmacySnapshotBillLight implements Serializable {
 
     public void setCompleted(Boolean completed) {
         this.completed = completed;
+    }
+
+    public DepartmentType getDepartmentType() {
+        return departmentType;
+    }
+
+    public void setDepartmentType(DepartmentType departmentType) {
+        this.departmentType = departmentType;
     }
 
     /**

--- a/src/main/webapp/pharmacy/pharmacy_stock_take.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_stock_take.xhtml
@@ -119,6 +119,27 @@
 
                         <p:divider />
 
+                        <!-- Department Type Filter Section -->
+                        <div class="mb-4">
+                            <h:outputText value="Department Type" styleClass="fw-bold d-block mb-3" />
+                            <div class="row g-3">
+                                <div class="col-md-4">
+                                    <p:outputLabel for="deptType" value="Department Type" styleClass="d-block mb-2"/>
+                                    <p:selectOneMenu id="deptType"
+                                                     styleClass="w-100"
+                                                     value="#{pharmacyStockTakeController.selectedDepartmentType}">
+                                        <f:selectItem itemLabel="All Types" itemValue="#{null}"/>
+                                        <f:selectItems value="#{pharmacyStockTakeController.availableDepartmentTypes}"
+                                                      var="dt"
+                                                      itemLabel="#{dt.name()}"
+                                                      itemValue="#{dt}"/>
+                                    </p:selectOneMenu>
+                                </div>
+                            </div>
+                        </div>
+
+                        <p:divider />
+
                         <!-- Stock Configuration Section -->
                         <div class="mb-4">
                             <h:outputText value="Stock Configuration" styleClass="fw-bold d-block mb-3" />

--- a/src/main/webapp/pharmacy/pharmacy_stock_take.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_stock_take.xhtml
@@ -127,8 +127,9 @@
                                     <p:outputLabel for="deptType" value="Department Type" styleClass="d-block mb-2"/>
                                     <p:selectOneMenu id="deptType"
                                                      styleClass="w-100"
-                                                     value="#{pharmacyStockTakeController.selectedDepartmentType}">
-                                        <f:selectItem itemLabel="All Types" itemValue="#{null}"/>
+                                                     value="#{pharmacyStockTakeController.selectedDepartmentType}"
+                                                     title="Select the department type to include in this stock count (required)">
+                                        <f:selectItem itemLabel="-- Select Department Type --" itemValue="#{null}"/>
                                         <f:selectItems value="#{pharmacyStockTakeController.availableDepartmentTypes}"
                                                       var="dt"
                                                       itemLabel="#{dt.name()}"

--- a/src/main/webapp/pharmacy/pharmacy_stock_take_print.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_stock_take_print.xhtml
@@ -110,6 +110,9 @@
                                                         <h:outputText value="Department:" style="font-weight:bold; color: #6c757d;"/>
                                                         <h:outputText value="#{pharmacyStockTakeController.snapshotBillDisplay.departmentName}"
                                                                       style="color: #495057;"/>
+                                                        <h:outputText value="Department Type:" style="font-weight:bold; color: #6c757d;"/>
+                                                        <h:outputText value="#{pharmacyStockTakeController.snapshotBillDisplay.departmentType}"
+                                                                      style="color: #495057;"/>
                                                         <h:outputText value="Bill No:" style="font-weight:bold; color: #6c757d;"/>
                                                         <h:outputText value="#{pharmacyStockTakeController.snapshotBillDisplay.deptId}"
                                                                       style="color: #495057; font-family: monospace;"/>
@@ -197,17 +200,10 @@
                                                             </p:autoComplete>
                                                         </div>
                                                         <div class="col-lg-4">
-                                                            <h:outputLabel for="departmentTypeFilter" value="Department Type (optional):" styleClass="form-label font-weight-bold"/>
-                                                            <p:selectOneMenu id="departmentTypeFilter"
-                                                                             value="#{pharmacyStockTakeController.selectedDepartmentType}"
-                                                                             styleClass="w-100">
-                                                                <f:selectItem itemLabel="-- All --" itemValue="#{null}" noSelectionOption="true"/>
-                                                                <f:selectItems value="#{pharmacyStockTakeController.availableDepartmentTypes}"
-                                                                               var="dt"
-                                                                               itemLabel="#{dt.label}"
-                                                                               itemValue="#{dt}"/>
-                                                                <p:ajax update="filteredDownloadButtons"/>
-                                                            </p:selectOneMenu>
+                                                            <h:outputLabel value="Department Type:" styleClass="form-label font-weight-bold"/>
+                                                            <h:outputText value="#{pharmacyStockTakeController.snapshotBillDisplay.departmentType}"
+                                                                          styleClass="form-control-plaintext"
+                                                                          style="color: #495057; font-weight: bold;"/>
                                                         </div>
                                                     </div>
                                                     <div class="row mt-2">

--- a/src/main/webapp/pharmacy/pharmacy_stock_take_settle.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_stock_take_settle.xhtml
@@ -26,6 +26,9 @@
                                             <h:outputText value="Department:" style="font-weight:bold; color: #6c757d;"/>
                                             <h:outputText value="#{pharmacyStockTakeController.snapshotBill.department.name}"
                                                           style="color: #495057;"/>
+                                            <h:outputText value="Department Type:" style="font-weight:bold; color: #6c757d;"/>
+                                            <h:outputText value="#{pharmacyStockTakeController.snapshotBill.departmentType}"
+                                                          style="color: #495057;"/>
                                             <h:outputText value="Cost Value:" style="font-weight:bold; color: #155724;"/>
                                             <h:outputText value="#{pharmacyStockTakeController.inMemoryCostTotal}"
                                                           style="font-weight: bold; color: #155724; font-size: 1.1rem;">


### PR DESCRIPTION
## Summary
- Adds `resolveDepartmentType(Item)` helper to `PharmacyAdjustmentController` that returns the item's `DepartmentType`, defaulting to `DepartmentType.Pharmacy` when null (matching the pattern in `PharmacyIssueController`)
- Sets `bill.departmentType` in all 8 `save*Bill()` private methods covering every adjustment type: department stock, single stock, staff stock, purchase rate, cost rate, retail sale rate, wholesale rate, and expiry date adjustments
- In bulk-all loops (`adjustDepartmentStockAll`, `adjustDepartmentStockAllZero`), `departmentType` is resolved from the first/current stock item before bill creation

## Test plan
- [ ] Perform a stock adjustment and verify `departmentType` is saved on the bill in the database
- [ ] Perform a purchase rate, cost rate, retail rate, and wholesale rate adjustment — confirm `departmentType` is non-null
- [ ] Perform an expiry date adjustment and staff stock adjustment — confirm `departmentType` is non-null
- [ ] Confirm existing adjustment functionality is unaffected

Closes #20340

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Stock take page now includes department type filtering controls, enabling users to view and manage pharmacy inventory filtered by specific departments or across all departments in the system.
* **Improvements**
  * Pharmacy adjustment operations now properly track and assign department types throughout all operations, ensuring accurate categorization and reporting across all adjustment bill types and batches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->