### PR TITLE
19887 need to improve collection center receipt report print pdf excel

### DIFF
--- a/src/main/java/com/divudi/bean/report/ReportController.java
+++ b/src/main/java/com/divudi/bean/report/ReportController.java
@@ -3894,6 +3894,101 @@ public class ReportController implements Serializable, ControllerWithReportFilte
         return filters;
     }
     
+    public void exportCollectionCenterReciptReportToPDF(){
+        if (bundle == null || bundle.getReportTemplateRows() == null || bundle.getReportTemplateRows().isEmpty()) {
+            JsfUtil.addErrorMessage("No data to export. Please process the report first.");
+            return;
+        }
+
+        com.itextpdf.text.Font bodyFontSmall = com.itextpdf.text.FontFactory.getFont(com.itextpdf.text.FontFactory.HELVETICA, 8);
+        FacesContext context = FacesContext.getCurrentInstance();
+        ExternalContext externalContext = context.getExternalContext();
+        HttpServletResponse response = (HttpServletResponse) externalContext.getResponse();
+        response.reset();
+        String dates = CommonFunctions.dateRangeForFileName(fromDate, toDate, sessionController.getApplicationPreference().getLongDateFormat());
+
+        response.setContentType("application/pdf");
+        if (dates != null && !dates.isEmpty()) {
+            response.setHeader("Content-Disposition", "attachment; filename=Collection_center_recipt_report_" + dates + ".pdf");
+        } else {
+            response.setHeader("Content-Disposition", "attachment; filename=Collection_center_recipt_report.pdf");
+        }
+
+        SimpleDateFormat sdf = new SimpleDateFormat("dd MM yyyy hh:mm:ss a");
+        DecimalFormat df = new DecimalFormat("#,##0.##");
+        String institutionName = sessionController.getInstitution() != null ? sessionController.getInstitution().getName() : "";
+
+        try (OutputStream out = response.getOutputStream()) {
+            com.itextpdf.text.Document document = new com.itextpdf.text.Document(com.itextpdf.text.PageSize.A4.rotate());
+            com.itextpdf.text.pdf.PdfWriter.getInstance(document, out);
+            document.open();
+
+            if (institutionName != null && !institutionName.isEmpty()) {
+                document.add(new com.itextpdf.text.Paragraph(institutionName, com.itextpdf.text.FontFactory.getFont(com.itextpdf.text.FontFactory.HELVETICA_BOLD, 18)));
+            }
+            document.add(new com.itextpdf.text.Paragraph("Collection Center Recipt Report", com.itextpdf.text.FontFactory.getFont(com.itextpdf.text.FontFactory.HELVETICA_BOLD, 16)));
+            document.add(new com.itextpdf.text.Paragraph("Date: " + sdf.format(new Date()), com.itextpdf.text.FontFactory.getFont(com.itextpdf.text.FontFactory.HELVETICA, 12)));
+            document.add(new com.itextpdf.text.Paragraph(" "));
+
+            int columnCount = 9;
+
+            Map<String, Object> filters = getFiltersForCollectionCenterReciptReport();
+            com.itextpdf.text.pdf.PdfPTable infoTable = pharmacyController.createInfoTablePdfExport(sdf, filters);
+            if (infoTable != null) {
+                document.add(infoTable);
+            }
+
+            com.itextpdf.text.pdf.PdfPTable table = new com.itextpdf.text.pdf.PdfPTable(columnCount);
+            table.setWidthPercentage(100);
+
+            float[] columnWidths;
+            String[] headers;
+
+            columnWidths = new float[]{0.5f, 3f, 2f, 2f, 1f, 1f, 3f, 2f, 2f};
+            headers = new String[]{"S. No.", "Bill No.", "Billed At", "Billed By", "Payment Method", "Agent Code", "Agent Name", "Amount", "Comments"};
+
+            table.setWidths(columnWidths);
+
+            for (String header : headers) {
+                com.itextpdf.text.pdf.PdfPCell cell = new com.itextpdf.text.pdf.PdfPCell(new com.itextpdf.text.Phrase(header, com.itextpdf.text.FontFactory.getFont(com.itextpdf.text.FontFactory.HELVETICA_BOLD, 8)));
+                cell.setBackgroundColor(com.itextpdf.text.BaseColor.LIGHT_GRAY);
+                table.addCell(cell);
+            }
+            int indexRow = 1;
+            for (ReportTemplateRow row : bundle.getReportTemplateRows()) {
+                table.addCell(textCell(String.valueOf(indexRow), bodyFontSmall));
+                Bill b = row.getBill();
+                table.addCell(textCell(b.getDeptId(), bodyFontSmall));
+                table.addCell(textCell( b.getCreatedAt() != null ? sdf.format(b.getCreatedAt()) : "-", bodyFontSmall));
+                table.addCell(textCell(b.getCreater().getName(), bodyFontSmall));
+                table.addCell(textCell(b.getPaymentMethod().getLabel(), bodyFontSmall));
+                table.addCell(textCell(b.getFromInstitution().getCode(), bodyFontSmall));
+                table.addCell(textCell(b.getFromInstitution().getName(), bodyFontSmall));
+
+                table.addCell(numCell(b.getTotal(), bodyFontSmall));
+                table.addCell(textCell(b.getComments(), bodyFontSmall));
+                indexRow++;
+
+            }
+            com.itextpdf.text.pdf.PdfPCell footerCell = new com.itextpdf.text.pdf.PdfPCell(new com.itextpdf.text.Phrase("Total", com.itextpdf.text.FontFactory.getFont(com.itextpdf.text.FontFactory.HELVETICA_BOLD, 10)));
+            footerCell.setColspan(7);
+            footerCell.setBackgroundColor(com.itextpdf.text.BaseColor.LIGHT_GRAY);
+            footerCell.setHorizontalAlignment(Element.ALIGN_CENTER);
+            table.addCell(footerCell);
+            table.addCell(numCell(bundle.getTotal(), bodyFontSmall));
+            table.addCell(textCell("-", bodyFontSmall));
+            
+            document.add(table);
+            document.close();
+            context.responseComplete();
+
+        } catch (Exception e) {
+            Logger.getLogger(ReportController.class
+                    .getName()).log(Level.SEVERE, "Error exporting Test Wise Count Report to PDF", e);
+        }
+    }
+    
+            
         // PostProcessor for collection center recipt report excel export
     public void postProcessCollectionCenterReciptReportExcel(Object document) {
         if (document == null) {

--- a/src/main/java/com/divudi/bean/report/ReportController.java
+++ b/src/main/java/com/divudi/bean/report/ReportController.java
@@ -3954,15 +3954,15 @@ public class ReportController implements Serializable, ControllerWithReportFilte
             for (ReportTemplateRow row : bundle.getReportTemplateRows()) {
                 table.addCell(textCell(String.valueOf(indexRow), bodyFontSmall));
                 Bill b = row.getBill();
-                table.addCell(textCell(b.getDeptId(), bodyFontSmall));
+                table.addCell(textCell(b.getDeptId() != null ? b.getDeptId() : "-" , bodyFontSmall));
                 table.addCell(textCell( b.getCreatedAt() != null ? sdf.format(b.getCreatedAt()) : "-", bodyFontSmall));
-                table.addCell(textCell(b.getCreater().getName(), bodyFontSmall));
-                table.addCell(textCell(b.getPaymentMethod().getLabel(), bodyFontSmall));
-                table.addCell(textCell(b.getFromInstitution().getCode(), bodyFontSmall));
-                table.addCell(textCell(b.getFromInstitution().getName(), bodyFontSmall));
+                table.addCell(textCell(b.getCreater() != null ?  b.getCreater().getName() : "-", bodyFontSmall));
+                table.addCell(textCell(b.getPaymentMethod() != null ? b.getPaymentMethod().getLabel() : "-", bodyFontSmall));
+                table.addCell(textCell(b.getFromInstitution() != null ?  b.getFromInstitution().getCode() : "-", bodyFontSmall));
+                table.addCell(textCell(b.getFromInstitution() != null ? b.getFromInstitution().getName() : "-", bodyFontSmall));
 
                 table.addCell(numCell(b.getTotal(), bodyFontSmall));
-                table.addCell(textCell(b.getComments(), bodyFontSmall));
+                table.addCell(textCell(b.getComments() != null ? b.getComments() : "-", bodyFontSmall));
                 indexRow++;
 
             }
@@ -3980,7 +3980,7 @@ public class ReportController implements Serializable, ControllerWithReportFilte
 
         } catch (Exception e) {
             Logger.getLogger(ReportController.class
-                    .getName()).log(Level.SEVERE, "Error exporting Test Wise Count Report to PDF", e);
+                    .getName()).log(Level.SEVERE, "Error exporting Collection center recipt report to PDF", e);
         }
     }
     

