### PR TITLE
refarefactor: apply consistent grid layout to staff loan and installment view

### DIFF
--- a/src/main/webapp/hr/hr_staff_loan_installment.xhtml
+++ b/src/main/webapp/hr/hr_staff_loan_installment.xhtml
@@ -5,340 +5,405 @@
                 xmlns:h="http://xmlns.jcp.org/jsf/html"
                 xmlns:p="http://primefaces.org/ui"
                 xmlns:f="http://xmlns.jcp.org/jsf/core"
-
                 xmlns:hr="http://xmlns.jcp.org/jsf/composite/autocomplete">
 
-
     <ui:define name="subContent">
+        <h:panelGroup style="display: block; overflow-x: hidden; width: 100%;">
+            <h:form>
 
-        <h:panelGroup >
-            <h:form  >  
+                <div style="display: grid; grid-template-columns: 1fr 1fr; gap: 1.25rem; align-items: start; min-width: 0;">
 
-                <div class="row">
-                    <div class="col-6">
-                        <p:panel>
+                    <!-- LEFT: Loan And Advances -->
+                    <p:panel header="Loan And Advances" style="min-width: 0;">
+                        <div style="display: flex; flex-direction: column; gap: 1rem;">
 
-                            <f:facet name="header">
-                                <h:outputLabel value="Loan And Advances"/>
-                            </f:facet>
-                            <h:panelGrid columns="2" class="w-100">
-                                <h:outputLabel value="Component "/>
-                                <p:selectOneMenu class="w-100 mx-2" value="#{staffLoanController.current.paysheetComponent}">
+                            <div style="min-width: 0;">
+                                <h:outputLabel value="Component" style="display: block; margin-bottom: 4px;" />
+                                <p:selectOneMenu style="width: 100%;" value="#{staffLoanController.current.paysheetComponent}">
                                     <f:selectItem itemLabel="Select Component"/>
                                     <f:selectItems value="#{staffLoanController.compnent}"
-                                                   var="i"  itemLabel="#{i.name}" itemValue="#{i}"/>
+                                                   var="i" itemLabel="#{i.name}" itemValue="#{i}"/>
                                 </p:selectOneMenu>
-
-                                <h:outputLabel value="From"/>
-                                <p:calendar class="w-100 mx-2" inputStyleClass="w-100" value="#{staffLoanController.current.fromDate}"  navigator="true" pattern="#{sessionController.applicationPreference.shortDateFormat}">                            
-                                </p:calendar>
-
-                                <h:outputLabel value="To"/>
-                                <p:calendar class="w-100 mx-2" inputStyleClass="w-100"  value="#{staffLoanController.current.toDate}" navigator="true" pattern="#{sessionController.applicationPreference.shortDateFormat}">                            
-                                </p:calendar>
-
-                                <h:outputLabel value="Staff "/>
-                                <hr:completeStaff value="#{staffLoanController.current.staff}"/>
-                                <h:outputLabel value="Loan No"/>
-                                <p:inputText class="w-100 mx-2" autocomplete="off"  value="#{staffLoanController.current.loanNo}"/>
-                                <h:outputLabel value="Account No"/>
-                                <p:inputText class="w-100 mx-2" autocomplete="off"  value="#{staffLoanController.current.accountNo}"/>
-                                <p:outputLabel value="Bank Branch"/>                                           
-                                <hr:completeBank_Branch value="#{staffLoanController.current.bankBranch}"/>  
-                                <h:outputLabel value="Starting Balance"/>
-                                <p:inputText class="w-100 mx-2"  autocomplete="off"  value="#{staffLoanController.current.startingBalance}"/>
-                                <h:outputLabel value="Full Amount"/>
-                                <p:inputText class="w-100 mx-2" autocomplete="off"  value="#{staffLoanController.current.loanFullAmount}"/>  
-                                <h:outputLabel value="Shedule For Paid"/>
-                                <p:selectBooleanCheckbox class="w-100 mx-2" value="#{staffLoanController.current.sheduleForPaid}" 
-                                                         />
-                                <h:outputLabel value="Monthly Installment"/>                        
-                                <p:inputText class="w-100 mx-2"  autocomplete="off"  value="#{staffLoanController.current.staffPaySheetComponentValue}"/>                    
-                                <h:outputLabel value="Comments"/>
-                                <p:inputText class="w-100 mx-2" autocomplete="off"  value="#{staffLoanController.current.comment}"/>
-                                <h:outputLabel value="Completed"/>
-                                <p:selectBooleanCheckbox class="mx-2" value="#{staffLoanController.current.completed}" 
-                                                         >
-                                    <f:ajax event="change" render="calComplete" execute="@this" />
-                                </p:selectBooleanCheckbox>
-                                <h:outputLabel value="Complete Date"/>
-                                <p:calendar class="w-100 mx-2" inputStyleClass="w-100" id="calComplete" value="#{staffLoanController.current.completedAt}"  navigator="true" pattern="#{sessionController.applicationPreference.shortDateFormat}"  />
-
-                            </h:panelGrid>
-                            <div class="d-flex mt-2">
-                                <p:commandButton class="w-25 ui-button-warning" icon="fas fa-save" value="Save" action="#{staffLoanController.save}" ajax="false" />
-                                <p:commandButton class="mx-1 w-25 ui-button-Warning" icon="fas fa-eraser" value="Clear" action="#{staffLoanController.makeNull}" ajax="false" />
-                                <p:commandButton class="mx-1 ui-button-Danger" icon="fas fa-trash" value="Remove" action="#{staffLoanController.remove}" ajax="false" />
                             </div>
