### PR TITLE
fix(pharmacy): address review comments on native retail sale print composites

### DIFF
--- a/src/main/webapp/pharmacy/pharmacy_bill_retail_sale_native.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_bill_retail_sale_native.xhtml
@@ -771,6 +771,16 @@
                                     bill="#{retailSaleNativeSqlController.printBill}"
                                     items="#{retailSaleNativeSqlController.printBillItems}" />
                             </h:panelGroup>
+                            <h:panelGroup rendered="#{configOptionController.getBooleanValueByKey('Pharmacy Retail Sale Bill Paper is Custom 1', false)}">
+                                <phi:saleBill_native
+                                    bill="#{retailSaleNativeSqlController.printBill}"
+                                    items="#{retailSaleNativeSqlController.printBillItems}" />
+                            </h:panelGroup>
+                            <h:panelGroup rendered="#{configOptionController.getBooleanValueByKey('Pharmacy Retail Sale Bill Paper is Custom 2', false)}">
+                                <phi:saleBill_native
+                                    bill="#{retailSaleNativeSqlController.printBill}"
+                                    items="#{retailSaleNativeSqlController.printBillItems}" />
+                            </h:panelGroup>
                             <h:panelGroup rendered="#{configOptionController.getBooleanValueByKey('Pharmacy Retail Sale Bill Paper is Custom 3', false)}">
                                 <phi:sale_bill_five_five_custom_3_native
                                     bill="#{retailSaleNativeSqlController.printBill}"

--- a/src/main/webapp/resources/pharmacy/saleBill_Retail_Pos_paper_Custom_1_native.xhtml
+++ b/src/main/webapp/resources/pharmacy/saleBill_Retail_Pos_paper_Custom_1_native.xhtml
@@ -221,7 +221,7 @@
                             </td>
                         </tr>
                     </h:panelGroup>
-                    <h:panelGroup rendered="#{configOptionApplicationController.getBooleanValueByKey('Allow Tendered Amount for pharmacy sale for cashier', true)}">
+                    <h:panelGroup rendered="#{cc.attrs.bill.paymentMethodLabel eq 'Cash' and configOptionApplicationController.getBooleanValueByKey('Allow Tendered Amount for pharmacy sale for cashier', true)}">
                         <tr>
                             <td class="totalsItemBlock" style="text-align: left;">
                                 <h:outputLabel value="Tendered"/>

--- a/src/main/webapp/resources/pharmacy/saleBill_native.xhtml
+++ b/src/main/webapp/resources/pharmacy/saleBill_native.xhtml
@@ -150,10 +150,7 @@
             <div>
                 <table width="100%" style="width: 100%;">
                     <tr>
-                        <td style="width: 12%; text-align: left;">
-                            <h:outputLabel value="CODE" styleClass="itemHeadings"/>
-                        </td>
-                        <td style="width: 35%;">
+                        <td style="width: 47%; text-align: left;">
                             <h:outputLabel value="ITEM" styleClass="itemHeadings"/>
                         </td>
                         <td style="width: 18%; text-align: right;">
@@ -167,7 +164,7 @@
                         </td>
                     </tr>
                     <tr>
-                        <td colspan="5" style="width: 100%;">
+                        <td colspan="4" style="width: 100%;">
                             <div class="billline">
                                 <h:outputLabel value="-------------------------------------------------"/>
                             </div>
@@ -175,12 +172,12 @@
                     </tr>
                     <ui:repeat value="#{cc.attrs.items}" var="bip">
                         <tr>
-                            <td colspan="5">
+                            <td colspan="4">
                                 <h:outputLabel value="#{bip.itemName}" styleClass="itemsBlock" style="text-transform: capitalize!important; text-align: left;"/>
                             </td>
                         </tr>
                         <tr>
-                            <td colspan="2"/>
+                            <td colspan="1"/>
                             <td styleClass="itemsBlockRight" style="width: 20%; text-align: right;">
                                 <h:outputLabel value="#{bip.qty}" styleClass="itemsBlock" style="text-align: right;">
                                     <f:convertNumber integerOnly="true"/>

--- a/src/main/webapp/resources/pharmacy/sale_bill_five_five_custom_3_native.xhtml
+++ b/src/main/webapp/resources/pharmacy/sale_bill_five_five_custom_3_native.xhtml
@@ -187,12 +187,12 @@
                     <tr>
                         <td style="width: 4cm;">
                             <h:outputLabel value="Printed By : " style="font-size: 8pt;"/>
-                            <h:outputLabel style="font-size: 8pt;" value="#{cc.attrs.bill.creatorName}"/>
+                            <h:outputLabel style="font-size: 8pt;" value="#{sessionController.loggedUser.name}"/>
                         </td>
                         <td style="width: 2cm;"></td>
                         <td>
-                            <h:outputLabel style="font-size: 8pt;" value="#{cc.attrs.bill.createdAt}">
-                                <f:convertDateTime pattern="yyyy-MM-dd HH:mm" />
+                            <h:outputLabel style="font-size: 8pt;" value="#{sessionController.currentDate}">
+                                <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateTimeFormat}"/>
                             </h:outputLabel>
                         </td>
                     </tr>


### PR DESCRIPTION
## Summary

Fixes four issues raised in review comments across PRs #20374–#20379.

- **`saleBill_native.xhtml`** — Remove the `CODE` column header; `BillItemData` has no `itemCode` field so the column was always empty. Widen `ITEM` column to fill the space and adjust all colspans from 5→4.

- **`saleBill_Retail_Pos_paper_Custom_1_native.xhtml`** — Tendered/Balance rows now only render on cash bills (`paymentMethodLabel eq 'Cash'`), matching the guard in the original non-native composite. Previously non-cash receipts (credit, staff, card) could show misleading tendered/balance figures.

- **`sale_bill_five_five_custom_3_native.xhtml`** — Duplicate receipt footer now shows the actual reprinting user (`sessionController.loggedUser.name`) and current time (`sessionController.currentDate`) instead of the original bill creator and creation timestamp.

- **`pharmacy_bill_retail_sale_native.xhtml`** — Add Custom 1 and Custom 2 config key blocks (backed by `saleBill_native`) so the preview never renders blank when those paper types are selected in the settings dialog.

## Test plan
- [ ] Settle a cash sale — Tendered/Balance appear on POS Custom 1 print
- [ ] Settle a credit sale — Tendered/Balance absent on POS Custom 1 print
- [ ] Print a duplicate bill — "Printed By" shows current user, not original cashier
- [ ] Enable Custom 1 or Custom 2 paper in settings — bill preview renders correctly
- [ ] Verify POS Paper print has 4-column item table (ITEM, QTY, RATE, VALUE) with no CODE column

🤖 Generated with [Claude Code](https://claude.com/claude-code)