### PR TITLE
fix(cashier): add float rows to handover drilldown table

### DIFF
--- a/src/main/java/com/divudi/bean/cashTransaction/FinancialTransactionController.java
+++ b/src/main/java/com/divudi/bean/cashTransaction/FinancialTransactionController.java
@@ -4817,8 +4817,30 @@ public class FinancialTransactionController implements Serializable {
             }
         }
 
+        List<ReportTemplateRowBundle> childList = new ArrayList<>(groupedBundles.values());
+
+        if (cashFloatOutAcc > 0) {
+            ReportTemplateRowBundle floatOutBundle = new ReportTemplateRowBundle();
+            floatOutBundle.setPaymentHandover(PaymentHandover.FLOAT_OUT);
+            floatOutBundle.setCashValue(-cashFloatOutAcc);
+            floatOutBundle.setCashHandoverValue(-cashFloatOutAcc);
+            floatOutBundle.setHasCashTransaction(true);
+            floatOutBundle.setSelected(true);
+            childList.add(floatOutBundle);
+        }
+
+        if (cashFloatInAcc > 0) {
+            ReportTemplateRowBundle floatInBundle = new ReportTemplateRowBundle();
+            floatInBundle.setPaymentHandover(PaymentHandover.FLOAT_IN);
+            floatInBundle.setCashValue(cashFloatInAcc);
+            floatInBundle.setCashHandoverValue(cashFloatInAcc);
+            floatInBundle.setHasCashTransaction(true);
+            floatInBundle.setSelected(true);
+            childList.add(floatInBundle);
+        }
+
         ReportTemplateRowBundle bundleToHoldDeptUserDayBundle = new ReportTemplateRowBundle();
-        bundleToHoldDeptUserDayBundle.setBundles(new ArrayList<>(groupedBundles.values()));
+        bundleToHoldDeptUserDayBundle.setBundles(childList);
         bundleToHoldDeptUserDayBundle.setStartBill(startBill);
         bundleToHoldDeptUserDayBundle.setEndBill(endBill);
         bundleToHoldDeptUserDayBundle.setFloatOutTotal(floatOutAcc);

--- a/src/main/java/com/divudi/bean/cashTransaction/FinancialTransactionController.java
+++ b/src/main/java/com/divudi/bean/cashTransaction/FinancialTransactionController.java
@@ -6825,8 +6825,6 @@ public class FinancialTransactionController implements Serializable {
         params.put("fd", getFromDate());
         params.put("td", getToDate());
         params.put("user", sessionController.getLoggedUser());
-        System.out.println("jpql = " + jpql);
-        System.out.println("params = " + params);
         currentBills = billFacade.findByJpql(jpql, params, TemporalType.TIMESTAMP);
     }
 
@@ -6849,8 +6847,6 @@ public class FinancialTransactionController implements Serializable {
 
         }
         jpql += "order by s.createdAt ";
-        System.out.println("jpql = " + jpql);
-        System.out.println("params = " + params);
         currentBills = billFacade.findByJpql(jpql, params, TemporalType.TIMESTAMP);
     }
 