-                        </p:panel>
-                    </div>
-                    <div class="col-6">
-                        <p:panel>
-                            <f:facet name="header">
-                                <h:outputLabel value="Loan And Advances Search"/>
-                            </f:facet>
-                            <h:panelGrid columns="2" >
-                                <h:outputLabel value="From  " />
-                                <p:calendar class="w-100 mx-2" 
-                                            inputStyleClass="w-100" 
-                                            navigator="true" 
+
+                            <div style="display: grid; grid-template-columns: 1fr 1fr; gap: 1rem; min-width: 0;">
+                                <div style="min-width: 0;">
+                                    <h:outputLabel value="From" style="display: block; margin-bottom: 4px;" />
+                                    <p:calendar inputStyleClass="w-100" style="width: 100%;"
+                                                navigator="true"
+                                                value="#{staffLoanController.current.fromDate}"
+                                                pattern="#{sessionController.applicationPreference.shortDateFormat}" />
+                                </div>
+                                <div style="min-width: 0;">
+                                    <h:outputLabel value="To" style="display: block; margin-bottom: 4px;" />
+                                    <p:calendar inputStyleClass="w-100" style="width: 100%;"
+                                                navigator="true"
+                                                value="#{staffLoanController.current.toDate}"
+                                                pattern="#{sessionController.applicationPreference.shortDateFormat}" />
+                                </div>
+                            </div>
+
+                            <div>
+                                <h:outputLabel value="Staff" style="display: block; margin-bottom: 4px;" />
+                                <hr:completeStaff value="#{staffLoanController.current.staff}" />
+                            </div>
+
+                            <div style="display: grid; grid-template-columns: 1fr 1fr; gap: 1rem; min-width: 0;">
+                                <div style="min-width: 0;">
+                                    <h:outputLabel value="Loan No" style="display: block; margin-bottom: 4px;" />
+                                    <p:inputText style="width: 100%;" autocomplete="off"
+                                                 value="#{staffLoanController.current.loanNo}" />
+                                </div>
+                                <div style="min-width: 0;">
+                                    <h:outputLabel value="Account No" style="display: block; margin-bottom: 4px;" />
+                                    <p:inputText style="width: 100%;" autocomplete="off"
+                                                 value="#{staffLoanController.current.accountNo}" />
+                                </div>
+                            </div>
+
+                            <div>
+                                <h:outputLabel value="Bank Branch" style="display: block; margin-bottom: 4px;" />
+                                <hr:completeBank_Branch value="#{staffLoanController.current.bankBranch}" />
+                            </div>
+
+                            <div style="display: grid; grid-template-columns: 1fr 1fr; gap: 1rem; min-width: 0;">
+                                <div style="min-width: 0;">
+                                    <h:outputLabel value="Starting Balance" style="display: block; margin-bottom: 4px;" />
+                                    <p:inputText style="width: 100%;" autocomplete="off"
+                                                 value="#{staffLoanController.current.startingBalance}" />
+                                </div>
+                                <div style="min-width: 0;">
+                                    <h:outputLabel value="Full Amount" style="display: block; margin-bottom: 4px;" />
+                                    <p:inputText style="width: 100%;" autocomplete="off"
+                                                 value="#{staffLoanController.current.loanFullAmount}" />
+                                </div>
+                            </div>
+
+                            <div style="display: grid; grid-template-columns: 1fr 1fr; gap: 1rem; min-width: 0;">
+                                <div style="min-width: 0;">
+                                    <h:outputLabel value="Monthly Installment" style="display: block; margin-bottom: 4px;" />
+                                    <p:inputText style="width: 100%;" autocomplete="off"
+                                                 value="#{staffLoanController.current.staffPaySheetComponentValue}" />
+                                </div>
+                                <div style="min-width: 0;">
+                                    <h:outputLabel value="Comments" style="display: block; margin-bottom: 4px;" />
+                                    <p:inputText style="width: 100%;" autocomplete="off"
+                                                 value="#{staffLoanController.current.comment}" />
+                                </div>
+                            </div>
+
+                            <div style="display: grid; grid-template-columns: 1fr 1fr; gap: 1rem; min-width: 0;">
+                                <div style="min-width: 0;">
+                                    <h:outputLabel value="Schedule For Paid" style="display: block; margin-bottom: 4px;" />
+                                    <p:selectBooleanCheckbox value="#{staffLoanController.current.sheduleForPaid}" />
+                                </div>
+                                <div style="min-width: 0;">
+                                    <h:outputLabel value="Completed" style="display: block; margin-bottom: 4px;" />
+                                    <p:selectBooleanCheckbox value="#{staffLoanController.current.completed}">
+                                        <f:ajax event="change" render="calComplete" execute="@this" />
+                                    </p:selectBooleanCheckbox>
+                                </div>
+                            </div>
+
+                            <div style="min-width: 0;">
+                                <h:outputLabel value="Complete Date" style="display: block; margin-bottom: 4px;" />
+                                <p:calendar inputStyleClass="w-100" style="width: 100%;" id="calComplete"
+                                            navigator="true"
+                                            value="#{staffLoanController.current.completedAt}"
+                                            pattern="#{sessionController.applicationPreference.shortDateFormat}" />
+                            </div>
+
+                            <div style="display: flex; gap: 0.5rem; padding-top: 0.25rem;">
+                                <p:commandButton
+                                    value="Save"
+                                    icon="fas fa-save"
+                                    styleClass="ui-button-warning"
+                                    style="flex: 1;"
+                                    action="#{staffLoanController.save}"
+                                    ajax="false" />
+                                <p:commandButton
+                                    value="Clear"
+                                    icon="fas fa-eraser"
+                                    styleClass="ui-button-secondary"
+                                    style="flex: 1;"
+                                    action="#{staffLoanController.makeNull}"
+                                    ajax="false" />
+                                <p:commandButton
+                                    value="Remove"
+                                    icon="fas fa-trash"
+                                    styleClass="ui-button-danger"
+                                    style="flex: 1;"
+                                    action="#{staffLoanController.remove}"
+                                    ajax="false" />
+                            </div>
+
+                        </div>
+                    </p:panel>
+
+                    <!-- RIGHT: Loan And Advances Search -->
+                    <p:panel header="Loan And Advances Search" style="min-width: 0;">
+                        <div style="display: flex; flex-direction: column; gap: 1rem;">
+
+                            <div style="min-width: 0;">
+                                <h:outputLabel value="From" style="display: block; margin-bottom: 4px;" />
+                                <p:calendar inputStyleClass="w-100" style="width: 100%;"
+                                            navigator="true"
                                             value="#{staffLoanController.fromDate}"