--- a/src/main/java/com/divudi/bean/report/ReportController.java
+++ b/src/main/java/com/divudi/bean/report/ReportController.java
@@ -3890,6 +3890,7 @@ public class ReportController implements Serializable, ControllerWithReportFilte
         return filters;
     }
     
+    // collection center receipt report pdf generation method
     public void exportCollectionCenterReciptReportToPDF(){
         if (bundle == null || bundle.getReportTemplateRows() == null || bundle.getReportTemplateRows().isEmpty()) {
             JsfUtil.addErrorMessage("No data to export. Please process the report first.");
@@ -3905,9 +3906,9 @@ public class ReportController implements Serializable, ControllerWithReportFilte
 
         response.setContentType("application/pdf");
         if (dates != null && !dates.isEmpty()) {
-            response.setHeader("Content-Disposition", "attachment; filename=Collection_center_recipt_report_" + dates + ".pdf");
+            response.setHeader("Content-Disposition", "attachment; filename=Collection_center_receipt_report_" + dates + ".pdf");
         } else {
-            response.setHeader("Content-Disposition", "attachment; filename=Collection_center_recipt_report.pdf");
+            response.setHeader("Content-Disposition", "attachment; filename=Collection_center_receipt_report.pdf");
         }
 
         SimpleDateFormat sdf = new SimpleDateFormat("dd MM yyyy hh:mm:ss a");
@@ -3922,7 +3923,7 @@ public class ReportController implements Serializable, ControllerWithReportFilte
             if (institutionName != null && !institutionName.isEmpty()) {
                 document.add(new com.itextpdf.text.Paragraph(institutionName, com.itextpdf.text.FontFactory.getFont(com.itextpdf.text.FontFactory.HELVETICA_BOLD, 18)));
             }
-            document.add(new com.itextpdf.text.Paragraph("Collection Center Recipt Report", com.itextpdf.text.FontFactory.getFont(com.itextpdf.text.FontFactory.HELVETICA_BOLD, 16)));
+            document.add(new com.itextpdf.text.Paragraph("Collection Center Receipt Report", com.itextpdf.text.FontFactory.getFont(com.itextpdf.text.FontFactory.HELVETICA_BOLD, 16)));
             document.add(new com.itextpdf.text.Paragraph("Date: " + sdf.format(new Date()), com.itextpdf.text.FontFactory.getFont(com.itextpdf.text.FontFactory.HELVETICA, 12)));
             document.add(new com.itextpdf.text.Paragraph(" "));
 
@@ -3980,7 +3981,7 @@ public class ReportController implements Serializable, ControllerWithReportFilte
 
         } catch (Exception e) {
             Logger.getLogger(ReportController.class
-                    .getName()).log(Level.SEVERE, "Error exporting Collection center recipt report to PDF", e);
+                    .getName()).log(Level.SEVERE, "Error exporting Collection center receipt report to PDF", e);
         }
     }
     