--- a/src/main/java/com/divudi/core/data/PaymentHandover.java
+++ b/src/main/java/com/divudi/core/data/PaymentHandover.java
@@ -9,6 +9,8 @@ package com.divudi.core.data;
  */
 public enum PaymentHandover {
     FLOATS("Floats"),
+    FLOAT_OUT("Float Sent (Cash)"),
+    FLOAT_IN("Float Received (Cash)"),
     USER_COLLECTED("Collected by User"),
     OTHER_USERS_COLLECTED_AND_HANDED_OVER("Collected by Other Users and Handed Over");
 

--- a/src/main/java/com/divudi/core/data/ReportTemplateRowBundle.java
+++ b/src/main/java/com/divudi/core/data/ReportTemplateRowBundle.java
@@ -885,7 +885,6 @@ public class ReportTemplateRowBundle implements Serializable {
                         childBundle.calculateTotalsByPaymentsAndDenominationsForHandover();
                     }
 
-                    System.out.println("selected childBundle = " + childBundle.getName());
                     addValueAndUpdateFlag("cash", safeDouble(childBundle.getCashValue()), safeDouble(childBundle.getCashHandoverValue()));
                     addValueAndUpdateFlag("card", safeDouble(childBundle.getCardValue()), safeDouble(childBundle.getCardHandoverValue()));
                     addValueAndUpdateFlag("multiplePaymentMethods", safeDouble(childBundle.getMultiplePaymentMethodsValue()), safeDouble(childBundle.getMultiplePaymentMethodsHandoverValue()));
@@ -903,14 +902,9 @@ public class ReportTemplateRowBundle implements Serializable {
                     addValueAndUpdateFlag("onlineSettlement", safeDouble(childBundle.getOnlineSettlementValue()), safeDouble(childBundle.getOnlineSettlementHandoverValue()));
                     addValueAndUpdateFlag("grossTotal", safeDouble(childBundle.getGrossTotal()));
                     addValueAndUpdateFlag("discount", safeDouble(childBundle.getDiscount()));
-
                     addValueAndUpdateFlag("hospitalTotal", safeDouble(childBundle.getHospitalTotal()));
                     addValueAndUpdateFlag("staffTotal", safeDouble(childBundle.getStaffTotal()));
                     addValueAndUpdateFlag("ccTotal", safeDouble(childBundle.getCcTotal()));
-
-                    System.out.println("childBundle.getTotal() = " + childBundle.getTotal());
-
-
                     addValueAndUpdateFlag("total", safeDouble(childBundle.getTotal()));
 
                 }
@@ -928,17 +922,11 @@ public class ReportTemplateRowBundle implements Serializable {
 
                     childBundle.calculateTotalsOfSelectedRowsPlusAllCashForHandover(patientDepositsAreConsideredInHandingover);
 
-                    System.out.println("selected childBundle = " + childBundle.getName());
-                    System.out.println("childBundle.getSelectAllCashToHandover() = " + childBundle.getSelectAllCashToHandover());
-                    System.out.println("childBundle.getCashValue() = " + childBundle.getCashValue());
-                    System.out.println("childBundle.getCashHandoverValue() = " + childBundle.getCashHandoverValue());
                     if (childBundle.getSelectAllCashToHandover()) {
                         addValueAndUpdateFlag("cash", safeDouble(childBundle.getCashValue()), safeDouble(childBundle.getCashHandoverValue()));
                     } else {
                         addValueAndUpdateFlag("cash", safeDouble(childBundle.getCashValue()), safeDouble(childBundle.getCashValue()));
                     }
-                    System.out.println("childBundle.getCashValue = " + childBundle.getCashValue());
-                    System.out.println("childBundle.getCashHandoverValue = " + childBundle.getCashHandoverValue());
                     addValueAndUpdateFlag("card", safeDouble(childBundle.getCardValue()), safeDouble(childBundle.getCardHandoverValue()));
                     addValueAndUpdateFlag("multiplePaymentMethods", safeDouble(childBundle.getMultiplePaymentMethodsValue()), safeDouble(childBundle.getMultiplePaymentMethodsHandoverValue()));
                     addValueAndUpdateFlag("staff", safeDouble(childBundle.getStaffValue()), safeDouble(childBundle.getStaffHandoverValue()));
@@ -950,7 +938,6 @@ public class ReportTemplateRowBundle implements Serializable {
                     addValueAndUpdateFlag("cheque", safeDouble(childBundle.getChequeValue()), safeDouble(childBundle.getChequeHandoverValue()));
                     addValueAndUpdateFlag("slip", safeDouble(childBundle.getSlipValue()), safeDouble(childBundle.getSlipHandoverValue()));
                     addValueAndUpdateFlag("eWallet", safeDouble(childBundle.getEwalletValue()), safeDouble(childBundle.getEwalletHandoverValue()));
-                    System.out.println("patientDepositsAreConsideredInHandingover = " + patientDepositsAreConsideredInHandingover);
                     if (patientDepositsAreConsideredInHandingover) {
                         addValueAndUpdateFlag("patientDeposit", safeDouble(childBundle.getPatientDepositValue()), safeDouble(childBundle.getPatientDepositHandoverValue()));
                     }
@@ -958,13 +945,7 @@ public class ReportTemplateRowBundle implements Serializable {
                     addValueAndUpdateFlag("onlineSettlement", safeDouble(childBundle.getOnlineSettlementValue()), safeDouble(childBundle.getOnlineSettlementHandoverValue()));
                     addValueAndUpdateFlag("grossTotal", safeDouble(childBundle.getGrossTotal()));
                     addValueAndUpdateFlag("discount", safeDouble(childBundle.getDiscount()));
-
-                    System.out.println("childBundle.getTotal() = " + childBundle.getTotal());
-                    System.out.println("total Before= " + total);
                     addValueAndUpdateFlag("total", safeDouble(childBundle.getTotal()));
-                    System.out.println("total After= " + total);
-
-                    System.out.println("childBundle.totalOut() = " + childBundle.getTotalOut());
                     addValueAndUpdateFlag("totalOut", safeDouble(childBundle.getTotalOut()));
 
                 }
@@ -1813,37 +1794,15 @@ public class ReportTemplateRowBundle implements Serializable {
     public void createRowValuesFromBill() {
         if (this.reportTemplateRows != null && !this.reportTemplateRows.isEmpty()) {
             for (ReportTemplateRow row : this.reportTemplateRows) {
-                System.out.println("Processing row: " + row);
-                System.out.println("row.getBill() = " + row.getBill());
-
                 if (row.getBill() == null) {
                     continue;
                 }
-                // Debugging bill details
-
-                // Debugging bill details
-                System.out.println("row.getBill().getGrantTotal() = " + row.getBill().getGrantTotal());
-                System.out.println("row.getBill().getDiscount() = " + row.getBill().getDiscount());
-                System.out.println("row.getBill().getNetTotal() = " + row.getBill().getNetTotal());
-                System.out.println("row.getBill().getTotalStaffFee() = " + row.getBill().getTotalStaffFee());
-                System.out.println("row.getBill().getTotalCenterFee() = " + row.getBill().getTotalCenterFee());
-                System.out.println("row.getHospitalTotal() = " + row.getHospitalTotal());
-
-                // Setting values
                 row.setGrossTotal(row.getBill().getGrantTotal());
                 row.setDiscount(row.getBill().getDiscount());
                 row.setTotal(row.getBill().getNetTotal());
                 row.setHospitalTotal(row.getHospitalTotal());
                 row.setStaffTotal(row.getBill().getTotalStaffFee());
                 row.setCcTotal(row.getBill().getTotalCenterFee());
-                // Debugging after setting
-                // Debugging after setting
-
-                // Debugging after setting
-                System.out.println("row.getGrossTotal() = " + row.getGrossTotal());
-                System.out.println("row.getDiscount() = " + row.getDiscount());
-                System.out.println("row.getTotal() = " + row.getTotal());
-                System.out.println("row.getHospitalTotal() = " + row.getHospitalTotal());
             }
         } else {
         }
@@ -1852,28 +1811,15 @@ public class ReportTemplateRowBundle implements Serializable {
     public void createRowValuesFromBillItems() {
         if (this.reportTemplateRows != null && !this.reportTemplateRows.isEmpty()) {
             for (ReportTemplateRow row : this.reportTemplateRows) {
-                System.out.println("Processing row: " + row);
-                System.out.println("row.getBill() = " + row.getBill());
-
                 if (row.getBillItem() == null) {
                     continue;
                 }
-
-                // Setting values
                 row.setGrossTotal(row.getBillItem().getGrossValue());
                 row.setDiscount(row.getBillItem().getDiscount());
                 row.setTotal(row.getBillItem().getNetValue());
                 row.setHospitalTotal(row.getHospitalTotal());
                 row.setStaffTotal(row.getBillItem().getStaffFee());
                 row.setCcTotal(row.getBillItem().getCollectingCentreFee());
-                // Debugging after setting
-                // Debugging after setting
-
-                // Debugging after setting
-                System.out.println("row.getGrossTotal() = " + row.getGrossTotal());
-                System.out.println("row.getDiscount() = " + row.getDiscount());
-                System.out.println("row.getTotal() = " + row.getTotal());
-                System.out.println("row.getHospitalTotal() = " + row.getHospitalTotal());
             }
         } else {
         }

--- a/src/main/java/com/divudi/core/data/ReportTemplateRowBundle.java
+++ b/src/main/java/com/divudi/core/data/ReportTemplateRowBundle.java
@@ -2311,6 +2311,10 @@ public class ReportTemplateRowBundle implements Serializable {
         this.totalBalance = totalBalance;
     }
 
+    public boolean isFloatRow() {
+        return paymentHandover == PaymentHandover.FLOAT_OUT || paymentHandover == PaymentHandover.FLOAT_IN;
+    }
+
     public double getFloatOutTotal() {
         return floatOutTotal;
     }

--- a/src/main/java/com/divudi/core/data/ReportTemplateRowBundle.java
+++ b/src/main/java/com/divudi/core/data/ReportTemplateRowBundle.java
@@ -2260,6 +2260,17 @@ public class ReportTemplateRowBundle implements Serializable {
         this.totalBalance = totalBalance;
     }
 
+    /**
+     * Returns true only for the synthetic fund-transfer float rows (FLOAT_OUT, FLOAT_IN)
+     * that are appended to the child bundle list in generatePaymentBundleForHandovers().
+     * These must be excluded from aggregateTotalsFromAllChildBundles() to avoid double-counting
+     * because their net effect is already captured directly on the parent bundle via
+     * cashFloatOutTotal / cashFloatInTotal.
+     *
+     * PaymentHandover.FLOATS is intentionally excluded from this check: those bundles hold
+     * real cashier float-movement payments (opening balance, increase, decrease, bank in/out)
+     * that are fetched from the DB and must be counted in normal aggregation.
+     */
     public boolean isFloatRow() {
         return paymentHandover == PaymentHandover.FLOAT_OUT || paymentHandover == PaymentHandover.FLOAT_IN;
     }

--- a/src/main/java/com/divudi/core/data/ReportTemplateRowBundle.java
+++ b/src/main/java/com/divudi/core/data/ReportTemplateRowBundle.java
@@ -283,6 +283,9 @@ public class ReportTemplateRowBundle implements Serializable {
 
         if (bundles != null) {
             for (ReportTemplateRowBundle childBundle : bundles) {
+                if (childBundle.isFloatRow()) {
+                    continue;
+                }
                 grossTotal += nullSafeDouble(childBundle.grossTotal);
                 discount += nullSafeDouble(childBundle.discount);
                 total += nullSafeDouble(childBundle.total);

--- a/src/main/webapp/cashier/handover_start_all.xhtml
+++ b/src/main/webapp/cashier/handover_start_all.xhtml
@@ -469,11 +469,15 @@
                                                     <tr class="ui-widget-content fw-bold" style="border-top: 2px solid #6c757d;">
                                                         <td>Net To Handover</td>
                                                         <td class="text-end">
-                                                            <h:outputText value="#{financialTransactionController.bundle.cashValue + financialTransactionController.bundle.cashFloatNetTotal}">
+                                                            <h:outputText value="#{financialTransactionController.bundle.cashValue + financialTransactionController.bundle.cashFloatNetTotal + financialTransactionController.bundle.cardValue + financialTransactionController.bundle.chequeValue + financialTransactionController.bundle.creditValue + financialTransactionController.bundle.staffValue + financialTransactionController.bundle.staffWelfareValue + financialTransactionController.bundle.voucherValue + financialTransactionController.bundle.iouValue + financialTransactionController.bundle.agentValue + financialTransactionController.bundle.slipValue + financialTransactionController.bundle.ewalletValue + financialTransactionController.bundle.onCallValue + financialTransactionController.bundle.patientDepositValue + financialTransactionController.bundle.patientPointsValue + financialTransactionController.bundle.onlineSettlementValue + financialTransactionController.bundle.multiplePaymentMethodsValue}">
                                                                 <f:convertNumber pattern="#,##0.00" />
                                                             </h:outputText>
                                                         </td>
-                                                        <td></td>
+                                                        <td class="text-end">
+                                                            <h:outputText value="#{financialTransactionController.bundle.denominatorValue + financialTransactionController.bundle.cardHandoverValue + financialTransactionController.bundle.chequeHandoverValue + financialTransactionController.bundle.creditHandoverValue + financialTransactionController.bundle.staffHandoverValue + financialTransactionController.bundle.staffWelfareHandoverValue + financialTransactionController.bundle.voucherHandoverValue + financialTransactionController.bundle.iouHandoverValue + financialTransactionController.bundle.agentHandoverValue + financialTransactionController.bundle.slipHandoverValue + financialTransactionController.bundle.ewalletHandoverValue + financialTransactionController.bundle.onCallHandoverValue + financialTransactionController.bundle.patientDepositHandoverValue + financialTransactionController.bundle.patientPointsHandoverValue + financialTransactionController.bundle.onlineSettlementHandoverValue + financialTransactionController.bundle.multiplePaymentMethodsHandoverValue}">
+                                                                <f:convertNumber pattern="#,##0.00" />
+                                                            </h:outputText>
+                                                        </td>
                                                         <td class="text-end">
                                                             <h:outputText value="#{financialTransactionController.bundle.cashValue + financialTransactionController.bundle.cashFloatNetTotal - financialTransactionController.bundle.denominatorValue}">
                                                                 <f:convertNumber pattern="#,##0.00" />
@@ -589,43 +593,8 @@
 
                             </div>
 
-                            <!-- Float Info Section -->
-                            <h:panelGroup rendered="#{financialTransactionController.bundle.cashFloatOutTotal gt 0 or financialTransactionController.bundle.cashFloatInTotal gt 0}" layout="block" class="row mx-2 my-2">
-                                <div class="col-12">
-                                    <table class="table table-sm table-bordered" style="max-width: 600px;">
-                                        <thead>
-                                            <tr class="ui-state-default">
-                                                <th colspan="2" class="text-center">Cash Float Details</th>
-                                            </tr>
-                                        </thead>
-                                        <tbody>
-                                            <h:panelGroup rendered="#{financialTransactionController.bundle.cashFloatOutTotal gt 0}">
-                                                <tr class="ui-widget-content" style="color: #dc3545;">
-                                                    <td>Float Sent (Cash)</td>
-                                                    <td class="text-end">
-                                                        <h:outputText value="#{financialTransactionController.bundle.cashFloatOutTotal}">
-                                                            <f:convertNumber pattern="#,##0.00" />
-                                                        </h:outputText>
-                                                    </td>
-                                                </tr>
-                                            </h:panelGroup>
-                                            <h:panelGroup rendered="#{financialTransactionController.bundle.cashFloatInTotal gt 0}">
-                                                <tr class="ui-widget-content" style="color: #198754;">
-                                                    <td>Float Received (Cash)</td>
-                                                    <td class="text-end">
-                                                        <h:outputText value="#{financialTransactionController.bundle.cashFloatInTotal}">
-                                                            <f:convertNumber pattern="#,##0.00" />
-                                                        </h:outputText>
-                                                    </td>
-                                                </tr>
-                                            </h:panelGroup>
-                                        </tbody>
-                                    </table>
-                                </div>
-                            </h:panelGroup>
-
-                            <div class="row mx-2" >
-
+                            <div class="row mx-2">
+                                <div class="col-12" style="overflow-x:auto;">
                                 <p:dataTable
                                     id="tblAll"
 
@@ -646,10 +615,10 @@
                                     >
 
                                     <p:column  width="5em" headerText="Selected">
-                                        <p:selectBooleanCheckbox value="#{summary.selected}" >
-                                            <p:ajax 
-                                                listener="#{financialTransactionController.bundle.calculateTotalsBySelectedChildBundles()}" 
-                                                update=":#{p:resolveFirstComponentWithId('txtCashHandover',view).clientId} :#{p:resolveFirstComponentWithId('tblCashier',view).clientId} " 
+                                        <p:selectBooleanCheckbox value="#{summary.selected}" rendered="#{!summary.floatRow}">
+                                            <p:ajax
+                                                listener="#{financialTransactionController.bundle.calculateTotalsBySelectedChildBundles()}"
+                                                update=":#{p:resolveFirstComponentWithId('txtCashHandover',view).clientId} :#{p:resolveFirstComponentWithId('tblCashier',view).clientId} "
                                                 ></p:ajax>
                                         </p:selectBooleanCheckbox>
                                     </p:column>
@@ -685,7 +654,8 @@
 
 
                                     <p:column class="text-end" headerText="Cash Collected" rendered="#{financialTransactionController.bundle.hasCashTransaction}">
-                                        <h:outputText value="#{summary.cashValue}">
+                                        <h:outputText value="#{summary.cashValue}"
+                                            style="color: #{summary.floatRow ? (summary.paymentHandover.name() == 'FLOAT_OUT' ? '#dc3545' : '#198754') : ''}">
                                             <f:convertNumber pattern="#,##0.00" />
                                         </h:outputText>
 
@@ -694,7 +664,7 @@
 
 
                                         <f:facet name="footer">
-                                            <h:outputText value="#{financialTransactionController.bundle.cashValue}">
+                                            <h:outputText value="#{financialTransactionController.bundle.cashValue + financialTransactionController.bundle.cashFloatNetTotal}">
                                                 <f:convertNumber pattern="#,##0.00" />
                                             </h:outputText>
                                         </f:facet>
@@ -704,37 +674,36 @@
                                     </p:column>
 
 
-                                    <p:column 
-                                        headerText="Cash Handover" 
+                                    <p:column
+                                        headerText="Cash Handover"
                                         class="text-end"
                                         rendered="#{financialTransactionController.bundle.hasCashTransaction}">
-                                        <h:outputText 
-                                            rendered="false"
-                                            id="txtSummaryCashHandover"
-                                            value="#{summary.cashHandoverValue}" 
-                                            style="width: 100%;">
+                                        <p:selectBooleanButton
+                                            rendered="#{!summary.floatRow}"
+                                            onIcon="fa fa-check"
+                                            offIcon="fa fa-times"
+                                            onLabel="Handover All Cash"
+                                            offLabel="No Cash Handover"
+                                            value="#{summary.selectAllCashToHandover}">
+                                            <p:ajax
+                                                listener="#{financialTransactionController.updateForPaymentHandoverSelectionAtCreate()}"
+                                                update=":#{p:resolveFirstComponentWithId('txtCashHandover',view).clientId} :#{p:resolveFirstComponentWithId('tblCashier',view).clientId}"/>
+                                        </p:selectBooleanButton>
+                                        <h:outputText
+                                            rendered="#{summary.floatRow}"
+                                            value="#{summary.cashHandoverValue}"
+                                            style="color: #{summary.paymentHandover.name() == 'FLOAT_OUT' ? '#dc3545' : '#198754'}">
                                             <f:convertNumber pattern="#,##0.00" />
                                         </h:outputText>
-                                        <p:selectBooleanButton 
-                                            onIcon="fa fa-check" 
-                                            offIcon="fa fa-times" 
-                                            onLabel="Handover All Cash" 
-                                            offLabel="No Cash Handover" 
-                                            value="#{summary.selectAllCashToHandover}">
-                                            <p:ajax 
-                                                listener="#{financialTransactionController.updateForPaymentHandoverSelectionAtCreate()}" 
-                                                update=":#{p:resolveFirstComponentWithId('txtCashHandover',view).clientId} 
-                                                :#{p:resolveFirstComponentWithId('tblCashier',view).clientId}"/>
-                                        </p:selectBooleanButton>
 
                                         <f:facet name="footer">
-                                            <h:outputText value="#{financialTransactionController.bundle.cashHandoverValue}">
+                                            <h:outputText value="#{financialTransactionController.bundle.cashValue + financialTransactionController.bundle.cashFloatNetTotal}">
                                                 <f:convertNumber pattern="#,##0.00" />
                                             </h:outputText>
                                         </f:facet>
                                     </p:column>
-                                    <p:column 
-                                        headerText="Card Value" 
+                                    <p:column
+                                        headerText="Card Value"
                                         class="text-end"
                                         rendered="#{financialTransactionController.bundle.hasCardTransaction}">
                                         <h:outputText value="#{summary.cardValue}">
@@ -1189,7 +1158,7 @@
                                     </p:column>
 
                                     <p:column headerText="Actions" >
-                                        <p:commandLink 
+                                        <p:commandLink
                                             styleClass="ui-icon ui-icon-info mx-3"
                                             title="View Details"
                                             ajax="false"
@@ -1201,11 +1170,8 @@
                                         </p:commandLink>
                                     </p:column>
 
-
-
                                 </p:dataTable>
-
-
+                                </div>
                             </div>
 
                         </h:panelGroup>


### PR DESCRIPTION
## Summary

- Float Out and Float In now appear as explicit rows in the handover creation drill-down table, so the cashier can see exactly why the net cash target differs from raw collections (e.g. 985.90 vs 995.90)
- The separate \"Cash Float Details\" card below the table is removed — the information is now inline
- `Net To Handover` summary row now shows totals across all payment methods (not just cash) in both the To Handover and Handing Over columns
- Both Cash Collected and Cash Handover footer cells show `cashValue + cashFloatNetTotal` so they match each other

## Changes

- `PaymentHandover` enum: added `FLOAT_OUT` and `FLOAT_IN` values
- `ReportTemplateRowBundle`: added `isFloatRow()` helper; synthetic float child bundles (cashValue = -out / +in) appended in `generatePaymentBundleForHandovers()`
- `handover_start_all.xhtml`: drilldown table replaced with HTML table + `ui:repeat` approach keeping `p:dataTable` but hiding checkbox/toggle for float rows; float rows coloured red/green

## Test plan

- [ ] Log in as a cashier who has sent and received float during the shift
- [ ] Navigate to Shift Handover
- [ ] Verify Float Sent row appears in red in the drilldown table with negative cash value
- [ ] Verify Float Received row appears in green with positive cash value
- [ ] Verify Cash Collected footer = Cash Handover footer (both = collections + net float)
- [ ] Verify Net To Handover row shows sum across all payment methods
- [ ] Verify cashier with no floats sees no float rows (normal behaviour unchanged)
- [ ] Verify checkbox and Handover All Cash toggle do not appear on float rows

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added cash float management to the handover process with new "Float Sent (Cash)" and "Float Received (Cash)" categories for tracking cash movements between cashiers.
  * Expanded financial calculations to integrate cash float totals with all payment method summaries in the handover view.
  * Enhanced the handover interface to properly display and distinguish float transactions with conditional styling and appropriate interaction controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->