### PR TITLE
fix(inward): show payment details immediately when accessing interim bill from menu

### DIFF
--- a/src/main/java/com/divudi/bean/inward/BhtSummeryController.java
+++ b/src/main/java/com/divudi/bean/inward/BhtSummeryController.java
@@ -2312,17 +2312,18 @@ public class BhtSummeryController implements Serializable {
 
     }
 
-    public void createIntrimBillTable() {
+    public String createIntrimBillTable() {
         if (configOptionApplicationController.getBooleanValueByKey("Restrict Access to Intrim Bill if Provisional Bill is Created")) {
             if (patientEncounter != null
                     && admissionController.isAddmissionHaveProvisionalBill((Admission) patientEncounter)) {
                 JsfUtil.addErrorMessage("There is a Provisional Bill For This Admission");
-                clear();            // resets patientEncounter and cached data safely
-                return;
+                clear();
+                return "";
             }
         }
         childPatientEncouters = null;
         createTables();
+        return "/inward/inward_bill_intrim?faces-redirect=true";
     }
 
     public void createTables() {

--- a/src/main/java/com/divudi/bean/inward/BhtSummeryController.java
+++ b/src/main/java/com/divudi/bean/inward/BhtSummeryController.java
@@ -2313,9 +2313,12 @@ public class BhtSummeryController implements Serializable {
     }
 
     public String createIntrimBillTable() {
+        if (patientEncounter == null) {
+            JsfUtil.addErrorMessage("No Admission Selected");
+            return "";
+        }
         if (configOptionApplicationController.getBooleanValueByKey("Restrict Access to Intrim Bill if Provisional Bill is Created")) {
-            if (patientEncounter != null
-                    && admissionController.isAddmissionHaveProvisionalBill((Admission) patientEncounter)) {
+            if (admissionController.isAddmissionHaveProvisionalBill((Admission) patientEncounter)) {
                 JsfUtil.addErrorMessage("There is a Provisional Bill For This Admission");
                 clear();
                 return "";


### PR DESCRIPTION
## Summary

- `createIntrimBillTable()` was `void`, causing JSF to re-render the same POST view after the Continue button was clicked
- The payment details panel had `rendered=false` on the initial GET (because `patientEncounter` was null), and the component subtree did not reliably transition to `rendered=true` in the POST response
- Changed `createIntrimBillTable()` to return a `String` navigation with `faces-redirect=true`, applying the same Post-Redirect-Get (PRG) pattern already used by the dashboard path (`navigateToIntrimBillFromPatientProfile()`)
- After `createTables()` loads all data into the session bean, the browser is redirected to a fresh GET which builds a clean view — `patientEncounter != null` → payment details panel renders correctly

## Test plan

- [ ] Navigate to Interim Bill from the **menu**, search and select a BHT, click Continue — verify payment details (Paid by Patient, Grand Total, Payments tab) are populated correctly
- [ ] Navigate to Interim Bill from the **inpatient dashboard** — verify existing behaviour is unchanged
- [ ] Test the provisional bill restriction: if "Restrict Access to Intrim Bill if Provisional Bill is Created" is enabled and the admission has a provisional bill, verify the error message appears and the search form is shown again

Closes #19764

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved navigation and access control for interim bill creation. The system now properly prevents interim bill creation when a provisional bill already exists, with enhanced redirect handling for a better user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->