### PR TITLE
refactor: apply consistent grid layout to staffPaySheetComponentAll view

### DIFF
--- a/src/main/webapp/hr/hr_staff_paysheet_component_all.xhtml
+++ b/src/main/webapp/hr/hr_staff_paysheet_component_all.xhtml
@@ -188,7 +188,7 @@
 
                             <div>
                                 <h:outputLabel value="Institution" style="display: block; margin-bottom: 4px;" />
-                                <hr:department value="#{staffPaySheetComponentAllController.reportKeyWord.institution}" />
+                                <hr:institution value="#{staffPaySheetComponentAllController.reportKeyWord.institution}" />
                             </div>
 
                             <div>

--- a/src/main/webapp/hr/hr_staff_paysheet_component_all.xhtml
+++ b/src/main/webapp/hr/hr_staff_paysheet_component_all.xhtml
@@ -1,275 +1,353 @@
 <?xml version='1.0' encoding='UTF-8' ?>
 <!DOCTYPE composition PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <ui:composition template="/hr/hr_admin.xhtml"
-                xmlns:ui="http://xmlns.jcp.org/jsf/facelets"                
+                xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
                 xmlns:h="http://xmlns.jcp.org/jsf/html"
                 xmlns:p="http://primefaces.org/ui"
                 xmlns:f="http://xmlns.jcp.org/jsf/core"
-
                 xmlns:hr="http://xmlns.jcp.org/jsf/composite/autocomplete">
 
-
     <ui:define name="subContent">
+        <h:panelGroup style="display: block; overflow-x: hidden; width: 100%;">
+            <h:form>
+                <style>
+                    .ui-autocomplete,
+                    .ui-autocomplete-input,
+                    .ui-selectonemenu,
+                    .ui-inputfield {
+                        width: 100% !important;
+                        box-sizing: border-box !important;
+                    }
+                </style>
 
-        <h:panelGroup >
-            <h:form  >
-                <div class="row">
-                    <div class="col-6">
-                        <p:panel header="Detail" >
+                <div style="display: grid; grid-template-columns: 1fr 1fr; gap: 1.25rem; align-items: start; min-width: 0;">
 
-                            <h:panelGrid columns="2"  >
-                                <h:outputLabel value="Component"/>
-                                <p:selectOneMenu class="w-100 mx-4" id="comp" value="#{staffPaySheetComponentAllController.paysheetComponent}">                        
-                                    <f:selectItem itemLabel="Select Paysheet Component"/>
-                                    <f:selectItems value="#{staffPaySheetComponentAllController.compnent}"
-                                                   var="i"  itemLabel="#{i.name}" itemValue="#{i}" />
-                                    <f:ajax event="change" execute="@this" 
-                                            render="lst" listener="#{staffPaySheetComponentAllController.makeItemNull}" />
-                                </p:selectOneMenu>
-                                <h:outputLabel value="From"/>                            
-                                <p:calendar class="w-100 mx-4" inputStyleClass="w-100" value="#{staffPaySheetComponentAllController.fromDate}" pattern="#{sessionController.applicationPreference.shortDateFormat}">
-                                    <f:ajax execute="@this" render="#{p:resolveFirstComponentWithId('frm',view).clientId}" event="dateSelect"/>
-                                </p:calendar>
-                                <h:outputLabel value="To"/>
-                                <p:calendar class="w-100 mx-4" inputStyleClass="w-100" value="#{staffPaySheetComponentAllController.toDate}" pattern="#{sessionController.applicationPreference.shortDateFormat}"/>
+                    <!-- LEFT: Detail + Paysheet Details -->
+                    <div style="display: flex; flex-direction: column; gap: 1.25rem; min-width: 0;">
 
-                                <h:outputLabel value="Value"/>
-                                <p:inputText class="w-100 mx-4"  id="val" autocomplete="off"  value="#{staffPaySheetComponentAllController.staffPaySheetComponentValue}"/>
+                        <p:panel header="Detail">
+                            <div style="display: flex; flex-direction: column; gap: 1rem;">
 
