### PR TITLE
fix(ci): use --detach for asadmin deploy to avoid 600s client timeout on RMH prod

### DIFF
--- a/.github/workflows/rmh_prod_ci_cd.yml
+++ b/.github/workflows/rmh_prod_ci_cd.yml
@@ -113,8 +113,14 @@ jobs:
           # 15 minutes so the CI/CD still fails loudly if the deploy truly fails.
           ssh -i private_key.pem -o StrictHostKeyChecking=no $SERVER_USER@$SERVER_IP "
             echo 'AS_ADMIN_PASSWORD=$PAYARA_ADMIN_PASS' > /tmp/payara-admin-pass.txt
+            trap 'rm -f /tmp/payara-admin-pass.txt' EXIT
             /opt/payara5/bin/asadmin --user admin --passwordfile /tmp/payara-admin-pass.txt undeploy $APP_NAME || true
-            /opt/payara5/bin/asadmin --user admin --passwordfile /tmp/payara-admin-pass.txt --detach deploy --contextroot $APP_NAME $WAR_DIR/$WAR_NAME
+            /opt/payara5/bin/asadmin --user admin --passwordfile /tmp/payara-admin-pass.txt --detach deploy --force=true --contextroot $APP_NAME $WAR_DIR/$WAR_NAME
+            DEPLOY_EXIT=\$?
+            if [ \"\$DEPLOY_EXIT\" != '0' ]; then
+              echo 'Deploy submission failed (asadmin exit code '\$DEPLOY_EXIT').'
+              exit \$DEPLOY_EXIT
+            fi
             echo 'Deploy submitted. Polling for application start (up to 15 min)...'
             DEPLOYED=false
             for i in \$(seq 1 30); do
@@ -128,10 +134,8 @@ jobs:
             done
             if [ \"\$DEPLOYED\" = 'false' ]; then
               echo 'Application failed to start within 15 minutes.'
-              rm /tmp/payara-admin-pass.txt
               exit 1
             fi
-            rm /tmp/payara-admin-pass.txt
           "
 
           # Check if the application is reachable

--- a/.github/workflows/rmh_prod_ci_cd.yml
+++ b/.github/workflows/rmh_prod_ci_cd.yml
@@ -106,20 +106,30 @@ jobs:
           "
 
           # Deploy the WAR using asadmin
+          # Use --detach so the asadmin client does not block waiting for EclipseLink
+          # deploy-on-startup to finish (which previously caused the 600 s client
+          # timeout to fire even though Payara was still initialising normally).
+          # After submitting the detached deploy, poll list-applications for up to
+          # 15 minutes so the CI/CD still fails loudly if the deploy truly fails.
           ssh -i private_key.pem -o StrictHostKeyChecking=no $SERVER_USER@$SERVER_IP "
             echo 'AS_ADMIN_PASSWORD=$PAYARA_ADMIN_PASS' > /tmp/payara-admin-pass.txt
             /opt/payara5/bin/asadmin --user admin --passwordfile /tmp/payara-admin-pass.txt undeploy $APP_NAME || true
-            /opt/payara5/bin/asadmin --user admin --passwordfile /tmp/payara-admin-pass.txt deploy --force=true --contextroot $APP_NAME $WAR_DIR/$WAR_NAME
-            rm /tmp/payara-admin-pass.txt
-          "
-
-          # Validate if the application is running
-          ssh -i private_key.pem -o StrictHostKeyChecking=no $SERVER_USER@$SERVER_IP "
-            echo 'AS_ADMIN_PASSWORD=$PAYARA_ADMIN_PASS' > /tmp/payara-admin-pass.txt
-            if /opt/payara5/bin/asadmin --user admin --passwordfile /tmp/payara-admin-pass.txt list-applications | grep -q '$APP_NAME'; then
-              echo 'Application is running.'
-            else
-              echo 'Application failed to start.'
+            /opt/payara5/bin/asadmin --user admin --passwordfile /tmp/payara-admin-pass.txt --detach deploy --contextroot $APP_NAME $WAR_DIR/$WAR_NAME
+            echo 'Deploy submitted. Polling for application start (up to 15 min)...'
+            DEPLOYED=false
+            for i in \$(seq 1 30); do
+              sleep 30
+              if /opt/payara5/bin/asadmin --user admin --passwordfile /tmp/payara-admin-pass.txt list-applications | grep -q '^$APP_NAME '; then
+                echo 'Application is running.'
+                DEPLOYED=true
+                break
+              fi
+              echo \"  Still waiting... (\$i/30)\"
+            done
+            if [ \"\$DEPLOYED\" = 'false' ]; then
+              echo 'Application failed to start within 15 minutes.'
+              rm /tmp/payara-admin-pass.txt
+              exit 1
             fi
             rm /tmp/payara-admin-pass.txt
           "


### PR DESCRIPTION
## Summary

- Pass `--detach` to `asadmin deploy` so the client returns immediately instead of blocking on EclipseLink deploy-on-startup (which was hitting the 600s timeout)
- Poll `list-applications` in a loop for up to 15 minutes to detect genuine failures
- Clean up the password file in all code paths

Closes #20536

## Test plan

- [ ] Trigger a deploy to RMH prod and confirm the job no longer times out during normal EclipseLink initialisation
- [ ] Confirm a bad WAR still causes the CI job to fail (deploy does not appear in `list-applications` within 15 min)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Enhanced deployment verification to ensure applications start successfully. The system now actively monitors application startup with a 15-minute verification window and automatically fails the deployment if the application does not start within the timeout period.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->