### PR TITLE
20307 need to improve collection center balance report pdf

### DIFF
--- a/src/main/java/com/divudi/bean/report/ReportController.java
+++ b/src/main/java/com/divudi/bean/report/ReportController.java
@@ -1805,95 +1805,163 @@ public class ReportController implements Serializable, ControllerWithReportFilte
         }
     }
     
-    public void preProcessCollectionCenterBalanceReportPDF(Object document) {
-  try {
-            com.lowagie.text.Document pdf = (com.lowagie.text.Document) document;
-            pdf.setMargins(36f, 36f, 20f, 36f);
+    public void exportCollectionCenterBalanceReportToPDF() {
+        if (bundle.getReportTemplateRows() == null || bundle.getReportTemplateRows().isEmpty()) {
+            JsfUtil.addErrorMessage("No data to export. Please process the report first.");
+            return;
+        }
 
-            // ── BaseColor definitions ─────────────────────────────────────
-            java.awt.Color black      = new java.awt.Color(0,   0,   0);
-            java.awt.Color lightGray  = new java.awt.Color(245, 245, 245);
-            java.awt.Color borderGray = new java.awt.Color(180, 180, 180);
+        com.itextpdf.text.Font bodyFontSmall = com.itextpdf.text.FontFactory.getFont(
+                com.itextpdf.text.FontFactory.HELVETICA, 8);
 
-            // ── Font definitions ──────────────────────────────────────────
-            com.lowagie.text.Font hospitalFont = new com.lowagie.text.Font(com.lowagie.text.Font.HELVETICA, 16f, com.lowagie.text.Font.BOLD,   black);
-            com.lowagie.text.Font reportFont   = new com.lowagie.text.Font(com.lowagie.text.Font.HELVETICA, 13f, com.lowagie.text.Font.BOLD,   black);
-            com.lowagie.text.Font dateFont     = new com.lowagie.text.Font(com.lowagie.text.Font.HELVETICA, 10f, com.lowagie.text.Font.NORMAL, black);
-            com.lowagie.text.Font labelFont    = new com.lowagie.text.Font(com.lowagie.text.Font.HELVETICA,  9f, com.lowagie.text.Font.BOLD,   black);
-            com.lowagie.text.Font valueFont    = new com.lowagie.text.Font(com.lowagie.text.Font.HELVETICA,  9f, com.lowagie.text.Font.NORMAL, black);
+        FacesContext context = FacesContext.getCurrentInstance();
+        ExternalContext externalContext = context.getExternalContext();
+        HttpServletResponse response = (HttpServletResponse) externalContext.getResponse();
+        response.reset();
 
-            // ── Institution name ──────────────────────────────────────────
-            String institutionName = sessionController.getInstitution() != null ? sessionController.getInstitution().getName() : "";
-            com.lowagie.text.Paragraph hospitalName = new com.lowagie.text.Paragraph(institutionName, hospitalFont);
-            hospitalName.setAlignment(com.lowagie.text.Element.ALIGN_LEFT);
-            hospitalName.setSpacingAfter(2f);
-            pdf.add(hospitalName);
+        String dates = CommonFunctions.dateRangeForFileName(
+                fromDate, toDate,
+                sessionController.getApplicationPreference().getLongDateFormat());
 
-            // ── Report title ──────────────────────────────────────────────
-            com.lowagie.text.Paragraph reportTitle = new com.lowagie.text.Paragraph("Collection Center Balance Report", reportFont);
-            reportTitle.setAlignment(com.lowagie.text.Element.ALIGN_LEFT);
-            reportTitle.setSpacingAfter(2f);
-            pdf.add(reportTitle);
+        response.setContentType("application/pdf");
+        if (dates != null && !dates.isEmpty()) {
+            response.setHeader("Content-Disposition",
+                    "attachment; filename=Collection_center_balance_report_" + dates + ".pdf");
+        } else {
+            response.setHeader("Content-Disposition",
+                    "attachment; filename=Collection_center_balance_report.pdf");
+        }
 
-            // ── Generated date ────────────────────────────────────────────
-            SimpleDateFormat sdf = new SimpleDateFormat(
-                    sessionController.getApplicationPreference().getLongDateTimeFormat());
-            com.lowagie.text.Paragraph dateLine = new com.lowagie.text.Paragraph("Date: " + sdf.format(new Date()), dateFont);
-            dateLine.setAlignment(com.lowagie.text.Element.ALIGN_LEFT);
-            dateLine.setSpacingAfter(10f);
-            pdf.add(dateLine);
+        SimpleDateFormat sdf = new SimpleDateFormat("dd MM yyyy hh:mm:ss a");
+        String institutionName = sessionController.getInstitution() != null
+                ? sessionController.getInstitution().getName() : "";
 
-            // ── Filter summary table ──────────────────────────────────────
-            Map<String, Object> filters = getFiltersForCollectionCenterBalanceReport();
+        try (OutputStream out = response.getOutputStream()) {
 
-            com.lowagie.text.pdf.PdfPTable filterTable = new com.lowagie.text.pdf.PdfPTable(4); // ← changed from 8 to 4
+            com.itextpdf.text.Document document = new com.itextpdf.text.Document(
+                    com.itextpdf.text.PageSize.A4.rotate());
+            com.itextpdf.text.pdf.PdfWriter.getInstance(document, out);
+            document.open(); // ✅ fixed from [document.open](http://document.open)()
+
+            if (!institutionName.isEmpty()) {
+                document.add(new com.itextpdf.text.Paragraph(institutionName,
+                        com.itextpdf.text.FontFactory.getFont(
+                                com.itextpdf.text.FontFactory.HELVETICA_BOLD, 18)));
+            }
+            document.add(new com.itextpdf.text.Paragraph("Collection Center Balance Report",
+                    com.itextpdf.text.FontFactory.getFont(
+                            com.itextpdf.text.FontFactory.HELVETICA_BOLD, 16)));
+            document.add(new com.itextpdf.text.Paragraph("Date: " + sdf.format(new Date()),
+                    com.itextpdf.text.FontFactory.getFont(
+                            com.itextpdf.text.FontFactory.HELVETICA, 12)));
+            document.add(new com.itextpdf.text.Paragraph(" "));
+
+            // ✅ All colors now use iText BaseColor instead of java.awt.Color
+            com.itextpdf.text.BaseColor black      = new com.itextpdf.text.BaseColor(0,   0,   0);
+            com.itextpdf.text.BaseColor lightGray  = new com.itextpdf.text.BaseColor(245, 245, 245);
+            com.itextpdf.text.BaseColor borderGray = new com.itextpdf.text.BaseColor(180, 180, 180);
+
+            // ✅ Font now uses iText Font class with iText BaseColor
+            com.itextpdf.text.Font labelFont = new com.itextpdf.text.Font(
+                    com.itextpdf.text.Font.FontFamily.HELVETICA, 9f,
+                    com.itextpdf.text.Font.BOLD, black);
+            com.itextpdf.text.Font valueFont = new com.itextpdf.text.Font(
+                    com.itextpdf.text.Font.FontFamily.HELVETICA, 9f,
+                    com.itextpdf.text.Font.NORMAL, black);
+
+            // ── Filter Table ──────────────────────────────────────────────────
+            com.itextpdf.text.pdf.PdfPTable filterTable =
+                    new com.itextpdf.text.pdf.PdfPTable(4);
             filterTable.setWidthPercentage(100f);
-            filterTable.setWidths(new float[]{18f, 32f, 18f, 32f});                             // ← changed from 8 widths to 4
+            filterTable.setWidths(new float[]{18f, 32f, 18f, 32f});
             filterTable.setSpacingAfter(10f);
 
+            Map<String, Object> filters = getFiltersForCollectionCenterBalanceReport();
             List<Map.Entry<String, Object>> entries = new ArrayList<>(filters.entrySet());
             int totalEntries = entries.size();
-            int cols = 2;                                                                        // ← changed from 4 to 2 (pairs per row)
+            int cols = 2;
 
             for (Map.Entry<String, Object> entry : entries) {
 
-                // Label cell
-                com.lowagie.text.pdf.PdfPCell labelCell = new com.lowagie.text.pdf.PdfPCell(
-                        new com.lowagie.text.Phrase(entry.getKey(), labelFont));
+                // ✅ Label cell — fully iText
+                com.itextpdf.text.pdf.PdfPCell labelCell = new com.itextpdf.text.pdf.PdfPCell(
+                        new com.itextpdf.text.Phrase(entry.getKey(), labelFont));
                 labelCell.setBorderColor(borderGray);
                 labelCell.setBorderWidth(0.5f);
                 labelCell.setPadding(4f);
                 labelCell.setBackgroundColor(lightGray);
                 filterTable.addCell(labelCell);
 
-                // Value cell
+                // ✅ Value cell — fully iText
                 String val = entry.getValue() != null ? entry.getValue().toString() : "";
-                com.lowagie.text.pdf.PdfPCell valueCell = new com.lowagie.text.pdf.PdfPCell(
-                        new com.lowagie.text.Phrase(val, valueFont));
+                com.itextpdf.text.pdf.PdfPCell valueCell = new com.itextpdf.text.pdf.PdfPCell(
+                        new com.itextpdf.text.Phrase(val, valueFont));
                 valueCell.setBorderColor(borderGray);
                 valueCell.setBorderWidth(0.5f);
                 valueCell.setPadding(4f);
                 filterTable.addCell(valueCell);
             }
 
-            // ── Pad last row with empty cells if needed ───────────────────
+            // ── Pad last row if needed ────────────────────────────────────────
             int remainder = totalEntries % cols;
             if (remainder != 0) {
-                int emptyCells = (cols - remainder) * 2;                                        // ← still correct, uses updated cols
+                int emptyCells = (cols - remainder) * 2;
                 for (int i = 0; i < emptyCells; i++) {
-                    com.lowagie.text.pdf.PdfPCell empty = new com.lowagie.text.pdf.PdfPCell(
-                            new com.lowagie.text.Phrase(""));
+                    // ✅ Empty cell — fully iText
+                    com.itextpdf.text.pdf.PdfPCell empty = new com.itextpdf.text.pdf.PdfPCell(
+                            new com.itextpdf.text.Phrase(""));
                     empty.setBorderColor(borderGray);
                     empty.setBorderWidth(0.5f);
                     empty.setPadding(4f);
                     filterTable.addCell(empty);
                 }
             }
+            document.add(filterTable);
 
-            pdf.add(filterTable);
+            // ── Data Table ────────────────────────────────────────────────────
+            int columnCount = 8;
+            com.itextpdf.text.pdf.PdfPTable table =
+                    new com.itextpdf.text.pdf.PdfPTable(columnCount);
+            table.setWidthPercentage(100);
+            table.setWidths(new float[]{0.5f, 3f, 2f, 2f, 2f, 1f, 1f, 1f});
 
-        } catch (com.lowagie.text.DocumentException e) {
-            e.printStackTrace();
+            // ✅ Fixed [S.No](http://S.No) markdown artifact → plain "S.No"
+            String[] headers = {"S.No", "CC Name", "CC Route", "CC Code",
+                                 "CC Phone No.", "CC Credit Limit", "Max Credit Limit", "CC Balance"};
+
+            for (String header : headers) {
+                com.itextpdf.text.pdf.PdfPCell cell = new com.itextpdf.text.pdf.PdfPCell(
+                        new com.itextpdf.text.Phrase(header,
+                                com.itextpdf.text.FontFactory.getFont(
+                                        com.itextpdf.text.FontFactory.HELVETICA_BOLD, 7)));
+                cell.setBackgroundColor(com.itextpdf.text.BaseColor.LIGHT_GRAY);
+                table.addCell(cell);
+            }
+
+            List<ReportTemplateRow> rows = bundle.getReportTemplateRows();
+            int indexNumber = 1;
+            for (ReportTemplateRow row : rows) {
+                AgentHistory ac  = row.getAgentHistory();
+                Institution  acc = ac.getAgency();
+
+                table.addCell(textCell(String.valueOf(indexNumber), bodyFontSmall));
+                table.addCell(textCell(acc.getName(), bodyFontSmall));
+                table.addCell(textCell(acc.getRoute() != null ? acc.getRoute().getName() : "-", bodyFontSmall));
+                table.addCell(textCell(acc.getCode(), bodyFontSmall));
+                table.addCell(textCell(acc.getPhone(), bodyFontSmall));
+                table.addCell(numCell(acc.getMaxCreditLimit(), bodyFontSmall));
+                table.addCell(numCell(acc.getMaxCreditLimit(), bodyFontSmall)); // ⚠️ duplicate — verify correct field
+                table.addCell(numCell(ac.getBalanceAfterTransaction(), bodyFontSmall));
+                indexNumber++;
+            }
+
+            document.add(table);
+            document.close();
+            context.responseComplete();
+
+        } catch (Exception e) {
+            Logger.getLogger(ReportsController.class.getName())
+                    .log(Level.SEVERE, "Error exporting Collection Center Balance Report to PDF", e);
         }
     }
 

--- a/src/main/java/com/divudi/bean/report/ReportController.java
+++ b/src/main/java/com/divudi/bean/report/ReportController.java
@@ -1806,7 +1806,7 @@ public class ReportController implements Serializable, ControllerWithReportFilte
     }
     
     public void exportCollectionCenterBalanceReportToPDF() {
-        if (bundle.getReportTemplateRows() == null || bundle.getReportTemplateRows().isEmpty()) {
+        if (bundle == null || bundle.getReportTemplateRows() == null || bundle.getReportTemplateRows().isEmpty()) {
             JsfUtil.addErrorMessage("No data to export. Please process the report first.");
             return;
         }
@@ -1949,7 +1949,7 @@ public class ReportController implements Serializable, ControllerWithReportFilte
                 table.addCell(textCell(acc.getRoute() != null ? acc.getRoute().getName() : "-", bodyFontSmall));
                 table.addCell(textCell(acc.getCode(), bodyFontSmall));
                 table.addCell(textCell(acc.getPhone(), bodyFontSmall));
-                table.addCell(numCell(acc.getMaxCreditLimit(), bodyFontSmall));
+                table.addCell(numCell(acc.getAllowedCreditLimit(), bodyFontSmall));
                 table.addCell(numCell(acc.getMaxCreditLimit(), bodyFontSmall)); // ⚠️ duplicate — verify correct field
                 table.addCell(numCell(ac.getBalanceAfterTransaction(), bodyFontSmall));
                 indexNumber++;
@@ -1960,7 +1960,7 @@ public class ReportController implements Serializable, ControllerWithReportFilte
             context.responseComplete();
 
         } catch (Exception e) {
-            Logger.getLogger(ReportsController.class.getName())
+            Logger.getLogger(ReportController.class.getName())
                     .log(Level.SEVERE, "Error exporting Collection Center Balance Report to PDF", e);
         }
     }

--- a/src/main/webapp/reports/collectionCenterReports/collection_center_balance_report.xhtml
+++ b/src/main/webapp/reports/collectionCenterReports/collection_center_balance_report.xhtml
@@ -97,13 +97,13 @@
 
                                 </div>
                                 <div  class="col-md-2">
-                                    <p:commandButton class="mx-2 ui-button-danger" style="width: 150px" value="PDF" icon="pi pi-file-pdf" ajax="false">
-                                        <p:dataExporter
-                                            type="pdf" 
-                                            target="agentHistoriesTable" 
-                                            fileName="Collection_center_balance_report_#{reportController.fromDateFormatted()}_to_#{reportController.toDateFormatted()}"
-                                            preProcessor="#{reportController.preProcessCollectionCenterBalanceReportPDF}"
-                                            />
+                                    <p:commandButton 
+                                        class="mx-2 ui-button-danger" 
+                                        style="width: 150px" 
+                                        value="PDF" 
+                                        icon="pi pi-file-pdf" 
+                                        ajax="false"
+                                        action="#{reportController.exportCollectionCenterBalanceReportToPDF()}">
                                     </p:commandButton>
 
 


### PR DESCRIPTION
closes #20307 
Modified the CC balance report to give a clear view of the report. Removed the old dataExport component and created an export method to generate a better-looking PDF.
01) reportController.java (wrote PDF export method)
02) collection_center_balance_report.xhtml (removed dataExport component(old) generate PDF from the controller file)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Reworked Collection Center Balance PDF export to a server-driven flow with safer validation and error handling. Exports now produce a date-range-based filename, improved header and generated-date display, clearer filter summary, and a more consistent multi-column data table (including contact and balance details), yielding more stable, higher-quality PDF reports.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->