### PR TITLE
Online booking: consider session reserved numbers when assigning appointment numbers

### DIFF
--- a/src/main/java/com/divudi/ejb/ChannelBean.java
+++ b/src/main/java/com/divudi/ejb/ChannelBean.java
@@ -1046,6 +1046,7 @@ public class ChannelBean {
         newSs.setStaff(ss.getStaff());
         newSs.setRoomNo(ss.getRoomNo());
         newSs.setSessionNumberGenerator(saveSessionNumber(ss));
+        newSs.setReserveNumbers(ss.getReserveNumbers());
         try {
             sessionInstanceFacade.create(newSs);
         } catch (Exception e) {

--- a/src/main/java/com/divudi/service/ChannelService.java
+++ b/src/main/java/com/divudi/service/ChannelService.java
@@ -88,10 +88,12 @@ import java.util.Calendar;
 import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
+import java.util.Set;
 import java.util.UUID;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -372,6 +374,9 @@ public class ChannelService {
         hh.put("ss", session);
         List<BillSession> billSessionList = getBillSessionFacade().findByJpql(sql, hh, TemporalType.DATE);
 
+        List<Integer> reservedNumbersList = CommonFunctions.convertStringToIntegerList(session.getOriginatingSession().getReserveNumbers());
+        Set<Integer> reservedNumbers = new HashSet<>(reservedNumbersList);
+
         int nextNumber = 0;
         int activePatientCount = 0;
 
@@ -387,9 +392,15 @@ public class ChannelService {
                 }
             }
         }
+        nextNumber++;
+
+        // check for reserved numbers
+        while (reservedNumbers.contains(nextNumber)) {
+            nextNumber++;
+        }
 
         Map data = new HashMap();
-        data.put("nextNumber", ++nextNumber);
+        data.put("nextNumber", nextNumber);
         data.put("activePatients", activePatientCount);
 
         return data;
@@ -1031,7 +1042,36 @@ public class ChannelService {
         return getBillSessionFacade().findByJpql(sql, hh, TemporalType.DATE);
     }
 
-    public List getReleasedAppoinmentNumbersForApiBookings(SessionInstance ss) {
+    private List<Integer> getAllBillSessionSerialNumbersForSessionInstance(SessionInstance ss) {
+        List<BillSession> allBillSessions = new ArrayList<>();
+        BillType[] billTypes = {
+            BillType.ChannelAgent,
+            BillType.ChannelCash,
+            BillType.ChannelOnCall,
+            BillType.ChannelStaff,
+            BillType.ChannelCredit,
+            BillType.ChannelResheduleWithPayment,
+            BillType.ChannelResheduleWithOutPayment,};
+
+        List<BillType> bts = Arrays.asList(billTypes);
+        String sql = "Select bs.serialNo "
+                + " From BillSession bs "
+                + " where bs.retired=false"
+                + " and bs.bill.billType in :bts"
+                + " and type(bs.bill)=:class "
+                + " and bs.sessionInstance=:ss "
+                + " order by bs.serialNo ";
+        HashMap<String, Object> hh = new HashMap<>();
+
+        Bill b = new Bill();
+        b.getBillTypeAtomic();
+        hh.put("bts", bts);
+        hh.put("class", BilledBill.class);
+        hh.put("ss", ss);
+        return (List<Integer>) getBillSessionFacade().findLightsByJpql(sql, hh, TemporalType.DATE);
+    }
+
+    public List getReleasedAppoinmentNumbersForApiBookings(SessionInstance ss, List<Integer> reservedNumbers) {
         long nextNumber = 1L;
 
         if (ss.getNextAvailableAppointmentNumber() != null) {
@@ -1040,22 +1080,13 @@ public class ChannelService {
 
         List releasedNumberList = new ArrayList();
 
-        List<BillSession> allBillSessions = getAllBillSessionForSessionInstance(ss);
+        List<Integer> reservedSerialNumbers = getAllBillSessionSerialNumbersForSessionInstance(ss);
 
-        List<Integer> reservedSerialNumbers = allBillSessions.stream()
-                .map(BillSession::getSerialNo)
-                .collect(Collectors.toList());
+        Set<Integer> unavailableNumbers = new HashSet<>(reservedSerialNumbers);
+        unavailableNumbers.addAll(reservedNumbers);
 
         for (int i = 1; i < nextNumber; ++i) {
-            boolean isAssign = false;
-            for (Integer number : reservedSerialNumbers) {
-                if (i == number) {
-                    isAssign = true;
-
-                }
-            }
-
-            if (!isAssign) {
+            if (!unavailableNumbers.contains(i)) {
                 releasedNumberList.add(i);
             }
         }
@@ -1263,17 +1294,17 @@ public class ChannelService {
         bs.setSessionTime(session.getSessionTime());
         bs.setStaff(session.getStaff());
 
-        // List<Integer> reservedNumbers = CommonFunctions.convertStringToIntegerList(session.getOriginatingSession().getReserveNumbers());
+        List<Integer> reservedNumbers = CommonFunctions.convertStringToIntegerList(session.getOriginatingSession().getReserveNumbers());
         Integer count = null;
 
-        List<Integer> availableReleasedApoinmentNumbers = getReleasedAppoinmentNumbersForApiBookings(session);
+        List<Integer> availableReleasedApoinmentNumbers = getReleasedAppoinmentNumbersForApiBookings(session, reservedNumbers);
         Random rand = new Random();
         if (availableReleasedApoinmentNumbers != null && !availableReleasedApoinmentNumbers.isEmpty()) {
             count = availableReleasedApoinmentNumbers.get(rand.nextInt(availableReleasedApoinmentNumbers.size()));
         }
 
         if (count == null) {
-            count = serviceSessionBean.getNextNonReservedSerialNumber(session, Collections.EMPTY_LIST);
+            count = serviceSessionBean.getNextNonReservedSerialNumber(session, reservedNumbers);
         }
 
         if (count != null) {

--- a/src/main/java/com/divudi/service/ChannelService.java
+++ b/src/main/java/com/divudi/service/ChannelService.java
@@ -375,6 +375,9 @@ public class ChannelService {
         List<BillSession> billSessionList = getBillSessionFacade().findByJpql(sql, hh, TemporalType.DATE);
 
         List<Integer> reservedNumbersList = CommonFunctions.convertStringToIntegerList(session.getOriginatingSession().getReserveNumbers());
+        if (reservedNumbersList == null) {
+             reservedNumbersList = Collections.emptyList();
+        }
         Set<Integer> reservedNumbers = new HashSet<>(reservedNumbersList);
 
         int nextNumber = 0;
@@ -1295,6 +1298,9 @@ public class ChannelService {
         bs.setStaff(session.getStaff());
 
         List<Integer> reservedNumbers = CommonFunctions.convertStringToIntegerList(session.getOriginatingSession().getReserveNumbers());
+        if (reservedNumbers == null) {
+            reservedNumbers = Collections.emptyList();
+        }
         Integer count = null;
 
         List<Integer> availableReleasedApoinmentNumbers = getReleasedAppoinmentNumbersForApiBookings(session, reservedNumbers);

--- a/src/main/java/com/divudi/service/ChannelService.java
+++ b/src/main/java/com/divudi/service/ChannelService.java
@@ -374,7 +374,7 @@ public class ChannelService {
         hh.put("ss", session);
         List<BillSession> billSessionList = getBillSessionFacade().findByJpql(sql, hh, TemporalType.DATE);
 
-        List<Integer> reservedNumbersList = CommonFunctions.convertStringToIntegerList(session.getOriginatingSession().getReserveNumbers());
+        List<Integer> reservedNumbersList = CommonFunctions.convertStringToIntegerList(session.getReserveNumbers());
         if (reservedNumbersList == null) {
              reservedNumbersList = Collections.emptyList();
         }
@@ -1297,7 +1297,7 @@ public class ChannelService {
         bs.setSessionTime(session.getSessionTime());
         bs.setStaff(session.getStaff());
 
-        List<Integer> reservedNumbers = CommonFunctions.convertStringToIntegerList(session.getOriginatingSession().getReserveNumbers());
+        List<Integer> reservedNumbers = CommonFunctions.convertStringToIntegerList(session.getReserveNumbers());
         if (reservedNumbers == null) {
             reservedNumbers = Collections.emptyList();
         }


### PR DESCRIPTION
**Issue**: Previously, session reserved numbers could be assigned for online bookings.

**Expected**: Session reserved numbers should not be assigned for online bookings.

Files Changed:
- ChannelService
- ChannelBean

`ChannelBean` was modified to ensure reserved numbers are assigned when `sessionInstance`s are created via `ServiceSession`.

`getAllBillSessionSerialNumbersForSessionInstance()`, method defined to get the `BillSession`'s serialNo` directly.

Ensure that **appointment number** for online booking is not a reserved number.

`ChannelService.saveBillItem()` modified, because null pointer exception was caused as `BIllItem` Id generation was changed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Appointment allocation now preserves and respects reserved appointment numbers when creating session instances.
  * API booking availability excludes both already-used and explicitly reserved numbers to prevent conflicts.
  * Next-available appointment calculation now skips reserved numbers and falls back to the next non-reserved serial when needed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->