### PR TITLE
19542-add-print-icon-for-float-transfer-note

### DIFF
--- a/src/main/webapp/cashier/fund_transfer_bill_print.xhtml
+++ b/src/main/webapp/cashier/fund_transfer_bill_print.xhtml
@@ -103,6 +103,15 @@
                         </div>
 
                     </p:panel>
+                    
+                     <p:commandButton
+                            value="Print"
+                            ajax="false"
+                            icon="pi pi-print"
+                            style="margin-top: 10px; margin-bottom: 10px; margin-left: 20px">
+                        <p:printer target="panelPrint"/>
+                    </p:commandButton>
+
 
                     <h:panelGroup id="panelPrint">
                         <!-- POS Paper with header -->
@@ -136,14 +145,7 @@
                         </h:panelGroup>
                     </h:panelGroup>
 
-                    <p:commandButton
-                            value="Print"
-                            ajax="false"
-                            icon="pi pi-print"
-                            style="margin-top: 10px;">
-                        <p:printer target="panelPrint"/>
-                    </p:commandButton>
-
+                   
                     <!-- Fund Transfer Bill Configuration Dialog -->
                     <p:dialog id="fundTransferConfigDialog"
                               header="Fund Transfer Bill Printer Configuration"

--- a/src/main/webapp/resources/ezcomp/prints/float_transfer_five_five.xhtml
+++ b/src/main/webapp/resources/ezcomp/prints/float_transfer_five_five.xhtml
@@ -15,10 +15,23 @@
     <cc:implementation>
 
         <div style="#{configOptionApplicationController.getLongTextValueByKey('Float Transfer Note CSS')}">
-
-            <div style="text-align: center; font-size: 20px; font-weight: bold; padding: 10px; border-bottom: 2px solid #000;">
-                <h:outputText value="#{configOptionApplicationController.getLongTextValueByKey('Float Transfer Note Header Text')}" escape="false"></h:outputText>
+            <div style="padding-left: 10px; padding-right: 10px; padding-top: 10px">
+            
+            <!-- Header Section with Institution Details -->
+            <div class="institutionName" style="text-align: center!important; font-weight: bold!important; font-size: 16px!important;">
+                <h:outputLabel value="#{cc.attrs.bill.department.printingName}" />
             </div>
+            <div class="institutionContact" style="text-align: center; font-size: 11px;">
+                <div>
+                    <h:outputLabel value="#{cc.attrs.bill.department.address}"/>
+                </div>
+                <div>
+                    <h:outputLabel value="#{cc.attrs.bill.department.telephone1} "/>
+                    <h:outputLabel value=" / " rendered="#{cc.attrs.bill.department.telephone2 ne null and cc.attrs.bill.department.telephone2 ne ''}"/>
+                    <h:outputLabel value="#{cc.attrs.bill.department.telephone2}"/>
+                </div>
+            </div>
+            
 
             <div style="text-align: center; font-size: 18px; font-weight: bold; padding: 5px;">
                 <h:outputLabel value="Float Transfer Note"/>
@@ -27,7 +40,7 @@
 
             <hr style="border-top: 1px solid #000;"/>
 
-            <div style="padding: 10px;">
+            <div style="padding: 10px; font-size: 13px;">
                 <table style="width: 100%; border-collapse: collapse;">
                     <tr>
                         <td style="font-weight: bold;">From:</td>
@@ -52,9 +65,12 @@
                 <hr style="border-top: 1px solid #000;"/>
             </div>
 
-            <div style="padding: 10px;">
-                <h3 style="text-align: center; font-weight: normal">Payment Details</h3>
-                <table style="width: 100%; border-collapse: collapse; border: 1px solid #ccc;">
+            <div style="padding-bottom: 10px;padding-top: 0px; font-size: 13px">
+                 <div style="text-align: center; font-size: 18px; font-weight: bold; padding: 5px;">
+                     <h:outputLabel value="Payment Details"/>
+                </div>
+                <!--<h3 style="text-align: center; font-weight: normal">Payment Details</h3>-->
+                <table style="width: 100%;font-size: 13px;padding-left: 10px;border-collapse: collapse; border: 1px solid #ccc;">
                     <tr style="background: #f2f2f2;">
                         <th style="padding: 8px; text-align: left;">Payment Method</th>
                         <th style="padding: 8px; text-align: left;">Details</th>
@@ -101,7 +117,7 @@
                 <hr/>
             </div>
 
-            <div style="text-align: right; font-size: 18px; font-weight: bold; padding: 10px;">
+            <div style="text-align: right; font-size: 15px; font-weight: bold; padding: 10px;">
                 <h:panelGroup rendered="#{cc.attrs.bill.margin > 0? 'false':'true'}">
                     Total Amount:
                     <h:outputLabel value="#{cc.attrs.bill.absoluteNetTotalTransient}">
