### PR TITLE
Fix service search JPQL and add Investigation REST API

### DIFF
--- a/src/main/java/com/divudi/core/data/dto/investigation/InvestigationCreateRequestDTO.java
+++ b/src/main/java/com/divudi/core/data/dto/investigation/InvestigationCreateRequestDTO.java
@@ -1,0 +1,24 @@
+package com.divudi.core.data.dto.investigation;
+
+public class InvestigationCreateRequestDTO {
+    private String name;
+    private String code;
+    private String printName;
+    private Boolean inactive;
+    private String reportType;
+    private Boolean bypassSampleWorkflow;
+
+    public boolean isValid() { return name != null && !name.trim().isEmpty(); }
+    public String getName() { return name; }
+    public void setName(String name) { this.name = name; }
+    public String getCode() { return code; }
+    public void setCode(String code) { this.code = code; }
+    public String getPrintName() { return printName; }
+    public void setPrintName(String printName) { this.printName = printName; }
+    public Boolean getInactive() { return inactive; }
+    public void setInactive(Boolean inactive) { this.inactive = inactive; }
+    public String getReportType() { return reportType; }
+    public void setReportType(String reportType) { this.reportType = reportType; }
+    public Boolean getBypassSampleWorkflow() { return bypassSampleWorkflow; }
+    public void setBypassSampleWorkflow(Boolean bypassSampleWorkflow) { this.bypassSampleWorkflow = bypassSampleWorkflow; }
+}

--- a/src/main/java/com/divudi/core/data/dto/investigation/InvestigationResponseDTO.java
+++ b/src/main/java/com/divudi/core/data/dto/investigation/InvestigationResponseDTO.java
@@ -1,0 +1,15 @@
+package com.divudi.core.data.dto.investigation;
+
+public class InvestigationResponseDTO extends InvestigationSearchResultDTO {
+    private String message;
+
+    public InvestigationResponseDTO() {}
+
+    public InvestigationResponseDTO(Long id, String name, String code, String printName, Boolean inactive, String reportType, Boolean bypassSampleWorkflow, String message) {
+        super(id, name, code, printName, inactive, reportType, bypassSampleWorkflow);
+        this.message = message;
+    }
+
+    public String getMessage() { return message; }
+    public void setMessage(String message) { this.message = message; }
+}

--- a/src/main/java/com/divudi/core/data/dto/investigation/InvestigationSearchResultDTO.java
+++ b/src/main/java/com/divudi/core/data/dto/investigation/InvestigationSearchResultDTO.java
@@ -1,0 +1,37 @@
+package com.divudi.core.data.dto.investigation;
+
+public class InvestigationSearchResultDTO {
+    private Long id;
+    private String name;
+    private String code;
+    private String printName;
+    private Boolean inactive;
+    private String reportType;
+    private Boolean bypassSampleWorkflow;
+
+    public InvestigationSearchResultDTO() {}
+
+    public InvestigationSearchResultDTO(Long id, String name, String code, String printName, Boolean inactive, String reportType, Boolean bypassSampleWorkflow) {
+        this.id = id;
+        this.name = name;
+        this.code = code;
+        this.printName = printName;
+        this.inactive = inactive;
+        this.reportType = reportType;
+        this.bypassSampleWorkflow = bypassSampleWorkflow;
+    }
+    public Long getId() { return id; }
+    public void setId(Long id) { this.id = id; }
+    public String getName() { return name; }
+    public void setName(String name) { this.name = name; }
+    public String getCode() { return code; }
+    public void setCode(String code) { this.code = code; }
+    public String getPrintName() { return printName; }
+    public void setPrintName(String printName) { this.printName = printName; }
+    public Boolean getInactive() { return inactive; }
+    public void setInactive(Boolean inactive) { this.inactive = inactive; }
+    public String getReportType() { return reportType; }
+    public void setReportType(String reportType) { this.reportType = reportType; }
+    public Boolean getBypassSampleWorkflow() { return bypassSampleWorkflow; }
+    public void setBypassSampleWorkflow(Boolean bypassSampleWorkflow) { this.bypassSampleWorkflow = bypassSampleWorkflow; }
+}

--- a/src/main/java/com/divudi/core/data/dto/investigation/InvestigationUpdateRequestDTO.java
+++ b/src/main/java/com/divudi/core/data/dto/investigation/InvestigationUpdateRequestDTO.java
@@ -1,0 +1,26 @@
+package com.divudi.core.data.dto.investigation;
+
+public class InvestigationUpdateRequestDTO {
+    private String name;
+    private String code;
+    private String printName;
+    private Boolean inactive;
+    private String reportType;
+    private Boolean bypassSampleWorkflow;
+
+    public boolean isValid() {
+        return name != null || code != null || printName != null || inactive != null || reportType != null || bypassSampleWorkflow != null;
+    }
+    public String getName() { return name; }
+    public void setName(String name) { this.name = name; }
+    public String getCode() { return code; }
+    public void setCode(String code) { this.code = code; }
+    public String getPrintName() { return printName; }
+    public void setPrintName(String printName) { this.printName = printName; }
+    public Boolean getInactive() { return inactive; }
+    public void setInactive(Boolean inactive) { this.inactive = inactive; }
+    public String getReportType() { return reportType; }
+    public void setReportType(String reportType) { this.reportType = reportType; }
+    public Boolean getBypassSampleWorkflow() { return bypassSampleWorkflow; }
+    public void setBypassSampleWorkflow(Boolean bypassSampleWorkflow) { this.bypassSampleWorkflow = bypassSampleWorkflow; }
+}