-                                            pattern="#{sessionController.applicationPreference.longDateTimeFormat}"  />                       
-                                <h:outputLabel value="Component "/>
-                                <p:selectOneMenu class="w-100 mx-2" value="#{staffLoanController.paysheetComponent}">
+                                            pattern="#{sessionController.applicationPreference.longDateTimeFormat}" />
+                            </div>
+
+                            <div style="min-width: 0;">
+                                <h:outputLabel value="Component" style="display: block; margin-bottom: 4px;" />
+                                <p:selectOneMenu style="width: 100%;" value="#{staffLoanController.paysheetComponent}">
                                     <f:selectItem itemLabel="Select Component"/>
                                     <f:selectItems value="#{staffLoanController.compnent}"
-                                                   var="i"  itemLabel="#{i.name}" itemValue="#{i}"/>
+                                                   var="i" itemLabel="#{i.name}" itemValue="#{i}"/>
                                 </p:selectOneMenu>
+                            </div>
 
-                                <h:outputLabel value="Employee  "/>
-                                <hr:completeStaff value="#{staffLoanController.reportKeyWord.staff}"/>
-                                <h:outputLabel  value="Department  "/>
-                                <hr:department value="#{staffLoanController.reportKeyWord.department}"/>
-                                <h:outputLabel value="Institution  "/>
-                                <hr:institution value="#{staffLoanController.reportKeyWord.institution}"/>
-                                <h:outputLabel value="Staff Category  "/>
-                                <hr:completeStaffCategory value="#{staffLoanController.reportKeyWord.staffCategory}"/>
-                                <h:outputLabel value="Designation  "/>
-                                <hr:completeDesignation value="#{staffLoanController.reportKeyWord.designation}"/>
-                                <h:outputLabel value="Roster  "/>
-                                <hr:completeRoster value="#{staffLoanController.reportKeyWord.roster}"/>                
+                            <div>
+                                <h:outputLabel value="Employee" style="display: block; margin-bottom: 4px;" />
+                                <hr:completeStaff value="#{staffLoanController.reportKeyWord.staff}" />
+                            </div>
 
