### PR TITLE
Release rooms when admin discharge tools mark encounters discharged

### DIFF
--- a/src/main/java/com/divudi/bean/common/DataAdministrationController.java
+++ b/src/main/java/com/divudi/bean/common/DataAdministrationController.java
@@ -5117,12 +5117,11 @@ public class DataAdministrationController implements Serializable {
                     + "  WHERE pe2.discharged = 0 AND pe2.paymentFinalized = 0 AND pe2.currentPatientRoom_id IS NOT NULL "
                     + "  GROUP BY prm2.roomFacilityCharge_id "
                     + ") latest ON prm.roomFacilityCharge_id = latest.roomFacilityCharge_id "
-                    + "SET pe.discharged = 1 "
+                    + "SET pe.discharged = 1, pe.currentPatientRoom_id = NULL, prm.discharged = 1, prm.dischargedAt = NOW() "
                     + "WHERE pe.discharged = 0 AND pe.paymentFinalized = 0 "
                     + "AND pe.id != latest.keep_id "
                     + "AND pe.currentPatientRoom_id IS NOT NULL";
             patientEncounterFacade.executeNativeSql(sql);
-            releaseCurrentRoomsOfDischargedEncounters();
             JsfUtil.addSuccessMessage("Done. Old duplicate undischarged encounters have been discharged, and their current rooms have been released.");
         } catch (Exception e) {
             JsfUtil.addErrorMessage("Error: " + getExceptionMessage(e));
@@ -5138,32 +5137,18 @@ public class DataAdministrationController implements Serializable {
         }
         try {
             String t = patientEncounterFacade.getTableName();
-            String sql = "UPDATE " + t + " "
-                    + "SET discharged = 1 "
-                    + "WHERE discharged = 0 AND paymentFinalized = 0 "
-                    + "AND createdAt < DATE_SUB(NOW(), INTERVAL " + staleEncounterDays + " DAY)";
+            String pr = patientRoomFacade.getTableName();
+            String sql = "UPDATE " + t + " pe "
+                    + "JOIN " + pr + " prm ON pe.currentPatientRoom_id = prm.id "
+                    + "SET pe.discharged = 1, pe.currentPatientRoom_id = NULL, prm.discharged = 1, prm.dischargedAt = NOW() "
+                    + "WHERE pe.discharged = 0 AND pe.paymentFinalized = 0 "
+                    + "AND pe.currentPatientRoom_id IS NOT NULL "
+                    + "AND pe.createdAt < DATE_SUB(NOW(), INTERVAL " + staleEncounterDays + " DAY)";
             patientEncounterFacade.executeNativeSql(sql);
-            releaseCurrentRoomsOfDischargedEncounters();
             JsfUtil.addSuccessMessage("Done. Undischarged encounters older than " + staleEncounterDays + " days have been marked as discharged and their current rooms have been released.");
         } catch (Exception e) {
             JsfUtil.addErrorMessage("Error: " + getExceptionMessage(e));
         }
-    }
-
-    private void releaseCurrentRoomsOfDischargedEncounters() {
-        String pe = patientEncounterFacade.getTableName();
-        String pr = patientRoomFacade.getTableName();
-
-        String dischargeRoomsSql = "UPDATE " + pr + " prm "
-                + "JOIN " + pe + " pe ON pe.currentPatientRoom_id = prm.id "
-                + "SET prm.discharged = 1, prm.dischargedAt = NOW() "
-                + "WHERE pe.discharged = 1 AND prm.discharged = 0";
-        patientRoomFacade.executeNativeSql(dischargeRoomsSql);
-
-        String clearCurrentRoomSql = "UPDATE " + pe + " "
-                + "SET currentPatientRoom_id = NULL "
-                + "WHERE discharged = 1 AND currentPatientRoom_id IS NOT NULL";
-        patientEncounterFacade.executeNativeSql(clearCurrentRoomSql);
     }
 
     public int getStaleEncounterDays() {

--- a/src/main/java/com/divudi/bean/common/DataAdministrationController.java
+++ b/src/main/java/com/divudi/bean/common/DataAdministrationController.java
@@ -5122,7 +5122,8 @@ public class DataAdministrationController implements Serializable {
                     + "AND pe.id != latest.keep_id "
                     + "AND pe.currentPatientRoom_id IS NOT NULL";
             patientEncounterFacade.executeNativeSql(sql);
-            JsfUtil.addSuccessMessage("Done. Old duplicate undischarged encounters have been discharged, keeping the latest per room.");
+            releaseCurrentRoomsOfDischargedEncounters();
+            JsfUtil.addSuccessMessage("Done. Old duplicate undischarged encounters have been discharged, and their current rooms have been released.");
         } catch (Exception e) {
             JsfUtil.addErrorMessage("Error: " + getExceptionMessage(e));
         }
@@ -5142,10 +5143,27 @@ public class DataAdministrationController implements Serializable {
                     + "WHERE discharged = 0 AND paymentFinalized = 0 "
                     + "AND createdAt < DATE_SUB(NOW(), INTERVAL " + staleEncounterDays + " DAY)";
             patientEncounterFacade.executeNativeSql(sql);
-            JsfUtil.addSuccessMessage("Done. Undischarged encounters older than " + staleEncounterDays + " days have been marked as discharged.");
+            releaseCurrentRoomsOfDischargedEncounters();
+            JsfUtil.addSuccessMessage("Done. Undischarged encounters older than " + staleEncounterDays + " days have been marked as discharged and their current rooms have been released.");
         } catch (Exception e) {
             JsfUtil.addErrorMessage("Error: " + getExceptionMessage(e));
         }
+    }
+
+    private void releaseCurrentRoomsOfDischargedEncounters() {
+        String pe = patientEncounterFacade.getTableName();
+        String pr = patientRoomFacade.getTableName();
+
+        String dischargeRoomsSql = "UPDATE " + pr + " prm "
+                + "JOIN " + pe + " pe ON pe.currentPatientRoom_id = prm.id "
+                + "SET prm.discharged = 1, prm.dischargedAt = NOW() "
+                + "WHERE pe.discharged = 1 AND prm.discharged = 0";
+        patientRoomFacade.executeNativeSql(dischargeRoomsSql);
+
+        String clearCurrentRoomSql = "UPDATE " + pe + " "
+                + "SET currentPatientRoom_id = NULL "
+                + "WHERE discharged = 1 AND currentPatientRoom_id IS NOT NULL";
+        patientEncounterFacade.executeNativeSql(clearCurrentRoomSql);
     }
 
     public int getStaleEncounterDays() {


### PR DESCRIPTION
### Motivation
- Admin maintenance actions `Discharge Duplicate Encounters` and `Discharge Stale Encounters` left rooms assigned to encounters, preventing those rooms from becoming selectable in the inward admission room autocomplete, so released rooms must be freed when these admin actions discharge encounters.

### Description
- Updated `dischargeOldDuplicateEncounters()` and `dischargeStaleEncounters()` in `DataAdministrationController` to invoke a shared helper after marking encounters discharged.
- Added private helper `releaseCurrentRoomsOfDischargedEncounters()` in `src/main/java/com/divudi/bean/common/DataAdministrationController.java` that runs native SQL to set `prm.discharged = 1` with `prm.dischargedAt = NOW()` on linked `PatientRoom` rows and to clear `currentPatientRoom_id` on discharged `PatientEncounter` rows.
- Adjusted success messages to indicate rooms have been released.

### Testing
- No automated tests or Maven compilation were executed for this backend change.
- Verified changes via `git diff` and created a commit successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f4e3f36b78832fbd593abd33ccdf51)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Discharge operations now automatically release patient rooms and clear associated room assignments when encounters are discharged.
  * Updated confirmation messages to indicate when rooms have been released and are available for reassignment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->