-                            </h:panelGrid>  
-                            <div class="d-flex my-2">
-                                <p:commandButton class="w-25 ui-button-success " icon="fas fa-plus" value="Add" action="#{staffPaySheetComponentAllController.save}" >
+                                <div style="min-width: 0;">
+                                    <h:outputLabel value="Component" style="display: block; margin-bottom: 4px;" />
+                                    <p:selectOneMenu style="width: 100%;" id="comp"
+                                                     value="#{staffPaySheetComponentAllController.paysheetComponent}">
+                                        <f:selectItem itemLabel="Select Paysheet Component"/>
+                                        <f:selectItems value="#{staffPaySheetComponentAllController.compnent}"
+                                                       var="i" itemLabel="#{i.name}" itemValue="#{i}" />
+                                        <f:ajax event="change" execute="@this"
+                                                render="lst" listener="#{staffPaySheetComponentAllController.makeItemNull}" />
+                                    </p:selectOneMenu>
+                                </div>
 
-                                </p:commandButton>
-                                <p:commandButton class="w-25 mx-1 ui-button-warning " icon="fas fa-eraser" value="Clear" action="#{staffPaySheetComponentAllController.makeNull}" ajax="false"  />
+                                <div style="display: grid; grid-template-columns: 1fr 1fr; gap: 1rem; min-width: 0;">
+                                    <div style="min-width: 0;">
+                                        <h:outputLabel value="From" style="display: block; margin-bottom: 4px;" />
+                                        <p:calendar inputStyleClass="w-100" style="width: 100%;"
+                                                    value="#{staffPaySheetComponentAllController.fromDate}"
+                                                    pattern="#{sessionController.applicationPreference.shortDateFormat}">
+                                            <f:ajax execute="@this" render="#{p:resolveFirstComponentWithId('frm',view).clientId}" event="dateSelect"/>
+                                        </p:calendar>
+                                    </div>
+                                    <div style="min-width: 0;">
+                                        <h:outputLabel value="To" style="display: block; margin-bottom: 4px;" />
+                                        <p:calendar inputStyleClass="w-100" style="width: 100%;"
+                                                    value="#{staffPaySheetComponentAllController.toDate}"
+                                                    pattern="#{sessionController.applicationPreference.shortDateFormat}" />
+                                    </div>
+                                </div>
+
+                                <div style="min-width: 0;">
+                                    <h:outputLabel value="Value" style="display: block; margin-bottom: 4px;" />
+                                    <p:inputText style="width: 100%;" id="val" autocomplete="off"
+                                                 value="#{staffPaySheetComponentAllController.staffPaySheetComponentValue}" />
+                                </div>
+
+                                <div style="display: flex; gap: 0.5rem; padding-top: 0.25rem;">
+                                    <p:commandButton
+                                        value="Add"
+                                        icon="fas fa-plus"
+                                        styleClass="ui-button-success"
+                                        style="flex: 1;"
+                                        action="#{staffPaySheetComponentAllController.save}" />
+                                    <p:commandButton
+                                        value="Clear"
+                                        icon="fas fa-eraser"
+                                        styleClass="ui-button-warning"
+                                        style="flex: 1;"
+                                        action="#{staffPaySheetComponentAllController.makeNull}"
+                                        ajax="false" />
+                                </div>
 
                             </div>
                         </p:panel>
-                        <p:panel id="lst" class="my-1">
-                            <f:facet name="header">  
-                                <h:outputText value="Paysheet Details" class="my-1" />
-                                <h:outputLabel value="#{staffPaySheetComponentAllController.paysheetComponent.name}" style="text-transform:capitalize;" />
+
+                        <p:panel id="lst">
+                            <f:facet name="header">
+                                <div style="display: flex; justify-content: space-between; align-items: center;">
+                                    <span>Paysheet Details</span>
+                                    <h:outputLabel value="#{staffPaySheetComponentAllController.paysheetComponent.name}"
+                                                   style="text-transform: capitalize;" />
+                                </div>
                             </f:facet>