-                            </h:panelGrid>
+                            <div>
+                                <h:outputLabel value="Department" style="display: block; margin-bottom: 4px;" />
+                                <hr:department value="#{staffLoanController.reportKeyWord.department}" />
+                            </div>
 
-                            <div class="d-flex mt-2">
-                                <!--                        <h:outputLabel value="With Account No"/>
-                                                        <p:selectBooleanCheckbox value="#{staffLoanController.showAccountNo}" />-->
-                                <p:commandButton class="w-25 ui-button-Warning" icon="fas fa-fill" ajax="false" value="Fill" action="#{staffLoanController.createLones()}" />
-                                <p:commandButton class="mx-1 ui-button-Warning w-25" icon="fas fa-fill" ajax="false" value="Fill Deleted" action="#{staffLoanController.createLonesDeleted()}" />
-                                <p:commandButton class="ui-button-Warning" icon="fas fa-fill" ajax="false" value="Fill For Paid" action="#{staffLoanController.createsheduleForPaidLones()}" />
-                                <p:commandButton class="mx-1 ui-button-success w-25" icon="fas fa-file-excel" ajax="false" value="Excel"  >
-                                    <p:dataExporter type="xlsx" target="tb5" fileName="hr_staff_loan_installment"  />
+                            <div>
+                                <h:outputLabel value="Institution" style="display: block; margin-bottom: 4px;" />
+                                <hr:institution value="#{staffLoanController.reportKeyWord.institution}" />
+                            </div>
+
+                            <div>
+                                <h:outputLabel value="Staff Category" style="display: block; margin-bottom: 4px;" />
+                                <hr:completeStaffCategory value="#{staffLoanController.reportKeyWord.staffCategory}" />
+                            </div>
+
+                            <div>
+                                <h:outputLabel value="Designation" style="display: block; margin-bottom: 4px;" />
+                                <hr:completeDesignation value="#{staffLoanController.reportKeyWord.designation}" />
+                            </div>
+
+                            <div>
+                                <h:outputLabel value="Roster" style="display: block; margin-bottom: 4px;" />
+                                <hr:completeRoster value="#{staffLoanController.reportKeyWord.roster}" />
+                            </div>
+
+                            <div style="display: flex; gap: 0.5rem; flex-wrap: wrap; padding-top: 0.25rem;">
+                                <p:commandButton
+                                    ajax="false"
+                                    value="Fill"
+                                    icon="fas fa-fill"
+                                    styleClass="ui-button-warning"
+                                    style="flex: 1;"
+                                    action="#{staffLoanController.createLones()}" />
+                                <p:commandButton
+                                    ajax="false"
+                                    value="Fill Deleted"
+                                    icon="fas fa-fill"
+                                    styleClass="ui-button-warning"
+                                    style="flex: 1;"
+                                    action="#{staffLoanController.createLonesDeleted()}" />
+                                <p:commandButton
+                                    ajax="false"
+                                    value="Fill For Paid"
+                                    icon="fas fa-fill"
+                                    styleClass="ui-button-warning"
+                                    style="flex: 1;"
+                                    action="#{staffLoanController.createsheduleForPaidLones()}" />
+                                <p:commandButton
+                                    ajax="false"
+                                    value="Excel"
+                                    icon="fas fa-file-excel"
+                                    styleClass="ui-button-success"
+                                    style="flex: 1;">
+                                    <p:dataExporter type="xlsx" target="tb5" fileName="hr_staff_loan_installment" />
                                 </p:commandButton>
