### PR TITLE
fix(drawer): show adjustment amounts in drawer history reports (#19487)

### DIFF
--- a/src/main/java/com/divudi/service/DrawerService.java
+++ b/src/main/java/com/divudi/service/DrawerService.java
@@ -601,7 +601,14 @@ public class DrawerService {
             return;
         }
         synchronized (drawer) {
-            drawerEntryUpdate(bill, drawer, paymentMethod, user, delta);
+            // The drawer history filters by webUser, so the entry must be tagged with the
+            // drawer owner (cashier whose drawer changed), not the actor approving/applying it.
+            WebUser drawerOwner = drawer.getDrawerUser() != null ? drawer.getDrawerUser() : user;
+            drawerEntryUpdate(bill, drawer, paymentMethod, drawerOwner, delta);
+            if (drawerEntry != null) {
+                drawerEntry.setCreater(user);
+                save(drawerEntry);
+            }
             switch (paymentMethod) {
                 case OnCall:
                     drawer.setOnCallInHandValue(safeAdd(drawer.getOnCallInHandValue(), delta));

--- a/src/main/webapp/cashier/cashier_drawer_entry_history.xhtml
+++ b/src/main/webapp/cashier/cashier_drawer_entry_history.xhtml
@@ -126,8 +126,8 @@
                                 </p:column>
 
                                 <p:column headerText="Paid" style="text-align: right; padding: 6px;" >
-                                    <p:outputLabel 
-                                        value="#{drawerentry.payment.paidValue}" class="d-flex justify-content-end" >
+                                    <p:outputLabel
+                                        value="#{drawerentry.transactionValue}" class="d-flex justify-content-end" >
                                         <f:convertNumber pattern="#,##0.00"/>
                                     </p:outputLabel>
                                 </p:column>

--- a/src/main/webapp/reports/financialReports/all_users_drawer_history.xhtml
+++ b/src/main/webapp/reports/financialReports/all_users_drawer_history.xhtml
@@ -187,7 +187,7 @@
                             </p:column>
 
                             <p:column style="padding: 1px;" width="10em">
-                                <h:outputText value="#{drawerentry.payment.bill.billTypeAtomic.billFinanceType}" />
+                                <h:outputText value="#{drawerentry.bill.billTypeAtomic.billFinanceType.label}" />
                             </p:column>
 
                             <p:column style="padding: 6px;" width="12em">
@@ -195,7 +195,7 @@
                             </p:column>
 
                             <p:column style="padding: 1px;" width="12em">
-                                <h:outputText value="#{drawerentry.bill.deptId}" />
+                                <h:outputText value="#{drawerentry.bill.referenceBill.deptId}" />
                             </p:column>
 
                             <p:column style="padding: 1px;" width="8em">
@@ -214,228 +214,228 @@
 
                             <!-- Cash columns -->
                             <p:column style="padding: 4px;" width="7em" rendered="#{userSettingsController.allUsersDrawerHistoryCashVisible}">
-                                <h:outputText value="#{drawerentry.beforeBalance}" styleClass="text-end d-block" rendered="#{drawerentry.payment.paymentMethod eq 'Cash'}">
+                                <h:outputText value="#{drawerentry.beforeBalance}" styleClass="text-end d-block" rendered="#{drawerentry.paymentMethod eq 'Cash'}">
                                     <f:convertNumber groupingUsed="true" minFractionDigits="2" maxFractionDigits="2"/>
                                 </h:outputText>
                             </p:column>
                             <p:column style="padding: 4px;" width="7em" rendered="#{userSettingsController.allUsersDrawerHistoryCashVisible}">
-                                <h:outputText value="#{drawerentry.payment.paidValue}" styleClass="text-end d-block" rendered="#{drawerentry.payment.paymentMethod eq 'Cash'}">
+                                <h:outputText value="#{drawerentry.transactionValue}" styleClass="text-end d-block" rendered="#{drawerentry.paymentMethod eq 'Cash'}">
                                     <f:convertNumber groupingUsed="true" minFractionDigits="2" maxFractionDigits="2"/>
                                 </h:outputText>
                             </p:column>
                             <p:column style="padding: 4px;" width="7em" rendered="#{userSettingsController.allUsersDrawerHistoryCashVisible}">
-                                <h:outputText value="#{drawerentry.afterBalance}" styleClass="text-end d-block" rendered="#{drawerentry.payment.paymentMethod eq 'Cash'}">
+                                <h:outputText value="#{drawerentry.afterBalance}" styleClass="text-end d-block" rendered="#{drawerentry.paymentMethod eq 'Cash'}">
                                     <f:convertNumber groupingUsed="true" minFractionDigits="2" maxFractionDigits="2"/>
                                 </h:outputText>
                             </p:column>
 
                             <!-- Credit Card columns -->
                             <p:column style="padding: 4px;" width="7em" rendered="#{userSettingsController.allUsersDrawerHistoryCardVisible}">
-                                <h:outputText value="#{drawerentry.beforeBalance}" styleClass="text-end d-block" rendered="#{drawerentry.payment.paymentMethod eq 'Card'}">
+                                <h:outputText value="#{drawerentry.beforeBalance}" styleClass="text-end d-block" rendered="#{drawerentry.paymentMethod eq 'Card'}">
                                     <f:convertNumber groupingUsed="true" minFractionDigits="2" maxFractionDigits="2"/>
                                 </h:outputText>
                             </p:column>
                             <p:column style="padding: 4px;" width="7em" rendered="#{userSettingsController.allUsersDrawerHistoryCardVisible}">
-                                <h:outputText value="#{drawerentry.payment.paidValue}" styleClass="text-end d-block" rendered="#{drawerentry.payment.paymentMethod eq 'Card'}">
+                                <h:outputText value="#{drawerentry.transactionValue}" styleClass="text-end d-block" rendered="#{drawerentry.paymentMethod eq 'Card'}">
                                     <f:convertNumber groupingUsed="true" minFractionDigits="2" maxFractionDigits="2"/>
                                 </h:outputText>
                             </p:column>
                             <p:column style="padding: 4px;" width="7em" rendered="#{userSettingsController.allUsersDrawerHistoryCardVisible}">
-                                <h:outputText value="#{drawerentry.afterBalance}" styleClass="text-end d-block" rendered="#{drawerentry.payment.paymentMethod eq 'Card'}">
+                                <h:outputText value="#{drawerentry.afterBalance}" styleClass="text-end d-block" rendered="#{drawerentry.paymentMethod eq 'Card'}">
                                     <f:convertNumber groupingUsed="true" minFractionDigits="2" maxFractionDigits="2"/>
                                 </h:outputText>
                             </p:column>
 
                             <!-- Cheque columns -->
                             <p:column style="padding: 4px;" width="7em" rendered="#{userSettingsController.allUsersDrawerHistoryChequeVisible}">
-                                <h:outputText value="#{drawerentry.beforeBalance}" styleClass="text-end d-block" rendered="#{drawerentry.payment.paymentMethod eq 'Cheque'}">
+                                <h:outputText value="#{drawerentry.beforeBalance}" styleClass="text-end d-block" rendered="#{drawerentry.paymentMethod eq 'Cheque'}">
                                     <f:convertNumber groupingUsed="true" minFractionDigits="2" maxFractionDigits="2"/>
                                 </h:outputText>
                             </p:column>
                             <p:column style="padding: 4px;" width="7em" rendered="#{userSettingsController.allUsersDrawerHistoryChequeVisible}">
-                                <h:outputText value="#{drawerentry.payment.paidValue}" styleClass="text-end d-block" rendered="#{drawerentry.payment.paymentMethod eq 'Cheque'}">
+                                <h:outputText value="#{drawerentry.transactionValue}" styleClass="text-end d-block" rendered="#{drawerentry.paymentMethod eq 'Cheque'}">
                                     <f:convertNumber groupingUsed="true" minFractionDigits="2" maxFractionDigits="2"/>
                                 </h:outputText>
                             </p:column>
                             <p:column style="padding: 4px;" width="7em" rendered="#{userSettingsController.allUsersDrawerHistoryChequeVisible}">
-                                <h:outputText value="#{drawerentry.afterBalance}" styleClass="text-end d-block" rendered="#{drawerentry.payment.paymentMethod eq 'Cheque'}">
+                                <h:outputText value="#{drawerentry.afterBalance}" styleClass="text-end d-block" rendered="#{drawerentry.paymentMethod eq 'Cheque'}">
                                     <f:convertNumber groupingUsed="true" minFractionDigits="2" maxFractionDigits="2"/>
                                 </h:outputText>
                             </p:column>
 
                             <!-- Slip columns -->
                             <p:column style="padding: 4px;" width="7em" rendered="#{userSettingsController.allUsersDrawerHistorySlipVisible}">
-                                <h:outputText value="#{drawerentry.beforeBalance}" styleClass="text-end d-block" rendered="#{drawerentry.payment.paymentMethod eq 'Slip'}">
+                                <h:outputText value="#{drawerentry.beforeBalance}" styleClass="text-end d-block" rendered="#{drawerentry.paymentMethod eq 'Slip'}">
                                     <f:convertNumber groupingUsed="true" minFractionDigits="2" maxFractionDigits="2"/>
                                 </h:outputText>
                             </p:column>
                             <p:column style="padding: 4px;" width="7em" rendered="#{userSettingsController.allUsersDrawerHistorySlipVisible}">
-                                <h:outputText value="#{drawerentry.payment.paidValue}" styleClass="text-end d-block" rendered="#{drawerentry.payment.paymentMethod eq 'Slip'}">
+                                <h:outputText value="#{drawerentry.transactionValue}" styleClass="text-end d-block" rendered="#{drawerentry.paymentMethod eq 'Slip'}">
                                     <f:convertNumber groupingUsed="true" minFractionDigits="2" maxFractionDigits="2"/>
                                 </h:outputText>
                             </p:column>
                             <p:column style="padding: 4px;" width="7em" rendered="#{userSettingsController.allUsersDrawerHistorySlipVisible}">
-                                <h:outputText value="#{drawerentry.afterBalance}" styleClass="text-end d-block" rendered="#{drawerentry.payment.paymentMethod eq 'Slip'}">
+                                <h:outputText value="#{drawerentry.afterBalance}" styleClass="text-end d-block" rendered="#{drawerentry.paymentMethod eq 'Slip'}">
                                     <f:convertNumber groupingUsed="true" minFractionDigits="2" maxFractionDigits="2"/>
                                 </h:outputText>
                             </p:column>
 
                             <!-- IOU columns -->
                             <p:column style="padding: 4px;" width="7em" rendered="#{userSettingsController.allUsersDrawerHistoryIouVisible}">
-                                <h:outputText value="#{drawerentry.beforeBalance}" styleClass="text-end d-block" rendered="#{drawerentry.payment.paymentMethod eq 'IOU'}">
+                                <h:outputText value="#{drawerentry.beforeBalance}" styleClass="text-end d-block" rendered="#{drawerentry.paymentMethod eq 'IOU'}">
                                     <f:convertNumber groupingUsed="true" minFractionDigits="2" maxFractionDigits="2"/>
                                 </h:outputText>
                             </p:column>
                             <p:column style="padding: 4px;" width="7em" rendered="#{userSettingsController.allUsersDrawerHistoryIouVisible}">
-                                <h:outputText value="#{drawerentry.payment.paidValue}" styleClass="text-end d-block" rendered="#{drawerentry.payment.paymentMethod eq 'IOU'}">
+                                <h:outputText value="#{drawerentry.transactionValue}" styleClass="text-end d-block" rendered="#{drawerentry.paymentMethod eq 'IOU'}">
                                     <f:convertNumber groupingUsed="true" minFractionDigits="2" maxFractionDigits="2"/>
                                 </h:outputText>
                             </p:column>
                             <p:column style="padding: 4px;" width="7em" rendered="#{userSettingsController.allUsersDrawerHistoryIouVisible}">
-                                <h:outputText value="#{drawerentry.afterBalance}" styleClass="text-end d-block" rendered="#{drawerentry.payment.paymentMethod eq 'IOU'}">
+                                <h:outputText value="#{drawerentry.afterBalance}" styleClass="text-end d-block" rendered="#{drawerentry.paymentMethod eq 'IOU'}">
                                     <f:convertNumber groupingUsed="true" minFractionDigits="2" maxFractionDigits="2"/>
                                 </h:outputText>
                             </p:column>
 
                             <!-- Credit columns -->
                             <p:column style="padding: 4px;" width="7em" rendered="#{userSettingsController.allUsersDrawerHistoryCreditVisible}">
-                                <h:outputText value="#{drawerentry.beforeBalance}" styleClass="text-end d-block" rendered="#{drawerentry.payment.paymentMethod eq 'Credit'}">
+                                <h:outputText value="#{drawerentry.beforeBalance}" styleClass="text-end d-block" rendered="#{drawerentry.paymentMethod eq 'Credit'}">
                                     <f:convertNumber groupingUsed="true" minFractionDigits="2" maxFractionDigits="2"/>
                                 </h:outputText>
                             </p:column>
                             <p:column style="padding: 4px;" width="7em" rendered="#{userSettingsController.allUsersDrawerHistoryCreditVisible}">
-                                <h:outputText value="#{drawerentry.payment.paidValue}" styleClass="text-end d-block" rendered="#{drawerentry.payment.paymentMethod eq 'Credit'}">
+                                <h:outputText value="#{drawerentry.transactionValue}" styleClass="text-end d-block" rendered="#{drawerentry.paymentMethod eq 'Credit'}">
                                     <f:convertNumber groupingUsed="true" minFractionDigits="2" maxFractionDigits="2"/>
                                 </h:outputText>
                             </p:column>
                             <p:column style="padding: 4px;" width="7em" rendered="#{userSettingsController.allUsersDrawerHistoryCreditVisible}">
-                                <h:outputText value="#{drawerentry.afterBalance}" styleClass="text-end d-block" rendered="#{drawerentry.payment.paymentMethod eq 'Credit'}">
+                                <h:outputText value="#{drawerentry.afterBalance}" styleClass="text-end d-block" rendered="#{drawerentry.paymentMethod eq 'Credit'}">
                                     <f:convertNumber groupingUsed="true" minFractionDigits="2" maxFractionDigits="2"/>
                                 </h:outputText>
                             </p:column>
 
                             <!-- eWallet columns -->
                             <p:column style="padding: 4px;" width="7em" rendered="#{userSettingsController.allUsersDrawerHistoryEwalletVisible}">
-                                <h:outputText value="#{drawerentry.beforeBalance}" styleClass="text-end d-block" rendered="#{drawerentry.payment.paymentMethod eq 'ewallet'}">
+                                <h:outputText value="#{drawerentry.beforeBalance}" styleClass="text-end d-block" rendered="#{drawerentry.paymentMethod eq 'ewallet'}">
                                     <f:convertNumber groupingUsed="true" minFractionDigits="2" maxFractionDigits="2"/>
                                 </h:outputText>
                             </p:column>
                             <p:column style="padding: 4px;" width="7em" rendered="#{userSettingsController.allUsersDrawerHistoryEwalletVisible}">
-                                <h:outputText value="#{drawerentry.payment.paidValue}" styleClass="text-end d-block" rendered="#{drawerentry.payment.paymentMethod eq 'ewallet'}">
+                                <h:outputText value="#{drawerentry.transactionValue}" styleClass="text-end d-block" rendered="#{drawerentry.paymentMethod eq 'ewallet'}">
                                     <f:convertNumber groupingUsed="true" minFractionDigits="2" maxFractionDigits="2"/>
                                 </h:outputText>
                             </p:column>
                             <p:column style="padding: 4px;" width="7em" rendered="#{userSettingsController.allUsersDrawerHistoryEwalletVisible}">
-                                <h:outputText value="#{drawerentry.afterBalance}" styleClass="text-end d-block" rendered="#{drawerentry.payment.paymentMethod eq 'ewallet'}">
+                                <h:outputText value="#{drawerentry.afterBalance}" styleClass="text-end d-block" rendered="#{drawerentry.paymentMethod eq 'ewallet'}">
                                     <f:convertNumber groupingUsed="true" minFractionDigits="2" maxFractionDigits="2"/>
                                 </h:outputText>
                             </p:column>
 
                             <!-- Agent columns -->
                             <p:column style="padding: 4px;" width="7em" rendered="#{userSettingsController.allUsersDrawerHistoryAgentVisible}">
-                                <h:outputText value="#{drawerentry.beforeBalance}" styleClass="text-end d-block" rendered="#{drawerentry.payment.paymentMethod eq 'Agent'}">
+                                <h:outputText value="#{drawerentry.beforeBalance}" styleClass="text-end d-block" rendered="#{drawerentry.paymentMethod eq 'Agent'}">
                                     <f:convertNumber groupingUsed="true" minFractionDigits="2" maxFractionDigits="2"/>
                                 </h:outputText>
                             </p:column>
                             <p:column style="padding: 4px;" width="7em" rendered="#{userSettingsController.allUsersDrawerHistoryAgentVisible}">
-                                <h:outputText value="#{drawerentry.payment.paidValue}" styleClass="text-end d-block" rendered="#{drawerentry.payment.paymentMethod eq 'Agent'}">
+                                <h:outputText value="#{drawerentry.transactionValue}" styleClass="text-end d-block" rendered="#{drawerentry.paymentMethod eq 'Agent'}">
                                     <f:convertNumber groupingUsed="true" minFractionDigits="2" maxFractionDigits="2"/>
                                 </h:outputText>
                             </p:column>
                             <p:column style="padding: 4px;" width="7em" rendered="#{userSettingsController.allUsersDrawerHistoryAgentVisible}">
-                                <h:outputText value="#{drawerentry.afterBalance}" styleClass="text-end d-block" rendered="#{drawerentry.payment.paymentMethod eq 'Agent'}">
+                                <h:outputText value="#{drawerentry.afterBalance}" styleClass="text-end d-block" rendered="#{drawerentry.paymentMethod eq 'Agent'}">
                                     <f:convertNumber groupingUsed="true" minFractionDigits="2" maxFractionDigits="2"/>
                                 </h:outputText>
                             </p:column>
 
                             <!-- Staff Welfare columns -->
                             <p:column style="padding: 4px;" width="7em" rendered="#{userSettingsController.allUsersDrawerHistoryStaffWelfareVisible}">
-                                <h:outputText value="#{drawerentry.beforeBalance}" styleClass="text-end d-block" rendered="#{drawerentry.payment.paymentMethod eq 'Staff_Welfare'}">
+                                <h:outputText value="#{drawerentry.beforeBalance}" styleClass="text-end d-block" rendered="#{drawerentry.paymentMethod eq 'Staff_Welfare'}">
                                     <f:convertNumber groupingUsed="true" minFractionDigits="2" maxFractionDigits="2"/>
                                 </h:outputText>
                             </p:column>
                             <p:column style="padding: 4px;" width="7em" rendered="#{userSettingsController.allUsersDrawerHistoryStaffWelfareVisible}">
-                                <h:outputText value="#{drawerentry.payment.paidValue}" styleClass="text-end d-block" rendered="#{drawerentry.payment.paymentMethod eq 'Staff_Welfare'}">
+                                <h:outputText value="#{drawerentry.transactionValue}" styleClass="text-end d-block" rendered="#{drawerentry.paymentMethod eq 'Staff_Welfare'}">
                                     <f:convertNumber groupingUsed="true" minFractionDigits="2" maxFractionDigits="2"/>
                                 </h:outputText>
                             </p:column>
                             <p:column style="padding: 4px;" width="7em" rendered="#{userSettingsController.allUsersDrawerHistoryStaffWelfareVisible}">
-                                <h:outputText value="#{drawerentry.afterBalance}" styleClass="text-end d-block" rendered="#{drawerentry.payment.paymentMethod eq 'Staff_Welfare'}">
+                                <h:outputText value="#{drawerentry.afterBalance}" styleClass="text-end d-block" rendered="#{drawerentry.paymentMethod eq 'Staff_Welfare'}">
                                     <f:convertNumber groupingUsed="true" minFractionDigits="2" maxFractionDigits="2"/>
                                 </h:outputText>
                             </p:column>
 
                             <!-- Voucher columns -->
                             <p:column style="padding: 4px;" width="7em" rendered="#{userSettingsController.allUsersDrawerHistoryVoucherVisible}">
-                                <h:outputText value="#{drawerentry.beforeBalance}" styleClass="text-end d-block" rendered="#{drawerentry.payment.paymentMethod eq 'Voucher'}">
+                                <h:outputText value="#{drawerentry.beforeBalance}" styleClass="text-end d-block" rendered="#{drawerentry.paymentMethod eq 'Voucher'}">
                                     <f:convertNumber groupingUsed="true" minFractionDigits="2" maxFractionDigits="2"/>
                                 </h:outputText>
                             </p:column>
                             <p:column style="padding: 4px;" width="7em" rendered="#{userSettingsController.allUsersDrawerHistoryVoucherVisible}">
-                                <h:outputText value="#{drawerentry.payment.paidValue}" styleClass="text-end d-block" rendered="#{drawerentry.payment.paymentMethod eq 'Voucher'}">
+                                <h:outputText value="#{drawerentry.transactionValue}" styleClass="text-end d-block" rendered="#{drawerentry.paymentMethod eq 'Voucher'}">
                                     <f:convertNumber groupingUsed="true" minFractionDigits="2" maxFractionDigits="2"/>
                                 </h:outputText>
                             </p:column>
                             <p:column style="padding: 4px;" width="7em" rendered="#{userSettingsController.allUsersDrawerHistoryVoucherVisible}">
-                                <h:outputText value="#{drawerentry.afterBalance}" styleClass="text-end d-block" rendered="#{drawerentry.payment.paymentMethod eq 'Voucher'}">
+                                <h:outputText value="#{drawerentry.afterBalance}" styleClass="text-end d-block" rendered="#{drawerentry.paymentMethod eq 'Voucher'}">
                                     <f:convertNumber groupingUsed="true" minFractionDigits="2" maxFractionDigits="2"/>
                                 </h:outputText>
                             </p:column>
 
                             <!-- Patient Deposit columns -->
                             <p:column style="padding: 4px;" width="7em" rendered="#{userSettingsController.allUsersDrawerHistoryPatientDepositVisible}">
-                                <h:outputText value="#{drawerentry.beforeBalance}" styleClass="text-end d-block" rendered="#{drawerentry.payment.paymentMethod eq 'PatientDeposit'}">
+                                <h:outputText value="#{drawerentry.beforeBalance}" styleClass="text-end d-block" rendered="#{drawerentry.paymentMethod eq 'PatientDeposit'}">
                                     <f:convertNumber groupingUsed="true" minFractionDigits="2" maxFractionDigits="2"/>
                                 </h:outputText>
                             </p:column>
                             <p:column style="padding: 4px;" width="7em" rendered="#{userSettingsController.allUsersDrawerHistoryPatientDepositVisible}">
-                                <h:outputText value="#{drawerentry.payment.paidValue}" styleClass="text-end d-block" rendered="#{drawerentry.payment.paymentMethod eq 'PatientDeposit'}">
+                                <h:outputText value="#{drawerentry.transactionValue}" styleClass="text-end d-block" rendered="#{drawerentry.paymentMethod eq 'PatientDeposit'}">
                                     <f:convertNumber groupingUsed="true" minFractionDigits="2" maxFractionDigits="2"/>
                                 </h:outputText>
                             </p:column>
                             <p:column style="padding: 4px;" width="7em" rendered="#{userSettingsController.allUsersDrawerHistoryPatientDepositVisible}">
-                                <h:outputText value="#{drawerentry.afterBalance}" styleClass="text-end d-block" rendered="#{drawerentry.payment.paymentMethod eq 'PatientDeposit'}">
+                                <h:outputText value="#{drawerentry.afterBalance}" styleClass="text-end d-block" rendered="#{drawerentry.paymentMethod eq 'PatientDeposit'}">
                                     <f:convertNumber groupingUsed="true" minFractionDigits="2" maxFractionDigits="2"/>
                                 </h:outputText>
                             </p:column>
 
                             <!-- Patient Points columns -->
                             <p:column style="padding: 4px;" width="7em" rendered="#{userSettingsController.allUsersDrawerHistoryPatientPointsVisible}">
-                                <h:outputText value="#{drawerentry.beforeBalance}" styleClass="text-end d-block" rendered="#{drawerentry.payment.paymentMethod eq 'PatientPoints'}">
+                                <h:outputText value="#{drawerentry.beforeBalance}" styleClass="text-end d-block" rendered="#{drawerentry.paymentMethod eq 'PatientPoints'}">
                                     <f:convertNumber groupingUsed="true" minFractionDigits="2" maxFractionDigits="2"/>
                                 </h:outputText>
                             </p:column>
                             <p:column style="padding: 4px;" width="7em" rendered="#{userSettingsController.allUsersDrawerHistoryPatientPointsVisible}">
-                                <h:outputText value="#{drawerentry.payment.paidValue}" styleClass="text-end d-block" rendered="#{drawerentry.payment.paymentMethod eq 'PatientPoints'}">
+                                <h:outputText value="#{drawerentry.transactionValue}" styleClass="text-end d-block" rendered="#{drawerentry.paymentMethod eq 'PatientPoints'}">
                                     <f:convertNumber groupingUsed="true" minFractionDigits="2" maxFractionDigits="2"/>
                                 </h:outputText>
                             </p:column>
                             <p:column style="padding: 4px;" width="7em" rendered="#{userSettingsController.allUsersDrawerHistoryPatientPointsVisible}">
-                                <h:outputText value="#{drawerentry.afterBalance}" styleClass="text-end d-block" rendered="#{drawerentry.payment.paymentMethod eq 'PatientPoints'}">
+                                <h:outputText value="#{drawerentry.afterBalance}" styleClass="text-end d-block" rendered="#{drawerentry.paymentMethod eq 'PatientPoints'}">
                                     <f:convertNumber groupingUsed="true" minFractionDigits="2" maxFractionDigits="2"/>
                                 </h:outputText>
                             </p:column>
 
                             <!-- Online Settlement columns -->
                             <p:column style="padding: 4px;" width="7em" rendered="#{userSettingsController.allUsersDrawerHistoryOnlineSettlementVisible}">
-                                <h:outputText value="#{drawerentry.beforeBalance}" styleClass="text-end d-block" rendered="#{drawerentry.payment.paymentMethod eq 'OnlineSettlement'}">
+                                <h:outputText value="#{drawerentry.beforeBalance}" styleClass="text-end d-block" rendered="#{drawerentry.paymentMethod eq 'OnlineSettlement'}">
                                     <f:convertNumber groupingUsed="true" minFractionDigits="2" maxFractionDigits="2"/>
                                 </h:outputText>
                             </p:column>
                             <p:column style="padding: 4px;" width="7em" rendered="#{userSettingsController.allUsersDrawerHistoryOnlineSettlementVisible}">
-                                <h:outputText value="#{drawerentry.payment.paidValue}" styleClass="text-end d-block" rendered="#{drawerentry.payment.paymentMethod eq 'OnlineSettlement'}">
+                                <h:outputText value="#{drawerentry.transactionValue}" styleClass="text-end d-block" rendered="#{drawerentry.paymentMethod eq 'OnlineSettlement'}">
                                     <f:convertNumber groupingUsed="true" minFractionDigits="2" maxFractionDigits="2"/>
                                 </h:outputText>
                             </p:column>
                             <p:column style="padding: 4px;" width="7em" rendered="#{userSettingsController.allUsersDrawerHistoryOnlineSettlementVisible}">
-                                <h:outputText value="#{drawerentry.afterBalance}" styleClass="text-end d-block" rendered="#{drawerentry.payment.paymentMethod eq 'OnlineSettlement'}">
+                                <h:outputText value="#{drawerentry.afterBalance}" styleClass="text-end d-block" rendered="#{drawerentry.paymentMethod eq 'OnlineSettlement'}">
                                     <f:convertNumber groupingUsed="true" minFractionDigits="2" maxFractionDigits="2"/>
                                 </h:outputText>
                             </p:column>
 
                             <!-- Total Transaction Value column -->
                             <p:column style="padding: 6px;" width="8em">
-                                <h:outputText value="#{drawerentry.payment.paidValue}" styleClass="text-end d-block">
+                                <h:outputText value="#{drawerentry.transactionValue}" styleClass="text-end d-block">
                                     <f:convertNumber groupingUsed="true" minFractionDigits="2" maxFractionDigits="2"/>
                                 </h:outputText>
                             </p:column>

--- a/src/main/webapp/reports/financialReports/drawer_history.xhtml
+++ b/src/main/webapp/reports/financialReports/drawer_history.xhtml
@@ -153,115 +153,115 @@
                             </p:column>
 
                             <p:column headerText="Cash" style="width:8em; text-align:right;">
-                                <h:outputText rendered="#{drawerentry.paymentMethod eq 'Cash'}" value="#{drawerentry.payment.paidValue}">
+                                <h:outputText rendered="#{drawerentry.paymentMethod eq 'Cash'}" value="#{drawerentry.transactionValue}">
                                     <f:convertNumber pattern="#,##0.00" />
                                 </h:outputText>
                             </p:column>
 
                             <p:column headerText="Card" style="width:8em; text-align:right;">
-                                <h:outputText rendered="#{drawerentry.paymentMethod eq 'Card'}" value="#{drawerentry.payment.paidValue}">
+                                <h:outputText rendered="#{drawerentry.paymentMethod eq 'Card'}" value="#{drawerentry.transactionValue}">
                                     <f:convertNumber pattern="#,##0.00" />
                                 </h:outputText>
                             </p:column>
 
                             <p:column headerText="Cheque" style="width:8em; text-align:right;">
-                                <h:outputText rendered="#{drawerentry.paymentMethod eq 'Cheque'}" value="#{drawerentry.payment.paidValue}">
+                                <h:outputText rendered="#{drawerentry.paymentMethod eq 'Cheque'}" value="#{drawerentry.transactionValue}">
                                     <f:convertNumber pattern="#,##0.00" />
                                 </h:outputText>
                             </p:column>
 
                             <p:column headerText="e-Wallet" style="width:8em; text-align:right;">
-                                <h:outputText rendered="#{drawerentry.paymentMethod eq 'ewallet'}" value="#{drawerentry.payment.paidValue}">
+                                <h:outputText rendered="#{drawerentry.paymentMethod eq 'ewallet'}" value="#{drawerentry.transactionValue}">
                                     <f:convertNumber pattern="#,##0.00" />
                                 </h:outputText>
                             </p:column>
 
                             <p:column headerText="Slip" style="width:8em; text-align:right;">
-                                <h:outputText rendered="#{drawerentry.paymentMethod eq 'Slip'}" value="#{drawerentry.payment.paidValue}">
+                                <h:outputText rendered="#{drawerentry.paymentMethod eq 'Slip'}" value="#{drawerentry.transactionValue}">
                                     <f:convertNumber pattern="#,##0.00" />
                                 </h:outputText>
                             </p:column>
 
                             <p:column headerText="Agent" style="width:8em; text-align:right;">
-                                <h:outputText rendered="#{drawerentry.paymentMethod eq 'Agent'}" value="#{drawerentry.payment.paidValue}">
+                                <h:outputText rendered="#{drawerentry.paymentMethod eq 'Agent'}" value="#{drawerentry.transactionValue}">
                                     <f:convertNumber pattern="#,##0.00" />
                                 </h:outputText>
                             </p:column>
 
                             <p:column headerText="IOU" style="width:8em; text-align:right;">
-                                <h:outputText rendered="#{drawerentry.paymentMethod eq 'IOU'}" value="#{drawerentry.payment.paidValue}">
+                                <h:outputText rendered="#{drawerentry.paymentMethod eq 'IOU'}" value="#{drawerentry.transactionValue}">
                                     <f:convertNumber pattern="#,##0.00" />
                                 </h:outputText>
                             </p:column>
 
                             <p:column headerText="Staff Credit" style="width:8em; text-align:right;">
-                                <h:outputText rendered="#{drawerentry.paymentMethod eq 'Staff'}" value="#{drawerentry.payment.paidValue}">
+                                <h:outputText rendered="#{drawerentry.paymentMethod eq 'Staff'}" value="#{drawerentry.transactionValue}">
                                     <f:convertNumber pattern="#,##0.00" />
                                 </h:outputText>
                             </p:column>
 
                             <p:column headerText="Credit" style="width:8em; text-align:right;">
-                                <h:outputText rendered="#{drawerentry.paymentMethod eq 'Credit'}" value="#{drawerentry.payment.paidValue}">
+                                <h:outputText rendered="#{drawerentry.paymentMethod eq 'Credit'}" value="#{drawerentry.transactionValue}">
                                     <f:convertNumber pattern="#,##0.00" />
                                 </h:outputText>
                             </p:column>
 
                             <p:column headerText="Staff Welfare" style="width:8em; text-align:right;">
-                                <h:outputText rendered="#{drawerentry.paymentMethod eq 'Staff_Welfare'}" value="#{drawerentry.payment.paidValue}">
+                                <h:outputText rendered="#{drawerentry.paymentMethod eq 'Staff_Welfare'}" value="#{drawerentry.transactionValue}">
                                     <f:convertNumber pattern="#,##0.00" />
                                 </h:outputText>
                             </p:column>
 
                             <p:column headerText="Patient Deposit" style="width:9em; text-align:right;">
-                                <h:outputText rendered="#{drawerentry.paymentMethod eq 'PatientDeposit'}" value="#{drawerentry.payment.paidValue}">
+                                <h:outputText rendered="#{drawerentry.paymentMethod eq 'PatientDeposit'}" value="#{drawerentry.transactionValue}">
                                     <f:convertNumber pattern="#,##0.00" />
                                 </h:outputText>
                             </p:column>
 
                             <p:column headerText="Patient Points" style="width:9em; text-align:right;">
-                                <h:outputText rendered="#{drawerentry.paymentMethod eq 'PatientPoints'}" value="#{drawerentry.payment.paidValue}">
+                                <h:outputText rendered="#{drawerentry.paymentMethod eq 'PatientPoints'}" value="#{drawerentry.transactionValue}">
                                     <f:convertNumber pattern="#,##0.00" />
                                 </h:outputText>
                             </p:column>
 
                             <p:column headerText="Online Settlement" style="width:10em; text-align:right;">
-                                <h:outputText rendered="#{drawerentry.paymentMethod eq 'OnlineSettlement'}" value="#{drawerentry.payment.paidValue}">
+                                <h:outputText rendered="#{drawerentry.paymentMethod eq 'OnlineSettlement'}" value="#{drawerentry.transactionValue}">
                                     <f:convertNumber pattern="#,##0.00" />
                                 </h:outputText>
                             </p:column>
 
                             <p:column headerText="Multiple" style="width:8em; text-align:right;">
-                                <h:outputText rendered="#{drawerentry.paymentMethod eq 'MultiplePaymentMethods'}" value="#{drawerentry.payment.paidValue}">
+                                <h:outputText rendered="#{drawerentry.paymentMethod eq 'MultiplePaymentMethods'}" value="#{drawerentry.transactionValue}">
                                     <f:convertNumber pattern="#,##0.00" />
                                 </h:outputText>
                             </p:column>
 
                             <p:column headerText="Voucher" style="width:8em; text-align:right;">
-                                <h:outputText rendered="#{drawerentry.paymentMethod eq 'Voucher'}" value="#{drawerentry.payment.paidValue}">
+                                <h:outputText rendered="#{drawerentry.paymentMethod eq 'Voucher'}" value="#{drawerentry.transactionValue}">
                                     <f:convertNumber pattern="#,##0.00" />
                                 </h:outputText>
                             </p:column>
 
                             <p:column headerText="You Owe Me" style="width:8em; text-align:right;">
-                                <h:outputText rendered="#{drawerentry.paymentMethod eq 'YouOweMe'}" value="#{drawerentry.payment.paidValue}">
+                                <h:outputText rendered="#{drawerentry.paymentMethod eq 'YouOweMe'}" value="#{drawerentry.transactionValue}">
                                     <f:convertNumber pattern="#,##0.00" />
                                 </h:outputText>
                             </p:column>
 
                             <p:column headerText="Online Booking" style="width:9em; text-align:right;">
-                                <h:outputText rendered="#{drawerentry.paymentMethod eq 'OnlineBookingAgent'}" value="#{drawerentry.payment.paidValue}">
+                                <h:outputText rendered="#{drawerentry.paymentMethod eq 'OnlineBookingAgent'}" value="#{drawerentry.transactionValue}">
                                     <f:convertNumber pattern="#,##0.00" />
                                 </h:outputText>
                             </p:column>
 
                             <p:column headerText="On Call" style="width:8em; text-align:right;">
-                                <h:outputText rendered="#{drawerentry.paymentMethod eq 'OnCall'}" value="#{drawerentry.payment.paidValue}">
+                                <h:outputText rendered="#{drawerentry.paymentMethod eq 'OnCall'}" value="#{drawerentry.transactionValue}">
                                     <f:convertNumber pattern="#,##0.00" />
                                 </h:outputText>
                             </p:column>
 
                             <p:column headerText="None" style="width:8em; text-align:right;">
-                                <h:outputText rendered="#{drawerentry.paymentMethod eq 'None'}" value="#{drawerentry.payment.paidValue}">
+                                <h:outputText rendered="#{drawerentry.paymentMethod eq 'None'}" value="#{drawerentry.transactionValue}">
                                     <f:convertNumber pattern="#,##0.00" />
                                 </h:outputText>
                             </p:column>


### PR DESCRIPTION
## Summary
- Bind drawer-history report columns to `DrawerEntry`'s own fields (`paymentMethod`, `transactionValue`, `bill.billTypeAtomic.billFinanceType`) instead of `drawerentry.payment.*`, which is null on adjustment entries — that's why adjustment rows showed up empty.
- Fix `DrawerService.applyDrawerAdjustment` to tag the `DrawerEntry` with the **drawer owner** rather than the approver/admin actor, so user-filtered drawer history surfaces the adjustment under the correct cashier. The actor is preserved as the entry's `creater`.
- Replace the duplicate "Ref Bill No" column (was just `bill.deptId` again) with the actual `bill.referenceBill.deptId`.

### Files
- `src/main/webapp/reports/financialReports/all_users_drawer_history.xhtml` — primary report from the issue
- `src/main/webapp/reports/financialReports/drawer_history.xhtml` — same `payment.paidValue` antipattern
- `src/main/webapp/cashier/cashier_drawer_entry_history.xhtml` — same `payment.paidValue` antipattern in the "Paid" column
- `src/main/java/com/divudi/service/DrawerService.java` — `applyDrawerAdjustment` user-assignment fix

## Test plan
- [ ] As a cashier, submit a Drawer Adjustment Request from `/cashier/drawer_adjustment_request.xhtml`; have a supervisor approve it.
- [ ] As an admin, perform a direct adjustment via the admin adjustment page.
- [ ] Open `/reports/financialReports/all_users_drawer_history.xhtml`, set the date range, and verify:
  - The adjustment row appears with Transaction Type "Float Change".
  - The adjusted amount renders in the correct payment-method "Tra." column.
  - "Total Transaction Value" shows the delta.
  - Filtering by the **cashier** whose drawer was adjusted (not the approver) returns the row.
- [ ] Verify the same row also appears correctly in `/reports/financialReports/drawer_history.xhtml` and `/cashier/cashier_drawer_entry_history.xhtml`.
- [ ] Verify normal payment-driven entries still display correctly (no regression for Cash/Card/etc. bills).

Closes #19487

🤖 Generated with [Claude Code](https://claude.com/claude-code)