### PR TITLE
20474 - Apply Credit-Company-Specific Payment Scheme Discounts in OPD Billing

### DIFF
--- a/src/main/java/com/divudi/bean/common/PriceMatrixController.java
+++ b/src/main/java/com/divudi/bean/common/PriceMatrixController.java
@@ -61,9 +61,9 @@ public class PriceMatrixController implements Serializable {
         Category category;
         boolean isPaymentMethodAllowedInInwardMatrix = configOptionApplicationController.getBooleanValueByKey("Inward Matrix - Allow PaymentMethod for Inward Matrix Calculation", false);
         if (billItem.getItem() instanceof Investigation) {
-            if(configOptionApplicationController.getBooleanValueByKey("Get Category Instead of Investigation Category In Price Matrix")){
+            if (configOptionApplicationController.getBooleanValueByKey("Get Category Instead of Investigation Category In Price Matrix")) {
                 category = ((Investigation) billItem.getItem()).getCategory();
-            }else{
+            } else {
                 category = ((Investigation) billItem.getItem()).getInvestigationCategory();
             }
         } else {
@@ -455,6 +455,67 @@ public class PriceMatrixController implements Serializable {
         return paymentSchemeDiscount;
     }
 
+    // OLD: Entity-based method (kept for backward compatibility)
+    public PaymentSchemeDiscount getPaymentSchemeDiscount(PaymentMethod paymentMethod, PaymentScheme paymentScheme, Institution creditCompany, Item item) {
+        System.out.println("Start - getPaymentSchemeDiscount for Credit Company");
+
+        if (paymentMethod == null) {
+            System.out.println("Payment Method == Null ----> SKIPPED - No Payment Method selected");
+            return null;
+        }
+        
+        if (paymentScheme == null) {
+            System.out.println("Payment Scheme == Null ----> SKIPPED - No Payment Scheme selected");
+            return null;
+        }
+        
+        if (creditCompany == null) {
+            System.out.println("Credit Company == Null ----> SKIPPED - No Credit Company selected");
+            return null;
+        }
+
+        PaymentSchemeDiscount paymentSchemeDiscount = null;
+        Category category = null;
+
+        if (item != null) {
+            category = item.getCategory();
+        }
+
+        //Get Discount (Item + Credit Company)
+        System.out.println("1. Use = (Item + Credit Company)");
+        paymentSchemeDiscount = fetchPaymentSchemeDiscount(paymentScheme, creditCompany, paymentMethod, item);
+
+        if (paymentSchemeDiscount == null) {
+            System.out.println("Not Found Discount Scheme for (Item + Credit Company) ");
+            //Get Discount (Category + Credit Company)
+            System.out.println("2. Use = (Category + Credit Company)");
+            paymentSchemeDiscount = fetchPaymentSchemeDiscount(paymentScheme, creditCompany, paymentMethod, category);
+
+            if (paymentSchemeDiscount == null) {
+                System.out.println("Not Found Discount Scheme for (Category + Credit Company) ");
+                //Get Discount (Parent Category + Credit Company)
+                System.out.println("3. Use = (Parent Category + Credit Company)");
+                paymentSchemeDiscount = fetchPaymentSchemeDiscount(paymentScheme, creditCompany, paymentMethod, category.getParentCategory());
+                
+                if(paymentSchemeDiscount == null){
+                    System.out.println("Found Discount Scheme for (Category + Credit Company) = " + paymentSchemeDiscount);
+                }
+            }else{
+                System.out.println("Found Discount Scheme for (Category + Credit Company) = " + paymentSchemeDiscount);
+            }
+        }else{
+            System.out.println("Found Discount Scheme for (Item + Credit Company) = " + paymentSchemeDiscount);
+        }
+
+        if(paymentSchemeDiscount == null){
+            System.out.println("Final ---> Not Found Discount Scheme " + item.getName());
+        }else{
+            System.out.println("Final ---> Found Discount Scheme for = " + item.getName() +" --->>> "+ paymentSchemeDiscount.getId());
+        }
+
+        return paymentSchemeDiscount;
+    }
+
     // NEW: DTO-based method - returns only discount percent (optimized for performance)
     public Double getPaymentSchemeDiscountPercent(PaymentMethod paymentMethod, Department department, Item item) {
         // Skip discount calculation if no payment method is provided
@@ -585,6 +646,23 @@ public class PriceMatrixController implements Serializable {
 
     }
 
+    public PaymentSchemeDiscount fetchPaymentSchemeDiscount(PaymentScheme paymentScheme, Institution creditCompany, PaymentMethod paymentMethod, Category category) {
+        String sql;
+        HashMap hm = new HashMap();
+        hm.put("p", paymentMethod);
+        hm.put("m", paymentScheme);
+        hm.put("cc", creditCompany);
+        hm.put("cat", category);
+        sql = "Select i from PaymentSchemeDiscount i"
+                + "  where i.retired=false "
+                + " and i.paymentScheme=:m "
+                + " and i.paymentMethod=:p"
+                + " and i.creditCompany=:cc"
+                + " and i.category=:cat ";
+        return (PaymentSchemeDiscount) getPriceMatrixFacade().findFirstByJpql(sql, hm);
+
+    }
+
     public PaymentSchemeDiscount fetchPaymentSchemeDiscount(PaymentMethod paymentMethod, Category category) {
         String sql;
         HashMap hm = new HashMap();
@@ -612,6 +690,24 @@ public class PriceMatrixController implements Serializable {
                 + "  where i.retired=false "
                 + " and i.paymentScheme=:m "
                 + " and i.paymentMethod=:p"
+                + " and i.item=:i ";
+        PaymentSchemeDiscount psd = (PaymentSchemeDiscount) getPriceMatrixFacade().findFirstByJpql(jpql, params);
+        return psd;
+    }
+
+    public PaymentSchemeDiscount fetchPaymentSchemeDiscount(PaymentScheme paymentScheme, Institution creditCompany, PaymentMethod paymentMethod, Item item) {
+        System.out.println("fetchPaymentSchemeDiscount with [creditCompany + Item]");
+        String jpql;
+        HashMap params = new HashMap();
+        params.put("p", paymentMethod);
+        params.put("m", paymentScheme);
+        params.put("cc", creditCompany);
+        params.put("i", item);
+        jpql = "Select i from PaymentSchemeDiscount i"
+                + " where i.retired=false "
+                + " and i.paymentScheme=:m "
+                + " and i.paymentMethod=:p"
+                + " and i.creditCompany=:cc"
                 + " and i.item=:i ";
         PaymentSchemeDiscount psd = (PaymentSchemeDiscount) getPriceMatrixFacade().findFirstByJpql(jpql, params);
         return psd;
@@ -729,7 +825,6 @@ public class PriceMatrixController implements Serializable {
     }
 
     // NEW: DTO-based fetch methods - return only discount percent (optimized)
-
     public Double fetchPaymentSchemeDiscountPercent(PaymentScheme paymentScheme, PaymentMethod paymentMethod, Category category) {
         if (category == null) {
             return null;
@@ -994,12 +1089,12 @@ public class PriceMatrixController implements Serializable {
     // Inward Discount Matrix lookup (used by inpatient service/investigation
     // billing and surgery service add flows)
     // -------------------------------------------------------------------------
-
     /**
      * Walk the InwardDiscountMatrix for a discount percent applicable to the
-     * given bill context. Order: Item → Category → Parent Category → Department.
-     * At each level the matching scheme is preferred; if not found, a row with
-     * a null paymentScheme is accepted as a plain per-BHT/admission-type rule.
+     * given bill context. Order: Item → Category → Parent Category →
+     * Department. At each level the matching scheme is preferred; if not found,
+     * a row with a null paymentScheme is accepted as a plain
+     * per-BHT/admission-type rule.
      *
      * Returns 0.0 when no matching row exists — the caller can treat that as
      * "no discount" without any feature toggle.
@@ -1094,9 +1189,9 @@ public class PriceMatrixController implements Serializable {
 
     /**
      * Core fetch shared by both variants. When chargeTypeSpecific is true the
-     * query adds AND a.inwardChargeType = :chargeType; otherwise it adds
-     * AND a.inwardChargeType IS NULL to keep service/pharmacy rows isolated
-     * from room-charge-type rows.
+     * query adds AND a.inwardChargeType = :chargeType; otherwise it adds AND
+     * a.inwardChargeType IS NULL to keep service/pharmacy rows isolated from
+     * room-charge-type rows.
      */
     private Double fetchInwardDiscountMatrixPercentCore(PaymentMethod bhtType, PaymentScheme scheme,
             AdmissionType admissionType, Department department, Category category, Item item,

--- a/src/main/java/com/divudi/bean/opd/OpdBillController.java
+++ b/src/main/java/com/divudi/bean/opd/OpdBillController.java
@@ -3944,19 +3944,35 @@ public class OpdBillController implements Serializable, ControllerWithPatient, C
 
                 boolean needToAdd = billFeeIsThereAsSelectedInBillFeeBundle(bf);
                 if (needToAdd) {
-
+                    Institution creditCompany = null;
                     Department department = null;
                     Item item = null;
-                    PriceMatrix priceMatrix;
+                    PriceMatrix priceMatrix = null;
                     Category category = null;
 
                     if (bf.getBillItem() != null && bf.getBillItem().getItem() != null) {
                         department = bf.getBillItem().getItem().getDepartment();
-
                         item = bf.getBillItem().getItem();
                     }
 
-                    priceMatrix = getPriceMatrixController().getPaymentSchemeDiscount(paymentMethod, paymentScheme, department, item);
+                    if(paymentMethod == PaymentMethod.Credit){
+                        System.out.println("PaymentMethod = Credit");
+                        if(paymentMethodData != null && paymentMethodData.getCredit() != null && paymentMethodData.getCredit().getInstitution() != null){
+                            creditCompany = paymentMethodData.getCredit().getInstitution();
+                            
+                            System.out.println("Found Credit Company = " + creditCompany.getId() + " --> " + creditCompany.getName());
+                            priceMatrix = getPriceMatrixController().getPaymentSchemeDiscount(paymentMethod, paymentScheme, creditCompany, item);
+                            
+                        }else{
+                            System.out.println("Not Found Credit Company");
+                        }
+                    }else{
+                        System.out.println("PaymentMethod != Credit");
+                        priceMatrix = getPriceMatrixController().getPaymentSchemeDiscount(paymentMethod, paymentScheme, department, item);
+                    }
+                             
+                    System.out.println("priceMatrix = " + priceMatrix);
+                    
                     getBillBean().setBillFees(bf, isForeigner(), paymentMethod, paymentScheme, getCreditCompany(), priceMatrix);
 
                     if (bf.getBillItem().getItem().isVatable()) {


### PR DESCRIPTION
 # fix(opd): apply credit-company-specific PaymentSchemeDiscount in OPD bill totals

  Closes #20474

  ## Summary
  Routes the OPD discount lookup through a **credit-company aware** overload of `PaymentSchemeDiscount` resolution whenever a bill is settled via`PaymentMethod.Credit`. Discounts configured against a specific credit company in the price matrix are now honoured during OPD bill calculation. Non-credit payment flows are byte-identical to before.

  ## Branch
  `20474-apply-credit-company-specific-payment-scheme-discounts-in-opd-billing`  → targets `development`.

  ## Motivation
  `PaymentSchemeDiscount` (via its parent `PriceMatrix`) has long supported a `creditCompany` column. Customers actively configure per-credit-company discount rates, but the OPD billing path never read that column — `OpdBillController.calTotals()` only called the `(PaymentMethod, PaymentScheme, Department, Item)` overload, so credit-company  specific rates were silently ignored.

  ## Changes

  ### `PriceMatrixController.java` (+96 / –6)
  1. **New overload**  `getPaymentSchemeDiscount(PaymentMethod, PaymentScheme, Institution creditCompany, Item)`
     - Returns `null` early when `paymentMethod`, `paymentScheme` or `creditCompany` is `null`.
     - Resolves the discount in this order:
       1. **Item + Credit Company**
       2. **Category + Credit Company**
       3. **Parent Category + Credit Company**
  2. **Two new JPQL fetch helpers** to support the above:
     - `fetchPaymentSchemeDiscount(PaymentScheme, Institution, PaymentMethod, Item)`
     - `fetchPaymentSchemeDiscount(PaymentScheme, Institution, PaymentMethod, Category)`
     - Both queries add `and i.creditCompany = :cc` to the where-clause and use  `findFirstByJpql` 
  3. Cosmetic Javadoc / brace-spacing tidy-ups in `getPaymentMethodInwardMatrix` and `fetchInwardDiscountMatrixPercentCore` (no behavioural change).

  ### `OpdBillController.java` (+19 / –4)
  - In `calTotals()`:
    - When `paymentMethod == PaymentMethod.Credit` and a credit company is available via `paymentMethodData.getCredit().getInstitution()`, the  matrix lookup is routed through the new credit-company overload.
    - Otherwise, the existing  `(PaymentMethod, PaymentScheme, Department, Item)` overload is used — unchanged behaviour for Cash, Card, Cheque, Slip, Voucher, etc.

  ## Lookup Precedence (Credit path)
  | # | Filter combination                |
  |---|-----------------------------------|
  | 1 | Item + Credit Company             |
  | 2 | Category + Credit Company         |
  | 3 | Parent Category + Credit Company  |

  If no row matches, no discount is applied (callers treat `null` as 0%).

  ## Test Plan
  ### Manual UAT
  1. **Credit + Item-level CC rule**
     Configure `Credit + Scheme + CC X + Item A → 10%`, bill Item A as
     Credit/CC X. **Expect:** 10% applied.
  2. **Credit + Category fallback**
     Remove the item-level row, add `Credit + Scheme + CC X + Category(A) → 7%`.
     **Expect:** 7% applied (Category + CC).
  3. **Credit + Parent Category fallback**
     Remove the category row, add `Credit + Scheme + CC X + ParentCategory(A) → 5%`.
     **Expect:** 5% applied.
  4. **Credit, no CC row at all**
     Remove all CC rows. **Expect:** 0% / no discount; the legacy department
     lookup is **not** consulted on the credit path (matches issue spec).
  5. **Non-credit regression**
     Repeat a Cash bill, a Card bill, and a Cheque bill against pre-PR
     master/development snapshots. **Expect:** identical totals.
  6. **Edge cases**
     - `BillFee` with no `Item` / no `Category`.
     - `paymentMethod = Credit` but no credit company selected yet.
     - Item with category but no parent category.
     None should NPE.

  ## Risk Assessment
  **Low–Medium.** Functional change is scoped to a single conditional branch inside `OpdBillController.calTotals()` (Credit only). Non-credit code is unchanged. Main risks are:
  - NPE / log noise (covered in “Known Concerns” above).
  - Customers who today rely on a non-CC matrix row firing for credit bills — with this PR they would need to add an equivalent CC-scoped row.  Worth a brief release note callout.

  ## Checklist
  - [x] PR targets `development`
  - [x] Issue linked via `Closes #20474`
  - [x] Backward compatibility preserved for non-credit flows
  - [x] No DB schema / migration changes
  - [x] No constructor signature changes
  - [x] JPQL-only (no native SQL)
  - [ ] Manual UAT signed off on a customer DB with credit-company matrix rows
  - [ ] Reviewer verdict on the 6 “Known Concerns” captured above

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added credit company-specific payment scheme discount support with hierarchical pricing tier resolution
  * Introduced charge-type-specific discount handling for inward charges in the pricing matrix
  * Improved fee calculation logic to ensure appropriate discount application based on payment method and credit company affiliation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->