-                                <p:commandButton class="w-25 ui-button-info" icon="fas fa-print" value="Print" ajax="false" action="#" >
-                                    <p:printer target="loaninstall" ></p:printer>
+                                <p:commandButton
+                                    value="Print"
+                                    icon="fas fa-print"
+                                    styleClass="ui-button-info"
+                                    style="flex: 1;"
+                                    ajax="false"
+                                    action="#">
+                                    <p:printer target="loaninstall" />
                                 </p:commandButton>
                             </div>
-                            <h:panelGrid columns="2">
 
-                            </h:panelGrid>
+                        </div>
+                    </p:panel>
 
-
-                        </p:panel>
-                    </div>
                 </div>
-                <p:panel id="loaninstall" styleClass="noBorder summeryBorder" class="mt-1" >
+
+                <p:spacer height="20" />
+
+                <p:panel id="loaninstall" styleClass="noBorder summeryBorder">
                     <f:facet name="header">
-                        <h:outputLabel value="Loan And Advances" styleClass="noPrintButton"/>
-                        <!--<p:commandButton ajax="false" value="Save Selected" action="#{staffLoanController.saveSelected}" style="float: right;"  styleClass="noPrintButton"/>-->
+                        <div style="display: flex; justify-content: space-between; align-items: center;">
+                            <span>Loan And Advances</span>
+                        </div>
                     </f:facet>
-                    <p:dataTable value="#{staffLoanController.paysheetComponents}" id="tb5"
-                                 var="i" scrollHeight="200"
-                                 rowKey="#{i.id}" rowIndexVar="a"
-                                 selectionMode="multiple"
-                                 selection="#{staffLoanController.selectedList}" >
+
+                    <p:dataTable
+                        id="tb5"
+                        value="#{staffLoanController.paysheetComponents}"
+                        var="i"
+                        scrollHeight="200"
+                        scrollable="true"
+                        scrollWidth="100%"
+                        style="table-layout: fixed; width: 100%;"
+                        rowKey="#{i.id}"
+                        rowIndexVar="a"
+                        selectionMode="multiple"
+                        selection="#{staffLoanController.selectedList}">
+
                         <f:facet name="header">
-                            <h:outputLabel value="#{staffLoanController.paysheetComponent.name}"/>
+                            <h:outputLabel value="#{staffLoanController.paysheetComponent.name}" />
                         </f:facet>
-                        <p:column   styleClass="noPrintButton" >                            
-                        </p:column>
-                        <p:column headerText="No">
-                            <f:facet name="header">
-                                <h:outputLabel value="No"/>
-                            </f:facet>
-                            <h:outputLabel value="#{a+1}" >
-                            </h:outputLabel>
+
+                        <p:column styleClass="noPrintButton" style="width: 2.5rem;" />
+
+                        <p:column headerText="#" style="width: 3rem; text-align: center;">
+                            <h:outputLabel value="#{a+1}" />
                         </p:column>
 
