### PR TITLE
feat(inward): Add fee calculation explanation panel to Fees tab

### DIFF
--- a/src/main/webapp/inward/inward_bill_service.xhtml
+++ b/src/main/webapp/inward/inward_bill_service.xhtml
@@ -655,9 +655,14 @@
                                                         rowIndexVar="rowIndex"
                                                         value="#{billBhtController.lstBillFees}"
                                                         var="bif"
+                                                        rowExpandMode="single"
                                                         rowStyleClass="#{(bif.billItem.item.chargesVisibleForInward)
                                                                          or (webUserController.hasPrivilege('ShowInwardFee'))
                                                                          ? '':'noDisplayRow'}">
+                                                        <p:column width="2em">
+                                                            <f:facet name="header"> </f:facet>
+                                                            <p:rowToggler />
+                                                        </p:column>
                                                         <p:column width="3em">
                                                             <f:facet name="header">No</f:facet>
                                                             <h:outputLabel value="#{rowIndex+1}"/>
@@ -743,6 +748,75 @@
                                                                     itemValue="#{bifs}" />
                                                             </p:selectOneMenu>
                                                         </p:column>
+
+                                                        <p:rowExpansion>
+                                                            <div class="p-3 ms-4 border-start border-primary" style="background-color: #f0f4ff;">
+                                                                <div class="row g-3">
+
+                                                                    <!-- Formula -->
+                                                                    <div class="col-12 col-md-5">
+                                                                        <div class="fw-bold mb-1">Calculation</div>
+                                                                        <div class="font-monospace small text-muted">Net = (Unit Rate × Qty) + Service Charge − Discount</div>
+                                                                        <div class="font-monospace mt-1">
+                                                                            =
+                                                                            (<h:outputText value="#{bif.feeUnitGrossValue != null ? bif.feeUnitGrossValue : 0.0}"><f:convertNumber pattern="#,##0.00"/></h:outputText>
+                                                                            ×
+                                                                            <h:outputText value="#{bif.billItem.qty != null ? bif.billItem.qty : 1}"><f:convertNumber pattern="#"/></h:outputText>)
+                                                                            +
+                                                                            <h:outputText value="#{bif.feeMargin}"><f:convertNumber pattern="#,##0.00"/></h:outputText>
+                                                                            −
+                                                                            <h:outputText value="#{bif.feeDiscount}"><f:convertNumber pattern="#,##0.00"/></h:outputText>
+                                                                        </div>
+                                                                        <div class="font-monospace fw-bold mt-1">
+                                                                            = <h:outputText value="#{bif.feeValue}"><f:convertNumber pattern="#,##0.00"/></h:outputText>
+                                                                        </div>
+                                                                    </div>
+
+                                                                    <!-- Service Charge detail -->
+                                                                    <div class="col-12 col-md-3">
+                                                                        <div class="fw-bold mb-1">Service Charge</div>
+                                                                        <h:panelGroup rendered="#{bif.priceMatrix != null and bif.priceMatrix.margin != null and bif.priceMatrix.margin != 0}">
+                                                                            <div class="small text-muted">
+                                                                                <h:outputText value="#{bif.priceMatrix.margin}"><f:convertNumber pattern="#,##0.##"/></h:outputText>%
+                                                                                of
+                                                                                <h:outputText value="#{bif.feeGrossValue}"><f:convertNumber pattern="#,##0.00"/></h:outputText>
+                                                                            </div>
+                                                                            <div class="text-success fw-bold">
+                                                                                + <h:outputText value="#{bif.feeMargin}"><f:convertNumber pattern="#,##0.00"/></h:outputText>
+                                                                            </div>
+                                                                            <h:panelGroup rendered="#{bif.priceMatrix.admissionType != null}">
+                                                                                <div class="text-muted small">Admission type: <h:outputText value="#{bif.priceMatrix.admissionType}"/></div>
+                                                                            </h:panelGroup>
+                                                                        </h:panelGroup>
+                                                                        <h:panelGroup rendered="#{bif.feeMargin == 0}">
+                                                                            <div class="text-muted small">Not applicable</div>
+                                                                        </h:panelGroup>
+                                                                    </div>
+
+                                                                    <!-- Discount detail -->
+                                                                    <div class="col-12 col-md-3">
+                                                                        <div class="fw-bold mb-1">Discount</div>
+                                                                        <h:panelGroup rendered="#{bif.feeDiscount != 0}">
+                                                                            <h:panelGroup rendered="#{bif.priceMatrix != null and bif.priceMatrix.discountPercent != 0}">
+                                                                                <div class="small text-muted">
+                                                                                    <h:outputText value="#{bif.priceMatrix.discountPercent}"><f:convertNumber pattern="#,##0.##"/></h:outputText>%
+                                                                                    of
+                                                                                    <h:outputText value="#{bif.feeGrossValue}"><f:convertNumber pattern="#,##0.00"/></h:outputText>
+                                                                                </div>
+                                                                            </h:panelGroup>
+                                                                            <div class="text-danger fw-bold">
+                                                                                − <h:outputText value="#{bif.feeDiscount}"><f:convertNumber pattern="#,##0.00"/></h:outputText>
+                                                                            </div>
+                                                                        </h:panelGroup>
+                                                                        <h:panelGroup rendered="#{bif.feeDiscount == 0}">
+                                                                            <div class="text-muted small">Not applicable</div>
+                                                                        </h:panelGroup>
+                                                                    </div>
+
+                                                                </div>
+                                                            </div>
+                                                        </p:rowExpansion>
+
                                                     </p:dataTable>
                                                 </p:tab>
                                             </p:tabView>


### PR DESCRIPTION
## Summary

Adds a row-expansion panel to each fee row in the **Fees tab** of `inward_bill_service.xhtml`. Clicking the toggle (▶) on any fee row reveals a breakdown showing exactly how the net total was computed.

## What the panel shows

```
Calculation
  Formula: Net = (Unit Rate × Qty) + Service Charge − Discount
         = (1,396.50 × 2) + 0.00 − 103.50
         = 2,689.50
```

| Service Charge | Discount |
|---|---|
| 5% of 2,793.00 → **+ 0.00** | 3.7% of 2,793.00 → **− 103.50** |
| Admission type: BHT | |

Rows where service charge or discount are zero show "Not applicable".

## Notes
- JSF-only change — no Java, no compilation needed
- `feeUnitGrossValue` is null-guarded (shows 0.00 for pre-migration bills, no EL error)
- `rowExpandMode="single"` ensures only one row is open at a time

## Test plan
- [ ] Open Fees tab, click ▶ on a fee row — panel expands showing formula with numbers
- [ ] Fee with service charge applied — margin % and admission type visible
- [ ] Fee with discount applied — discount % and amount visible
- [ ] Fee with neither — both sections show "Not applicable"
- [ ] Click ▶ on a second row — first row collapses
- [ ] Old bills (feeUnitGrossValue = null) — no error, shows 0.00 for unit rate

## Closes
Closes #20416

🤖 Generated with [Claude Code](https://claude.com/claude-code)