--- a/src/main/webapp/reports/collectionCenterReports/collection_center_recipt_report_view.xhtml
+++ b/src/main/webapp/reports/collectionCenterReports/collection_center_recipt_report_view.xhtml
@@ -11,10 +11,10 @@
             <ui:define name="content">
 
                 <h:form >
-                    <p:panel header="Collection Center Recipt Report Print" styleClass="w-100">
+                    <p:panel header="Collection Center Receipt Report Print" styleClass="w-100">
                         <f:facet name="header"  >
                             <div class="d-flex justify-content-between">
-                                <h:outputText value="Collection Center Recipt Report Print" class="mt-2"/>
+                                <h:outputText value="Collection Center Receipt Report Print" class="mt-2"/>
                                 <div class="d-flex gap-2">
                                     <p:commandButton 
                                         icon="fa-solid fa-print"
@@ -127,7 +127,7 @@
                                         <h:outputText value="#{sessionController.institution.name}"/>
                                     </div>
                                     <div class="d-flex justify-content-center text-5 gap-2" style="font-weight: 700; font-size: 18px;">
-                                        <h:outputText value="Collection Center Recipt Report Print"/>
+                                        <h:outputText value="Collection Center Receipt Report Print"/>
                                         <h:panelGroup  rendered="#{reportController.department ne null}">
                                             <div class="d-flex gap-2">
                                                 <h:outputText value="-" style="width: 1em!important;" class="text-center"/>