-                        <p:column headerText="Institution" sortBy="#{i.staff.workingDepartment.institution.name}"  >
-                            <f:facet name="header" >
-                                <h:outputLabel value="Institution"  />
-                            </f:facet>
-                            <h:outputLabel value="#{i.staff.workingDepartment.institution.name}" ></h:outputLabel>
-                        </p:column>
-                        <p:column headerText="Department" sortBy="#{i.staff.workingDepartment.name}" >
-                            <f:facet name="header" >
-                                <h:outputLabel value="Department"  />
-                            </f:facet>
-
-                            <h:outputLabel value="#{i.staff.workingDepartment.name}" ></h:outputLabel>
-                        </p:column>
-                        <p:column headerText="Roster"  >
-                            <f:facet name="header">
-                                <h:outputLabel value="Roster"  />
-                            </f:facet>
-                            <h:outputLabel value="#{i.staff.roster.name}" ></h:outputLabel>
-                        </p:column>
-                        <p:column headerText="EMP Code" sortBy="#{i.staff.codeInterger}" >
-                            <f:facet name="header">
-                                <h:outputLabel value="EMP Code"  />
-                            </f:facet>
-                            <h:outputLabel value="#{i.staff.code}" ></h:outputLabel>
-                        </p:column>
-                        <p:column headerText="Bank" sortBy="#{i.staff.bankBranch.institution.name}"  >
-                            <f:facet name="header">
-                                <h:outputLabel value="Bank"  />
-                            </f:facet>
-                            <h:outputLabel value="#{i.staff.bankBranch.institution.name}" ></h:outputLabel>
-                        </p:column>
-                        <p:column headerText="Acc. No" sortBy="#{i.staff.accountNo}"  >
-                            <f:facet name="header">
-                                <h:outputLabel value="Acc. No"  />
-                            </f:facet>
-                            <h:outputLabel value="#{i.staff.accountNo}" ></h:outputLabel>
-                        </p:column>
-                        <p:column headerText="componentType" rendered="false">
-                            <f:facet name="header">
-                                <h:outputLabel value="componentType"  />
-                            </f:facet>
-                            <h:outputLabel value="#{i.paysheetComponent.componentType}"/>
-                        </p:column>
-                        <p:column headerText="Roster">
-                            <h:outputLabel value="#{i.staff.roster.name}"/>
-                        </p:column>
-                        <p:column headerText="Starting Balance">
-                            <h:outputLabel value="#{i.startingBalance}"/>
+                        <p:column headerText="EMP Code" sortBy="#{i.staff.codeInterger}" style="width: 6rem;">
+                            <h:outputLabel value="#{i.staff.code}" />
                         </p:column>
 
-                        <p:column headerText="From"  >
-                            <f:facet name="header">
-                                <h:outputLabel value="From"  />
-                            </f:facet>
-                            <p:cellEditor>  
+                        <p:column headerText="Staff" style="width: 14rem;">
+                            <h:outputLabel value="#{i.staff.person.nameWithTitle}" />
+                        </p:column>
+
+                        <p:column headerText="Institution" sortBy="#{i.staff.workingDepartment.institution.name}" style="width: 10rem;">
+                            <h:outputLabel value="#{i.staff.workingDepartment.institution.name}" />
+                        </p:column>
+
+                        <p:column headerText="Department" sortBy="#{i.staff.workingDepartment.name}" style="width: 10rem;">
+                            <h:outputLabel value="#{i.staff.workingDepartment.name}" />
+                        </p:column>
+
+                        <p:column headerText="Category" style="width: 8rem;">
+                            <h:outputLabel value="#{i.staff.staffCategory.name}" />
+                        </p:column>
+
+                        <p:column headerText="Designation" style="width: 9rem;">
+                            <h:outputLabel value="#{i.staff.designation.name}" />
+                        </p:column>
+
+                        <p:column headerText="Roster" style="width: 7rem;">
+                            <h:outputLabel value="#{i.staff.roster.name}" />
+                        </p:column>
+
+                        <p:column headerText="Grade" style="width: 5rem;">
+                            <h:outputLabel value="#{i.staff.grade.name}" />
+                        </p:column>
+
+                        <p:column headerText="Bank" sortBy="#{i.staff.bankBranch.institution.name}" style="width: 9rem;">
+                            <h:outputLabel value="#{i.staff.bankBranch.institution.name}" />
+                        </p:column>
+
+                        <p:column headerText="Acc. No" sortBy="#{i.staff.accountNo}" style="width: 8rem;">
+                            <h:outputLabel value="#{i.staff.accountNo}" />
+                        </p:column>
+
+                        <p:column headerText="Starting Balance" style="width: 8rem;">
+                            <h:outputLabel value="#{i.startingBalance}" />
+                        </p:column>
+
+                        <p:column headerText="From" style="width: 7rem;">
+                            <p:cellEditor>
                                 <f:facet name="output">
                                     <h:outputLabel value="#{i.fromDate}">
-                                        <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateFormat}"/>
+                                        <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateFormat}" />
                                     </h:outputLabel>
                                 </f:facet>
                                 <f:facet name="input">
-                                    <p:calendar value="#{i.fromDate}" pattern="#{sessionController.applicationPreference.shortDateFormat}" navigator="true"/>
+                                    <p:calendar value="#{i.fromDate}" navigator="true"
+                                                pattern="#{sessionController.applicationPreference.shortDateFormat}" />
                                 </f:facet>
                             </p:cellEditor>
                         </p:column>
