### PR TITLE
feat(inward): support qty for inward service bills with per-unit fee fields

### DIFF
--- a/src/main/java/com/divudi/bean/common/BillBeanController.java
+++ b/src/main/java/com/divudi/bean/common/BillBeanController.java
@@ -2664,13 +2664,12 @@ public class BillBeanController implements Serializable {
         BillFee f;
         f = new BillFee();
         f.setFee(i);
-        if (patientEncounter.isForiegner()) {
-            f.setFeeValue(i.getFfee());
-            f.setFeeGrossValue(i.getFfee());
-        } else {
-            f.setFeeValue(i.getFee());
-            f.setFeeGrossValue(i.getFee());
-        }
+        double unitRate = patientEncounter.isForiegner() ? i.getFfee() : i.getFee();
+        double qty = (billItem.getQty() != null && billItem.getQty() > 0) ? billItem.getQty() : 1.0;
+        f.setFeeUnitGrossValue(unitRate);
+        f.setFeeUnitValue(unitRate);
+        f.setFeeGrossValue(unitRate * qty);
+        f.setFeeValue(unitRate * qty);
         f.setDepartment(billItem.getItem().getDepartment());
         f.setBillItem(billItem);
 
@@ -4204,23 +4203,21 @@ public class BillBeanController implements Serializable {
     }
 
     public void updateBillByBillFee(Bill b) {
-        String sql = "SELECT sum(b.feeGrossValue)"
-                + " FROM BillFee b "
-                + " WHERE b.retired=false"
-                + " and b.bill=:bill ";
+        String sql = "SELECT sum(bi.grossValue)"
+                + " FROM BillItem bi "
+                + " WHERE bi.bill=:bill ";
         HashMap hm = new HashMap();
         hm.put("bill", b);
-        double val = getBillFeeFacade().findDoubleByJpql(sql, hm);
+        double val = getBillItemFacade().findDoubleByJpql(sql, hm);
 
         b.setTotal(val);
 
-        sql = "SELECT sum(b.feeValue)"
-                + " FROM BillFee b "
-                + " WHERE b.retired=false"
-                + " and b.bill=:bill ";
+        sql = "SELECT sum(bi.netValue)"
+                + " FROM BillItem bi "
+                + " WHERE bi.bill=:bill ";
         hm = new HashMap();
         hm.put("bill", b);
-        val = getBillFeeFacade().findDoubleByJpql(sql, hm);
+        val = getBillItemFacade().findDoubleByJpql(sql, hm);
 
         b.setNetTotal(val);
 

--- a/src/main/java/com/divudi/bean/common/BillBeanController.java
+++ b/src/main/java/com/divudi/bean/common/BillBeanController.java
@@ -4203,21 +4203,23 @@ public class BillBeanController implements Serializable {
     }
 
     public void updateBillByBillFee(Bill b) {
-        String sql = "SELECT sum(bi.grossValue)"
-                + " FROM BillItem bi "
-                + " WHERE bi.bill=:bill ";
+        String sql = "SELECT sum(b.feeGrossValue)"
+                + " FROM BillFee b "
+                + " WHERE b.retired=false"
+                + " and b.bill=:bill ";
         HashMap hm = new HashMap();
         hm.put("bill", b);
-        double val = getBillItemFacade().findDoubleByJpql(sql, hm);
+        double val = getBillFeeFacade().findDoubleByJpql(sql, hm);
 
         b.setTotal(val);
 
-        sql = "SELECT sum(bi.netValue)"
-                + " FROM BillItem bi "
-                + " WHERE bi.bill=:bill ";
+        sql = "SELECT sum(b.feeValue)"
+                + " FROM BillFee b "
+                + " WHERE b.retired=false"
+                + " and b.bill=:bill ";
         hm = new HashMap();
         hm.put("bill", b);
-        val = getBillItemFacade().findDoubleByJpql(sql, hm);
+        val = getBillFeeFacade().findDoubleByJpql(sql, hm);
 
         b.setNetTotal(val);
 

--- a/src/main/java/com/divudi/bean/inward/BillBhtController.java
+++ b/src/main/java/com/divudi/bean/inward/BillBhtController.java
@@ -181,6 +181,7 @@ public class BillBhtController implements Serializable {
     private List<ItemLight> inwardItem;
     
     private Priority currentBillItemPriority;
+    private Double currentBillItemQty;
 
     public String navigateToAddServiceFromMenu() {
         resetBillData();
@@ -283,6 +284,7 @@ public class BillBhtController implements Serializable {
         bills = null;
         referredBy = null;
         currentBillItemPriority = null;
+        currentBillItemQty = null;
     }
 
     public InwardBeanController getInwardBean() {
@@ -329,6 +331,7 @@ public class BillBhtController implements Serializable {
         batchBill = null;
         bills = null;
         referredBy = null;
+        currentBillItemQty = null;
         bhtSummeryController.setInstitution(sessionController.getInstitution());
         return "/inward/inward_bill_service?faces-redirect=true";
     }
@@ -356,6 +359,7 @@ public class BillBhtController implements Serializable {
         bills = null;
         referredBy = null;
         marginTotal = 0.0;
+        currentBillItemQty = null;
         bhtSummeryController.setInstitution(sessionController.getInstitution());
         return "/inward/inward_bill_service?faces-redirect=true";
     }
@@ -488,8 +492,8 @@ public class BillBhtController implements Serializable {
             billItem.setSearialNo(list.size());
 
             for (BillFee bf : billItem.getBillFees()) {
-                PriceMatrix priceMatrix = getPriceMatrixController().fetchInwardMargin(billItem, bf.getFeeGrossValue(), matrixDepartment, paymentMethod);
-                getInwardBean().setBillFeeMargin(bf, bf.getBillItem().getItem(), priceMatrix,bill.getPatientEncounter());
+                PriceMatrix priceMatrix = getPriceMatrixController().fetchInwardMargin(billItem, bf.getFeeUnitGrossValue() != null ? bf.getFeeUnitGrossValue() : bf.getFeeGrossValue(), matrixDepartment, paymentMethod);
+                getInwardBean().setBillFeeMargin(bf, bf.getBillItem().getItem(), priceMatrix, bill.getPatientEncounter());
                 getBillFeeFacade().edit(bf);
 
                 if (bf.getFee().getFeeType() == FeeType.CollectingCentre) {
@@ -851,45 +855,57 @@ public class BillBhtController implements Serializable {
             }
         }
 
-        if (getCurrentBillItem().getQty() == null) {
-            getCurrentBillItem().setQty(1.0);
+        if (getCurrentBillItem().getItem().isRequestForQuentity()) {
+            if (currentBillItemQty == null || currentBillItemQty == 0.0) {
+                currentBillItemQty = null;
+                JsfUtil.addErrorMessage("Quantity is missing.");
+                return;
+            }
+            if (currentBillItemQty < 0) {
+                currentBillItemQty = null;
+                JsfUtil.addErrorMessage("Quantity cannot be negative.");
+                return;
+            }
+            if (currentBillItemQty % 1 != 0) {
+                JsfUtil.addErrorMessage("Quantity cannot be a decimal. Please enter a whole number.");
+                return;
+            }
+        } else {
+            currentBillItemQty = 1.0;
         }
-        
+
         if (getCurrentBillItem().getItem().isAllowedForBillingPriority()) {
             if (currentBillItemPriority == null) {
                 currentBillItemPriority = Priority.NORMAL;
             }
-        }else{
+        } else {
             currentBillItemPriority = null;
         }
 
-        for (int i = 0; i < getCurrentBillItem().getQty(); i++) {
-            BillEntry addingEntry = new BillEntry();
-            BillItem bItem = new BillItem();
+        BillEntry addingEntry = new BillEntry();
+        BillItem bItem = new BillItem();
+        bItem.copy(currentBillItem);
+        bItem.setQty(currentBillItemQty);
+        if (currentBillItemPriority != null) {
+            bItem.setPriority(currentBillItemPriority);
+        }
+        addingEntry.setBillItem(bItem);
+        addingEntry.setLstBillComponents(getBillBean().billComponentsFromBillItem(bItem));
+        if (patientEncounter.getAdmissionType().isRoomChargesAllowed() || getPatientEncounter().getCurrentPatientRoom() != null) {
+            addingEntry.setLstBillFees(billFeeFromBillItemWithMatrix(bItem, getPatientEncounter(), getPatientEncounter().getCurrentPatientRoom().getRoomFacilityCharge().getDepartment(), getPatientEncounter().getPaymentMethod()));
+        } else {
+            addingEntry.setLstBillFees(billFeeFromBillItemWithMatrix(bItem, getPatientEncounter(), getPatientEncounter().getDepartment(), getPatientEncounter().getPaymentMethod()));
+        }
+        addingEntry.setLstBillSessions(getBillBean().billSessionsfromBillItem(bItem));
+        bItem.setMarginValue(getBillBean().calBillItemMargin(addingEntry));
+        lstBillEntries.add(addingEntry);
 
-            bItem.copy(currentBillItem);
-            bItem.setQty(1.0);
-            if(currentBillItemPriority != null){
-                bItem.setPriority(currentBillItemPriority);
-            }
-            addingEntry.setBillItem(bItem);
-            addingEntry.setLstBillComponents(getBillBean().billComponentsFromBillItem(bItem));
-            if (patientEncounter.getAdmissionType().isRoomChargesAllowed() || getPatientEncounter().getCurrentPatientRoom() != null) {
-                addingEntry.setLstBillFees(billFeeFromBillItemWithMatrix(bItem, getPatientEncounter(), getPatientEncounter().getCurrentPatientRoom().getRoomFacilityCharge().getDepartment(), getPatientEncounter().getPaymentMethod()));
-            } else {
-                addingEntry.setLstBillFees(billFeeFromBillItemWithMatrix(bItem, getPatientEncounter(), getPatientEncounter().getDepartment(), getPatientEncounter().getPaymentMethod()));
-            }
-            addingEntry.setLstBillSessions(getBillBean().billSessionsfromBillItem(bItem));
-            bItem.setMarginValue(getBillBean().calBillItemMargin(addingEntry));
-            lstBillEntries.add(addingEntry);
+        bItem.setRate(getBillBean().billItemRate(addingEntry));
 
-            bItem.setRate(getBillBean().billItemRate(addingEntry));
-
-            calTotals();
-            if (bItem.getNetValue() == 0.0) {
-                JsfUtil.addErrorMessage("Please enter the rate");
-                return;
-            }
+        calTotals();
+        if (bItem.getNetValue() == 0.0) {
+            JsfUtil.addErrorMessage("Please enter the rate");
+            return;
         }
 
         clearBillItemValues();
@@ -968,6 +984,7 @@ public class BillBhtController implements Serializable {
     public void clearBillItemValues() {
         setCurrentBillItem(null);
         setItemLight(null);
+        currentBillItemQty = null;
         recreateBillItems();
     }
 
@@ -987,16 +1004,19 @@ public class BillBhtController implements Serializable {
 
         for (BillEntry be : getLstBillEntries()) {
             BillItem bi = be.getBillItem();
+
             bi.setDiscount(0.0);
             bi.setGrossValue(0.0);
             bi.setNetValue(0.0);
+            bi.setMarginValue(0.0);
 
             for (BillFee bf : be.getLstBillFees()) {
                 tot += bf.getFeeGrossValue();
                 net += bf.getFeeValue();
-                bf.getBillItem().setNetValue(bf.getBillItem().getNetValue() + bf.getFeeValue());
-                bf.getBillItem().setGrossValue(bf.getBillItem().getGrossValue() + bf.getFeeGrossValue());
+                bi.setNetValue(bi.getNetValue() + bf.getFeeValue());
+                bi.setGrossValue(bi.getGrossValue() + bf.getFeeGrossValue());
                 margin += bf.getFeeMargin();
+                bi.setMarginValue(bi.getMarginValue() + bf.getFeeMargin());
             }
 
             bi.setDiscount(bi.getGrossValue() + bi.getMarginValue() - bi.getNetValue());
@@ -1297,6 +1317,9 @@ public class BillBhtController implements Serializable {
         this.itemLight = itemLight;
         if (itemLight != null) {
             getCurrentBillItem().setItem(itemController.findItem(itemLight.getId()));
+            if (currentBillItemQty == null) {
+                currentBillItemQty = 1.0;
+            }
         }
     }
 
@@ -1612,6 +1635,14 @@ public class BillBhtController implements Serializable {
 
     public void setCurrentBillItemPriority(Priority currentBillItemPriority) {
         this.currentBillItemPriority = currentBillItemPriority;
+    }
+
+    public Double getCurrentBillItemQty() {
+        return currentBillItemQty;
+    }
+
+    public void setCurrentBillItemQty(Double currentBillItemQty) {
+        this.currentBillItemQty = currentBillItemQty;
     }
 
 }

--- a/src/main/java/com/divudi/bean/inward/BillBhtController.java
+++ b/src/main/java/com/divudi/bean/inward/BillBhtController.java
@@ -867,6 +867,7 @@ public class BillBhtController implements Serializable {
                 return;
             }
             if (currentBillItemQty % 1 != 0) {
+                currentBillItemQty = null;
                 JsfUtil.addErrorMessage("Quantity cannot be a decimal. Please enter a whole number.");
                 return;
             }
@@ -1040,7 +1041,13 @@ public class BillBhtController implements Serializable {
         lstBillItems = null;
         getLstBillItems();
 
-        PriceMatrix priceMatrix = getPriceMatrixController().fetchInwardMargin(bf.getBillItem(), bf.getFeeGrossValue(), getPatientEncounter().getCurrentPatientRoom().getRoomFacilityCharge().getDepartment(), getPatientEncounter().getPaymentMethod());
+        // Recalculate the per-unit gross from the edited total so that setBillFeeMargin
+        // uses the current unit rate rather than the stale creation-time value.
+        double qty = (bf.getBillItem() != null && bf.getBillItem().getQty() != null && bf.getBillItem().getQty() > 0)
+                ? bf.getBillItem().getQty() : 1.0;
+        bf.setFeeUnitGrossValue(bf.getFeeGrossValue() / qty);
+
+        PriceMatrix priceMatrix = getPriceMatrixController().fetchInwardMargin(bf.getBillItem(), bf.getFeeUnitGrossValue(), getPatientEncounter().getCurrentPatientRoom().getRoomFacilityCharge().getDepartment(), getPatientEncounter().getPaymentMethod());
 
         getInwardBean().updateBillItemMargin(bf, bf.getFeeGrossValue(), getPatientEncounter(), getPatientEncounter().getCurrentPatientRoom().getRoomFacilityCharge().getDepartment(), priceMatrix);
 

--- a/src/main/java/com/divudi/bean/inward/InwardBeanController.java
+++ b/src/main/java/com/divudi/bean/inward/InwardBeanController.java
@@ -2398,8 +2398,6 @@ public class InwardBeanController implements Serializable {
     }
 
     public void setBillFeeMargin(BillFee billFee, Item item, PriceMatrix priceMatrix, PatientEncounter patientEncounter) {
-        double margin = 0;
-
         if (billFee == null || item.isMarginNotAllowed()) {
             return;
         }
@@ -2407,19 +2405,28 @@ public class InwardBeanController implements Serializable {
             return;
         }
 
+        double qty = (billFee.getBillItem() != null && billFee.getBillItem().getQty() != null && billFee.getBillItem().getQty() > 0)
+                ? billFee.getBillItem().getQty() : 1.0;
+        double unitGross = (billFee.getFeeUnitGrossValue() != null)
+                ? billFee.getFeeUnitGrossValue()
+                : (billFee.getFeeGrossValue() != null ? billFee.getFeeGrossValue() / qty : 0.0);
+
+        double unitMargin = 0;
         if (patientEncounter.getAdmissionType().isAllowToCalculateMargin()) {
             if (billFee.getFee().getFeeType() != FeeType.Staff && priceMatrix != null) {
-                margin = (billFee.getFeeGrossValue() * priceMatrix.getMargin()) / 100;
-                billFee.setFeeMargin(margin);
+                unitMargin = (unitGross * priceMatrix.getMargin()) / 100;
+                billFee.setFeeUnitMargin(unitMargin);
+                billFee.setFeeMargin(unitMargin * qty);
                 billFeeFacade.edit(billFee);
             }
         }
 
         applyInwardDiscountToBillFee(billFee, item, patientEncounter);
 
-        double net = (billFee.getFeeGrossValue() + margin) - billFee.getFeeDiscount();
-
-        billFee.setFeeValue(net);
+        double unitDiscount = (billFee.getFeeUnitDiscount() != null) ? billFee.getFeeUnitDiscount() : 0.0;
+        double unitNet = (unitGross + unitMargin) - unitDiscount;
+        billFee.setFeeUnitValue(unitNet);
+        billFee.setFeeValue(unitNet * qty);
     }
 
     /**
@@ -2452,9 +2459,14 @@ public class InwardBeanController implements Serializable {
                 patientEncounter.getAdmissionType(),
                 matrixDept,
                 item);
-        double gross = billFee.getFeeGrossValue();
-        double discount = pct > 0.0 ? (gross * pct) / 100.0 : 0.0;
-        billFee.setFeeDiscount(discount);
+        double qty = (billFee.getBillItem() != null && billFee.getBillItem().getQty() != null && billFee.getBillItem().getQty() > 0)
+                ? billFee.getBillItem().getQty() : 1.0;
+        double unitGross = (billFee.getFeeUnitGrossValue() != null)
+                ? billFee.getFeeUnitGrossValue()
+                : (billFee.getFeeGrossValue() != null ? billFee.getFeeGrossValue() / qty : 0.0);
+        double unitDiscount = pct > 0.0 ? (unitGross * pct) / 100.0 : 0.0;
+        billFee.setFeeUnitDiscount(unitDiscount);
+        billFee.setFeeDiscount(unitDiscount * qty);
     }
 
     public void updateBillItemMargin(BillItem billItem, double serviceValue, PatientEncounter patientEncounter, Department matrixDepartment, PriceMatrix priceMatrix) {

--- a/src/main/java/com/divudi/core/entity/BillFee.java
+++ b/src/main/java/com/divudi/core/entity/BillFee.java
@@ -97,6 +97,13 @@ public class BillFee implements Serializable, RetirableEntity {
     double feeMargin;
     double feeAdjusted;
 
+    // Per-unit rate fields — store the rate for a single unit before qty multiplication.
+    // The main fee fields (feeGrossValue, feeValue, feeMargin, feeDiscount) hold totals (unit × qty).
+    private Double feeUnitGrossValue;
+    private Double feeUnitValue;
+    private Double feeUnitMargin;
+    private Double feeUnitDiscount;
+
     //This records the payment made for the payment due staff or institution
     double paidValue = 0.0;
     //This records the value paid out of the total from the customer
@@ -723,6 +730,38 @@ public class BillFee implements Serializable, RetirableEntity {
 
     public void setFeeGrossValue(Double feeGrossValue) {
         this.feeGrossValue = feeGrossValue;
+    }
+
+    public Double getFeeUnitGrossValue() {
+        return feeUnitGrossValue;
+    }
+
+    public void setFeeUnitGrossValue(Double feeUnitGrossValue) {
+        this.feeUnitGrossValue = feeUnitGrossValue;
+    }
+
+    public Double getFeeUnitValue() {
+        return feeUnitValue;
+    }
+
+    public void setFeeUnitValue(Double feeUnitValue) {
+        this.feeUnitValue = feeUnitValue;
+    }
+
+    public Double getFeeUnitMargin() {
+        return feeUnitMargin;
+    }
+
+    public void setFeeUnitMargin(Double feeUnitMargin) {
+        this.feeUnitMargin = feeUnitMargin;
+    }
+
+    public Double getFeeUnitDiscount() {
+        return feeUnitDiscount;
+    }
+
+    public void setFeeUnitDiscount(Double feeUnitDiscount) {
+        this.feeUnitDiscount = feeUnitDiscount;
     }
 
     public double getSettleValue() {

--- a/src/main/webapp/inward/inward_bill_service.xhtml
+++ b/src/main/webapp/inward/inward_bill_service.xhtml
@@ -443,13 +443,16 @@
                                                         </div>
                                                         <div class="col-9">
                                                             <h:panelGroup id="gpQtyTxt">
-                                                                <h:inputText 
-                                                                    autocomplete="off" 
+                                                                <p:inputText
+                                                                    autocomplete="off"
                                                                     id="txtQty"
                                                                     rendered="#{billBhtController.currentBillItem.item.requestForQuentity}"
-                                                                    value="#{billBhtController.currentBillItem.qty}"
-                                                                    style="text-align: right; padding-right: 10px;">
-                                                                </h:inputText> </h:panelGroup>
+                                                                    value="#{billBhtController.currentBillItemQty}"
+                                                                    styleClass="text-end"
+                                                                    style="padding-right: 10px;">
+                                                                    <f:convertNumber pattern="#" />
+                                                                </p:inputText>
+                                                            </h:panelGroup>
                                                         </div>
                                                     </div>
 
@@ -577,8 +580,22 @@
 
                                                         </p:column>
 
-                                                        <p:column width="8em" class="text-end">
+                                                        <p:column width="7em" class="text-end">
                                                             <f:facet name="header">Rate</f:facet>
+                                                            <h:outputLabel value="#{bi.billItem.rate}">
+                                                                <f:convertNumber pattern="#,##0.00" />
+                                                            </h:outputLabel>
+                                                        </p:column>
+
+                                                        <p:column width="4em" class="text-end">
+                                                            <f:facet name="header">Qty</f:facet>
+                                                            <h:outputLabel value="#{bi.billItem.qty}">
+                                                                <f:convertNumber pattern="#" />
+                                                            </h:outputLabel>
+                                                        </p:column>
+
+                                                        <p:column width="8em" class="text-end">
+                                                            <f:facet name="header">Gross Value</f:facet>
                                                             <h:outputLabel value="#{bi.billItem.grossValue}">
                                                                 <f:convertNumber pattern="#,##0.00" />
                                                             </h:outputLabel>
@@ -633,6 +650,7 @@
                                                     </p:dataTable>
                                                 </p:tab>
                                                 <p:tab id="tabBillFee" title="Fees" >
+                                                    <p:outputLabel value="Fee values are per unit. Totals in the Bill Details panel reflect quantity." styleClass="text-muted small d-block mb-2" />
                                                     <p:dataTable
                                                         rowIndexVar="rowIndex"
                                                         value="#{billBhtController.lstBillFees}"


### PR DESCRIPTION
## Summary

- Adds quantity support to inward service billing: a service with qty > 1 is now stored as a single `BillItem` with the quantity field set, rather than multiple separate items
- Introduces `feeUnitGrossValue`, `feeUnitValue`, `feeUnitMargin`, `feeUnitDiscount` fields on `BillFee` to store **per-unit rates**; the existing fee fields (`feeGrossValue`, `feeValue`, `feeMargin`, `feeDiscount`) now consistently hold **totals** (unit rate × qty)
- All aggregation methods (`calTotals`, `calculateBillItems`, `updateBillItemByBillFee`, `saveBillItems`) sum the main BillFee fields directly without additional qty multiplication, since fields already hold totals
- `setBillFeeMargin` and `applyInwardDiscountToBillFee` updated to compute per-unit values and store them in unit fields, with totals in main fields
- `inward_bill_service.xhtml`: added Qty input (for items with `requestForQuantity`), Qty column and Gross Value column in the bill items table
- Backward compatible: for qty = 1 items (all existing data), unit value = total value, so no change in stored amounts

Closes #20413

## Test plan

- [ ] Add an inward service item with `requestForQuantity = true`, set qty = 2, verify bill item shows rate × 2 for gross/net
- [ ] Add an inward service item without `requestForQuantity`, verify qty defaults to 1 and totals are unchanged
- [ ] Settle the bill and verify `BILL.TOTAL` and `BILL.NETTOTAL` reflect the qty-multiplied totals in the database
- [ ] Verify interim bill print shows correct totals
- [ ] Verify `BillFee.feeUnitGrossValue` stored = per-unit rate, `feeGrossValue` stored = total (unit × qty)
- [ ] Verify existing bills (qty = 1) are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added quantity-based billing calculation with per-unit rate tracking.
  * Bill items table now displays unit rates and quantities.

* **Bug Fixes**
  * Fixed fee calculation to properly account for item quantities and patient type.
  * Improved margin and discount calculations for accurate billing totals.
  * Added clarification that fee values are per-unit in the billing interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->