### PR TITLE
20307 need to improve collection center balance report pdf

### DIFF
--- a/src/main/java/com/divudi/bean/common/ReportsController.java
+++ b/src/main/java/com/divudi/bean/common/ReportsController.java
@@ -5348,7 +5348,7 @@ public class ReportsController implements Serializable {
         try {
             String value = supplier.get();
             return (value != null && !value.isEmpty()) ? value : "-";
-        } catch (Exception e) {
+        } catch (NullPointerException e) {
             return "-";
         }
     }

--- a/src/main/java/com/divudi/bean/common/ReportsController.java
+++ b/src/main/java/com/divudi/bean/common/ReportsController.java
@@ -5106,121 +5106,265 @@ public class ReportsController implements Serializable {
             JsfUtil.addErrorMessage("No data to export. Please process the report first.");
             return;
         }
-        
-        com.itextpdf.text.Font bodyFontSmall = com.itextpdf.text.FontFactory.getFont(com.itextpdf.text.FontFactory.HELVETICA, 6);
+
         FacesContext context = FacesContext.getCurrentInstance();
         ExternalContext externalContext = context.getExternalContext();
         HttpServletResponse response = (HttpServletResponse) externalContext.getResponse();
         response.reset();
-        String dates = CommonFunctions.dateRangeForFileName(fromDate, toDate, sessionController.getApplicationPreference().getLongDateFormat());
 
+        String dates = CommonFunctions.dateRangeForFileName(fromDate, toDate,
+                sessionController.getApplicationPreference().getLongDateFormat());
         response.setContentType("application/pdf");
-        if (dates != null && !dates.isEmpty()) {
-            response.setHeader("Content-Disposition", "attachment; filename=Laboratory_workload_detailed_" + dates + ".pdf");
-        } else {
-            response.setHeader("Content-Disposition", "attachment; filename=Laboratory_workload_detailed_report.pdf");
-        }
+        String filename = (dates != null && !dates.isEmpty())
+                ? "Laboratory_workload_detailed_" + dates + ".pdf"
+                : "Laboratory_workload_detailed_report.pdf";
+        response.setHeader("Content-Disposition", "attachment; filename=" + filename);
 
         SimpleDateFormat sdf = new SimpleDateFormat("dd MM yyyy hh:mm:ss a");
