### PR TITLE
fix(inward): respect item and fee discountAllowed flags in inward discount matrix

### DIFF
--- a/src/main/java/com/divudi/bean/inward/InwardBeanController.java
+++ b/src/main/java/com/divudi/bean/inward/InwardBeanController.java
@@ -2432,20 +2432,21 @@ public class InwardBeanController implements Serializable {
     /**
      * Apply the Inward Discount Matrix discount to a BillFee.
      *
-     * Runs on hospital-portion fees only (skips Staff fees, mirrors the margin
-     * rule) and requires the item to allow discount. The discount scheme is
-     * taken from the admission/encounter itself (set at admission time).
-     * BHT type is the encounter's paymentMethod. When no matrix row matches
-     * the discount is 0, so existing behaviour is preserved for sites that
-     * have not configured the matrix.
+     * Runs on hospital-portion fees only (skips Staff fees). Skipped when the
+     * item does not allow discount or the fee does not allow discount.
+     * The discount scheme is taken from the admission/encounter itself
+     * (set at admission time). BHT type is the encounter's paymentMethod.
+     * When no matrix row matches the discount is 0, so existing behaviour is
+     * preserved for sites that have not configured the matrix.
      */
     public void applyInwardDiscountToBillFee(BillFee billFee, Item item, PatientEncounter patientEncounter) {
         if (billFee == null || item == null || patientEncounter == null) {
             return;
         }
-        if (!item.isDiscountAllowed()
-                || billFee.getFee() == null
-                || billFee.getFee().getFeeType() == FeeType.Staff) {
+        if (billFee.getFee() == null
+                || billFee.getFee().getFeeType() == FeeType.Staff
+                || Boolean.FALSE.equals(item.isDiscountAllowed())
+                || !billFee.getFee().isDiscountAllowed()) {
             billFee.setFeeDiscount(0.0);
             return;
         }

--- a/src/main/java/com/divudi/bean/inward/InwardBeanController.java
+++ b/src/main/java/com/divudi/bean/inward/InwardBeanController.java
@@ -2445,8 +2445,9 @@ public class InwardBeanController implements Serializable {
         }
         if (billFee.getFee() == null
                 || billFee.getFee().getFeeType() == FeeType.Staff
-                || Boolean.FALSE.equals(item.isDiscountAllowed())
+                || !Boolean.TRUE.equals(item.isDiscountAllowed())
                 || !billFee.getFee().isDiscountAllowed()) {
+            billFee.setFeeUnitDiscount(0.0);
             billFee.setFeeDiscount(0.0);
             return;
         }


### PR DESCRIPTION
## Summary

- `applyInwardDiscountToBillFee` previously checked `!item.isDiscountAllowed()` using a boxed `Boolean`, which risks NPE for DB rows where the column is NULL
- The `fee.discountAllowed` flag was never checked, so the fee-level configuration had no effect on inward discounts

## Changes

- Use `Boolean.FALSE.equals(item.isDiscountAllowed())` for a null-safe item check
- Add `!billFee.getFee().isDiscountAllowed()` so the fee-level flag is honoured
- Reorder guards: null-check `billFee.getFee()` before dereferencing it

## Rules now enforced

| Condition | Result |
|---|---|
| `item.discountAllowed = false` | No discount |
| `fee.discountAllowed = false` | No discount |
| Fee type = Staff | No discount |

Closes #20483

## Test plan

- [ ] Admit a patient with a payment scheme that has an Inward Discount Matrix entry
- [ ] Ensure the service item has `discountAllowed = true` and the fee has `discountAllowed = true`
- [ ] Add an inward service — discount should be applied from the matrix
- [ ] Verify that items/fees with `discountAllowed = false` still receive zero discount

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved inward discount application to properly exclude staff fees from discount calculations.
  * Enhanced validation to ensure discounts are only applied when all eligibility conditions are met.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->