-                        <p:column headerText="To" >
-                            <f:facet name="header">
-                                <h:outputLabel value="To"  />
-                            </f:facet>
-                            <p:cellEditor>  
+
+                        <p:column headerText="To" style="width: 7rem;">
+                            <p:cellEditor>
                                 <f:facet name="output">
                                     <h:outputLabel value="#{i.toDate}">
-                                        <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateFormat}"/>
+                                        <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateFormat}" />
                                     </h:outputLabel>
                                 </f:facet>
                                 <f:facet name="input">
-                                    <p:calendar value="#{i.toDate}" pattern="#{sessionController.applicationPreference.shortDateFormat}" navigator="true"/>
+                                    <p:calendar value="#{i.toDate}" navigator="true"
+                                                pattern="#{sessionController.applicationPreference.shortDateFormat}" />
                                 </f:facet>
                             </p:cellEditor>
-
                         </p:column>
 
-                        <p:column headerText="Grade" >
-                            <f:facet name="header">
-                                <h:outputLabel value="Grade"  />
-                            </f:facet>
-                            <h:outputLabel value="#{i.staff.grade.name}"/>                           
-                        </p:column>
-
-                        <p:column headerText="Category" >
-                            <f:facet name="header">
-                                <h:outputLabel value="Category"  />
-                            </f:facet>
-                            <h:outputLabel value="#{i.staff.staffCategory.name}"/>
-                        </p:column>
-
-                        <p:column headerText="Designtion" >
-                            <f:facet name="header">
-                                <h:outputLabel value="Designtion"  />
-                            </f:facet>
-                            <h:outputLabel value="#{i.staff.designation.name}"/>
-                        </p:column>
-                        <p:column headerText="Resign Date" >
-                            <f:facet name="header">
-                                <h:outputLabel value="Resign Date"  />
-                            </f:facet>
+                        <p:column headerText="Resign Date" style="width: 7rem;">
                             <h:outputLabel value="#{i.staff.dateLeft}">
-                                <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateFormat}"/>
+                                <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateFormat}" />
                             </h:outputLabel>
                         </p:column>
-                        <p:column headerText="Staff" >
-                            <f:facet name="header">
-                                <h:outputLabel value="Staff"  />
-                            </f:facet>
-                            <h:outputLabel value="#{i.staff.person.nameWithTitle}"/>
-                        </p:column>                   
-                        <p:column headerText="Loan Name" >
-                            <f:facet name="header">
-                                <h:outputLabel value="Loan Name"  />
-                            </f:facet>
-                            <h:outputLabel value="#{i.paysheetComponent.name}"/>
-                        </p:column>
-                        <p:column headerText="Bank" >
-                            <f:facet name="header">
-                                <h:outputLabel value="Bank"  />
-                            </f:facet>
-                            <h:outputLabel value="#{i.bankBranch.institution.name} - #{i.bankBranch.name}"/>
-                        </p:column>
-                        <p:column headerText="Loan No" >
-                            <f:facet name="header">
-                                <h:outputLabel value="Loan No"  />
-                            </f:facet>
-                            <h:outputLabel value="#{i.loanNo}"/>
+
+                        <p:column headerText="Loan Name" style="width: 9rem;">
+                            <h:outputLabel value="#{i.paysheetComponent.name}" />
                         </p:column>
 
-                        <p:column headerText="Account No" >
-                            <f:facet name="header">
-                                <h:outputLabel value="Account No"  />
-                            </f:facet>
-                            <h:outputLabel value="#{i.accountNo}"/>
+                        <p:column headerText="Bank" style="width: 12rem;">
+                            <h:outputLabel value="#{i.bankBranch.institution.name} - #{i.bankBranch.name}" />
                         </p:column>
 
-                        <p:column headerText="Loan Full Amount" >
-                            <f:facet name="header">
-                                <h:outputLabel value="Loan Full Amount"  />
-                            </f:facet>
-                            <h:outputLabel value="#{i.loanFullAmount}"/>
-                        </p:column>    
-                        <p:column headerText="Monthly Installment" >
-                            <f:facet name="header">
-                                <h:outputLabel value="Monthly Installment"  />
-                            </f:facet>
-                            <h:outputLabel value="#{i.staffPaySheetComponentValue}"/>
-                        </p:column>
-                        <p:column headerText="Cheque Number" rendered="#{staffLoanController.chequeDetails}">
-                            <p:inputText autocomplete="off"  value="#{i.chequeNumber}"/>
-                        </p:column>    
-                        <p:column headerText="Cheque Date" rendered="#{staffLoanController.chequeDetails}">
-                            <p:calendar navigator="true" value="#{i.chequeDate}" pattern="#{sessionController.applicationPreference.shortDateFormat}" />  
+                        <p:column headerText="Loan No" style="width: 7rem;">
+                            <h:outputLabel value="#{i.loanNo}" />
                         </p:column>
 