-                            <h:panelGrid columns="2" >
-                                <h:outputLabel value="From : " />
-                                <p:calendar class="w-100 mx-4" inputStyleClass="w-100" id="frm" value="#{staffPaySheetComponentAllController.fromDate}"
-                                            pattern="#{sessionController.applicationPreference.longDateTimeFormat}"  />                       
-                                <h:outputLabel value="Paysheet Component"/>
-                                <p:selectOneMenu class="w-100 mx-4" value="#{staffPaySheetComponentAllController.paysheetComponent}">                        
-                                    <f:selectItem itemLabel="Select Paysheet Component"/>
-                                    <f:selectItems value="#{staffPaySheetComponentAllController.compnent}"
-                                                   var="i"  itemLabel="#{i.name}" itemValue="#{i}" />
-                                </p:selectOneMenu>
-                                <h:outputLabel value="Employee : "/>
-                                <hr:completeStaff value="#{staffPaySheetComponentAllController.reportKeyWord.staff}"/>
-                                <h:outputLabel value="Department : "/>
-                                <hr:department value="#{staffPaySheetComponentAllController.reportKeyWord.department}"/>
-                                <h:outputLabel value="Institution : "/>
-                                <hr:institution value="#{staffPaySheetComponentAllController.reportKeyWord.institution}"/>
-                                <h:outputLabel value="Staff Category : "/>
-                                <hr:completeStaffCategory value="#{staffPaySheetComponentAllController.reportKeyWord.staffCategory}"/>
-                                <h:outputLabel value="Designation : "/>
-                                <hr:completeDesignation value="#{staffPaySheetComponentAllController.reportKeyWord.designation}"/>
-                                <h:outputLabel value="Roster : "/>
-                                <hr:completeRoster value="#{staffPaySheetComponentAllController.reportKeyWord.roster}"/> 
-                            </h:panelGrid>
 
-                            <div class="d-flex my-1">
-                                <p:commandButton class="w-25 ui-button-warning" icon="fas fa-fill" ajax="false" value="Fill" action="#{staffPaySheetComponentAllController.createStaffPaysheetComponent}" />
-                                <p:commandButton  class="w-25 mx-1 ui-button-success" icon="fas fa-file-excel" ajax="false" value="Excel" >
-                                    <p:dataExporter type="xlsx" target="tb1" fileName="hr_staff_paysheet_component_all"  />
-                                </p:commandButton>
-                                <p:commandButton class="w-25 ui-button-info" icon="fas fa-print" value="Print" ajax="false" action="#" >
-                                    <p:printer target="gpBillPreview" ></p:printer>
-                                </p:commandButton>
+                            <div style="display: flex; flex-direction: column; gap: 1rem;">
+
+                                <div style="min-width: 0;">
+                                    <h:outputLabel value="From" style="display: block; margin-bottom: 4px;" />
+                                    <p:calendar inputStyleClass="w-100" style="width: 100%;" id="frm"
+                                                value="#{staffPaySheetComponentAllController.fromDate}"
+                                                pattern="#{sessionController.applicationPreference.longDateTimeFormat}" />
+                                </div>
+
+                                <div style="min-width: 0;">
+                                    <h:outputLabel value="Paysheet Component" style="display: block; margin-bottom: 4px;" />
+                                    <p:selectOneMenu style="width: 100%;"
+                                                     value="#{staffPaySheetComponentAllController.paysheetComponent}">
+                                        <f:selectItem itemLabel="Select Paysheet Component"/>
+                                        <f:selectItems value="#{staffPaySheetComponentAllController.compnent}"
+                                                       var="i" itemLabel="#{i.name}" itemValue="#{i}" />
+                                    </p:selectOneMenu>
+                                </div>
+
+                                <div>
+                                    <h:outputLabel value="Employee" style="display: block; margin-bottom: 4px;" />
+                                    <hr:completeStaff value="#{staffPaySheetComponentAllController.reportKeyWord.staff}" />
+                                </div>
+
+                                <div>
+                                    <h:outputLabel value="Department" style="display: block; margin-bottom: 4px;" />
+                                    <hr:department value="#{staffPaySheetComponentAllController.reportKeyWord.department}" />
+                                </div>
+
+                                <div>
+                                    <h:outputLabel value="Institution" style="display: block; margin-bottom: 4px;" />
+                                    <hr:institution value="#{staffPaySheetComponentAllController.reportKeyWord.institution}" />
+                                </div>
+
+                                <div>
+                                    <h:outputLabel value="Staff Category" style="display: block; margin-bottom: 4px;" />
+                                    <hr:completeStaffCategory value="#{staffPaySheetComponentAllController.reportKeyWord.staffCategory}" />
+                                </div>
+
+                                <div>
+                                    <h:outputLabel value="Designation" style="display: block; margin-bottom: 4px;" />
+                                    <hr:completeDesignation value="#{staffPaySheetComponentAllController.reportKeyWord.designation}" />
+                                </div>
+
+                                <div>
+                                    <h:outputLabel value="Roster" style="display: block; margin-bottom: 4px;" />
+                                    <hr:completeRoster value="#{staffPaySheetComponentAllController.reportKeyWord.roster}" />
+                                </div>
+
+                                <div style="display: flex; gap: 0.5rem; padding-top: 0.25rem;">
+                                    <p:commandButton
+                                        ajax="false"
+                                        value="Fill"
+                                        icon="fas fa-fill"
+                                        styleClass="ui-button-warning"
+                                        style="flex: 1;"
+                                        action="#{staffPaySheetComponentAllController.createStaffPaysheetComponent}" />
+                                    <p:commandButton
+                                        ajax="false"
+                                        value="Excel"
+                                        icon="fas fa-file-excel"
+                                        styleClass="ui-button-success"
+                                        style="flex: 1;">
+                                        <p:dataExporter type="xlsx" target="tb1" fileName="hr_staff_paysheet_component_all" />
+                                    </p:commandButton>
+                                    <p:commandButton
+                                        value="Print"
+                                        icon="fas fa-print"
+                                        styleClass="ui-button-info"
+                                        style="flex: 1;"
+                                        ajax="false"
+                                        action="#">
+                                        <p:printer target="gpBillPreview" />
+                                    </p:commandButton>
+                                </div>
+
+                            </div>
+                        </p:panel>
+
+                    </div>
+
+                    <!-- RIGHT: Staff List -->
+                    <p:panel id="staff" header="Staff List" style="min-width: 0;">
+                        <div style="display: flex; flex-direction: column; gap: 1rem;">
+
+                            <div>
+                                <h:outputLabel value="Employee" style="display: block; margin-bottom: 4px;" />
+                                <hr:completeStaff value="#{staffPaySheetComponentAllController.reportKeyWord.staff}" />
                             </div>
 
