### PR TITLE
feat(pharmacy): saleBill_without_item_native composite for PrintBillData DTO (#20364)

### DIFF
--- a/src/main/webapp/resources/pharmacy/saleBill_without_item_native.xhtml
+++ b/src/main/webapp/resources/pharmacy/saleBill_without_item_native.xhtml
@@ -1,0 +1,166 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:cc="http://xmlns.jcp.org/jsf/composite"
+      xmlns:f="http://xmlns.jcp.org/jsf/core"
+      xmlns:h="http://xmlns.jcp.org/jsf/html"
+      xmlns:ui="http://xmlns.jcp.org/jsf/facelets">
+
+    <cc:interface>
+        <cc:attribute name="bill"      required="true"  type="com.divudi.core.data.dto.PrintBillData" />
+        <cc:attribute name="duplicate" required="false" />
+    </cc:interface>
+
+    <cc:implementation>
+
+        <h:outputStylesheet library="css" name="pharmacypos.css" />
+        <div class="posbill" style="page-break-after: always!important;">
+
+            <div class="institutionName" style="text-align: center!important;
+                 font-weight: bold!important;
+                 font-size: 15px!important;">
+                <h:outputLabel value="#{cc.attrs.bill.departmentPrintingName}" />
+            </div>
+            <div class="institutionContact">
+                <div>
+                    <h:outputLabel value="#{cc.attrs.bill.institutionAddress}" />
+                </div>
+                <div>
+                    <h:outputLabel value="#{cc.attrs.bill.departmentTelephone1}" />
+                </div>
+            </div>
+
+            <div class="headingBill">
+                <h:outputLabel value="Sale Bill" />
+                <h:outputLabel value="**Duplicate**" rendered="#{cc.attrs.duplicate eq true}" />
+            </div>
+
+            <div class="billline">
+                <h:outputLabel value="-----------------------------------------------" />
+            </div>
+
+            <div class="billDetails">
+                <table style="width: 100%;">
+                    <tr>
+                        <td style="width: 15%; text-align: left;">
+                            <h:outputLabel value="Date" class="billDetails" />
+                        </td>
+                        <td>:</td>
+                        <td style="width: 30%;">
+                            <h:outputLabel value="#{cc.attrs.bill.createdAt}" class="billDetails">
+                                <f:convertDateTime pattern="#{sessionController.applicationPreference.shortDateFormat}" />
+                            </h:outputLabel>
+                        </td>
+                        <td style="width: 10%;" />
+                        <td style="width: 15%;" />
+                        <td style="width: 30%;">
+                            <h:outputLabel value="#{cc.attrs.bill.createdAt}" class="billDetails">
+                                <f:convertDateTime timeZone="Asia/Colombo" pattern="#{sessionController.applicationPreference.shortTimeFormat}" />
+                            </h:outputLabel>
+                        </td>
+                    </tr>
+                    <tr>
+                        <td style="width: 15%; text-align: left;">
+                            <h:outputLabel value="Inv.No" class="billDetails" />
+                        </td>
+                        <td>:</td>
+                        <td style="width: 30%;">
+                            <h:outputLabel value="#{cc.attrs.bill.billNo}" class="billDetails" />
+                        </td>
+                        <td style="width: 10%;" />
+                        <td style="width: 15%;" />
+                        <td style="width: 30%;" />
+                    </tr>
+                    <tr>
+                        <td style="width: 15%; text-align: left;">
+                            <h:outputLabel value="Method" class="billDetails" />
+                        </td>
+                        <td>:</td>
+                        <td style="width: 30%;">
+                            <h:outputLabel value="#{cc.attrs.bill.paymentMethodLabel}" class="billDetails" />
+                        </td>
+                        <td style="width: 10%;" />
+                        <td style="width: 15%;" />
+                        <td style="width: 30%;" />
+                    </tr>
+                    <h:panelGroup rendered="#{cc.attrs.bill.patientName ne null and cc.attrs.bill.patientName ne ''}">
+                        <tr>
+                            <td style="width: 15%; text-align: left;">
+                                <h:outputLabel value="Name" class="billDetails" />
+                            </td>
+                            <td>:</td>
+                            <td style="width: 30%;">
+                                <h:outputLabel value="#{cc.attrs.bill.patientName}" class="billDetails" />
+                            </td>
+                            <td style="width: 10%;" />
+                            <td style="width: 15%;" />
+                            <td style="width: 30%;" />
+                        </tr>
+                    </h:panelGroup>
+                    <h:panelGroup rendered="#{cc.attrs.bill.comment ne null and cc.attrs.bill.comment ne ''}">
+                        <tr>
+                            <td style="width: 15%; text-align: left;">
+                                <h:outputLabel value="Note" class="billDetails" />
+                            </td>
+                            <td>:</td>
+                            <td colspan="4">
+                                <h:outputLabel value="#{cc.attrs.bill.comment}" class="billDetails" />
+                            </td>
+                        </tr>
+                    </h:panelGroup>
+                </table>
+            </div>
+
+            <div class="billline">
+                <h:outputLabel value="-----------------------------------------------" />
+            </div>
+
+            <div>
+                <table style="width: 100%;">
+                    <tr>
+                        <td class="totalsBlock" style="text-align: left; width: 60%;">
+                            <h:outputLabel value="Net Total" />
+                        </td>
+                        <td class="totalsBlock" style="text-align: right!important; width: 40%; padding-right: 30px; font-weight: bold;">
+                            <h:outputLabel value="#{cc.attrs.bill.netTotal}">
+                                <f:convertNumber pattern="#,##0.00" />
+                            </h:outputLabel>
+                        </td>
+                    </tr>
+                    <tr>
+                        <td class="totalsBlock" style="text-align: left;">
+                            <h:outputLabel value="Cash Paid" />
+                        </td>
+                        <td class="totalsBlock" style="text-align: right!important; padding-right: 30px;">
+                            <h:outputLabel value="#{cc.attrs.bill.cashPaid}">
+                                <f:convertNumber pattern="#,##0.00" />
+                            </h:outputLabel>
+                        </td>
+                    </tr>
+                    <tr>
+                        <td class="totalsBlock" style="text-align: left;">
+                            <h:outputLabel value="Balance" />
+                        </td>
+                        <td class="totalsBlock" style="text-align: right!important; padding-right: 30px;">
+                            <h:outputLabel value="#{cc.attrs.bill.balance}">
+                                <f:convertNumber pattern="#,##0.00" />
+                            </h:outputLabel>
+                        </td>
+                    </tr>
+                </table>
+            </div>
+
+            <div class="footer">
+                <br />
+                THANK YOU. PLEASE COME AGAIN<br />
+                <h:outputLabel value="#{sessionController.loggedPreference.pharmacyBillFooter}" />
+                <h:panelGroup rendered="#{sessionController.loggedPreference.pharmacyBillFooter ne null}">
+                    <br />
+                </h:panelGroup>
+                <h:outputText value="Powered by CareCode (Pvt) Ltd." />
+                <br />
+            </div>
+
+        </div>
+    </cc:implementation>
+</html>


### PR DESCRIPTION
## Summary

- Adds `saleBill_without_item_native.xhtml` — a summary-only (no item lines) POS receipt composite that works with `PrintBillData` DTO instead of a JPA `Bill` entity
- All `bill.department.*` / `bill.institution.*` / `bill.patient.*` navigation paths replaced with flat DTO properties (`departmentPrintingName`, `institutionAddress`, `departmentTelephone1`, `billNo`, `patientName`, `paymentMethodLabel`, `netTotal`, `cashPaid`, `balance`, `comment`)
- Patient name and comment rows are conditionally rendered (hidden when null/empty)

## Part of series
This is step 1 of 6 for issue #20260 native print support:
- **#20364 (this PR)** — `saleBill_without_item_native`
- #20365 — `saleBill_native`
- #20366 — `saleBill_five_five_native`
- #20367 — `saleBill_Retail_Pos_paper_Custom_1_native`
- #20368 — `sale_bill_five_five_custom_3_native`
- #20369 — wire all into `pharmacy_bill_retail_sale_native.xhtml`

## Test plan
- [ ] XHTML parses without error on deploy
- [ ] No `--` inside XML comments
- [ ] Department printing name, address, telephone shown
- [ ] Bill No, date, time, payment method shown
- [ ] Patient name row hidden when no patient selected
- [ ] Net total, cash paid, balance shown correctly

Closes #20364

🤖 Generated with [Claude Code](https://claude.com/claude-code)