### PR TITLE
fix(cashier): update drawer balance for shortage and excess bills

### DIFF
--- a/src/main/java/com/divudi/bean/cashTransaction/FinancialTransactionController.java
+++ b/src/main/java/com/divudi/bean/cashTransaction/FinancialTransactionController.java
@@ -7901,8 +7901,11 @@ public class FinancialTransactionController implements Serializable {
         billController.save(currentBill);
         for (Payment p : currentBillPayments) {
             p.setBill(currentBill);
+            p.setCurrentHolder(sessionController.getLoggedUser());
             paymentController.save(p);
         }
+        // Reflect the excess in the cashier's drawer: positive cash inflow per payment.
+        drawerController.updateDrawer(currentBillPayments, sessionController.getLoggedUser());
         JsfUtil.addSuccessMessage("All shift excess records have been successfully settled.");
         return "/cashier/record_shift_excess_print?faces-redirect=true";  // Redirect to a summary page or another relevant page
     }
@@ -7966,6 +7969,9 @@ public class FinancialTransactionController implements Serializable {
                 p.setCurrentHolder(sessionController.getLoggedUser());
                 paymentController.save(p);
             }
+            // Shortage payments carry negative paidValue, so updateDrawer subtracts
+            // them from the cashier's cash balance — keeping drawer in sync with the bill.
+            drawerController.updateDrawer(currentBillPayments, sessionController.getLoggedUser());
 
             JsfUtil.addSuccessMessage("All shift shortage records have been successfully recorded.");
             return "/cashier/record_shift_shortage_print?faces-redirect=true";  // Redirect to a summary page
