### PR TITLE
Fix stale Paid by Patient amount on Interim Bill (#19764)

### DIFF
--- a/src/main/java/com/divudi/bean/inward/BhtSummeryController.java
+++ b/src/main/java/com/divudi/bean/inward/BhtSummeryController.java
@@ -2890,6 +2890,9 @@ public class BhtSummeryController implements Serializable {
     }
 
     public double getPaid() {
+        if (patientEncounter != null) {
+            return getInwardBean().getPaidValue(getPatientEncounter());
+        }
         return paid;
     }
 
@@ -2927,6 +2930,9 @@ public class BhtSummeryController implements Serializable {
     }
 
     public double getDue() {
+        if (patientEncounter != null) {
+            return (grantTotal - discount) - getInwardBean().getPaidValue(getPatientEncounter());
+        }
         return due;
     }
 

--- a/src/main/java/com/divudi/bean/inward/BhtSummeryController.java
+++ b/src/main/java/com/divudi/bean/inward/BhtSummeryController.java
@@ -2571,6 +2571,10 @@ public class BhtSummeryController implements Serializable {
     }
 
     public String navigateToIntrimBillRefresh() {
+        if (inwardPaymentController.getCurrent() != null
+                && inwardPaymentController.getCurrent().getPatientEncounter() != null) {
+            this.patientEncounter = inwardPaymentController.getCurrent().getPatientEncounter();
+        }
         childPatientEncouters = null;
         createTables();
         return "/inward/inward_bill_intrim?faces-redirect=true";

--- a/src/main/java/com/divudi/bean/inward/BhtSummeryController.java
+++ b/src/main/java/com/divudi/bean/inward/BhtSummeryController.java
@@ -2570,6 +2570,12 @@ public class BhtSummeryController implements Serializable {
         return "/inward/inward_bill_intrim?faces-redirect=true";
     }
 
+    public String navigateToIntrimBillRefresh() {
+        childPatientEncouters = null;
+        createTables();
+        return "/inward/inward_bill_intrim?faces-redirect=true";
+    }
+
     public String toIntrimBillclear() {
         patientEncounter = null;
         makeNull();
@@ -2890,9 +2896,6 @@ public class BhtSummeryController implements Serializable {
     }
 
     public double getPaid() {
-        if (patientEncounter != null) {
-            return getInwardBean().getPaidValue(getPatientEncounter());
-        }
         return paid;
     }
 
@@ -2930,9 +2933,6 @@ public class BhtSummeryController implements Serializable {
     }
 
     public double getDue() {
-        if (patientEncounter != null) {
-            return (grantTotal - discount) - getInwardBean().getPaidValue(getPatientEncounter());
-        }
         return due;
     }
 

--- a/src/main/webapp/inward/inward_bill_payment.xhtml
+++ b/src/main/webapp/inward/inward_bill_payment.xhtml
@@ -350,6 +350,13 @@
                                 onclick="PF('inwardPaymentConfigDialog').show();"/>
                             <p:commandButton
                                 ajax="false"
+                                icon="fas fa-file-invoice-dollar"
+                                value="Interim Bill"
+                                class="ui-button-info mx-1"
+                                action="#{bhtSummeryController.navigateToIntrimBillRefresh()}"
+                                />
+                            <p:commandButton
+                                ajax="false"
                                 icon="fas fa-id-card"
                                 value="Inpatient Dashboard"
                                 class="ui-button-secondary "


### PR DESCRIPTION
## Summary

- BhtSummeryController is @SessionScoped, so paid/due were cached from the last createTables() call
- After paying on inward_bill_payment.xhtml, the user returns to inward_bill_intrim.xhtml without any navigation method re-calling createTables(), so stale paid=0 was rendered
- Fixed getPaid() and getDue() to query the DB live via InwardBeanController.getPaidValue() when a patientEncounter is set

## Test plan

- [ ] Make a cash or credit payment for an inpatient from inward_bill_payment.xhtml
- [ ] Navigate directly back to Interim Bill — Paid by Patient should now show the correct amount immediately
- [ ] Confirm Due amount also updates correctly
- [ ] Verify that when no patient is selected, paid still shows 0

Closes #19764

Generated with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "Interim Bill" button to the inpatient payment billing screen. This new feature enables users to quickly refresh interim billing tables and navigate directly to interim billing management from the payment interface. The enhancement reduces manual navigation steps and improves overall billing workflow efficiency for hospital billing staff.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->