### PR TITLE
fix(cashier): validate float transfer amount against drawer balance

### DIFF
--- a/src/main/java/com/divudi/bean/cashTransaction/FinancialTransactionController.java
+++ b/src/main/java/com/divudi/bean/cashTransaction/FinancialTransactionController.java
@@ -2846,6 +2846,23 @@ public class FinancialTransactionController implements Serializable {
             return;
         }
         currentPayment.setPaymentMethod(PaymentMethod.Cash);
+
+        if (configOptionApplicationController.getBooleanValueByKey("Enable Drawer Manegment", true)) {
+            Drawer drawer = getLoggedUserDrawer();
+            double drawerBalance = (drawer != null && drawer.getCashInHandValue() != null)
+                    ? drawer.getCashInHandValue() : 0.0;
+            double cumulativeCash = Math.abs(currentPayment.getPaidValue());
+            for (Payment p : getCurrentBillPayments()) {
+                if (p.getPaymentMethod() == PaymentMethod.Cash) {
+                    cumulativeCash += Math.abs(p.getPaidValue());
+                }
+            }
+            if (cumulativeCash > drawerBalance) {
+                JsfUtil.addErrorMessage("Transfer amount cannot exceed available drawer balance (" + drawerBalance + ").");
+                return;
+            }
+        }
+
         getCurrentBillPayments().add(currentPayment);
         calculateFundTransferBillTotal();
         currentPayment = null;
@@ -3184,6 +3201,23 @@ public class FinancialTransactionController implements Serializable {
             floatTransferStarted = false;
             JsfUtil.addErrorMessage("At least one float must be added before settlement");
             return "";
+        }
+
+        if (configOptionApplicationController.getBooleanValueByKey("Enable Drawer Manegment", true)) {
+            Drawer drawer = getLoggedUserDrawer();
+            double drawerBalance = (drawer != null && drawer.getCashInHandValue() != null)
+                    ? drawer.getCashInHandValue() : 0.0;
+            double totalCash = 0.0;
+            for (Payment p : getCurrentBillPayments()) {
+                if (p.getPaymentMethod() == PaymentMethod.Cash) {
+                    totalCash += Math.abs(p.getPaidValue());
+                }
+            }
+            if (totalCash > drawerBalance) {
+                floatTransferStarted = false;
+                JsfUtil.addErrorMessage("Transfer amount cannot exceed available drawer balance (" + drawerBalance + ").");
+                return "";
+            }
         }
 
         // Check for pending transactions before allowing fund transfer creation

--- a/src/main/java/com/divudi/bean/cashTransaction/FinancialTransactionController.java
+++ b/src/main/java/com/divudi/bean/cashTransaction/FinancialTransactionController.java
@@ -2848,7 +2848,9 @@ public class FinancialTransactionController implements Serializable {
         currentPayment.setPaymentMethod(PaymentMethod.Cash);
 
         if (configOptionApplicationController.getBooleanValueByKey("Enable Drawer Manegment", true)) {
-            Drawer drawer = getLoggedUserDrawer();
+            Drawer drawer = sessionController.getLoggedUserDrawer() != null
+                    ? drawerFacade.find(sessionController.getLoggedUserDrawer().getId())
+                    : null;
             double drawerBalance = (drawer != null && drawer.getCashInHandValue() != null)
                     ? drawer.getCashInHandValue() : 0.0;
             double cumulativeCash = Math.abs(currentPayment.getPaidValue());
@@ -3204,7 +3206,9 @@ public class FinancialTransactionController implements Serializable {
         }
 
         if (configOptionApplicationController.getBooleanValueByKey("Enable Drawer Manegment", true)) {
-            Drawer drawer = getLoggedUserDrawer();
+            Drawer drawer = sessionController.getLoggedUserDrawer() != null
+                    ? drawerFacade.find(sessionController.getLoggedUserDrawer().getId())
+                    : null;
             double drawerBalance = (drawer != null && drawer.getCashInHandValue() != null)
                     ? drawer.getCashInHandValue() : 0.0;
             double totalCash = 0.0;


### PR DESCRIPTION
## Summary
- Float Transfer (`cashier/fund_transfer_bill.xhtml`) was accepting transfers larger than the user's drawer balance — e.g. a Rs. 100,000 transfer with only Rs. 50,000 in the drawer would settle silently.
- Added cumulative cash-vs-`cashInHandValue` validation in both `addPaymentToFundTransferBill()` (per-row) and `settleFundTransferBill()` (defense-in-depth at settle), gated on the existing `Enable Drawer Manegment` config flag.
- Mirrors the pattern already used by `addPaymentToExpenseBill()` and `settleDepositFundBill()` so the float flow is consistent with the rest of the cashier module. Float is now cash-only, so no per-method check is needed.

Closes #19815

## Test plan
- [ ] Drawer = Rs. 50,000 → try transferring Rs. 100,000 → error message `"Transfer amount cannot exceed available drawer balance (50000.0)."` is shown and the bill does not settle
- [ ] Drawer = Rs. 50,000 → stack two Add clicks of Rs. 30,000 each (Rs. 60,000 cumulative) → second Add is rejected
- [ ] Drawer = Rs. 50,000 → transfer Rs. 50,000 exactly → settles normally and drawer balance becomes 0
- [ ] With `Enable Drawer Manegment` config set to `false` → validation is skipped (current behaviour preserved)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Drawer balance validation is now enforced when adding cash payments and settling fund transfers, preventing cash transfer operations that exceed the available drawer balance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->