### PR TITLE
20530 showing cash balance on the pharmacy bill

### DIFF
--- a/src/main/webapp/pharmacy/report_pharmacy_sale_bill_summary.xhtml
+++ b/src/main/webapp/pharmacy/report_pharmacy_sale_bill_summary.xhtml
@@ -63,7 +63,7 @@
                             class="ui-button-info " >
                             <p:printer target="gpBillPreview"  />
                         </p:commandButton>
-                        <h:panelGroup rendered="#{webUserController.hasPrivilege('ChangeReceiptPrintingPaperTypes')}">
+                        <h:panelGroup >
                             <p:outputLabel value="Paper Type" class="m-2"></p:outputLabel>
                             <p:selectOneMenu value="#{sessionController.departmentPreference.pharmacyBillPaperType}" class="m-1" id='ph' style="width: 13em;">
                                 <f:selectItem itemLabel="Please Select Paper Type" />

--- a/src/main/webapp/resources/pharmacy/saleBill.xhtml
+++ b/src/main/webapp/resources/pharmacy/saleBill.xhtml
@@ -368,7 +368,7 @@
                                 <h:outputLabel   value="Balance" />
                             </td>
                             <td  class="totalsItemBlock" style="text-align: right;">
-                                <h:outputLabel   value="#{cc.attrs.bill.balance}">
+                                <h:outputLabel   value="#{cc.attrs.bill.cashPaid-cc.attrs.bill.netTotal}">
                                     <f:convertNumber pattern="#,##0.00" />
                                 </h:outputLabel>
                             </td>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Balance calculation in pharmacy sale bills now displays the correct difference between cash paid and net total.

* **Changes**
  * Paper Type selection in pharmacy sale bill summary is now available to all users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->