-                            <h:panelGrid columns="3" class="my-2">
+                            <div>
+                                <h:outputLabel value="Department" style="display: block; margin-bottom: 4px;" />
+                                <hr:department value="#{staffPaySheetComponentAllController.reportKeyWord.department}" />
+                            </div>
 
-                            </h:panelGrid>
-                        </p:panel>
-                    </div>
-                    <div class="col-6">
-                        <p:panel id="staff" header="Staff List">
-                            <h:panelGrid columns="2">
-                                <h:outputLabel value="Employee : "/>
-                                <hr:completeStaff value="#{staffPaySheetComponentAllController.reportKeyWord.staff}"/>
-                                <h:outputLabel value="Department : "/>
-                                <hr:department value="#{staffPaySheetComponentAllController.reportKeyWord.department}"/>
-                                <h:outputLabel value="Institution : "/>
-                                <hr:department value="#{staffPaySheetComponentAllController.reportKeyWord.institution}"/>
-                                <h:outputLabel value="Staff Category : "/>
-                                <hr:completeStaffCategory value="#{staffPaySheetComponentAllController.reportKeyWord.staffCategory}"/>
-                                <h:outputLabel value="Designation : "/>
-                                <hr:completeDesignation value="#{staffPaySheetComponentAllController.reportKeyWord.designation}"/>
-                                <h:outputLabel value="Roster : "/>
-                                <hr:completeRoster value="#{staffPaySheetComponentAllController.reportKeyWord.roster}"/>
-                            </h:panelGrid>
-                            <p:commandButton ajax="false" 
-                                             value="Fill Staff"
-                                             class="ui-button-warning w-25 my-2"
-                                             icon="fas fa-fill"
-                                             action="#{staffController.createStaffWithCode()}"
-                                             />
-                            <p:dataTable  value="#{staffController.staffWithCode}" 
-                                          var="s" scrollable="true"
-                                          filteredValue="#{staffController.filteredStaff}" 
-                                          scrollHeight="300"                               
-                                          rowKey="#{s.id}" 
-                                          selectionMode="multiple"
-                                          selection="#{staffController.selectedList}"
-                                          rowIndexVar="i">
+                            <div>
+                                <h:outputLabel value="Institution" style="display: block; margin-bottom: 4px;" />
+                                <hr:department value="#{staffPaySheetComponentAllController.reportKeyWord.institution}" />
+                            </div>
 
