### PR TITLE
Migrate inward payment bill paper type selection to config options

### DIFF
--- a/src/main/java/com/divudi/bean/pharmacy/PharmacyConfigController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacyConfigController.java
@@ -165,6 +165,12 @@ public class PharmacyConfigController implements Serializable {
     private boolean inwardCopaymentFiveFivePaper;
     private boolean inwardCopaymentA4Paper;
 
+    // Inward Payment Bill Settings
+    private boolean inwardPaymentPosPaper;
+    private boolean inwardPaymentFiveFivePaper;
+    private boolean inwardPaymentFiveFiveCustom3Paper;
+    private boolean inwardPaymentA4Paper;
+
     // Petty Cash Settings
     private boolean pettyCashPosPaper;
     private boolean pettyCashA4Paper;
@@ -337,6 +343,12 @@ public class PharmacyConfigController implements Serializable {
         inwardCopaymentPosPaper = configOptionController.getBooleanValueByKey("Inward Copayment Bill POS Paper", true);
         inwardCopaymentFiveFivePaper = configOptionController.getBooleanValueByKey("Inward Copayment Bill Five Five Paper", false);
         inwardCopaymentA4Paper = configOptionController.getBooleanValueByKey("Inward Copayment Bill A4 Paper", false);
+
+        // Inward Payment Bill Settings
+        inwardPaymentPosPaper = configOptionController.getBooleanValueByKey("Inward Payment Bill POS Paper", true);
+        inwardPaymentFiveFivePaper = configOptionController.getBooleanValueByKey("Inward Payment Bill Five Five Paper", false);
+        inwardPaymentFiveFiveCustom3Paper = configOptionController.getBooleanValueByKey("Inward Payment Bill Five Five Custom 3 Paper", false);
+        inwardPaymentA4Paper = configOptionController.getBooleanValueByKey("Inward Payment Bill A4 Paper", false);
 
         // Petty Cash Settings
         pettyCashPosPaper = configOptionController.getBooleanValueByKey("Petty Cash Receipt POS Paper", true);
@@ -743,6 +755,22 @@ public class PharmacyConfigController implements Serializable {
             loadCurrentConfig();
         } catch (Exception e) {
             JsfUtil.addErrorMessage("Error saving Inward Copayment Bill configuration: " + e.getMessage());
+        }
+    }
+
+    /**
+     * Save Inward Payment Bill configuration changes specifically
+     */
+    public void saveInwardPaymentConfig() {
+        try {
+            configOptionController.setBooleanValueByKey("Inward Payment Bill POS Paper", inwardPaymentPosPaper);
+            configOptionController.setBooleanValueByKey("Inward Payment Bill Five Five Paper", inwardPaymentFiveFivePaper);
+            configOptionController.setBooleanValueByKey("Inward Payment Bill Five Five Custom 3 Paper", inwardPaymentFiveFiveCustom3Paper);
+            configOptionController.setBooleanValueByKey("Inward Payment Bill A4 Paper", inwardPaymentA4Paper);
+            JsfUtil.addSuccessMessage("Inward Payment Bill configuration saved successfully");
+            loadCurrentConfig();
+        } catch (Exception e) {
+            JsfUtil.addErrorMessage("Error saving Inward Payment Bill configuration: " + e.getMessage());
         }
     }
 
@@ -1579,6 +1607,39 @@ public class PharmacyConfigController implements Serializable {
 
     public void setInwardCopaymentA4Paper(boolean inwardCopaymentA4Paper) {
         this.inwardCopaymentA4Paper = inwardCopaymentA4Paper;
+    }
+
+    // Inward Payment Bill Getters and Setters
+    public boolean isInwardPaymentPosPaper() {
+        return inwardPaymentPosPaper;
+    }
+
+    public void setInwardPaymentPosPaper(boolean inwardPaymentPosPaper) {
+        this.inwardPaymentPosPaper = inwardPaymentPosPaper;
+    }
+
+    public boolean isInwardPaymentFiveFivePaper() {
+        return inwardPaymentFiveFivePaper;
+    }
+
+    public void setInwardPaymentFiveFivePaper(boolean inwardPaymentFiveFivePaper) {
+        this.inwardPaymentFiveFivePaper = inwardPaymentFiveFivePaper;
+    }
+
+    public boolean isInwardPaymentFiveFiveCustom3Paper() {
+        return inwardPaymentFiveFiveCustom3Paper;
+    }
+
+    public void setInwardPaymentFiveFiveCustom3Paper(boolean inwardPaymentFiveFiveCustom3Paper) {
+        this.inwardPaymentFiveFiveCustom3Paper = inwardPaymentFiveFiveCustom3Paper;
+    }
+
+    public boolean isInwardPaymentA4Paper() {
+        return inwardPaymentA4Paper;
+    }
+
+    public void setInwardPaymentA4Paper(boolean inwardPaymentA4Paper) {
+        this.inwardPaymentA4Paper = inwardPaymentA4Paper;
     }
 
     // Patient Deposit Getters and Setters

--- a/src/main/webapp/inward/inward_bill_payment.xhtml
+++ b/src/main/webapp/inward/inward_bill_payment.xhtml
@@ -342,6 +342,13 @@
                                 <p:printer target="gpBillPreview" ></p:printer>
                             </p:commandButton>
                             <p:commandButton
+                                rendered="#{webUserController.hasPrivilege('ChangeReceiptPrintingPaperTypes')}"
+                                value="Settings"
+                                icon="fas fa-cog"
+                                class="ui-button-secondary"
+                                type="button"
+                                onclick="PF('inwardPaymentConfigDialog').show();"/>
+                            <p:commandButton
                                 ajax="false"
                                 icon="fas fa-id-card"
                                 value="Inpatient Dashboard"
@@ -352,38 +359,24 @@
                     </f:facet>
 
                     <div class="row">
-                        <div class="col-6"></div>
-                        <div class="col-6">
-                            <div class="d-flex gap-3" style="float: right;">
-                                <p:outputLabel value="Paper Type" class="m-2"></p:outputLabel>
-                                <p:selectOneMenu value="#{sessionController.departmentPreference.inwardDepositPaymentBillPaper}" class="m-1" style="width: 18em;">
-                                    <f:selectItem itemLabel="Please Select Paper Type" />
-                                    <f:selectItems value="#{enumController.paperTypes}" />
-                                </p:selectOneMenu>
-                                <p:commandButton ajax="false" icon="fa fa-sync-alt" class="ui-button m-1" title="Redraw Bill"></p:commandButton>
-                            </div>
-                        </div>
-                    </div>
-
-                    <div class="row">
                         <h:panelGroup id="gpBillPreview">
 
                             <div class="d-flex justify-content-center">
 
-                                <h:panelGroup rendered="#{sessionController.departmentPreference.inwardDepositPaymentBillPaper eq 'FiveFivePaper'}" >
-                                    <bill:FiveFivePaymentBill bill="#{inwardPaymentController.current}" /> 
-                                </h:panelGroup> 
+                                <h:panelGroup rendered="#{configOptionController.getBooleanValueByKey('Inward Payment Bill Five Five Paper', false)}" >
+                                    <bill:FiveFivePaymentBill bill="#{inwardPaymentController.current}" />
+                                </h:panelGroup>
 
-                                <h:panelGroup rendered="#{sessionController.departmentPreference.inwardDepositPaymentBillPaper eq 'FiveFiveCustom3'}" >
+                                <h:panelGroup rendered="#{configOptionController.getBooleanValueByKey('Inward Payment Bill Five Five Custom 3 Paper', false)}" >
                                     <prints:five_five_custom_3_inward_payments bill="#{inwardPaymentController.current}" />
                                 </h:panelGroup>
 
-                                <h:panelGroup rendered="#{sessionController.departmentPreference.inwardDepositPaymentBillPaper eq 'A4Paper'}" >
-                                    <bill:A4PaperPaymentBill bill="#{inwardPaymentController.current}" />                        
-                                </h:panelGroup> 
+                                <h:panelGroup rendered="#{configOptionController.getBooleanValueByKey('Inward Payment Bill A4 Paper', false)}" >
+                                    <bill:A4PaperPaymentBill bill="#{inwardPaymentController.current}" />
+                                </h:panelGroup>
 
-                                <h:panelGroup rendered="#{sessionController.departmentPreference.inwardDepositPaymentBillPaper eq 'PosPaper'}" style="align-items: center;">
-                                    <bill:posPaperPaymentBill bill="#{inwardPaymentController.current}"/>                        
+                                <h:panelGroup rendered="#{configOptionController.getBooleanValueByKey('Inward Payment Bill POS Paper', true)}" style="align-items: center;">
+                                    <bill:posPaperPaymentBill bill="#{inwardPaymentController.current}"/>
                                 </h:panelGroup>
 
                             </div>
@@ -393,5 +386,52 @@
                 </p:panel>
             </h:form>
         </h:panelGroup>
+        <p:dialog id="inwardPaymentConfigDialog"
+                  header="Inward Payment Bill Printer Configuration"
+                  widgetVar="inwardPaymentConfigDialog"
+                  modal="true"
+                  width="560"
+                  resizable="false"
+                  closeOnEscape="true">
+            <p:ajax event="open" listener="#{pharmacyConfigController.loadCurrentConfig}" update="inwardPaymentConfigForm"/>
+            <h:form id="inwardPaymentConfigForm">
+                <div class="card config-section">
+                    <div class="card-header">
+                        <i class="fas fa-file-alt me-2"/>
+                        <h:outputText value="Paper Format Settings"/>
+                    </div>
+                    <div class="card-body">
+                        <div class="mb-3">
+                            <h:selectBooleanCheckbox id="inwardPaymentPOS" value="#{pharmacyConfigController.inwardPaymentPosPaper}"/>
+                            <h:outputLabel for="inwardPaymentPOS" value="POS Paper" class="ms-2"/>
+                        </div>
+                        <div class="mb-3">
+                            <h:selectBooleanCheckbox id="inwardPaymentFiveFive" value="#{pharmacyConfigController.inwardPaymentFiveFivePaper}"/>
+                            <h:outputLabel for="inwardPaymentFiveFive" value="5×5 Paper" class="ms-2"/>
+                        </div>
+                        <div class="mb-3">
+                            <h:selectBooleanCheckbox id="inwardPaymentFiveFiveCustom3" value="#{pharmacyConfigController.inwardPaymentFiveFiveCustom3Paper}"/>
+                            <h:outputLabel for="inwardPaymentFiveFiveCustom3" value="5×5 Custom 3 Paper" class="ms-2"/>
+                        </div>
+                        <div class="mb-3">
+                            <h:selectBooleanCheckbox id="inwardPaymentA4" value="#{pharmacyConfigController.inwardPaymentA4Paper}"/>
+                            <h:outputLabel for="inwardPaymentA4" value="A4 Paper" class="ms-2"/>
+                        </div>
+                    </div>
+                </div>
+                <div class="d-flex gap-2 mt-3">
+                    <p:commandButton value="Apply &amp; Close"
+                                     icon="fas fa-save"
+                                     class="ui-button-success"
+                                     ajax="false"
+                                     action="#{pharmacyConfigController.saveInwardPaymentConfig}"/>
+                    <p:commandButton value="Cancel"
+                                     icon="fas fa-times"
+                                     class="ui-button-secondary"
+                                     type="button"
+                                     onclick="PF('inwardPaymentConfigDialog').hide(); return false;"/>
+                </div>
+            </h:form>
+        </p:dialog>
     </ui:define>
 </ui:composition>

--- a/src/main/webapp/inward/inward_reprint_bill_payment.xhtml
+++ b/src/main/webapp/inward/inward_reprint_bill_payment.xhtml
@@ -93,12 +93,13 @@
                                 <div class="d-flex justify-content-between">
                                     <p:outputLabel value="Bill Preview" class="m-2"></p:outputLabel>
                                     <div class="d-flex gap-3">
-                                        <p:outputLabel value="Paper Type" class="m-2"></p:outputLabel>
-                                        <p:selectOneMenu value="#{sessionController.departmentPreference.inwardDepositPaymentBillPaper}" class="m-1" style="width: 18em;">
-                                            <f:selectItem itemLabel="Please Select Paper Type" />
-                                            <f:selectItems value="#{enumController.paperTypes}" />
-                                        </p:selectOneMenu>
-                                        <p:commandButton ajax="false" icon="fa fa-sync-alt" class="ui-button m-1" title="Redraw Bill"></p:commandButton>
+                                        <p:commandButton
+                                            rendered="#{webUserController.hasPrivilege('ChangeReceiptPrintingPaperTypes')}"
+                                            value="Settings"
+                                            icon="fas fa-cog"
+                                            class="ui-button-secondary"
+                                            type="button"
+                                            onclick="PF('inwardPaymentConfigDialog').show();"/>
                                     </div>
                                 </div>
                             </f:facet>
@@ -106,19 +107,19 @@
                             <div class="d-flex justify-content-center">
                                 <h:panelGroup id="gpBillPreview" >
 
-                                    <h:panelGroup rendered="#{sessionController.departmentPreference.inwardDepositPaymentBillPaper eq 'A4Paper'}" >
+                                    <h:panelGroup rendered="#{configOptionController.getBooleanValueByKey('Inward Payment Bill A4 Paper', false)}" >
                                         <bill:A4PaperPaymentBill bill="#{inwardSearch.bill}" duplicate="true"/>                        
                                     </h:panelGroup>
 
-                                    <h:panelGroup rendered="#{sessionController.departmentPreference.inwardDepositPaymentBillPaper eq 'FiveFivePaper'}" >
+                                    <h:panelGroup rendered="#{configOptionController.getBooleanValueByKey('Inward Payment Bill Five Five Paper', false)}" >
                                         <bill:FiveFivePaymentBill bill="#{inwardSearch.bill}" duplicate="true" />    
                                     </h:panelGroup> 
 
-                                    <h:panelGroup rendered="#{sessionController.departmentPreference.inwardDepositPaymentBillPaper eq 'PosPaper'}" style="align-items: center;">
+                                    <h:panelGroup rendered="#{configOptionController.getBooleanValueByKey('Inward Payment Bill POS Paper', true)}" style="align-items: center;">
                                         <bill:posPaperPaymentBill bill="#{inwardSearch.bill}"/> 
                                     </h:panelGroup>
                                     
-                                     <h:panelGroup rendered="#{sessionController.departmentPreference.inwardDepositPaymentBillPaper eq 'FiveFiveCustom3'}" >
+                                     <h:panelGroup rendered="#{configOptionController.getBooleanValueByKey('Inward Payment Bill Five Five Custom 3 Paper', false)}" >
                                          <prints:five_five_custom_3_inward_payments bill="#{inwardSearch.bill}" duplicate="true" />
                                 </h:panelGroup>
 
@@ -127,6 +128,54 @@
                         </p:panel>
                     </p:panel>
                 </h:form>
+
+        <p:dialog id="inwardPaymentConfigDialog"
+                  header="Inward Payment Bill Printer Configuration"
+                  widgetVar="inwardPaymentConfigDialog"
+                  modal="true"
+                  width="560"
+                  resizable="false"
+                  closeOnEscape="true">
+            <p:ajax event="open" listener="#{pharmacyConfigController.loadCurrentConfig}" update="inwardPaymentConfigForm"/>
+            <h:form id="inwardPaymentConfigForm">
+                <div class="card config-section">
+                    <div class="card-header">
+                        <i class="fas fa-file-alt me-2"/>
+                        <h:outputText value="Paper Format Settings"/>
+                    </div>
+                    <div class="card-body">
+                        <div class="mb-3">
+                            <h:selectBooleanCheckbox id="inwardPaymentPOS" value="#{pharmacyConfigController.inwardPaymentPosPaper}"/>
+                            <h:outputLabel for="inwardPaymentPOS" value="POS Paper" class="ms-2"/>
+                        </div>
+                        <div class="mb-3">
+                            <h:selectBooleanCheckbox id="inwardPaymentFiveFive" value="#{pharmacyConfigController.inwardPaymentFiveFivePaper}"/>
+                            <h:outputLabel for="inwardPaymentFiveFive" value="5×5 Paper" class="ms-2"/>
+                        </div>
+                        <div class="mb-3">
+                            <h:selectBooleanCheckbox id="inwardPaymentFiveFiveCustom3" value="#{pharmacyConfigController.inwardPaymentFiveFiveCustom3Paper}"/>
+                            <h:outputLabel for="inwardPaymentFiveFiveCustom3" value="5×5 Custom 3 Paper" class="ms-2"/>
+                        </div>
+                        <div class="mb-3">
+                            <h:selectBooleanCheckbox id="inwardPaymentA4" value="#{pharmacyConfigController.inwardPaymentA4Paper}"/>
+                            <h:outputLabel for="inwardPaymentA4" value="A4 Paper" class="ms-2"/>
+                        </div>
+                    </div>
+                </div>
+                <div class="d-flex gap-2 mt-3">
+                    <p:commandButton value="Apply &amp; Close"
+                                     icon="fas fa-save"
+                                     class="ui-button-success"
+                                     ajax="false"
+                                     action="#{pharmacyConfigController.saveInwardPaymentConfig}"/>
+                    <p:commandButton value="Cancel"
+                                     icon="fas fa-times"
+                                     class="ui-button-secondary"
+                                     type="button"
+                                     onclick="PF('inwardPaymentConfigDialog').hide(); return false;"/>
+                </div>
+            </h:form>
+        </p:dialog>
             </ui:define>
         </ui:composition>
     </h:body>


### PR DESCRIPTION
### Motivation
- Replace the deprecated department-preference dropdown for inward payment paper type with the centralized config-option pattern described in the printer configuration guide. 
- Provide a consistent, permission-gated UI (Settings dialog) so administrators can control paper types without changing code or department preferences. 

### Description
- Replaced the legacy `sessionController.departmentPreference.inwardDepositPaymentBillPaper` dropdown and per-value `sessionController` render checks with `configOptionController.getBooleanValueByKey(...)` checks in `inward_bill_payment.xhtml`. 
- Added a privilege-gated `Settings` button (requires `ChangeReceiptPrintingPaperTypes`) in the inward payment print-preview header that opens a new `Inward Payment Bill Printer Configuration` dialog. 
- Implemented the dialog using native JSF checkboxes (`h:selectBooleanCheckbox`) and wired the Apply action to a new controller save method. 
- Extended `PharmacyConfigController` with new inward-payment properties, loading in `loadCurrentConfig()`, a `saveInwardPaymentConfig()` action, and corresponding getters/setters for these keys: `Inward Payment Bill POS Paper`, `Inward Payment Bill Five Five Paper`, `Inward Payment Bill Five Five Custom 3 Paper`, and `Inward Payment Bill A4 Paper`.

### Testing
- Static verification: searched the codebase for affected keys and pages with `rg` and inspected the modified files to ensure render conditions were switched to `configOptionController` and the dialog/button are present. (success)
- Diff inspection: reviewed the changes in `inward_bill_payment.xhtml` and `PharmacyConfigController.java` to confirm the new config keys are loaded/saved and getters/setters were added. (success)
- No automated unit or integration tests were executed and no Maven build/compile was run per repository guidelines for this change set.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f50e9f5148832f8f6a1de45daa340b)