### PR TITLE
Normalize default fromDate to start-of-day in PharmacyController

### DIFF
--- a/src/main/java/com/divudi/bean/pharmacy/PharmacyController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacyController.java
@@ -2121,7 +2121,7 @@ public class PharmacyController implements Serializable {
         grantIssueQty = 0.00;
         grantIssueValue = 0.00;
 
-        fromDate = CommonFunctions.addDaysToDate(new Date(), -30L);
+        fromDate = CommonFunctions.getStartOfDay(CommonFunctions.addDaysToDate(new Date(), -30L));
         toDate = CommonFunctions.getEndOfDay(new Date());
 
         pharmacyItem = null;


### PR DESCRIPTION
### Motivation
- Ensure the default 30-day window used by `PharmacyController.clearItemHistory()` includes records on the boundary day by normalizing `fromDate` to 00:00:00 of the day 30 days ago because the previous code preserved the current time-of-day and could exclude early-day records.

### Description
- Replace `fromDate = CommonFunctions.addDaysToDate(new Date(), -30L);` with `fromDate = CommonFunctions.getStartOfDay(CommonFunctions.addDaysToDate(new Date(), -30L));` in `PharmacyController.clearItemHistory()`, keeping `toDate = CommonFunctions.getEndOfDay(new Date());` unchanged.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7bdf0c5b0832fad11272cbbec161c)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved date handling in pharmacy item history clearing by ensuring dates are consistently reset to start-of-day for the past 30-day period.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->