### PR TITLE
Refactor pharmacy transfer issued list to use DTOs

### DIFF
--- a/src/main/java/com/divudi/bean/common/SearchController.java
+++ b/src/main/java/com/divudi/bean/common/SearchController.java
@@ -84,6 +84,8 @@ import com.divudi.core.data.dto.PharmacyPreBillSearchDTO;
 import com.divudi.core.data.dto.PharmacyTransferRequestIssueDTO;
 import com.divudi.core.data.dto.PharmacyTransferRequestListDTO;
 import com.divudi.core.data.dto.PharmacyPurchaseOrderDTO;
+import com.divudi.core.data.dto.PharmacyTransferIssuedListDTO;
+import com.divudi.core.data.dto.PharmacyTransferReceivedListDTO;
 import com.divudi.core.entity.AgentHistory;
 import com.divudi.core.entity.Category;
 import com.divudi.core.entity.Payment;
@@ -304,6 +306,8 @@ public class SearchController implements Serializable {
     private Map<Long, List<PharmacyPreBillSearchDTO>> returnBillsByParentBillId;
     // DTO list for pharmacy transfer requests
     private List<PharmacyTransferRequestListDTO> transferRequestDtos;
+    // DTO list for pharmacy transfer issued list (pharmacy_transfer_issued_list.xhtml)
+    private List<PharmacyTransferIssuedListDTO> transferIssuedListDtos = new ArrayList<>();
     // DTO lists for disposal issue search results
     private List<PharmacyItemPurchaseDTO> disposalIssueBillDtos;
     private List<PharmacyItemPurchaseDTO> disposalIssueBillItemDtos;
@@ -4142,42 +4146,106 @@ public class SearchController implements Serializable {
     }
 
     public void listTransferIssuesToReceiveForLoggedDepartment() {
-        String jpql;
+        fetchTransferIssuedListDtos(null);
+    }
+
+    public void listFullyReceivedTransferIssues() {
+        fetchTransferIssuedListDtos(Boolean.TRUE);
+    }
+
+    public void listYetToReceiveTransferIssues() {
+        fetchTransferIssuedListDtos(Boolean.FALSE);
+    }
+
+    private void fetchTransferIssuedListDtos(Boolean fullyIssuedFilter) {
         List<BillTypeAtomic> btas = new ArrayList<>();
         btas.add(BillTypeAtomic.PHARMACY_ISSUE);
         btas.add(BillTypeAtomic.PHARMACY_DIRECT_ISSUE);
-        HashMap params = new HashMap();
+        Map<String, Object> params = new HashMap<>();
         params.put("toDate", getToDate());
         params.put("fromDate", getFromDate());
-        params.put("dep", getSessionController().getDepartment());
+        params.put("toDep", getSessionController().getDepartment());
         params.put("bTp", btas);
 
-        jpql = "Select b "
-                + " From Bill b "
-                + " where b.retired=false "
-                + " and b.toDepartment=:dep "
-                + " and b.billTypeAtomic in :bTp "
-                + " and b.createdAt between :fromDate and :toDate ";
+        StringBuilder jpql = new StringBuilder();
+        jpql.append("SELECT NEW com.divudi.core.data.dto.PharmacyTransferIssuedListDTO(");
+        jpql.append("b.id, b.deptId, d.name, b.departmentType, wup.name, stfp.name, ");
+        jpql.append("b.createdAt, b.cancelled, b.fullyIssued, cbwup.name, cb.createdAt) ");
+        jpql.append("FROM Bill b ");
+        jpql.append("LEFT JOIN b.department d ");
+        jpql.append("LEFT JOIN b.creater wu ");
+        jpql.append("LEFT JOIN wu.webUserPerson wup ");
+        jpql.append("LEFT JOIN b.toStaff stf ");
+        jpql.append("LEFT JOIN stf.person stfp ");
+        jpql.append("LEFT JOIN b.cancelledBill cb ");
+        jpql.append("LEFT JOIN cb.creater cbwu ");
+        jpql.append("LEFT JOIN cbwu.webUserPerson cbwup ");
+        jpql.append("WHERE b.retired = false ");
+        jpql.append("AND b.toDepartment = :toDep ");
+        jpql.append("AND b.billTypeAtomic IN :bTp ");
+        jpql.append("AND b.createdAt BETWEEN :fromDate AND :toDate ");
 
-        if (getSearchKeyword().getBillNo() != null && !getSearchKeyword().getBillNo().trim().equals("")) {
-            jpql += " and  ((b.deptId) like :billNo )";
+        if (getSearchKeyword().getBillNo() != null && !getSearchKeyword().getBillNo().trim().isEmpty()) {
+            jpql.append("AND UPPER(b.deptId) LIKE :billNo ");
             params.put("billNo", "%" + getSearchKeyword().getBillNo().trim().toUpperCase() + "%");
         }
-
-        if (getSearchKeyword().getStaffName() != null && !getSearchKeyword().getStaffName().trim().equals("")) {
-            jpql += " and  ((b.toStaff.person.name) like :stf )";
+        if (getSearchKeyword().getStaffName() != null && !getSearchKeyword().getStaffName().trim().isEmpty()) {
+            jpql.append("AND UPPER(stfp.name) LIKE :stf ");
             params.put("stf", "%" + getSearchKeyword().getStaffName().trim().toUpperCase() + "%");
         }
-
-        if (getSearchKeyword().getFromDepartment() != null && !getSearchKeyword().getFromDepartment().trim().equals("")) {
-            jpql += " and  (upper(b.fromDepartment.name) like :fDep )";
+        if (getSearchKeyword().getFromDepartment() != null && !getSearchKeyword().getFromDepartment().trim().isEmpty()) {
+            jpql.append("AND UPPER(d.name) LIKE :fDep ");
             params.put("fDep", "%" + getSearchKeyword().getFromDepartment().trim().toUpperCase() + "%");
         }
-        jpql += " order by b.createdAt desc  ";
-        bills = getBillFacade().findByJpql(jpql, params, TemporalType.TIMESTAMP, 50);
-        for (Bill b : bills) {
-            b.setTmpRefBill(getPharmacyTransferReceivedBills(b));
+
+        if (fullyIssuedFilter != null) {
+            if (Boolean.TRUE.equals(fullyIssuedFilter)) {
+                jpql.append("AND b.fullyIssued = true ");
+            } else {
+                jpql.append("AND b.fullyIssued = false AND b.cancelled = false ");
+            }
         }
+
+        jpql.append("ORDER BY b.createdAt DESC ");
+
+        transferIssuedListDtos = (List<PharmacyTransferIssuedListDTO>) getBillFacade()
+                .findDTOsByJpql(jpql.toString(), params, TemporalType.TIMESTAMP);
+        if (transferIssuedListDtos == null) {
+            transferIssuedListDtos = new ArrayList<>();
+        }
+
+        if (!transferIssuedListDtos.isEmpty()) {
+            List<Long> issuedBillIds = transferIssuedListDtos.stream()
+                    .map(PharmacyTransferIssuedListDTO::getBillId)
+                    .collect(Collectors.toList());
+            List<PharmacyTransferReceivedListDTO> allReceived = fetchReceivedBillsForIssuedIds(issuedBillIds);
+            Map<Long, List<PharmacyTransferReceivedListDTO>> byIssued = allReceived.stream()
+                    .collect(Collectors.groupingBy(PharmacyTransferReceivedListDTO::getIssuedBillId));
+            for (PharmacyTransferIssuedListDTO dto : transferIssuedListDtos) {
+                dto.setReceivedBills(byIssued.getOrDefault(dto.getBillId(), new ArrayList<>()));
+            }
+        }
+    }
+
+    private List<PharmacyTransferReceivedListDTO> fetchReceivedBillsForIssuedIds(List<Long> issuedBillIds) {
+        Map<String, Object> params = new HashMap<>();
+        params.put("btp", BillTypeAtomic.PHARMACY_RECEIVE);
+        params.put("issuedBillIds", issuedBillIds);
+        String jpql = "SELECT NEW com.divudi.core.data.dto.PharmacyTransferReceivedListDTO("
+                + "b.id, b.referenceBill.id, b.deptId, b.createdAt, b.cancelled, wup.name, b.netTotal, "
+                + "cbwup.name, cb.createdAt) "
+                + "FROM Bill b "
+                + "LEFT JOIN b.creater wu "
+                + "LEFT JOIN wu.webUserPerson wup "
+                + "LEFT JOIN b.cancelledBill cb "
+                + "LEFT JOIN cb.creater cbwu "
+                + "LEFT JOIN cbwu.webUserPerson cbwup "
+                + "WHERE b.retired = false "
+                + "AND b.billTypeAtomic = :btp "
+                + "AND b.referenceBill.id IN :issuedBillIds";
+        List<PharmacyTransferReceivedListDTO> result = (List<PharmacyTransferReceivedListDTO>)
+                getBillFacade().findDTOsByJpql(jpql, params);
+        return result != null ? result : new ArrayList<>();
     }
 
     public void createIssueReport1() {
@@ -22591,6 +22659,14 @@ public class SearchController implements Serializable {
 
     public void setTransferRequestDtos(List<PharmacyTransferRequestListDTO> transferRequestDtos) {
         this.transferRequestDtos = transferRequestDtos;
+    }
+
+    public List<PharmacyTransferIssuedListDTO> getTransferIssuedListDtos() {
+        return transferIssuedListDtos;
+    }
+
+    public void setTransferIssuedListDtos(List<PharmacyTransferIssuedListDTO> transferIssuedListDtos) {
+        this.transferIssuedListDtos = transferIssuedListDtos;
     }
 
     public List<PharmacyItemPurchaseDTO> getDisposalIssueBillDtos() {

--- a/src/main/java/com/divudi/bean/pharmacy/PharmacyBillSearch.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacyBillSearch.java
@@ -3879,6 +3879,7 @@ public class PharmacyBillSearch implements Serializable {
 
     }
 
+
     public List<BillEntry> getBillEntrys() {
         return billEntrys;
     }

--- a/src/main/java/com/divudi/bean/pharmacy/TransferReceiveController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/TransferReceiveController.java
@@ -195,6 +195,12 @@ public class TransferReceiveController implements Serializable {
         this.issuedBill = issuedBill;
     }
 
+    public void setIssuedBillId(Long billId) {
+        if (billId != null) {
+            this.issuedBill = billFacade.find(billId);
+        }
+    }
+
 //   public String navigateBackToRecieveList(){
 //        return "/pharmacy/pharmacy_transfer_issued_list?faces-redirect=true";
 //    }

--- a/src/main/java/com/divudi/bean/pharmacy/TransferReceiveController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/TransferReceiveController.java
@@ -196,9 +196,11 @@ public class TransferReceiveController implements Serializable {
     }
 
     public void setIssuedBillId(Long billId) {
-        if (billId != null) {
-            this.issuedBill = billFacade.find(billId);
+        if (billId == null) {
+            this.issuedBill = null;
+            return;
         }
+        this.issuedBill = billFacade.find(billId);
     }
 
 //   public String navigateBackToRecieveList(){

--- a/src/main/java/com/divudi/bean/pharmacy/TransferReceiveNativeSqlController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/TransferReceiveNativeSqlController.java
@@ -781,9 +781,11 @@ public class TransferReceiveNativeSqlController implements Serializable {
     }
 
     public void setIssuedBillId(Long billId) {
-        if (billId != null) {
-            this.issuedBill = billFacade.find(billId);
+        if (billId == null) {
+            this.issuedBill = null;
+            return;
         }
+        this.issuedBill = billFacade.find(billId);
     }
 
     public Long getReceivedBillId() {

--- a/src/main/java/com/divudi/core/data/dto/PharmacyTransferIssuedListDTO.java
+++ b/src/main/java/com/divudi/core/data/dto/PharmacyTransferIssuedListDTO.java
@@ -1,0 +1,143 @@
+package com.divudi.core.data.dto;
+
+import com.divudi.core.data.DepartmentType;
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+
+public class PharmacyTransferIssuedListDTO implements Serializable {
+
+    private Long billId;
+    private String deptId;
+    private String fromDepartmentName;
+    private DepartmentType departmentType;
+    private String issuerName;
+    private String staffName;
+    private Date createdAt;
+    private Boolean cancelled;
+    private Boolean fullyIssued;
+    private String cancelledByName;
+    private Date cancelledAt;
+    private List<PharmacyTransferReceivedListDTO> receivedBills = new ArrayList<>();
+
+    public PharmacyTransferIssuedListDTO() {
+    }
+
+    public PharmacyTransferIssuedListDTO(Long billId, String deptId, String fromDepartmentName,
+            DepartmentType departmentType, String issuerName, String staffName,
+            Date createdAt, Boolean cancelled, Boolean fullyIssued,
+            String cancelledByName, Date cancelledAt) {
+        this.billId = billId;
+        this.deptId = deptId;
+        this.fromDepartmentName = fromDepartmentName;
+        this.departmentType = departmentType;
+        this.issuerName = issuerName;
+        this.staffName = staffName;
+        this.createdAt = createdAt;
+        this.cancelled = cancelled != null ? cancelled : false;
+        this.fullyIssued = fullyIssued != null ? fullyIssued : false;
+        this.cancelledByName = cancelledByName;
+        this.cancelledAt = cancelledAt;
+    }
+
+    public String getDepartmentTypeLabel() {
+        return departmentType != null ? departmentType.getLabel() : null;
+    }
+
+    public Long getBillId() {
+        return billId;
+    }
+
+    public void setBillId(Long billId) {
+        this.billId = billId;
+    }
+
+    public String getDeptId() {
+        return deptId;
+    }
+
+    public void setDeptId(String deptId) {
+        this.deptId = deptId;
+    }
+
+    public String getFromDepartmentName() {
+        return fromDepartmentName;
+    }
+
+    public void setFromDepartmentName(String fromDepartmentName) {
+        this.fromDepartmentName = fromDepartmentName;
+    }
+
+    public DepartmentType getDepartmentType() {
+        return departmentType;
+    }
+
+    public void setDepartmentType(DepartmentType departmentType) {
+        this.departmentType = departmentType;
+    }
+
+    public String getIssuerName() {
+        return issuerName;
+    }
+
+    public void setIssuerName(String issuerName) {
+        this.issuerName = issuerName;
+    }
+
+    public String getStaffName() {
+        return staffName;
+    }
+
+    public void setStaffName(String staffName) {
+        this.staffName = staffName;
+    }
+
+    public Date getCreatedAt() {
+        return createdAt;
+    }
+
+    public void setCreatedAt(Date createdAt) {
+        this.createdAt = createdAt;
+    }
+
+    public Boolean getCancelled() {
+        return cancelled;
+    }
+
+    public void setCancelled(Boolean cancelled) {
+        this.cancelled = cancelled;
+    }
+
+    public Boolean getFullyIssued() {
+        return fullyIssued;
+    }
+
+    public void setFullyIssued(Boolean fullyIssued) {
+        this.fullyIssued = fullyIssued;
+    }
+
+    public String getCancelledByName() {
+        return cancelledByName;
+    }
+
+    public void setCancelledByName(String cancelledByName) {
+        this.cancelledByName = cancelledByName;
+    }
+
+    public Date getCancelledAt() {
+        return cancelledAt;
+    }
+
+    public void setCancelledAt(Date cancelledAt) {
+        this.cancelledAt = cancelledAt;
+    }
+
+    public List<PharmacyTransferReceivedListDTO> getReceivedBills() {
+        return receivedBills;
+    }
+
+    public void setReceivedBills(List<PharmacyTransferReceivedListDTO> receivedBills) {
+        this.receivedBills = receivedBills;
+    }
+}

--- a/src/main/java/com/divudi/core/data/dto/PharmacyTransferReceivedListDTO.java
+++ b/src/main/java/com/divudi/core/data/dto/PharmacyTransferReceivedListDTO.java
@@ -1,0 +1,106 @@
+package com.divudi.core.data.dto;
+
+import java.io.Serializable;
+import java.util.Date;
+
+public class PharmacyTransferReceivedListDTO implements Serializable {
+
+    private Long billId;
+    private Long issuedBillId;
+    private String deptId;
+    private Date createdAt;
+    private Boolean cancelled;
+    private String createrName;
+    private Double netTotal;
+    private String cancelledByName;
+    private Date cancelledAt;
+
+    public PharmacyTransferReceivedListDTO() {
+    }
+
+    public PharmacyTransferReceivedListDTO(Long billId, Long issuedBillId, String deptId,
+            Date createdAt, Boolean cancelled, String createrName, Double netTotal,
+            String cancelledByName, Date cancelledAt) {
+        this.billId = billId;
+        this.issuedBillId = issuedBillId;
+        this.deptId = deptId;
+        this.createdAt = createdAt;
+        this.cancelled = cancelled != null ? cancelled : false;
+        this.createrName = createrName;
+        this.netTotal = netTotal != null ? netTotal : 0.0;
+        this.cancelledByName = cancelledByName;
+        this.cancelledAt = cancelledAt;
+    }
+
+    public Long getBillId() {
+        return billId;
+    }
+
+    public void setBillId(Long billId) {
+        this.billId = billId;
+    }
+
+    public Long getIssuedBillId() {
+        return issuedBillId;
+    }
+
+    public void setIssuedBillId(Long issuedBillId) {
+        this.issuedBillId = issuedBillId;
+    }
+
+    public String getDeptId() {
+        return deptId;
+    }
+
+    public void setDeptId(String deptId) {
+        this.deptId = deptId;
+    }
+
+    public Date getCreatedAt() {
+        return createdAt;
+    }
+
+    public void setCreatedAt(Date createdAt) {
+        this.createdAt = createdAt;
+    }
+
+    public Boolean getCancelled() {
+        return cancelled;
+    }
+
+    public void setCancelled(Boolean cancelled) {
+        this.cancelled = cancelled;
+    }
+
+    public String getCreaterName() {
+        return createrName;
+    }
+
+    public void setCreaterName(String createrName) {
+        this.createrName = createrName;
+    }
+
+    public Double getNetTotal() {
+        return netTotal;
+    }
+
+    public void setNetTotal(Double netTotal) {
+        this.netTotal = netTotal;
+    }
+
+    public String getCancelledByName() {
+        return cancelledByName;
+    }
+
+    public void setCancelledByName(String cancelledByName) {
+        this.cancelledByName = cancelledByName;
+    }
+
+    public Date getCancelledAt() {
+        return cancelledAt;
+    }
+
+    public void setCancelledAt(Date cancelledAt) {
+        this.cancelledAt = cancelledAt;
+    }
+}

--- a/src/main/webapp/pharmacy/pharmacy_transfer_issued_list.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_transfer_issued_list.xhtml
@@ -13,7 +13,7 @@
             <p:panel>
 
                 <f:facet name="header">
-                    <p:outputLabel value="Select Request For Department : #{sessionController.department.name}"/> 
+                    <p:outputLabel value="Select Request For Department : #{sessionController.department.name}"/>
 
 
                     <!-- Admin Config Button (Admin Only) -->
@@ -34,97 +34,100 @@
                 <div class='row'>
                     <div class='col-2'>
                         <h:outputLabel value="From Date"/>
-                        <p:calendar styleClass="dateTimePicker" id="fromDate" value="#{searchController.fromDate}" class="w-100" inputStyleClass="w-100" navigator="false" pattern="#{sessionController.applicationPreference.longDateTimeFormat}" >      
+                        <p:calendar styleClass="dateTimePicker" id="fromDate" value="#{searchController.fromDate}" class="w-100" inputStyleClass="w-100" navigator="false" pattern="#{sessionController.applicationPreference.longDateTimeFormat}" >
                         </p:calendar>
                         <h:outputLabel value="To Date"/>
-                        <p:calendar id="toDate" value="#{searchController.toDate}" class="w-100" inputStyleClass="w-100" navigator="false" pattern="#{sessionController.applicationPreference.longDateTimeFormat}" >                                                                              
+                        <p:calendar id="toDate" value="#{searchController.toDate}" class="w-100" inputStyleClass="w-100" navigator="false" pattern="#{sessionController.applicationPreference.longDateTimeFormat}" >
                         </p:calendar>
-                        <p:commandButton 
-                            id="btnSearch" 
-                            ajax="false" 
-                            value="Search" 
+                        <p:commandButton
+                            id="btnSearch"
+                            ajax="false"
+                            value="Search"
                             icon="fas fa-search"
                             class="ui-button-warning w-100 my-1"
-                            action="#{searchController.listTransferIssuesToReceiveForLoggedDepartment()}"/> 
-                        <h:outputLabel value="Issue No"/>   
-                        <p:inputText autocomplete="off"  value="#{searchController.searchKeyword.billNo}" class="w-100"/>  
-                        <h:outputLabel value="From Deprtment"/> 
-                        <p:inputText autocomplete="off"  value="#{searchController.searchKeyword.fromDepartment}" class="w-100"/> 
+                            action="#{searchController.listTransferIssuesToReceiveForLoggedDepartment()}"/>
+                        <p:commandButton
+                            id="btnFullyReceived"
+                            ajax="false"
+                            value="Fully Received"
+                            icon="fas fa-check-double"
+                            class="ui-button-success w-100 my-1"
+                            action="#{searchController.listFullyReceivedTransferIssues()}"/>
+                        <p:commandButton
+                            id="btnYetToReceive"
+                            ajax="false"
+                            value="Yet to Receive"
+                            icon="fas fa-hourglass-half"
+                            class="ui-button-info w-100 my-1"
+                            action="#{searchController.listYetToReceiveTransferIssues()}"/>
+                        <h:outputLabel value="Issue No"/>
+                        <p:inputText autocomplete="off"  value="#{searchController.searchKeyword.billNo}" class="w-100"/>
+                        <h:outputLabel value="From Deprtment"/>
+                        <p:inputText autocomplete="off"  value="#{searchController.searchKeyword.fromDepartment}" class="w-100"/>
                         <h:outputLabel value="Staff "/>
-                        <p:inputText autocomplete="off"  value="#{searchController.searchKeyword.staffName}" class="w-100"/>  
+                        <p:inputText autocomplete="off"  value="#{searchController.searchKeyword.staffName}" class="w-100"/>
                     </div>
                     <div class='col-10'>
-                        <p:dataTable 
-                            value="#{searchController.bills}" 
+                        <p:dataTable
+                            value="#{searchController.transferIssuedListDtos}"
                             var="p"
                             paginator="true" paginatorPosition="bottom"
                             paginatorTemplate="{CurrentPageReport}  {FirstPageLink} {PreviousPageLink} {PageLinks} {NextPageLink} {LastPageLink} {RowsPerPageDropdown}"
                             rowsPerPageTemplate="5,10,15"
-                            >                       
-                            <p:column headerText="Issue No" width="6em">                        
-                                <h:outputLabel value="#{p.deptId}"/>                          
+                            >
+                            <p:column headerText="Issue No" width="6em">
+                                <h:outputLabel value="#{p.deptId}"/>
                             </p:column>
                             <p:column headerText="From Department" width="150px">
-                                <h:outputLabel value="#{p.department.name}"/>
+                                <h:outputLabel value="#{p.fromDepartmentName}"/>
                             </p:column>
                             <p:column headerText="Department Type" width="120px">
-                                <h:outputText value="#{p.departmentType.label}"
+                                <h:outputText value="#{p.departmentTypeLabel}"
                                               rendered="#{p.departmentType != null}"/>
                                 <h:outputText value="-"
                                               rendered="#{p.departmentType == null}"/>
                             </p:column>
                             <p:column headerText="Issued By" width="6em">
-                                <h:outputLabel value="#{p.creater.webUserPerson.name}"/>     
+                                <h:outputLabel value="#{p.issuerName}"/>
                                 <br/>
                                 <h:panelGroup rendered="#{p.cancelled}" >
                                     <h:outputLabel style="color: red;" value="Cancelled By " />
-                                    <h:outputLabel style="color: red;" rendered="#{p.cancelled}" value="#{p.cancelledBill.creater.webUserPerson.name}" >                                       
-                                    </h:outputLabel>
+                                    <h:outputLabel style="color: red;" value="#{p.cancelledByName}" />
                                 </h:panelGroup>
-                            </p:column> 
-                            <p:column headerText="Staff" width="6em">                       
-                                <h:outputLabel value="#{p.toStaff.person.nameWithTitle}"/>                            
-                            </p:column> 
-                            <p:column headerText="Issued At" width="6em">                      
+                            </p:column>
+                            <p:column headerText="Staff" width="6em">
+                                <h:outputLabel value="#{p.staffName}"/>
+                            </p:column>
+                            <p:column headerText="Issued At" width="6em">
                                 <h:outputLabel value="#{p.createdAt}">
                                     <f:convertDateTime  timeZone="Asia/Colombo" pattern="#{sessionController.applicationPreference.longDateTimeFormat}" />
-                                </h:outputLabel>                       
+                                </h:outputLabel>
                                 <h:panelGroup rendered="#{p.cancelled}" >
                                     <br/>
                                     <h:outputLabel style="color: red;" value="Cancelled at " />
-                                    <h:outputLabel style="color: red;" rendered="#{p.cancelled}" 
-                                                   value="#{p.cancelledBill.createdAt}" >
+                                    <h:outputLabel style="color: red;" value="#{p.cancelledAt}" >
                                         <f:convertDateTime  timeZone="Asia/Colombo" pattern="#{sessionController.applicationPreference.longDateTimeFormat}" />
                                     </h:outputLabel>
                                 </h:panelGroup>
                             </p:column>
 
                             <p:column headerText="Action" width="6em">
-                                <p:commandButton 
-                                    ajax="false" 
-                                    icon="far fa-eye"
-                                    rendered="false"
-                                    class="ui-button-info"
-                                    action="/pharmacy/pharmacy_reprint_transfer_isssue?faces-redirect=true">
-                                    <f:setPropertyActionListener target="#{pharmacyBillSearch.bill}" value="#{p}"/>
-                                </p:commandButton>
-
-                                <p:commandButton 
+                                <p:commandButton
                                     id="btnToReceive"
                                     ajax="false"
                                     value="Receive"
                                     class="ui-button-warning mx-2"
                                     action="#{transferReceiveController.navigateToRecieveRequest()}"
                                     disabled="#{p.cancelled or p.fullyIssued}">
-                                    <f:setPropertyActionListener target="#{transferReceiveController.issuedBill}" value="#{p}"/>
+                                    <f:setPropertyActionListener target="#{transferReceiveController.issuedBillId}" value="#{p.billId}"/>
                                 </p:commandButton>
 
                             </p:column>
 
-                            <p:column headerText="Received" style="text-align: center">                   
-                                <p:dataTable var="b" value="#{p.forwardReferenceBills}">                           
-                                    <p:column  >                                                               
-                                        <h:outputLabel  value="#{b.deptId}"/>                                   
+                            <p:column headerText="Received" style="text-align: center">
+                                <p:dataTable var="b" value="#{p.receivedBills}">
+                                    <p:column  >
+                                        <h:outputLabel  value="#{b.deptId}"/>
                                     </p:column>
                                     <p:column >
                                         <h:outputLabel value="#{b.createdAt}" >
@@ -133,26 +136,24 @@
                                         <br/>
                                         <h:panelGroup rendered="#{b.cancelled}" >
                                             <h:outputLabel style="color: red;" value="Cancelled At " />
-                                            <h:outputLabel style="color: red;" rendered="#{b.cancelled}" value="#{b.cancelledBill.createdAt}" >
+                                            <h:outputLabel style="color: red;" value="#{b.cancelledAt}" >
                                                 <f:convertDateTime  timeZone="Asia/Colombo" pattern="#{sessionController.applicationPreference.longDateTimeFormat}" />
                                             </h:outputLabel>
-                                        </h:panelGroup>                               
-                                    </p:column> 
-                                    <p:column >                               
-                                        <h:outputLabel value="#{b.creater.webUserPerson.name}" >                                      
-                                        </h:outputLabel>                                
+                                        </h:panelGroup>
+                                    </p:column>
+                                    <p:column >
+                                        <h:outputLabel value="#{b.createrName}" >
+                                        </h:outputLabel>
                                         <br/>
                                         <h:panelGroup rendered="#{b.cancelled}" >
                                             <h:outputLabel style="color: red;" value="Cancelled By " />
-                                            <h:outputLabel style="color: red;" rendered="#{b.cancelled}"
-                                                           value="#{b.cancelledBill.creater.webUserPerson.name}" >                                       
-                                            </h:outputLabel>
-                                        </h:panelGroup> 
-                                    </p:column>                                                     
+                                            <h:outputLabel style="color: red;" value="#{b.cancelledByName}" />
+                                        </h:panelGroup>
+                                    </p:column>
                                     <p:column rendered="#{webUserController.hasPrivilege('PharmacyTransferViewRates')}">
                                         <h:outputLabel value="#{b.netTotal}">
                                             <f:convertNumber pattern="#,##0.00" />
-                                        </h:outputLabel>                                  
+                                        </h:outputLabel>
                                     </p:column>
                                     <p:column>
                                         <p:commandButton
@@ -161,9 +162,9 @@
                                             title="View Recieve Issue"
                                             ajax="false"
                                             action="#{transferReceiveController.navigateToReprintRecieveIssue()}"
-                                            disabled="#{b.referenceBill eq null}"
+                                            disabled="#{b.issuedBillId == null}"
                                             >
-                                            <f:setPropertyActionListener target="#{pharmacyBillSearch.bill}" value="#{b}"/>
+                                            <f:setPropertyActionListener target="#{pharmacyBillSearch.billId}" value="#{b.billId}"/>
                                         </p:commandButton>
                                     </p:column>
 
@@ -175,6 +176,6 @@
                 </div>
             </p:panel>
         </h:form>
-    </ui:define>  
+    </ui:define>
 
 </ui:composition>

--- a/src/main/webapp/pharmacy/pharmacy_transfer_issued_list.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_transfer_issued_list.xhtml
@@ -62,7 +62,7 @@
                             action="#{searchController.listYetToReceiveTransferIssues()}"/>
                         <h:outputLabel value="Issue No"/>
                         <p:inputText autocomplete="off"  value="#{searchController.searchKeyword.billNo}" class="w-100"/>
-                        <h:outputLabel value="From Deprtment"/>
+                        <h:outputLabel value="From Department"/>
                         <p:inputText autocomplete="off"  value="#{searchController.searchKeyword.fromDepartment}" class="w-100"/>
                         <h:outputLabel value="Staff "/>
                         <p:inputText autocomplete="off"  value="#{searchController.searchKeyword.staffName}" class="w-100"/>


### PR DESCRIPTION
## Summary
Refactored the pharmacy transfer issued list functionality to use Data Transfer Objects (DTOs) instead of directly binding entity objects to the UI. This improves separation of concerns, reduces unnecessary entity loading, and provides better control over displayed data.

## Key Changes

- **New DTOs Created:**
  - `PharmacyTransferIssuedListDTO`: Represents issued transfer bills with flattened data (bill ID, department info, issuer/staff names, cancellation details)
  - `PharmacyTransferReceivedListDTO`: Represents received transfer bills linked to issued bills

- **SearchController Updates:**
  - Refactored `listTransferIssuesToReceiveForLoggedDepartment()` to use new DTO-based query
  - Added `listFullyReceivedTransferIssues()` and `listYetToReceiveTransferIssues()` methods for filtering
  - Implemented `fetchTransferIssuedListDtos()` with optional filtering by fully issued status
  - Added `fetchReceivedBillsForIssuedIds()` to efficiently load related received bills
  - Updated JPQL queries to use constructor expressions for DTO instantiation
  - Added `transferIssuedListDtos` field to store DTO list results

- **UI Updates (pharmacy_transfer_issued_list.xhtml):**
  - Changed data table binding from `#{searchController.bills}` to `#{searchController.transferIssuedListDtos}`
  - Updated column bindings to use DTO properties instead of entity relationships:
    - `p.fromDepartmentName` instead of `p.department.name`
    - `p.departmentTypeLabel` instead of `p.departmentType.label`
    - `p.issuerName` instead of `p.creater.webUserPerson.name`
    - `p.staffName` instead of `p.toStaff.person.nameWithTitle`
    - `p.cancelledByName` instead of `p.cancelledBill.creater.webUserPerson.name`
  - Added filter buttons for "Fully Received" and "Yet to Receive" transfer issues
  - Updated nested received bills table to use `p.receivedBills` DTO list

- **TransferReceiveController Enhancement:**
  - Added `setIssuedBillId(Long billId)` method to support setting issued bill by ID from UI

## Implementation Details

- DTOs use constructor-based instantiation in JPQL queries for efficient data loading
- Received bills are fetched separately and grouped by issued bill ID for optimal query performance
- Null-safe handling for boolean and numeric fields in DTO constructors
- Improved search filtering with case-insensitive JPQL comparisons
- Cleaner separation between entity model and presentation layer

https://claude.ai/code/session_01H7Mu7EGkYtahFZtVwZthSN

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added new filter buttons ("Fully Received", "Yet to Receive") to pharmacy transfer search with enhanced date range selection.
  * Improved tracking and display of issued versus received pharmacy transfers with detailed cancellation information.
  * Enhanced "Fast Receive" workflow for streamlined transfer processing.

* **Bug Fixes**
  * Removed extraneous content from pharmacy bill search file.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hmislk/hmis/pull/20563)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->