### PR TITLE
fix(inward): room charge overbills when remainder is within overshoot grace period

### DIFF
--- a/src/main/java/com/divudi/bean/inward/BhtSummeryController.java
+++ b/src/main/java/com/divudi/bean/inward/BhtSummeryController.java
@@ -2819,14 +2819,7 @@ public class BhtSummeryController implements Serializable {
         }
 
         if (getPatientEncounter().getCurrentPatientRoom().equals(patientRoom)) {
-            if (patientRoom.isDischarged()) {
-                //System.out.println("value * getInwardBean().calCount(timedFee, patientRoom.getAdmittedAt(), dischargeAt); = " + value * getInwardBean().calCount(timedFee, patientRoom.getAdmittedAt(), dischargeAt));
-                return value * getInwardBean().calCount(timedFee, patientRoom.getAdmittedAt(), dischargeAt);
-            } else {
-                // System.out.println("value * getInwardBean().calCountWithoutOverShoot(timedFee, patientRoom.getAdmittedAt(), dischargeAt) = " + value * getInwardBean().calCountWithoutOverShoot(timedFee, patientRoom.getAdmittedAt(), dischargeAt));
-                return value * getInwardBean().calCountWithoutOverShoot(timedFee, patientRoom.getAdmittedAt(), dischargeAt);
-            }
-
+            return value * getInwardBean().calCount(timedFee, patientRoom.getAdmittedAt(), dischargeAt);
         } else {
             //System.out.println("value * getInwardBean().calCount(timedFee, patientRoom.getAdmittedAt(), dischargeAt) = " + value * getInwardBean().calCount(timedFee, patientRoom.getAdmittedAt(), dischargeAt));
             return value * getInwardBean().calCount(timedFee, patientRoom.getAdmittedAt(), dischargeAt);


### PR DESCRIPTION
## Summary

- Room charge for active (non-discharged) patients was calculated using `calCountWithoutOverShoot()`, which ignores the configured overshoot grace period and adds an extra slot for **any** non-zero remainder
- Switched to `calCount()` which correctly respects the overshoot limit, making the charge consistent with the Billed Slots display panel

## Example (BHT/55645)

| | Before | After |
|---|---|---|
| Billed slots | 3 (wrong) | 2 (correct) |
| Room charge | 7,500 | 5,000 |
| Admin charge | 1,200 | 800 |

Stay: 24h 20min · Slot: 12hr · Overshoot limit: 3hr · Remainder: 20min (within grace period)

## Test plan

- [ ] Verify BHT/55645 on coop staging shows room charge of 5,000 after recalculate
- [ ] Verify that a patient with remainder > overshoot limit still gets billed the extra slot
- [ ] Verify discharged patients are unaffected

Closes #20470

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed inconsistent billing calculations for inpatient room charges to ensure uniform slot-counting behavior regardless of room status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->