### PR TITLE
fix(pharmacy): pre-fill returning qty and compute totals on BHT retur…

### DIFF
--- a/src/main/java/com/divudi/bean/pharmacy/BhtIssueReturnController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/BhtIssueReturnController.java
@@ -360,7 +360,13 @@ public class BhtIssueReturnController implements Serializable {
 //                System.out.println("bi.getPharmaceuticalBillItem().getQtyInUnit() = " + bi.getPharmaceuticalBillItem().getQtyInUnit());
 //                System.out.println("bi.getQty() = " + bi.getQty());
 //                System.out.println("bi.getPharmaceuticalBillItem().getQty() = " + bi.getPharmaceuticalBillItem().getQty());
-                double liveAvailableQty = getPharmacyRecieveBean().calQty4(bi.getReferanceBillItem());
+                double returnedQty = getPharmacyRecieveBean().getTotalQty(
+                        bi.getReferanceBillItem(),
+                        getBill().getBillType()
+                );
+                double liveAvailableQty = Math.abs(
+                        bi.getReferanceBillItem().getPharmaceuticalBillItem().getQtyInUnit()
+                ) - Math.abs(returnedQty);
                 if (bi.getQty() > liveAvailableQty) {
 //                    System.out.println("bi.getQty = " + bi.getQty());
                     JsfUtil.addErrorMessage("You cant return over than ballanced Qty ");

--- a/src/main/java/com/divudi/bean/pharmacy/BhtIssueReturnController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/BhtIssueReturnController.java
@@ -360,7 +360,8 @@ public class BhtIssueReturnController implements Serializable {
 //                System.out.println("bi.getPharmaceuticalBillItem().getQtyInUnit() = " + bi.getPharmaceuticalBillItem().getQtyInUnit());
 //                System.out.println("bi.getQty() = " + bi.getQty());
 //                System.out.println("bi.getPharmaceuticalBillItem().getQty() = " + bi.getPharmaceuticalBillItem().getQty());
-                if (bi.getPharmaceuticalBillItem().getQtyInUnit() < bi.getQty()) {
+                double liveAvailableQty = getPharmacyRecieveBean().calQty4(bi.getReferanceBillItem());
+                if (bi.getQty() > liveAvailableQty) {
 //                    System.out.println("bi.getQty = " + bi.getQty());
                     JsfUtil.addErrorMessage("You cant return over than ballanced Qty ");
                     return;

--- a/src/main/java/com/divudi/bean/pharmacy/BhtIssueReturnController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/BhtIssueReturnController.java
@@ -470,12 +470,13 @@ public class BhtIssueReturnController implements Serializable {
             }
 
             tmp.setQtyInUnit(tmpQty);
+            bi.setQty(tmpQty);
 
             bi.setPharmaceuticalBillItem(tmp);
 
             getBillItems().add(bi);
         }
-
+        calTotal();
     }
 
 //    private double calRemainingQty(PharmaceuticalBillItem i) {


### PR DESCRIPTION
…n page load

generateBillComponent() previously initialised bi.qty to 0.0 for every row, requiring users to manually type each fractional return quantity (e.g. 0.098, 0.078) before they could save. Now:

- bi.setQty(tmpQty) pre-populates the Returning Qty input with the full outstanding balance, so users can submit immediately or adjust down.
- calTotal() called at the end of generateBillComponent() so Receivable Gross/Margin/Net amounts are calculated on page load rather than showing 0.00 until the first blur event.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed pharmacy billing and returns so returned quantities cannot exceed available stock; returns that exceed limits are invalidated, quantities are set correctly, totals are recalculated, and the same error is shown.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->