--- a/src/main/webapp/reports/collectionCenterReports/collection_center_recipt_report_view.xhtml
+++ b/src/main/webapp/reports/collectionCenterReports/collection_center_recipt_report_view.xhtml
@@ -1,0 +1,281 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
+      xmlns:h="http://xmlns.jcp.org/jsf/html"
+      xmlns:p="http://primefaces.org/ui"
+      xmlns:f="http://xmlns.jcp.org/jsf/core">
+
+    <h:body>
+        <ui:composition template="/resources/template/template.xhtml">
+            <ui:define name="content">
+
+                <h:form >
+                    <p:panel header="Collection Center Recipt Report Print" styleClass="w-100">
+                        <f:facet name="header"  >
+                            <div class="d-flex justify-content-between">
+                                <h:outputText value="Collection Center Recipt Report Print" class="mt-2"/>
+                                <div class="d-flex gap-2">
+                                    <p:commandButton 
+                                        icon="fa-solid fa-print"
+                                        class="ui-button-info"
+                                        style="width: 150px"
+                                        ajax="false" 
+                                        value="Print">
+                                        <p:printer target="reportView" />
+                                    </p:commandButton>
+                                    <p:commandButton 
+                                        ajax="false" 
+                                        value="Back to Report" 
+                                        style="width: 200px"
+                                        icon="fa fa-arrow-left"
+                                        class="ui-button-warning"
+                                        action="collection_center_recipt_reports?faces-redirect=true" >
+                                    </p:commandButton>
+                                </div>
+
+                            </div>
+                        </f:facet>
+
+                        <style>
+
+                            @media screen{
+                                .paper{
+                                    position: static !important;
+                                    width: 297mm!important;
+                                    zoom: 2.0;
+                                }
+                                
+                                table {
+                                    border-collapse: collapse;
+                                    width: 100%;
+                                    font-size: 12px!important;
+                                    margin-top: 1mm!important;
+                                }
+                                
+                                th, td {
+                                    border: 1px solid #000;
+                                    padding: 0px!important;
+                                    margin: 2px!important;
+                                    text-align: left;
+                                    margin-left: 10mm!important;
+                                }
+                                
+                                .header{
+                                    font-size: 16px!important;
+                                }
+                                
+                                tfoot{
+                                    font-weight: 700!important;
+                                    font-size: 11px!important;
+                                }
+                            }
+
+                            @media print {
+                                @page {
+                                    @bottom-right {
+                                        content: "Page " counter(page) " of " counter(pages);
+                                        font-family: Arial, sans-serif;
+                                        font-size: 10pt;
+                                    }
+                                    size: A4 landscape;
+                                }
+
+                                body {
+                                    counter-reset: page;
+                                }
+
+                                .paper{
+                                    position: static !important;
+                                    width: 297mm!important;
+
+                                }
+
+                                .header{
+                                    line-height: 1.1;
+                                    margin: 0mm!important;
+                                    font-size: 13px!important;
+                                }
+
+                                table {
+                                    border-collapse: collapse;
+                                    width: 99.9%;
+                                    font-size: 12px!important;
+                                    margin-top: 1mm!important;
+                                }
+                                th, td {
+                                    border: 1px solid #000;
+                                    padding: 0px!important;
+                                    margin: 2px!important;
+                                    text-align: left;
+                                    margin-left: 10mm!important;
+                                }
+                                th {
+
+                                }
+                                tfoot{
+                                    font-weight: 700!important;
+                                    font-size: 11px!important;
+                                }
+                            }
+                        </style>
+
+                        <h:panelGroup id="reportView" class="d-flex justify-content-center">
+                            <div class="paper">
+                                <div class="header" >
+                                    <div class="d-flex justify-content-center text-5 gap-2" style="font-weight: 700; font-size: 22px;">
+                                        <h:outputText value="#{sessionController.institution.name}"/>
+                                    </div>
+                                    <div class="d-flex justify-content-center text-5 gap-2" style="font-weight: 700; font-size: 18px;">
+                                        <h:outputText value="Collection Center Recipt Report Print"/>
+                                        <h:panelGroup  rendered="#{reportController.department ne null}">
+                                            <div class="d-flex gap-2">
+                                                <h:outputText value="-" style="width: 1em!important;" class="text-center"/>
+                                                <h:outputText value="#{reportController.department.name}"/>
+                                            </div>
+                                        </h:panelGroup>
+                                    </div>
+                                    <div class="d-flex justify-content-center mt-2" style="font-size:12px; flex-wrap:wrap; gap:16px;">
+    
+                                        <div class="d-flex gap-2">
+                                            <h:outputText value="From Date" style="font-weight:600;"/>
+                                            <h:outputText value="#{reportController.fromDate}">
+                                                <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateTimeFormat}" />
+                                            </h:outputText>
+                                        </div>
+
+                                        <div class="d-flex gap-2">
+                                            <h:outputText value="To Date" style="font-weight:600;"/>
+                                            <h:outputText value="#{reportController.toDate}">
+                                                <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateTimeFormat}" />
+                                            </h:outputText>
+                                        </div>
+                                        
+                                        <div class="d-flex gap-2">
+                                            <h:outputText value="Institution" style="font-weight:600;"/>
+                                            <h:outputText value="#{empty reportController.institution ? 'All institutions' : reportContrller.institution.name}"/>
+                                        </div>
+
+                                        <div class="d-flex gap-2">
+                                            <h:outputText value="Site" style="font-weight:600;"/>
+                                            <h:outputText value="#{empty reportController.site ? 'All Sites' : reportController.site.name}"/>
+                                        </div>
+
+                                        <div class="d-flex gap-2">
+                                            <h:outputText value="Department" style="font-weight:600;"/>
+                                            <h:outputText 
+                                                value="#{empty reportController.department ? 'All departments' : reportController.department.name}"/>
+                                        </div>
+
+                                        <div class="d-flex gap-2">
+                                            <h:outputText value="CC Route" style="font-weight:600;"/>
+                                            <h:outputText 
+                                                value="#{empty reportController.route ? 'All Routes' : reportController.route.name}"/>
+                                        </div>
+
+                                        <div class="d-flex gap-2">
+                                            <h:outputText value="CC Name" style="font-weight:600;"/>
+                                            <h:outputText value="#{empty reportController.collectingCentre ? 'All Collection Centers' : reportController.collectingCentre.name}"/>
+                                        </div>
+
+                                    </div>
+                                </div>
+
+                                <div>
+                                    <table>
+                                        <thead>
+                                            <tr>
+                                                <th style="width: 7mm; font-weight: 700;">
+                                                    <h:outputText value="S. No." style="margin-left: 1mm;"/>
+                                                </th>
+                                                <th style="width: 25mm;font-weight: 700;">
+                                                    <h:outputText value="Bill No" style="margin-left: 1mm;"/>
+                                                </th>
+                                                <th style="width: 17mm; font-weight: 700; text-align: left;">
+                                                    <h:outputText value="Billed At" style="margin-left:  1mm;"/>
+                                                </th>
+                                                <th style="width: 17mm; font-weight: 700; text-align: right;">
+                                                    <h:outputText value="Billed By" style="margin-right: 1mm;"/>
+                                                </th>
+                                                <th style="width: 17mm; font-weight: 700; text-align: right;">
+                                                    <h:outputText value="Payment Method" style="margin-right: 1mm;"/>
+                                                </th>
+                                                <th style="width: 17mm; font-weight: 700; text-align: right;">
+                                                    <h:outputText value="Agent Code" style="margin-right: 1mm;"/>
+                                                </th>
+                                                <th style="width: 17mm; font-weight: 700; text-align: right;">
+                                                    <h:outputText value="Agent Name" style="margin-right: 1mm;"/>
+                                                </th>
+                                                <th style="width: 17mm; font-weight: 700; text-align: right;">
+                                                    <h:outputText value="Amount" style="margin-right: 1mm;"/>
+                                                </th>
+                                                <th style="width: 17mm; font-weight: 700; text-align: center;">
+                                                    <h:outputText value="Comments" style="margin-right: 1mm;"/>
+                                                </th>
+                                               
+                                            </tr>
+                                        </thead>
+                                        <tbody>
+                                            <ui:repeat value="#{reportController.bundle.reportTemplateRows}" var="row" varStatus="i">
+                                                <tr>
+                                                    <td style="width: 8mm;">
+                                                        <h:outputText value="#{i.index + 1}" style="margin-left: 1mm;"/>
+                                                    </td>
+                                                    <td style="width: 25mm; text-align: left;">
+                                                        <h:outputText value="#{row.bill.deptId}" style="margin-left: 1mm;"/>
+                                                    </td>
+                                                    <td style="width: 25mm; text-align: left;">
+                                                        <h:outputText value="#{row.bill.createdAt}" style="margin-left: 1mm;">
+                                                            <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateTimeFormat}" />
+                                                        </h:outputText>
+                                                    </td>
+                                                    <td style="width: 20mm; text-align: left;">
+                                                        <h:outputText value="#{row.bill.creater.name}" style="margin-left: 1mm;"/>
+                                                    </td>
+                                                    <td style="width: 20mm; text-align: left;">
+                                                        <h:outputText value="#{row.bill.paymentMethod}" style="margin-left: 1mm;"/>
+                                                    </td>
+                                                    <td style="width: 17mm; text-align: left;">
+                                                        <h:outputText value="#{row.bill.fromInstitution.code}" style="margin-left: 1mm;"/>
+                                                    </td>
+                                                    <td style="width: 25mm; text-align: left;">
+                                                        <h:outputText value="#{row.bill.fromInstitution.name}" style="margin-left: 1mm;"/>
+                                                    </td>
+                                                    <td style="width: 17mm; text-align: right;">
+                                                        <h:outputText value="#{row.bill.total}" style="margin-right: 1mm;">
+                                                            <f:convertNumber pattern="#,##0.00" />
+                                                        </h:outputText>
+                                                    </td>
+                                                    <td style="width: 30mm; text-align: left;">
+                                                        <h:outputText value="#{row.bill.comments}" style="margin-left: 1mm;"/>
+                                                    </td>
+                                                </tr>
+                                            </ui:repeat>
+                                        </tbody>
+                                        <tfoot>
+                                            <tr>
+                                                <td colspan="7" style="120mm; text-align: center" >
+                                                    <h:outputText value="Total"/>
+                                                </td>
+                                                <td style="width: 17mm; text-align: right;">
+                                                    <h:outputText value="#{reportController.bundle.total}" style="padding: 0px!important; margin: 0px!important; font-weight: bold; margin-right: 1mm;">
+                                                        <f:convertNumber pattern="#,##0.00" />
+                                                    </h:outputText>
+                                                </td>
+                                                <td style="width: 30mm; text-align: left;" />
+                                            </tr>
+                                        </tfoot>
+                                    </table>
+
+                                </div>
+
+                            </div>
+                        </h:panelGroup>
+
+                    </p:panel>
+                </h:form>
+            </ui:define>
+        </ui:composition>
+
+    </h:body>
+</html>

