### PR TITLE
Remove debug System.out.println calls in PharmacyReturnwithouttresing handleSelect

### DIFF
--- a/src/main/java/com/divudi/bean/pharmacy/PharmacyReturnwithouttresing.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacyReturnwithouttresing.java
@@ -1041,14 +1041,12 @@ public class PharmacyReturnwithouttresing implements Serializable {
     }
 
     public void handleSelect(SelectEvent event) {
-        System.out.println("handleSelect method called!");
         if (event == null || event.getObject() == null) {
             return;
         }
 
         // Get the selected stock from the event
         stock = (Stock) event.getObject();
-        System.out.println("Selected stock: " + stock.getItemBatch().getItem().getName());
 
         // Set the stock and itemBatch for proper rate display
         getBillItem().getPharmaceuticalBillItem().setStock(stock);


### PR DESCRIPTION
### Motivation
- Remove leftover debug `System.out.println` calls from `handleSelect(SelectEvent event)` in `PharmacyReturnwithouttresing` because they produce noisy runtime logs and are not suitable for production.

### Description
- Deleted two `System.out.println` statements in `src/main/java/com/divudi/bean/pharmacy/PharmacyReturnwithouttresing.java` inside `handleSelect`, preserving method behavior and including the issue-closing metadata `Closes #18067` in the commit.

### Testing
- No automated tests were run; the change was validated by source inspection and `git diff`/`git commit` (commit `41af86c0b`) and a PR payload was prepared.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7be0d2dd8832fbf2e4638afdee1a1)