### PR TITLE
fix(channel): completeBooking NPE — coop production hotfix

### DIFF
--- a/src/main/java/com/divudi/service/ChannelService.java
+++ b/src/main/java/com/divudi/service/ChannelService.java
@@ -2809,8 +2809,8 @@ public class ChannelService {
         bi.copy(bs.getBillItem());
         bi.setCreatedAt(new Date());
         bi.setBill(b);
-        getBillItemFacade().create(bi);
-        return getBillItemFacade().find(bi.getId());
+        getBillItemFacade().createAndFlush(bi);
+        return bi;
     }
 
     private void savePaidBillFee(Bill b, BillItem bi, BillSession bs) {

--- a/src/main/java/com/divudi/service/ChannelService.java
+++ b/src/main/java/com/divudi/service/ChannelService.java
@@ -2757,7 +2757,7 @@ public class ChannelService {
 
         List<Payment> p = createPayment(paidBill, paidBill.getPaymentMethod());
 
-        OnlineBooking bookingDetails = paidBill.getReferenceBill().getOnlineBooking();
+        OnlineBooking bookingDetails = preBillSession.getBill().getOnlineBooking();
         bookingDetails.setOnlineBookingPayment(agencyCharge);
         bookingDetails.setHospitalFee(paidBill.getHospitalFee());
         bookingDetails.setDoctorFee(paidBill.getStaffFee());
@@ -2765,7 +2765,7 @@ public class ChannelService {
         bookingDetails.setOnlineBookingStatus(OnlineBookingStatus.ACTIVE);
         bookingDetails.setAppoinmentTotalAmount(paidBill.getNetTotal());
 
-        getOnlineBookingFacade().edit(paidBill.getReferenceBill().getOnlineBooking());
+        getOnlineBookingFacade().edit(bookingDetails);
 
         fillBillSessionsAndUpdateBookingsCountInSessionInstance(preBillSession.getSessionInstance());
 

--- a/src/main/java/com/divudi/ws/channel/ChannelApi.java
+++ b/src/main/java/com/divudi/ws/channel/ChannelApi.java
@@ -1459,7 +1459,7 @@ public class ChannelApi {
 
         Bill completedBill = channelService.settleOnlineAgentInitialBooking(temporarySavedBill.getSingleBillSession(), clientsReferanceNo, agencyCharge);
 
-        OnlineBooking bookingDetails = channelService.findOnlineBookingFromRefNo(clientsReferanceNo, false, creditCompany);
+        OnlineBooking bookingDetails = bookingData;
         SessionInstance session = completedBill.getSingleBillSession().getSessionInstance();
 
         try {
@@ -1489,7 +1489,7 @@ public class ChannelApi {
 
         sessionDetails.put("hosId", completedBill.getToInstitution().getId());
         sessionDetails.put("docname", session.getStaff().getPerson().getNameWithTitle());
-        sessionDetails.put("amount", bookingDetails.getNetTotalForOnlineBooking());
+        sessionDetails.put("amount", completedBill.getNetTotal() + agencyCharge);
         sessionDetails.put("hosAmount", completedBill.getHospitalFee());
         sessionDetails.put("docAmount", completedBill.getStaffFee());
         sessionDetails.put("specialization", i.getStaff().getSpeciality().getName());
@@ -1512,7 +1512,7 @@ public class ChannelApi {
         patientDetails.put("nid", bookingDetails.getNic());
 
         Map<String, Object> priceDetails = new HashMap<>();
-        priceDetails.put("totalAmount", bookingDetails.getNetTotalForOnlineBooking());
+        priceDetails.put("totalAmount", completedBill.getNetTotal() + agencyCharge);
         priceDetails.put("docCharge", completedBill.getStaffFee());
         priceDetails.put("hosCharge", completedBill.getHospitalFee());
 

--- a/src/main/java/com/divudi/ws/channel/ChannelApi.java
+++ b/src/main/java/com/divudi/ws/channel/ChannelApi.java
@@ -1459,7 +1459,7 @@ public class ChannelApi {
 
         Bill completedBill = channelService.settleOnlineAgentInitialBooking(temporarySavedBill.getSingleBillSession(), clientsReferanceNo, agencyCharge);
 
-        OnlineBooking bookingDetails = completedBill.getReferenceBill().getOnlineBooking();
+        OnlineBooking bookingDetails = bookingData;
         SessionInstance session = completedBill.getSingleBillSession().getSessionInstance();
 
         try {

--- a/src/main/java/com/divudi/ws/channel/ChannelApi.java
+++ b/src/main/java/com/divudi/ws/channel/ChannelApi.java
@@ -1459,7 +1459,7 @@ public class ChannelApi {
 
         Bill completedBill = channelService.settleOnlineAgentInitialBooking(temporarySavedBill.getSingleBillSession(), clientsReferanceNo, agencyCharge);
 
-        OnlineBooking bookingDetails = bookingData;
+        OnlineBooking bookingDetails = channelService.findOnlineBookingFromRefNo(clientsReferanceNo, false, creditCompany);
         SessionInstance session = completedBill.getSingleBillSession().getSessionInstance();
 
         try {


### PR DESCRIPTION
## Summary

Hotfix for `coop-prod` — cherry-picked from PR #20462 (merged to `development`).

The `/api/channel/complete` endpoint was returning an HTML JSF error page instead of JSON for all calls, due to three chained bugs triggered by JPA lazy-loading and JTA flush timing.

### Bugs fixed

1. **Lazy `referenceBill` NPE** (`ChannelService.java`) — after `editAndCommit()`, the `@ManyToOne(LAZY) referenceBill` proxy on `paidBill` became unresolvable. Fixed by reading `onlineBooking` directly from `preBillSession.getBill()` (already in persistence context).

2. **`savePaidBillItem()` returns null** (`ChannelService.java`) — `create()` only calls `persist()` with no flush, so `bi.getId()` is null under JTA. `find(null)` returns null → NPE. Fixed by using `createAndFlush(bi)` and returning `bi` directly.

3. **`bookingData` null after re-fetch** (`ChannelApi.java`) — after settlement the `OnlineBooking` was re-fetched by ref no, but the auto-retire background timer had already set `RETIRED=1`. Fixed by using the pre-fetched `bookingData` reference for patient/booking fields and deriving financial totals from `completedBill.getNetTotal() + agencyCharge`.

## Impact

- `/api/channel/complete` has never successfully completed on coop production
- All 7 pending bookings in the DB timed out and were retired due to this bug
- Affects doc990 integration (and any future online booking agent)

## Testing

- Reproduced and fixed locally against coop DB backup
- Full end-to-end test (save → complete) confirmed returning `202` JSON with `status: ACTIVE`
- Also verified against staging (`stg.carecode.org/coop`) which uses the production DB

Closes #20461

Co-Authored-By: Claude <noreply@anthropic.com>