### PR TITLE
fix(pharmacy): allow decimal return quantities on BHT return page

### DIFF
--- a/src/main/webapp/inward/pharmacy_bill_return_bht_issue.xhtml
+++ b/src/main/webapp/inward/pharmacy_bill_return_bht_issue.xhtml
@@ -100,9 +100,9 @@
                                 <h:outputText value=" #{ph.item.name}"  />                     
                             </p:column>  
 
-                            <p:column headerText="Balance Qty in Unit" style="padding: 9px; width: 12em;"> 
-                                <h:outputText value="#{ph.pharmaceuticalBillItem.qty}" >  
-                                    <f:convertNumber pattern="#0" />
+                            <p:column headerText="Balance Qty in Unit" style="padding: 9px; width: 12em;">
+                                <h:outputText value="#{ph.pharmaceuticalBillItem.qty}" >
+                                    <f:convertNumber pattern="#0.####" />
                                 </h:outputText>
                             </p:column>  
 
@@ -146,7 +146,7 @@
                                         execute="@this" 
                                         listener="#{bhtIssueReturnController.onEdit(ph)}" >
                                     </f:ajax>                               
-                                    <f:convertNumber pattern="#,##" />
+                                    <f:convertNumber pattern="#,##0.####" />
                                 </p:inputText>
                             </p:column>  
 


### PR DESCRIPTION
## Summary

- **Balance Qty column** (`#0` → `#0.####`): fractional remaining balances like `0.25` were being rounded to `"0"`, making items appear fully returned when they were not
- **Returning Qty input** (`#,##` → `#,##0.####`): user-entered decimal values were silently truncated to `0` before reaching the backing bean, making it impossible to save any fractional return quantity

## Root cause

Both `f:convertNumber` patterns in `pharmacy_bill_return_bht_issue.xhtml` lacked a decimal separator, so JSF's `NumberConverter` rounded/truncated all fractional parts before updating the model.

## Verified against production data

Confirmed on coop bill `theatre//26/022405` which has six items with outstanding fractional quantities (SEVOFLURANE 0.25, Hemitadine 0.6, Surgical Spirit 0.098, Betadine Scrub 0.078, Soft Cloth Tape 0.12, Autoclave Tape 0.14). All quantities are stored correctly in the DB as negative doubles in `pharmaceuticalbillitem.qty`; the filter in `generateBillComponent()` correctly includes them (`tmpQty > 0`). The fault was purely in the display/input converters.

## Test plan

- [ ] Navigate to BHT pharmacy return page for a bill that has items with outstanding qty between 0 and 1
- [ ] Verify the **Balance Qty** column shows the correct decimal value (e.g. `0.25`) instead of `0`
- [ ] Enter a decimal return quantity (e.g. `0.25`) — verify it is accepted and held after blur
- [ ] Enter a quantity exceeding the balance — verify the "can't return over balanced qty" error fires and resets to 0
- [ ] Submit the return — verify it saves correctly and the item no longer appears on subsequent navigation

Closes #20390

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced quantity value precision in pharmacy billing. The "Balance Qty in Unit" and "Returning Qty in Unit" fields now display values with up to 4 decimal places instead of rounding to whole numbers, providing more accurate representation of fractional quantities during inventory tracking and return processing operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->