### PR TITLE
fix(api): address consultant API review issues (sex handling, pagination, query parsing)

### DIFF
--- a/developer_docs/api/rest-api-development-guide.md
+++ b/developer_docs/api/rest-api-development-guide.md
@@ -53,6 +53,7 @@ Different header schemes by module:
 {"status":"success","code":200,"data":{...}}
 {"status":"error","code":400,"message":"..."}
 ```
+For create endpoints, use HTTP `201 Created`, and set `"code": "201"` in the response body.
 
 For POST duplicate detection (not wrapped in the success envelope):
 ```json
@@ -185,7 +186,7 @@ facade.edit(entity);
 ## Post-Implementation Testing Checklist
 
 ```bash
-BASE="http://localhost:9090/rh/api/<path>"
+BASE="http://localhost:8080/rh/api/<path>"
 KEY="<finance-api-key>"
 
 # 1. GET list
@@ -209,7 +210,7 @@ curl -s -H "Finance: $KEY" -H "Content-Type: application/json" \
 curl -s -H "Finance: $KEY" -X DELETE "$BASE/<id>" | python -m json.tool
 
 # 7. Capabilities endpoint shows new entry
-curl -s http://localhost:9090/rh/api/capabilities | python -m json.tool
+curl -s http://localhost:8080/rh/api/capabilities | python -m json.tool
 
 # 8. AI Chat can list and create via manage_* tool
 # Open /ai_chat.xhtml and prompt: "List all procedures in the clinical metadata API"

--- a/src/main/java/com/divudi/service/AnthropicApiService.java
+++ b/src/main/java/com/divudi/service/AnthropicApiService.java
@@ -1738,12 +1738,13 @@ public class AnthropicApiService implements Serializable {
 
         // ── Staff / Consultants ───────────────────────────────────────────────
         appendModule(sb, "Consultant Management", "/channel/consultant",
-                "Create new consultant (doctor) records and update existing ones. "
+                "List, create, and update consultant (doctor) records. "
                 + "IMPORTANT: Uses the 'Token' header, not 'Finance'.",
                 githubUrl(branch, "developer_docs/API_CONSULTANT_MANAGEMENT.md"),
                 new String[][]{
-                    {"POST", "/channel/consultant",      "Create a new consultant. Required: name. Optional: title, mobile, phone, fax, address, code, serialNo, specialityId, institutionId, registration, qualification, description"},
-                    {"PUT",  "/channel/consultant/{id}", "Update an existing consultant by ID. Returns 400 for invalid field values, 404 if not found."}
+                    {"GET",  "/channel/consultant",      "List consultants. Supports query, page, size, specialityId."},
+                    {"POST", "/channel/consultant",      "Create a new consultant. Required: name. Optional: title, sex, mobile, phone, fax, address, code, serialNo, specialityId, institutionId, registration, qualification, description. Returns already_exists/409 for duplicates by name+title."},
+                    {"PUT",  "/channel/consultant/{id}", "Update an existing consultant by ID. Supports sex and returns 400 for invalid field values, 404 if not found."}
                 });
 
         // ── Channel / Booking ─────────────────────────────────────────────────

--- a/src/main/java/com/divudi/ws/channel/ChannelApi.java
+++ b/src/main/java/com/divudi/ws/channel/ChannelApi.java
@@ -21,6 +21,7 @@ import com.divudi.core.data.OnlineBookingStatus;
 import com.divudi.core.data.PaymentMethod;
 import com.divudi.core.data.PersonInstitutionType;
 import com.divudi.core.data.SessionStatusForOnlineBooking;
+import com.divudi.core.data.Sex;
 import com.divudi.core.data.Title;
 import com.divudi.ejb.BillNumberGenerator;
 import com.divudi.ejb.ChannelBean;
@@ -3916,6 +3917,23 @@ public class ChannelApi {
         if (requestBody.get("address") != null) {
             person.setAddress(requestBody.get("address").toString());
         }
+        if (requestBody.get("sex") != null) {
+            Sex sex = parseSex(requestBody.get("sex"));
+            if (sex == null) {
+                return Response.status(Response.Status.BAD_REQUEST)
+                        .entity(errorResponse(400, "Invalid sex value: " + requestBody.get("sex")).toString()).build();
+            }
+            person.setSex(sex);
+        }
+
+        Consultant existingConsultant = findActiveConsultantByNameAndTitle(name, person.getTitle());
+        if (existingConsultant != null) {
+            Map<String, Object> duplicateResponse = new HashMap<>();
+            duplicateResponse.put("status", "already_exists");
+            duplicateResponse.put("id", existingConsultant.getId());
+            duplicateResponse.put("name", existingConsultant.getPerson() != null ? existingConsultant.getPerson().getName() : name);
+            return Response.status(Response.Status.CONFLICT).entity(duplicateResponse).build();
+        }
 
         Consultant consultant = new Consultant();
         consultant.setPerson(person);
@@ -3999,7 +4017,7 @@ public class ChannelApi {
      *
      * Updatable fields (all optional — only supplied fields are changed):
      *   name, title, mobile, phone, fax, address, code, serialNo,
-     *   specialityId, institutionId, registration, qualification, description
+     *   specialityId, institutionId, registration, qualification, description, sex
      */
     @PUT
     @Path("/consultant/{id}")
@@ -4065,6 +4083,19 @@ public class ChannelApi {
         if (requestBody.containsKey("address")) {
             Object v = requestBody.get("address");
             person.setAddress(v != null ? v.toString() : null);
+        }
+        if (requestBody.containsKey("sex")) {
+            Object v = requestBody.get("sex");
+            if (v == null || v.toString().trim().isEmpty()) {
+                person.setSex(null);
+            } else {
+                Sex sex = parseSex(v);
+                if (sex == null) {
+                    return Response.status(Response.Status.BAD_REQUEST)
+                            .entity(errorResponse(400, "Invalid sex value: " + v).toString()).build();
+                }
+                person.setSex(sex);
+            }
         }
 
         if (requestBody.containsKey("code")) {
@@ -4149,6 +4180,109 @@ public class ChannelApi {
         response.put("detailMessage", "Consultant updated successfully");
 
         return Response.status(Response.Status.ACCEPTED).entity(response).build();
+    }
+
+    @GET
+    @Path("/consultant")
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response listConsultants(@Context HttpServletRequest requestContext) {
+        String key = requestContext.getHeader("Token");
+        if (!isValidKey(key)) {
+            return Response.status(Response.Status.UNAUTHORIZED)
+                    .entity(errorMessageNotValidKey().toString()).build();
+        }
+
+        String query = context.getQueryParameters().getFirst("query");
+        int page = Math.max(parseIntParam(context.getQueryParameters().getFirst("page"), 0), 0);
+        int size = parseIntParam(context.getQueryParameters().getFirst("size"), 20);
+        if (size < 1) {
+            size = 20;
+        }
+        if (size > 200) {
+            size = 200;
+        }
+
+        Long specialityId = null;
+        String specialityIdRaw = context.getQueryParameters().getFirst("specialityId");
+        if (specialityIdRaw != null && !specialityIdRaw.trim().isEmpty()) {
+            try {
+                specialityId = Long.valueOf(specialityIdRaw.trim());
+            } catch (NumberFormatException e) {
+                return Response.status(Response.Status.BAD_REQUEST)
+                        .entity(errorResponse(400, "Invalid specialityId value: " + specialityIdRaw).toString()).build();
+            }
+        }
+
+        long offsetLong = (long) page * size;
+        long endLong = offsetLong + size - 1L;
+        if (offsetLong > Integer.MAX_VALUE || endLong > Integer.MAX_VALUE) {
+            return Response.status(Response.Status.BAD_REQUEST)
+                    .entity(errorResponse(400, "page is too large").toString()).build();
+        }
+
+        String jpql = "select c from Consultant c where c.retired=false "
+                + " and c.person is not null ";
+        Map<String, Object> params = new HashMap<>();
+        if (query != null && !query.trim().isEmpty()) {
+            jpql += " and upper(c.person.name) like :q ";
+            params.put("q", "%" + query.trim().toUpperCase() + "%");
+        }
+        if (specialityId != null) {
+            jpql += " and c.speciality.id = :sid ";
+            params.put("sid", specialityId);
+        }
+        jpql += " order by c.person.name";
+
+        List<Consultant> consultants = consultantFacade.findByJpql(jpql, params, (int) offsetLong, (int) endLong);
+        List<Map<String, Object>> data = new ArrayList<>();
+        for (Consultant consultant : consultants) {
+            Map<String, Object> item = new HashMap<>();
+            item.put("id", consultant.getId());
+            item.put("name", consultant.getPerson() != null ? consultant.getPerson().getName() : null);
+            item.put("title", consultant.getPerson() != null && consultant.getPerson().getTitle() != null ? consultant.getPerson().getTitle().toString() : null);
+            item.put("sex", consultant.getPerson() != null && consultant.getPerson().getSex() != null ? consultant.getPerson().getSex().toString() : null);
+            item.put("specialityId", consultant.getSpeciality() != null ? consultant.getSpeciality().getId() : null);
+            item.put("speciality", consultant.getSpeciality() != null ? consultant.getSpeciality().getName() : null);
+            item.put("institutionId", consultant.getInstitution() != null ? consultant.getInstitution().getId() : null);
+            item.put("institution", consultant.getInstitution() != null ? consultant.getInstitution().getName() : null);
+            item.put("mobile", consultant.getPerson() != null ? consultant.getPerson().getMobile() : null);
+            data.add(item);
+        }
+
+        Map<String, Object> response = new HashMap<>();
+        response.put("code", "200");
+        response.put("message", "OK");
+        response.put("data", data);
+        return Response.ok(response).build();
+    }
+
+    private Sex parseSex(Object raw) {
+        if (raw == null) {
+            return null;
+        }
+        String sexString = raw.toString().trim();
+        if (sexString.isEmpty()) {
+            return null;
+        }
+        for (Sex sex : Sex.values()) {
+            if (sex.name().equalsIgnoreCase(sexString) || sex.getLabel().equalsIgnoreCase(sexString) || sex.getShortLabel().equalsIgnoreCase(sexString)) {
+                return sex;
+            }
+        }
+        return null;
+    }
+
+    private Consultant findActiveConsultantByNameAndTitle(String name, Title title) {
+        if (name == null || name.trim().isEmpty() || title == null) {
+            return null;
+        }
+        String jpql = "select c from Consultant c where c.retired=false and c.person is not null "
+                + " and upper(c.person.name)=:n and c.person.title=:t order by c.id";
+        Map<String, Object> params = new HashMap<>();
+        params.put("n", name.trim().toUpperCase());
+        params.put("t", title);
+        List<Consultant> existing = consultantFacade.findByJpql(jpql, params, 1);
+        return existing == null || existing.isEmpty() ? null : existing.get(0);
     }
 
 }

--- a/src/main/java/com/divudi/ws/channel/ChannelApi.java
+++ b/src/main/java/com/divudi/ws/channel/ChannelApi.java
@@ -21,6 +21,7 @@ import com.divudi.core.data.OnlineBookingStatus;
 import com.divudi.core.data.PaymentMethod;
 import com.divudi.core.data.PersonInstitutionType;
 import com.divudi.core.data.SessionStatusForOnlineBooking;
+import com.divudi.core.data.Sex;
 import com.divudi.core.data.Title;
 import com.divudi.ejb.BillNumberGenerator;
 import com.divudi.ejb.ChannelBean;
@@ -3916,6 +3917,26 @@ public class ChannelApi {
         if (requestBody.get("address") != null) {
             person.setAddress(requestBody.get("address").toString());
         }
+        if (requestBody.get("sex") != null) {
+            Object sexRaw = requestBody.get("sex");
+            if (sexRaw != null && !sexRaw.toString().trim().isEmpty()) {
+                Sex sex = parseSex(sexRaw);
+                if (sex == null) {
+                    return Response.status(Response.Status.BAD_REQUEST)
+                            .entity(errorResponse(400, "Invalid sex value: " + sexRaw).toString()).build();
+                }
+                person.setSex(sex);
+            }
+        }
+
+        Consultant existingConsultant = findActiveConsultantByNameAndTitle(name, person.getTitle());
+        if (existingConsultant != null) {
+            Map<String, Object> duplicateResponse = new HashMap<>();
+            duplicateResponse.put("status", "already_exists");
+            duplicateResponse.put("id", existingConsultant.getId());
+            duplicateResponse.put("name", existingConsultant.getPerson() != null ? existingConsultant.getPerson().getName() : name);
+            return Response.status(Response.Status.CONFLICT).entity(duplicateResponse).build();
+        }
 
         Consultant consultant = new Consultant();
         consultant.setPerson(person);
@@ -3999,7 +4020,7 @@ public class ChannelApi {
      *
      * Updatable fields (all optional — only supplied fields are changed):
      *   name, title, mobile, phone, fax, address, code, serialNo,
-     *   specialityId, institutionId, registration, qualification, description
+     *   specialityId, institutionId, registration, qualification, description, sex
      */
     @PUT
     @Path("/consultant/{id}")
@@ -4065,6 +4086,19 @@ public class ChannelApi {
         if (requestBody.containsKey("address")) {
             Object v = requestBody.get("address");
             person.setAddress(v != null ? v.toString() : null);
+        }
+        if (requestBody.containsKey("sex")) {
+            Object v = requestBody.get("sex");
+            if (v == null || v.toString().trim().isEmpty()) {
+                person.setSex(null);
+            } else {
+                Sex sex = parseSex(v);
+                if (sex == null) {
+                    return Response.status(Response.Status.BAD_REQUEST)
+                            .entity(errorResponse(400, "Invalid sex value: " + v).toString()).build();
+                }
+                person.setSex(sex);
+            }
         }
 
         if (requestBody.containsKey("code")) {
@@ -4149,6 +4183,120 @@ public class ChannelApi {
         response.put("detailMessage", "Consultant updated successfully");
 
         return Response.status(Response.Status.ACCEPTED).entity(response).build();
+    }
+
+    @GET
+    @Path("/consultant")
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response listConsultants(@Context HttpServletRequest requestContext) {
+        String key = requestContext.getHeader("Token");
+        if (!isValidKey(key)) {
+            return Response.status(Response.Status.UNAUTHORIZED)
+                    .entity(errorMessageNotValidKey().toString()).build();
+        }
+
+        String query = context.getQueryParameters().getFirst("query");
+        int page = Math.max(parseIntParam(context.getQueryParameters().getFirst("page"), 0), 0);
+        int size = parseIntParam(context.getQueryParameters().getFirst("size"), 20);
+        if (size < 1) {
+            size = 20;
+        }
+        if (size > 200) {
+            size = 200;
+        }
+
+        Long specialityId = null;
+        String specialityIdRaw = context.getQueryParameters().getFirst("specialityId");
+        if (specialityIdRaw != null && !specialityIdRaw.trim().isEmpty()) {
+            try {
+                specialityId = Long.valueOf(specialityIdRaw.trim());
+            } catch (NumberFormatException e) {
+                return Response.status(Response.Status.BAD_REQUEST)
+                        .entity(errorResponse(400, "Invalid specialityId value: " + specialityIdRaw).toString()).build();
+            }
+        }
+
+        long offsetLong = (long) page * size;
+        long toRecordLong = offsetLong + size;
+        if (offsetLong > Integer.MAX_VALUE || toRecordLong > Integer.MAX_VALUE) {
+            return Response.status(Response.Status.BAD_REQUEST)
+                    .entity(errorResponse(400, "page is too large").toString()).build();
+        }
+
+        String jpql = "select c from Consultant c where c.retired=false "
+                + " and c.person is not null ";
+        Map<String, Object> params = new HashMap<>();
+        if (query != null && !query.trim().isEmpty()) {
+            jpql += " and upper(c.person.name) like :q ";
+            params.put("q", "%" + query.trim().toUpperCase() + "%");
+        }
+        if (specialityId != null) {
+            jpql += " and c.speciality.id = :sid ";
+            params.put("sid", specialityId);
+        }
+        jpql += " order by c.person.name";
+
+        List<Consultant> consultants = consultantFacade.findByJpql(jpql, params, (int) offsetLong, (int) toRecordLong);
+        List<Map<String, Object>> data = new ArrayList<>();
+        for (Consultant consultant : consultants) {
+            Map<String, Object> item = new HashMap<>();
+            item.put("id", consultant.getId());
+            item.put("name", consultant.getPerson() != null ? consultant.getPerson().getName() : null);
+            item.put("title", consultant.getPerson() != null && consultant.getPerson().getTitle() != null ? consultant.getPerson().getTitle().toString() : null);
+            item.put("sex", consultant.getPerson() != null && consultant.getPerson().getSex() != null ? consultant.getPerson().getSex().toString() : null);
+            item.put("specialityId", consultant.getSpeciality() != null ? consultant.getSpeciality().getId() : null);
+            item.put("speciality", consultant.getSpeciality() != null ? consultant.getSpeciality().getName() : null);
+            item.put("institutionId", consultant.getInstitution() != null ? consultant.getInstitution().getId() : null);
+            item.put("institution", consultant.getInstitution() != null ? consultant.getInstitution().getName() : null);
+            item.put("mobile", consultant.getPerson() != null ? consultant.getPerson().getMobile() : null);
+            data.add(item);
+        }
+
+        Map<String, Object> response = new HashMap<>();
+        response.put("code", "200");
+        response.put("message", "OK");
+        response.put("data", data);
+        return Response.ok(response).build();
+    }
+
+
+    private int parseIntParam(String raw, int defaultValue) {
+        if (raw == null || raw.trim().isEmpty()) {
+            return defaultValue;
+        }
+        try {
+            return Integer.parseInt(raw.trim());
+        } catch (NumberFormatException e) {
+            return defaultValue;
+        }
+    }
+    private Sex parseSex(Object raw) {
+        if (raw == null) {
+            return null;
+        }
+        String sexString = raw.toString().trim();
+        if (sexString.isEmpty()) {
+            return null;
+        }
+        for (Sex sex : Sex.values()) {
+            if (sex.name().equalsIgnoreCase(sexString) || sex.getLabel().equalsIgnoreCase(sexString) || sex.getShortLabel().equalsIgnoreCase(sexString)) {
+                return sex;
+            }
+        }
+        return null;
+    }
+
+    private Consultant findActiveConsultantByNameAndTitle(String name, Title title) {
+        if (name == null || name.trim().isEmpty() || title == null) {
+            return null;
+        }
+        String jpql = "select c from Consultant c where c.retired=false and c.person is not null "
+                + " and upper(c.person.name)=:n and c.person.title=:t order by c.id";
+        Map<String, Object> params = new HashMap<>();
+        params.put("n", name.trim().toUpperCase());
+        params.put("t", title);
+        List<Consultant> existing = consultantFacade.findByJpql(jpql, params, 1);
+        return existing == null || existing.isEmpty() ? null : existing.get(0);
     }
 
 }

--- a/src/main/java/com/divudi/ws/channel/ChannelSpecialityApi.java
+++ b/src/main/java/com/divudi/ws/channel/ChannelSpecialityApi.java
@@ -144,7 +144,7 @@ public class ChannelSpecialityApi {
                     .entity(errorResponse(400, "name is required").toString()).build();
         }
 
-        String dupJpql = "select d from DoctorSpeciality d where d.retired = false and d.name = :n";
+        String dupJpql = "select d from DoctorSpeciality d where d.retired = false and upper(d.name) = upper(:n)";
         Map<String, Object> dupParams = new HashMap<>();
         dupParams.put("n", name);
         List<DoctorSpeciality> existing = doctorSpecialityFacade.findByJpql(dupJpql, dupParams);
@@ -214,7 +214,7 @@ public class ChannelSpecialityApi {
                 String newName = v.toString().trim();
                 if (!newName.equalsIgnoreCase(ds.getName())) {
                     String dupJpql = "select d from DoctorSpeciality d"
-                            + " where d.retired = false and d.id <> :id and d.name = :n";
+                            + " where d.retired = false and d.id <> :id and upper(d.name) = upper(:n)";
                     Map<String, Object> dupParams = new HashMap<>();
                     dupParams.put("id", id);
                     dupParams.put("n", newName);

--- a/src/main/java/com/divudi/ws/common/CapabilityStatementResource.java
+++ b/src/main/java/com/divudi/ws/common/CapabilityStatementResource.java
@@ -57,11 +57,13 @@ public class CapabilityStatementResource {
                         "API Key",
                         "GET", "POST"))
                 .add(resource("Consultant", "/api/channel/consultant",
-                        "Create a new consultant via POST. Update an existing consultant by ID via PUT /api/channel/consultant/{id}. "
-                        + "Required field for POST: name. Optional: title, mobile, phone, fax, address, code, serialNo, "
+                        "List consultants via GET (supports query, page, size, specialityId). "
+                        + "Create a new consultant via POST with duplicate detection (returns already_exists/409 when matched by name+title). "
+                        + "Update an existing consultant by ID via PUT /api/channel/consultant/{id}. "
+                        + "Required field for POST: name. Optional: title, sex, mobile, phone, fax, address, code, serialNo, "
                         + "specialityId, institutionId, registration, qualification, description.",
                         "API Key (Token header)",
-                        "POST", "PUT"))
+                        "GET", "POST", "PUT"))
                 .add(resource("Doctor Speciality", "/api/channel/speciality",
                         "CRUD for DoctorSpeciality records. "
                         + "GET lists active specialities (supports ?query=&page=&size=). "


### PR DESCRIPTION
### Motivation
- Ensure `POST /channel/consultant` treats blank `sex` values as omitted to match `PUT` behavior and avoid rejecting empty form submissions. 
- Prevent unbounded result sets for small page sizes by correcting pagination bounds so `size=1` does not disable `setMaxResults(...)`. 
- Resolve a missing utility for parsing integer query params and improve related API discovery/docs to reflect the new list endpoint and field behavior.

### Description
- Modified `ChannelApi` to only parse/validate `sex` on create when the incoming value is non-blank and to preserve the previous semantics where blank means “do not set”, and extended `PUT` to continue supporting clearing the field via blank/null. 
- Fixed pagination by changing the upper bound calculation from `offset + size - 1` to `offset + size` and updated the `consultantFacade.findByJpql(...)` call accordingly so the facade receives a proper `toRecord` value. 
- Added a private helper `parseIntParam(String raw, int defaultValue)` in `ChannelApi` and used it for `page`/`size` parsing to avoid compile failures and provide robust defaults. 
- Added a `GET /channel/consultant` listing implementation that supports `query`, `page`, `size`, and `specialityId`, and returns the consistent response envelope. 
- Updated `ChannelSpecialityApi` duplicate checks to use case-insensitive name comparisons by applying `upper(...)` in JPQL. 
- Updated API capability/docs: `CapabilityStatementResource`, `AnthropicApiService`, and `developer_docs/api/rest-api-development-guide.md` to reflect the consultant list endpoint, `sex` field, response codes, and small doc fixes (including base URL port adjustments).

### Testing
- No automated tests were executed in this rollout; please run `./detect-maven.sh test` or `mvn -DskipTests=false test` in CI to validate the Java build and unit/integration tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f46da5f3d8832f876fc9a2c9333e0c)