--- a/src/main/webapp/reports/collectionCenterReports/collection_center_recipt_report_view.xhtml
+++ b/src/main/webapp/reports/collectionCenterReports/collection_center_recipt_report_view.xhtml
@@ -153,7 +153,7 @@
                                         
                                         <div class="d-flex gap-2">
                                             <h:outputText value="Institution" style="font-weight:600;"/>
-                                            <h:outputText value="#{empty reportController.institution ? 'All institutions' : reportContrller.institution.name}"/>
+                                            <h:outputText value="#{empty reportController.institution ? 'All institutions' : reportController.institution.name}"/>
                                         </div>
 
                                         <div class="d-flex gap-2">
@@ -254,7 +254,7 @@
                                         </tbody>
                                         <tfoot>
                                             <tr>
-                                                <td colspan="7" style="120mm; text-align: center" >
+                                                <td colspan="7" style="width: 120mm; text-align: center" >
                                                     <h:outputText value="Total"/>
                                                 </td>
                                                 <td style="width: 17mm; text-align: right;">

--- a/src/main/webapp/reports/collectionCenterReports/collection_center_recipt_reports.xhtml
+++ b/src/main/webapp/reports/collectionCenterReports/collection_center_recipt_reports.xhtml
@@ -157,8 +157,8 @@
                                 class="mx-1 ui-button-info"
                                 style="width: 150px"
                                 ajax="false" 