@@ -110,13 +126,16 @@
                 </h:panelGroup>
             </div>
 
-            <div   style="#{configOptionApplicationController.getLongTextValueByKey('Float Transfer Note Horizontal Line CSS')}">
+<!--            <div   style="#{configOptionApplicationController.getLongTextValueByKey('Float Transfer Note Horizontal Line CSS')}">
                 <hr style="border-top: 1px solid #000;"/>
             </div>
 
             <div style="text-align: center; font-size: 14px; padding: 10px; color: gray;">
                 <h:outputText value="#{configOptionApplicationController.getLongTextValueByKey('Float Transfer Note Footer Text')}" escape="false"></h:outputText>
+            </div>-->
             </div>
+
+    
 
 
         </div>

--- a/src/main/webapp/resources/ezcomp/prints/float_transfer_five_five_printed.xhtml
+++ b/src/main/webapp/resources/ezcomp/prints/float_transfer_five_five_printed.xhtml
@@ -15,8 +15,8 @@
     <cc:implementation>
 
         <div style="#{configOptionApplicationController.getLongTextValueByKey('Float Transfer Note CSS')}">
-
-            <!-- Blank Header Space for Pre-printed Letterhead -->
+            <div style="padding-left: 10px; padding-right: 10px">
+                 <!-- Blank Header Space for Pre-printed Letterhead -->
             <div style="height: 80px;"></div>
 
             <div style="text-align: center; font-size: 18px; font-weight: bold; padding: 5px;">
@@ -26,7 +26,7 @@
 
             <hr style="border-top: 1px solid #000;"/>
 
-            <div style="padding: 10px;">
+            <div style="padding: 10px; font-size:13px ">
                 <table style="width: 100%; border-collapse: collapse;">
                     <tr>
                         <td style="font-weight: bold;">From:</td>
@@ -51,9 +51,11 @@
                 <hr style="border-top: 1px solid #000;"/>
             </div>
 
-            <div style="padding: 10px;">
-                <h3 style="text-align: center; font-weight: normal">Payment Details</h3>
-                <table style="width: 100%; border-collapse: collapse; border: 1px solid #ccc;">
+            <div style="padding-bottom: 10px;">
+                 <div style="text-align: center; font-size: 18px; font-weight: bold; padding: 5px;">
+                     <h:outputLabel value="Payment Details"/>
+                </div>
+                <table style="width: 100%; font-size: 13px; border-collapse: collapse; border: 1px solid #ccc;">
                     <tr style="background: #f2f2f2;">
                         <th style="padding: 8px; text-align: left;">Payment Method</th>
                         <th style="padding: 8px; text-align: left;">Details</th>
@@ -96,25 +98,25 @@
                 </table>
             </div>
 
-            <div style="#{configOptionApplicationController.getLongTextValueByKey('Float Transfer Note Horizontal Line CSS')}">
+<!--            <div style="#{configOptionApplicationController.getLongTextValueByKey('Float Transfer Note Horizontal Line CSS')}">
                 <hr/>
-            </div>
+            </div>-->
 
-            <div style="text-align: right; font-size: 18px; font-weight: bold; padding: 10px;">
+            <div style="text-align: right; font-size: 15px; font-weight: bold; padding: 10px;">
                 Total Amount:
                 <h:outputLabel value="#{cc.attrs.bill.absoluteNetTotalTransient}">
                     <f:convertNumber pattern="#,##0.00"/>
                 </h:outputLabel>
             </div>
 
-            <div style="#{configOptionApplicationController.getLongTextValueByKey('Float Transfer Note Horizontal Line CSS')}">
+<!--            <div style="#{configOptionApplicationController.getLongTextValueByKey('Float Transfer Note Horizontal Line CSS')}">
                 <hr style="border-top: 1px solid #000;"/>
             </div>
 
             <div style="text-align: center; font-size: 14px; padding: 10px; color: gray;">
                 <h:outputText value="#{configOptionApplicationController.getLongTextValueByKey('Float Transfer Note Footer Text')}" escape="false"></h:outputText>
+            </div>-->
             </div>
-
         </div>
     </cc:implementation>
 </html>


### PR DESCRIPTION
closes #19542
Relocate the print button.
Tested, the bill is correctly previewed on each paper type.
Modified bill that is suitable for the 5*5 inch paper type.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Repositioned and styled the Print button with improved margins in fund transfer bill print view.
  * Redesigned Float Transfer Note layout with institution details header, reworked section styling, and right-aligned total amount presentation.
  * Simplified print template design by removing decorative elements and adjusting typography for cleaner, more professional appearance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->