### PR TITLE
feat(pharmacy): wire all native print composites into retail sale native page (#20369)

### DIFF
--- a/src/main/webapp/pharmacy/pharmacy_bill_retail_sale_native.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_bill_retail_sale_native.xhtml
@@ -748,9 +748,39 @@
                         </div>
 
                         <h:panelGroup id="gpBillPreview">
-                            <phi:saleBill_Header_Inward_native
-                                bill="#{retailSaleNativeSqlController.printBill}"
-                                items="#{retailSaleNativeSqlController.printBillItems}" />
+                            <h:panelGroup rendered="#{configOptionController.getBooleanValueByKey('Pharmacy Retail Sale Bill Paper is POS Paper', true)}">
+                                <phi:saleBill_without_item_native
+                                    bill="#{retailSaleNativeSqlController.printBill}"
+                                    items="#{retailSaleNativeSqlController.printBillItems}" />
+                                <phi:saleBill_native
+                                    bill="#{retailSaleNativeSqlController.printBill}"
+                                    items="#{retailSaleNativeSqlController.printBillItems}" />
+                            </h:panelGroup>
+                            <h:panelGroup rendered="#{configOptionController.getBooleanValueByKey('Pharmacy Retail Sale Bill Paper is POS Paper Custom 1', false)}">
+                                <phi:saleBill_Retail_Pos_paper_Custom_1_native
+                                    bill="#{retailSaleNativeSqlController.printBill}"
+                                    items="#{retailSaleNativeSqlController.printBillItems}" />
+                            </h:panelGroup>
+                            <h:panelGroup rendered="#{configOptionController.getBooleanValueByKey('Pharmacy Retail Sale Bill Paper is FiveFive Paper without Blank Space for Header', true)}">
+                                <phi:saleBill_five_five_native
+                                    bill="#{retailSaleNativeSqlController.printBill}"
+                                    items="#{retailSaleNativeSqlController.printBillItems}" />
+                            </h:panelGroup>
+                            <h:panelGroup rendered="#{configOptionController.getBooleanValueByKey('Pharmacy Retail Sale Bill Paper is POS paper with header', true)}">
+                                <phi:saleBill_Header_Inward_native
+                                    bill="#{retailSaleNativeSqlController.printBill}"
+                                    items="#{retailSaleNativeSqlController.printBillItems}" />
+                            </h:panelGroup>
+                            <h:panelGroup rendered="#{configOptionController.getBooleanValueByKey('Pharmacy Retail Sale Bill Paper is Custom 3', false)}">
+                                <phi:sale_bill_five_five_custom_3_native
+                                    bill="#{retailSaleNativeSqlController.printBill}"
+                                    items="#{retailSaleNativeSqlController.printBillItems}" />
+                            </h:panelGroup>
+                            <h:panelGroup rendered="#{configOptionController.getBooleanValueByKey('Pharmacy Retail Sale Bill is PosHeaderPaper', false)}">
+                                <phi:saleBill_Header_Inward_native
+                                    bill="#{retailSaleNativeSqlController.printBill}"
+                                    items="#{retailSaleNativeSqlController.printBillItems}" />
+                            </h:panelGroup>
                         </h:panelGroup>
                     </p:panel>
                 </h:form>


### PR DESCRIPTION
## Summary

- Replaces the single unconditional `saleBill_Header_Inward_native` in `gpBillPreview` with six config-key-gated blocks
- Exactly mirrors the composite selection logic from `pharmacy_bill_retail_sale.xhtml`, but using the native DTO composites
- All composites pass `PrintBillData` + `List<BillItemData>` — zero JPA entity navigation at print time

## Composite mapping

| Config key | Default | Native composite |
|---|---|---|
| `Pharmacy Retail Sale Bill Paper is POS Paper` | true | `saleBill_without_item_native` + `saleBill_native` |
| `Pharmacy Retail Sale Bill Paper is POS Paper Custom 1` | false | `saleBill_Retail_Pos_paper_Custom_1_native` |
| `Pharmacy Retail Sale Bill Paper is FiveFive Paper without Blank Space for Header` | true | `saleBill_five_five_native` |
| `Pharmacy Retail Sale Bill Paper is POS paper with header` | true | `saleBill_Header_Inward_native` |
| `Pharmacy Retail Sale Bill Paper is Custom 3` | false | `sale_bill_five_five_custom_3_native` |
| `Pharmacy Retail Sale Bill is PosHeaderPaper` | false | `saleBill_Header_Inward_native` |

Custom 1 and Custom 2 formats have no native composites and are not rendered (same as before).

Closes #20369

🤖 Generated with [Claude Code](https://claude.com/claude-code)