### PR TITLE
DataTable rowKey not defined causing 500 error in Inward Bill Service screen #20431

### DIFF
--- a/src/main/webapp/inward/inward_bill_service.xhtml
+++ b/src/main/webapp/inward/inward_bill_service.xhtml
@@ -652,9 +652,11 @@
                                                 <p:tab id="tabBillFee" title="Fees" >
                                                     <p:outputLabel value="Unit Rate × Qty = Total Gross. Edit Total Gross to override the charge; Discount and Service Charge are applied automatically." styleClass="text-muted small d-block mb-2" />
                                                     <p:dataTable
+                                                        id="feeTable"
                                                         rowIndexVar="rowIndex"
                                                         value="#{billBhtController.lstBillFees}"
                                                         var="bif"
+                                                        rowKey="#{rowIndex}"
                                                         rowExpandMode="single"
                                                         rowStyleClass="#{(bif.billItem.item.chargesVisibleForInward)
                                                                          or (webUserController.hasPrivilege('ShowInwardFee'))

--- a/src/main/webapp/inward/inward_bill_service.xhtml
+++ b/src/main/webapp/inward/inward_bill_service.xhtml
@@ -656,7 +656,7 @@
                                                         rowIndexVar="rowIndex"
                                                         value="#{billBhtController.lstBillFees}"
                                                         var="bif"
-                                                        rowKey="#{rowIndex}"
+                                                        rowKey="#{bif.id}"
                                                         rowExpandMode="single"
                                                         rowStyleClass="#{(bif.billItem.item.chargesVisibleForInward)
                                                                          or (webUserController.hasPrivilege('ShowInwardFee'))


### PR DESCRIPTION
DataTable rowKey not defined causing 500 error in Inward Bill Service screen #20431

closes #20431
Signed-off-by: damithdeshan98 <hkddrajapaksha@gmail.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved table row identification in the Fees section for enhanced stability and state management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->