-                                value="Print">
-                                <p:printer target="tblData" />
+                                value="Print"
+                                action="collection_center_recipt_report_view?faces-redirect=true">
                             </p:commandButton>
                             <p:commandButton 
                                 class="m-2 ui-button-success" 
@@ -178,8 +178,8 @@
                                 icon="fa-solid fa-file-pdf"
                                 style="width: 150px"
                                 ajax="false" 
-                                onclick="generatePDF()"
-                                value="PDF">
+                                value="PDF"
+                                action="#{reportController.exportCollectionCenterReciptReportToPDF()}">
                             </p:commandButton>
 
                         </h:panelGrid>
@@ -242,6 +242,10 @@
                             </p:column>
                             <p:column headerText="Agent Name" >
                                 <h:outputText value="#{row.bill.fromInstitution.name}" ></h:outputText>
+                                <f:facet name="footer" >
+                                    <h:outputLabel value="Total" >
+                                    </h:outputLabel>
+                                </f:facet>
                             </p:column>
                             <p:column headerText="Amount" class="text-end" sortBy="#{row.bill.total}">
                                 <h:outputText value="#{row.bill.total}" >
@@ -257,65 +261,6 @@
                                 <h:outputText value="#{row.bill.comments}" ></h:outputText>
                             </p:column>
                         </p:dataTable>
