### PR TITLE
feat(billing): Add per-unit rate fields to BillFee and data migration v2.3.0

### DIFF
--- a/developer_docs/database/migration-development-guide.md
+++ b/developer_docs/database/migration-development-guide.md
@@ -4,6 +4,23 @@
 
 The HMIS Database Migration System provides a comprehensive framework for managing database schema changes across development, testing, and production environments. This guide covers the technical implementation details for developers working with the migration system.
 
+## Schema changes vs. data migrations
+
+**Schema changes** (adding new columns, tables, or indexes) are handled automatically — do NOT write a migration script for them:
+- EclipseLink's DDL auto-update adds missing columns on application startup in development.
+- On production, the admin runs **`/faces/dataAdmin/missing_database_fields.xhtml`** to detect and apply any missing columns before deploying new code.
+
+**Data migrations** (backfilling values in existing rows, transforming data, fixing historical records) require a migration script under `src/main/resources/db/migrations/`. The admin executes these via **`/faces/admin/database_migration.xhtml`**.
+
+> Rule of thumb: if your change is `ALTER TABLE … ADD COLUMN`, skip the migration script. If your change is `UPDATE … SET`, write one.
+
+## Admin UI pages
+
+| Page | Purpose |
+|------|---------|
+| `/faces/dataAdmin/missing_database_fields.xhtml` | Detects and adds schema columns that JPA entities declare but the database does not yet have. Run this **before** deploying code that adds new entity fields. |
+| `/faces/admin/database_migration.xhtml` | Lists, executes, and rolls back data migration scripts. Run this **after** schema is up to date. |
+
 ## Architecture Components
 
 ### Core Classes
@@ -144,9 +161,13 @@ git checkout -b feature/consumption-allowed
 
 ### 2. Version Determination
 
-- Check current latest version: Look in existing migration directories
-- Determine increment type based on change scope
-- Assign next sequential version number
+Find the current highest version:
+```bash
+ls src/main/resources/db/migrations/ | sort -V | tail -1
+```
+
+Determine increment type based on change scope, then assign the next sequential version.
+Coordinate with other open feature branches to avoid two PRs claiming the same version number.
 
 ### 3. Migration Creation
 
