### PR TITLE
feat(inward): add fee-level Service Charge Allowed flag

### DIFF
--- a/src/main/java/com/divudi/bean/inward/InwardBeanController.java
+++ b/src/main/java/com/divudi/bean/inward/InwardBeanController.java
@@ -2384,7 +2384,7 @@ public class InwardBeanController implements Serializable {
 
         if (billFee == null || item.isMarginNotAllowed()
                 || billFee.getFee() == null
-                || Boolean.FALSE.equals(billFee.getFee().isMarginAllowed())) {
+                || Boolean.FALSE.equals(billFee.getFee().getMarginAllowed())) {
             return;
         }
 
@@ -2402,7 +2402,7 @@ public class InwardBeanController implements Serializable {
     public void setBillFeeMargin(BillFee billFee, Item item, PriceMatrix priceMatrix, PatientEncounter patientEncounter) {
         if (billFee == null || item.isMarginNotAllowed()
                 || billFee.getFee() == null
-                || Boolean.FALSE.equals(billFee.getFee().isMarginAllowed())) {
+                || Boolean.FALSE.equals(billFee.getFee().getMarginAllowed())) {
             return;
         }
         if (patientEncounter == null || patientEncounter.getAdmissionType() == null) {

--- a/src/main/java/com/divudi/bean/inward/InwardBeanController.java
+++ b/src/main/java/com/divudi/bean/inward/InwardBeanController.java
@@ -2382,7 +2382,9 @@ public class InwardBeanController implements Serializable {
     public void setBillFeeMargin(BillFee billFee, Item item, PriceMatrix priceMatrix) {
         double margin = 0;
 
-        if (billFee == null || item.isMarginNotAllowed()) {
+        if (billFee == null || item.isMarginNotAllowed()
+                || billFee.getFee() == null
+                || Boolean.FALSE.equals(billFee.getFee().isMarginAllowed())) {
             return;
         }
 
@@ -2398,7 +2400,9 @@ public class InwardBeanController implements Serializable {
     }
 
     public void setBillFeeMargin(BillFee billFee, Item item, PriceMatrix priceMatrix, PatientEncounter patientEncounter) {
-        if (billFee == null || item.isMarginNotAllowed()) {
+        if (billFee == null || item.isMarginNotAllowed()
+                || billFee.getFee() == null
+                || Boolean.FALSE.equals(billFee.getFee().isMarginAllowed())) {
             return;
         }
         if (patientEncounter == null || patientEncounter.getAdmissionType() == null) {

--- a/src/main/java/com/divudi/core/entity/Fee.java
+++ b/src/main/java/com/divudi/core/entity/Fee.java
@@ -436,7 +436,7 @@ public class Fee implements Serializable {
         this.discountAllowed = discountAllowed;
     }
 
-    public Boolean isMarginAllowed() {
+    public Boolean getMarginAllowed() {
         return marginAllowed;
     }
 

--- a/src/main/java/com/divudi/core/entity/Fee.java
+++ b/src/main/java/com/divudi/core/entity/Fee.java
@@ -107,6 +107,7 @@ public class Fee implements Serializable {
     private boolean primaryFee;
     
     private boolean discountAllowed;
+    private Boolean marginAllowed;
 
     public Fee() {
     }
@@ -433,6 +434,14 @@ public class Fee implements Serializable {
 
     public void setDiscountAllowed(boolean discountAllowed) {
         this.discountAllowed = discountAllowed;
+    }
+
+    public Boolean isMarginAllowed() {
+        return marginAllowed;
+    }
+
+    public void setMarginAllowed(Boolean marginAllowed) {
+        this.marginAllowed = marginAllowed;
     }
 
     public double getCcFee() {

--- a/src/main/webapp/admin/pricing/manage_item_fees.xhtml
+++ b/src/main/webapp/admin/pricing/manage_item_fees.xhtml
@@ -121,9 +121,15 @@
                                 </p:selectOneMenu>
 
                                 <p:outputLabel value="Discounts Allowed" ></p:outputLabel>
-                                <p:selectBooleanButton 
+                                <p:selectBooleanButton
                                     class="w-100"
                                     value="#{itemFeeManager.itemFee.discountAllowed}" offLabel="Discounts NOT Allowed" onLabel="Discounts Allowed" >
+                                </p:selectBooleanButton>
+
+                                <p:outputLabel value="Service Charge Allowed" ></p:outputLabel>
+                                <p:selectBooleanButton
+                                    class="w-100"
+                                    value="#{itemFeeManager.itemFee.marginAllowed}" offLabel="Service Charge NOT Allowed" onLabel="Service Charge Allowed" >
                                 </p:selectBooleanButton>
 
                                 <h:panelGroup id="gpLblIns" rendered="#{itemFeeManager.itemFee.feeType eq 'OtherInstitution' or itemFeeManager.itemFee.feeType eq 'OwnInstitution'  or itemFeeManager.itemFee.feeType eq 'Referral' }" >
@@ -222,7 +228,11 @@
                                     </p:selectBooleanButton>
                                 </p:column>
 
-
+                                <p:column headerText="Service Charge Allowed" >
+                                    <p:selectBooleanButton value="#{f.marginAllowed}" offLabel="Service Charge NOT Allowed" onLabel="Service Charge Allowed" >
+                                        <p:ajax process="@this" listener="#{itemFeeManager.updateFee(f)}" ></p:ajax>
+                                    </p:selectBooleanButton>
+                                </p:column>
 
                                 <p:column headerText="For" >
 


### PR DESCRIPTION
## Summary

Adds a `marginAllowed` flag to the `Fee` entity so individual base fees can opt out of inward service charge (margin) calculation — implementing hmislk/hmis#20492.

- `marginAllowed` is a nullable `Boolean` (not primitive) so existing DB rows with `NULL` are treated as **allowed**, preserving current behaviour. This avoids the Codex PR #20493 defect where a primitive `boolean` default would cause EclipseLink to add the column as `NOT NULL DEFAULT 0`, blocking service charges on all existing fees.
- Guard: `Boolean.FALSE.equals(fee.isMarginAllowed())` — only `false` blocks the margin; `null` (legacy rows) passes through.
- Both `setBillFeeMargin` overloads updated, mirroring the existing `item.isMarginNotAllowed()` check.
- UI toggle added to the add-fee dialog and fee datatable in `manage_item_fees.xhtml` using the same AJAX `updateFee` pattern as `discountAllowed`.

## Rules now enforced (item + fee level)

| Flag | Level | Effect |
|---|---|---|
| `Item.marginNotAllowed = true` | Item | No service charge for all fees of that item |
| `Fee.marginAllowed = false` | Fee | No service charge for this fee only |
| `Item.discountAllowed = false/null` | Item | No discount for all fees of that item |
| `Fee.discountAllowed = false` | Fee | No discount for this fee only |

## Wiki

https://github.com/hmislk/hmis/wiki/Fee-Discount-and-Service-Charge-Flags

## Test plan

- [ ] Existing inward bills: service charges continue to be calculated (existing fees have `marginAllowed = NULL` → treated as allowed)
- [ ] Set `marginAllowed = false` on a fee → service charge becomes 0 for that fee in inward billing
- [ ] Set `marginAllowed = false` on a fee → other fees on the same item still calculate their margin normally
- [ ] Toggle in the Base Item Fees page saves immediately via AJAX

🤖 Generated with [Claude Code](https://claude.com/claude-code)