### PR TITLE
feat(pharmacy): native-SQL retail sale bypass EAGER cascade load (#20260)

### DIFF
--- a/src/main/java/com/divudi/bean/pharmacy/RetailSaleNativeSqlController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/RetailSaleNativeSqlController.java
@@ -1,0 +1,1021 @@
+/*
+ * Open Hospital Management Information System
+ * Dr M H B Ariyaratne
+ * buddhika.ari@gmail.com
+ */
+package com.divudi.bean.pharmacy;
+
+import com.divudi.bean.common.ConfigOptionApplicationController;
+import com.divudi.bean.common.ConfigOptionController;
+import com.divudi.bean.common.ControllerWithPatient;
+import com.divudi.service.DiscountSchemeValidationService;
+import com.divudi.bean.common.PatientDepositController;
+import com.divudi.bean.common.PriceMatrixController;
+import com.divudi.bean.common.SessionController;
+import com.divudi.core.data.BillType;
+import com.divudi.core.data.BillTypeAtomic;
+import com.divudi.core.data.BooleanMessage;
+import com.divudi.core.data.PaymentMethod;
+import com.divudi.core.data.dataStructure.PaymentMethodData;
+import com.divudi.core.data.dto.BillItemData;
+import com.divudi.core.data.dto.PrintBillData;
+import com.divudi.core.data.dto.StockDTO;
+import com.divudi.core.entity.Bill;
+import com.divudi.core.entity.BillItem;
+import com.divudi.core.entity.Department;
+import com.divudi.core.entity.Institution;
+import com.divudi.core.entity.Item;
+import com.divudi.core.entity.Patient;
+import com.divudi.core.entity.PaymentScheme;
+import com.divudi.core.entity.PriceMatrix;
+import com.divudi.core.entity.Staff;
+import com.divudi.core.entity.clinical.Prescription;
+import com.divudi.core.entity.pharmacy.PharmaceuticalBillItem;
+import com.divudi.core.facade.ItemBatchFacade;
+import com.divudi.core.facade.ItemFacade;
+import com.divudi.core.facade.PatientFacade;
+import com.divudi.core.facade.PersonFacade;
+import com.divudi.core.facade.StockFacade;
+import com.divudi.core.util.CommonFunctions;
+import com.divudi.core.util.JsfUtil;
+import com.divudi.ejb.BillNumberGenerator;
+import com.divudi.ejb.PharmacyService;
+import com.divudi.service.pharmacy.RetailSaleNativeSqlService;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Calendar;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import javax.annotation.PostConstruct;
+import javax.ejb.EJB;
+import javax.enterprise.context.SessionScoped;
+import javax.faces.component.UIComponent;
+import javax.faces.context.FacesContext;
+import javax.faces.convert.Converter;
+import javax.inject.Inject;
+import javax.inject.Named;
+import javax.persistence.TemporalType;
+import org.primefaces.event.RowEditEvent;
+import org.primefaces.event.SelectEvent;
+
+/**
+ * Controller for the native-SQL pharmacy retail sale page.
+ *
+ * The settle path uses RetailSaleNativeSqlService (native SQL inserts), avoiding
+ * the EAGER cascade load (Stock → ItemBatch → Item) that is the dominant cold-start
+ * cost in the original PharmacySaleController settle path.
+ *
+ * Patterned on InpatientDirectIssueNativeSqlController (issue #20214).
+ * Issue: #20260
+ */
+@Named
+@SessionScoped
+public class RetailSaleNativeSqlController implements Serializable, ControllerWithPatient {
+
+    private static final Logger LOGGER = Logger.getLogger(RetailSaleNativeSqlController.class.getName());
+
+    // ---- CDI ----
+    @Inject
+    private SessionController sessionController;
+    @Inject
+    private ConfigOptionApplicationController configOptionApplicationController;
+    @Inject
+    private ConfigOptionController configOptionController;
+    @Inject
+    private PriceMatrixController priceMatrixController;
+    @Inject
+    private PatientDepositController patientDepositController;
+
+    // ---- EJB ----
+    @EJB
+    private StockFacade stockFacade;
+    @EJB
+    private ItemFacade itemFacade;
+    @EJB
+    private ItemBatchFacade itemBatchFacade;
+    @EJB
+    private BillNumberGenerator billNumberGenerator;
+    @EJB
+    private PharmacyService pharmacyService;
+    @EJB
+    private RetailSaleNativeSqlService nativeSqlService;
+    @EJB
+    private DiscountSchemeValidationService discountSchemeValidationService;
+    @EJB
+    private PatientFacade patientFacade;
+    @EJB
+    private PersonFacade personFacade;
+
+    // ---- Working state ----
+    private Patient patient;
+    private Bill preBill;
+    private PrintBillData printBill;
+    private List<BillItemData> printBillItems;
+    private BillItem billItem;
+    private Integer intQty;
+    private StockDTO stockDto;
+    private Long selectedStockId;
+    private List<StockDTO> lastAutocompleteResults;
+    private List<BillItemData> billItemDataList;
+    private boolean billPreview = false;
+    private boolean billSettlingStarted = false;
+    private boolean patientDetailsEditable = false;
+    private String comment = "";
+    private double cashPaid;
+    private double balance;
+    private PaymentMethod paymentMethod;
+    private PaymentScheme paymentScheme;
+    private PaymentMethodData paymentMethodData;
+    private Staff toStaff;
+    private Institution toInstitution;
+
+    @PostConstruct
+    public void init() {
+        resetAll();
+    }
+
+    // -----------------------------------------------------------------------
+    // Navigation
+    // -----------------------------------------------------------------------
+
+    public String pharmacyRetailSaleNative() {
+        resetAll();
+        billSettlingStarted = false;
+        return "/pharmacy/pharmacy_bill_retail_sale_native?faces-redirect=true";
+    }
+
+    // -----------------------------------------------------------------------
+    // Settle
+    // -----------------------------------------------------------------------
+
+    public String settleBillWithPay() {
+        if (billSettlingStarted) {
+            return null;
+        }
+        billSettlingStarted = true;
+
+        if (sessionController.getApplicationPreference().isCheckPaymentSchemeValidation()) {
+            if (paymentScheme == null) {
+                billSettlingStarted = false;
+                JsfUtil.addErrorMessage("Please select Payment Scheme");
+                return null;
+            }
+        }
+
+        if (paymentMethod == null) {
+            billSettlingStarted = false;
+            JsfUtil.addErrorMessage("Please select Payment Method");
+            return null;
+        }
+
+        if (billItemDataList == null || billItemDataList.isEmpty()) {
+            billSettlingStarted = false;
+            JsfUtil.addErrorMessage("Please add items to the bill.");
+            return null;
+        }
+
+        if ((getPatient().getMobileNumberStringTransient() == null
+                || getPatient().getMobileNumberStringTransient().trim().isEmpty()
+                || getPatient().getPerson().getName().trim().isEmpty())
+                && configOptionApplicationController.getBooleanValueByKey("Patient details are required for retail sale")) {
+            billSettlingStarted = false;
+            JsfUtil.addErrorMessage("Please enter patient name and mobile number.");
+            return null;
+        }
+
+        if (paymentMethod == PaymentMethod.Card) {
+            String cardNumber = getPaymentMethodData().getCreditCard().getNo();
+            if ((cardNumber == null || cardNumber.trim().isEmpty() || cardNumber.trim().length() != 4)
+                    && configOptionApplicationController.getBooleanValueByKey("Pharmacy retail sale CreditCard last digits is Mandatory")) {
+                billSettlingStarted = false;
+                JsfUtil.addErrorMessage("Please enter a Credit Card last 4 digits");
+                return null;
+            }
+        }
+
+        if (paymentMethod == PaymentMethod.Staff_Welfare
+                && configOptionApplicationController.getBooleanValueByKey(
+                        "Pharmacy discount should be staff when select Staff_welfare as payment method", false)) {
+            if (paymentScheme == null || !paymentScheme.getName().equalsIgnoreCase("staff")) {
+                billSettlingStarted = false;
+                JsfUtil.addErrorMessage("Staff Welfare needs to set staff discount scheme.");
+                return null;
+            }
+        }
+
+        BooleanMessage discountValidation = discountSchemeValidationService.validateDiscountScheme(
+                paymentMethod, paymentScheme, getPaymentMethodData());
+        if (!discountValidation.isFlag()) {
+            billSettlingStarted = false;
+            JsfUtil.addErrorMessage(discountValidation.getMessage());
+            return null;
+        }
+
+        boolean patientRequired = configOptionApplicationController.getBooleanValueByKey(
+                "Patient is required in Pharmacy Retail Sale Bill for "
+                + sessionController.getDepartment().getName(), false);
+        if (patientRequired) {
+            if (getPatient() == null || getPatient().getPerson() == null
+                    || getPatient().getPerson().getName() == null
+                    || getPatient().getPerson().getName().trim().isEmpty()) {
+                billSettlingStarted = false;
+                JsfUtil.addErrorMessage("Please Select a Patient");
+                return null;
+            }
+        }
+
+        if (configOptionApplicationController.getBooleanValueByKey(
+                "Enable blacklist patient management in the system", false)
+                && configOptionApplicationController.getBooleanValueByKey(
+                        "Enable blacklist patient management for Pharmacy from the system", false)) {
+            if (getPatient().isBlacklisted()) {
+                billSettlingStarted = false;
+                JsfUtil.addErrorMessage("This patient is blacklisted from the system. Can't Bill.");
+                return null;
+            }
+        }
+
+        if (configOptionApplicationController.getBooleanValueByKey(
+                "Need Patient Title And Gender To Save Patient in Pharmacy Sale", false)) {
+            if (getPatient().getPerson().getTitle() == null) {
+                billSettlingStarted = false;
+                JsfUtil.addErrorMessage("Please select title.");
+                return null;
+            }
+            if (getPatient().getPerson().getSex() == null) {
+                billSettlingStarted = false;
+                JsfUtil.addErrorMessage("Please select gender.");
+                return null;
+            }
+        }
+
+        if (configOptionApplicationController.getBooleanValueByKey(
+                "Need Patient Name to save Patient in Pharmacy Sale", false)) {
+            if (getPatient().getPerson().getName() == null
+                    || getPatient().getPerson().getName().trim().isEmpty()) {
+                billSettlingStarted = false;
+                JsfUtil.addErrorMessage("Please enter name.");
+                return null;
+            }
+        }
+
+        if (configOptionApplicationController.getBooleanValueByKey(
+                "Need Patient Age to Save Patient in Pharmacy Sale", false)) {
+            if (getPatient().getPerson().getDob() == null) {
+                billSettlingStarted = false;
+                JsfUtil.addErrorMessage("Please enter patient date of birth.");
+                return null;
+            }
+        }
+
+        if (configOptionApplicationController.getBooleanValueByKey(
+                "Need Patient Phone Number to save Patient in Pharmacy Sale", false)) {
+            if (getPatient().getPerson().getPhone() == null
+                    || getPatient().getPerson().getPhone().trim().isEmpty()) {
+                billSettlingStarted = false;
+                JsfUtil.addErrorMessage("Please enter phone number.");
+                return null;
+            }
+        }
+
+        if (configOptionApplicationController.getBooleanValueByKey(
+                "Need Patient Address to save Patient in Pharmacy Sale", false)) {
+            if (getPatient().getPerson().getAddress() == null
+                    || getPatient().getPerson().getAddress().trim().isEmpty()) {
+                billSettlingStarted = false;
+                JsfUtil.addErrorMessage("Please enter patient address.");
+                return null;
+            }
+        }
+
+        if (configOptionApplicationController.getBooleanValueByKey(
+                "Need Patient Mail to save Patient in Pharmacy Sale", false)) {
+            if (getPatient().getPerson().getEmail() == null
+                    || getPatient().getPerson().getEmail().trim().isEmpty()) {
+                billSettlingStarted = false;
+                JsfUtil.addErrorMessage("Please enter patient email.");
+                return null;
+            }
+        }
+
+        if (configOptionApplicationController.getBooleanValueByKey(
+                "Need Patient NIC to save Patient in Pharmacy Sale", false)) {
+            if (getPatient().getPerson().getNic() == null
+                    || getPatient().getPerson().getNic().trim().isEmpty()) {
+                billSettlingStarted = false;
+                JsfUtil.addErrorMessage("Please enter patient NIC.");
+                return null;
+            }
+        }
+
+        if (configOptionApplicationController.getBooleanValueByKey(
+                "Need Patient Area to save Patient in Pharmacy Sale", false)) {
+            if (getPatient().getPerson().getArea() == null
+                    || getPatient().getPerson().getArea().getName() == null
+                    || getPatient().getPerson().getArea().getName().trim().isEmpty()) {
+                billSettlingStarted = false;
+                JsfUtil.addErrorMessage("Please select patient area.");
+                return null;
+            }
+        }
+
+        if (configOptionApplicationController.getBooleanValueByKey(
+                "Need Referring Doctor to settlle bill in Pharmacy Sale", false)) {
+            if (getPreBill().getReferredBy() == null) {
+                billSettlingStarted = false;
+                JsfUtil.addErrorMessage("Please select referring doctor.");
+                return null;
+            }
+        }
+
+        // Save or update the patient record
+        savePatientIfNeeded();
+
+        // Build bill header
+        Bill bill = buildBillHeader();
+
+        // Stamp dept/institution IDs on each item (needed by native service for StockHistory aggregates)
+        long deptId = sessionController.getLoggedUser().getDepartment().getId();
+        long instId = sessionController.getLoggedUser().getDepartment().getInstitution().getId();
+        for (BillItemData bid : billItemDataList) {
+            bid.setDepartmentId(deptId);
+            bid.setInstitutionId(instId);
+        }
+
+        try {
+            nativeSqlService.settle(bill, billItemDataList, paymentMethod, getPaymentMethodData(), paymentScheme);
+
+            buildPrintBill(bill);
+            clearBill();
+            clearBillItem();
+            billPreview = true;
+            billSettlingStarted = false;
+            JsfUtil.addSuccessMessage("Bill settled successfully.");
+        } catch (RuntimeException e) {
+            LOGGER.log(Level.SEVERE, "Native retail sale settle failed", e);
+            billSettlingStarted = false;
+            JsfUtil.addErrorMessage("Failed to settle bill: " + e.getMessage());
+        }
+        return null;
+    }
+
+    private void savePatientIfNeeded() {
+        try {
+            if (patient == null) {
+                return;
+            }
+            if (patient.getPerson() != null) {
+                patient.setMobileNumberStringTransient(patient.getMobileNumberStringTransient());
+                patient.setPhoneNumberStringTransient(patient.getPhoneNumberStringTransient());
+            }
+            if (patient.getId() == null) {
+                if (patient.getPerson() != null) {
+                    personFacade.create(patient.getPerson());
+                }
+                patientFacade.create(patient);
+            } else {
+                if (patient.getPerson() != null) {
+                    personFacade.edit(patient.getPerson());
+                }
+                patientFacade.edit(patient);
+            }
+        } catch (Exception e) {
+            LOGGER.log(Level.WARNING, "Could not save patient", e);
+        }
+    }
+
+    private Bill buildBillHeader() {
+        Bill b = preBill != null ? preBill : new Bill();
+
+        b.setBillType(BillType.PharmacySale);
+        b.setBillTypeAtomic(BillTypeAtomic.PHARMACY_RETAIL_SALE);
+
+        String billNo = generateBillNumber();
+        b.setInsId(billNo);
+        b.setDeptId(billNo);
+
+        b.setDepartment(sessionController.getLoggedUser().getDepartment());
+        b.setInstitution(sessionController.getLoggedUser().getDepartment().getInstitution());
+        b.setPatient(patient);
+        b.setFromDepartment(sessionController.getLoggedUser().getDepartment());
+        b.setFromInstitution(sessionController.getLoggedUser().getDepartment().getInstitution());
+        b.setBillDate(new Date());
+        b.setBillTime(new Date());
+        b.setCreatedAt(Calendar.getInstance().getTime());
+        b.setCreater(sessionController.getLoggedUser());
+        b.setComments(comment);
+        b.setCashPaid(cashPaid);
+        b.setPaymentMethod(paymentMethod);
+        b.setPaymentScheme(paymentScheme);
+
+        if (paymentMethod == PaymentMethod.Credit && getPaymentMethodData().getCredit().getInstitution() != null) {
+            b.setToInstitution(getPaymentMethodData().getCredit().getInstitution());
+            b.setCreditCompany(getPaymentMethodData().getCredit().getInstitution());
+        }
+        if ((paymentMethod == PaymentMethod.Staff || paymentMethod == PaymentMethod.Staff_Welfare)
+                && toStaff != null) {
+            b.setToStaff(toStaff);
+        }
+
+        if (getPreBill().getReferredBy() != null) {
+            b.setReferredBy(getPreBill().getReferredBy());
+        }
+
+        double netTot = 0.0;
+        for (BillItemData bid : billItemDataList) {
+            netTot += Math.abs(bid.getNetValue());
+        }
+        b.setTotal(netTot);
+        b.setNetTotal(netTot);
+        b.setGrantTotal(netTot);
+        b.setBalance(paymentMethod == PaymentMethod.Credit ? netTot : 0.0);
+        b.setPaidAmount(paymentMethod == PaymentMethod.Credit ? 0.0 : netTot);
+
+        return b;
+    }
+
+    private String generateBillNumber() {
+        if (configOptionApplicationController.getBooleanValueByKey(
+                "Bill Number Generation Strategy for Pharmacy Sale Pre Bill - Prefix + Department Code + Institution Code + Year + Yearly Number", false)) {
+            return billNumberGenerator.departmentBillNumberGeneratorYearlyWithPrefixDeptInsYearCount(
+                    sessionController.getDepartment(), BillTypeAtomic.PHARMACY_RETAIL_SALE);
+        } else if (configOptionApplicationController.getBooleanValueByKey(
+                "Bill Number Generation Strategy for Pharmacy Sale Pre Bill - Prefix + Institution Code + Department Code + Year + Yearly Number", false)) {
+            return billNumberGenerator.departmentBillNumberGeneratorYearlyWithPrefixInsDeptYearCount(
+                    sessionController.getDepartment(), BillTypeAtomic.PHARMACY_RETAIL_SALE);
+        } else if (configOptionApplicationController.getBooleanValueByKey(
+                "Bill Number Generation Strategy for Pharmacy Sale Pre Bill - Prefix + Institution Code + Year + Yearly Number", false)) {
+            return billNumberGenerator.institutionBillNumberGeneratorYearlyWithPrefixInsYearCount(
+                    sessionController.getDepartment(), BillTypeAtomic.PHARMACY_RETAIL_SALE);
+        }
+        return billNumberGenerator.departmentBillNumberGeneratorYearly(
+                sessionController.getDepartment(), BillTypeAtomic.PHARMACY_RETAIL_SALE);
+    }
+
+    private void buildPrintBill(Bill bill) {
+        PrintBillData pbd = new PrintBillData();
+        Department dept = sessionController.getLoggedUser().getDepartment();
+        pbd.setDepartmentName(dept.getName());
+        pbd.setDepartmentPrintingName(dept.getPrintingName() != null ? dept.getPrintingName() : dept.getName());
+        pbd.setDepartmentTelephone1(dept.getTelephone1());
+        if (dept.getInstitution() != null) {
+            pbd.setInstitutionName(dept.getInstitution().getName());
+            pbd.setInstitutionAddress(dept.getInstitution().getAddress());
+        }
+        if (patient != null && patient.getPerson() != null) {
+            pbd.setPatientName(patient.getPerson().getNameWithTitle());
+        }
+        pbd.setBillNo(bill.getDeptId());
+        pbd.setCreatedAt(bill.getCreatedAt());
+        pbd.setPaymentMethodLabel(paymentMethod != null ? paymentMethod.name() : "");
+        pbd.setComment(comment);
+        double tot = 0.0;
+        for (BillItemData bid : billItemDataList) {
+            tot += Math.abs(bid.getNetValue());
+        }
+        pbd.setNetTotal(tot);
+        pbd.setCashPaid(cashPaid);
+        pbd.setBalance(cashPaid - tot);
+
+        printBill = pbd;
+
+        List<BillItemData> printCopy = new ArrayList<>();
+        for (BillItemData src : billItemDataList) {
+            BillItemData p = new BillItemData();
+            p.setItemId(src.getItemId());
+            p.setItemName(src.getItemName());
+            p.setQty(Math.abs(src.getQty()));
+            p.setRate(src.getRate());
+            p.setNetRate(src.getNetRate());
+            p.setNetValue(Math.abs(src.getNetValue()));
+            p.setGrossValue(Math.abs(src.getGrossValue()));
+            p.setDoe(src.getDoe());
+            printCopy.add(p);
+        }
+        printBillItems = printCopy;
+    }
+
+    // -----------------------------------------------------------------------
+    // Add item
+    // -----------------------------------------------------------------------
+
+    public void addBillItem() {
+        if (stockDto == null || selectedStockId == null || stockDto.getItemId() == null) {
+            JsfUtil.addErrorMessage("No stock selected.");
+            return;
+        }
+        if (intQty == null || intQty <= 0) {
+            JsfUtil.addErrorMessage("Please enter a quantity.");
+            return;
+        }
+        if (stockDto.getDateOfExpire() != null
+                && stockDto.getDateOfExpire().before(CommonFunctions.getCurrentDateTime())) {
+            JsfUtil.addErrorMessage("You are not allowed to select expired items.");
+            return;
+        }
+        if (stockDto.getStockQty() != null && intQty > stockDto.getStockQty()) {
+            JsfUtil.addErrorMessage("No sufficient stock available.");
+            return;
+        }
+
+        double qty = intQty.doubleValue();
+
+        double[] batchRates = fetchBatchRates(stockDto.getItemBatchId());
+        double batchRetailRate    = batchRates[0];
+        double batchPurchaseRate  = batchRates[1];
+        double batchWholesaleRate = batchRates[2];
+        Double batchCostRate      = batchRates[3] > 0 ? batchRates[3] : null;
+
+        long ampItemId = resolveAmpItemId(stockDto.getItemId());
+
+        BillItemData bid = new BillItemData();
+        bid.setItemId(stockDto.getItemId());
+        bid.setItemName(stockDto.getItemName());
+        bid.setAmpItemId(ampItemId);
+        bid.setStockId(selectedStockId);
+        bid.setItemBatchId(stockDto.getItemBatchId());
+        bid.setQty(qty);
+        bid.setPbiQty(-Math.abs(qty));
+        bid.setFreeQty(0.0);
+        bid.setRetailRate(stockDto.getRetailRate() != null ? stockDto.getRetailRate() : 0.0);
+        bid.setPurchaseRate(batchPurchaseRate);
+        bid.setWholesaleRate(batchWholesaleRate);
+        bid.setCostRate(batchCostRate != null ? batchCostRate : batchPurchaseRate);
+        bid.setBatchRetailRate(batchRetailRate);
+        bid.setBatchPurchaseRate(batchPurchaseRate);
+        bid.setBatchWholesaleRate(batchWholesaleRate);
+        bid.setBatchCostRate(batchCostRate);
+        bid.setDoe(stockDto.getDateOfExpire());
+        bid.setDescription(stockDto.getItemName());
+        bid.setCreatedAt(new Date());
+        bid.setCreaterId(sessionController.getLoggedUser().getId());
+
+        double lineRetailRate = stockDto.getRetailRate() != null ? stockDto.getRetailRate() : 0.0;
+        double grossValue = lineRetailRate * qty;
+        double discountPct = 0.0;
+        double discountValue = 0.0;
+        try {
+            Item itemRef = itemFacade.find(stockDto.getItemId());
+            if (Boolean.TRUE.equals(itemRef.isDiscountAllowed())) {
+                Double pct = priceMatrixController.getPaymentSchemeDiscountPercent(
+                        paymentMethod, paymentScheme, sessionController.getDepartment(), itemRef);
+                discountPct = pct != null ? pct : 0.0;
+                discountValue = (discountPct / 100.0) * grossValue;
+            }
+        } catch (Exception e) {
+            LOGGER.log(Level.WARNING, "Discount lookup failed for item {0}: {1}",
+                    new Object[]{stockDto.getItemId(), e.getMessage()});
+        }
+        double netValue = grossValue - discountValue;
+        double netRate = qty > 0 ? netValue / qty : lineRetailRate;
+
+        bid.setRate(lineRetailRate);
+        bid.setNetRate(netRate);
+        bid.setDiscountPercent(discountPct);
+        bid.setDiscountValue(discountValue);
+        bid.setMarginValue(0.0);
+        bid.setNetValue(-netValue);
+        bid.setGrossValue(-grossValue);
+
+        if (billItemDataList == null) {
+            billItemDataList = new ArrayList<>();
+        }
+        billItemDataList.add(bid);
+
+        calTotal();
+        clearBillItem();
+    }
+
+    private double[] fetchBatchRates(Long itemBatchId) {
+        if (itemBatchId == null) {
+            return new double[]{0, 0, 0, 0};
+        }
+        Map<String, Object> params = new HashMap<>();
+        params.put("id", itemBatchId);
+        String jpql = "SELECT ib.retailsaleRate, ib.purcahseRate, ib.wholesaleRate, COALESCE(ib.costRate, 0) "
+                + "FROM ItemBatch ib WHERE ib.id = :id";
+        try {
+            Object[] row = (Object[]) itemBatchFacade.findLightsByJpql(jpql, params, TemporalType.DATE, 1)
+                    .stream().findFirst().orElse(null);
+            if (row == null) return new double[]{0, 0, 0, 0};
+            return new double[]{toDouble(row[0]), toDouble(row[1]), toDouble(row[2]), toDouble(row[3])};
+        } catch (Exception e) {
+            LOGGER.log(Level.WARNING, "Could not fetch batch rates for itemBatchId={0}", itemBatchId);
+            return new double[]{0, 0, 0, 0};
+        }
+    }
+
+    private long resolveAmpItemId(Long itemId) {
+        if (itemId == null) return 0L;
+        try {
+            Map<String, Object> params = new HashMap<>();
+            params.put("id", itemId);
+            List<?> result = itemFacade.findLightsByJpql(
+                    "SELECT i.amp.id FROM Item i WHERE i.id = :id AND TYPE(i) = Ampp",
+                    params, TemporalType.DATE, 1);
+            if (result != null && !result.isEmpty() && result.get(0) != null) {
+                return ((Number) result.get(0)).longValue();
+            }
+            return itemId;
+        } catch (Exception e) {
+            LOGGER.log(Level.WARNING, "Could not resolve AMP for itemId={0}", itemId);
+            return itemId;
+        }
+    }
+
+    private static double toDouble(Object o) {
+        return o == null ? 0.0 : ((Number) o).doubleValue();
+    }
+
+    // -----------------------------------------------------------------------
+    // Edit row
+    // -----------------------------------------------------------------------
+
+    public void onEdit(RowEditEvent<BillItemData> event) {
+        BillItemData bid = event.getObject();
+        if (bid.getQty() <= 0) {
+            bid.setQty(0);
+            JsfUtil.addErrorMessage("Quantity must be greater than zero.");
+            return;
+        }
+        double absQty = Math.abs(bid.getQty());
+        double gross = absQty * bid.getRate();
+        double discountVal = (bid.getDiscountPercent() / 100.0) * gross;
+        double netVal = gross - discountVal;
+        bid.setGrossValue(-gross);
+        bid.setDiscountValue(discountVal);
+        bid.setNetValue(-netVal);
+        bid.setNetRate(absQty > 0 ? netVal / absQty : bid.getRate());
+        bid.setPbiQty(-absQty);
+        calTotal();
+    }
+
+    public void onEditCancel(RowEditEvent<BillItemData> event) {
+        calTotal();
+    }
+
+    public void removeBillItem(BillItemData bid) {
+        if (billItemDataList != null) {
+            billItemDataList.remove(bid);
+        }
+        calTotal();
+    }
+
+    // -----------------------------------------------------------------------
+    // Autocomplete
+    // -----------------------------------------------------------------------
+
+    public List<StockDTO> completeAvailableStockOptimizedDto(String qry) {
+        if (qry == null || qry.trim().isEmpty()) {
+            lastAutocompleteResults = new ArrayList<>();
+            return lastAutocompleteResults;
+        }
+        qry = qry.replaceAll("[\\n\\r]", "").trim();
+
+        Map<String, Object> parameters = new HashMap<>();
+        parameters.put("department", sessionController.getLoggedUser().getDepartment());
+        parameters.put("stockMin", 0.0);
+        parameters.put("query", "%" + qry + "%");
+
+        boolean searchByItemCode = configOptionApplicationController.getBooleanValueByKey(
+                "Enable search medicines by item code", true);
+        boolean searchByBarcode = qry.length() > 6
+                ? configOptionApplicationController.getBooleanValueByKey("Enable search medicines by barcode", true)
+                : configOptionApplicationController.getBooleanValueByKey("Enable search medicines by barcode", false);
+        boolean searchByGeneric = configOptionApplicationController.getBooleanValueByKey(
+                "Enable search medicines by generic name(VMP)", false);
+
+        StringBuilder sql = new StringBuilder(
+                "SELECT NEW com.divudi.core.data.dto.StockDTO("
+                + "i.id, i.itemBatch.id, i.itemBatch.item.id, i.itemBatch.item.name, i.itemBatch.item.code, "
+                + "i.itemBatch.item.name, i.itemBatch.retailsaleRate, i.stock, i.itemBatch.dateOfExpire) "
+                + "FROM Stock i "
+                + "WHERE i.stock > :stockMin "
+                + "AND i.department = :department "
+                + "AND (i.itemBatch.item.name LIKE :query ");
+
+        if (searchByItemCode) {
+            sql.append("OR i.itemBatch.item.code LIKE :query ");
+        }
+        if (searchByBarcode) {
+            sql.append("OR i.itemBatch.item.barcode = :query ");
+        }
+        if (searchByGeneric) {
+            sql.append("OR i.itemBatch.item.vmp.vtm.name LIKE :query ");
+        }
+        sql.append(") ORDER BY i.itemBatch.item.name, i.itemBatch.dateOfExpire");
+
+        lastAutocompleteResults = (List<StockDTO>) stockFacade.findLightsByJpql(
+                sql.toString(), parameters, TemporalType.TIMESTAMP, 20);
+        return lastAutocompleteResults != null ? lastAutocompleteResults : new ArrayList<>();
+    }
+
+    public void handleSelect(SelectEvent<StockDTO> event) {
+        StockDTO selected = event.getObject();
+        this.stockDto = selected;
+        this.selectedStockId = selected != null ? selected.getId() : null;
+        if (billItem == null) getBillItem();
+        billItem.setNetRate(selected != null && selected.getRetailRate() != null ? selected.getRetailRate() : 0.0);
+    }
+
+    // -----------------------------------------------------------------------
+    // Totals
+    // -----------------------------------------------------------------------
+
+    public void calTotal() {
+        double netTot = 0.0;
+        double grossTot = 0.0;
+        double discountTot = 0.0;
+        if (billItemDataList != null) {
+            for (BillItemData bid : billItemDataList) {
+                netTot += Math.abs(bid.getNetValue());
+                grossTot += Math.abs(bid.getGrossValue());
+                discountTot += bid.getDiscountValue();
+            }
+        }
+        getPreBill().setNetTotal(netTot);
+        getPreBill().setTotal(grossTot);
+        getPreBill().setGrantTotal(grossTot);
+        getPreBill().setDiscount(discountTot);
+        balance = cashPaid - netTot;
+    }
+
+    public void listnerForPaymentMethodChange() {
+        calTotal();
+    }
+
+    public void calculateDobFromAge() {
+        // Called from age year/month/day keyup events to recalculate DOB
+        if (patient != null && patient.getPerson() != null) {
+            patient.getPerson().calDobFromAge();
+        }
+    }
+
+    public void calculateBillItemListner() {
+        if (stockDto != null && intQty != null) {
+            double rate = stockDto.getRetailRate() != null ? stockDto.getRetailRate() : 0.0;
+            getBillItem().setRate(rate);
+            getBillItem().setNetRate(rate);
+            getBillItem().setNetValue(rate * intQty);
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Reset / clear
+    // -----------------------------------------------------------------------
+
+    public void resetAll() {
+        patient = null;
+        preBill = null;
+        printBill = null;
+        printBillItems = null;
+        billItem = null;
+        intQty = null;
+        stockDto = null;
+        selectedStockId = null;
+        lastAutocompleteResults = null;
+        billItemDataList = null;
+        billPreview = false;
+        billSettlingStarted = false;
+        patientDetailsEditable = false;
+        comment = "";
+        cashPaid = 0.0;
+        balance = 0.0;
+        paymentMethod = null;
+        paymentScheme = null;
+        paymentMethodData = null;
+        toStaff = null;
+        toInstitution = null;
+    }
+
+    private void clearBill() {
+        preBill = null;
+        billItemDataList = null;
+    }
+
+    private void clearBillItem() {
+        billItem = null;
+        intQty = null;
+        stockDto = null;
+        selectedStockId = null;
+        lastAutocompleteResults = null;
+    }
+
+    // -----------------------------------------------------------------------
+    // Getters / Setters
+    // -----------------------------------------------------------------------
+
+    public Patient getPatient() {
+        if (patient == null) {
+            patient = new Patient();
+        }
+        return patient;
+    }
+
+    public void setPatient(Patient patient) {
+        this.patient = patient;
+    }
+
+    public Bill getPreBill() {
+        if (preBill == null) {
+            preBill = new Bill();
+        }
+        return preBill;
+    }
+
+    public void setPreBill(Bill preBill) {
+        this.preBill = preBill;
+    }
+
+    public PrintBillData getPrintBill() {
+        return printBill;
+    }
+
+    public List<BillItemData> getPrintBillItems() {
+        return printBillItems;
+    }
+
+    public BillItem getBillItem() {
+        if (billItem == null) {
+            billItem = new BillItem();
+            PharmaceuticalBillItem pbi = new PharmaceuticalBillItem();
+            pbi.setBillItem(billItem);
+            billItem.setPharmaceuticalBillItem(pbi);
+        }
+        return billItem;
+    }
+
+    public void setBillItem(BillItem billItem) {
+        this.billItem = billItem;
+    }
+
+    public Integer getIntQty() {
+        return intQty;
+    }
+
+    public void setIntQty(Integer intQty) {
+        this.intQty = intQty;
+    }
+
+    public StockDTO getStockDto() {
+        return stockDto;
+    }
+
+    public void setStockDto(StockDTO stockDto) {
+        this.stockDto = stockDto;
+        this.selectedStockId = stockDto != null ? stockDto.getId() : null;
+    }
+
+    public List<BillItemData> getBillItemDataList() {
+        if (billItemDataList == null) {
+            billItemDataList = new ArrayList<>();
+        }
+        return billItemDataList;
+    }
+
+    public void setBillItemDataList(List<BillItemData> billItemDataList) {
+        this.billItemDataList = billItemDataList;
+    }
+
+    public boolean isBillPreview() {
+        return billPreview;
+    }
+
+    public void setBillPreview(boolean billPreview) {
+        this.billPreview = billPreview;
+    }
+
+    public boolean isBillSettlingStarted() {
+        return billSettlingStarted;
+    }
+
+    public boolean isPatientDetailsEditable() {
+        return patientDetailsEditable;
+    }
+
+    public void setPatientDetailsEditable(boolean patientDetailsEditable) {
+        this.patientDetailsEditable = patientDetailsEditable;
+    }
+
+    public void toggalePatientEditable() {
+        patientDetailsEditable = !patientDetailsEditable;
+    }
+
+    public String getComment() {
+        return comment;
+    }
+
+    public void setComment(String comment) {
+        this.comment = comment;
+    }
+
+    public double getCashPaid() {
+        return cashPaid;
+    }
+
+    public void setCashPaid(double cashPaid) {
+        this.cashPaid = cashPaid;
+        calTotal();
+    }
+
+    public double getBalance() {
+        return balance;
+    }
+
+    public PaymentMethod getPaymentMethod() {
+        return paymentMethod;
+    }
+
+    public void setPaymentMethod(PaymentMethod paymentMethod) {
+        this.paymentMethod = paymentMethod;
+    }
+
+    public PaymentScheme getPaymentScheme() {
+        return paymentScheme;
+    }
+
+    public void setPaymentScheme(PaymentScheme paymentScheme) {
+        this.paymentScheme = paymentScheme;
+    }
+
+    public PaymentMethodData getPaymentMethodData() {
+        if (paymentMethodData == null) {
+            paymentMethodData = new PaymentMethodData();
+        }
+        return paymentMethodData;
+    }
+
+    public void setPaymentMethodData(PaymentMethodData paymentMethodData) {
+        this.paymentMethodData = paymentMethodData;
+    }
+
+    public Staff getToStaff() {
+        return toStaff;
+    }
+
+    public void setToStaff(Staff toStaff) {
+        this.toStaff = toStaff;
+        if (toStaff != null) {
+            getPaymentMethodData().getStaffCredit().setToStaff(toStaff);
+            getPaymentMethodData().getStaffWelfare().setToStaff(toStaff);
+        }
+    }
+
+    public Double getPreviewRate() {
+        if (stockDto == null) return null;
+        return stockDto.getRetailRate();
+    }
+
+    public Double getPreviewNetValue() {
+        if (stockDto == null || intQty == null) return null;
+        double rate = stockDto.getRetailRate() != null ? stockDto.getRetailRate() : 0.0;
+        return rate * intQty;
+    }
+
+    public StockDtoConverter getStockDtoConverter() {
+        return new StockDtoConverter();
+    }
+
+    public class StockDtoConverter implements Converter {
+
+        @Override
+        public Object getAsObject(FacesContext context, UIComponent component, String value) {
+            if (value == null || value.trim().isEmpty()) {
+                return null;
+            }
+            try {
+                Long id = Long.valueOf(value);
+                if (stockDto != null && id.equals(stockDto.getId())) {
+                    return stockDto;
+                }
+                if (lastAutocompleteResults != null) {
+                    for (StockDTO dto : lastAutocompleteResults) {
+                        if (dto != null && id.equals(dto.getId())) {
+                            return dto;
+                        }
+                    }
+                }
+                StockDTO dto = new StockDTO();
+                dto.setId(id);
+                return dto;
+            } catch (NumberFormatException e) {
+                return null;
+            }
+        }
+
+        @Override
+        public String getAsString(FacesContext context, UIComponent component, Object value) {
+            if (value == null) return "";
+            if (value instanceof StockDTO) {
+                StockDTO dto = (StockDTO) value;
+                return dto.getId() != null ? dto.getId().toString() : "";
+            }
+            return value.toString();
+        }
+    }
+}

--- a/src/main/java/com/divudi/core/data/dto/PrintBillData.java
+++ b/src/main/java/com/divudi/core/data/dto/PrintBillData.java
@@ -19,6 +19,10 @@ public class PrintBillData implements Serializable {
     private String billNo;
     private Date createdAt;
     private double netTotal;
+    private String paymentMethodLabel;
+    private String comment;
+    private double cashPaid;
+    private double balance;
 
     public String getDepartmentName() { return departmentName; }
     public void setDepartmentName(String departmentName) { this.departmentName = departmentName; }
@@ -55,4 +59,16 @@ public class PrintBillData implements Serializable {
 
     public double getNetTotal() { return netTotal; }
     public void setNetTotal(double netTotal) { this.netTotal = netTotal; }
+
+    public String getPaymentMethodLabel() { return paymentMethodLabel; }
+    public void setPaymentMethodLabel(String paymentMethodLabel) { this.paymentMethodLabel = paymentMethodLabel; }
+
+    public String getComment() { return comment; }
+    public void setComment(String comment) { this.comment = comment; }
+
+    public double getCashPaid() { return cashPaid; }
+    public void setCashPaid(double cashPaid) { this.cashPaid = cashPaid; }
+
+    public double getBalance() { return balance; }
+    public void setBalance(double balance) { this.balance = balance; }
 }

--- a/src/main/java/com/divudi/service/pharmacy/RetailSaleNativeSqlService.java
+++ b/src/main/java/com/divudi/service/pharmacy/RetailSaleNativeSqlService.java
@@ -1,0 +1,624 @@
+/*
+ * Open Hospital Management Information System
+ * Dr M H B Ariyaratne
+ * buddhika.ari@gmail.com
+ */
+package com.divudi.service.pharmacy;
+
+import com.divudi.core.data.PaymentMethod;
+import com.divudi.core.data.dataStructure.PaymentMethodData;
+import com.divudi.core.data.dto.BillItemData;
+import com.divudi.core.data.dto.StockAggregateResult;
+import com.divudi.core.entity.Bill;
+import com.divudi.core.entity.BillFinanceDetails;
+import com.divudi.core.entity.BillItem;
+import com.divudi.core.entity.BillItemFinanceDetails;
+import com.divudi.core.entity.Payment;
+import com.divudi.core.entity.PaymentScheme;
+import com.divudi.core.entity.pharmacy.Stock;
+import com.divudi.core.entity.pharmacy.StockHistory;
+import javax.ejb.Stateless;
+import javax.ejb.TransactionAttribute;
+import javax.ejb.TransactionAttributeType;
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+import java.math.BigDecimal;
+import java.sql.Timestamp;
+import java.util.Calendar;
+import java.util.Date;
+import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * Persists pharmacy retail sale bills using native SQL for the hot-path
+ * operations (stock deduction, aggregates, StockHistory INSERT, Payment INSERT).
+ *
+ * BillItem and PharmaceuticalBillItem are persisted via native SQL;
+ * BillItemFinanceDetails and BillFinanceDetails via JPA (IDENTITY PKs).
+ *
+ * Avoids the dominant cold-start cost:
+ *  - EAGER cascade Stock → ItemBatch → Item on PharmacySaleController settle
+ *  - 9 separate JPQL aggregate queries per item for StockHistory values
+ *
+ * Patterned on InpatientDirectIssueNativeSqlService (issue #20214).
+ * Issue: #20260
+ */
+@Stateless
+public class RetailSaleNativeSqlService {
+
+    private static final Logger LOGGER = Logger.getLogger(RetailSaleNativeSqlService.class.getName());
+
+    @PersistenceContext(unitName = "hmisPU")
+    private EntityManager em;
+
+    // Cached resolved table names (cross-deployment case safety via INFORMATION_SCHEMA)
+    private volatile String tStockHistory = null;
+    private volatile String tStock = null;
+    private volatile String tItemBatch = null;
+    private volatile String tDepartment = null;
+    private volatile String tBill = null;
+    private volatile String tBillItem = null;
+    private volatile String tPharmBillItem = null;
+    // -----------------------------------------------------------------------
+    // Public API
+    // -----------------------------------------------------------------------
+
+    @TransactionAttribute(TransactionAttributeType.REQUIRED)
+    public void settle(Bill bill, List<BillItemData> items,
+                       PaymentMethod paymentMethod, PaymentMethodData paymentMethodData,
+                       PaymentScheme paymentScheme) {
+        if (items == null || items.isEmpty()) {
+            throw new IllegalArgumentException("No items to settle");
+        }
+
+        long t0 = System.currentTimeMillis();
+
+        // Step 1: Persist bill header via JPA (gets DTYPE + IDENTITY ID).
+        bill.setBillItems(null);
+        em.persist(bill);
+        em.flush();
+        long billId = bill.getId();
+
+        LOGGER.log(Level.INFO, "[RetailNativeSettle] Bill header persisted id={0} ms={1}",
+                new Object[]{billId, System.currentTimeMillis() - t0});
+
+        // Step 2: Native INSERT BillItem + PharmaceuticalBillItem per line item
+        long[] biIds = new long[items.size()];
+        long[] pbIds = new long[items.size()];
+
+        for (int i = 0; i < items.size(); i++) {
+            BillItemData d = items.get(i);
+            Date createdAt = d.getCreatedAt() != null ? d.getCreatedAt() : new Date();
+
+            double absQty       = Math.abs(d.getQty());
+            double absNetValue  = Math.abs(d.getNetValue());
+            double absGrossValue = Math.abs(d.getGrossValue());
+            double netRate      = absQty > 0 ? absNetValue / absQty : 0.0;
+
+            em.createNativeQuery(
+                "INSERT INTO " + billItemTable()
+                + " (bill_ID, item_ID, qty, descreption, netValue, grossValue, netRate,"
+                + " createdAt, creater_ID, retired, refunded, billItemRefunded,"
+                + " consideredForCosting, inwardChargeType)"
+                + " VALUES (?,?,?,?,?,?,?,?,?,0,0,0,1,'Medicine')")
+                .setParameter(1, billId)
+                .setParameter(2, d.getItemId())
+                .setParameter(3, absQty)
+                .setParameter(4, d.getDescription())
+                .setParameter(5, absNetValue)
+                .setParameter(6, absGrossValue)
+                .setParameter(7, netRate)
+                .setParameter(8, new Timestamp(createdAt.getTime()))
+                .setParameter(9, d.getCreaterId())
+                .executeUpdate();
+            biIds[i] = ((Number) em.createNativeQuery("SELECT LAST_INSERT_ID()").getSingleResult()).longValue();
+
+            em.createNativeQuery(
+                "INSERT INTO " + pharmBillItemTable()
+                + " (billItem_ID, itemBatch_ID, stock_ID, qty, stringValue,"
+                + " costRate, purchaseRate, retailRate, wholesaleRate, doe, description)"
+                + " VALUES (?,?,?,?,?,?,?,?,?,?,?)")
+                .setParameter(1, biIds[i])
+                .setParameter(2, d.getItemBatchId())
+                .setParameter(3, d.getStockId())
+                .setParameter(4, d.getPbiQty())
+                .setParameter(5, d.getStringValue())
+                .setParameter(6, d.getCostRate())
+                .setParameter(7, d.getPurchaseRate())
+                .setParameter(8, d.getRetailRate())
+                .setParameter(9, d.getWholesaleRate())
+                .setParameter(10, d.getDoe() != null ? new Timestamp(d.getDoe().getTime()) : null)
+                .setParameter(11, d.getDescription())
+                .executeUpdate();
+            pbIds[i] = ((Number) em.createNativeQuery("SELECT LAST_INSERT_ID()").getSingleResult()).longValue();
+        }
+
+        LOGGER.log(Level.INFO, "[RetailNativeSettle] BillItem+PBI inserted ms={0}", System.currentTimeMillis() - t0);
+
+        // Step 3: Per-item: atomic stock deduction + aggregates + StockHistory
+        for (int i = 0; i < items.size(); i++) {
+            BillItemData item = items.get(i);
+            double qty = Math.abs(item.getQty());
+
+            deductStock(item.getStockId(), qty);
+            double postDeductQty = fetchStockQty(item.getStockId());
+
+            long ampItemId     = item.getAmpItemId()     != null ? item.getAmpItemId()     : (item.getItemId() != null ? item.getItemId() : 0L);
+            long itemBatchId   = item.getItemBatchId()   != null ? item.getItemBatchId()   : 0L;
+            long departmentId  = item.getDepartmentId()  != null ? item.getDepartmentId()  : 0L;
+            long institutionId = item.getInstitutionId() != null ? item.getInstitutionId() : 0L;
+
+            StockAggregateResult agg = computeAggregates(
+                    ampItemId, itemBatchId, departmentId, institutionId,
+                    postDeductQty,
+                    item.getBatchRetailRate(), item.getBatchPurchaseRate(),
+                    item.getBatchCostRate() != null ? item.getBatchCostRate() : item.getBatchPurchaseRate());
+
+            insertStockHistory(pbIds[i], item, agg, ampItemId, itemBatchId, departmentId, institutionId);
+        }
+
+        // Evict natively-written entity classes from EclipseLink L2 cache
+        javax.persistence.Cache cache = em.getEntityManagerFactory().getCache();
+        cache.evict(StockHistory.class);
+        cache.evict(Stock.class);
+        cache.evict(BillItem.class);
+        cache.evict(Bill.class);
+
+        LOGGER.log(Level.INFO, "[RetailNativeSettle] Stock deducted + history inserted ms={0}", System.currentTimeMillis() - t0);
+
+        // Step 4: Finance details (JPA IDENTITY PKs — one BillItemFinanceDetails per line)
+        double[] billTotals = insertFinanceDetails(billId, biIds, pbIds, items);
+
+        // Step 5: Update bill-level totals
+        em.createNativeQuery(
+                "UPDATE " + billTable() + " SET total=?, netTotal=? WHERE ID=?")
+                .setParameter(1, billTotals[0])
+                .setParameter(2, billTotals[1])
+                .setParameter(3, billId)
+                .executeUpdate();
+
+        // Step 6: Insert Payment record
+        insertPayment(bill, billId, billTotals[1], paymentMethod, paymentMethodData, paymentScheme);
+
+        LOGGER.log(Level.INFO, "[RetailNativeSettle] DONE items={0} ms={1}",
+                new Object[]{items.size(), System.currentTimeMillis() - t0});
+    }
+
+    // -----------------------------------------------------------------------
+    // Payment
+    // -----------------------------------------------------------------------
+
+    private void insertPayment(Bill bill, long billId, double netTotal,
+                                PaymentMethod paymentMethod, PaymentMethodData pmd,
+                                PaymentScheme paymentScheme) {
+        Payment p = new Payment();
+        p.setBill(em.getReference(Bill.class, billId));
+        p.setInstitution(bill.getInstitution());
+        p.setDepartment(bill.getDepartment());
+        p.setCreatedAt(new Date());
+        p.setCreater(bill.getCreater());
+        p.setPaymentMethod(paymentMethod);
+        p.setPaidValue(netTotal);
+
+        if (paymentMethod != null && pmd != null) {
+            switch (paymentMethod) {
+                case Card:
+                    p.setBank(pmd.getCreditCard().getInstitution());
+                    p.setCreditCardRefNo(pmd.getCreditCard().getNo());
+                    p.setComments(pmd.getCreditCard().getComment());
+                    break;
+                case Cheque:
+                    p.setChequeDate(pmd.getCheque().getDate());
+                    p.setChequeRefNo(pmd.getCheque().getNo());
+                    p.setBank(pmd.getCheque().getInstitution());
+                    p.setComments(pmd.getCheque().getComment());
+                    break;
+                case ewallet:
+                    p.setPolicyNo(pmd.getEwallet().getReferralNo());
+                    p.setComments(pmd.getEwallet().getComment());
+                    p.setReferenceNo(pmd.getEwallet().getReferenceNo());
+                    p.setBank(pmd.getEwallet().getInstitution());
+                    break;
+                case Credit:
+                    p.setPolicyNo(pmd.getCredit().getReferralNo());
+                    p.setReferenceNo(pmd.getCredit().getReferenceNo());
+                    p.setCreditCompany(pmd.getCredit().getInstitution());
+                    p.setComments(pmd.getCredit().getComment());
+                    break;
+                case PatientDeposit:
+                case Agent:
+                    break;
+                case Slip:
+                    p.setBank(pmd.getSlip().getInstitution());
+                    p.setRealizedAt(pmd.getSlip().getDate());
+                    p.setPaymentDate(pmd.getSlip().getDate());
+                    p.setComments(pmd.getSlip().getComment());
+                    p.setReferenceNo(pmd.getSlip().getReferenceNo());
+                    break;
+                case OnlineSettlement:
+                    p.setBank(pmd.getOnlineSettlement().getInstitution());
+                    p.setRealizedAt(pmd.getOnlineSettlement().getDate());
+                    p.setPaymentDate(pmd.getOnlineSettlement().getDate());
+                    p.setReferenceNo(pmd.getOnlineSettlement().getReferenceNo());
+                    p.setComments(pmd.getOnlineSettlement().getComment());
+                    break;
+                case IOU:
+                    p.setBank(pmd.getIou().getInstitution());
+                    p.setRealizedAt(pmd.getIou().getDate());
+                    p.setPaymentDate(pmd.getIou().getDate());
+                    p.setReferenceNo(pmd.getIou().getReferenceNo());
+                    p.setComments(pmd.getIou().getComment());
+                    break;
+                case Staff:
+                    p.setToStaff(pmd.getStaffCredit().getToStaff());
+                    break;
+                case Staff_Welfare:
+                    p.setToStaff(pmd.getStaffWelfare().getToStaff());
+                    break;
+                default:
+                    break;
+            }
+        }
+
+        em.persist(p);
+        em.flush();
+    }
+
+    // -----------------------------------------------------------------------
+    // Stock deduction
+    // -----------------------------------------------------------------------
+
+    private void deductStock(long stockId, double qty) {
+        int updated = em.createNativeQuery(
+                "UPDATE " + stockTable() + " SET stock=stock-? WHERE ID=? AND stock>=?")
+                .setParameter(1, qty)
+                .setParameter(2, stockId)
+                .setParameter(3, qty)
+                .executeUpdate();
+        if (updated == 0) {
+            throw new RuntimeException("Insufficient stock for stock ID " + stockId
+                    + " (requested qty=" + qty + ")");
+        }
+    }
+
+    private double fetchStockQty(long stockId) {
+        Object result = em.createNativeQuery(
+                "SELECT stock FROM " + stockTable() + " WHERE ID=?")
+                .setParameter(1, stockId)
+                .getSingleResult();
+        return result == null ? 0.0 : ((Number) result).doubleValue();
+    }
+
+    // -----------------------------------------------------------------------
+    // Aggregate computation
+    // -----------------------------------------------------------------------
+
+    private StockAggregateResult computeAggregates(
+            long ampItemId, long itemBatchId,
+            long departmentId, long institutionId,
+            double postDeductStockQty,
+            double retailRate, double purchaseRate, double costRate) {
+
+        StockAggregateResult r = new StockAggregateResult();
+        r.setStockQty(postDeductStockQty);
+
+        String batchSql =
+            "SELECT "
+            + "  SUM(CASE WHEN d.institution_ID = ? THEN s.stock ELSE 0 END) AS instBatchQty,"
+            + "  SUM(s.stock) AS totalBatchQty "
+            + "FROM " + stockTable() + " s "
+            + "JOIN " + departmentTable() + " d ON s.department_ID = d.ID "
+            + "WHERE s.itemBatch_ID = ?";
+
+        Object[] batchRow = (Object[]) em.createNativeQuery(batchSql)
+                .setParameter(1, institutionId)
+                .setParameter(2, itemBatchId)
+                .getSingleResult();
+
+        double instBatchQty  = batchRow[0] == null ? 0.0 : ((Number) batchRow[0]).doubleValue();
+        double totalBatchQty = batchRow[1] == null ? 0.0 : ((Number) batchRow[1]).doubleValue();
+
+        r.setInstitutionBatchQty(instBatchQty);
+        r.setTotalBatchQty(totalBatchQty);
+        r.setInstitutionBatchStockValueAtPurchaseRate(instBatchQty * purchaseRate);
+        r.setTotalBatchStockValueAtPurchaseRate(totalBatchQty * purchaseRate);
+        r.setInstitutionBatchStockValueAtSaleRate(instBatchQty * retailRate);
+        r.setTotalBatchStockValueAtSaleRate(totalBatchQty * retailRate);
+        r.setInstitutionBatchStockValueAtCostRate(instBatchQty * costRate);
+        r.setTotalBatchStockValueAtCostRate(totalBatchQty * costRate);
+
+        String itemSql =
+            "SELECT "
+            + "  SUM(CASE WHEN s.department_ID = ? THEN s.stock ELSE 0 END) AS deptItemQty,"
+            + "  SUM(CASE WHEN d.institution_ID = ? THEN s.stock ELSE 0 END) AS instItemQty,"
+            + "  SUM(s.stock) AS totalItemQty,"
+            + "  SUM(CASE WHEN s.department_ID = ? THEN COALESCE(ib.purcahseRate,0)*s.stock ELSE 0 END) AS deptItemPurchVal,"
+            + "  SUM(CASE WHEN d.institution_ID = ? THEN COALESCE(ib.purcahseRate,0)*s.stock ELSE 0 END) AS instItemPurchVal,"
+            + "  SUM(COALESCE(ib.purcahseRate,0)*s.stock) AS totalItemPurchVal,"
+            + "  SUM(CASE WHEN s.department_ID = ? THEN COALESCE(ib.costRate,0)*s.stock ELSE 0 END) AS deptItemCostVal,"
+            + "  SUM(CASE WHEN d.institution_ID = ? THEN COALESCE(ib.costRate,0)*s.stock ELSE 0 END) AS instItemCostVal,"
+            + "  SUM(COALESCE(ib.costRate,0)*s.stock) AS totalItemCostVal,"
+            + "  SUM(CASE WHEN s.department_ID = ? THEN COALESCE(ib.retailsaleRate,0)*s.stock ELSE 0 END) AS deptItemRetailVal,"
+            + "  SUM(CASE WHEN d.institution_ID = ? THEN COALESCE(ib.retailsaleRate,0)*s.stock ELSE 0 END) AS instItemRetailVal,"
+            + "  SUM(COALESCE(ib.retailsaleRate,0)*s.stock) AS totalItemRetailVal "
+            + "FROM " + stockTable() + " s "
+            + "JOIN " + itemBatchTable() + " ib ON s.itemBatch_ID = ib.ID "
+            + "JOIN " + departmentTable() + " d ON s.department_ID = d.ID "
+            + "WHERE ib.item_ID = ?";
+
+        Object[] itemRow = (Object[]) em.createNativeQuery(itemSql)
+                .setParameter(1, departmentId)
+                .setParameter(2, institutionId)
+                .setParameter(3, departmentId)
+                .setParameter(4, institutionId)
+                .setParameter(5, departmentId)
+                .setParameter(6, institutionId)
+                .setParameter(7, departmentId)
+                .setParameter(8, institutionId)
+                .setParameter(9, ampItemId)
+                .getSingleResult();
+
+        r.setDepartmentItemStock(toDouble(itemRow[0]));
+        r.setInstitutionItemStock(toDouble(itemRow[1]));
+        r.setTotalItemStock(toDouble(itemRow[2]));
+        r.setItemStockValueAtPurchaseRate(toDouble(itemRow[3]));
+        r.setInstitutionItemStockValueAtPurchaseRate(toDouble(itemRow[4]));
+        r.setTotalItemStockValueAtPurchaseRate(toDouble(itemRow[5]));
+        r.setItemStockValueAtCostRate(toDouble(itemRow[6]));
+        r.setInstitutionItemStockValueAtCostRate(toDouble(itemRow[7]));
+        r.setTotalItemStockValueAtCostRate(toDouble(itemRow[8]));
+        r.setItemStockValueAtSaleRate(toDouble(itemRow[9]));
+        r.setInstitutionItemStockValueAtSaleRate(toDouble(itemRow[10]));
+        r.setTotalItemStockValueAtSaleRate(toDouble(itemRow[11]));
+
+        return r;
+    }
+
+    private static double toDouble(Object o) {
+        return o == null ? 0.0 : ((Number) o).doubleValue();
+    }
+
+    // -----------------------------------------------------------------------
+    // StockHistory native INSERT
+    // -----------------------------------------------------------------------
+
+    private void insertStockHistory(long pbId, BillItemData item, StockAggregateResult agg,
+                                    long ampItemId, long itemBatchId, long departmentId, long institutionId) {
+        Date now = new Date();
+        Calendar cal = Calendar.getInstance();
+
+        em.createNativeQuery(
+            "INSERT INTO " + stockHistoryTable()
+            + " (pbItem_ID, itemBatch_ID, institution_ID, department_ID, item_ID,"
+            + " retailRate, wholesaleRate, purchaseRate, costRate,"
+            + " stockAt, fromDate, createdAt,"
+            + " stockQty, instituionBatchQty, totalBatchQty,"
+            + " itemStock, institutionItemStock, totalItemStock,"
+            + " stockSaleValue, stockPurchaseValue, stockCostValue,"
+            + " institutionBatchStockValueAtSaleRate, totalBatchStockValueAtSaleRate,"
+            + " institutionBatchStockValueAtPurchaseRate, totalBatchStockValueAtPurchaseRate,"
+            + " institutionBatchStockValueAtCostRate, totalBatchStockValueAtCostRate,"
+            + " itemStockValueAtSaleRate, institutionItemStockValueAtSaleRate, totalItemStockValueAtSaleRate,"
+            + " itemStockValueAtPurchaseRate, institutionItemStockValueAtPurchaseRate, totalItemStockValueAtPurchaseRate,"
+            + " itemStockValueAtCostRate, institutionItemStockValueAtCostRate, totalItemStockValueAtCostRate,"
+            + " hxYear, hxMonth, hxDate, hxWeek,"
+            + " retired)"
+            + " VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,0)")
+            .setParameter(1, pbId)
+            .setParameter(2, itemBatchId)
+            .setParameter(3, institutionId)
+            .setParameter(4, departmentId)
+            .setParameter(5, ampItemId)
+            .setParameter(6, item.getBatchRetailRate())
+            .setParameter(7, item.getBatchWholesaleRate())
+            .setParameter(8, item.getBatchPurchaseRate())
+            .setParameter(9, item.getBatchCostRate() != null ? item.getBatchCostRate() : item.getBatchPurchaseRate())
+            .setParameter(10, new java.sql.Date(now.getTime()))
+            .setParameter(11, new Timestamp(now.getTime()))
+            .setParameter(12, new Timestamp(now.getTime()))
+            .setParameter(13, agg.getStockQty())
+            .setParameter(14, agg.getInstitutionBatchQty())
+            .setParameter(15, agg.getTotalBatchQty())
+            .setParameter(16, agg.getDepartmentItemStock())
+            .setParameter(17, agg.getInstitutionItemStock())
+            .setParameter(18, agg.getTotalItemStock())
+            .setParameter(19, agg.getStockQty() * item.getBatchRetailRate())
+            .setParameter(20, agg.getStockQty() * item.getBatchPurchaseRate())
+            .setParameter(21, agg.getStockQty() * (item.getBatchCostRate() != null ? item.getBatchCostRate() : item.getBatchPurchaseRate()))
+            .setParameter(22, agg.getInstitutionBatchStockValueAtSaleRate())
+            .setParameter(23, agg.getTotalBatchStockValueAtSaleRate())
+            .setParameter(24, agg.getInstitutionBatchStockValueAtPurchaseRate())
+            .setParameter(25, agg.getTotalBatchStockValueAtPurchaseRate())
+            .setParameter(26, agg.getInstitutionBatchStockValueAtCostRate())
+            .setParameter(27, agg.getTotalBatchStockValueAtCostRate())
+            .setParameter(28, agg.getItemStockValueAtSaleRate())
+            .setParameter(29, agg.getInstitutionItemStockValueAtSaleRate())
+            .setParameter(30, agg.getTotalItemStockValueAtSaleRate())
+            .setParameter(31, agg.getItemStockValueAtPurchaseRate())
+            .setParameter(32, agg.getInstitutionItemStockValueAtPurchaseRate())
+            .setParameter(33, agg.getTotalItemStockValueAtPurchaseRate())
+            .setParameter(34, agg.getItemStockValueAtCostRate())
+            .setParameter(35, agg.getInstitutionItemStockValueAtCostRate())
+            .setParameter(36, agg.getTotalItemStockValueAtCostRate())
+            .setParameter(37, cal.get(Calendar.YEAR))
+            .setParameter(38, cal.get(Calendar.MONTH))
+            .setParameter(39, cal.get(Calendar.DATE))
+            .setParameter(40, cal.get(Calendar.WEEK_OF_YEAR))
+            .executeUpdate();
+    }
+
+    // -----------------------------------------------------------------------
+    // Finance details (JPA IDENTITY)
+    // -----------------------------------------------------------------------
+
+    private double[] insertFinanceDetails(long billId, long[] biIds, long[] pbIds,
+                                          List<BillItemData> items) {
+        BigDecimal totalCostValue = BigDecimal.ZERO;
+        BigDecimal totalPurchaseValue = BigDecimal.ZERO;
+        BigDecimal totalRetailSaleValue = BigDecimal.ZERO;
+        BigDecimal totalWholesaleValue = BigDecimal.ZERO;
+        BigDecimal totalQuantity = BigDecimal.ZERO;
+        BigDecimal totalFreeQuantity = BigDecimal.ZERO;
+        BigDecimal billNetTotal = BigDecimal.ZERO;
+
+        for (int i = 0; i < items.size(); i++) {
+            BillItemData item = items.get(i);
+
+            BigDecimal qty = BigDecimal.valueOf(Math.abs(item.getQty()));
+            BigDecimal freeQty = BigDecimal.valueOf(Math.abs(item.getFreeQty()));
+            BigDecimal totalQty = qty.add(freeQty);
+
+            BigDecimal retailRate    = BigDecimal.valueOf(item.getRetailRate());
+            BigDecimal purchaseRate  = BigDecimal.valueOf(item.getPurchaseRate());
+            BigDecimal wholesaleRate = BigDecimal.valueOf(item.getWholesaleRate());
+            BigDecimal batchRetail   = BigDecimal.valueOf(item.getBatchRetailRate());
+            BigDecimal batchPurchase = BigDecimal.valueOf(item.getBatchPurchaseRate());
+            BigDecimal batchWholesale = BigDecimal.valueOf(item.getBatchWholesaleRate());
+            BigDecimal costRate = item.getBatchCostRate() != null && item.getBatchCostRate() > 0
+                    ? BigDecimal.valueOf(item.getBatchCostRate())
+                    : batchPurchase;
+
+            BigDecimal itemCostValue      = costRate.multiply(qty);
+            BigDecimal itemRetailValue    = batchRetail.multiply(totalQty);
+            BigDecimal itemPurchaseValue  = batchPurchase.multiply(totalQty);
+            BigDecimal itemWholesaleValue = batchWholesale.multiply(totalQty);
+
+            BigDecimal netValue   = BigDecimal.valueOf(Math.abs(item.getNetValue()));
+            BigDecimal grossValue = BigDecimal.valueOf(Math.abs(item.getGrossValue()));
+            BigDecimal lineNetRate = qty.compareTo(BigDecimal.ZERO) > 0
+                    ? netValue.divide(qty, 4, java.math.RoundingMode.HALF_UP)
+                    : BigDecimal.ZERO;
+
+            BillItemFinanceDetails bifd = new BillItemFinanceDetails();
+            bifd.setBillItem(em.getReference(BillItem.class, biIds[i]));
+            bifd.setCreatedAt(new Date());
+
+            bifd.setLineNetRate(lineNetRate);
+            bifd.setGrossRate(BigDecimal.valueOf(item.getRate()));
+            bifd.setLineGrossRate(BigDecimal.valueOf(item.getRate()));
+            bifd.setBillCostRate(BigDecimal.ZERO);
+            bifd.setTotalCostRate(costRate);
+            bifd.setLineCostRate(costRate);
+            bifd.setCostRate(costRate);
+            bifd.setPurchaseRate(purchaseRate);
+            bifd.setRetailSaleRate(retailRate);
+            bifd.setWholesaleRate(wholesaleRate);
+
+            bifd.setLineGrossTotal(grossValue);
+            bifd.setGrossTotal(grossValue);
+            bifd.setLineNetTotal(netValue);
+            bifd.setNetTotal(netValue);
+
+            bifd.setLineCost(itemCostValue);
+            bifd.setBillCost(BigDecimal.ZERO);
+            bifd.setTotalCost(itemCostValue);
+
+            bifd.setValueAtCostRate(costRate.multiply(totalQty).negate());
+            bifd.setValueAtPurchaseRate(batchPurchase.multiply(totalQty).negate());
+            bifd.setValueAtRetailRate(batchRetail.multiply(totalQty).negate());
+            bifd.setValueAtWholesaleRate(batchWholesale.multiply(totalQty).negate());
+
+            bifd.setQuantity(qty.negate());
+            bifd.setQuantityByUnits(qty.negate());
+            bifd.setTotalQuantity(totalQty.negate());
+            bifd.setFreeQuantity(freeQty.negate());
+
+            em.persist(bifd);
+            em.flush();
+
+            em.createNativeQuery("UPDATE " + billItemTable()
+                    + " SET BILLITEMFINANCEDETAILS_ID=? WHERE ID=?")
+                    .setParameter(1, bifd.getId())
+                    .setParameter(2, biIds[i])
+                    .executeUpdate();
+
+            em.createNativeQuery("UPDATE " + pharmBillItemTable()
+                    + " SET costRate=?, costValue=?, retailValue=?, purchaseValue=? WHERE ID=?")
+                    .setParameter(1, costRate.doubleValue())
+                    .setParameter(2, itemCostValue.doubleValue())
+                    .setParameter(3, itemRetailValue.doubleValue())
+                    .setParameter(4, itemPurchaseValue.doubleValue())
+                    .setParameter(5, pbIds[i])
+                    .executeUpdate();
+
+            totalCostValue        = totalCostValue.add(itemCostValue);
+            totalPurchaseValue    = totalPurchaseValue.add(itemPurchaseValue);
+            totalRetailSaleValue  = totalRetailSaleValue.add(itemRetailValue);
+            totalWholesaleValue   = totalWholesaleValue.add(itemWholesaleValue);
+            totalQuantity         = totalQuantity.add(qty);
+            totalFreeQuantity     = totalFreeQuantity.add(freeQty);
+            billNetTotal          = billNetTotal.add(netValue);
+        }
+
+        Bill billRef = em.getReference(Bill.class, billId);
+        BillFinanceDetails bfd = new BillFinanceDetails();
+        bfd.setBill(billRef);
+        bfd.setCreatedAt(new Date());
+        bfd.setNetTotal(billNetTotal);
+        bfd.setGrossTotal(billNetTotal);
+        bfd.setTotalCostValue(totalCostValue);
+        bfd.setTotalPurchaseValue(totalPurchaseValue);
+        bfd.setTotalRetailSaleValue(totalRetailSaleValue);
+        bfd.setTotalWholesaleValue(totalWholesaleValue);
+        bfd.setTotalQuantity(totalQuantity);
+        bfd.setTotalFreeQuantity(totalFreeQuantity);
+        em.persist(bfd);
+        em.flush();
+
+        em.createNativeQuery("UPDATE " + billTable() + " SET BILLFINANCEDETAILS_ID=? WHERE ID=?")
+                .setParameter(1, bfd.getId())
+                .setParameter(2, billId)
+                .executeUpdate();
+
+        return new double[]{billNetTotal.doubleValue(), billNetTotal.doubleValue()};
+    }
+
+    // -----------------------------------------------------------------------
+    // Table name resolution
+    // -----------------------------------------------------------------------
+
+    private String resolveTable(String upperName) {
+        Object name = em.createNativeQuery(
+                "SELECT TABLE_NAME FROM INFORMATION_SCHEMA.TABLES "
+                + "WHERE TABLE_SCHEMA = DATABASE() AND UPPER(TABLE_NAME) = ? LIMIT 1")
+                .setParameter(1, upperName)
+                .getSingleResult();
+        return name.toString();
+    }
+
+    private String stockHistoryTable() {
+        if (tStockHistory == null) tStockHistory = resolveTable("STOCKHISTORY");
+        return tStockHistory;
+    }
+
+    private String stockTable() {
+        if (tStock == null) tStock = resolveTable("STOCK");
+        return tStock;
+    }
+
+    private String itemBatchTable() {
+        if (tItemBatch == null) tItemBatch = resolveTable("ITEMBATCH");
+        return tItemBatch;
+    }
+
+    private String departmentTable() {
+        if (tDepartment == null) tDepartment = resolveTable("DEPARTMENT");
+        return tDepartment;
+    }
+
+    private String billTable() {
+        if (tBill == null) tBill = resolveTable("BILL");
+        return tBill;
+    }
+
+    private String billItemTable() {
+        if (tBillItem == null) tBillItem = resolveTable("BILLITEM");
+        return tBillItem;
+    }
+
+    private String pharmBillItemTable() {
+        if (tPharmBillItem == null) tPharmBillItem = resolveTable("PHARMACEUTICALBILLITEM");
+        return tPharmBillItem;
+    }
+}

--- a/src/main/webapp/pharmacy/pharmacy_bill_retail_sale.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_bill_retail_sale.xhtml
@@ -79,6 +79,7 @@
                                 <p:commandButton class="m-1"  icon="fas fa-file-invoice" value="Sale 2" action="pharmacy_bill_retail_sale_1?faces-redirect=true" rendered="#{webUserController.hasPrivilege('PharmacySale')}" actionListener="#{pharmacySaleController1.pharmacyRetailSale()}" />
                                 <p:commandButton class="m-1"  icon="fas fa-file-invoice" value="Sale 3" action="pharmacy_bill_retail_sale_2?faces-redirect=true" rendered="#{webUserController.hasPrivilege('PharmacySale')}" actionListener="#{pharmacySaleController2.pharmacyRetailSale()}" />
                                 <p:commandButton class="m-1"  icon="fas fa-file-invoice" value="Sale 4" action="pharmacy_bill_retail_sale_3?faces-redirect=true" rendered="#{webUserController.hasPrivilege('PharmacySale')}" actionListener="#{pharmacySaleController3.pharmacyRetailSale()}" />
+                                <p:commandButton class="m-1 ui-button-warning" icon="fas fa-bolt" value="Fast Sale" action="pharmacy_bill_retail_sale_native?faces-redirect=true" rendered="#{webUserController.hasPrivilege('PharmacySale')}" actionListener="#{retailSaleNativeSqlController.resetAll()}" />
                                 <!-- Admin Configuration Button (only for administrators) -->
                                 <h:panelGroup rendered="#{webUserController.hasPrivilege('Admin')}">
                                     <p:commandButton
@@ -1345,6 +1346,7 @@
                                     <p:commandButton class="m-1"  icon="fas fa-file-invoice" value="Sale 2" action="pharmacy_bill_retail_sale_1?faces-redirect=true" rendered="#{webUserController.hasPrivilege('PharmacySale')}" actionListener="#{pharmacySaleController1.pharmacyRetailSale()}" />
                                     <p:commandButton class="m-1"  icon="fas fa-file-invoice" value="Sale 3" action="pharmacy_bill_retail_sale_2?faces-redirect=true" rendered="#{webUserController.hasPrivilege('PharmacySale')}" actionListener="#{pharmacySaleController2.pharmacyRetailSale()}" />
                                     <p:commandButton class="m-1"  icon="fas fa-file-invoice" value="Sale 4" action="pharmacy_bill_retail_sale_3?faces-redirect=true" rendered="#{webUserController.hasPrivilege('PharmacySale')}" actionListener="#{pharmacySaleController3.pharmacyRetailSale()}" />
+                                    <p:commandButton class="m-1 ui-button-warning" icon="fas fa-bolt" value="Fast Sale" action="pharmacy_bill_retail_sale_native?faces-redirect=true" rendered="#{webUserController.hasPrivilege('PharmacySale')}" actionListener="#{retailSaleNativeSqlController.resetAll()}" />
                                 </div>
                             </div>
                             <div class="col-3">

--- a/src/main/webapp/pharmacy/pharmacy_bill_retail_sale_native.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_bill_retail_sale_native.xhtml
@@ -1,0 +1,809 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
+      xmlns:h="http://xmlns.jcp.org/jsf/html"
+      xmlns:p="http://primefaces.org/ui"
+      xmlns:f="http://xmlns.jcp.org/jsf/core"
+      xmlns:phi="http://xmlns.jcp.org/jsf/composite/pharmacy"
+      xmlns:pa="http://xmlns.jcp.org/jsf/composite/paymentMethod">
+    <h:body>
+        <ui:composition template="/resources/template/template.xhtml">
+            <ui:define name="content">
+                <h:form id="bill">
+                    <script>
+                        window.onload = function () {
+                            var ac = document.getElementById("bill:acStock");
+                            if (ac) { ac.focus(); }
+                        };
+                    </script>
+                    <p:growl id="panelError" />
+                    <p:defaultCommand target="btnAdd" />
+
+                    <!-- ============================================================
+                         ENTRY PANEL (hidden after settle)
+                         ============================================================ -->
+                    <p:panel rendered="#{!retailSaleNativeSqlController.billPreview}">
+
+                        <p:panel class="w-100">
+                            <f:facet name="header">
+                                <h:outputText styleClass="fas fa-mortar-pestle" />
+                                <h:outputLabel value="Pharmacy Retail Sale (Native)" class="mx-4" />
+                                <p:commandButton
+                                    icon="fa fa-plus"
+                                    value="New Bill"
+                                    style="float: right;"
+                                    ajax="false"
+                                    action="pharmacy_bill_retail_sale_native"
+                                    class="mx-1 ui-button-warning"
+                                    actionListener="#{retailSaleNativeSqlController.resetAll()}" />
+                                <p:commandButton
+                                    ajax="false"
+                                    accesskey="s"
+                                    value="Settle"
+                                    icon="fa fa-check"
+                                    style="float: right;"
+                                    class="ui-button-success mx-1"
+                                    onclick="if (!confirm('Are you sure?')) return false"
+                                    action="#{retailSaleNativeSqlController.settleBillWithPay}" />
+                                <h:panelGroup rendered="#{webUserController.hasPrivilege('Admin')}">
+                                    <p:commandButton
+                                        value="Config"
+                                        icon="fa fa-cog"
+                                        title="Page Configuration"
+                                        action="#{pageAdminController.navigateToPageAdmin('pharmacy/pharmacy_bill_retail_sale_native')}"
+                                        ajax="false"
+                                        class="ui-button-secondary mx-2" />
+                                </h:panelGroup>
+                            </f:facet>
+
+                            <div class="row">
+                                <!-- Left column: item entry + bill items -->
+                                <div class="col-md-7">
+                                    <p:panel>
+                                        <f:facet name="header">
+                                            <h:outputText styleClass="fa-solid fa-circle-plus" />
+                                            <h:outputText value="Add New Items" class="mx-4" />
+                                        </f:facet>
+                                        <div class="row w-100 m-1 p-1">
+                                            <div class="col-md-5">
+                                                <p:focus id="focusForAcIx" for="acStock" />
+                                                <p:outputLabel class="w-100" for="acStock">Medicines or Devices</p:outputLabel>
+                                                <h:panelGroup id="acStock">
+                                                    <p:autoComplete
+                                                        id="acStockField"
+                                                        accesskey="i"
+                                                        inputStyleClass="w-100"
+                                                        minQueryLength="3"
+                                                        maxResults="10"
+                                                        styleClass="w-100"
+                                                        forceSelection="true"
+                                                        value="#{retailSaleNativeSqlController.stockDto}"
+                                                        completeMethod="#{retailSaleNativeSqlController.completeAvailableStockOptimizedDto}"
+                                                        converter="#{retailSaleNativeSqlController.stockDtoConverter}"
+                                                        var="i"
+                                                        itemLabel="#{i.itemName}"
+                                                        itemValue="#{i}">
+                                                        <p:column
+                                                            headerText="Item"
+                                                            width="400"
+                                                            styleClass="#{pharmacyController.getExpiryStyleClass(i.dateOfExpire)}">
+                                                            <h:outputText value="#{i.itemName}" />
+                                                            &#160;<p:tag
+                                                                rendered="#{commonFunctionsProxy.currentDateTime > i.dateOfExpire ? 'true' : commonFunctionsProxy.dateAfterThreeMonthsCurrentDateTime > i.dateOfExpire ? 'true' : 'false'}"
+                                                                value="#{commonFunctionsProxy.currentDateTime > i.dateOfExpire ? 'Expired ' : commonFunctionsProxy.dateAfterThreeMonthsCurrentDateTime > i.dateOfExpire ? 'Expiring Soon' : ''}"
+                                                                severity="#{commonFunctionsProxy.currentDateTime > i.dateOfExpire ? 'danger' : commonFunctionsProxy.dateAfterThreeMonthsCurrentDateTime > i.dateOfExpire ? 'warning' : ''}" />
+                                                        </p:column>
+                                                        <p:column
+                                                            width="20em"
+                                                            rendered="#{configOptionApplicationController.getBooleanValueByKey('Medicine Identification Codes Used', true)}"
+                                                            headerText="Code"
+                                                            styleClass="#{pharmacyController.getExpiryStyleClass(i.dateOfExpire)}">
+                                                            <h:outputText value="#{i.code}" />
+                                                        </p:column>
+                                                        <p:column
+                                                            width="20em"
+                                                            headerText="Rate"
+                                                            styleClass="text-end #{pharmacyController.getExpiryStyleClass(i.dateOfExpire)}">
+                                                            <h:outputLabel value="#{i.retailRate}">
+                                                                <f:convertNumber pattern="#,##0.00" />
+                                                            </h:outputLabel>
+                                                        </p:column>
+                                                        <p:column
+                                                            width="20em"
+                                                            headerText="Stocks"
+                                                            styleClass="text-end #{pharmacyController.getExpiryStyleClass(i.dateOfExpire)}">
+                                                            <h:outputLabel value="#{i.stockQty}">
+                                                                <f:convertNumber pattern="#,###" />
+                                                            </h:outputLabel>
+                                                        </p:column>
+                                                        <p:column
+                                                            width="20em"
+                                                            headerText="Expiry"
+                                                            styleClass="text-end #{pharmacyController.getExpiryStyleClass(i.dateOfExpire)}">
+                                                            <h:outputLabel value="#{i.dateOfExpire}">
+                                                                <f:convertDateTime pattern="#{sessionController.applicationPreference.shortDateFormat}" />
+                                                            </h:outputLabel>
+                                                        </p:column>
+                                                        <p:ajax event="itemSelect" listener="#{retailSaleNativeSqlController.handleSelect}" update="txtQty txtRate focusQty" />
+                                                        <p:ajax event="query" process="acStock" />
+                                                    </p:autoComplete>
+                                                </h:panelGroup>
+                                            </div>
+                                            <div class="col-md-2">
+                                                <p:outputLabel class="w-100" for="txtQty">Quantity</p:outputLabel>
+                                                <p:inputText
+                                                    id="txtQty"
+                                                    accesskey="q"
+                                                    autocomplete="off"
+                                                    class="w-100"
+                                                    style="text-align: right;"
+                                                    value="#{retailSaleNativeSqlController.intQty}">
+                                                    <p:ajax event="keyup" listener="#{retailSaleNativeSqlController.calculateBillItemListner}" process="acStock txtQty" update="txtRate txtVal" />
+                                                    <p:ajax event="blur" listener="#{retailSaleNativeSqlController.calculateBillItemListner}" process="acStock txtQty" update="txtRate txtVal" />
+                                                </p:inputText>
+                                            </div>
+                                            <div class="col-md-5">
+                                                <div class="row">
+                                                    <div class="col-md-4">
+                                                        <p:outputLabel value="&#160;" class="w-100" />
+                                                        <p:commandButton
+                                                            id="btnAdd"
+                                                            accesskey="a"
+                                                            icon="fa fa-plus"
+                                                            value="Add"
+                                                            styleClass="ui-button-success"
+                                                            action="#{retailSaleNativeSqlController.addBillItem()}"
+                                                            process="@this acStock txtQty focusForAcIx"
+                                                            update=":#{p:resolveFirstComponentWithId('netTotal', view).clientId} :#{p:resolveFirstComponentWithId('dis', view).clientId} :#{p:resolveFirstComponentWithId('total', view).clientId} :#{p:resolveFirstComponentWithId('panelBillDetails', view).clientId} tblBillItem txtRate txtQty acStock focusItem :#{p:resolveFirstComponentWithId('panelError', view).clientId}" />
+                                                    </div>
+                                                    <div class="col-md-4">
+                                                        <p:outputLabel class="w-100" for="txtRate">Rate</p:outputLabel>
+                                                        <p:inputText
+                                                            id="txtRate"
+                                                            style="text-align: right;"
+                                                            class="w-100"
+                                                            readonly="true"
+                                                            value="#{retailSaleNativeSqlController.billItem.netRate}">
+                                                            <f:convertNumber pattern="#,##0.00" />
+                                                        </p:inputText>
+                                                    </div>
+                                                    <div class="col-md-4">
+                                                        <p:outputLabel class="w-100" value="Value" for="txtVal" />
+                                                        <p:inputText
+                                                            id="txtVal"
+                                                            style="text-align: right;"
+                                                            class="w-100"
+                                                            readonly="true"
+                                                            value="#{retailSaleNativeSqlController.previewNetValue}">
+                                                            <f:convertNumber pattern="#,##0.00" />
+                                                        </p:inputText>
+                                                    </div>
+                                                </div>
+                                            </div>
+                                        </div>
+                                        <p:focus id="focusQty" for="txtQty" />
+                                        <p:focus id="focusItem" for="acStock" />
+                                    </p:panel>
+
+                                    <!-- Bill Items table -->
+                                    <p:panel id="pBis">
+                                        <f:facet name="header">
+                                            <h:outputText styleClass="fas fa-money-bill" />
+                                            <h:outputLabel value="Bill Items" class="mx-4" />
+                                        </f:facet>
+                                        <p:dataTable
+                                            id="tblBillItem"
+                                            value="#{retailSaleNativeSqlController.billItemDataList}"
+                                            var="bi"
+                                            rowIndexVar="s"
+                                            editable="true"
+                                            class="w-100">
+                                            <p:ajax event="rowEdit" listener="#{retailSaleNativeSqlController.onEdit}" update="@this :#{p:resolveFirstComponentWithId('panelBillDetails', view).clientId}" />
+                                            <p:ajax event="rowEditCancel" listener="#{retailSaleNativeSqlController.onEditCancel}" update="@this :#{p:resolveFirstComponentWithId('panelBillDetails', view).clientId}" />
+
+                                            <p:column headerText="No" style="width: 2em; padding: 6px;">
+                                                <h:outputLabel value="#{s+1}">
+                                                    <f:convertNumber pattern="#,##0" />
+                                                </h:outputLabel>
+                                            </p:column>
+                                            <p:column headerText="Item" style="padding: 6px;">
+                                                <h:outputLabel value="#{bi.itemName}" />
+                                            </p:column>
+                                            <p:column headerText="Rate" style="width: 5em; padding: 6px;">
+                                                <h:outputLabel value="#{bi.rate}">
+                                                    <f:convertNumber pattern="#,##0.00" />
+                                                </h:outputLabel>
+                                            </p:column>
+                                            <p:column headerText="Value" style="width: 5em; padding: 6px;">
+                                                <h:outputLabel value="#{bi.netValue &lt; 0 ? -bi.netValue : bi.netValue}" id="gros">
+                                                    <f:convertNumber pattern="#,##0.00" />
+                                                </h:outputLabel>
+                                            </p:column>
+                                            <p:column headerText="Expiry" style="width: 7em; padding: 6px;">
+                                                <h:outputLabel value="#{bi.doe}">
+                                                    <f:convertDateTime timeZone="Asia/Colombo" pattern="#{sessionController.applicationPreference.shortDateFormat}" />
+                                                </h:outputLabel>
+                                            </p:column>
+                                            <p:column headerText="Qty" style="width: 3em; padding: 6px;">
+                                                <p:cellEditor>
+                                                    <f:facet name="output">
+                                                        <h:outputText value="#{bi.qty}">
+                                                            <f:convertNumber integerOnly="true" pattern="#,##0" />
+                                                        </h:outputText>
+                                                    </f:facet>
+                                                    <f:facet name="input">
+                                                        <p:inputText
+                                                            id="ipTblQty"
+                                                            autocomplete="off"
+                                                            value="#{bi.qty}"
+                                                            style="width:96%"
+                                                            converterMessage="Please enter a valid integer value.">
+                                                            <f:convertNumber integerOnly="true" pattern="#,##0" />
+                                                        </p:inputText>
+                                                    </f:facet>
+                                                </p:cellEditor>
+                                            </p:column>
+                                            <p:column style="width: 10em; padding: 6px;">
+                                                <p:rowEditor style="display: inline-block; margin-right: 10px;" />
+                                                <p:commandButton
+                                                    id="btnDelete"
+                                                    icon="fas fa-trash"
+                                                    action="#{retailSaleNativeSqlController.removeBillItem(bi)}"
+                                                    class="ui-button-danger"
+                                                    process="btnDelete"
+                                                    update="tblBillItem :#{p:resolveFirstComponentWithId('panelBillDetails', view).clientId}"
+                                                    style="display: inline-block;" />
+                                            </p:column>
+                                        </p:dataTable>
+                                    </p:panel>
+                                </div>
+
+                                <!-- Right column: patient + payment -->
+                                <div class="col-md-5">
+                                    <h:panelGrid id="sale" columns="1" class="alignTop w-100">
+
+                                        <!-- Patient panel -->
+                                        <p:panel id="panelPatient">
+                                            <f:facet name="header">
+                                                <h:panelGroup layout="block" styleClass="d-flex justify-content-between align-items-center">
+                                                    <h:panelGroup id="headerFacet">
+                                                        <h:outputText styleClass="fas fa-user" />
+                                                        <h:outputText
+                                                            rendered="#{retailSaleNativeSqlController.patient.id eq null}"
+                                                            value="Patient" class="mx-4" />
+                                                        <h:outputText
+                                                            rendered="#{retailSaleNativeSqlController.patient.id ne null}"
+                                                            value="Searched Patient Details" class="mx-2" />
+                                                        <p:selectBooleanButton
+                                                            value="#{retailSaleNativeSqlController.patientDetailsEditable}"
+                                                            offIcon="pi pi-pencil"
+                                                            onIcon="pi pi-eye"
+                                                            class="mx-2">
+                                                            <p:ajax process="@this" update="viewPatient editPatient btnDone" />
+                                                        </p:selectBooleanButton>
+                                                        <p:commandButton
+                                                            id="btnDone"
+                                                            alt="Save Patient Details"
+                                                            class="ui-button-success"
+                                                            icon="fas fa-check"
+                                                            action="#{patientController.saveSelected(retailSaleNativeSqlController.patient)}"
+                                                            rendered="#{retailSaleNativeSqlController.patientDetailsEditable}"
+                                                            update=":#{p:resolveFirstComponentWithId('panelPatient', view).clientId}" />
+</h:panelGroup>
+                                                    <h:panelGroup layout="block" styleClass="form-inline">
+                                                        <p:inputText
+                                                            autocomplete="off"
+                                                            id="txtQuickSearchPhoneNumber"
+                                                            value="#{patientController.quickSearchPhoneNumber}"
+                                                            placeholder="Phone Number"
+                                                            class="form-control-sm mx-1"
+                                                            onfocus="this.select()" />
+                                                        <p:commandButton
+                                                            id="btnSearchbyPhoneNo"
+                                                            icon="fa fa-search"
+                                                            title="Quick Search from Phone Number"
+                                                            action="#{patientController.quickSearchPatientLongPhoneNumber(retailSaleNativeSqlController)}"
+                                                            process="btnSearchbyPhoneNo txtQuickSearchPhoneNumber"
+                                                            update="panelPatient selectPatient editPatient viewPatient panelPayment panelBillDetails"
+                                                            styleClass="btn-sm mx-1" />
+                                                        <p:commandButton
+                                                            id="btnAddNewPatient"
+                                                            icon="fa fa-plus-circle"
+                                                            title="Add New Patient"
+                                                            action="#{patientController.quickSearchNewPatient(retailSaleNativeSqlController)}"
+                                                            process="btnAddNewPatient"
+                                                            update="panelPatient selectPatient editPatient viewPatient panelPayment panelBillDetails"
+                                                            styleClass="btn-sm mx-1" />
+                                                    </h:panelGroup>
+                                                </h:panelGroup>
+                                            </f:facet>
+
+                                            <h:panelGroup id="selectPatient">
+                                                <h:panelGroup rendered="#{patientController.quickSearchPatientList ne null and not empty patientController.quickSearchPatientList}">
+                                                    <p:dataTable id="tblPatients" value="#{patientController.quickSearchPatientList}" var="ps">
+                                                        <p:column headerText="Name">#{ps.person.name}</p:column>
+                                                        <p:column headerText="Phone Number">#{ps.person.phone}</p:column>
+                                                        <p:column headerText="Mobile Number">#{ps.person.mobile}</p:column>
+                                                        <p:column>
+                                                            <p:commandButton
+                                                                id="btnSelectPt"
+                                                                action="#{patientController.selectQuickOneFromQuickSearchPatient(retailSaleNativeSqlController)}"
+                                                                process="btnSelectPt"
+                                                                update=":#{p:resolveFirstComponentWithId('panelPatient', view).clientId} :#{p:resolveFirstComponentWithId('panelPayment', view).clientId} :#{p:resolveFirstComponentWithId('panelBillDetails', view).clientId}"
+                                                                value="Select">
+                                                                <f:setPropertyActionListener value="#{ps}" target="#{patientController.current}" />
+                                                            </p:commandButton>
+                                                        </p:column>
+                                                    </p:dataTable>
+                                                </h:panelGroup>
+                                            </h:panelGroup>
+
+                                            <h:panelGroup id="editPatient">
+                                                <h:panelGroup rendered="#{retailSaleNativeSqlController.patientDetailsEditable}">
+                                                    <h:panelGroup rendered="#{patientController.quickSearchPatientList eq null or empty patientController.quickSearchPatientList}">
+                                                        <div class="row">
+                                                            <div class="col-md-3 p-1">
+                                                                <p:selectOneMenu id="cmbTitle" class="form-control w-100" value="#{retailSaleNativeSqlController.patient.person.title}">
+                                                                    <f:selectItem itemLabel="Select Title" />
+                                                                    <f:selectItems value="#{opdBillController.title}" var="i" itemLabel="#{i.label}" itemValue="#{i}" />
+                                                                    <p:ajax event="change" process="cmbTitle" update="cmbSex" />
+                                                                </p:selectOneMenu>
+                                                            </div>
+                                                            <div class="col-md-9 p-1">
+                                                                <p:inputText
+                                                                    autocomplete="off"
+                                                                    id="txtNewPtName"
+                                                                    placeholder="Patient Name"
+                                                                    value="#{retailSaleNativeSqlController.patient.person.name}"
+                                                                    class="form-control" />
+                                                            </div>
+                                                        </div>
+                                                        <div class="row">
+                                                            <div class="col-md-3 p-1">
+                                                                <p:selectOneMenu id="cmbSex" value="#{retailSaleNativeSqlController.patient.person.sex}" class="form-control w-100">
+                                                                    <f:selectItem itemLabel="Select Gender" />
+                                                                    <f:selectItems value="#{opdBillController.sex}" />
+                                                                </p:selectOneMenu>
+                                                            </div>
+                                                            <div class="col-md-9 p-1">
+                                                                <div class="row">
+                                                                    <div class="col-md-2">
+                                                                        <p:inputText autocomplete="off" id="year" placeholder="Years" value="#{retailSaleNativeSqlController.patient.person.ageYearsComponent}" class="form-control">
+                                                                            <f:ajax event="keyup" execute="@this" render="dpDob" listener="#{retailSaleNativeSqlController.calculateDobFromAge}" />
+                                                                        </p:inputText>
+                                                                    </div>
+                                                                    <div class="col-md-2">
+                                                                        <p:inputText autocomplete="off" id="month" placeholder="Months" value="#{retailSaleNativeSqlController.patient.person.ageMonthsComponent}" class="form-control">
+                                                                            <f:ajax event="keyup" execute="@this" render="dpDob" listener="#{retailSaleNativeSqlController.calculateDobFromAge}" />
+                                                                        </p:inputText>
+                                                                    </div>
+                                                                    <div class="col-md-2">
+                                                                        <p:inputText autocomplete="off" id="day" placeholder="Days" value="#{retailSaleNativeSqlController.patient.person.ageDaysComponent}" class="form-control">
+                                                                            <f:ajax event="keyup" execute="@this" render="dpDob" listener="#{retailSaleNativeSqlController.calculateDobFromAge}" />
+                                                                        </p:inputText>
+                                                                    </div>
+                                                                    <div class="col-md-6">
+                                                                        <p:datePicker
+                                                                            value="#{retailSaleNativeSqlController.patient.person.dob}"
+                                                                            id="dpDob"
+                                                                            class="w-100"
+                                                                            yearNavigator="true"
+                                                                            monthNavigator="true"
+                                                                            inputStyleClass="form-control"
+                                                                            pattern="#{sessionController.applicationPreference.longDateFormat}"
+                                                                            placeholder="Date of Birth">
+                                                                            <p:ajax event="dateSelect" process="@this" update="year month day" />
+                                                                        </p:datePicker>
+                                                                    </div>
+                                                                </div>
+                                                            </div>
+                                                        </div>
+                                                        <div class="row">
+                                                            <div class="col-md-3 p-1">
+                                                                <p:inputText id="txtMobile" autocomplete="off" placeholder="Mobile Number" value="#{retailSaleNativeSqlController.patient.mobileNumberStringTransient}" class="form-control" />
+                                                            </div>
+                                                            <div class="col-md-3 p-1">
+                                                                <p:inputText id="txtPhone" autocomplete="off" placeholder="Phone Number" value="#{retailSaleNativeSqlController.patient.phoneNumberStringTransient}" class="form-control" />
+                                                            </div>
+                                                            <div class="col-md-3 p-1">
+                                                                <p:inputText autocomplete="off" id="txtEmail" placeholder="Email" value="#{retailSaleNativeSqlController.patient.person.email}" class="form-control" />
+                                                            </div>
+                                                            <div class="col-md-3 p-1">
+                                                                <p:inputText id="txtNic" autocomplete="off" placeholder="National ID Number" value="#{retailSaleNativeSqlController.patient.person.nic}" class="form-control" />
+                                                            </div>
+                                                        </div>
+                                                        <div class="row">
+                                                            <div class="col-md-8 p-1">
+                                                                <p:inputText id="txtAddress" autocomplete="off" placeholder="Address" value="#{retailSaleNativeSqlController.patient.person.address}" class="form-control" />
+                                                            </div>
+                                                            <div class="col-md-4 p-1">
+                                                                <p:autoComplete
+                                                                    id="acNewPtArea"
+                                                                    placeholder="Search Area"
+                                                                    completeMethod="#{areaController.completeArea}"
+                                                                    var="pta" itemLabel="#{pta.name}"
+                                                                    itemValue="#{pta}" forceSelection="true"
+                                                                    value="#{retailSaleNativeSqlController.patient.person.area}"
+                                                                    inputStyleClass="form-control"
+                                                                    class="w-100" />
+                                                            </div>
+                                                        </div>
+                                                    </h:panelGroup>
+                                                </h:panelGroup>
+                                            </h:panelGroup>
+
+                                            <h:panelGroup id="viewPatient">
+                                                <h:panelGroup rendered="#{not retailSaleNativeSqlController.patientDetailsEditable}">
+                                                    <h:panelGroup rendered="#{patientController.quickSearchPatientList eq null}">
+                                                        <h:panelGrid columns="3" class="my-1" rendered="#{retailSaleNativeSqlController.patient ne null}">
+                                                            <h:outputLabel value="Name" class="mx-3" />
+                                                            <h:outputLabel value=" : " class="mx-3" />
+                                                            <h:outputText value="#{retailSaleNativeSqlController.patient.person.nameWithTitle}" />
+                                                            <h:outputLabel value="Gender" class="mx-3" />
+                                                            <h:outputLabel value=" : " class="mx-3" />
+                                                            <h:outputText value="#{retailSaleNativeSqlController.patient.person.sex}" />
+                                                            <h:outputLabel value="Mobile No." class="mx-3" />
+                                                            <h:outputLabel value=" : " class="mx-3" />
+                                                            <h:outputText value="#{retailSaleNativeSqlController.patient.person.mobile}" />
+                                                            <h:outputLabel value="Phone No." class="mx-3" />
+                                                            <h:outputLabel value=" : " class="mx-3" />
+                                                            <h:outputText value="#{retailSaleNativeSqlController.patient.person.phone}" />
+                                                            <h:outputLabel value="NIC" class="mx-3" />
+                                                            <h:outputLabel value=" : " class="mx-3" />
+                                                            <h:outputText value="#{empty retailSaleNativeSqlController.patient.person.nic ? 'N/A' : retailSaleNativeSqlController.patient.person.nic}" />
+                                                        </h:panelGrid>
+                                                    </h:panelGroup>
+                                                </h:panelGroup>
+                                            </h:panelGroup>
+                                        </p:panel>
+
+                                        <!-- Payment panel -->
+                                        <div class="row">
+                                            <div class="col">
+                                                <p:panel id="panelPayment" class="w-100">
+                                                    <f:facet name="header">
+                                                        <h:outputText styleClass="fas fa-money-bill-wave" />
+                                                        <h:outputLabel value="Payment Details" class="mx-4" />
+                                                    </f:facet>
+                                                    <div class="row">
+                                                        <div class="col-md-5">
+                                                            <p:selectOneMenu
+                                                                id="pay"
+                                                                value="#{retailSaleNativeSqlController.paymentMethod}"
+                                                                required="true"
+                                                                requiredMessage="Please select a payment method">
+                                                                <f:selectItems value="#{enumController.paymentMethodsForPharmacyBilling}" var="p" itemLabel="#{p.label}" itemValue="#{p}" />
+                                                                <p:ajax process="@this cmbPs cmbPaymentScheme" update="panelBillDetails panelPaymentDetails" event="change" listener="#{retailSaleNativeSqlController.listnerForPaymentMethodChange()}" />
+                                                            </p:selectOneMenu>
+
+                                                            <p:selectOneMenu
+                                                                id="cmbPaymentScheme"
+                                                                value="#{retailSaleNativeSqlController.paymentScheme}"
+                                                                rendered="#{sessionController.loggedPreference.checkPaymentSchemeValidation eq true}"
+                                                                required="true"
+                                                                requiredMessage="Please select a payment scheme">
+                                                                <f:selectItems value="#{paymentSchemeController.items}" var="i" itemLabel="#{i.name}" itemValue="#{i}" />
+                                                                <p:ajax process="@this pay" update="panelBillDetails panelPaymentDetails" event="change" listener="#{retailSaleNativeSqlController.listnerForPaymentMethodChange()}" />
+                                                            </p:selectOneMenu>
+                                                        </div>
+                                                    </div>
+
+                                                    <div class="row">
+                                                        <div class="my-1">
+                                                            <h:panelGroup id="panelPaymentDetails" class="row">
+                                                                <div class="col">
+                                                                    <h:panelGroup class="row" layout="block" rendered="#{retailSaleNativeSqlController.paymentMethod eq 'Credit'}">
+                                                                        <div class="my-1">
+                                                                            <div class="row">
+                                                                                <div class="col-12">
+                                                                                    <div class="d-flex gap-2">
+                                                                                        <p:autoComplete
+                                                                                            id="creditCompany"
+                                                                                            class="w-100"
+                                                                                            inputStyleClass="form-control"
+                                                                                            forceSelection="true"
+                                                                                            value="#{retailSaleNativeSqlController.paymentMethodData.credit.institution}"
+                                                                                            completeMethod="#{institutionController.completeCreditCompany}"
+                                                                                            var="ix"
+                                                                                            required="true"
+                                                                                            requiredMessage="Please Select a Company"
+                                                                                            minQueryLength="2"
+                                                                                            placeholder="Company"
+                                                                                            itemLabel="#{ix.name}"
+                                                                                            itemValue="#{ix}"
+                                                                                            size="10">
+                                                                                            <f:ajax event="itemSelect" listener="#{retailSaleNativeSqlController.calTotal()}" execute="@this" render=":#{p:resolveFirstComponentWithId('panelBillDetails', view).clientId}" />
+                                                                                        </p:autoComplete>
+                                                                                        <p:inputText id="polNo" style="width: 100px;" value="#{retailSaleNativeSqlController.paymentMethodData.credit.referralNo}" placeholder="Policy NO" required="true" requiredMessage="Please enter a policy number" />
+                                                                                        <p:inputText id="refNo" style="width: 100px;" required="true" requiredMessage="Please enter a Reference Number" value="#{retailSaleNativeSqlController.paymentMethodData.credit.referenceNo}" placeholder="Reference NO" />
+                                                                                        <p:inputText id="memo" style="width: 300px;" required="true" requiredMessage="Please Enter a comment" value="#{retailSaleNativeSqlController.paymentMethodData.credit.comment}" placeholder="Memo" />
+                                                                                    </div>
+                                                                                </div>
+                                                                            </div>
+                                                                        </div>
+                                                                    </h:panelGroup>
+
+                                                                    <h:panelGroup class="row" layout="block" rendered="#{retailSaleNativeSqlController.paymentMethod eq 'Staff'}">
+                                                                        <div class="my-1">
+                                                                            <div class="row mt-1">
+                                                                                <div class="col-12">
+                                                                                    <p:autoComplete
+                                                                                        minQueryLength="2"
+                                                                                        forceSelection="true"
+                                                                                        value="#{retailSaleNativeSqlController.toStaff}"
+                                                                                        id="creditStaff"
+                                                                                        completeMethod="#{staffController.completeStaff}"
+                                                                                        var="mys"
+                                                                                        class="w-100"
+                                                                                        required="true"
+                                                                                        requiredMessage="Please select a staff member"
+                                                                                        placeholder="Staff (Type at least 2 letters)"
+                                                                                        inputStyleClass="form-control"
+                                                                                        itemLabel="#{mys.person.name}"
+                                                                                        itemValue="#{mys}"
+                                                                                        size="10">
+                                                                                        <p:column headerText="Name" style="padding: 2px;"><h:outputText value="#{mys.person.nameWithTitle}" /></p:column>
+                                                                                        <p:column headerText="EPF" style="padding: 2px;"><h:outputText value="#{mys.epfNo}" /></p:column>
+                                                                                        <p:ajax process="@this" update=":#{p:resolveFirstComponentWithId('panelBillDetails', view).clientId}" event="itemSelect" listener="#{retailSaleNativeSqlController.calTotal()}" />
+                                                                                    </p:autoComplete>
+                                                                                </div>
+                                                                            </div>
+                                                                        </div>
+                                                                    </h:panelGroup>
+
+                                                                    <h:panelGroup class="row" layout="block" rendered="#{retailSaleNativeSqlController.paymentMethod eq 'Staff_Welfare'}">
+                                                                        <div class="my-1">
+                                                                            <div class="row mt-1">
+                                                                                <div class="col-12">
+                                                                                    <p:autoComplete
+                                                                                        minQueryLength="1"
+                                                                                        forceSelection="true"
+                                                                                        value="#{retailSaleNativeSqlController.toStaff}"
+                                                                                        id="welfareStaff"
+                                                                                        completeMethod="#{staffController.completeStaff}"
+                                                                                        var="mys"
+                                                                                        class="w-100"
+                                                                                        required="true"
+                                                                                        requiredMessage="Please select a staff member"
+                                                                                        placeholder="Staff"
+                                                                                        inputStyleClass="form-control"
+                                                                                        itemLabel="#{mys.person.name}"
+                                                                                        itemValue="#{mys}"
+                                                                                        size="10">
+                                                                                        <p:column headerText="Name" style="padding: 2px;"><h:outputText value="#{mys.person.nameWithTitle}" /></p:column>
+                                                                                        <p:column headerText="EPF" style="padding: 2px;"><h:outputText value="#{mys.epfNo}" /></p:column>
+                                                                                        <p:ajax process="@this" update=":#{p:resolveFirstComponentWithId('panelBillDetails', view).clientId}" event="itemSelect" listener="#{retailSaleNativeSqlController.calTotal()}" />
+                                                                                    </p:autoComplete>
+                                                                                </div>
+                                                                            </div>
+                                                                        </div>
+                                                                    </h:panelGroup>
+
+                                                                    <h:panelGroup id="creditCard" rendered="#{retailSaleNativeSqlController.paymentMethod eq 'Card'}">
+                                                                        <pa:creditCardDetailsAsOnlyPayment paymentMethodData="#{retailSaleNativeSqlController.paymentMethodData}" />
+                                                                    </h:panelGroup>
+                                                                    <h:panelGroup id="ptdeposit" rendered="#{retailSaleNativeSqlController.paymentMethod eq 'PatientDeposit'}">
+                                                                        <pa:patient_deposit paymentMethodData="#{retailSaleNativeSqlController.paymentMethodData}" />
+                                                                    </h:panelGroup>
+                                                                    <h:panelGroup id="ewallet" rendered="#{retailSaleNativeSqlController.paymentMethod eq 'ewallet'}">
+                                                                        <pa:ewalletDetailsAsOnlyPayment paymentMethodData="#{retailSaleNativeSqlController.paymentMethodData}" />
+                                                                    </h:panelGroup>
+                                                                    <h:panelGroup id="cheque" rendered="#{retailSaleNativeSqlController.paymentMethod eq 'Cheque'}">
+                                                                        <pa:chequeDetailsAsOnlyPayment paymentMethodData="#{retailSaleNativeSqlController.paymentMethodData}" />
+                                                                    </h:panelGroup>
+                                                                    <h:panelGroup id="slip" rendered="#{retailSaleNativeSqlController.paymentMethod eq 'Slip'}">
+                                                                        <pa:slipDetailsAsOnlyPayment paymentMethodData="#{retailSaleNativeSqlController.paymentMethodData}" />
+                                                                    </h:panelGroup>
+                                                                    <h:panelGroup id="iou" rendered="#{retailSaleNativeSqlController.paymentMethod eq 'IOU'}">
+                                                                        <pa:iouDetailsAsOnlyPayment paymentMethodData="#{retailSaleNativeSqlController.paymentMethodData}" />
+                                                                    </h:panelGroup>
+                                                                    <h:panelGroup class="row my-1 w-100" layout="block" id="multiplePaymentMethods" rendered="#{retailSaleNativeSqlController.paymentMethod eq 'MultiplePaymentMethods'}">
+                                                                        <pa:multiple_payment_methods
+                                                                            id="panelMultiplePaymentDetails"
+                                                                            class="w-100"
+                                                                            controller="#{retailSaleNativeSqlController}"
+                                                                            paymentMethods="#{enumController.paymentMethodsUnderMultipleForPharmacyBilling}" />
+                                                                    </h:panelGroup>
+                                                                </div>
+                                                            </h:panelGroup>
+                                                        </div>
+                                                    </div>
+
+                                                    <div class="col-5">
+                                                        <p:selectOneMenu
+                                                            id="cmbPs"
+                                                            value="#{retailSaleNativeSqlController.paymentScheme}"
+                                                            rendered="#{sessionController.loggedPreference.checkPaymentSchemeValidation eq false}"
+                                                            class="my-1">
+                                                            <f:selectItem itemLabel="Discount Scheme" />
+                                                            <f:selectItems value="#{paymentSchemeController.paymentSchemesForPharmacy}" var="i" itemLabel="#{i.name}" itemValue="#{i}" />
+                                                            <p:ajax process="@this pay" update="panelBillDetails panelPaymentDetails" event="change" listener="#{retailSaleNativeSqlController.listnerForPaymentMethodChange()}" />
+                                                        </p:selectOneMenu>
+                                                    </div>
+
+                                                    <h:panelGrid columns="2" class="my-2">
+                                                        <p:outputLabel value="Referring Doctor" />
+                                                        <p:autoComplete
+                                                            forceSelection="true"
+                                                            id="cmbDoc"
+                                                            value="#{retailSaleNativeSqlController.preBill.referredBy}"
+                                                            completeMethod="#{doctorController.completeDoctor}"
+                                                            var="ix" itemLabel="#{ix.person.name}"
+                                                            itemValue="#{ix}" size="40"
+                                                            class="mx-4 w-100 mt-1"
+                                                            inputStyleClass="form-control" />
+                                                        <p:outputLabel value="Comments" />
+                                                        <p:inputTextarea id="txtComment" class="w-100 mx-4" value="#{retailSaleNativeSqlController.comment}" />
+                                                    </h:panelGrid>
+                                                </p:panel>
+
+                                                <!-- Bill Details panel -->
+                                                <p:panel id="panelBillDetails" class="my-1">
+                                                    <f:facet name="header">
+                                                        <h:outputText styleClass="fas fa-list" />
+                                                        <h:outputLabel value="Bill Details" class="mx-4" />
+                                                    </f:facet>
+                                                    <h:panelGrid columns="2" columnClasses="numberCol, textCol">
+                                                        <h:outputLabel value="Total" />
+                                                        <h:panelGroup layout="block" class="text-end mx-4 my-1">
+                                                            <h:outputLabel id="total" value="#{retailSaleNativeSqlController.preBill.total}">
+                                                                <f:convertNumber pattern="#,##0.00" />
+                                                            </h:outputLabel>
+                                                        </h:panelGroup>
+                                                        <h:outputLabel value="Discount" />
+                                                        <h:panelGroup layout="block" class="text-end mx-4 my-1">
+                                                            <h:outputLabel id="dis" value="#{retailSaleNativeSqlController.preBill.discount}">
+                                                                <f:convertNumber pattern="#,##0.00" />
+                                                            </h:outputLabel>
+                                                        </h:panelGroup>
+                                                        <h:outputLabel value="Net Total" />
+                                                        <h:panelGroup layout="block" class="text-end mx-4 my-1">
+                                                            <h:outputLabel id="netTotal" value="#{retailSaleNativeSqlController.preBill.netTotal}">
+                                                                <f:convertNumber pattern="#,##0.00" />
+                                                            </h:outputLabel>
+                                                        </h:panelGroup>
+                                                        <h:outputLabel value="Tendered" />
+                                                        <h:panelGroup layout="block" class="text-end mx-4 my-1">
+                                                            <p:inputText
+                                                                id="paid"
+                                                                value="#{retailSaleNativeSqlController.cashPaid}"
+                                                                class="form-control text-end"
+                                                                autocomplete="off"
+                                                                accesskey="t"
+                                                                onfocus="this.select()">
+                                                                <p:ajax process="total dis netTotal paid" update="balance netTotal" event="keyup" />
+                                                            </p:inputText>
+                                                        </h:panelGroup>
+                                                        <h:outputLabel value="Balance" />
+                                                        <h:panelGroup layout="block" class="text-end mx-4 my-1">
+                                                            <h:outputLabel id="balance" value="#{retailSaleNativeSqlController.balance}">
+                                                                <f:convertNumber pattern="#,##0.00" />
+                                                            </h:outputLabel>
+                                                        </h:panelGroup>
+                                                    </h:panelGrid>
+                                                </p:panel>
+                                            </div>
+                                        </div>
+                                    </h:panelGrid>
+                                </div>
+                            </div>
+                        </p:panel>
+                    </p:panel>
+                </h:form>
+
+                <!-- ============================================================
+                     PRINT / PREVIEW PANEL (shown after settle)
+                     ============================================================ -->
+                <h:form>
+                    <p:panel rendered="#{retailSaleNativeSqlController.billPreview}">
+                        <div class="row">
+                            <div class="col-3">
+                                <p:commandButton
+                                    rendered="#{webUserController.hasPrivilege('ChangeReceiptPrintingPaperTypes')}"
+                                    value="Settings"
+                                    icon="fas fa-cog"
+                                    class="ui-button-secondary mx-1"
+                                    type="button"
+                                    onclick="PF('retailSaleNativeConfigDialog').show();" />
+                            </div>
+                            <div class="col-6 text-center">
+                                <p:commandButton
+                                    class="m-1"
+                                    icon="fas fa-file-invoice"
+                                    value="Sale 1"
+                                    action="pharmacy_bill_retail_sale?faces-redirect=true"
+                                    rendered="#{webUserController.hasPrivilege('PharmacySale')}"
+                                    actionListener="#{pharmacySaleController.pharmacyRetailSale()}" />
+                                <p:commandButton
+                                    class="m-1"
+                                    icon="fas fa-file-invoice"
+                                    value="Native Sale"
+                                    disabled="true"
+                                    rendered="#{webUserController.hasPrivilege('PharmacySale')}" />
+                            </div>
+                            <div class="col-3">
+                                <div class="float-end">
+                                    <p:commandButton
+                                        accesskey="n"
+                                        value="New Pharmacy Retail Sale"
+                                        icon="fa fa-plus"
+                                        ajax="false"
+                                        action="pharmacy_bill_retail_sale_native"
+                                        class="ui-button-success mx-2"
+                                        actionListener="#{retailSaleNativeSqlController.resetAll()}" />
+                                    <p:commandButton
+                                        accesskey="p"
+                                        id="btnPrint"
+                                        icon="fas fa-print"
+                                        value="Print Bill"
+                                        style="width: 10em;"
+                                        class="ui-button-success"
+                                        rendered="#{!configOptionApplicationController.getBooleanValueByKey('Pharmacy Bill Support for Native Printers')}"
+                                        ajax="false">
+                                        <p:printer target="gpBillPreview" />
+                                    </p:commandButton>
+                                </div>
+                            </div>
+                        </div>
+
+                        <h:panelGroup id="gpBillPreview">
+                            <phi:saleBill_Header_Inward_native
+                                bill="#{retailSaleNativeSqlController.printBill}"
+                                items="#{retailSaleNativeSqlController.printBillItems}" />
+                        </h:panelGroup>
+                    </p:panel>
+                </h:form>
+
+                <!-- Printer Config Dialog -->
+                <p:dialog id="retailSaleNativeConfigDialog"
+                          rendered="#{webUserController.hasPrivilege('ChangeReceiptPrintingPaperTypes')}"
+                          header="Retail Sale (Native) Printer Configuration"
+                          widgetVar="retailSaleNativeConfigDialog"
+                          modal="true"
+                          width="600"
+                          resizable="true"
+                          closeOnEscape="true">
+                    <p:ajax event="open" listener="#{pharmacyConfigController.loadCurrentConfig}" update="retailSaleNativeConfigForm" />
+                    <h:form id="retailSaleNativeConfigForm">
+                        <div class="card-body">
+                            <div class="mb-3">
+                                <h:selectBooleanCheckbox id="posPaper" value="#{pharmacyConfigController.posPaper}" />
+                                <p:outputLabel for="posPaper" value="POS Paper (Default)" class="ms-2" />
+                            </div>
+                            <div class="mb-3">
+                                <h:selectBooleanCheckbox id="posPaperCustom1" value="#{pharmacyConfigController.posPaperCustom1}" />
+                                <p:outputLabel for="posPaperCustom1" value="POS Paper Custom 1" class="ms-2" />
+                            </div>
+                            <div class="mb-3">
+                                <h:selectBooleanCheckbox id="fiveFivePaper" value="#{pharmacyConfigController.fiveFivePaper}" />
+                                <p:outputLabel for="fiveFivePaper" value="5.5 Inch Paper" class="ms-2" />
+                            </div>
+                            <div class="mb-3">
+                                <h:selectBooleanCheckbox id="posHeaderPaper" value="#{pharmacyConfigController.posHeaderPaper}" />
+                                <p:outputLabel for="posHeaderPaper" value="POS Paper with Header" class="ms-2" />
+                            </div>
+                            <div class="mb-3">
+                                <h:selectBooleanCheckbox id="custom1Paper" value="#{pharmacyConfigController.custom1Paper}" />
+                                <p:outputLabel for="custom1Paper" value="Custom Format 1" class="ms-2" />
+                            </div>
+                            <div class="mb-3">
+                                <h:selectBooleanCheckbox id="custom2Paper" value="#{pharmacyConfigController.custom2Paper}" />
+                                <p:outputLabel for="custom2Paper" value="Custom Format 2" class="ms-2" />
+                            </div>
+                            <div class="mb-3">
+                                <h:selectBooleanCheckbox id="custom3Paper" value="#{pharmacyConfigController.custom3Paper}" />
+                                <p:outputLabel for="custom3Paper" value="Custom Format 3" class="ms-2" />
+                            </div>
+                        </div>
+                        <div class="d-flex gap-2 mt-2">
+                            <p:commandButton value="Apply &amp; Close" icon="fas fa-save" class="ui-button-success" ajax="false" action="#{pharmacyConfigController.saveRetailSaleConfig}" />
+                            <p:commandButton value="Cancel" icon="fas fa-times" class="ui-button-secondary" onclick="PF('retailSaleNativeConfigDialog').hide(); return false;" type="button" />
+                        </div>
+                    </h:form>
+                </p:dialog>
+
+            </ui:define>
+        </ui:composition>
+    </h:body>
+</html>

--- a/src/main/webapp/resources/ezcomp/menu.xhtml
+++ b/src/main/webapp/resources/ezcomp/menu.xhtml
@@ -962,6 +962,13 @@
                             rendered="#{webUserController.hasPrivilege('PharmacySale') and configOptionApplicationController.getBooleanValueByKey('Pharmacy Retail Sale - By Batch Search', true)}" ></p:menuitem>
                         <p:menuitem
                             ajax="false"
+                            action="/pharmacy/pharmacy_bill_retail_sale_native?faces-redirect=true"
+                            actionListener="#{retailSaleNativeSqlController.resetAll()}"
+                            value="Sale by Batch (Fast)"
+                            icon="fas fa-bolt"
+                            rendered="#{webUserController.hasPrivilege('PharmacySale')}" ></p:menuitem>
+                        <p:menuitem
+                            ajax="false"
                             action="/pharmacy/pharmacy_fast_retail_sale?faces-redirect=true"
                             actionListener="#{pharmacyFastRetailSaleController.resetAll()}"
                             value="Sale by Item"


### PR DESCRIPTION
## Summary

- Adds `RetailSaleNativeSqlController` + `RetailSaleNativeSqlService` + `pharmacy_bill_retail_sale_native.xhtml` — a new pharmacy retail sale path that uses native SQL inserts to avoid the `Stock → ItemBatch → Item` EAGER cascade that dominates cold-start latency in the original settle path
- `PrintBillData` DTO extended with `paymentMethodLabel`, `comment`, `cashPaid`, `balance` fields required by the print preview
- Menu item "Native Sale" added under Pharmacy → Sale by Batch
- Print preview uses `phi:saleBill_Header_Inward_native` which accepts `PrintBillData` directly (no JPA entity required)

## Key design decisions

- Native SQL path handles: Bill header (JPA persist), BillItems + PharmaceuticalBillItems (native INSERT batch), Payment (native INSERT), StockHistory updates (native UPDATE)
- `LAST_INSERT_ID()` used to retrieve natively inserted row IDs
- Autocomplete uses a JPQL constructor query (`StockDTO`) — no JPA managed entities loaded for the item list
- Discount calculation uses `PriceMatrixController.getPaymentSchemeDiscountPercent` with a fallback JPA `Item` fetch only for the discount-allowed flag
- `ControllerWithPatient` interface implemented so `PatientController.quickSearchPatientLongPhoneNumber` resolves correctly

## Test plan

- [ ] Add items via autocomplete, verify qty/rate/value update correctly
- [ ] Settle with Cash — bill settles, print preview appears
- [ ] Settle with Credit — credit company + policy/ref fields required
- [ ] Settle with Staff / Staff Welfare — staff autocomplete required
- [ ] Patient search by phone number works; new patient creation works
- [ ] "New Bill" button resets all state
- [ ] Stock quantity is decremented after settle
- [ ] Menu item "Native Sale" is visible in the Pharmacy menu

Closes #20260

🤖 Generated with [Claude Code](https://claude.com/claude-code)