--- a/src/main/java/com/divudi/service/AnthropicApiService.java
+++ b/src/main/java/com/divudi/service/AnthropicApiService.java
@@ -567,6 +567,21 @@ public class AnthropicApiService implements Serializable {
                 .add(collectingCentreFeesTool)
                 .add(inwardDiscountMatrixTool)
                 .add(inwardRoomsTool)
+                .add(Json.createObjectBuilder()
+                .add("name", "manage_investigations")
+                .add("description", "Manage investigation master records: search, get, create, update, activate, deactivate.")
+                .add("input_schema", Json.createObjectBuilder().add("type", "object").add("properties", Json.createObjectBuilder()
+                    .add("method", Json.createObjectBuilder().add("type", "string").add("description", "GET|GET_BY_ID|POST|PUT|ACTIVATE|DEACTIVATE"))
+                    .add("id", Json.createObjectBuilder().add("type", "string"))
+                    .add("query", Json.createObjectBuilder().add("type", "string"))
+                    .add("inactive", Json.createObjectBuilder().add("type", "string"))
+                    .add("limit", Json.createObjectBuilder().add("type", "string"))
+                    .add("name", Json.createObjectBuilder().add("type", "string"))
+                    .add("code", Json.createObjectBuilder().add("type", "string"))
+                    .add("printName", Json.createObjectBuilder().add("type", "string"))
+                    .add("reportType", Json.createObjectBuilder().add("type", "string"))
+                    .add("bypassSampleWorkflow", Json.createObjectBuilder().add("type", "string"))
+                ).add("required", Json.createArrayBuilder().add("method"))).build())
                 .build();
     }
 
@@ -647,7 +662,20 @@ public class AnthropicApiService implements Serializable {
                             admissionTypeId, paymentSchemeId, paymentMethodStr, discountPercent,
                             query, limit, retireComments, hmisBaseUrl, hmisApiKey);
                 }
