### PR TITLE
Fix credit company details not shown in interim bill

### DIFF
--- a/src/main/java/com/divudi/bean/inward/BhtSummeryController.java
+++ b/src/main/java/com/divudi/bean/inward/BhtSummeryController.java
@@ -2561,6 +2561,13 @@ public class BhtSummeryController implements Serializable {
         return patientEncounter;
     }
 
+    public List<EncounterCreditCompany> getEncounterCreditCompanys() {
+        if (patientEncounter == null) {
+            return new ArrayList<>();
+        }
+        return fillCreditCompaniesByPatient(patientEncounter);
+    }
+
     public void setPatientEncounter(PatientEncounter patientEncounter) {
 //        makeNull();
         this.patientEncounter = patientEncounter;

--- a/src/main/webapp/inward/inward_bill_intrim.xhtml
+++ b/src/main/webapp/inward/inward_bill_intrim.xhtml
@@ -271,8 +271,9 @@
                                             <p:outputLabel value="Summary" class="mx-2"/>
                                         </f:facet>
 
-                                        <h:panelGroup id="crd" class="w-100" style="display: #{bhtSummeryController.patientEncounter.paymentMethod eq 'Credit' ? 'block' : 'none'} ; ">
-                                            <credit:outputCredit  class="w-100" patientEncounter="#{bhtSummeryController.patientEncounter}"/>
+                                        <h:panelGroup id="crd" layout="block" class="w-100"
+                                                      rendered="#{bhtSummeryController.patientEncounter.paymentMethod eq 'Credit'}">
+                                            <credit:creditCompanyListView controller="#{bhtSummeryController}"/>
                                         </h:panelGroup>
 
 


### PR DESCRIPTION
## Summary
- The interim bill (`inward_bill_intrim.xhtml`) was reading credit company details from old legacy fields directly on the `PatientEncounter` entity (`creditCompany`, `policyNo`, `referanceNo`, etc.) via the `outputCredit` composite component
- These fields are **not updated** when the user changes payment details via *Edit Payment Details*, which writes to the `EncounterCreditCompany` table instead
- Fix: replaced `credit:outputCredit` with `credit:creditCompanyListView` — the same component used by the Edit Payment Details page — so both pages read from the same `EncounterCreditCompany` table
- Added `getEncounterCreditCompanys()` getter to `BhtSummeryController` (delegates to the existing `fillCreditCompaniesByPatient()`) to satisfy the component's `controller` contract
- Also converted the panel visibility from an inline `style="display:..."` to a proper JSF `rendered=` attribute

## Test plan
- [ ] Admit a patient with Cash payment, then use Edit Payment Details to switch to Credit and assign a credit company + policy number
- [ ] Open the Interim Bill — verify the Credit Company, Policy No, and Reference No are now displayed
- [ ] Verify the credit company section is hidden when payment method is not Credit

Closes #20331

🤖 Generated with [Claude Code](https://claude.com/claude-code)