-
-                        <table id="tbl" style="display: none;">
-                            <thead>
-                                <tr>
-                                    <th style="width: 3em;">S. No</th>
-                                    <th>Bill No</th>
-                                    <th>Billed at</th>
-                                    <th>Billed By</th>
-                                    <th>Payment Method</th>
-                                    <th>Agent Code</th>
-                                    <th>Agent Name</th>
-                                    <th>Amount</th>
-                                    <th>Comments</th>
-                                </tr>
-                            </thead>
-                            <tbody>
-                                <ui:repeat value="#{reportController.bundle.reportTemplateRows}" var="row" varStatus="status">
-                                    <tr>
-                                        <td>#{status.index + 1}</td>
-                                        <td>
-                                            #{row.bill.referenceNumber}
-                                        </td>
-                                        <td>
-                                            <h:outputText value="#{row.bill.createdAt}">
-                                                <f:convertDateTime pattern="#{sessionController.applicationPreference.shortDateTimeFormat}" />
-                                            </h:outputText>
-                                        </td>
-                                        <td>#{row.bill.creater.name}</td>
-                                        <td>#{row.bill.paymentMethod}</td>
-                                        <td>#{row.bill.fromInstitution.code}</td>
-                                        <td>#{row.bill.fromInstitution.name}</td>
-                                        <td>#{row.bill.total}</td>
-                                        <td>#{row.bill.comments}</td>
-                                    </tr>
-                                </ui:repeat>
-                            </tbody>
-                            <tfoot>
-                                <tr>
-                                    <th colspan="7">Total</th>
-                                    <th>
-                                        <h:outputLabel value="#{reportController.bundle.total}" >
-                                            <f:convertNumber pattern="#,##0.00" ></f:convertNumber>
-                                        </h:outputLabel>
-                                    </th>
-                                    <th></th>
-                                </tr>
-                            </tfoot>
-                        </table>
-
-
-                        <script>
-                                    function generatePDF() {
-                                        const {jsPDF} = window.jspdf;
-                                        const doc = new jsPDF();
-                                        doc.autoTable({html: '#tbl'});
-                                        doc.save('collecting_center_receipt_report.pdf');
-                                    }
-                        </script>
-
                     </p:panel>
                 </h:form>
 


### PR DESCRIPTION
closes #19887 
Improved PDF generation using a separate method instead of dataExporter. Also, I created a page to give a better view of the print preview.
Changed files,
01) reportController.java (create method to generate PDF)
02) collection_center_recipt_report.xhtml (removed unwanted scripts that write to generate PDF)
03) collection_center_recipt_report_view.html (to give better print preview)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Server-side PDF export for Collection Center Receipt Report
  * Dedicated print/preview view for the report

* **Improvements**
  * Print and PDF actions now use server-side processing for more reliable output
  * Report layout updated: formatted date range/header, per-row details, and a “Total” footer for clearer summaries
<!-- end of auto-generated comment: release notes by coderabbit.ai -->