### PR TITLE
Add username and name columns to All Cashier Shifts report

### DIFF
--- a/src/main/webapp/reports/cashier_reports/all_cashier_shifts.xhtml
+++ b/src/main/webapp/reports/cashier_reports/all_cashier_shifts.xhtml
@@ -115,6 +115,14 @@
                             value="#{financialTransactionController.bundle.reportTemplateRows}" 
                             var="ssb" 
                             rowKey="#{ssb.id}">
+                            <p:column headerText="Username" width="10em">
+                                <h:outputText value="#{ssb.bill.creater.name}" rendered="#{ssb.bill.creater ne null}" />
+                            </p:column>
+
+                            <p:column headerText="Name" width="15em">
+                                <h:outputText value="#{ssb.bill.creater.webUserPerson.name}" rendered="#{ssb.bill.creater ne null and ssb.bill.creater.webUserPerson ne null}" />
+                            </p:column>
+
                             <p:column headerText="Shift" width="15em" styleClass="text-center">
                                 <h:outputText value="#{ssb.bill.deptId}" styleClass="font-weight-bold mb-2" />
                                 <p:spacer height="5" />


### PR DESCRIPTION
### Motivation
- Expose the cashier `username` and the cashier `name` for each listed shift in the All Cashier Shifts report so report consumers can identify users at a glance.

### Description
- Added two left-side `<p:column>` entries to `src/main/webapp/reports/cashier_reports/all_cashier_shifts.xhtml` that render `#{ssb.bill.creater.name}` and `#{ssb.bill.creater.webUserPerson.name}` with null-safe `rendered` checks.

### Testing
- No automated tests were run because this is a JSF/XHTML-only UI change; the file change was committed and visually inspected.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f495da1610832f9bc431cc0572d8dc)