### PR TITLE
feat(pharmacy): saleBill_without_item_native composite (issue #20364)

### DIFF
--- a/src/main/webapp/resources/pharmacy/saleBill_without_item_native.xhtml
+++ b/src/main/webapp/resources/pharmacy/saleBill_without_item_native.xhtml
@@ -1,0 +1,215 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:cc="http://xmlns.jcp.org/jsf/composite"
+      xmlns:f="http://xmlns.jcp.org/jsf/core"
+      xmlns:h="http://xmlns.jcp.org/jsf/html">
+
+    <cc:interface>
+        <cc:attribute name="bill"      required="true"  type="com.divudi.core.data.dto.PrintBillData" />
+        <cc:attribute name="items"     required="true"  type="java.util.List" />
+        <cc:attribute name="duplicate" required="false" />
+    </cc:interface>
+
+    <cc:implementation>
+
+        <h:outputStylesheet library="css" name="pharmacypos.css"/>
+        <div class="posbill" style="page-break-after: always!important;">
+
+            <div class="institutionName" style="text-align: center!important; font-weight: bold!important; font-size: 15px!important;">
+                <h:outputLabel value="#{cc.attrs.bill.departmentPrintingName}"/>
+            </div>
+            <div class="institutionContact">
+                <div>
+                    <h:outputLabel value="#{cc.attrs.bill.departmentAddress}"/>
+                </div>
+                <div>
+                    <h:outputLabel value="#{cc.attrs.bill.departmentTelephone1}"/>
+                </div>
+            </div>
+
+            <div class="headingBill">
+                <h:outputLabel value="Sale Bill"/>
+                <h:outputLabel value="**Duplicate**" rendered="#{cc.attrs.duplicate eq true}"/>
+            </div>
+
+            <div class="billline">
+                <h:outputLabel value="-----------------------------------------------"/>
+            </div>
+
+            <div class="billDetails">
+                <table style="width: 100%;">
+                    <tr>
+                        <td style="width: 15%; text-align: left;">
+                            <h:outputLabel value="Date" class="billDetails"/>
+                        </td>
+                        <td>:</td>
+                        <td style="width: 30%;">
+                            <h:outputLabel value="#{cc.attrs.bill.createdAt}" class="billDetails">
+                                <f:convertDateTime pattern="#{sessionController.applicationPreference.shortDateFormat}"/>
+                            </h:outputLabel>
+                        </td>
+                        <td style="width: 10%;"/>
+                        <td style="width: 15%;"/>
+                        <td style="width: 30%;">
+                            <h:outputLabel value="#{cc.attrs.bill.createdAt}" class="billDetails">
+                                <f:convertDateTime timeZone="Asia/Colombo" pattern="#{sessionController.applicationPreference.shortTimeFormat}"/>
+                            </h:outputLabel>
+                        </td>
+                    </tr>
+                    <tr>
+                        <td style="width: 15%; text-align: left;">
+                            <h:outputLabel value="Inv.No" class="billDetails"/>
+                        </td>
+                        <td>:</td>
+                        <td style="width: 30%;">
+                            <h:outputLabel value="#{cc.attrs.bill.billNo}" class="billDetails"/>
+                        </td>
+                        <td style="width: 10%;"/>
+                        <td style="width: 15%;"/>
+                        <td style="width: 30%;"/>
+                    </tr>
+                    <tr>
+                        <td style="width: 15%; text-align: left;">
+                            <h:outputLabel value="Method" class="billDetails"/>
+                        </td>
+                        <td>:</td>
+                        <td style="width: 30%;">
+                            <h:outputLabel value="#{cc.attrs.bill.paymentMethodLabel}" class="billDetails"/>
+                        </td>
+                        <td style="width: 10%;"/>
+                        <td style="width: 15%;"/>
+                        <td style="width: 30%;"/>
+                    </tr>
+                    <h:panelGroup rendered="#{cc.attrs.bill.patientName ne null}">
+                        <tr>
+                            <td style="width: 15%; text-align: left;">
+                                <h:outputLabel value="Name" class="billDetails"/>
+                            </td>
+                            <td>:</td>
+                            <td style="width: 30%;">
+                                <h:outputLabel value="#{cc.attrs.bill.patientName}" class="billDetails"/>
+                            </td>
+                            <td style="width: 10%;"/>
+                            <td style="width: 15%;"/>
+                            <td style="width: 30%;"/>
+                        </tr>
+                    </h:panelGroup>
+                    <h:panelGroup rendered="#{cc.attrs.bill.toStaffName ne null}">
+                        <tr>
+                            <td style="width: 15%; text-align: left;">
+                                <h:outputLabel value="Staff Name" class="billDetails"/>
+                            </td>
+                            <td>:</td>
+                            <td style="width: 30%;">
+                                <h:outputLabel value="#{cc.attrs.bill.toStaffName}" class="billDetails"/>
+                            </td>
+                            <td style="width: 10%;"/>
+                            <td style="width: 15%;"/>
+                            <td style="width: 30%;"/>
+                        </tr>
+                    </h:panelGroup>
+                    <h:panelGroup rendered="#{cc.attrs.bill.toDepartmentName ne null}">
+                        <tr>
+                            <td style="width: 15%; text-align: left;">
+                                <h:outputLabel value="To Unit" class="billDetails"/>
+                            </td>
+                            <td>:</td>
+                            <td style="width: 30%;">
+                                <h:outputLabel value="#{cc.attrs.bill.toDepartmentName}" class="billDetails"/>
+                            </td>
+                            <td style="width: 10%;"/>
+                            <td style="width: 15%;"/>
+                            <td style="width: 30%;"/>
+                        </tr>
+                    </h:panelGroup>
+                    <h:panelGroup rendered="#{cc.attrs.bill.toInstitutionName ne null}">
+                        <tr>
+                            <td style="width: 15%; text-align: left;">
+                                <h:outputLabel value="Company" class="billDetails"/>
+                            </td>
+                            <td>:</td>
+                            <td style="width: 30%;">
+                                <h:outputLabel value="#{cc.attrs.bill.toInstitutionName}" class="billDetails"/>
+                            </td>
+                            <td style="width: 10%;"/>
+                            <td style="width: 15%;"/>
+                            <td style="width: 30%;"/>
+                        </tr>
+                    </h:panelGroup>
+                </table>
+            </div>
+
+            <div class="billline">
+                <h:outputLabel value="-----------------------------------------------"/>
+            </div>
+
+            <div>
+                <table style="width: 100%;">
+                    <tr>
+                        <td class="totalsBlock" style="text-align: left; width: 60%;">
+                            <h:outputLabel value="Total"/>
+                        </td>
+                        <td class="totalsBlock" style="text-align: right!important; width: 40%; padding-right: 30px;">
+                            <h:outputLabel value="#{cc.attrs.bill.total}">
+                                <f:convertNumber pattern="#,##0.00"/>
+                            </h:outputLabel>
+                        </td>
+                    </tr>
+                    <tr>
+                        <td class="totalsBlock" style="text-align: left;">
+                            <h:outputLabel rendered="#{cc.attrs.bill.discount ne 0.0}" value="Discount" style="font-weight: bolder!important;"/>
+                        </td>
+                        <td class="totalsBlock" style="text-align: right!important; padding-right: 30px;">
+                            <h:outputLabel rendered="#{cc.attrs.bill.discount ne 0.0}" value="#{-cc.attrs.bill.discount}" style="font-weight: bolder!important;">
+                                <f:convertNumber pattern="#,##0.00"/>
+                            </h:outputLabel>
+                        </td>
+                    </tr>
+                    <tr>
+                        <td class="totalsBlock" style="text-align: left;">
+                            <h:outputLabel rendered="#{cc.attrs.bill.discount ne 0.0}" value="Net Total"/>
+                        </td>
+                        <td class="totalsBlock" style="text-align: right!important; font-weight: bold; padding-right: 30px;">
+                            <h:outputLabel rendered="#{cc.attrs.bill.discount ne 0.0}" value="#{cc.attrs.bill.netTotal}">
+                                <f:convertNumber pattern="#,##0.00"/>
+                            </h:outputLabel>
+                        </td>
+                    </tr>
+                    <tr>
+                        <td class="totalsBlock" style="text-align: left;">
+                            <h:outputLabel rendered="#{cc.attrs.bill.discountPercentPharmacy ne 0.0}" value="Discount Percent" style="font-weight: bolder!important;"/>
+                        </td>
+                        <td class="totalsBlock" style="text-align: right!important; font-weight: bold; padding-right: 30px;">
+                            <h:outputLabel rendered="#{cc.attrs.bill.discountPercentPharmacy ne 0.0}" value="#{cc.attrs.bill.discountPercentPharmacy} %">
+                                <f:convertNumber pattern="#,##0.0"/>
+                            </h:outputLabel>
+                        </td>
+                    </tr>
+                    <tr>
+                        <td class="totalsItemBlock" style="text-align: left;">
+                            <h:outputLabel value="Number of Items Count"/>
+                        </td>
+                        <td class="totalsItemBlock">
+                            <h:outputLabel value="#{cc.attrs.items.size()}">
+                                <f:convertNumber integerOnly="true"/>
+                            </h:outputLabel>
+                        </td>
+                    </tr>
+                </table>
+            </div>
+
+            <div class="footer">
+                <br/>
+                THANK YOU. PLEASE COME AGAIN<br/>
+                <h:outputLabel value="#{sessionController.loggedPreference.pharmacyBillFooter}"/>
+                <h:panelGroup rendered="#{sessionController.loggedPreference.pharmacyBillFooter ne null}">
+                    <br/>
+                </h:panelGroup>
+                <h:outputText value="Powered by CareCode (Pvt) Ltd."/>
+                <br/>
+            </div>
+
+        </div>
+    </cc:implementation>
+</html>


### PR DESCRIPTION
## Summary
- Adds `saleBill_without_item_native.xhtml` — a native-DTO version of `saleBill_without_item.xhtml`
- Uses flat `PrintBillData` properties (`departmentPrintingName`, `departmentAddress`, `departmentTelephone1`, `paymentMethodLabel`, `patientName`, `toStaffName`, `toDepartmentName`, `toInstitutionName`, `billNo`, `createdAt`, `total`, `discount`, `netTotal`, `discountPercentPharmacy`) instead of JPA entity navigation
- Item count comes from `cc.attrs.items.size()` on the passed `List<BillItemData>`
- No JPA lazy/eager load overhead on the retail sale native print path

Closes #20364

🤖 Generated with [Claude Code](https://claude.com/claude-code)