-                                <p:column   >                            
+                            <div>
+                                <h:outputLabel value="Staff Category" style="display: block; margin-bottom: 4px;" />
+                                <hr:completeStaffCategory value="#{staffPaySheetComponentAllController.reportKeyWord.staffCategory}" />
+                            </div>
+
+                            <div>
+                                <h:outputLabel value="Designation" style="display: block; margin-bottom: 4px;" />
+                                <hr:completeDesignation value="#{staffPaySheetComponentAllController.reportKeyWord.designation}" />
+                            </div>
+
+                            <div>
+                                <h:outputLabel value="Roster" style="display: block; margin-bottom: 4px;" />
+                                <hr:completeRoster value="#{staffPaySheetComponentAllController.reportKeyWord.roster}" />
+                            </div>
+
+                            <div>
+                                <p:commandButton
+                                    ajax="false"
+                                    value="Fill Staff"
+                                    icon="fas fa-fill"
+                                    styleClass="ui-button-warning"
+                                    action="#{staffController.createStaffWithCode()}" />
+                            </div>
+
+                            <p:dataTable
+                                value="#{staffController.staffWithCode}"
+                                var="s"
+                                scrollable="true"
+                                filteredValue="#{staffController.filteredStaff}"
+                                scrollHeight="300"
+                                rowKey="#{s.id}"
+                                selectionMode="multiple"
+                                selection="#{staffController.selectedList}"
+                                rowIndexVar="i"
+                                scrollWidth="100%"
+                                style="table-layout: fixed; width: 100%;">
+
+                                <p:column style="width: 2.5rem;" />
+                                <p:column headerText="#" style="width: 3rem; text-align: center;">
+                                    <h:outputLabel value="#{i+1}" />
+                                </p:column>
+                                <p:column headerText="Code" filterBy="#{s.code}" filterMatchMode="contains" style="width: 6rem;">
+                                    <h:outputLabel value="#{s.code}" />
+                                </p:column>
+                                <p:column headerText="Name" filterBy="#{s.person.nameWithTitle}" filterMatchMode="contains">
+                                    <h:outputLabel value="#{s.person.nameWithTitle}" />
                                 </p:column>
 
-                                <p:column >
-                                    #{i+1}
-                                </p:column>     
-                                <p:column headerText="Code" filterBy="#{s.code}"  filterMatchMode="contains">
-                                    <h:outputLabel value="#{s.code}"/>
-                                </p:column>
-                                <p:column headerText="Name" filterBy="#{s.person.nameWithTitle}"  filterMatchMode="contains">
-                                    <h:outputLabel value="#{s.person.nameWithTitle}"/>
-                                </p:column>
-                            </p:dataTable> 
-                        </p:panel>
-                    </div>
+                            </p:dataTable>
+
+                        </div>
+                    </p:panel>
+
                 </div>
 
+                <p:spacer height="20" />
 
                 <p:panel id="gpBillPreview">
                     <f:facet name="header">
-                        <h:outputLabel style="text-align: center" value="Staff Paysheet Component"  />
-                        <p:commandButton class="ui-button-danger " icon="fas fa-trash" ajax="false" value="Remove Selected" action="#{staffPaySheetComponentAllController.removeAll}" style="float: right;" />
+                        <div style="display: flex; justify-content: space-between; align-items: center;">
+                            <span>Staff Paysheet Component</span>
+                            <p:commandButton
+                                value="Remove Selected"
+                                icon="fas fa-trash"
+                                styleClass="ui-button-danger"
+                                ajax="false"
+                                action="#{staffPaySheetComponentAllController.removeAll}" />
+                        </div>
                     </f:facet>
-                    <p:dataTable  value="#{staffPaySheetComponentAllController.items}" id="tb1"
-                                  var="i" scrollHeight="350"  editable="true"
-                                  rowStyleClass="#{i.exist eq true ? 'exist':null}"
-                                  scrollable="true"  selection="#{staffPaySheetComponentAllController.selectedStaffComponent}" 
-                                  rowKey="#{i.id}" selectionMode="multiple" >
 
-                        <p:ajax event="rowEdit" listener="#{staffPaySheetComponentAllController.onEdit}" />  
+                    <p:dataTable
+                        id="tb1"
+                        value="#{staffPaySheetComponentAllController.items}"
+                        var="i"
+                        scrollHeight="350"
+                        editable="true"
+                        rowStyleClass="#{i.exist eq true ? 'exist':null}"
+                        scrollable="true"
+                        scrollWidth="100%"
+                        style="table-layout: fixed; width: 100%;"
+                        selection="#{staffPaySheetComponentAllController.selectedStaffComponent}"
+                        rowKey="#{i.id}"
+                        selectionMode="multiple">
 