-                        <p:column headerText="Compleated At" >
-                            <f:facet name="header">
-                                <h:outputLabel value="Compleated At"/>
-                            </f:facet>
-                            <p:outputLabel value="#{i.completedAt}" >
-                                <f:convertDateTime  timeZone="Asia/Colombo" pattern="#{sessionController.applicationPreference.shortDateFormat}"  />
+                        <p:column headerText="Account No" style="width: 8rem;">
+                            <h:outputLabel value="#{i.accountNo}" />
+                        </p:column>
+
+                        <p:column headerText="Loan Full Amount" style="width: 9rem;">
+                            <h:outputLabel value="#{i.loanFullAmount}" />
+                        </p:column>
+
+                        <p:column headerText="Monthly Installment" style="width: 10rem;">
+                            <h:outputLabel value="#{i.staffPaySheetComponentValue}" />
+                        </p:column>
+
+                        <p:column headerText="componentType" rendered="false">
+                            <h:outputLabel value="#{i.paysheetComponent.componentType}" />
+                        </p:column>
+
+                        <p:column headerText="Cheque Number" rendered="#{staffLoanController.chequeDetails}" style="width: 9rem;">
+                            <p:inputText autocomplete="off" value="#{i.chequeNumber}" />
+                        </p:column>
+
+                        <p:column headerText="Cheque Date" rendered="#{staffLoanController.chequeDetails}" style="width: 8rem;">
+                            <p:calendar navigator="true" value="#{i.chequeDate}"
+                                        pattern="#{sessionController.applicationPreference.shortDateFormat}" />
+                        </p:column>
+
+                        <p:column headerText="Completed At" style="width: 8rem;">
+                            <p:outputLabel value="#{i.completedAt}">
+                                <f:convertDateTime timeZone="Asia/Colombo"
+                                                   pattern="#{sessionController.applicationPreference.shortDateFormat}" />
                             </p:outputLabel>
-                            <!--<p:calendar value="#{i.completedAt}" pattern="#{sessionController.applicationPreference.shortDateFormat}" />-->
                         </p:column>
 
-                        <p:column styleClass="noPrintButton">
-                            <p:commandButton value="Edit" ajax="false">
-                                <f:setPropertyActionListener target="#{staffLoanController.current}"  value="#{i}" />
+                        <p:column styleClass="noPrintButton" style="width: 5rem;" exportable="false">
+                            <p:commandButton value="Edit" ajax="false"
+                                             styleClass="ui-button-info"
+                                             style="padding: 0.25rem 0.4rem; font-size: 0.82rem;">
+                                <f:setPropertyActionListener target="#{staffLoanController.current}" value="#{i}" />
                             </p:commandButton>
                         </p:column>
 
                     </p:dataTable>
                 </p:panel>
 
-
-
-
-
-
             </h:form>
-
         </h:panelGroup>
-
     </ui:define>
 
 </ui:composition>


### PR DESCRIPTION
Refactored the hr_staff_loan_installment.xhtml layout to match the established
UI pattern used across other HR module views.

Changes:
- Replaced h:panelGrid with CSS grid/flex layout for form panels
- Applied inline label styling (display: block, margin-bottom: 4px)
- Grouped related fields into sub-grids (From/To, Loan No/Account No,
  Starting Balance/Full Amount, Monthly Installment/Comments,
  Schedule For Paid/Completed)
- Stacked hr: composite fields vertically to prevent overflow issues
- Standardised button styles using styleClass with flex: 1
- Added flex-wrap on search action buttons to handle overflow
- Added scrollable, fixed-width columns to the data table

No functional changes — all bindings, fields, and logic are unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Redesigned HR staff loan installment form layout with improved visual organization of loan entry fields and action buttons
  * Enhanced search panel interface with better structured filter widgets and updated button layout
  * Improved results table presentation with refined column structure and optimized display of staff and loan information

<!-- end of auto-generated comment: release notes by coderabbit.ai -->