### PR TITLE
fix(pharmacy): reload deptAdjustmentPreBill after dept/staff stock adjustment

### DIFF
--- a/src/main/java/com/divudi/bean/pharmacy/PharmacyAdjustmentController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacyAdjustmentController.java
@@ -1833,7 +1833,7 @@ public class PharmacyAdjustmentController implements Serializable {
 
 //        getDeptAdjustmentPreBill().getBillItems().add(getBillItem());
 //        getBillFacade().edit(getDeptAdjustmentPreBill());
-        setBill(getBillFacade().find(getDeptAdjustmentPreBill().getId()));
+        deptAdjustmentPreBill = getBillFacade().find(getDeptAdjustmentPreBill().getId());
         getPharmacyBean().resetStock(ph, stock, qty, getSessionController().getDepartment());
 
         printPreview = true;
@@ -1859,7 +1859,7 @@ public class PharmacyAdjustmentController implements Serializable {
         PharmaceuticalBillItem ph = saveDeptAdjustmentBillItems();
 //        getDeptAdjustmentPreBill().getBillItems().add(getBillItem());
 //        getBillFacade().edit(getDeptAdjustmentPreBill());
-        setBill(getBillFacade().find(getDeptAdjustmentPreBill().getId()));
+        deptAdjustmentPreBill = getBillFacade().find(getDeptAdjustmentPreBill().getId());
         getPharmacyBean().resetStock(ph, stock, qty, getSessionController().getDepartment());
 
         printPreview = true;


### PR DESCRIPTION
## Summary

- `adjustStockForDepartment()` and `adjustStaffStock()` both called `setBill(getBillFacade().find(...))`, which reloaded the saved bill into `this.bill` instead of `deptAdjustmentPreBill`
- The XHTML print composite at line 320 binds to `pharmacyAdjustmentController.deptAdjustmentPreBill`, so it received the stale in-memory object with no items
- Fix: assign the reloaded bill to `deptAdjustmentPreBill`, matching the pattern already used by `adjustPurchaseRate()`

## Test plan

- [ ] Navigate to Pharmacy → Adjustments → Department Stock Adjustment
- [ ] Select a stock item, enter quantity and comment, click **Make Adjustment**
- [ ] Verify the print preview shows the item row (ITEM NAME / EXPIRY DATE / BEFORE QTY / CHANGED QTY / AFTER QTY)
- [ ] Repeat for Staff Stock Adjustment page
- [ ] Confirm no regression on Purchase Rate, Sale Rate, and Cost Rate adjustment print previews

Closes #20345

🤖 Generated with [Claude Code](https://claude.com/claude-code)