### PR TITLE
Align patient deposit confirmation text with button label

### DIFF
--- a/src/main/webapp/patient_deposit/receive.xhtml
+++ b/src/main/webapp/patient_deposit/receive.xhtml
@@ -30,7 +30,7 @@
                                                  id="btnSettle"
                                                  value="Receive Patient Deposit"
                                                  action="#{patientDepositController.settlePatientDeposit}"
-                                                 onclick="if (!confirm('Are you sure you want to Settle This Bill ?'))
+                                                 onclick="if (!confirm('Are you sure you want to receive this patient deposit?'))
                                                              return false;"
                                                  ajax="false" >
                                 </p:commandButton>


### PR DESCRIPTION
### Motivation
- Fix wording mismatch in the patient deposit UI where the confirmation dialog referenced settling a bill while the action is to receive a patient deposit (issue #18025).

### Description
- Updated confirmation text in `src/main/webapp/patient_deposit/receive.xhtml` by changing the `onclick` confirm message from `Are you sure you want to Settle This Bill ?` to `Are you sure you want to receive this patient deposit?`.

### Testing
- Verified the change with `git diff` and committed the file with `git commit`; no automated unit or integration tests were run because this is a JSF/XHTML text-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7bde6ee84832f8a807a322f54e7b5)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced the confirmation message when receiving patient deposits to provide clearer, more descriptive guidance on the action being performed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->