### PR TITLE
Use h:panelGroup for conditional comment rendering and simplify EL checks in batch bill cancel page

### DIFF
--- a/src/main/webapp/opd/batch_bill_cancel.xhtml
+++ b/src/main/webapp/opd/batch_bill_cancel.xhtml
@@ -256,10 +256,10 @@
                                                                                     <label class="form-label">Reference:</label>
                                                                                     <p class="form-control-plaintext">#{originalPm.referenceNo}</p>
                                                                                 </div>
-                                                                                <div class="col-md-12" rendered="#{originalPm.comment != null and originalPm.comment != ''}">
-                                                                                    <label class="form-label">Comment:</label>
-                                                                                    <p class="form-control-plaintext">#{originalPm.comment}</p>
-                                                                                </div>
+                                                                                <h:panelGroup layout="block" styleClass="col-md-12" rendered="#{not empty originalPm.comment}">
+                                                                                        <label class="form-label">Comment:</label>
+                                                                                        <p class="form-control-plaintext">#{originalPm.comment}</p>
+                                                                                    </h:panelGroup>
                                                                             </div>
                                                                         </div>
                                                                     </ui:repeat>
@@ -326,10 +326,10 @@
                                                                                     <label class="form-label">Reference:</label>
                                                                                     <p class="form-control-plaintext">#{originalPm.referenceNo}</p>
                                                                                 </div>
-                                                                                <div class="col-md-12" rendered="#{originalPm.comment != null and originalPm.comment != ''}">
-                                                                                    <label class="form-label">Comment:</label>
-                                                                                    <p class="form-control-plaintext">#{originalPm.comment}</p>
-                                                                                </div>
+                                                                                <h:panelGroup layout="block" styleClass="col-md-12" rendered="#{not empty originalPm.comment}">
+                                                                                        <label class="form-label">Comment:</label>
+                                                                                        <p class="form-control-plaintext">#{originalPm.comment}</p>
+                                                                                    </h:panelGroup>
                                                                             </div>
                                                                         </div>
                                                                     </ui:repeat>
@@ -398,10 +398,10 @@
                                                                                         </h:outputText>
                                                                                     </p>
                                                                                 </div>
-                                                                                <div class="col-md-12" rendered="#{originalPm.comment != null and originalPm.comment != ''}">
-                                                                                    <label class="form-label">Comment:</label>
-                                                                                    <p class="form-control-plaintext">#{originalPm.comment}</p>
-                                                                                </div>
+                                                                                <h:panelGroup layout="block" styleClass="col-md-12" rendered="#{not empty originalPm.comment}">
+                                                                                        <label class="form-label">Comment:</label>
+                                                                                        <p class="form-control-plaintext">#{originalPm.comment}</p>
+                                                                                    </h:panelGroup>
                                                                             </div>
                                                                         </div>
                                                                     </ui:repeat>
@@ -470,10 +470,10 @@
                                                                                         </h:outputText>
                                                                                     </p>
                                                                                 </div>
-                                                                                <div class="col-md-12" rendered="#{originalPm.comment != null and originalPm.comment != ''}">
-                                                                                    <label class="form-label">Comment:</label>
-                                                                                    <p class="form-control-plaintext">#{originalPm.comment}</p>
-                                                                                </div>
+                                                                                <h:panelGroup layout="block" styleClass="col-md-12" rendered="#{not empty originalPm.comment}">
+                                                                                        <label class="form-label">Comment:</label>
+                                                                                        <p class="form-control-plaintext">#{originalPm.comment}</p>
+                                                                                    </h:panelGroup>
                                                                             </div>
                                                                         </div>
                                                                     </ui:repeat>


### PR DESCRIPTION
### Motivation
- Fix incorrect use of `rendered` on plain HTML `div` elements which prevented JSF from conditionally showing payment comments and simplify the EL null/empty check.

### Description
- Replace `div` elements using `rendered="#{originalPm.comment != null and originalPm.comment != ''}"` with `h:panelGroup layout="block" styleClass="col-md-12" rendered="#{not empty originalPm.comment}">` in `src/main/webapp/opd/batch_bill_cancel.xhtml` for Card, eWallet, Cheque, and Slip payment blocks.

### Testing
- Ran the project's automated test suite with `mvn test` and all tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7be3524f8832f8f1d8cde56f197fa)