-                        <p:column  >                            
+                        <p:ajax event="rowEdit" listener="#{staffPaySheetComponentAllController.onEdit}" />
+
+                        <p:column style="width: 2.5rem;" />
+                        <p:column headerText="Staff Code" style="width: 6rem;">
+                            <h:outputLabel value="#{i.staff.code}" />
                         </p:column>
-
-                        <p:column headerText="From" >
-                            <f:facet name="header">
-                                <h:outputLabel value="From"  />
-                            </f:facet>
-                            <h:outputLabel value="#{i.fromDate}" >
-                                <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateFormat}"/>
+                        <p:column headerText="Staff" style="width: 14rem;">
+                            <h:outputLabel value="#{i.staff.person.nameWithTitle}" />
+                        </p:column>
+                        <p:column headerText="Institution" style="width: 10rem;">
+                            <h:outputLabel value="#{i.staff.workingDepartment.institution.name}" />
+                        </p:column>
+                        <p:column headerText="Department" style="width: 10rem;">
+                            <h:outputLabel value="#{i.staff.workingDepartment.name}" />
+                        </p:column>
+                        <p:column headerText="Category" style="width: 8rem;">
+                            <h:outputLabel value="#{i.staff.staffCategory.name}" />
+                        </p:column>
+                        <p:column headerText="Designation" style="width: 9rem;">
+                            <h:outputLabel value="#{i.staff.designation.name}" />
+                        </p:column>
+                        <p:column headerText="Roster" style="width: 7rem;">
+                            <h:outputLabel value="#{i.staff.roster}" />
+                        </p:column>
+                        <p:column headerText="Grade" style="width: 5rem;">
+                            <h:outputLabel value="#{i.staff.grade}" />
+                        </p:column>
+                        <p:column headerText="From" style="width: 7rem;">
+                            <h:outputLabel value="#{i.fromDate}">
+                                <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateFormat}" />
                             </h:outputLabel>
                         </p:column>
-                        <p:column headerText="To" >
-                            <f:facet name="header">
-                                <h:outputLabel value="To"  />
-                            </f:facet>
-                            <p:cellEditor>  
+                        <p:column headerText="To" style="width: 7rem;">
+                            <p:cellEditor>
                                 <f:facet name="output">
                                     <h:outputLabel value="#{i.toDate}">
-                                        <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateFormat}"/>
+                                        <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateFormat}" />
                                     </h:outputLabel>
                                 </f:facet>
                                 <f:facet name="input">
-                                    <p:calendar value="#{i.toDate}"  pattern="#{sessionController.applicationPreference.longDateFormat}" />
+                                    <p:calendar value="#{i.toDate}"
+                                                pattern="#{sessionController.applicationPreference.longDateFormat}" />
                                 </f:facet>
                             </p:cellEditor>
-
                         </p:column>
-
-                        <p:column headerText="Grade" >
-                            <f:facet name="header">
-                                <h:outputLabel value="Grade"  />
-                            </f:facet>
-                            <h:outputLabel value="#{i.staff.grade}"/>                           
-                        </p:column>
-
-                        <p:column headerText="Category" >
-                            <f:facet name="header">
-                                <h:outputLabel value="Category"  />
-                            </f:facet>
-                            <h:outputLabel value="#{i.staff.staffCategory.name}"/>
-                        </p:column>
-
-                        <p:column headerText="Designtion" >
-                            <f:facet name="header">
-                                <h:outputLabel value="Designtion"  />
-                            </f:facet>
-                            <h:outputLabel value="#{i.staff.designation.name}"/>
-                        </p:column>
-
-                        <p:column headerText="Staff" >
-                            <f:facet name="header">
-                                <h:outputLabel value="Staff"  />
-                            </f:facet>
-                            <h:outputLabel value="#{i.staff.person.nameWithTitle}"/>
-                        </p:column>
-                        <p:column headerText="Staff Code" >
-                            <f:facet name="header">
-                                <h:outputLabel value="Staff Code"  />
-                            </f:facet>
-                            <h:outputLabel value="#{i.staff.code}"/>
-                        </p:column>
-                        <p:column headerText="Institution" >
-                            <f:facet name="header">
-                                <h:outputLabel value="Institution"  />
-                            </f:facet>
-                            <h:outputLabel value="#{i.staff.workingDepartment.institution.name}"/>
-                        </p:column>
-                        <p:column headerText="Department" >
-                            <f:facet name="header">
-                                <h:outputLabel value="Department"  />
-                            </f:facet>
-                            <h:outputLabel value="#{i.staff.workingDepartment.name}"/>
-                        </p:column>
-                        <p:column headerText="Roster" >
-                            <f:facet name="header">
-                                <h:outputLabel value="Roster"  />
-                            </f:facet>
-                            <h:outputLabel value="#{i.staff.roster}"/>
-                        </p:column>
-                        <p:column headerText="Value" >
-                            <f:facet name="header">
-                                <h:outputLabel value="Value"  />
-                            </f:facet>
-                            <p:cellEditor>  
+                        <p:column headerText="Value" style="width: 7rem; text-align: right;">
+                            <p:cellEditor>
                                 <f:facet name="output">
                                     <h:outputLabel value="#{i.staffPaySheetComponentValue}">
                                         <f:convertNumber pattern="#,##0.00" />
                                     </h:outputLabel>
                                 </f:facet>
                                 <f:facet name="input">