@@ -298,7 +319,7 @@ try {
 ### SQL Script Guidelines
 
 1. **Atomic Operations**: Each migration should be atomic
-2. **Idempotent Scripts**: Handle re-execution gracefully
+2. **Idempotent Scripts**: Handle re-execution gracefully — for `UPDATE` backfills use `WHERE <new_col> IS NULL` so re-runs are safe and fast
 3. **Data Preservation**: Avoid data loss operations
 4. **Performance Impact**: Consider query execution time
 5. **Index Management**: Add/drop indexes strategically

--- a/src/main/java/com/divudi/core/entity/BillFee.java
+++ b/src/main/java/com/divudi/core/entity/BillFee.java
@@ -199,6 +199,10 @@ public class BillFee implements Serializable, RetirableEntity {
         feeVatPlusValue = billFee.getFeeVatPlusValue();
         feeMargin = billFee.getFeeMargin();
         paidValue = billFee.getPaidValue();
+        feeUnitGrossValue = billFee.getFeeUnitGrossValue();
+        feeUnitValue = billFee.getFeeUnitValue();
+        feeUnitMargin = billFee.getFeeUnitMargin();
+        feeUnitDiscount = billFee.getFeeUnitDiscount();
     }
 
     public void copyWithoutFinancialData(BillFee billFee) {
@@ -236,6 +240,10 @@ public class BillFee implements Serializable, RetirableEntity {
         feeMargin = 0 - billFee.getFeeMargin();
         feeAdjusted = 0 - billFee.getFeeAdjusted();
         paidValue = 0 - billFee.getPaidValue();
+        feeUnitGrossValue = billFee.getFeeUnitGrossValue() != null ? 0 - billFee.getFeeUnitGrossValue() : null;
+        feeUnitValue = billFee.getFeeUnitValue() != null ? 0 - billFee.getFeeUnitValue() : null;
+        feeUnitMargin = billFee.getFeeUnitMargin() != null ? 0 - billFee.getFeeUnitMargin() : null;
+        feeUnitDiscount = billFee.getFeeUnitDiscount() != null ? 0 - billFee.getFeeUnitDiscount() : null;
     }
 
     public void invertValue() {
@@ -249,6 +257,10 @@ public class BillFee implements Serializable, RetirableEntity {
         feeMargin = 0 - feeMargin;
         feeAdjusted = 0 - feeAdjusted;
         paidValue = 0 - paidValue;
+        if (feeUnitGrossValue != null) feeUnitGrossValue = 0 - feeUnitGrossValue;
+        if (feeUnitValue != null) feeUnitValue = 0 - feeUnitValue;
+        if (feeUnitMargin != null) feeUnitMargin = 0 - feeUnitMargin;
+        if (feeUnitDiscount != null) feeUnitDiscount = 0 - feeUnitDiscount;
     }
 
     public BillFee() {
@@ -284,6 +296,7 @@ public class BillFee implements Serializable, RetirableEntity {
 
     public void setFeeValueBoolean(boolean foriegn) {
         if (tmpChangedValue != null) {
+            this.feeUnitGrossValue = tmpChangedValue;
             this.feeGrossValue = tmpChangedValue * this.getBillItem().getQty();
             this.feeValue = tmpChangedValue * this.getBillItem().getQty();
 //            this.feeVatPlusValue = this.feeVat + this.feeValue;
@@ -291,10 +304,12 @@ public class BillFee implements Serializable, RetirableEntity {
         }
 
         if (foriegn) {
+            this.feeUnitGrossValue = getFee().getFfee();
             this.feeGrossValue = getFee().getFfee() * this.getBillItem().getQty();
             this.feeValue = getFee().getFfee() * this.getBillItem().getQty();
 //            this.feeVatPlusValue = this.feeVat + this.feeValue;
         } else {
+            this.feeUnitGrossValue = getFee().getFee();
             this.feeGrossValue = getFee().getFee() * this.getBillItem().getQty();
             this.feeValue = getFee().getFee() * this.getBillItem().getQty();
 //            this.feeVatPlusValue = this.feeVat + this.feeValue;
@@ -304,6 +319,7 @@ public class BillFee implements Serializable, RetirableEntity {
 
     public void setFeeValueForDiscountAllowedAndUserChangable(boolean foriegn, double discountPercent) {
         if (tmpChangedValue != null) {
+            this.feeUnitGrossValue = tmpChangedValue;
             this.feeGrossValue = tmpChangedValue * this.getBillItem().getQty();
             this.feeValue = tmpChangedValue * this.getBillItem().getQty();
             return;
@@ -311,9 +327,11 @@ public class BillFee implements Serializable, RetirableEntity {
 
         if (discountPercent == 0) {
             if (foriegn) {
+                this.feeUnitGrossValue = getFee().getFfee();
                 this.feeGrossValue = getFee().getFfee() * this.getBillItem().getQty();
                 this.feeValue = getFee().getFfee() * this.getBillItem().getQty();
             } else {
+                this.feeUnitGrossValue = getFee().getFee();
                 this.feeGrossValue = getFee().getFee() * this.getBillItem().getQty();
                 this.feeValue = getFee().getFee() * this.getBillItem().getQty();
 
@@ -322,9 +340,11 @@ public class BillFee implements Serializable, RetirableEntity {
 
         if (discountPercent != 0) {
             if (foriegn) {
+                this.feeUnitGrossValue = getFee().getFfee();
                 this.feeGrossValue = getFee().getFfee() * this.getBillItem().getQty();
                 this.feeValue = (getFee().getFfee() / 100 * (100 - discountPercent)) * this.getBillItem().getQty();
             } else {
+                this.feeUnitGrossValue = getFee().getFee();
                 this.feeGrossValue = getFee().getFee() * this.getBillItem().getQty();
                 this.feeValue = (getFee().getFee() / 100 * (100 - discountPercent)) * this.getBillItem().getQty();
 
@@ -342,9 +362,11 @@ public class BillFee implements Serializable, RetirableEntity {
 
         if (discountPercent == 0) {
             if (foriegn) {
+                this.feeUnitGrossValue = getFee().getFfee();
                 this.feeGrossValue = getFee().getFfee() * this.getBillItem().getQty();
                 this.feeValue = getFee().getFfee() * this.getBillItem().getQty();
             } else {
+                this.feeUnitGrossValue = getFee().getFee();
                 this.feeGrossValue = getFee().getFee() * this.getBillItem().getQty();
                 this.feeValue = getFee().getFee() * this.getBillItem().getQty();
 
@@ -353,9 +375,11 @@ public class BillFee implements Serializable, RetirableEntity {
 
         if (discountPercent != 0) {
             if (foriegn) {
+                this.feeUnitGrossValue = getFee().getFfee();
                 this.feeGrossValue = getFee().getFfee() * this.getBillItem().getQty();
                 this.feeValue = (getFee().getFfee() / 100 * (100 - discountPercent)) * this.getBillItem().getQty();
             } else {
+                this.feeUnitGrossValue = getFee().getFee();
                 this.feeGrossValue = getFee().getFee() * this.getBillItem().getQty();
                 this.feeValue = (getFee().getFee() / 100 * (100 - discountPercent)) * this.getBillItem().getQty();
 
@@ -366,15 +390,18 @@ public class BillFee implements Serializable, RetirableEntity {
 
     public void setFeeValueForUserChangableAndNotDiscountAllowed(boolean foriegn) {
         if (tmpChangedValue != null) {
+            this.feeUnitGrossValue = tmpChangedValue;
             this.feeGrossValue = tmpChangedValue * this.getBillItem().getQty();
             this.feeValue = tmpChangedValue * this.getBillItem().getQty();
             return;
         }
 
         if (foriegn) {
+            this.feeUnitGrossValue = getFee().getFfee();
             this.feeGrossValue = getFee().getFfee() * this.getBillItem().getQty();
             this.feeValue = getFee().getFfee() * this.getBillItem().getQty();
         } else {
+            this.feeUnitGrossValue = getFee().getFee();
             this.feeGrossValue = getFee().getFee() * this.getBillItem().getQty();
             this.feeValue = getFee().getFee() * this.getBillItem().getQty();
 
@@ -392,10 +419,12 @@ public class BillFee implements Serializable, RetirableEntity {
         if (tmpChangedValue == null) {
             if (getFee().getFeeType() != FeeType.Staff) {
                 if (foriegn) {
+                    this.feeUnitGrossValue = getFee().getFfee();
                     this.feeGrossValue = getFee().getFfee() * this.getBillItem().getQty();
                     this.feeDiscount = (getFee().getFfee() / 100 * (discountPercent)) * this.getBillItem().getQty();
                     this.feeValue = feeGrossValue - feeDiscount;
                 } else {
+                    this.feeUnitGrossValue = getFee().getFee();
                     this.feeGrossValue = getFee().getFee() * this.getBillItem().getQty();
                     this.feeDiscount = (getFee().getFee() / 100 * (discountPercent)) * this.getBillItem().getQty();
                     this.feeValue = feeGrossValue - feeDiscount;
@@ -403,14 +432,17 @@ public class BillFee implements Serializable, RetirableEntity {
 
             } else {
                 if (foriegn) {
+                    this.feeUnitGrossValue = getFee().getFfee();
                     this.feeGrossValue = getFee().getFfee() * this.getBillItem().getQty();
                     this.feeValue = getFee().getFfee() * this.getBillItem().getQty();
                 } else {
+                    this.feeUnitGrossValue = getFee().getFee();
                     this.feeGrossValue = getFee().getFee() * this.getBillItem().getQty();
                     this.feeValue = getFee().getFee() * this.getBillItem().getQty();
                 }
             }
         } else {
+            this.feeUnitGrossValue = tmpChangedValue;
             if (getFee().getFeeType() != FeeType.Staff) {
                 this.feeGrossValue = tmpChangedValue * this.getBillItem().getQty();
                 if (tmpChangedValue != 0) {
@@ -431,8 +463,10 @@ public class BillFee implements Serializable, RetirableEntity {
         if (tmpChangedValue == null) {
             if (getFee().getFeeType() != FeeType.Staff) {
                 if (foriegn) {
+                    this.feeUnitGrossValue = getFee().getFfee();
                     this.feeGrossValue = getFee().getFfee() * this.getBillItem().getQty();
                 } else {
+                    this.feeUnitGrossValue = getFee().getFee();
                     this.feeGrossValue = getFee().getFee() * this.getBillItem().getQty();
                 }
 
@@ -442,14 +476,17 @@ public class BillFee implements Serializable, RetirableEntity {
 
             } else {
                 if (foriegn) {
+                    this.feeUnitGrossValue = getFee().getFfee();
                     this.feeGrossValue = getFee().getFfee() * this.getBillItem().getQty();
                     this.feeValue = getFee().getFfee() * this.getBillItem().getQty();
                 } else {
+                    this.feeUnitGrossValue = getFee().getFee();
                     this.feeGrossValue = getFee().getFee() * this.getBillItem().getQty();
                     this.feeValue = getFee().getFee() * this.getBillItem().getQty();
                 }
             }
         } else {
+            this.feeUnitGrossValue = tmpChangedValue;
             if (getFee().getFeeType() != FeeType.Staff) {
                 this.feeGrossValue = tmpChangedValue * this.getBillItem().getQty();
                 if (tmpChangedValue != 0) {

--- a/src/main/resources/db/migrations/v2.3.0/migration-info.json
+++ b/src/main/resources/db/migrations/v2.3.0/migration-info.json
@@ -1,0 +1,27 @@
+{
+    "version": "v2.3.0",
+    "description": "Backfill per-unit rate fields in BillFee (feeUnitGrossValue, feeUnitValue, feeUnitMargin, feeUnitDiscount)",
+    "author": "Dr M H B Ariyaratne",
+    "estimatedDurationMinutes": 10,
+    "requiresDowntime": false,
+    "affectedTables": ["billfee"],
+    "affectedModules": ["Inward", "Billing"],
+    "preRequisites": [
+        "Run missing_database_fields.xhtml first to ensure the four feeUnit* columns exist in BILLFEE",
+        "Database backup completed"
+    ],
+    "migrationSteps": [
+        {
+            "description": "Detect actual BILLFEE and BILLITEM table names (handles MySQL case sensitivity)"
+        },
+        {
+            "description": "Detect actual column names for feeGrossValue, feeValue, feeMargin, feeDiscount and the four new feeUnit* columns"
+        },
+        {
+            "description": "Backfill feeUnitGrossValue = feeGrossValue / qty for all existing rows where feeUnitGrossValue IS NULL"
+        },
+        {
+            "description": "Backfill feeUnitValue, feeUnitMargin, feeUnitDiscount the same way"
+        }
+    ]
+}

--- a/src/main/resources/db/migrations/v2.3.0/migration.sql
+++ b/src/main/resources/db/migrations/v2.3.0/migration.sql
@@ -1,0 +1,155 @@
+-- Migration v2.3.0: Backfill per-unit rate fields in BillFee
+-- Author: Dr M H B Ariyaratne
+-- Issue: #20413
+--
+-- Context:
+--   BillFee now has four persisted per-unit fields:
+--     feeUnitGrossValue, feeUnitValue, feeUnitMargin, feeUnitDiscount
+--   The corresponding total fields (feeGrossValue, feeValue, feeMargin, feeDiscount)
+--   already hold  unit × qty  values.  This migration derives unit = total / qty
+--   for all existing rows so that historical bills display correct per-unit rates.
+--
+-- Pre-requisite:
+--   Run missing_database_fields.xhtml BEFORE this migration to ensure the four
+--   new columns have been added to the BILLFEE table by EclipseLink.
+--
+-- Idempotent: the WHERE clause limits updates to rows where feeUnitGrossValue IS NULL,
+--   so re-running this script is safe.
+
+SELECT 'Migration v2.3.0 - BillFee per-unit rate backfill starting' AS status;
+
+-- ============================================================
+-- STEP 1: Detect actual table names (cross-deployment safety)
+-- ============================================================
+
+SET @billfee_table = (
+    SELECT TABLE_NAME FROM INFORMATION_SCHEMA.TABLES
+    WHERE TABLE_SCHEMA = DATABASE() AND UPPER(TABLE_NAME) = 'BILLFEE'
+    LIMIT 1
+);
+
+SET @billitem_table = (
+    SELECT TABLE_NAME FROM INFORMATION_SCHEMA.TABLES
+    WHERE TABLE_SCHEMA = DATABASE() AND UPPER(TABLE_NAME) = 'BILLITEM'
+    LIMIT 1
+);
+
+SELECT CONCAT('BILLFEE table: ', COALESCE(@billfee_table, 'NOT FOUND')) AS status;
+SELECT CONCAT('BILLITEM table: ', COALESCE(@billitem_table, 'NOT FOUND')) AS status;
+
+-- ============================================================
+-- STEP 2: Detect actual column names in BILLFEE
+-- ============================================================
+
+-- Source total columns
+SET @col_feegross = (
+    SELECT COLUMN_NAME FROM INFORMATION_SCHEMA.COLUMNS
+    WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = @billfee_table
+    AND UPPER(COLUMN_NAME) = 'FEEGROSSVALUE' LIMIT 1
+);
+SET @col_feevalue = (
+    SELECT COLUMN_NAME FROM INFORMATION_SCHEMA.COLUMNS
+    WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = @billfee_table
+    AND UPPER(COLUMN_NAME) = 'FEEVALUE' LIMIT 1
+);
+SET @col_feemargin = (
+    SELECT COLUMN_NAME FROM INFORMATION_SCHEMA.COLUMNS
+    WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = @billfee_table
+    AND UPPER(COLUMN_NAME) = 'FEEMARGIN' LIMIT 1
+);
+SET @col_feediscount = (
+    SELECT COLUMN_NAME FROM INFORMATION_SCHEMA.COLUMNS
+    WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = @billfee_table
+    AND UPPER(COLUMN_NAME) = 'FEEDISCOUNT' LIMIT 1
+);
+
+-- Target unit columns
+SET @col_unitgross = (
+    SELECT COLUMN_NAME FROM INFORMATION_SCHEMA.COLUMNS
+    WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = @billfee_table
+    AND UPPER(COLUMN_NAME) = 'FEEUNITGROSSVALUE' LIMIT 1
+);
+SET @col_unitvalue = (
+    SELECT COLUMN_NAME FROM INFORMATION_SCHEMA.COLUMNS
+    WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = @billfee_table
+    AND UPPER(COLUMN_NAME) = 'FEEUNITVALUE' LIMIT 1
+);
+SET @col_unitmargin = (
+    SELECT COLUMN_NAME FROM INFORMATION_SCHEMA.COLUMNS
+    WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = @billfee_table
+    AND UPPER(COLUMN_NAME) = 'FEEUNITMARGIN' LIMIT 1
+);
+SET @col_unitdiscount = (
+    SELECT COLUMN_NAME FROM INFORMATION_SCHEMA.COLUMNS
+    WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = @billfee_table
+    AND UPPER(COLUMN_NAME) = 'FEEUNITDISCOUNT' LIMIT 1
+);
+
+-- FK column linking BILLFEE → BILLITEM
+SET @col_billitem_fk = (
+    SELECT COLUMN_NAME FROM INFORMATION_SCHEMA.COLUMNS
+    WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = @billfee_table
+    AND UPPER(COLUMN_NAME) = 'BILLITEM_ID' LIMIT 1
+);
+
+-- QTY column in BILLITEM
+SET @col_qty = (
+    SELECT COLUMN_NAME FROM INFORMATION_SCHEMA.COLUMNS
+    WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = @billitem_table
+    AND UPPER(COLUMN_NAME) = 'QTY' LIMIT 1
+);
+
+SELECT CONCAT('Columns detected — feegross:', COALESCE(@col_feegross,'?'),
+    ' feevalue:', COALESCE(@col_feevalue,'?'),
+    ' feemargin:', COALESCE(@col_feemargin,'?'),
+    ' feediscount:', COALESCE(@col_feediscount,'?')) AS status;
+SELECT CONCAT('Unit columns — unitgross:', COALESCE(@col_unitgross,'MISSING'),
+    ' unitvalue:', COALESCE(@col_unitvalue,'MISSING'),
+    ' unitmargin:', COALESCE(@col_unitmargin,'MISSING'),
+    ' unitdiscount:', COALESCE(@col_unitdiscount,'MISSING')) AS status;
+
+-- ============================================================
+-- STEP 3: Guard — abort if any required column is missing
+-- ============================================================
+-- If missing_database_fields.xhtml has not been run yet the unit columns will be
+-- NULL here and we should not proceed (the UPDATE would reference a non-existent column).
+
+SET @abort = (
+    @col_unitgross IS NULL OR @col_unitvalue IS NULL
+    OR @col_unitmargin IS NULL OR @col_unitdiscount IS NULL
+);
+
+-- ============================================================
+-- STEP 4: Backfill unit fields  (idempotent: only NULL rows)
+-- ============================================================
+-- Uses LEFT JOIN so that BillFee rows with no BillItem (BILLITEM_ID IS NULL)
+-- are treated as qty = 1  (unit = total).
+
+SET @sql = IF(@abort,
+    'SELECT "SKIPPED: one or more feeUnit* columns are missing — run missing_database_fields.xhtml first" AS status',
+    CONCAT(
+        'UPDATE ', @billfee_table, ' bf ',
+        'LEFT JOIN ', @billitem_table, ' bi ON bf.', @col_billitem_fk, ' = bi.ID ',
+        'SET ',
+          'bf.', @col_unitgross,    ' = CASE WHEN bi.', @col_qty, ' > 0 THEN bf.', @col_feegross,    ' / bi.', @col_qty, ' ELSE bf.', @col_feegross,    ' END, ',
+          'bf.', @col_unitvalue,    ' = CASE WHEN bi.', @col_qty, ' > 0 THEN bf.', @col_feevalue,    ' / bi.', @col_qty, ' ELSE bf.', @col_feevalue,    ' END, ',
+          'bf.', @col_unitmargin,   ' = CASE WHEN bi.', @col_qty, ' > 0 THEN bf.', @col_feemargin,   ' / bi.', @col_qty, ' ELSE bf.', @col_feemargin,   ' END, ',
+          'bf.', @col_unitdiscount, ' = CASE WHEN bi.', @col_qty, ' > 0 THEN bf.', @col_feediscount, ' / bi.', @col_qty, ' ELSE bf.', @col_feediscount, ' END ',
+        'WHERE bf.', @col_unitgross, ' IS NULL'
+    )
+);
+
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+-- ============================================================
+-- STEP 5: Verification
+-- ============================================================
+SET @verify_sql = CONCAT(
+    'SELECT ',
+    'COUNT(*) AS total_rows, ',
+    'SUM(CASE WHEN bf.', @col_unitgross, ' IS NULL THEN 1 ELSE 0 END) AS still_null ',
+    'FROM ', @billfee_table, ' bf'
+);
+PREPARE stmt FROM @verify_sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+SELECT 'Migration v2.3.0 complete' AS status;

--- a/src/main/resources/db/migrations/v2.3.0/migration.sql
+++ b/src/main/resources/db/migrations/v2.3.0/migration.sql
@@ -139,17 +139,24 @@ SET @sql = IF(@abort,
     )
 );
 
-PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+PREPARE stmt FROM @sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
 
 -- ============================================================
--- STEP 5: Verification
+-- STEP 5: Verification (skipped when aborted — @col_unitgross is NULL in that path)
 -- ============================================================
-SET @verify_sql = CONCAT(
-    'SELECT ',
-    'COUNT(*) AS total_rows, ',
-    'SUM(CASE WHEN bf.', @col_unitgross, ' IS NULL THEN 1 ELSE 0 END) AS still_null ',
-    'FROM ', @billfee_table, ' bf'
+SET @verify_sql = IF(@abort,
+    'SELECT "Verification skipped — migration was aborted (missing columns)" AS status',
+    CONCAT(
+        'SELECT ',
+        'COUNT(*) AS total_rows, ',
+        'SUM(CASE WHEN bf.', @col_unitgross, ' IS NULL THEN 1 ELSE 0 END) AS still_null ',
+        'FROM ', @billfee_table, ' bf'
+    )
 );
-PREPARE stmt FROM @verify_sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+PREPARE stmt FROM @verify_sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
 
 SELECT 'Migration v2.3.0 complete' AS status;

--- a/src/main/resources/db/migrations/v2.3.0/rollback.sql
+++ b/src/main/resources/db/migrations/v2.3.0/rollback.sql
@@ -42,6 +42,8 @@ SET @sql = CONCAT(
     @col_unitmargin,   ' = NULL, ',
     @col_unitdiscount, ' = NULL'
 );
-PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+PREPARE stmt FROM @sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
 
 SELECT 'Rollback v2.3.0 complete' AS status;

--- a/src/main/resources/db/migrations/v2.3.0/rollback.sql
+++ b/src/main/resources/db/migrations/v2.3.0/rollback.sql
@@ -1,0 +1,47 @@
+-- Rollback v2.3.0: Clear backfilled per-unit rate fields in BillFee
+-- Author: Dr M H B Ariyaratne
+--
+-- Sets feeUnit* columns back to NULL so the migration can be re-run if needed.
+-- NOTE: This does NOT remove the columns themselves — those were added by
+-- missing_database_fields.xhtml and are owned by the schema management system.
+
+SELECT 'Rollback v2.3.0 - clearing BillFee per-unit rate backfill' AS status;
+
+SET @billfee_table = (
+    SELECT TABLE_NAME FROM INFORMATION_SCHEMA.TABLES
+    WHERE TABLE_SCHEMA = DATABASE() AND UPPER(TABLE_NAME) = 'BILLFEE'
+    LIMIT 1
+);
+
+SET @col_unitgross = (
+    SELECT COLUMN_NAME FROM INFORMATION_SCHEMA.COLUMNS
+    WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = @billfee_table
+    AND UPPER(COLUMN_NAME) = 'FEEUNITGROSSVALUE' LIMIT 1
+);
+SET @col_unitvalue = (
+    SELECT COLUMN_NAME FROM INFORMATION_SCHEMA.COLUMNS
+    WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = @billfee_table
+    AND UPPER(COLUMN_NAME) = 'FEEUNITVALUE' LIMIT 1
+);
+SET @col_unitmargin = (
+    SELECT COLUMN_NAME FROM INFORMATION_SCHEMA.COLUMNS
+    WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = @billfee_table
+    AND UPPER(COLUMN_NAME) = 'FEEUNITMARGIN' LIMIT 1
+);
+SET @col_unitdiscount = (
+    SELECT COLUMN_NAME FROM INFORMATION_SCHEMA.COLUMNS
+    WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = @billfee_table
+    AND UPPER(COLUMN_NAME) = 'FEEUNITDISCOUNT' LIMIT 1
+);
+
+SET @sql = CONCAT(
+    'UPDATE ', @billfee_table,
+    ' SET ',
+    @col_unitgross,    ' = NULL, ',
+    @col_unitvalue,    ' = NULL, ',
+    @col_unitmargin,   ' = NULL, ',
+    @col_unitdiscount, ' = NULL'
+);
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+SELECT 'Rollback v2.3.0 complete' AS status;

--- a/src/main/webapp/inward/inward_bill_service.xhtml
+++ b/src/main/webapp/inward/inward_bill_service.xhtml
@@ -539,7 +539,7 @@
                                                             <f:facet name="header">No</f:facet>
                                                             <h:outputLabel value="#{rowIndex+1}"/>
                                                         </p:column>
-                                                        <p:column>
+                                                        <p:column style="min-width: 16em;">
                                                             <f:facet name="header">Item</f:facet>
                                                             <h:outputLabel value="#{bi.billItem.item.name}"/>
                                                         </p:column>


### PR DESCRIPTION
## Summary

- All 6 `setFeeValue*` methods in `BillFee` now persist `feeUnitGrossValue` (the per-unit rate before qty multiplication) at billing time, replacing the fragile `tmpChangedValue` transient workaround as the authoritative unit rate source
- `copy()` and both `invertValue()` overloads now propagate/negate all 4 `feeUnit*` fields so cancellation bills carry correct per-unit data
- Data migration **v2.3.0** backfills `feeUnitGrossValue`, `feeUnitValue`, `feeUnitMargin`, `feeUnitDiscount` for all existing `BILLFEE` rows by dividing stored totals by `BillItem.qty` (LEFT JOIN handles fees without a BillItem; `WHERE IS NULL` makes it idempotent)
- Developer docs updated: schema changes → `missing_database_fields.xhtml`; data migrations → `database_migration.xhtml`; added version-lookup command and idempotency guidance

## Pre-requisites for migration

Run **`/faces/dataAdmin/missing_database_fields.xhtml`** first to add the four `feeUnit*` columns to `BILLFEE`, then run migration v2.3.0 via **`/faces/admin/database_migration.xhtml`**.

## Test plan

- [ ] Bill a service with qty = 1 — confirm `BILLFEE.FEEUNITGROSSVALUE` = unit rate in DB
- [ ] Bill a service with qty > 1 — confirm `FEEUNITGROSSVALUE` = unit rate (not total)
- [ ] Cancel a bill — confirm the cancellation BillFee has negated `feeUnit*` values
- [ ] Copy a BillFee (e.g. reprint/copy flow) — confirm unit fields are copied
- [ ] Run migration v2.3.0 on a DB with existing rows — confirm `still_null` count = 0 in verification output
- [ ] Re-run migration — confirm it completes instantly with no rows updated (idempotent)

## Related

- Closes #20413
- Tracking issue for other billing modules: #20417

🤖 Generated with [Claude Code](https://claude.com/claude-code)