@@ -8006,6 +8012,9 @@ public class FinancialTransactionController implements Serializable {
             currentPayment.setBill(currentBill);
             currentPayment.setCurrentHolder(sessionController.getLoggedUser());
             paymentController.save(currentPayment);
+            // paidValue is already negative for a shortage; this subtracts it from
+            // the cashier's cash drawer so the balance reflects the recorded shortage.
+            drawerController.updateDrawer(currentPayment, currentPayment.getPaidValue(), sessionController.getLoggedUser());
             JsfUtil.addSuccessMessage("Shift shortage recorded successfully.");
             return "/cashier/record_shift_shortage_print?faces-redirect=true";
         } catch (Exception e) {
@@ -8161,6 +8170,8 @@ public class FinancialTransactionController implements Serializable {
             currentPayment.setDepartment(null);
             currentPayment.setCurrentHolder(sessionController.getLoggedUser());
             paymentController.save(currentPayment);
+            // Cashier paying back the shortage: cash flowing into the drawer.
+            drawerController.updateDrawerForIns(currentPayment, sessionController.getLoggedUser());
 
             if (shortageOutstanding - currentPayment.getPaidValue() <= 0.001) {
                 selectedBill.setPaid(true);

--- a/src/main/java/com/divudi/bean/cashTransaction/FinancialTransactionController.java
+++ b/src/main/java/com/divudi/bean/cashTransaction/FinancialTransactionController.java
@@ -7969,16 +7969,17 @@ public class FinancialTransactionController implements Serializable {
                 p.setCurrentHolder(sessionController.getLoggedUser());
                 paymentController.save(p);
             }
-            // Shortage payments carry negative paidValue, so updateDrawer subtracts
-            // them from the cashier's cash balance — keeping drawer in sync with the bill.
-            drawerController.updateDrawer(currentBillPayments, sessionController.getLoggedUser());
-
-            JsfUtil.addSuccessMessage("All shift shortage records have been successfully recorded.");
-            return "/cashier/record_shift_shortage_print?faces-redirect=true";  // Redirect to a summary page
         } catch (Exception e) {
             JsfUtil.addErrorMessage("Error settling shift shortages: " + e.getMessage());
             return "";  // Optionally, redirect to an error page
         }
+        // Drawer update is intentionally outside the try/catch: a drawer failure
+        // must not be misreported as a save failure and must not trigger any
+        // compensating rollback (matching the convention used in fund-transfer,
+        // cancellation, and handover flows).
+        drawerController.updateDrawer(currentBillPayments, sessionController.getLoggedUser());
+        JsfUtil.addSuccessMessage("All shift shortage records have been successfully recorded.");
+        return "/cashier/record_shift_shortage_print?faces-redirect=true";  // Redirect to a summary page
     }
 
     public String recordAndSettleShiftShortage() {
@@ -8012,11 +8013,6 @@ public class FinancialTransactionController implements Serializable {
             currentPayment.setBill(currentBill);
             currentPayment.setCurrentHolder(sessionController.getLoggedUser());
             paymentController.save(currentPayment);
-            // paidValue is already negative for a shortage; this subtracts it from
-            // the cashier's cash drawer so the balance reflects the recorded shortage.
-            drawerController.updateDrawer(currentPayment, currentPayment.getPaidValue(), sessionController.getLoggedUser());
-            JsfUtil.addSuccessMessage("Shift shortage recorded successfully.");
-            return "/cashier/record_shift_shortage_print?faces-redirect=true";
         } catch (Exception e) {
             // If the bill was persisted but the payment failed, cancel the bill so it
             // does not appear as an unmatched record in shortage searches.
@@ -8032,6 +8028,12 @@ public class FinancialTransactionController implements Serializable {
         } finally {
             shortageSubmitting = false;
         }
+        // Drawer update is outside the save try/catch so a drawer failure does
+        // NOT trigger bill cancellation. paidValue is already negative for a
+        // shortage; this subtracts it from the cashier's cash drawer.
+        drawerController.updateDrawer(currentPayment, currentPayment.getPaidValue(), sessionController.getLoggedUser());
+        JsfUtil.addSuccessMessage("Shift shortage recorded successfully.");
+        return "/cashier/record_shift_shortage_print?faces-redirect=true";
     }
 
     public String navigateToCashierShiftBillSearchWithTodayResults() {
@@ -8170,8 +8172,6 @@ public class FinancialTransactionController implements Serializable {
             currentPayment.setDepartment(null);
             currentPayment.setCurrentHolder(sessionController.getLoggedUser());
             paymentController.save(currentPayment);
-            // Cashier paying back the shortage: cash flowing into the drawer.
-            drawerController.updateDrawerForIns(currentPayment, sessionController.getLoggedUser());
 
             if (shortageOutstanding - currentPayment.getPaidValue() <= 0.001) {
                 selectedBill.setPaid(true);
@@ -8180,8 +8180,6 @@ public class FinancialTransactionController implements Serializable {
                 billController.save(selectedBill);
             }
             computeShortageSettlementSummary(selectedBill);
-            JsfUtil.addSuccessMessage("Shortage settlement recorded successfully.");
-            return "/cashier/settle_shift_shortage_print?faces-redirect=true";
         } catch (Exception e) {
             if (currentBill != null && currentBill.getId() != null) {
                 try {
@@ -8195,6 +8193,12 @@ public class FinancialTransactionController implements Serializable {
         } finally {
             settlementSubmitting = false;
         }
+        // Drawer update is outside the save try/catch so a drawer failure does
+        // NOT cancel the settlement bill. Cashier is paying back, so cash flows
+        // into the drawer.
+        drawerController.updateDrawerForIns(currentPayment, sessionController.getLoggedUser());
+        JsfUtil.addSuccessMessage("Shortage settlement recorded successfully.");
+        return "/cashier/settle_shift_shortage_print?faces-redirect=true";
     }
 
     private Bill findOriginalShortageBill(Bill bill) {


### PR DESCRIPTION
## Summary
- Shortage/excess bill flows persisted the bill and payments but never called `drawerController.updateDrawer`, so the cashier's cash balance and drawer log were unchanged after recording the bill.
- Added the drawer update after persistence in all four affected paths in `FinancialTransactionController`:
  - `settleShiftExcesses` — positive cash inflow per payment
  - `settleShiftShortages` (multi-record) — negative `paidValue` so drawer is reduced
  - `recordAndSettleShiftShortage` (single-record) — drawer reduced by the shortage
  - `settleShiftShortageBill` (cashier paying back) — cash inflow back into drawer
- Also set `currentHolder` in the excess loop for symmetry with the other flows.

## Why
A shortage bill represents missing cash; the drawer's `cashInHandValue` / `cashBalance` should drop the moment it is recorded. Conversely an excess (or shortage settlement) should increase it. Other billing flows in the same controller (cancellation, fund transfer, handover, decline, petty cash) already call `drawerController` — only shortage/excess were missed.

`paymentController.save` does not touch the drawer and there is no JPA listener that does either, so this single explicit call is required and safe — it will not recreate the historical doubling reported in #8328.

## Issues closed
- Closes #20460 — Cash drawer not updated after creating shortage bill
- Closes #11075 — After adding the shortage, the bill amount in the drawer is not reduced (duplicate of #20460)

## Test plan
- [ ] Start a shift with a known cash float (e.g. 1000)
- [ ] Record a shortage bill of 200 via `cashier/record_shift_shortage` — drawer cash should drop to 800 immediately, drawer log should show the entry
- [ ] Record a multi-record shortage during handover — drawer should reflect the sum
- [ ] Record an excess bill of 150 via `cashier/record_shift_excess` — drawer cash should go up by 150
- [ ] Settle a shortage bill by paying back via `cashier/settle_shift_shortage_bill` — drawer cash should go up by the settlement amount
- [ ] Verify shift end summary and handover receipt reflect the updated drawer balance
- [ ] Verify no double counting (drawer changes by exactly the bill amount, not 2x)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* Enhanced drawer state management to accurately track cash during shift excess and shortage settlement processes.
* Improved cash inflow recording for individual shift shortage resolutions to ensure precise financial reconciliation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->