### PR TITLE
feat(inward): Add Unit Rate, Qty, Discount columns to fee tables on bill entry and reprint pages

### DIFF
--- a/src/main/webapp/inward/inward_bill_service.xhtml
+++ b/src/main/webapp/inward/inward_bill_service.xhtml
@@ -650,7 +650,7 @@
                                                     </p:dataTable>
                                                 </p:tab>
                                                 <p:tab id="tabBillFee" title="Fees" >
-                                                    <p:outputLabel value="Fee values are per unit. Totals in the Bill Details panel reflect quantity." styleClass="text-muted small d-block mb-2" />
+                                                    <p:outputLabel value="Unit Rate × Qty = Total Gross. Edit Total Gross to override the charge; Discount and Service Charge are applied automatically." styleClass="text-muted small d-block mb-2" />
                                                     <p:dataTable
                                                         rowIndexVar="rowIndex"
                                                         value="#{billBhtController.lstBillFees}"
@@ -663,16 +663,30 @@
                                                             <h:outputLabel value="#{rowIndex+1}"/>
                                                         </p:column>
 
-                                                        <p:column>
+                                                        <p:column style="min-width: 14em;">
                                                             <f:facet name="header">Item Name</f:facet>
                                                             <h:outputLabel value="#{bif.billItem.item.name}"/>
                                                         </p:column>
 
+                                                        <p:column width="8em" class="text-end">
+                                                            <f:facet name="header">Unit Rate</f:facet>
+                                                            <h:outputLabel value="#{bif.feeUnitGrossValue}">
+                                                                <f:convertNumber pattern="#,##0.00" />
+                                                            </h:outputLabel>
+                                                        </p:column>
+
+                                                        <p:column width="4em" class="text-end">
+                                                            <f:facet name="header">Qty</f:facet>
+                                                            <h:outputLabel value="#{bif.billItem.qty}">
+                                                                <f:convertNumber pattern="#" />
+                                                            </h:outputLabel>
+                                                        </p:column>
+
                                                         <p:column width="10em" class="text-end">
-                                                            <f:facet name="header">Fee Gross Value</f:facet>
-                                                            <p:inputText 
+                                                            <f:facet name="header">Total Gross</f:facet>
+                                                            <p:inputText
                                                                 class="text-end w-100"
-                                                                autocomplete="off" 
+                                                                autocomplete="off"
                                                                 onfocus="this.select();"
                                                                 value="#{bif.feeGrossValue}"
                                                                 disabled="#{!bif.billItem.item.userChangable
@@ -687,9 +701,16 @@
                                                         </p:column>
 
                                                         <p:column width="8em" class="text-end">
-                                                            <f:facet name="header">Margin Value</f:facet>
-                                                            <h:outputLabel 
-                                                                id="matrix" 
+                                                            <f:facet name="header">Discount</f:facet>
+                                                            <h:outputLabel value="#{bif.feeDiscount}" class="text-end w-100">
+                                                                <f:convertNumber pattern="#,##0.00" />
+                                                            </h:outputLabel>
+                                                        </p:column>
+
+                                                        <p:column width="8em" class="text-end">
+                                                            <f:facet name="header">Service Charge</f:facet>
+                                                            <h:outputLabel
+                                                                id="matrix"
                                                                 class="text-end w-100"
                                                                 value="#{bif.feeMargin}">
                                                                 <f:convertNumber pattern="#,##0.00" />
@@ -697,9 +718,9 @@
                                                         </p:column>
 
                                                         <p:column width="8em" class="text-end">
-                                                            <f:facet name="header">Fee Value</f:facet>
-                                                            <h:outputLabel 
-                                                                id="feeValue"  
+                                                            <f:facet name="header">Net Total</f:facet>
+                                                            <h:outputLabel
+                                                                id="feeValue"
                                                                 value="#{bif.feeValue}"
                                                                 class="text-end w-100">
                                                                 <f:convertNumber pattern="#,##0.00" />

--- a/src/main/webapp/inward/inward_reprint_bill_service.xhtml
+++ b/src/main/webapp/inward/inward_reprint_bill_service.xhtml
@@ -250,38 +250,73 @@
                                         <f:facet name="header" >No</f:facet>
                                         <h:outputLabel value="#{rowIndex+1}"/>
                                     </p:column>
-                                    <p:column>
+                                    <p:column style="min-width: 14em;">
                                         <f:facet name="header">Item</f:facet>
                                         <h:outputLabel value="#{bip.billItem.item.name}"/>
                                     </p:column>
 
