### PR TITLE
feat(pharmacy): saleBill_Retail_Pos_paper_Custom_1_native composite (issue #20367)

### DIFF
--- a/src/main/webapp/resources/pharmacy/saleBill_Retail_Pos_paper_Custom_1_native.xhtml
+++ b/src/main/webapp/resources/pharmacy/saleBill_Retail_Pos_paper_Custom_1_native.xhtml
@@ -1,0 +1,269 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:cc="http://xmlns.jcp.org/jsf/composite"
+      xmlns:f="http://xmlns.jcp.org/jsf/core"
+      xmlns:h="http://xmlns.jcp.org/jsf/html"
+      xmlns:ui="http://xmlns.jcp.org/jsf/facelets">
+
+    <cc:interface>
+        <cc:attribute name="bill"      required="true"  type="com.divudi.core.data.dto.PrintBillData" />
+        <cc:attribute name="items"     required="true"  type="java.util.List" />
+        <cc:attribute name="duplicate" required="false" />
+    </cc:interface>
+
+    <cc:implementation>
+
+        <h:outputStylesheet library="css" name="pharmacypos.css"/>
+        <div class="posbill" style="page-break-after: always!important;">
+
+            <div class="institutionName" style="text-align: center!important; font-weight: bold!important; font-size: 15px!important;">
+                <h:outputLabel value="#{cc.attrs.bill.institutionName}"/>
+            </div>
+            <div style="text-align: center!important; font-weight: bold!important; font-size: 12px!important;">
+                <h:outputLabel value="#{cc.attrs.bill.departmentName}"/>
+            </div>
+            <div class="institutionContact">
+                <div>
+                    <h:outputLabel value="#{cc.attrs.bill.departmentAddress}"/>
+                </div>
+                <div>
+                    <h:outputLabel value="Tel: "/>
+                    <h:outputLabel value="#{cc.attrs.bill.departmentTelephone1}"/>
+                </div>
+                <div>
+                    <h:outputLabel value="#{cc.attrs.bill.institutionEmail}"/>
+                    <br/>
+                    <h:outputLabel value="#{cc.attrs.bill.institutionWeb}"/>
+                </div>
+            </div>
+
+            <div class="headingBill">
+                <h:outputLabel value="Sale Bill"/>
+                <h:outputLabel value="**Duplicate**" rendered="#{cc.attrs.duplicate eq true}"/>
+            </div>
+            <div class="billline">
+                <h:outputLabel value="-----------------------------------------------"/>
+            </div>
+
+            <div class="billDetails">
+                <table style="width: 90%; margin-left: 5%;">
+                    <tr>
+                        <td style="width: 30%; text-align: right;">
+                            <h:outputLabel value="Date"/>
+                        </td>
+                        <td style="width: 50px;" class="d-flex justify-content-center">:</td>
+                        <td style="width: 60%; text-align: left;">
+                            <h:outputLabel value="#{cc.attrs.bill.createdAt}">
+                                <f:convertDateTime pattern="dd MMM yyyy HH:mm"/>
+                            </h:outputLabel>
+                        </td>
+                    </tr>
+                    <tr>
+                        <td style="width: 30%; text-align: right;">
+                            <h:outputLabel value="Inv.No"/>
+                        </td>
+                        <td style="width: 50px;" class="d-flex justify-content-center">:</td>
+                        <td style="width: 60%; text-align: left;">
+                            <h:outputLabel value="#{cc.attrs.bill.billNo}" class="billDetails"/>
+                        </td>
+                    </tr>
+                    <h:panelGroup rendered="#{cc.attrs.bill.patientName ne null}">
+                        <tr>
+                            <td style="width: 30%; text-align: right;">
+                                <h:outputLabel value="Name" class="billDetails"/>
+                            </td>
+                            <td style="width: 50px;" class="d-flex justify-content-center">:</td>
+                            <td style="width: 60%; text-align: left;">
+                                <h:outputLabel value="#{cc.attrs.bill.patientName}" class="billDetails"/>
+                            </td>
+                        </tr>
+                        <tr>
+                            <td style="width: 30%; text-align: right;">
+                                <h:outputLabel value="MRN No" class="billDetails"/>
+                            </td>
+                            <td style="width: 50px;" class="d-flex justify-content-center">:</td>
+                            <td style="width: 30%; text-align: left;">
+                                <h:outputLabel value="#{cc.attrs.bill.patientPhn}" class="billDetails"/>
+                            </td>
+                        </tr>
+                    </h:panelGroup>
+                    <h:panelGroup rendered="#{cc.attrs.bill.toStaffName ne null}">
+                        <tr>
+                            <td style="width: 30%; text-align: right;">
+                                <h:outputLabel value="Staff Name" class="billDetails"/>
+                            </td>
+                            <td style="width: 50px;" class="d-flex justify-content-center">:</td>
+                            <td style="width: 60%; text-align: left;">
+                                <h:outputLabel value="#{cc.attrs.bill.toStaffName}" class="billDetails"/>
+                            </td>
+                        </tr>
+                    </h:panelGroup>
+                    <h:panelGroup rendered="#{cc.attrs.bill.toDepartmentName ne null}">
+                        <tr>
+                            <td style="width: 30%; text-align: right;">
+                                <h:outputLabel value="To Unit" class="billDetails"/>
+                            </td>
+                            <td style="width: 50px;" class="d-flex justify-content-center">:</td>
+                            <td style="width: 60%; text-align: left;">
+                                <h:outputLabel value="#{cc.attrs.bill.toDepartmentName}" class="billDetails"/>
+                            </td>
+                        </tr>
+                    </h:panelGroup>
+                    <h:panelGroup rendered="#{cc.attrs.bill.toInstitutionName ne null}">
+                        <tr>
+                            <td style="width: 30%; text-align: right;">
+                                <h:outputLabel value="Company" class="billDetails"/>
+                            </td>
+                            <td style="width: 50px;" class="d-flex justify-content-center">:</td>
+                            <td style="width: 60%; text-align: left;">
+                                <h:outputLabel value="#{cc.attrs.bill.toInstitutionName}" class="billDetails"/>
+                            </td>
+                        </tr>
+                    </h:panelGroup>
+                </table>
+            </div>
+
+            <div class="billline" style="width: 100%; margin-left: 5%;">
+                <h:outputLabel value="-------------------------------------------------"/>
+            </div>
+
+            <div style="padding-left: 5%;">
+                <table width="90%">
+                    <tr>
+                        <td style="width: 35%;">
+                            <h:outputLabel value="ITEM" style="font-size: 13px; font-weight: bold;"/>
+                        </td>
+                        <td style="width: 18%; text-align: right;">
+                            <h:outputLabel value="QTY" style="font-size: 13px; font-weight: bold;"/>
+                        </td>
+                        <h:panelGroup rendered="#{!configOptionApplicationController.getBooleanValueByKey('Remove Rate and Values From Printing on Cashier Sale Bill')}">
+                            <td style="width: 18%; text-align: right;">
+                                <h:outputLabel value="RATE" style="font-size: 13px; font-weight: bold;"/>
+                            </td>
+                            <td style="width: 22%; text-align: right;">
+                                <h:outputLabel value="VALUE" style="font-size: 13px; font-weight: bold;"/>
+                            </td>
+                        </h:panelGroup>
+                    </tr>
+                    <tr>
+                        <td colspan="4" style="width: 100%;">
+                            <div class="billline">
+                                <h:outputLabel value="-------------------------------------------------"/>
+                            </div>
+                        </td>
+                    </tr>
+                    <ui:repeat value="#{cc.attrs.items}" var="bip">
+                        <tr>
+                            <td colspan="4">
+                                <h:outputLabel value="#{bip.itemName}" styleClass="itemsBlock" style="text-transform: capitalize!important; text-align: left;"/>
+                            </td>
+                        </tr>
+                        <tr>
+                            <td colspan="1"/>
+                            <td styleClass="itemsBlockRight" style="width: 20%; text-align: right;">
+                                <h:outputLabel value="#{bip.qty}" styleClass="itemsBlockRight" style="text-align: right;">
+                                    <f:convertNumber integerOnly="true"/>
+                                </h:outputLabel>
+                            </td>
+                            <h:panelGroup rendered="#{!configOptionApplicationController.getBooleanValueByKey('Remove Rate and Values From Printing on Cashier Sale Bill')}">
+                                <td styleClass="itemsBlockRight" style="text-align: right; width: 18%;">
+                                    <h:outputLabel value="#{bip.rate}">
+                                        <f:convertNumber pattern="#,##0.00"/>
+                                    </h:outputLabel>
+                                </td>
+                                <td styleClass="itemsBlockRight" style="text-align: right; width: 42%;">
+                                    <h:outputLabel value="#{bip.grossValue}">
+                                        <f:convertNumber pattern="#,##0.00"/>
+                                    </h:outputLabel>
+                                </td>
+                            </h:panelGroup>
+                        </tr>
+                    </ui:repeat>
+                </table>
+            </div>
+
+            <div class="billline" style="width: 90%; margin-left: 5%;">
+                <h:outputLabel value="-----------------------------------------------------"/>
+            </div>
+
+            <div style="width: 95%; padding-left: 5%; padding-right: 3%;">
+                <table width="100%">
+                    <tr>
+                        <td class="totalsItemBlock" style="text-align: left; width: 60%;">
+                            <h:outputLabel value="Total"/>
+                        </td>
+                        <td class="totalsItemBlock" style="text-align: right!important; width: 40%;">
+                            <h:outputLabel value="#{cc.attrs.bill.total}">
+                                <f:convertNumber pattern="#,##0.00"/>
+                            </h:outputLabel>
+                        </td>
+                    </tr>
+                    <h:panelGroup rendered="#{configOptionApplicationController.getBooleanValueByKey('Print Net Total and Discount On Pharmacy Sale Bill For Cashier')}">
+                        <tr>
+                            <td class="totalsItemBlock" style="text-align: left;">
+                                <h:outputLabel value="Discount"/>
+                            </td>
+                            <td class="totalsItemBlock" style="text-align: right!important;">
+                                <h:outputLabel value="#{cc.attrs.bill.discount}">
+                                    <f:convertNumber pattern="#,##0.00"/>
+                                </h:outputLabel>
+                            </td>
+                        </tr>
+                        <tr>
+                            <td class="totalsItemBlock" style="text-align: left;">
+                                <h:outputLabel style="font-weight: bolder!important;" value="Net Total"/>
+                            </td>
+                            <td class="totalsItemBlock" style="text-align: right!important; font-weight: bold;">
+                                <h:outputLabel value="#{cc.attrs.bill.netTotal}">
+                                    <f:convertNumber pattern="#,##0.00"/>
+                                </h:outputLabel>
+                            </td>
+                        </tr>
+                    </h:panelGroup>
+                    <h:panelGroup rendered="#{configOptionApplicationController.getBooleanValueByKey('Allow Tendered Amount for pharmacy sale for cashier', true)}">
+                        <tr>
+                            <td class="totalsItemBlock" style="text-align: left;">
+                                <h:outputLabel value="Tendered"/>
+                            </td>
+                            <td class="totalsItemBlock" style="text-align: right;">
+                                <h:outputLabel value="#{cc.attrs.bill.cashPaid}">
+                                    <f:convertNumber pattern="#,##0.00"/>
+                                </h:outputLabel>
+                            </td>
+                        </tr>
+                        <tr>
+                            <td class="totalsItemBlock" style="text-align: left;">
+                                <h:outputLabel value="Balance"/>
+                            </td>
+                            <td class="totalsItemBlock" style="text-align: right;">
+                                <h:outputLabel value="#{cc.attrs.bill.balance}">
+                                    <f:convertNumber pattern="#,##0.00"/>
+                                </h:outputLabel>
+                            </td>
+                        </tr>
+                    </h:panelGroup>
+                    <tr>
+                        <td class="totalsItemBlock" style="text-align: left;">
+                            <h:outputLabel value="Items Count"/>
+                        </td>
+                        <td class="totalsItemBlock" style="text-align: right;">
+                            <h:outputLabel value="#{cc.attrs.items.size()}">
+                                <f:convertNumber integerOnly="true"/>
+                            </h:outputLabel>
+                        </td>
+                    </tr>
+                </table>
+            </div>
+
+            <div class="footer">
+                Return accepted within 3 days only
+                <br/>
+                THANK YOU !
+                <br/>
+                Powered by CareCode (Pvt) Ltd.
+            </div>
+
+        </div>
+    </cc:implementation>
+</html>


### PR DESCRIPTION
## Summary
- Adds `saleBill_Retail_Pos_paper_Custom_1_native.xhtml` — a native-DTO version of `saleBill_Retail_Pos_paper_Custom_1.xhtml`
- Uses flat `PrintBillData` properties: `institutionName`, `departmentName`, `departmentAddress`, `departmentTelephone1`, `institutionEmail`, `institutionWeb`, `billNo`, `createdAt`, `patientName`, `patientPhn`, `toStaffName`, `toDepartmentName`, `toInstitutionName`, `total`, `discount`, `netTotal`, `cashPaid`, `balance`
- Item lines use `List<BillItemData>` (`bip.itemName`, `bip.qty`, `bip.rate`, `bip.grossValue`)
- Preserves conditional RATE/VALUE columns via `'Remove Rate and Values From Printing on Cashier Sale Bill'` config key
- Preserves Tendered/Balance rows via `'Allow Tendered Amount for pharmacy sale for cashier'` config key
- Preserves Discount/Net Total rows via `'Print Net Total and Discount On Pharmacy Sale Bill For Cashier'` config key

Closes #20367

🤖 Generated with [Claude Code](https://claude.com/claude-code)