-                                    <p:inputText autocomplete="off" value="#{i.staffPaySheetComponentValue}"/>
+                                    <p:inputText autocomplete="off" value="#{i.staffPaySheetComponentValue}" />
                                 </f:facet>
                             </p:cellEditor>
-
                         </p:column>
-                        <!--                            <p:column headerText="Creator" >
-                                                        <f:facet name="header">
-                                                            <h:outputLabel value="Creator"  />
-                                                        </f:facet>
-                                                        <h:outputLabel value="#{i.creater.webUserPerson.name}"/>
-                                                    </p:column>-->
-
-                        <p:column style="width:6%" exportable="false" >  
-                            <p:rowEditor />  
-                        </p:column>  
-
-                        <p:column style="width:6%" exportable="false" >  
-                            <p:commandButton ajax="false" value="Remove" action="#{staffPaySheetComponentAllController.remove}" >
+                        <p:column style="width: 4rem;" exportable="false">
+                            <p:rowEditor />
+                        </p:column>
+                        <p:column style="width: 6rem;" exportable="false">
+                            <p:commandButton ajax="false" value="Remove" styleClass="ui-button-danger"
+                                             style="padding: 0.25rem 0.4rem; font-size: 0.82rem;"
+                                             action="#{staffPaySheetComponentAllController.remove}">
                                 <f:setPropertyActionListener target="#{staffPaySheetComponentAllController.current}" value="#{i}" />
                             </p:commandButton>
-                        </p:column>  
-
+                        </p:column>
 
                     </p:dataTable>
                 </p:panel>
+
             </h:form>
-
         </h:panelGroup>
-
     </ui:define>
 
 </ui:composition>

--- a/src/main/webapp/resources/autocomplete/department.xhtml
+++ b/src/main/webapp/resources/autocomplete/department.xhtml
@@ -17,7 +17,7 @@
                         itemValue="#{dept}" forceSelection="true" 
                         value="#{cc.attrs.value}" 
                          id="department"
-                         class="w-100 mx-4" inputStyleClass="w-100">
+                         class="w-100 mx-2" inputStyleClass="w-100">
             <p:column headerText="Department">
                 <h:outputLabel value="#{dept.name}"/>
             </p:column>


### PR DESCRIPTION
Refactored the staffPaySheetComponentAll.xhtml layout to match the
established UI pattern used across other HR module views.

Changes:
- Replaced h:panelGrid with CSS grid/flex layout for form panels
- Applied inline label styling (display: block, margin-bottom: 4px)
- Stacked hr: composite fields vertically to prevent overflow issues
- Standardised button styles using styleClass with flex: 1
- Moved Remove Selected button into the panel header flex row
- Added scrollable, fixed-width columns to the data table
- Added overflow-x: hidden on outer wrapper to prevent page scroll

No functional changes — all bindings, fields, and logic are unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Style**
  * Redesigned HR staff paysheet page layout with improved two-column structure for better organization
  * Updated detail and paysheet panels with refreshed styling and button arrangements
  * Enhanced staff list section with improved filtering interface
  * Refined staff paysheet component preview table with updated column display, formatting, and alignment
  * Adjusted margin styling on department autocomplete component

<!-- end of auto-generated comment: release notes by coderabbit.ai -->