-                                    <p:column>
-                                        <f:facet name="header">Fee</f:facet>
+                                    <p:column width="4em" class="text-end">
+                                        <f:facet name="header">Qty</f:facet>
+                                        <h:outputLabel value="#{bip.billItem.qty}">
+                                            <f:convertNumber pattern="#" />
+                                        </h:outputLabel>
+                                    </p:column>
+
+                                    <p:column width="8em" class="text-end">
+                                        <f:facet name="header">Unit Rate</f:facet>
+                                        <h:outputLabel value="#{bip.feeUnitGrossValue}">
+                                            <f:convertNumber pattern="#,##0.00"/>
+                                        </h:outputLabel>
+                                    </p:column>
+
+                                    <p:column width="8em" class="text-end">
+                                        <f:facet name="header">Total Gross</f:facet>
+                                        <h:outputLabel value="#{bip.feeGrossValue}">
+                                            <f:convertNumber pattern="#,##0.00"/>
+                                        </h:outputLabel>
+                                    </p:column>
+
+                                    <p:column width="8em" class="text-end">
+                                        <f:facet name="header">Discount</f:facet>
+                                        <h:outputLabel value="#{bip.feeDiscount}">
+                                            <f:convertNumber pattern="#,##0.00"/>
+                                        </h:outputLabel>
+                                    </p:column>
+
+                                    <p:column width="8em" class="text-end">
+                                        <f:facet name="header">Service Charge</f:facet>
+                                        <h:outputLabel value="#{bip.feeMargin}">
+                                            <f:convertNumber pattern="#,##0.00"/>
+                                        </h:outputLabel>
+                                    </p:column>
+
+                                    <p:column width="8em" class="text-end">
+                                        <f:facet name="header">Net Total</f:facet>
                                         <h:outputLabel value="#{bip.feeValue}">
                                             <f:convertNumber pattern="#,##0.00"/>
                                         </h:outputLabel>
-                                    </p:column>  
+                                    </p:column>
+
                                     <p:column>
                                         <f:facet name="header">Fee Name</f:facet>
                                         <h:outputLabel value="#{bip.fee.name}"/>
-                                    </p:column> 
+                                    </p:column>
                                     <p:column>
                                         <f:facet name="header">Speciality</f:facet>
                                         <h:outputLabel value="#{bip.fee.speciality.name}"/>
-                                    </p:column> 
+                                    </p:column>
                                     <p:column headerText="Payee">
-                                        <p:cellEditor>  
-                                            <f:facet name="output"> 
+                                        <p:cellEditor>
+                                            <f:facet name="output">
                                                 <h:outputLabel value="#{bip.staff.person.name}"  ></h:outputLabel>
-                                            </f:facet>  
-                                            <f:facet name="input">  
+                                            </f:facet>
+                                            <f:facet name="input">
                                                 <p:selectOneMenu value="#{bip.staff}" rendered="#{bip.fee.speciality!=null}" disabled="#{bip.paidValue!=0 or !webUserController.hasPrivilege('ChangeProfessionalFee')}" >
                                                     <f:selectItem itemLabel="Select Staff" />
                                                     <f:selectItems  value="#{staffController.getSpecialityStaff(bip.fee.speciality)}" var="bifs" itemLabel="#{bifs.person.name}" itemValue="#{bifs}" />
                                                 </p:selectOneMenu>
-                                            </f:facet>  
-                                        </p:cellEditor>  
-
+                                            </f:facet>
+                                        </p:cellEditor>
                                     </p:column>
 
                                     <p:column headerText="Returned" width="8em;">


### PR DESCRIPTION
## Summary

- **Fees tab** (`inward_bill_service.xhtml`): adds Unit Rate, Qty, and Discount columns; renames "Fee Gross Value" → "Total Gross", "Margin Value" → "Service Charge", "Fee Value" → "Net Total"; fixes misleading "per unit" hint label; widens Item Name column
- **Reprint fee table** (`inward_reprint_bill_service.xhtml`): adds Qty, Unit Rate, Total Gross, Discount, Service Charge columns alongside the existing Net Total; widens Item column

These are JSF-only changes — no Java or compilation required.

## Before / After

### Fees tab (bill entry page)
| Before | After |
|--------|-------|
| No, Item Name, Fee Gross Value (total, mislabelled), Margin Value, Fee Value, Speciality, Payee | No, Item Name, **Unit Rate**, **Qty**, Total Gross (editable), **Discount**, Service Charge, Net Total, Speciality, Payee |

### Reprint fee table
| Before | After |
|--------|-------|
| No, Item, Fee (net only), Fee Name, Speciality, Payee, Returned | No, Item, **Qty**, **Unit Rate**, **Total Gross**, **Discount**, **Service Charge**, Net Total, Fee Name, Speciality, Payee, Returned |

## Note on Unit Rate for historical bills
`feeUnitGrossValue` was added by PR #20418. For bills created before that PR was deployed, Unit Rate will appear blank until migration v2.3.0 is run via `/faces/admin/database_migration.xhtml`.

## Related
- Closes #20416
- Partial #20415 (print formats remain in #20421)
- Depends on per-unit fields from #20413 / PR #20418

## Test plan
- [ ] Open `inward_bill_service.xhtml`, add a service with qty = 1 — Fees tab shows Unit Rate = Total Gross, Discount and Service Charge columns visible
- [ ] Add a service with qty > 1 — Unit Rate shows per-unit value, Total Gross = Unit Rate × Qty
- [ ] Edit Total Gross for a userChangable fee — Unit Rate updates after save, Service Charge recalculates
- [ ] Open `inward_reprint_bill_service.xhtml` for an existing bill — new columns visible, no layout breakage
- [ ] Verify Item Name column is no longer truncated on either page

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Updated the Fees tab UI to display Unit Rate, Quantity, Total Gross, Discount, Service Charge, and Net Total in a clearer structured layout.
  * Reorganized fees data tables across billing and reprint views to show complete fee calculation breakdowns.
  * Improved explanatory messaging to clarify that Discount and Service Charge are applied automatically.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->