-        DecimalFormat df = new DecimalFormat("#,##0.##");
-        String institutionName = sessionController.getInstitution() != null ? sessionController.getInstitution().getName() : "";
+        String institutionName = sessionController.getInstitution() != null
+                ? sessionController.getInstitution().getName() : "";
+        boolean isVisitCC = "CC".equals(visitType);
+        boolean isVisitIP = "IP".equals(visitType);
+        int columnCount = isVisitCC ? 19 : 17;
 
         try (OutputStream out = response.getOutputStream()) {
-            com.itextpdf.text.Document document = new com.itextpdf.text.Document(com.itextpdf.text.PageSize.A4.rotate());
+            com.itextpdf.text.Document document = new com.itextpdf.text.Document(
+                    com.itextpdf.text.PageSize.A4.rotate());
             com.itextpdf.text.pdf.PdfWriter.getInstance(document, out);
             document.open();
 
+            // ── Header section ──────────────────────────────────────────────────
             if (institutionName != null && !institutionName.isEmpty()) {
-                document.add(new com.itextpdf.text.Paragraph(institutionName, com.itextpdf.text.FontFactory.getFont(com.itextpdf.text.FontFactory.HELVETICA_BOLD, 18)));
+                document.add(new com.itextpdf.text.Paragraph(institutionName,
+                        com.itextpdf.text.FontFactory.getFont(
+                                com.itextpdf.text.FontFactory.HELVETICA_BOLD, 18)));
             }
-            document.add(new com.itextpdf.text.Paragraph("Laboratory Workload Detail Report", com.itextpdf.text.FontFactory.getFont(com.itextpdf.text.FontFactory.HELVETICA_BOLD, 16)));
-            document.add(new com.itextpdf.text.Paragraph("Date: " + sdf.format(new Date()), com.itextpdf.text.FontFactory.getFont(com.itextpdf.text.FontFactory.HELVETICA, 12)));
+            document.add(new com.itextpdf.text.Paragraph("Laboratory Workload Detail Report",
+                    com.itextpdf.text.FontFactory.getFont(
+                            com.itextpdf.text.FontFactory.HELVETICA_BOLD, 16)));
+            document.add(new com.itextpdf.text.Paragraph("Date: " + sdf.format(new Date()),
+                    com.itextpdf.text.FontFactory.getFont(
+                            com.itextpdf.text.FontFactory.HELVETICA, 12)));
             document.add(new com.itextpdf.text.Paragraph(" "));
-            
-            boolean isVisitCC = "CC".equals(visitType);
 
-            int columnCount =isVisitCC  ? 19 : 17;
+            // ── Info / filter table ──────────────────────────────────────────────
             Map<String, Object> filters = getFiltersForLaboratoryWorkloadReport();
-            com.itextpdf.text.pdf.PdfPTable infoTable = pharmacyController.createInfoTablePdfExport(sdf, filters);
+            com.itextpdf.text.pdf.PdfPTable infoTable =
+                    pharmacyController.createInfoTablePdfExport(sdf, filters);
             if (infoTable != null) {
                 document.add(infoTable);
             }
 
-            com.itextpdf.text.pdf.PdfPTable table = new com.itextpdf.text.pdf.PdfPTable(columnCount);
-            table.setWidthPercentage(100);
-
-            float[] columnWidths;
+            // ── Column definitions ───────────────────────────────────────────────
             String[] headers;
-
-            if (isVisitCC){
-                headers = new String[]{"Sample ID", "Invoice No.", "MRN", "Name", "Age","Gender","Investigation","Lab Department", "CC", "CC Route","Invoiced Date","Invoiced By","Received Date","Received By","Remarks","Patient Source","Patient Type","Referring Doctor","Item Value"};
-                columnWidths = new float[]{1f, 2f, 1f, 2f, 1f, 0.5f, 2f, 1f,1f,1f,1f,1f,1f,1f,1f,0.5f,1f,2f,1f};
-            } else{
-                headers = new String[]{"Sample ID", "Invoice No.", "MRN", "Name", "Age","Gender","Investigation","Lab Department","Invoiced Date","Invoiced By","Received Date","Received By","Remarks","Patient Source","Patient Type","Referring Doctor","Item Value"};
-                columnWidths = new float[]{1f, 2f, 1f, 2f, 1f, 0.5f, 2f, 1f,1f,1f,1f,1f,1f,0.5f,1f,2f,1f};
+            float[] columnWidths;
+            if (isVisitCC) {
+                headers = new String[]{
+                    "Sample ID", "Invoice No.", "MRN", "Name", "Age", "Gender",
+                    "Investigation", "Lab Department", "CC", "CC Route",
+                    "Invoiced Date", "Invoiced By", "Received Date", "Received By",
+                    "Remarks", "Patient Source", "Patient Type", "Referring Doctor", "Item Value"
+                };
+                columnWidths = new float[]{
+                    1f, 2f, 1f, 2f, 1f, 0.5f, 2f, 1f,
+                    1f, 1f, 1f, 1f, 1f, 1f, 1f, 0.5f, 1f, 2f, 1f
+                };
+            } else {
+                headers = new String[]{
+                    "Sample ID", "Invoice No.", "MRN", "Name", "Age", "Gender",
+                    "Investigation", "Lab Department",
+                    "Invoiced Date", "Invoiced By", "Received Date", "Received By",
+                    "Remarks", "Patient Source", "Patient Type", "Referring Doctor", "Item Value"
+                };
+                columnWidths = new float[]{
+                    1f, 2f, 1f, 2f, 1f, 0.5f, 2f, 1f,
+                    1f, 1f, 1f, 1f, 1f, 0.5f, 1f, 2f, 1f
+                };
             }
+
+            // ── Build main table ─────────────────────────────────────────────────
+            com.itextpdf.text.Font bodyFontSmall =
+                    com.itextpdf.text.FontFactory.getFont(
+                            com.itextpdf.text.FontFactory.HELVETICA, 6);
+
+            com.itextpdf.text.pdf.PdfPTable table =
+                    new com.itextpdf.text.pdf.PdfPTable(columnCount);
+            table.setWidthPercentage(100);
             table.setWidths(columnWidths);
+            table.setHeaderRows(1); // repeat header row on every page
 
             for (String header : headers) {
-                com.itextpdf.text.pdf.PdfPCell cell = new com.itextpdf.text.pdf.PdfPCell(new com.itextpdf.text.Phrase(header, com.itextpdf.text.FontFactory.getFont(com.itextpdf.text.FontFactory.HELVETICA_BOLD, 7)));
+                com.itextpdf.text.pdf.PdfPCell cell = new com.itextpdf.text.pdf.PdfPCell(
+                        new com.itextpdf.text.Phrase(header,
+                                com.itextpdf.text.FontFactory.getFont(
+                                        com.itextpdf.text.FontFactory.HELVETICA_BOLD, 7)));
                 cell.setBackgroundColor(com.itextpdf.text.BaseColor.LIGHT_GRAY);
                 table.addCell(cell);
             }
 
-            // list of the sanple carrier reports
-            List<ReportTemplateRow> rows = bundle.getReportTemplateRows();
-            for (ReportTemplateRow row : rows) {
-                table.addCell(textCell(patientInvestigationController.getPatientSamplesByInvestigationAsString(row.getBillItem().getPatientInvestigation()), bodyFontSmall));
-                table.addCell(textCell(row.getBillItem().getPatientEncounter()!= null ? row.getBillItem().getPatientEncounter().getFinalBill().getDeptId() : row.getBillItem().getBill().getDeptId() ,bodyFontSmall));
-                table.addCell(textCell(row.getBillItem().getBill().getPatient().getPhn(),bodyFontSmall));
-                table.addCell(textCell(row.getBillItem().getBill().getPatient().getPerson().getNameWithTitle(),bodyFontSmall));
-                table.addCell(textCell(row.getBillItem().getBill().getPatient().getPerson().getAgeAsString(),bodyFontSmall));
-                table.addCell(textCell(row.getBillItem().getBill().getPatient().getPerson().getSex().getLabel(),bodyFontSmall));
-                table.addCell(textCell(row.getBillItem().getItem().getName(),bodyFontSmall));
-                table.addCell(textCell(row.getBillItem().getItem().getDepartment().getName(),bodyFontSmall));
-                
-                if (isVisitCC){
-                   Institution cc =  row.getBillItem().getBill().getCollectingCentre();
-                   table.addCell(textCell(cc != null ? cc.getName() : "-",bodyFontSmall)); 
-                   table.addCell(textCell( cc != null && cc.getRoute()!=null ? cc.getRoute().getName() : "-",bodyFontSmall)); 
+            // ── Data rows ────────────────────────────────────────────────────────
+            for (ReportTemplateRow row : bundle.getReportTemplateRows()) {
+                if (row == null || row.getBillItem() == null) {
+                    addEmptyRow(table, columnCount, bodyFontSmall);
+                    continue;
                 }
- 
-                table.addCell(textCell(row.getBillItem().getPatientEncounter() != null ? sdf.format(row.getBillItem().getPatientEncounter().getFinalBill().getCreatedAt()) : sdf.format(row.getBillItem().getBill().getCreatedAt()),bodyFontSmall));
-                table.addCell(textCell(row.getBillItem().getPatientEncounter() != null ? row.getBillItem().getPatientEncounter().getFinalBill().getCreater().getWebUserPerson().getNameWithTitle() : row.getBillItem().getBill().getCreater().getWebUserPerson().getNameWithTitle(),bodyFontSmall));
-                table.addCell(textCell(row.getBillItem().getPatientInvestigation().getSampleAcceptedAt() != null ? sdf.format(row.getBillItem().getPatientInvestigation().getSampleAcceptedAt()) : "-",bodyFontSmall));
-                table.addCell(textCell( row.getBillItem().getPatientInvestigation().getSampleAcceptedBy() != null ? row.getBillItem().getPatientInvestigation().getSampleAcceptedBy().getWebUserPerson().getNameWithTitle() : "-",bodyFontSmall));
-                table.addCell(textCell( row.getBillItem().getBill().getComments() != null ?row.getBillItem().getBill().getComments() : "-" ,bodyFontSmall));
-                table.addCell(textCell( row.getBillItem().getBill().getIpOpOrCc(),bodyFontSmall));
-                
-                if ("IP".equals(visitType)){
-                    table.addCell(textCell( row.getBillItem().getBill().getPatientEncounter().getPaymentMethod().getLabel(),bodyFontSmall));
+
+                BillItem billItem             = row.getBillItem();
+                Bill bill                     = billItem.getBill();
+                PatientEncounter encounter    = billItem.getPatientEncounter();
+                PatientInvestigation pi       = billItem.getPatientInvestigation();
+                Bill effectiveBill            = (encounter != null && encounter.getFinalBill() != null)
+                                                    ? encounter.getFinalBill() : bill;
+
+                // Sample ID
+                table.addCell(textCell(
+                        safeGet(() -> patientInvestigationController
+                                .getPatientSamplesByInvestigationAsString(pi)),
+                        bodyFontSmall));
+
+                // Invoice No.
+                table.addCell(textCell(
+                        safeGet(() -> effectiveBill != null ? effectiveBill.getDeptId() : null),
+                        bodyFontSmall));
+
+                // MRN / PHN
+                table.addCell(textCell(
+                        safeGet(() -> bill.getPatient().getPhn()),
+                        bodyFontSmall));
+
+                // Name
+                table.addCell(textCell(
+                        safeGet(() -> bill.getPatient().getPerson().getNameWithTitle()),
+                        bodyFontSmall));
+
+                // Age
+                table.addCell(textCell(
+                        safeGet(() -> bill.getPatient().getPerson().getAgeAsString()),
+                        bodyFontSmall));
+
+                // Gender
+                table.addCell(textCell(
+                        safeGet(() -> bill.getPatient().getPerson().getSex().getLabel()),
+                        bodyFontSmall));
+
+                // Investigation name
+                table.addCell(textCell(
+                        safeGet(() -> billItem.getItem().getName()),
+                        bodyFontSmall));
+
+                // Lab Department
+                table.addCell(textCell(
+                        safeGet(() -> billItem.getItem().getDepartment().getName()),
+                        bodyFontSmall));
+
+                // CC-only columns
+                if (isVisitCC) {
+                    Institution cc = (bill != null) ? bill.getCollectingCentre() : null;
+                    table.addCell(textCell(
+                            cc != null ? cc.getName() : "-",
+                            bodyFontSmall));
+                    table.addCell(textCell(
+                            (cc != null && cc.getRoute() != null) ? cc.getRoute().getName() : "-",
+                            bodyFontSmall));
+                }
+
+                // Invoiced Date
+                table.addCell(textCell(
+                        safeFormatDate(effectiveBill != null ? effectiveBill.getCreatedAt() : null, sdf),
+                        bodyFontSmall));
+
+                // Invoiced By
+                table.addCell(textCell(
+                        safeGet(() -> effectiveBill.getCreater().getWebUserPerson().getNameWithTitle()),
+                        bodyFontSmall));
+
+                // Received Date
+                table.addCell(textCell(
+                        (pi != null && pi.getSampleAcceptedAt() != null)
+                                ? sdf.format(pi.getSampleAcceptedAt()) : "-",
+                        bodyFontSmall));
+
+                // Received By
+                table.addCell(textCell(
+                        safeGet(() -> pi.getSampleAcceptedBy().getWebUserPerson().getNameWithTitle()),
+                        bodyFontSmall));
+
+                // Remarks
+                table.addCell(textCell(
+                        (bill != null && bill.getComments() != null) ? bill.getComments() : "-",
+                        bodyFontSmall));
+
+                // Patient Source (IP/OP/CC)
+                table.addCell(textCell(
+                        safeGet(() -> bill.getIpOpOrCc()),
+                        bodyFontSmall));
+
+                // Patient Type (payment method)
+                if (isVisitIP) {
+                    table.addCell(textCell(
+                            safeGet(() -> bill.getPatientEncounter().getPaymentMethod().getLabel()),
+                            bodyFontSmall));
                 } else {
-                    table.addCell(textCell( row.getBillItem().getBill().getPaymentMethod().getLabel(),bodyFontSmall));
+                    table.addCell(textCell(
+                            safeGet(() -> bill.getPaymentMethod().getLabel()),
+                            bodyFontSmall));
                 }
-                table.addCell(textCell( row.getBillItem().getBill().getReferredBy()!=null ? row.getBillItem().getBill().getReferredBy().getPerson().getNameWithTitle() : "-",bodyFontSmall));
-                table.addCell(numCell( row.getBillItem().getNetValue(),bodyFontSmall));
-          
+
+                // Referring Doctor
+                table.addCell(textCell(
+                        safeGet(() -> bill.getReferredBy().getPerson().getNameWithTitle()),
+                        bodyFontSmall));
+
+                // Item Value
+                table.addCell(numCell(
+                        billItem.getNetValue(),
+                        bodyFontSmall));
             }
-            com.itextpdf.text.pdf.PdfPCell footerCell = new com.itextpdf.text.pdf.PdfPCell(new com.itextpdf.text.Phrase("Total", com.itextpdf.text.FontFactory.getFont(com.itextpdf.text.FontFactory.HELVETICA_BOLD, 10)));
-            int footerSpan = 0;
-            if (isVisitCC){
-                footerSpan = 18;
-            }else {
-                footerSpan = 16;
-            }
+
+            // ── Footer / total row ───────────────────────────────────────────────
+            int footerSpan = isVisitCC ? 18 : 16;
+            com.itextpdf.text.pdf.PdfPCell footerCell = new com.itextpdf.text.pdf.PdfPCell(
+                    new com.itextpdf.text.Phrase("Total",
+                            com.itextpdf.text.FontFactory.getFont(
+                                    com.itextpdf.text.FontFactory.HELVETICA_BOLD, 10)));
             footerCell.setColspan(footerSpan);
             footerCell.setBackgroundColor(com.itextpdf.text.BaseColor.LIGHT_GRAY);
-            footerCell.setHorizontalAlignment(Element.ALIGN_RIGHT);
+            footerCell.setHorizontalAlignment(com.itextpdf.text.Element.ALIGN_RIGHT);
             table.addCell(footerCell);
             table.addCell(numCell(bundle.getTotal(), bodyFontSmall));
+
             document.add(table);
             document.close();
             context.responseComplete();
 
         } catch (Exception e) {
-            Logger.getLogger(ReportsController.class
-                    .getName()).log(Level.SEVERE, "Error exporting Test Wise Count Report to PDF", e);
-        } 
+            Logger.getLogger(ReportsController.class.getName())
+                    .log(Level.SEVERE, "Error exporting Laboratory Workload Detail Report to PDF", e);
+        }
+    }
+
+    // ── Helper: safely resolve a deeply-chained value, returns "-" on any NPE ──
+    private String safeGet(java.util.function.Supplier<String> supplier) {
+        try {
+            String value = supplier.get();
+            return (value != null && !value.isEmpty()) ? value : "-";
+        } catch (Exception e) {
+            return "-";
+        }
+    }
+
+    // ── Helper: format a nullable date ──────────────────────────────────────────
+    private String safeFormatDate(java.util.Date date, SimpleDateFormat sdf) {
+        return (date != null) ? sdf.format(date) : "-";
+    }
+
+    // ── Helper: add a full blank row when the row/billItem itself is null ────────
+    private void addEmptyRow(com.itextpdf.text.pdf.PdfPTable table,
+                             int columnCount,
+                             com.itextpdf.text.Font font) {
+        for (int i = 0; i < columnCount; i++) {
+            table.addCell(textCell("-", font));
+        }
     }
    
     // PostProcessor for laboratory_workload_report excel export
@@ -5249,97 +5393,92 @@ public class ReportsController implements Serializable {
         }
     }
     
-public void preProcessLaboratoryWorkloadSummaryReportPDF(Object document) {
-    try {
-        com.lowagie.text.Document pdf = (com.lowagie.text.Document) document;
-        pdf.setMargins(36f, 36f, 20f, 36f);
-
-        // ── BaseColor definitions ─────────────────────────────────────
-        java.awt.Color black      = new java.awt.Color(0,   0,   0);
-        java.awt.Color lightGray  = new java.awt.Color(245, 245, 245);
-        java.awt.Color borderGray = new java.awt.Color(180, 180, 180);
-
-        // ── Font definitions ──────────────────────────────────────────
-        com.lowagie.text.Font hospitalFont = new com.lowagie.text.Font(com.lowagie.text.Font.HELVETICA, 16f, com.lowagie.text.Font.BOLD,   black);
-        com.lowagie.text.Font reportFont   = new com.lowagie.text.Font(com.lowagie.text.Font.HELVETICA, 13f, com.lowagie.text.Font.BOLD,   black);
-        com.lowagie.text.Font dateFont     = new com.lowagie.text.Font(com.lowagie.text.Font.HELVETICA, 10f, com.lowagie.text.Font.NORMAL, black);
-        com.lowagie.text.Font labelFont    = new com.lowagie.text.Font(com.lowagie.text.Font.HELVETICA,  9f, com.lowagie.text.Font.BOLD,   black);
-        com.lowagie.text.Font valueFont    = new com.lowagie.text.Font(com.lowagie.text.Font.HELVETICA,  9f, com.lowagie.text.Font.NORMAL, black);
-
-        // ── Institution name ─────────────────────────────────────────────
-        String institutionName = sessionController.getInstitution() != null ? sessionController.getInstitution().getName() : "No Logged Institution";
-        com.lowagie.text.Paragraph hospitalName = new com.lowagie.text.Paragraph(institutionName, hospitalFont);
-        hospitalName.setAlignment(com.lowagie.text.Element.ALIGN_LEFT);
-        hospitalName.setSpacingAfter(2f);
-        pdf.add(hospitalName);
-
-        // ── Report title ──────────────────────────────────────────────
-        com.lowagie.text.Paragraph reportTitle = new com.lowagie.text.Paragraph("Laboratory Workload Summary Report", reportFont);
-        reportTitle.setAlignment(com.lowagie.text.Element.ALIGN_LEFT);
-        reportTitle.setSpacingAfter(2f);
-        pdf.add(reportTitle);
-
-        // ── Generated date ────────────────────────────────────────────
-        SimpleDateFormat sdf = new SimpleDateFormat(
-                sessionController.getApplicationPreference().getLongDateTimeFormat());
-        com.lowagie.text.Paragraph dateLine = new com.lowagie.text.Paragraph("Date: " + sdf.format(new Date()), dateFont);
-        dateLine.setAlignment(com.lowagie.text.Element.ALIGN_LEFT);
-        dateLine.setSpacingAfter(10f);
-        pdf.add(dateLine);
-
-        // ── Filter summary table ──────────────────────────────────────
-        Map<String, Object> filters = getFiltersForLaboratoryWorkloadReport();
-
-        com.lowagie.text.pdf.PdfPTable filterTable = new com.lowagie.text.pdf.PdfPTable(8);
-        filterTable.setWidthPercentage(100f);
-        filterTable.setWidths(new float[]{15f, 15f, 15f, 15f, 15f, 15f, 15f, 15f});
-        filterTable.setSpacingAfter(10f);
-
-        List<Map.Entry<String, Object>> entries = new ArrayList<>(filters.entrySet());
-        int totalEntries = entries.size();
-        int cols = 4;
-
-        for (Map.Entry<String, Object> entry : entries) {
-
-            // Label cell
-            com.lowagie.text.pdf.PdfPCell labelCell = new com.lowagie.text.pdf.PdfPCell(
-                    new com.lowagie.text.Phrase(entry.getKey(), labelFont));
-            labelCell.setBorderColor(borderGray);
-            labelCell.setBorderWidth(0.5f);
-            labelCell.setPadding(4f);
-            labelCell.setBackgroundColor(lightGray);
-            filterTable.addCell(labelCell);
-
-            // Value cell
-            String val = entry.getValue() != null ? entry.getValue().toString() : "";
-            com.lowagie.text.pdf.PdfPCell valueCell = new com.lowagie.text.pdf.PdfPCell(
-                    new com.lowagie.text.Phrase(val, valueFont));
-            valueCell.setBorderColor(borderGray);
-            valueCell.setBorderWidth(0.5f);
-            valueCell.setPadding(4f);
-            filterTable.addCell(valueCell);
+    public void exportLaboratoryWorkloadReportToPDF() {
+        if (bundle == null || bundle.getReportTemplateRows() == null || bundle.getReportTemplateRows().isEmpty()) {
+            JsfUtil.addErrorMessage("No data to export. Please process the report first.");
+            return;
         }
 
-        // ── Pad last row with empty cells if needed ───────────────────
-        int remainder = totalEntries % cols;
-        if (remainder != 0) {
-            int emptyCells = (cols - remainder) * 2;
-            for (int i = 0; i < emptyCells; i++) {
-                com.lowagie.text.pdf.PdfPCell empty = new com.lowagie.text.pdf.PdfPCell(
-                        new com.lowagie.text.Phrase(""));
-                empty.setBorderColor(borderGray);
-                empty.setBorderWidth(0.5f);
-                empty.setPadding(4f);
-                filterTable.addCell(empty);
+        com.itextpdf.text.Font bodyFontSmall = com.itextpdf.text.FontFactory.getFont(com.itextpdf.text.FontFactory.HELVETICA, 8);
+        FacesContext context = FacesContext.getCurrentInstance();
+        ExternalContext externalContext = context.getExternalContext();
+        HttpServletResponse response = (HttpServletResponse) externalContext.getResponse();
+        response.reset();
+        String dates = CommonFunctions.dateRangeForFileName(fromDate, toDate, sessionController.getApplicationPreference().getLongDateFormat());
+
+        response.setContentType("application/pdf");
+        if (dates != null && !dates.isEmpty()) {
+            response.setHeader("Content-Disposition", "attachment; filename=laboratory_workload_summmary_report_" + dates + ".pdf");
+        } else {
+            response.setHeader("Content-Disposition", "attachment; filename=laboratory_workload_summary_report.pdf");
+        }
+
+        SimpleDateFormat sdf = new SimpleDateFormat("dd MM yyyy hh:mm:ss a");
+        DecimalFormat df = new DecimalFormat("#,##0.##");
+        String institutionName = sessionController.getInstitution() != null ? sessionController.getInstitution().getName() : "";
+
+        try (OutputStream out = response.getOutputStream()) {
+            com.itextpdf.text.Document document = new com.itextpdf.text.Document(com.itextpdf.text.PageSize.A4.rotate());
+            com.itextpdf.text.pdf.PdfWriter.getInstance(document, out);
+            document.open();
+
+            if (institutionName != null && !institutionName.isEmpty()) {
+                document.add(new com.itextpdf.text.Paragraph(institutionName, com.itextpdf.text.FontFactory.getFont(com.itextpdf.text.FontFactory.HELVETICA_BOLD, 18)));
             }
+            document.add(new com.itextpdf.text.Paragraph("Laboratory Workload Summary Report", com.itextpdf.text.FontFactory.getFont(com.itextpdf.text.FontFactory.HELVETICA_BOLD, 16)));
+            document.add(new com.itextpdf.text.Paragraph("Date: " + sdf.format(new Date()), com.itextpdf.text.FontFactory.getFont(com.itextpdf.text.FontFactory.HELVETICA, 12)));
+            document.add(new com.itextpdf.text.Paragraph(" "));
+
+            int columnCount =3;
+
+            Map<String, Object> filters = getFiltersForLaboratoryWorkloadReport();
+            com.itextpdf.text.pdf.PdfPTable infoTable = pharmacyController.createInfoTablePdfExport(sdf, filters);
+            if (infoTable != null) {
+                document.add(infoTable);
+            }
+
+            com.itextpdf.text.pdf.PdfPTable table = new com.itextpdf.text.pdf.PdfPTable(columnCount);
+            table.setWidthPercentage(100);
+
+            float[] columnWidths;
+            String[] headers;
+
+            columnWidths = new float[]{1f, 3f, 3f};
+            headers = new String[]{"S. No.", "Test Name", "Total Test Performed"};
+
+            table.setWidths(columnWidths);
+
+            for (String header : headers) {
+                com.itextpdf.text.pdf.PdfPCell cell = new com.itextpdf.text.pdf.PdfPCell(new com.itextpdf.text.Phrase(header, com.itextpdf.text.FontFactory.getFont(com.itextpdf.text.FontFactory.HELVETICA_BOLD, 8)));
+                cell.setBackgroundColor(com.itextpdf.text.BaseColor.LIGHT_GRAY);
+                table.addCell(cell);
+            }
+            int indexRow = 1;
+            for (ReportTemplateRow row : bundle.getReportTemplateRows()) {
+                table.addCell(textCell(String.valueOf(indexRow), bodyFontSmall));
+                table.addCell(textCell(row.getCategoryName() !=null ? row.getCategoryName(): "-", bodyFontSmall));
+                
+                table.addCell(numCell(row.getRowValue(), bodyFontSmall));
+                indexRow++;
+
+            }
+            com.itextpdf.text.pdf.PdfPCell footerCell = new com.itextpdf.text.pdf.PdfPCell(new com.itextpdf.text.Phrase("Total", com.itextpdf.text.FontFactory.getFont(com.itextpdf.text.FontFactory.HELVETICA_BOLD, 10)));
+            footerCell.setColspan(2);
+            footerCell.setBackgroundColor(com.itextpdf.text.BaseColor.LIGHT_GRAY);
+            footerCell.setHorizontalAlignment(Element.ALIGN_CENTER);
+            table.addCell(footerCell);
+            table.addCell(numCell(bundle.getTotal(), bodyFontSmall));
+
+            document.add(table);
+            document.close();
+            context.responseComplete();
+
+        } catch (Exception e) {
+            Logger.getLogger(ReportsController.class
+                    .getName()).log(Level.SEVERE, "Error exporting Test Wise Count Report to PDF", e);
         }
-
-        pdf.add(filterTable);
-
-    } catch (com.lowagie.text.DocumentException e) {
-        e.printStackTrace();
     }
-}
+
     
 
     private List<BillTypeAtomic> cancelAndRefundBillTypeAtomics() {

--- a/src/main/webapp/reports/lab/laboratory_workload.xhtml
+++ b/src/main/webapp/reports/lab/laboratory_workload.xhtml
@@ -345,11 +345,8 @@
                             icon="fas fa-file-pdf"
                             ajax="false"
                             value="PDF"
-                            rendered="#{reportsController.reportType eq 'summary'}">
-                        <p:dataExporter type="pdf"
-                                        target="#{'tblExport2'}"
-                                        fileName="laborataory_workload_report_#{reportsController.fromDateFormatted()}_to_#{reportsController.toDateFormatted()}.pdf"
-                                        preProcessor="#{reportsController.preProcessLaboratoryWorkloadSummaryReportPDF}"/>
+                            rendered="#{reportsController.reportType eq 'summary'}"
+                            action="#{reportsController.exportLaboratoryWorkloadReportToPDF()}">
                     </p:commandButton>
                     <p:commandButton
                             class="ui-button-danger my-4 mx-2"


### PR DESCRIPTION
closes #20307
Added null safety on table cells in the laboratory workload detail report. Modified PDF of laboratory workload summary report while using a separate method instead of dataExported(old).
changed files,
01) reportsController.java (add null safety and writePDF exporter method for summary report )
02) laboratory_workload.xhtml (removed dataExporter component and directed to generate PDF from controller file)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved PDF export robustness for laboratory workload reports with null-safe value handling and consistent placeholders for missing data.
  * Fixed pagination and header repetition so large detailed PDFs render correctly across pages.

* **New Features**
  * Redesigned summary PDF export for a clean, consistent three-column layout with totals and filter info.
  * Detail PDF now adjusts columns dynamically by visit type and includes accurate footer totals.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->