### PR TITLE
Add fee-level service charge allowed toggle for inward billing fees

### DIFF
--- a/src/main/java/com/divudi/bean/inward/InwardBeanController.java
+++ b/src/main/java/com/divudi/bean/inward/InwardBeanController.java
@@ -2382,7 +2382,9 @@ public class InwardBeanController implements Serializable {
     public void setBillFeeMargin(BillFee billFee, Item item, PriceMatrix priceMatrix) {
         double margin = 0;
 
-        if (billFee == null || item.isMarginNotAllowed()) {
+        if (billFee == null || item.isMarginNotAllowed()
+                || billFee.getFee() == null
+                || !billFee.getFee().isMarginAllowed()) {
             return;
         }
 
@@ -2398,7 +2400,9 @@ public class InwardBeanController implements Serializable {
     }
 
     public void setBillFeeMargin(BillFee billFee, Item item, PriceMatrix priceMatrix, PatientEncounter patientEncounter) {
-        if (billFee == null || item.isMarginNotAllowed()) {
+        if (billFee == null || item.isMarginNotAllowed()
+                || billFee.getFee() == null
+                || !billFee.getFee().isMarginAllowed()) {
             return;
         }
         if (patientEncounter == null || patientEncounter.getAdmissionType() == null) {

--- a/src/main/java/com/divudi/core/entity/Fee.java
+++ b/src/main/java/com/divudi/core/entity/Fee.java
@@ -107,6 +107,7 @@ public class Fee implements Serializable {
     private boolean primaryFee;
     
     private boolean discountAllowed;
+    private boolean marginAllowed = true;
 
     public Fee() {
     }
@@ -433,6 +434,14 @@ public class Fee implements Serializable {
 
     public void setDiscountAllowed(boolean discountAllowed) {
         this.discountAllowed = discountAllowed;
+    }
+
+    public boolean isMarginAllowed() {
+        return marginAllowed;
+    }
+
+    public void setMarginAllowed(boolean marginAllowed) {
+        this.marginAllowed = marginAllowed;
     }
 
     public double getCcFee() {

--- a/src/main/webapp/admin/pricing/manage_item_fees.xhtml
+++ b/src/main/webapp/admin/pricing/manage_item_fees.xhtml
@@ -126,6 +126,12 @@
                                     value="#{itemFeeManager.itemFee.discountAllowed}" offLabel="Discounts NOT Allowed" onLabel="Discounts Allowed" >
                                 </p:selectBooleanButton>
 
+                                <p:outputLabel value="Service Charge Allowed" ></p:outputLabel>
+                                <p:selectBooleanButton 
+                                    class="w-100"
+                                    value="#{itemFeeManager.itemFee.marginAllowed}" offLabel="Service Charge NOT Allowed" onLabel="Service Charge Allowed" >
+                                </p:selectBooleanButton>
+
                                 <h:panelGroup id="gpLblIns" rendered="#{itemFeeManager.itemFee.feeType eq 'OtherInstitution' or itemFeeManager.itemFee.feeType eq 'OwnInstitution'  or itemFeeManager.itemFee.feeType eq 'Referral' }" >
                                     <p:outputLabel value="Institution" ></p:outputLabel>
                                 </h:panelGroup>
@@ -218,6 +224,12 @@
                                 </p:column>
                                 <p:column headerText="Discount Allowed" >
                                     <p:selectBooleanButton value="#{f.discountAllowed}" offLabel="Discounts NOT Allowed" onLabel="Discounts Allowed" >
+                                        <p:ajax process="@this" listener="#{itemFeeManager.updateFee(f)}" ></p:ajax>
+                                    </p:selectBooleanButton>
+                                </p:column>
+
+                                <p:column headerText="Service Charge Allowed" >
+                                    <p:selectBooleanButton value="#{f.marginAllowed}" offLabel="Service Charge NOT Allowed" onLabel="Service Charge Allowed" >
                                         <p:ajax process="@this" listener="#{itemFeeManager.updateFee(f)}" ></p:ajax>
                                     </p:selectBooleanButton>
                                 </p:column>


### PR DESCRIPTION
### Motivation
- Provide a per-fee switch to opt out of inward service charge (margin) calculation so base fees can independently disable margins while preserving existing item-level `marginNotAllowed` behavior. 
- Preserve default behavior where margins are calculated unless explicitly disabled at the fee level.

### Description
- Added `private boolean marginAllowed = true;` to `Fee` with `isMarginAllowed()`/`setMarginAllowed()` accessors so new fees default to allowing margins. 
- Updated inward margin logic in `InwardBeanController.setBillFeeMargin(...)` (both overloads) to skip margin calculation when `billFee.getFee()` is `null` or `!billFee.getFee().isMarginAllowed()`. 
- Exposed the toggle in the Base Fees UI at `/admin/pricing/manage_item_fees.xhtml` in the add/edit dialog (`itemFeeManager.itemFee.marginAllowed`) and in the fees table (`f.marginAllowed`) with labels "Service Charge Allowed / Service Charge NOT Allowed". 
- Files changed: `src/main/java/com/divudi/core/entity/Fee.java`, `src/main/java/com/divudi/bean/inward/InwardBeanController.java`, and `src/main/webapp/admin/pricing/manage_item_fees.xhtml`.

### Testing
- No automated build or test suite was executed for this change (per repository policy no Maven/compile/test run unless explicitly requested).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fbbd588db0832fa0341c046568bdbd)