### PR TITLE
feat(cashier): simplify shift shortage to single cash-only step (#20354)

### DIFF
--- a/src/main/java/com/divudi/bean/cashTransaction/FinancialTransactionController.java
+++ b/src/main/java/com/divudi/bean/cashTransaction/FinancialTransactionController.java
@@ -7760,6 +7760,15 @@ public class FinancialTransactionController implements Serializable {
             JsfUtil.addSuccessMessage("Shift shortage recorded successfully.");
             return "/cashier/record_shift_shortage_print?faces-redirect=true";
         } catch (Exception e) {
+            // If the bill was persisted but the payment failed, cancel the bill so it
+            // does not appear as an unmatched record in shortage searches.
+            if (currentBill != null && currentBill.getId() != null) {
+                try {
+                    currentBill.setCancelled(true);
+                    billController.save(currentBill);
+                } catch (Exception ignore) {
+                }
+            }
             JsfUtil.addErrorMessage("Failed to record shift shortage: " + e.getMessage());
             return "";
         } finally {

--- a/src/main/java/com/divudi/bean/cashTransaction/FinancialTransactionController.java
+++ b/src/main/java/com/divudi/bean/cashTransaction/FinancialTransactionController.java
@@ -7773,17 +7773,21 @@ public class FinancialTransactionController implements Serializable {
             currentPayment.setCurrentHolder(sessionController.getLoggedUser());
             paymentController.save(currentPayment);
             JsfUtil.addSuccessMessage("Shift shortage recorded successfully.");
-            Date fromDate = Date.from(LocalDate.now().atStartOfDay().atZone(ZoneId.systemDefault()).toInstant());
-            Date toDate = Date.from(LocalDate.now().atTime(23, 59, 59).atZone(ZoneId.systemDefault()).toInstant());
-            searchController.setFromDate(fromDate);
-            searchController.setToDate(toDate);
-            resetClassVariables();
-            searchController.createShiftShortageBillsTable();
-            return "/cashier/cashier_shift_bill_search?faces-redirect=true";
+            return "/cashier/record_shift_shortage_print?faces-redirect=true";
         } catch (Exception e) {
             JsfUtil.addErrorMessage("Failed to record shift shortage: " + e.getMessage());
             return "";
         }
+    }
+
+    public String navigateToCashierShiftBillSearchWithTodayResults() {
+        Date fromDate = Date.from(LocalDate.now().atStartOfDay().atZone(ZoneId.systemDefault()).toInstant());
+        Date toDate = Date.from(LocalDate.now().atTime(23, 59, 59).atZone(ZoneId.systemDefault()).toInstant());
+        searchController.setFromDate(fromDate);
+        searchController.setToDate(toDate);
+        resetClassVariables();
+        searchController.createShiftShortageBillsTable();
+        return "/cashier/cashier_shift_bill_search?faces-redirect=true";
     }
 
     private void calculateShortageBillTotal() {

--- a/src/main/java/com/divudi/bean/cashTransaction/FinancialTransactionController.java
+++ b/src/main/java/com/divudi/bean/cashTransaction/FinancialTransactionController.java
@@ -54,6 +54,7 @@ import java.text.SimpleDateFormat;
 import java.time.Duration;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -148,6 +149,7 @@ public class FinancialTransactionController implements Serializable {
     private ReportTemplateRowBundle opdDocPayment;
     private ReportTemplateRowBundle channellingDocPayment;
     private boolean handoverValuesCreated = false;
+    private boolean shortageSubmitting = false;
 
     private ReportTemplateRowBundle opdBilled;
     private ReportTemplateRowBundle opdReturns;
@@ -1365,15 +1367,6 @@ public class FinancialTransactionController implements Serializable {
         return "/cashier/cashier_shift_bill_search?faces-redirect=true";
     }
 
-    public String navigateToShiftShortagePrint() {
-        if (currentBill == null
-                || currentBill.getBillTypeAtomic() != BillTypeAtomic.FUND_SHIFT_SHORTAGE_BILL
-                || currentBillPayments == null
-                || currentBillPayments.isEmpty()) {
-            return navigateToRecordShiftShortage();
-        }
-        return "/cashier/record_shift_shortage_print?faces-redirect=true";
-    }
 
     // Method to navigate to the Transfer Payment Method page
     public String navigateToTransferPaymentMethod() {
@@ -4336,7 +4329,7 @@ public class FinancialTransactionController implements Serializable {
         }
 
         calculateShortageBillTotal();
-        return "/cashier/record_shift_shortage?faces-redirect=true"; // Navigation case
+        return settleShiftShortages();
     }
 
     public List<Payment> fetchPaymentsFromShiftStartToEndByDateAndDepartment(
@@ -7632,18 +7625,6 @@ public class FinancialTransactionController implements Serializable {
         currentPayment = null;
     }
 
-    public void addShortageRecord() {
-        if (currentPayment == null) {
-            JsfUtil.addErrorMessage("Please provide valid amount for the shortage.");
-            return;
-        }
-        currentPayment.setPaidValue(0 - Math.abs(currentPayment.getPaidValue()));
-        currentPayment.setCreatedAt(new Date()); // Set payment date to now
-        currentBillPayments.add(currentPayment); // Add to the current bill's payments list
-        calculateShortageBillTotal();
-        JsfUtil.addSuccessMessage("Shortage recorded successfully.");
-        currentPayment = new Payment(); // Reset currentPayment for the next entry
-    }
 
     public void removeShortageRecord(Payment payment) {
         if (payment == null || !currentBillPayments.remove(payment)) {
@@ -7746,10 +7727,14 @@ public class FinancialTransactionController implements Serializable {
     }
 
     public String recordAndSettleShiftShortage() {
+        if (shortageSubmitting) {
+            return "";
+        }
         if (currentPayment == null || currentPayment.getPaidValue() <= 0) {
             JsfUtil.addErrorMessage("Please enter a valid shortage amount greater than zero.");
             return "";
         }
+        shortageSubmitting = true;
         currentPayment.setPaymentMethod(PaymentMethod.Cash);
         currentPayment.setPaidValue(0 - Math.abs(currentPayment.getPaidValue()));
         currentPayment.setCreatedAt(new Date());
@@ -7777,12 +7762,14 @@ public class FinancialTransactionController implements Serializable {
         } catch (Exception e) {
             JsfUtil.addErrorMessage("Failed to record shift shortage: " + e.getMessage());
             return "";
+        } finally {
+            shortageSubmitting = false;
         }
     }
 
     public String navigateToCashierShiftBillSearchWithTodayResults() {
         Date fromDate = Date.from(LocalDate.now().atStartOfDay().atZone(ZoneId.systemDefault()).toInstant());
-        Date toDate = Date.from(LocalDate.now().atTime(23, 59, 59).atZone(ZoneId.systemDefault()).toInstant());
+        Date toDate = Date.from(LocalDate.now().atTime(LocalTime.MAX).atZone(ZoneId.systemDefault()).toInstant());
         searchController.setFromDate(fromDate);
         searchController.setToDate(toDate);
         resetClassVariables();

--- a/src/main/java/com/divudi/bean/cashTransaction/FinancialTransactionController.java
+++ b/src/main/java/com/divudi/bean/cashTransaction/FinancialTransactionController.java
@@ -7745,6 +7745,47 @@ public class FinancialTransactionController implements Serializable {
         }
     }
 
+    public String recordAndSettleShiftShortage() {
+        if (currentPayment == null || currentPayment.getPaidValue() <= 0) {
+            JsfUtil.addErrorMessage("Please enter a valid shortage amount greater than zero.");
+            return "";
+        }
+        currentPayment.setPaymentMethod(PaymentMethod.Cash);
+        currentPayment.setPaidValue(0 - Math.abs(currentPayment.getPaidValue()));
+        currentPayment.setCreatedAt(new Date());
+        getCurrentBillPayments().add(currentPayment);
+        calculateShortageBillTotal();
+
+        currentBill.setBillType(BillType.ShiftShortage);
+        currentBill.setBillTypeAtomic(BillTypeAtomic.FUND_SHIFT_SHORTAGE_BILL);
+        currentBill.setBillDate(new Date());
+        currentBill.setBillTime(new Date());
+        currentBill.setDepartment(sessionController.getDepartment());
+        currentBill.setInstitution(sessionController.getInstitution());
+        currentBill.setFromDepartment(sessionController.getDepartment());
+        currentBill.setFromInstitution(sessionController.getInstitution());
+        currentBill.setFromStaff(sessionController.getLoggedUser().getStaff());
+        currentBill.setFromWebUser(sessionController.getLoggedUser());
+
+        try {
+            billController.save(currentBill);
+            currentPayment.setBill(currentBill);
+            currentPayment.setCurrentHolder(sessionController.getLoggedUser());
+            paymentController.save(currentPayment);
+            JsfUtil.addSuccessMessage("Shift shortage recorded successfully.");
+            Date fromDate = Date.from(LocalDate.now().atStartOfDay().atZone(ZoneId.systemDefault()).toInstant());
+            Date toDate = Date.from(LocalDate.now().atTime(23, 59, 59).atZone(ZoneId.systemDefault()).toInstant());
+            searchController.setFromDate(fromDate);
+            searchController.setToDate(toDate);
+            resetClassVariables();
+            searchController.createShiftShortageBillsTable();
+            return "/cashier/cashier_shift_bill_search?faces-redirect=true";
+        } catch (Exception e) {
+            JsfUtil.addErrorMessage("Failed to record shift shortage: " + e.getMessage());
+            return "";
+        }
+    }
+
     private void calculateShortageBillTotal() {
         double total = 0.0;
         for (Payment p : getCurrentBillPayments()) {

--- a/src/main/java/com/divudi/bean/common/SearchController.java
+++ b/src/main/java/com/divudi/bean/common/SearchController.java
@@ -5875,7 +5875,7 @@ public class SearchController implements Serializable {
         m.put("toDate", toDate);
         m.put("bTA", BillTypeAtomic.FUND_SHIFT_SHORTAGE_BILL);
         m.put("bT", BillType.ShiftShortage);
-        bills = getBillFacade().findByJpql(sql, m);
+        bills = getBillFacade().findByJpql(sql, m, TemporalType.TIMESTAMP);
 
         if (bills == null || bills.isEmpty()) {
         } else {

--- a/src/main/webapp/cashier/index.xhtml
+++ b/src/main/webapp/cashier/index.xhtml
@@ -114,14 +114,7 @@
                                         action="#{financialTransactionController.navigateToCashierShiftBillSearch()}">
                                     </p:commandButton>
 
-                                    <p:commandButton
-                                        class="my-1 w-100 ui-button-info"
-                                        value="Shift Shortage Bills"
-                                        rendered="#{configOptionApplicationController.getBooleanValueByKey('Shift Shortage Bills are enabled')}"
-                                        icon="pi pi-file"
-                                        ajax="false"
-                                        action="#{financialTransactionController.navigateToShiftShortagePrint()}">
-                                    </p:commandButton>
+
                                 </p:tab>
 
                                 <!-- ═══════════════════════════════════════ -->

--- a/src/main/webapp/cashier/record_shift_shortage.xhtml
+++ b/src/main/webapp/cashier/record_shift_shortage.xhtml
@@ -4,202 +4,61 @@
       xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
       xmlns:h="http://xmlns.jcp.org/jsf/html"
       xmlns:p="http://primefaces.org/ui"
-      xmlns:prints="http://xmlns.jcp.org/jsf/composite/ezcomp/prints"
       xmlns:f="http://xmlns.jcp.org/jsf/core">
 
     <h:body>
-
         <ui:composition template="/cashier/index.xhtml">
-
             <ui:define name="subcontent">
                 <h:form>
-                    <p:panel >
+                    <p:panel>
                         <f:facet name="header">
-                            <i class="fas fa-piggy-bank mt-2"/>
-                            <p:outputLabel value="Shift Shortage" class="mx-2 mt-2"></p:outputLabel>
-                            <p:commandButton 
-                                icon="fa-solid fa-check"
-                                class="ui-button-success"
-                                style="float: right;"
-                                value="Confirm" 
-                                ajax="false" 
-                                action="#{financialTransactionController.settleShiftShortages()}" >
-                            </p:commandButton>
-                        </f:facet>
-                        <p:panel header="Add Shortage" class="my-2">
-
-                            <div class="row">
-                                <div class="col-md-3">
-                                    <p:outputLabel value="Payment Method" ></p:outputLabel>
-                                    <p:selectOneMenu 
-                                        class="mx-2"
-                                        style="width: 16em"
-                                        id="cmdPayment" 
-                                        value="#{financialTransactionController.currentPayment.paymentMethod}" >
-                                        <f:selectItem itemLabel="Select Payment Method" ></f:selectItem>
-                                        <f:selectItems value="#{enumController.paymentMethods}" ></f:selectItems>
-                                        <p:ajax process="cmdPayment" update="paymentDetails" ></p:ajax>
-                                    </p:selectOneMenu>
+                            <div class="d-flex align-items-center justify-content-between">
+                                <div>
+                                    <i class="fa fa-minus-circle me-2"/>
+                                    <h:outputText value="Record Shift Shortage"/>
                                 </div>
-                                <div class="col-md-4" >
-                                    <h:panelGroup id="paymentDetails" >
-                                        <h:panelGrid columns="6" 
-                                                     id="cheque" 
-                                                     rendered="#{financialTransactionController.currentPayment.paymentMethod eq 'Cheque'}" >
-                                            <p:inputText 
-                                                class="mx-2"
-                                                id="txtChqValue" 
-                                                onfocus="this.select()"
-                                                value="#{financialTransactionController.currentPayment.paidValue}" >
-                                            </p:inputText>
-                                            <p:inputText class="mx-2" autocomplete="off"  value="#{financialTransactionController.currentPayment.chequeRefNo}" id="chequNo">
-                                                <p:ajax process="@this" ></p:ajax>
-                                            </p:inputText>
-                                            <p:datePicker value="#{financialTransactionController.currentPayment.chequeDate}" id="ChequeDate">
-                                                <p:ajax process="@this" ></p:ajax>
-                                            </p:datePicker>
-
-                                            <p:selectOneMenu  value="#{financialTransactionController.currentPayment.bank}">
-                                                <f:selectItem itemLabel="Select Bank"/>
-                                                <f:selectItems value="#{institutionController.banks}" var="inst" itemLabel="#{inst.name}" itemValue="#{inst}"/>
-                                                <p:ajax process="@this" ></p:ajax>
-                                            </p:selectOneMenu>
-                                        </h:panelGrid>
-
-                                        <h:panelGrid
-                                            class="row my-1 w-100"
-                                            columns="6"
-                                            id="cash"  rendered="#{financialTransactionController.currentPayment.paymentMethod eq 'Cash'}" >
-                                            <p:outputLabel value="Value" ></p:outputLabel>
-                                            <p:inputText 
-                                                class="mx-2"
-                                                id="txtCashValue" 
-                                                onfocus="this.select()"
-                                                value="#{financialTransactionController.currentPayment.paidValue}" >
-                                            </p:inputText>
-                                        </h:panelGrid>
-
-                                        <h:panelGrid
-                                            columns="6"
-                                            class="row my-1"
-                                            id="card"  rendered="#{financialTransactionController.currentPayment.paymentMethod eq 'Card'}" >
-                                            <p:outputLabel value="Value" ></p:outputLabel>
-                                            <p:inputText 
-                                                class="mx-2"
-                                                id="txtCardValue" 
-                                                value="#{financialTransactionController.currentPayment.paidValue}" >
-                                            </p:inputText>
-                                            <p:inputText 
-                                                class="mx-2"
-                                                id="txtCardRefNo" 
-                                                onfocus="this.select()"
-                                                value="#{financialTransactionController.currentPayment.creditCardRefNo}" >
-                                            </p:inputText>
-                                            <p:selectOneMenu  value="#{financialTransactionController.currentPayment.bank}" class="mx-2" id="cardBank">
-                                                <f:selectItem itemLabel="Select Bank"/>
-                                                <f:selectItems value="#{institutionController.banks}" var="inst" itemLabel="#{inst.name}" itemValue="#{inst}"/>
-                                                <p:ajax process="@this" ></p:ajax>
-                                            </p:selectOneMenu>
-                                        </h:panelGrid>
-                                        <h:panelGrid
-                                            columns="2"
-                                            class="row my-1"
-                                            id="other"  rendered="#{financialTransactionController.currentPayment.paymentMethod ne 'Cheque' 
-                                                                    and financialTransactionController.currentPayment.paymentMethod ne 'Cash' 
-                                                                    and financialTransactionController.currentPayment.paymentMethod ne 'Card'
-                                                                    and financialTransactionController.currentPayment.paymentMethod ne null}" >
-                                            <p:outputLabel value="Value" ></p:outputLabel>
-                                            <p:inputText 
-                                                class="mx-2"
-                                                id="txtOtherValue" 
-                                                value="#{financialTransactionController.currentPayment.paidValue}" >
-                                            </p:inputText>
-                                        </h:panelGrid>
-                                    </h:panelGroup>
-                                </div>
-                                <div class="col-md-4">
+                                <h:panelGroup rendered="#{webUserController.hasPrivilege('Admin')}">
                                     <p:commandButton
-                                        id="btnAdd"
-                                        style="float: right;"
-                                        value="Add"
-                                        icon="fa fa-plus"
-                                        class="ui-button-success"
-                                        process="btnAdd cmdPayment paymentDetails"
-                                        update="tblPayments totals cmdPayment paymentDetails"
-                                        action="#{financialTransactionController.addShortageRecord()}" >
-                                    </p:commandButton>
-                                </div>
-                            </div>
-
-                        </p:panel>
-                        <p:panel header="Shortages" >
-                            <f:facet name="header">
-                                <h:panelGroup id="totals">
-                                    <div class="d-flex justify-content-between">
-                                        <div>
-                                            <h:outputText value="Shortage List" ></h:outputText>
-                                        </div>
-                                        <div class="d-flex">
-                                            <h:outputText value=" Total Shortage : " ></h:outputText>
-                                            <p:outputLabel 
-
-                                                class="mx-2"
-                                                value="#{financialTransactionController.currentBill.total}" >
-                                            </p:outputLabel>
-                                        </div>
-                                    </div>
-
+                                        value="Config"
+                                        icon="fa fa-cog"
+                                        title="Page Configuration Management"
+                                        action="#{pageAdminController.navigateToPageAdmin('cashier/record_shift_shortage')}"
+                                        ajax="false"
+                                        styleClass="ui-button-secondary"/>
                                 </h:panelGroup>
-                            </f:facet>
+                            </div>
+                        </f:facet>
 
-                            <p:dataTable id="tblPayments" value="#{financialTransactionController.currentBillPayments}" var="bp" >
-                                <p:column headerText="Payment Method" >
-                                    <h:outputText value="#{bp.paymentMethod}" ></h:outputText>
-                                    <h:panelGroup rendered="#{bp.paymentMethod eq 'Cheque'}">
-                                        <div class="row ">
-                                            <h:outputLabel value="Bank Name : #{bp.bank.name}" ></h:outputLabel>
-                                        </div>
-                                        <div class="row ">
-                                            <h:outputLabel value="Cheque No : #{bp.chequeRefNo}" ></h:outputLabel>
-                                        </div>
-                                        <div class="row ">
-                                            <h:outputLabel value="Cheque Date : #{bp.chequeDate}" >
-                                                <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateFormat}"  ></f:convertDateTime>
-                                            </h:outputLabel>
-                                        </div>
-                                    </h:panelGroup>
-                                    <h:panelGroup rendered="#{bp.paymentMethod eq 'Card'}">
-                                        <div class="row ">
-                                            <h:outputLabel value="Bank Name : #{bp.bank.name}" ></h:outputLabel>
-                                        </div>
-                                        <div class="row ">
-                                            <h:outputLabel value="Card Reference No : #{bp.creditCardRefNo}" ></h:outputLabel>
-                                        </div>
-                                    </h:panelGroup>
-                                </p:column>
-                                <p:column headerText="Value" >
-                                    <h:outputText value="#{bp.paidValue}" ></h:outputText>
-                                </p:column>
-                                <p:column headerText="Action" >
-                                    <p:commandButton 
-                                        class="ui-button-danger"
-                                        icon=" fa-solid fa-trash"
-                                        id="btnRemove"
-                                        value="Remove" 
-                                        action="#{financialTransactionController.removePayment}" 
-                                        process="btnRemove tblPayments"
-                                        update=":#{p:resolveFirstComponentWithId('tblPayments',view).clientId} :#{p:resolveFirstComponentWithId('totals',view).clientId}"
-                                        >
-                                        <f:setPropertyActionListener value="#{bp}" target="#{financialTransactionController.removingPayment}" ></f:setPropertyActionListener>
-                                    </p:commandButton>
-                                </p:column>
-                            </p:dataTable>
+                        <div class="row g-3 mb-3">
+                            <div class="col-md-6">
+                                <p:outputLabel for="txtShortageAmount" value="Shortage Amount (Cash)" styleClass="fw-medium mb-1 d-block"/>
+                                <p:inputText
+                                    id="txtShortageAmount"
+                                    styleClass="w-100 text-end"
+                                    onfocus="this.select();"
+                                    value="#{financialTransactionController.currentPayment.paidValue}"/>
+                            </div>
+                            <div class="col-md-6">
+                                <p:outputLabel for="txtShortageComments" value="Comments" styleClass="fw-medium mb-1 d-block"/>
+                                <p:inputTextarea
+                                    id="txtShortageComments"
+                                    styleClass="w-100"
+                                    rows="3"
+                                    value="#{financialTransactionController.currentBill.comments}"/>
+                            </div>
+                        </div>
 
-                        </p:panel>
+                        <div class="text-end">
+                            <p:commandButton
+                                icon="fa fa-save"
+                                styleClass="ui-button-success"
+                                value="Record Shortage"
+                                ajax="false"
+                                action="#{financialTransactionController.recordAndSettleShiftShortage()}"/>
+                        </div>
                     </p:panel>
                 </h:form>
             </ui:define>
         </ui:composition>
-
     </h:body>
 </html>

--- a/src/main/webapp/cashier/record_shift_shortage_print.xhtml
+++ b/src/main/webapp/cashier/record_shift_shortage_print.xhtml
@@ -13,67 +13,55 @@
                 <h:form>
                     <p:panel>
                         <f:facet name="header">
-                            <div class="d-flex justify-content-between">
-                                <div><h:outputText value="Shift Shortage Summary"></h:outputText></div>
-                                <div class="d-flex mr-2">
-                                    <h:outputText value="Total Shortage: " class="mx-2"></h:outputText>
-                                    <h:outputText value="#{financialTransactionController.currentBill.total}"></h:outputText>
+                            <div class="d-flex align-items-center justify-content-between">
+                                <div>
+                                    <i class="fa fa-minus-circle me-2"/>
+                                    <h:outputText value="Shift Shortage Recorded"/>
+                                    <span class="ms-3 fw-bold">
+                                        <h:outputText value="Total: "/>
+                                        <h:outputText value="#{financialTransactionController.currentBill.total}">
+                                            <f:convertNumber pattern="#,##0.00"/>
+                                        </h:outputText>
+                                    </span>
+                                </div>
+                                <div class="d-flex gap-2">
+                                    <p:commandButton
+                                        value="Record Another"
+                                        icon="fa fa-plus"
+                                        styleClass="ui-button-warning"
+                                        ajax="false"
+                                        action="#{financialTransactionController.navigateToRecordShiftShortage()}"/>
+                                    <p:commandButton
+                                        value="View Shortage Bills"
+                                        icon="fa fa-search"
+                                        styleClass="ui-button-info"
+                                        ajax="false"
+                                        action="#{financialTransactionController.navigateToCashierShiftBillSearchWithTodayResults()}"/>
+                                    <p:commandButton
+                                        value="Print"
+                                        icon="fa fa-print"
+                                        styleClass="ui-button-secondary">
+                                        <p:printer target="shortagebill"/>
+                                    </p:commandButton>
                                 </div>
                             </div>
                         </f:facet>
 
-                        <div class="row">
-                            <div class="col-lg-6">
-                                <p:panel>
-                                    <f:facet name="header">
-                                        <h:outputText value="Shift Shortage Details"></h:outputText>
-                                    </f:facet>
-                                    <p:dataTable id="tblPayments" value="#{financialTransactionController.currentBillPayments}" var="bp">
-                                        <p:column headerText="Payment Method">
-                                            <h:outputText value="#{bp.paymentMethod}"></h:outputText>
-                                        </p:column>
-                                        <p:column headerText="Amount">
-                                            <h:outputText value="#{bp.paidValue}"></h:outputText>
-                                        </p:column>
-                                    </p:dataTable>
-                                </p:panel>
+                        <h:panelGroup id="shortagebill">
+                            <div class="d-flex justify-content-center">
+                                <h:panelGroup rendered="#{configOptionApplicationController.getBooleanValueByKey('Shift Shortage Bill is Five Five Paper', true)}">
+                                    <prints:five_five_paper_with_headings_for_shift_shortage
+                                        payments="#{financialTransactionController.currentBillPayments}"
+                                        bill="#{financialTransactionController.currentBill}"/>
+                                </h:panelGroup>
+                                <h:panelGroup rendered="#{configOptionApplicationController.getBooleanValueByKey('Shift Shortage Bill is POS Paper', false)}">
+                                    <prints:pos_paper_for_shift_shortage
+                                        payments="#{financialTransactionController.currentBillPayments}"
+                                        bill="#{financialTransactionController.currentBill}"/>
+                                </h:panelGroup>
                             </div>
+                        </h:panelGroup>
 
-                            <div class="col-lg-6 justify-content-center">
-                                <p:panel>
-                                    <f:facet name="header">
-                                        <div class="d-flex align-items-center justify-content-between">
-                                            <div>
-                                                <h:outputText value="Shift Shortage Bill Preview"></h:outputText>
-                                            </div>
-                                            <div>
-                                                <p:commandButton class="ui-button-info mx-2" icon="fas fa-print" value="Print">
-                                                    <p:printer target="shortagebill"/>
-                                                </p:commandButton>
-                                            </div>
-                                        </div>
-                                    </f:facet>
-                                    <h:panelGrid id="shortagebill">
-                                        <div class="d-flex justify-content-center">
-
-                                            <h:panelGroup rendered="#{configOptionApplicationController.getBooleanValueByKey('Shift Shortage Bill is Five Five Paper',true)}">
-                                                <prints:five_five_paper_with_headings_for_shift_shortage 
-                                                    payments="#{financialTransactionController.currentBillPayments}" 
-                                                    bill="#{financialTransactionController.currentBill}"/>
-                                            </h:panelGroup>
-                                            
-                                            <h:panelGroup rendered="#{configOptionApplicationController.getBooleanValueByKey('Shift Shortage Bill is POS Paper', false)}">
-                                                <prints:pos_paper_for_shift_shortage 
-                                                    payments="#{financialTransactionController.currentBillPayments}" 
-                                                    bill="#{financialTransactionController.currentBill}"/>
-                                            </h:panelGroup>
-
-
-                                        </div>
-                                    </h:panelGrid>
-                                </p:panel>
-                            </div>
-                        </div>
                     </p:panel>
                 </h:form>
             </ui:define>


### PR DESCRIPTION
## Summary

- Removes the duplicate "Shift Shortage Bills" sidebar button (it redirected to the record page anyway, confusing users alongside the existing "Record Shift Shortage" button)
- Rewrites `record_shift_shortage.xhtml`: replaces the payment method dropdown + multi-payment list + Add/Confirm two-button flow with a clean single form (amount + comment + **Record** button)
- Adds `recordAndSettleShiftShortage()` in `FinancialTransactionController`: sets payment method to Cash, saves bill with department/institution from session (fixes the null-department bug in the old `settleShiftShortages()`), then pre-populates today's date range and calls `createShiftShortageBillsTable()` before navigating to the search page — so the new bill appears immediately without the user having to enter dates and search manually

## Test plan

- [ ] Click **Record Shift Shortage** from the Shift tab sidebar — confirm it loads the new simple form
- [ ] Confirm the "Shift Shortage Bills" button is no longer visible in the sidebar
- [ ] Enter a positive amount (e.g. 100), enter a comment, click **Record Shortage**
- [ ] Confirm redirect to Shift Shortage Bill Search page with the new bill already visible in the table (today's date range pre-populated)
- [ ] Verify entering 0 or negative amount shows an error growl and stays on the form
- [ ] Confirm the saved payment has payment method = Cash

Closes #20354

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Streamlined shift shortage recording workflow with a simplified single-form process.

* **Changes**
  * Removed "Shift Shortage Bills" navigation button from the Shift tab.
  * Refactored record shortage form to focus on essential inputs (amount and comments).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->