-                case "manage_inward_rooms": {
+                                case "manage_investigations": {
+                    String method = toolInput.getString("method", "GET");
+                    String id = toolInput.containsKey("id") ? toolInput.getString("id", "") : "";
+                    String query = toolInput.containsKey("query") ? toolInput.getString("query", "") : "";
+                    String inactive = toolInput.containsKey("inactive") ? toolInput.getString("inactive", "") : "";
+                    String limit = toolInput.containsKey("limit") ? toolInput.getString("limit", "20") : "20";
+                    String name = toolInput.containsKey("name") ? toolInput.getString("name", "") : "";
+                    String code = toolInput.containsKey("code") ? toolInput.getString("code", "") : "";
+                    String printName = toolInput.containsKey("printName") ? toolInput.getString("printName", "") : "";
+                    String reportType = toolInput.containsKey("reportType") ? toolInput.getString("reportType", "") : "";
+                    String bypass = toolInput.containsKey("bypassSampleWorkflow") ? toolInput.getString("bypassSampleWorkflow", "") : "";
+                    return callInvestigationApi(method,id,query,inactive,limit,name,code,printName,reportType,bypass,hmisBaseUrl,hmisApiKey);
+                }
+case "manage_inward_rooms": {
                     String method         = toolInput.getString("method", "LIST_CATEGORIES");
                     String id             = toolInput.containsKey("id")                             ? toolInput.getString("id", "")                             : "";
                     String name           = toolInput.containsKey("name")                           ? toolInput.getString("name", "")                           : "";
@@ -1549,6 +1577,28 @@ public class AnthropicApiService implements Serializable {
      * @param userHmisApiKey  The logged-in user's active HMIS API key value
      * @param githubBranch    The GitHub branch for documentation links (e.g. "development")
      */
+    private String callInvestigationApi(String method, String id, String query, String inactive, String limit, String name, String code, String printName, String reportType, String bypassSampleWorkflow, String hmisBaseUrl, String hmisApiKey) {
+        try {
+            String root = normalizeBaseUrl(hmisBaseUrl);
+            if (root.isEmpty()) return "Error: HMIS base URL is not configured.";
+            String key = (hmisApiKey != null) ? hmisApiKey.trim() : "";
+            HttpClient client = HttpClient.newBuilder().connectTimeout(Duration.ofSeconds(10)).build();
+            HttpRequest.Builder rb;
+            if ("GET".equalsIgnoreCase(method)) {
+                String url = root+"/api/investigations/search?query="+URLEncoder.encode(query, StandardCharsets.UTF_8)+"&limit="+URLEncoder.encode(limit, StandardCharsets.UTF_8);
+                if(inactive!=null&&!inactive.isEmpty()) url += "&inactive="+URLEncoder.encode(inactive, StandardCharsets.UTF_8);
+                rb = HttpRequest.newBuilder().uri(URI.create(url)).GET();
+            } else if ("GET_BY_ID".equalsIgnoreCase(method)) { rb = HttpRequest.newBuilder().uri(URI.create(root+"/api/investigations/"+id)).GET(); }
+            else if ("POST".equalsIgnoreCase(method) || "PUT".equalsIgnoreCase(method)) {
+                javax.json.JsonObjectBuilder b = Json.createObjectBuilder().add("name", name==null?"":name);
+                if(code!=null&&!code.isEmpty()) b.add("code", code); if(printName!=null&&!printName.isEmpty()) b.add("printName", printName); if(reportType!=null&&!reportType.isEmpty()) b.add("reportType", reportType); if(bypassSampleWorkflow!=null&&!bypassSampleWorkflow.isEmpty()) b.add("bypassSampleWorkflow", Boolean.parseBoolean(bypassSampleWorkflow));
+                String u = "POST".equalsIgnoreCase(method) ? root+"/api/investigations" : root+"/api/investigations/"+id;
+                rb = HttpRequest.newBuilder().uri(URI.create(u)).method("POST".equalsIgnoreCase(method)?"POST":"PUT", HttpRequest.BodyPublishers.ofString(b.build().toString())).header("Content-Type", "application/json");
+            } else { String u=root+"/api/investigations/"+id+("ACTIVATE".equalsIgnoreCase(method)?"/activate":"/deactivate"); rb=HttpRequest.newBuilder().uri(URI.create(u)).method("PATCH", HttpRequest.BodyPublishers.noBody()); }
+            if(!key.isEmpty()) rb.header("Finance", key); HttpResponse<String> resp=client.send(rb.build(), HttpResponse.BodyHandlers.ofString()); return "HTTP "+resp.statusCode()+"\n"+resp.body();
+        } catch (Exception e) { return "Investigation API error: "+e.getMessage(); }
+    }
+
     public String buildSystemPrompt(String hmisApiBaseUrl, String userHmisApiKey, String githubBranch) {
         String branch = (githubBranch != null && !githubBranch.trim().isEmpty())
                 ? githubBranch.trim() : "development";
@@ -1577,7 +1627,7 @@ public class AnthropicApiService implements Serializable {
         }
 
         sb.append("## Tools Available to You\n");
-        sb.append("You have six tools to ground your answers in the actual codebase, live configuration, clinical master data, collecting-centre fees, and inward discount matrix entries:\n\n");
+        sb.append("You have seven tools to ground your answers in the actual codebase, live configuration, clinical master data, collecting-centre fees, and inward discount matrix entries:\n\n");
         sb.append("### search_github_code\n");
         sb.append("Searches the hmislk/hmis repository source code for files matching keywords. ");
         sb.append("Use this first when a user asks about system behaviour, page logic, or wants to understand how something works.\n\n");

--- a/src/main/java/com/divudi/service/AnthropicApiService.java
+++ b/src/main/java/com/divudi/service/AnthropicApiService.java
@@ -1594,7 +1594,15 @@ case "manage_inward_rooms": {
                 if(code!=null&&!code.isEmpty()) b.add("code", code); if(printName!=null&&!printName.isEmpty()) b.add("printName", printName); if(reportType!=null&&!reportType.isEmpty()) b.add("reportType", reportType); if(bypassSampleWorkflow!=null&&!bypassSampleWorkflow.isEmpty()) b.add("bypassSampleWorkflow", Boolean.parseBoolean(bypassSampleWorkflow));
                 String u = "POST".equalsIgnoreCase(method) ? root+"/api/investigations" : root+"/api/investigations/"+id;
                 rb = HttpRequest.newBuilder().uri(URI.create(u)).method("POST".equalsIgnoreCase(method)?"POST":"PUT", HttpRequest.BodyPublishers.ofString(b.build().toString())).header("Content-Type", "application/json");
-            } else { String u=root+"/api/investigations/"+id+("ACTIVATE".equalsIgnoreCase(method)?"/activate":"/deactivate"); rb=HttpRequest.newBuilder().uri(URI.create(u)).method("PATCH", HttpRequest.BodyPublishers.noBody()); }
+            } else if ("ACTIVATE".equalsIgnoreCase(method) || "DEACTIVATE".equalsIgnoreCase(method)) {
+                String u = root + "/api/investigations/" + id
+                        + ("ACTIVATE".equalsIgnoreCase(method) ? "/activate" : "/deactivate");
+                rb = HttpRequest.newBuilder().uri(URI.create(u))
+                        .method("PATCH", HttpRequest.BodyPublishers.noBody());
+            } else {
+                return "Error: Unsupported method for manage_investigations: " + method
+                        + ". Allowed methods are GET, GET_BY_ID, POST, PUT, ACTIVATE, DEACTIVATE.";
+            }
             if(!key.isEmpty()) rb.header("Finance", key); HttpResponse<String> resp=client.send(rb.build(), HttpResponse.BodyHandlers.ofString()); return "HTTP "+resp.statusCode()+"\n"+resp.body();
         } catch (Exception e) { return "Investigation API error: "+e.getMessage(); }
     }

--- a/src/main/java/com/divudi/service/AnthropicApiService.java
+++ b/src/main/java/com/divudi/service/AnthropicApiService.java
@@ -1579,7 +1579,7 @@ case "manage_inward_rooms": {
      */
     private String callInvestigationApi(String method, String id, String query, String inactive, String limit, String name, String code, String printName, String reportType, String bypassSampleWorkflow, String hmisBaseUrl, String hmisApiKey) {
         try {
-            String root = normalizeBaseUrl(hmisBaseUrl);
+            String root = (hmisBaseUrl != null) ? hmisBaseUrl.trim().replaceAll("/+$", "") : "";
             if (root.isEmpty()) return "Error: HMIS base URL is not configured.";
             String key = (hmisApiKey != null) ? hmisApiKey.trim() : "";
             HttpClient client = HttpClient.newBuilder().connectTimeout(Duration.ofSeconds(10)).build();

--- a/src/main/java/com/divudi/service/investigation/InvestigationApiService.java
+++ b/src/main/java/com/divudi/service/investigation/InvestigationApiService.java
@@ -1,0 +1,75 @@
+package com.divudi.service.investigation;
+
+import com.divudi.core.data.InvestigationReportType;
+import com.divudi.core.data.dto.investigation.*;
+import com.divudi.core.entity.WebUser;
+import com.divudi.core.entity.lab.Investigation;
+import com.divudi.core.facade.InvestigationFacade;
+import com.divudi.core.util.CommonFunctions;
+
+import javax.ejb.EJB;
+import javax.ejb.Stateless;
+import javax.persistence.TemporalType;
+import java.io.Serializable;
+import java.util.*;
+
+@Stateless
+public class InvestigationApiService implements Serializable {
+    @EJB private InvestigationFacade investigationFacade;
+
+    public List<InvestigationSearchResultDTO> search(String query, Boolean inactive, int limit) {
+        Map<String, Object> m = new HashMap<>();
+        StringBuilder j = new StringBuilder("select i from Investigation i where i.retired=false ");
+        if (query != null && !query.trim().isEmpty()) {
+            j.append("and (lower(i.name) like :q or lower(i.code) like :q or lower(i.printName) like :q) ");
+            m.put("q", "%" + query.trim().toLowerCase() + "%");
+        }
+        if (inactive != null) { j.append("and i.inactive=:inactive "); m.put("inactive", inactive); }
+        j.append("order by i.name");
+        List<Investigation> rows = investigationFacade.findByJpql(j.toString(), m, TemporalType.TIMESTAMP, limit);
+        List<InvestigationSearchResultDTO> out = new ArrayList<>();
+        for (Investigation i : rows) out.add(toSearch(i));
+        return out;
+    }
+
+    public InvestigationResponseDTO findById(Long id) throws Exception { return toResponse(load(id), "Investigation found successfully"); }
+
+    public InvestigationResponseDTO create(InvestigationCreateRequestDTO req, WebUser user) throws Exception {
+        if (req == null || !req.isValid()) throw new Exception("Valid request is required");
+        Map<String, Object> m = new HashMap<>(); m.put("name", req.getName().trim().toLowerCase());
+        List<Investigation> ex = investigationFacade.findByJpql("select i from Investigation i where i.retired=false and lower(i.name)=:name", m, TemporalType.TIMESTAMP, 1);
+        if (!ex.isEmpty()) throw new IllegalStateException(String.valueOf(ex.get(0).getId()));
+        Investigation i = new Investigation();
+        i.setName(req.getName().trim());
+        i.setCode(req.getCode() != null && !req.getCode().trim().isEmpty() ? req.getCode().trim() : CommonFunctions.nameToCode(req.getName()));
+        i.setPrintName(req.getPrintName());
+        i.setInactive(Boolean.TRUE.equals(req.getInactive()));
+        i.setBypassSampleWorkflow(Boolean.TRUE.equals(req.getBypassSampleWorkflow()));
+        if (req.getReportType() != null && !req.getReportType().trim().isEmpty()) i.setReportType(InvestigationReportType.valueOf(req.getReportType().trim()));
+        i.setCreater(user); i.setCreatedAt(new Date()); i.setRetired(false);
+        investigationFacade.create(i); i.setBilledAs(i); i.setReportedAs(i); investigationFacade.edit(i);
+        return toResponse(i, "Investigation created successfully");
+    }
+
+    public InvestigationResponseDTO update(Long id, InvestigationUpdateRequestDTO req, WebUser user) throws Exception {
+        Investigation i = load(id);
+        if (req == null || !req.isValid()) throw new Exception("Valid update request is required");
+        if (req.getName() != null && !req.getName().trim().isEmpty()) i.setName(req.getName().trim());
+        if (req.getCode() != null) i.setCode(req.getCode().trim());
+        if (req.getPrintName() != null) i.setPrintName(req.getPrintName());
+        if (req.getInactive() != null) i.setInactive(req.getInactive());
+        if (req.getBypassSampleWorkflow() != null) i.setBypassSampleWorkflow(req.getBypassSampleWorkflow());
+        if (req.getReportType() != null && !req.getReportType().trim().isEmpty()) i.setReportType(InvestigationReportType.valueOf(req.getReportType().trim()));
+        i.setEditer(user); i.setEditedAt(new Date()); investigationFacade.edit(i);
+        return toResponse(i, "Investigation updated successfully");
+    }
+
+    public InvestigationResponseDTO setActive(Long id, boolean inactive, WebUser user) throws Exception {
+        Investigation i = load(id); i.setInactive(inactive); i.setEditer(user); i.setEditedAt(new Date()); investigationFacade.edit(i);
+        return toResponse(i, inactive ? "Investigation deactivated successfully" : "Investigation activated successfully");
+    }
+
+    private Investigation load(Long id) throws Exception { Investigation i = investigationFacade.find(id); if (i == null || i.isRetired()) throw new Exception("Investigation not found with ID: " + id); return i; }
+    private InvestigationSearchResultDTO toSearch(Investigation i) { return new InvestigationSearchResultDTO(i.getId(), i.getName(), i.getCode(), i.getPrintName(), i.isInactive(), i.getReportType() != null ? i.getReportType().name() : null, i.isBypassSampleWorkflow()); }
+    private InvestigationResponseDTO toResponse(Investigation i, String m) { return new InvestigationResponseDTO(i.getId(), i.getName(), i.getCode(), i.getPrintName(), i.isInactive(), i.getReportType() != null ? i.getReportType().name() : null, i.isBypassSampleWorkflow(), m); }
+}

--- a/src/main/java/com/divudi/service/service/ServiceApiService.java
+++ b/src/main/java/com/divudi/service/service/ServiceApiService.java
@@ -103,12 +103,12 @@ public class ServiceApiService implements Serializable {
 
         // Type filter using DTYPE discriminator
         if ("OPD".equalsIgnoreCase(serviceType)) {
-            jpql.append("AND type(i) = com.divudi.core.entity.Service ");
+            jpql.append("AND type(i) = Service ");
         } else if ("Inward".equalsIgnoreCase(serviceType)) {
-            jpql.append("AND type(i) = com.divudi.core.entity.inward.InwardService ");
+            jpql.append("AND type(i) = InwardService ");
         } else {
             // Default: restrict to OPD and Inward only, excluding other subtypes (e.g. TheatreService)
-            jpql.append("AND (type(i) = com.divudi.core.entity.Service OR type(i) = com.divudi.core.entity.inward.InwardService) ");
+            jpql.append("AND (type(i) = Service OR type(i) = InwardService) ");
         }
 
         if (query != null && !query.trim().isEmpty()) {

--- a/src/main/java/com/divudi/ws/common/ApplicationConfig.java
+++ b/src/main/java/com/divudi/ws/common/ApplicationConfig.java
@@ -57,6 +57,7 @@ public class ApplicationConfig extends Application {
         resources.add(com.divudi.ws.institution.DepartmentApi.class);
         resources.add(com.divudi.ws.institution.InstitutionApi.class);
         resources.add(com.divudi.ws.institution.SiteApi.class);
+        resources.add(com.divudi.ws.investigation.InvestigationApi.class);
         resources.add(com.divudi.ws.inward.ApiInward.class);
         resources.add(com.divudi.ws.inward.InwardDiscountMatrixApi.class);
         resources.add(com.divudi.ws.inward.InwardRoomApi.class);

--- a/src/main/java/com/divudi/ws/common/CapabilityStatementResource.java
+++ b/src/main/java/com/divudi/ws/common/CapabilityStatementResource.java
@@ -227,6 +227,10 @@ public class CapabilityStatementResource {
                         "User role CRUD and role-level privilege assignment with optional department scope.",
                         "API Key",
                         "GET", "POST", "PUT", "DELETE"))
+                                .add(resource("Investigations", "/api/investigations",
+                        "Investigation master management including search, create, update, and activate/deactivate for item import workflows",
+                        "API Key",
+                        "GET", "POST", "PUT", "PATCH"))
                 .add(resource("Services", "/api/services",
                         "OPD and Inward service management including fees and categories",
                         "API Key",

--- a/src/main/java/com/divudi/ws/investigation/InvestigationApi.java
+++ b/src/main/java/com/divudi/ws/investigation/InvestigationApi.java
@@ -1,0 +1,49 @@
+package com.divudi.ws.investigation;
+
+import com.divudi.bean.common.ApiKeyController;
+import com.divudi.core.data.dto.investigation.*;
+import com.divudi.core.entity.ApiKey;
+import com.divudi.core.entity.WebUser;
+import com.divudi.service.investigation.InvestigationApiService;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+
+import javax.enterprise.context.RequestScoped;
+import javax.inject.Inject;
+import javax.servlet.http.HttpServletRequest;
+import javax.ws.rs.*;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.UriInfo;
+import java.util.*;
+
+@Path("investigations") @RequestScoped
+public class InvestigationApi {
+    @Context private HttpServletRequest requestContext;
+    @Context private UriInfo uriInfo;
+    @Inject private ApiKeyController apiKeyController;
+    @Inject private InvestigationApiService investigationApiService;
+    private static final Gson gson = new GsonBuilder().setDateFormat("yyyy-MM-dd HH:mm:ss").create();
+
+    @GET @Path("/search") @Produces(MediaType.APPLICATION_JSON)
+    public Response search(){ try{ WebUser u=validateApiKey(requestContext.getHeader("Finance")); if(u==null) return error("Not a valid key",401); String q=uriInfo.getQueryParameters().getFirst("query"); String inactiveStr=uriInfo.getQueryParameters().getFirst("inactive"); String limitStr=uriInfo.getQueryParameters().getFirst("limit"); Boolean inactive = (inactiveStr==null||inactiveStr.trim().isEmpty())?null:Boolean.parseBoolean(inactiveStr.trim()); int limit=20; if(limitStr!=null&&!limitStr.trim().isEmpty()) limit=Math.min(Math.max(Integer.parseInt(limitStr.trim()),1),100); return ok(investigationApiService.search(q,inactive,limit)); } catch(Exception e){ return error("An error occurred: "+e.getMessage(),500);} }
+
+    @GET @Path("/{id}") @Produces(MediaType.APPLICATION_JSON)
+    public Response get(@PathParam("id") Long id){ try{ WebUser u=validateApiKey(requestContext.getHeader("Finance")); if(u==null) return error("Not a valid key",401); return ok(investigationApiService.findById(id)); } catch(Exception e){ return error("An error occurred: "+e.getMessage(),500);} }
+
+    @POST @Consumes(MediaType.APPLICATION_JSON) @Produces(MediaType.APPLICATION_JSON)
+    public Response create(String body){ try{ WebUser u=validateApiKey(requestContext.getHeader("Finance")); if(u==null) return error("Not a valid key",401); InvestigationCreateRequestDTO req=gson.fromJson(body, InvestigationCreateRequestDTO.class); InvestigationResponseDTO dto=investigationApiService.create(req,u); return Response.status(201).entity(gson.toJson(success(dto))).build(); } catch(IllegalStateException ex){ try{ Long id=Long.valueOf(ex.getMessage()); InvestigationResponseDTO existing=investigationApiService.findById(id); Map<String,Object> m=success(existing); m.put("status","already_exists"); m.put("id",id); return Response.status(409).entity(gson.toJson(m)).build(); } catch(Exception e){ return error("An error occurred: "+e.getMessage(),500);} } catch(Exception e){ return error("An error occurred: "+e.getMessage(),500);} }
+
+    @PUT @Path("/{id}") @Consumes(MediaType.APPLICATION_JSON) @Produces(MediaType.APPLICATION_JSON)
+    public Response update(@PathParam("id") Long id, String body){ try{ WebUser u=validateApiKey(requestContext.getHeader("Finance")); if(u==null) return error("Not a valid key",401); return ok(investigationApiService.update(id,gson.fromJson(body, InvestigationUpdateRequestDTO.class),u)); } catch(Exception e){ return error("An error occurred: "+e.getMessage(),500);} }
+
+    @PATCH @Path("/{id}/activate") @Produces(MediaType.APPLICATION_JSON) public Response activate(@PathParam("id") Long id){ try{ WebUser u=validateApiKey(requestContext.getHeader("Finance")); if(u==null) return error("Not a valid key",401); return ok(investigationApiService.setActive(id,false,u)); } catch(Exception e){ return error("An error occurred: "+e.getMessage(),500);} }
+    @PATCH @Path("/{id}/deactivate") @Produces(MediaType.APPLICATION_JSON) public Response deactivate(@PathParam("id") Long id){ try{ WebUser u=validateApiKey(requestContext.getHeader("Finance")); if(u==null) return error("Not a valid key",401); return ok(investigationApiService.setActive(id,true,u)); } catch(Exception e){ return error("An error occurred: "+e.getMessage(),500);} }
+
+    private WebUser validateApiKey(String key){ if(key==null||key.trim().isEmpty()) return null; ApiKey ak=apiKeyController.findAndUpdateLastUsedApiKey(key); return ak==null?null:ak.getWebUser(); }
+    private Response ok(Object d){ return Response.ok(gson.toJson(success(d))).build(); }
+    private Response error(String m,int c){ return Response.status(c).entity(gson.toJson(err(m,c))).build(); }
+    private Map<String,Object> success(Object d){ Map<String,Object> m=new HashMap<>(); m.put("status","success"); m.put("code",200); m.put("timestamp",new Date()); m.put("data",d); return m; }
+    private Map<String,Object> err(String m,int c){ Map<String,Object> x=new HashMap<>(); x.put("status","error"); x.put("code",c); x.put("message",m); x.put("timestamp",new Date()); x.put("data",Collections.emptyMap()); return x; }
+}

--- a/src/main/java/com/divudi/ws/investigation/InvestigationApi.java
+++ b/src/main/java/com/divudi/ws/investigation/InvestigationApi.java
@@ -1,7 +1,9 @@
 package com.divudi.ws.investigation;
 
 import com.divudi.bean.common.ApiKeyController;
-import com.divudi.core.data.dto.investigation.*;
+import com.divudi.core.data.dto.investigation.InvestigationCreateRequestDTO;
+import com.divudi.core.data.dto.investigation.InvestigationResponseDTO;
+import com.divudi.core.data.dto.investigation.InvestigationUpdateRequestDTO;
 import com.divudi.core.entity.ApiKey;
 import com.divudi.core.entity.WebUser;
 import com.divudi.service.investigation.InvestigationApiService;
@@ -11,39 +13,215 @@ import com.google.gson.GsonBuilder;
 import javax.enterprise.context.RequestScoped;
 import javax.inject.Inject;
 import javax.servlet.http.HttpServletRequest;
-import javax.ws.rs.*;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.PUT;
+import javax.ws.rs.PATCH;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.UriInfo;
-import java.util.*;
+import java.util.Collections;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
 
-@Path("investigations") @RequestScoped
+@Path("investigations")
+@RequestScoped
 public class InvestigationApi {
-    @Context private HttpServletRequest requestContext;
-    @Context private UriInfo uriInfo;
-    @Inject private ApiKeyController apiKeyController;
-    @Inject private InvestigationApiService investigationApiService;
-    private static final Gson gson = new GsonBuilder().setDateFormat("yyyy-MM-dd HH:mm:ss").create();
 
-    @GET @Path("/search") @Produces(MediaType.APPLICATION_JSON)
-    public Response search(){ try{ WebUser u=validateApiKey(requestContext.getHeader("Finance")); if(u==null) return error("Not a valid key",401); String q=uriInfo.getQueryParameters().getFirst("query"); String inactiveStr=uriInfo.getQueryParameters().getFirst("inactive"); String limitStr=uriInfo.getQueryParameters().getFirst("limit"); Boolean inactive = (inactiveStr==null||inactiveStr.trim().isEmpty())?null:Boolean.parseBoolean(inactiveStr.trim()); int limit=20; if(limitStr!=null&&!limitStr.trim().isEmpty()) limit=Math.min(Math.max(Integer.parseInt(limitStr.trim()),1),100); return ok(investigationApiService.search(q,inactive,limit)); } catch(Exception e){ return error("An error occurred: "+e.getMessage(),500);} }
+    @Context
+    private HttpServletRequest requestContext;
 
-    @GET @Path("/{id}") @Produces(MediaType.APPLICATION_JSON)
-    public Response get(@PathParam("id") Long id){ try{ WebUser u=validateApiKey(requestContext.getHeader("Finance")); if(u==null) return error("Not a valid key",401); return ok(investigationApiService.findById(id)); } catch(Exception e){ return error("An error occurred: "+e.getMessage(),500);} }
+    @Context
+    private UriInfo uriInfo;
 
-    @POST @Consumes(MediaType.APPLICATION_JSON) @Produces(MediaType.APPLICATION_JSON)
-    public Response create(String body){ try{ WebUser u=validateApiKey(requestContext.getHeader("Finance")); if(u==null) return error("Not a valid key",401); InvestigationCreateRequestDTO req=gson.fromJson(body, InvestigationCreateRequestDTO.class); InvestigationResponseDTO dto=investigationApiService.create(req,u); return Response.status(201).entity(gson.toJson(success(dto))).build(); } catch(IllegalStateException ex){ try{ Long id=Long.valueOf(ex.getMessage()); InvestigationResponseDTO existing=investigationApiService.findById(id); Map<String,Object> m=success(existing); m.put("status","already_exists"); m.put("id",id); return Response.status(409).entity(gson.toJson(m)).build(); } catch(Exception e){ return error("An error occurred: "+e.getMessage(),500);} } catch(Exception e){ return error("An error occurred: "+e.getMessage(),500);} }
+    @Inject
+    private ApiKeyController apiKeyController;
 
-    @PUT @Path("/{id}") @Consumes(MediaType.APPLICATION_JSON) @Produces(MediaType.APPLICATION_JSON)
-    public Response update(@PathParam("id") Long id, String body){ try{ WebUser u=validateApiKey(requestContext.getHeader("Finance")); if(u==null) return error("Not a valid key",401); return ok(investigationApiService.update(id,gson.fromJson(body, InvestigationUpdateRequestDTO.class),u)); } catch(Exception e){ return error("An error occurred: "+e.getMessage(),500);} }
+    @Inject
+    private InvestigationApiService investigationApiService;
 
-    @PATCH @Path("/{id}/activate") @Produces(MediaType.APPLICATION_JSON) public Response activate(@PathParam("id") Long id){ try{ WebUser u=validateApiKey(requestContext.getHeader("Finance")); if(u==null) return error("Not a valid key",401); return ok(investigationApiService.setActive(id,false,u)); } catch(Exception e){ return error("An error occurred: "+e.getMessage(),500);} }
-    @PATCH @Path("/{id}/deactivate") @Produces(MediaType.APPLICATION_JSON) public Response deactivate(@PathParam("id") Long id){ try{ WebUser u=validateApiKey(requestContext.getHeader("Finance")); if(u==null) return error("Not a valid key",401); return ok(investigationApiService.setActive(id,true,u)); } catch(Exception e){ return error("An error occurred: "+e.getMessage(),500);} }
+    private static final Gson gson = new GsonBuilder()
+            .setDateFormat("yyyy-MM-dd HH:mm:ss")
+            .create();
 
-    private WebUser validateApiKey(String key){ if(key==null||key.trim().isEmpty()) return null; ApiKey ak=apiKeyController.findAndUpdateLastUsedApiKey(key); return ak==null?null:ak.getWebUser(); }
-    private Response ok(Object d){ return Response.ok(gson.toJson(success(d))).build(); }
-    private Response error(String m,int c){ return Response.status(c).entity(gson.toJson(err(m,c))).build(); }
-    private Map<String,Object> success(Object d){ Map<String,Object> m=new HashMap<>(); m.put("status","success"); m.put("code",200); m.put("timestamp",new Date()); m.put("data",d); return m; }
-    private Map<String,Object> err(String m,int c){ Map<String,Object> x=new HashMap<>(); x.put("status","error"); x.put("code",c); x.put("message",m); x.put("timestamp",new Date()); x.put("data",Collections.emptyMap()); return x; }
+    @GET
+    @Path("/search")
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response search() {
+        try {
+            WebUser user = validateApiKey(requestContext.getHeader("Finance"));
+            if (user == null) {
+                return errorResponse("Not a valid key", 401);
+            }
+
+            String query = uriInfo.getQueryParameters().getFirst("query");
+            String inactiveStr = uriInfo.getQueryParameters().getFirst("inactive");
+            String limitStr = uriInfo.getQueryParameters().getFirst("limit");
+
+            Boolean inactive = null;
+            if (inactiveStr != null && !inactiveStr.trim().isEmpty()) {
+                inactive = Boolean.parseBoolean(inactiveStr.trim());
+            }
+
+            int limit = 20;
+            if (limitStr != null && !limitStr.trim().isEmpty()) {
+                limit = Math.min(Math.max(Integer.parseInt(limitStr.trim()), 1), 100);
+            }
+
+            return successResponse(investigationApiService.search(query, inactive, limit));
+        } catch (Exception e) {
+            return errorResponse("An error occurred: " + e.getMessage(), 500);
+        }
+    }
+
+    @GET
+    @Path("/{id}")
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response getById(@PathParam("id") Long id) {
+        try {
+            WebUser user = validateApiKey(requestContext.getHeader("Finance"));
+            if (user == null) {
+                return errorResponse("Not a valid key", 401);
+            }
+            return successResponse(investigationApiService.findById(id));
+        } catch (Exception e) {
+            return errorResponse("An error occurred: " + e.getMessage(), 500);
+        }
+    }
+
+    @POST
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response create(String requestBody) {
+        try {
+            WebUser user = validateApiKey(requestContext.getHeader("Finance"));
+            if (user == null) {
+                return errorResponse("Not a valid key", 401);
+            }
+
+            InvestigationCreateRequestDTO request = gson.fromJson(requestBody, InvestigationCreateRequestDTO.class);
+            InvestigationResponseDTO dto = investigationApiService.create(request, user);
+            return Response.status(201).entity(gson.toJson(successData(dto))).build();
+
+        } catch (IllegalStateException ex) {
+            try {
+                Long existingId = Long.valueOf(ex.getMessage());
+                InvestigationResponseDTO existing = investigationApiService.findById(existingId);
+                Map<String, Object> map = successData(existing);
+                map.put("status", "already_exists");
+                map.put("id", existingId);
+                return Response.status(409).entity(gson.toJson(map)).build();
+            } catch (Exception e) {
+                return errorResponse("An error occurred: " + e.getMessage(), 500);
+            }
+        } catch (Exception e) {
+            return errorResponse("An error occurred: " + e.getMessage(), 500);
+        }
+    }
+
+    @PUT
+    @Path("/{id}")
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response update(@PathParam("id") Long id, String requestBody) {
+        try {
+            WebUser user = validateApiKey(requestContext.getHeader("Finance"));
+            if (user == null) {
+                return errorResponse("Not a valid key", 401);
+            }
+
+            InvestigationUpdateRequestDTO request = gson.fromJson(requestBody, InvestigationUpdateRequestDTO.class);
+            return successResponse(investigationApiService.update(id, request, user));
+        } catch (Exception e) {
+            return errorResponse("An error occurred: " + e.getMessage(), 500);
+        }
+    }
+
+    @PATCH
+    @Path("/{id}/activate")
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response activate(@PathParam("id") Long id) {
+        try {
+            WebUser user = validateApiKey(requestContext.getHeader("Finance"));
+            if (user == null) {
+                return errorResponse("Not a valid key", 401);
+            }
+
+            return successResponse(investigationApiService.setActive(id, false, user));
+        } catch (Exception e) {
+            return errorResponse("An error occurred: " + e.getMessage(), 500);
+        }
+    }
+
+    @PATCH
+    @Path("/{id}/deactivate")
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response deactivate(@PathParam("id") Long id) {
+        try {
+            WebUser user = validateApiKey(requestContext.getHeader("Finance"));
+            if (user == null) {
+                return errorResponse("Not a valid key", 401);
+            }
+
+            return successResponse(investigationApiService.setActive(id, true, user));
+        } catch (Exception e) {
+            return errorResponse("An error occurred: " + e.getMessage(), 500);
+        }
+    }
+
+    private WebUser validateApiKey(String key) {
+        if (key == null || key.trim().isEmpty()) {
+            return null;
+        }
+
+        ApiKey apiKey = apiKeyController.findApiKey(key);
+        if (apiKey == null || apiKey.isRetired()) {
+            return null;
+        }
+
+        WebUser user = apiKey.getWebUser();
+        if (user == null || user.isRetired() || !user.isActivated()) {
+            return null;
+        }
+
+        Date expiry = apiKey.getDateOfExpiary();
+        if (expiry == null || expiry.before(new Date())) {
+            return null;
+        }
+
+        return user;
+    }
+
+    private Response successResponse(Object data) {
+        return Response.ok(gson.toJson(successData(data))).build();
+    }
+
+    private Response errorResponse(String message, int statusCode) {
+        return Response.status(statusCode).entity(gson.toJson(errorData(message, statusCode))).build();
+    }
+
+    private Map<String, Object> successData(Object data) {
+        Map<String, Object> map = new HashMap<>();
+        map.put("status", "success");
+        map.put("code", 200);
+        map.put("timestamp", new Date());
+        map.put("data", data);
+        return map;
+    }
+
+    private Map<String, Object> errorData(String message, int statusCode) {
+        Map<String, Object> map = new HashMap<>();
+        map.put("status", "error");
+        map.put("code", statusCode);
+        map.put("message", message);
+        map.put("timestamp", new Date());
+        map.put("data", Collections.emptyMap());
+        return map;
+    }
 }


### PR DESCRIPTION
### Motivation
- Fix a production bug where `GET /api/services/search` returned HTTP 500 due to invalid JPQL `type()` comparisons using fully-qualified class names. 
- Expose Investigation master records via REST so CSV import workflows can safely search-before-create and avoid duplicate investigations. 
- Make the Investigation resource discoverable to AI tooling and capability statements used by agent workflows.

### Description
- Corrected JPQL in `ServiceApiService.searchServices` to use JPQL entity type names (`type(i) = Service` / `InwardService`) instead of fully-qualified class paths to prevent EclipseLink errors. 
- Added Investigation DTOs: `InvestigationSearchResultDTO`, `InvestigationResponseDTO`, `InvestigationCreateRequestDTO`, and `InvestigationUpdateRequestDTO`. 
- Implemented `InvestigationApiService` with search, get-by-id, create (duplicate-safe normalized-name check), update, and activate/deactivate operations. 
- Added REST resource `com.divudi.ws.investigation.InvestigationApi` with endpoints `GET /search`, `GET /{id}`, `POST /`, `PUT /{id}`, `PATCH /{id}/activate`, and `PATCH /{id}/deactivate`, and registered it in `ApplicationConfig`. 
- Updated `CapabilityStatementResource` to list `Investigations` in `/api/capabilities`. 
- Extended `AnthropicApiService` to include a `manage_investigations` tool (tool declaration, execution switch-case, and HTTP helper `callInvestigationApi`) so AI tools can call the new API. 
- Commit includes `Closes #20360` in the message.

### Testing
- No automated Java build or test was executed for this change (`mvn`/`detect-maven.sh test` not run) in accordance with repository guidelines for this task. 
- Basic repository checks performed: `git status` and code searches (`rg`) were run to verify files were added/modified and tool wiring was inserted successfully; these checks completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f47c0e5d0c832fb00110b9c7f65f14)