### PR TITLE
fix(pharmacy): null-guard ItemBatch.dateOfExpire in all sale controllers

### DIFF
--- a/src/main/java/com/divudi/bean/optician/OpticianSaleController.java
+++ b/src/main/java/com/divudi/bean/optician/OpticianSaleController.java
@@ -1048,6 +1048,7 @@ public class OpticianSaleController implements Serializable, ControllerWithPatie
             return addedQty;
         }
         if (getStock().getItemBatch() == null) {
+            errorMessage = "Item batch not found for selected stock";
             JsfUtil.addErrorMessage("Item batch not found for selected stock");
             return addedQty;
         }

--- a/src/main/java/com/divudi/bean/optician/OpticianSaleController.java
+++ b/src/main/java/com/divudi/bean/optician/OpticianSaleController.java
@@ -1047,7 +1047,12 @@ public class OpticianSaleController implements Serializable, ControllerWithPatie
             JsfUtil.addErrorMessage("Please select an Item Batch to Dispense ??");
             return addedQty;
         }
-        if (getStock().getItemBatch().getDateOfExpire().before(CommonFunctions.getCurrentDateTime())) {
+        if (getStock().getItemBatch() == null) {
+            JsfUtil.addErrorMessage("Item batch not found for selected stock");
+            return addedQty;
+        }
+        if (getStock().getItemBatch().getDateOfExpire() != null
+                && getStock().getItemBatch().getDateOfExpire().before(CommonFunctions.getCurrentDateTime())) {
             JsfUtil.addErrorMessage("Please not select Expired Items");
             return addedQty;
         }

--- a/src/main/java/com/divudi/bean/pharmacy/PharmacyFastRetailSaleController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacyFastRetailSaleController.java
@@ -1017,6 +1017,7 @@ public class PharmacyFastRetailSaleController implements Serializable, Controlle
             return addedQty;
         }
         if (getStock().getItemBatch() == null) {
+            errorMessage = "Item batch not found for selected stock";
             JsfUtil.addErrorMessage("Item batch not found for selected stock");
             return addedQty;
         }

--- a/src/main/java/com/divudi/bean/pharmacy/PharmacyFastRetailSaleController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacyFastRetailSaleController.java
@@ -1016,7 +1016,12 @@ public class PharmacyFastRetailSaleController implements Serializable, Controlle
             JsfUtil.addErrorMessage("Please select an Item Batch to Dispense ??");
             return addedQty;
         }
-        if (getStock().getItemBatch().getDateOfExpire().before(CommonFunctions.getCurrentDateTime())) {
+        if (getStock().getItemBatch() == null) {
+            JsfUtil.addErrorMessage("Item batch not found for selected stock");
+            return addedQty;
+        }
+        if (getStock().getItemBatch().getDateOfExpire() != null
+                && getStock().getItemBatch().getDateOfExpire().before(CommonFunctions.getCurrentDateTime())) {
             JsfUtil.addErrorMessage("Please not select Expired Items");
             return addedQty;
         }

--- a/src/main/java/com/divudi/bean/pharmacy/PharmacySaleBhtController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacySaleBhtController.java
@@ -1785,6 +1785,7 @@ public class PharmacySaleBhtController implements Serializable {
             return;
         }
         if (getTmpStock().getItemBatch() == null) {
+            errorMessage = "Item batch not found for selected stock";
             JsfUtil.addErrorMessage("Item batch not found for selected stock");
             return;
         }

--- a/src/main/java/com/divudi/bean/pharmacy/PharmacySaleBhtController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacySaleBhtController.java
@@ -523,7 +523,8 @@ public class PharmacySaleBhtController implements Serializable {
             JsfUtil.addErrorMessage("Invalid stock - missing batch information");
             return;
         }
-        if (tempStock.getItemBatch().getDateOfExpire().before(CommonFunctions.getCurrentDateTime())) {
+        if (tempStock.getItemBatch().getDateOfExpire() != null
+                && tempStock.getItemBatch().getDateOfExpire().before(CommonFunctions.getCurrentDateTime())) {
             JsfUtil.addErrorMessage("Please not select Expired Items");
             return;
         }
@@ -1669,7 +1670,8 @@ public class PharmacySaleBhtController implements Serializable {
             JsfUtil.addErrorMessage("Please enter a Quantity?");
             return;
         }
-        if (selectedStockDto.getDateOfExpire().before(CommonFunctions.getCurrentDateTime())) {
+        if (selectedStockDto.getDateOfExpire() != null
+                && selectedStockDto.getDateOfExpire().before(CommonFunctions.getCurrentDateTime())) {
             JsfUtil.addErrorMessage("You are NOT allowed to select Expired Items");
             return;
         }
@@ -1782,7 +1784,12 @@ public class PharmacySaleBhtController implements Serializable {
             JsfUtil.addErrorMessage("Item?");
             return;
         }
-        if (getTmpStock().getItemBatch().getDateOfExpire().before(CommonFunctions.getCurrentDateTime())) {
+        if (getTmpStock().getItemBatch() == null) {
+            JsfUtil.addErrorMessage("Item batch not found for selected stock");
+            return;
+        }
+        if (getTmpStock().getItemBatch().getDateOfExpire() != null
+                && getTmpStock().getItemBatch().getDateOfExpire().before(CommonFunctions.getCurrentDateTime())) {
             JsfUtil.addErrorMessage("Please not select Expired Items");
             return;
         }

--- a/src/main/java/com/divudi/bean/pharmacy/PharmacySaleController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacySaleController.java
@@ -1747,7 +1747,12 @@ public class PharmacySaleController implements Serializable, ControllerWithPatie
             JsfUtil.addErrorMessage("Please select an Item Batch to Dispense ??");
             return addedQty;
         }
-        if (getStock().getItemBatch().getDateOfExpire().before(CommonFunctions.getCurrentDateTime())) {
+        if (getStock().getItemBatch() == null) {
+            JsfUtil.addErrorMessage("Item batch not found for selected stock");
+            return addedQty;
+        }
+        if (getStock().getItemBatch().getDateOfExpire() != null
+                && getStock().getItemBatch().getDateOfExpire().before(CommonFunctions.getCurrentDateTime())) {
             JsfUtil.addErrorMessage("Please not select Expired Items");
             return addedQty;
         }

--- a/src/main/java/com/divudi/bean/pharmacy/PharmacySaleController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacySaleController.java
@@ -1748,6 +1748,7 @@ public class PharmacySaleController implements Serializable, ControllerWithPatie
             return addedQty;
         }
         if (getStock().getItemBatch() == null) {
+            errorMessage = "Item batch not found for selected stock";
             JsfUtil.addErrorMessage("Item batch not found for selected stock");
             return addedQty;
         }

--- a/src/main/java/com/divudi/bean/pharmacy/PharmacySaleController1.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacySaleController1.java
@@ -1319,7 +1319,12 @@ public class PharmacySaleController1 implements Serializable, ControllerWithPati
             JsfUtil.addErrorMessage("Please select an Item Batch to Dispense ??");
             return addedQty;
         }
-        if (getStock().getItemBatch().getDateOfExpire().before(CommonFunctions.getCurrentDateTime())) {
+        if (getStock().getItemBatch() == null) {
+            JsfUtil.addErrorMessage("Item batch not found for selected stock");
+            return addedQty;
+        }
+        if (getStock().getItemBatch().getDateOfExpire() != null
+                && getStock().getItemBatch().getDateOfExpire().before(CommonFunctions.getCurrentDateTime())) {
             JsfUtil.addErrorMessage("Please not select Expired Items");
             return addedQty;
         }

--- a/src/main/java/com/divudi/bean/pharmacy/PharmacySaleController1.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacySaleController1.java
@@ -1320,6 +1320,7 @@ public class PharmacySaleController1 implements Serializable, ControllerWithPati
             return addedQty;
         }
         if (getStock().getItemBatch() == null) {
+            errorMessage = "Item batch not found for selected stock";
             JsfUtil.addErrorMessage("Item batch not found for selected stock");
             return addedQty;
         }

--- a/src/main/java/com/divudi/bean/pharmacy/PharmacySaleController2.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacySaleController2.java
@@ -1320,6 +1320,7 @@ public class PharmacySaleController2 implements Serializable, ControllerWithPati
             return addedQty;
         }
         if (getStock().getItemBatch() == null) {
+            errorMessage = "Item batch not found for selected stock";
             JsfUtil.addErrorMessage("Item batch not found for selected stock");
             return addedQty;
         }

--- a/src/main/java/com/divudi/bean/pharmacy/PharmacySaleController2.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacySaleController2.java
@@ -1319,7 +1319,12 @@ public class PharmacySaleController2 implements Serializable, ControllerWithPati
             JsfUtil.addErrorMessage("Please select an Item Batch to Dispense ??");
             return addedQty;
         }
-        if (getStock().getItemBatch().getDateOfExpire().before(CommonFunctions.getCurrentDateTime())) {
+        if (getStock().getItemBatch() == null) {
+            JsfUtil.addErrorMessage("Item batch not found for selected stock");
+            return addedQty;
+        }
+        if (getStock().getItemBatch().getDateOfExpire() != null
+                && getStock().getItemBatch().getDateOfExpire().before(CommonFunctions.getCurrentDateTime())) {
             JsfUtil.addErrorMessage("Please not select Expired Items");
             return addedQty;
         }

--- a/src/main/java/com/divudi/bean/pharmacy/PharmacySaleController3.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacySaleController3.java
@@ -1319,7 +1319,12 @@ public class PharmacySaleController3 implements Serializable, ControllerWithPati
             JsfUtil.addErrorMessage("Please select an Item Batch to Dispense ??");
             return addedQty;
         }
-        if (getStock().getItemBatch().getDateOfExpire().before(CommonFunctions.getCurrentDateTime())) {
+        if (getStock().getItemBatch() == null) {
+            JsfUtil.addErrorMessage("Item batch not found for selected stock");
+            return addedQty;
+        }
+        if (getStock().getItemBatch().getDateOfExpire() != null
+                && getStock().getItemBatch().getDateOfExpire().before(CommonFunctions.getCurrentDateTime())) {
             JsfUtil.addErrorMessage("Please not select Expired Items");
             return addedQty;
         }

--- a/src/main/java/com/divudi/bean/pharmacy/PharmacySaleController3.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacySaleController3.java
@@ -1320,6 +1320,7 @@ public class PharmacySaleController3 implements Serializable, ControllerWithPati
             return addedQty;
         }
         if (getStock().getItemBatch() == null) {
+            errorMessage = "Item batch not found for selected stock";
             JsfUtil.addErrorMessage("Item batch not found for selected stock");
             return addedQty;
         }

--- a/src/main/java/com/divudi/bean/pharmacy/PharmacySimpleRetailSaleController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacySimpleRetailSaleController.java
@@ -1078,6 +1078,7 @@ public class PharmacySimpleRetailSaleController implements Serializable, Control
             return addedQty;
         }
         if (getStock().getItemBatch() == null) {
+            errorMessage = "Item batch not found for selected stock";
             JsfUtil.addErrorMessage("Item batch not found for selected stock");
             return addedQty;
         }

--- a/src/main/java/com/divudi/bean/pharmacy/PharmacySimpleRetailSaleController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacySimpleRetailSaleController.java
@@ -1077,7 +1077,12 @@ public class PharmacySimpleRetailSaleController implements Serializable, Control
             JsfUtil.addErrorMessage("Please select an Item Batch to Dispense ??");
             return addedQty;
         }
-        if (getStock().getItemBatch().getDateOfExpire().before(CommonFunctions.getCurrentDateTime())) {
+        if (getStock().getItemBatch() == null) {
+            JsfUtil.addErrorMessage("Item batch not found for selected stock");
+            return addedQty;
+        }
+        if (getStock().getItemBatch().getDateOfExpire() != null
+                && getStock().getItemBatch().getDateOfExpire().before(CommonFunctions.getCurrentDateTime())) {
             JsfUtil.addErrorMessage("Please not select Expired Items");
             return addedQty;
         }

--- a/src/main/java/com/divudi/bean/pharmacy/PharmacyWholeSaleController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacyWholeSaleController.java
@@ -1546,7 +1546,12 @@ public class PharmacyWholeSaleController implements Serializable, ControllerWith
             return;
         }
 
-        if (getStock().getItemBatch().getDateOfExpire().before(CommonFunctions.getCurrentDateTime())) {
+        if (getStock().getItemBatch() == null) {
+            JsfUtil.addErrorMessage("Item batch not found for selected stock");
+            return;
+        }
+        if (getStock().getItemBatch().getDateOfExpire() != null
+                && getStock().getItemBatch().getDateOfExpire().before(CommonFunctions.getCurrentDateTime())) {
             JsfUtil.addErrorMessage("Please not select Expired Items");
             return;
         }

--- a/src/main/java/com/divudi/bean/pharmacy/PharmacyWholeSaleController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacyWholeSaleController.java
@@ -793,6 +793,11 @@ public class PharmacyWholeSaleController implements Serializable, ControllerWith
             return;
         }
 
+        if (getStock().getItemBatch() == null) {
+            errorMessage = "Item batch not found for selected stock";
+            JsfUtil.addErrorMessage("Item batch not found for selected stock");
+            return;
+        }
         billItem.getPharmaceuticalBillItem().setQtyInUnit(0 - qty);
         billItem.getPharmaceuticalBillItem().setStock(stock);
         billItem.getPharmaceuticalBillItem().setItemBatch(getStock().getItemBatch());
@@ -1547,6 +1552,7 @@ public class PharmacyWholeSaleController implements Serializable, ControllerWith
         }
 
         if (getStock().getItemBatch() == null) {
+            errorMessage = "Item batch not found for selected stock";
             JsfUtil.addErrorMessage("Item batch not found for selected stock");
             return;
         }

--- a/src/main/java/com/divudi/bean/pharmacy/PharmacyWholeSaleController1.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacyWholeSaleController1.java
@@ -793,6 +793,11 @@ public class PharmacyWholeSaleController1 implements Serializable, ControllerWit
             return;
         }
 
+        if (getStock().getItemBatch() == null) {
+            errorMessage = "Item batch not found for selected stock";
+            JsfUtil.addErrorMessage("Item batch not found for selected stock");
+            return;
+        }
         billItem.getPharmaceuticalBillItem().setQtyInUnit(0 - qty);
         billItem.getPharmaceuticalBillItem().setStock(stock);
         billItem.getPharmaceuticalBillItem().setItemBatch(getStock().getItemBatch());
@@ -1440,6 +1445,7 @@ public class PharmacyWholeSaleController1 implements Serializable, ControllerWit
         }
 
         if (getStock().getItemBatch() == null) {
+            errorMessage = "Item batch not found for selected stock";
             JsfUtil.addErrorMessage("Item batch not found for selected stock");
             return;
         }

--- a/src/main/java/com/divudi/bean/pharmacy/PharmacyWholeSaleController1.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacyWholeSaleController1.java
@@ -1439,7 +1439,12 @@ public class PharmacyWholeSaleController1 implements Serializable, ControllerWit
             return;
         }
 
-        if (getStock().getItemBatch().getDateOfExpire().before(CommonFunctions.getCurrentDateTime())) {
+        if (getStock().getItemBatch() == null) {
+            JsfUtil.addErrorMessage("Item batch not found for selected stock");
+            return;
+        }
+        if (getStock().getItemBatch().getDateOfExpire() != null
+                && getStock().getItemBatch().getDateOfExpire().before(CommonFunctions.getCurrentDateTime())) {
             JsfUtil.addErrorMessage("Please not select Expired Items");
             return;
         }

--- a/src/main/java/com/divudi/bean/pharmacy/PharmacyWholeSaleController2.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacyWholeSaleController2.java
@@ -1438,7 +1438,12 @@ public class PharmacyWholeSaleController2 implements Serializable, ControllerWit
             return;
         }
 
-        if (getStock().getItemBatch().getDateOfExpire().before(CommonFunctions.getCurrentDateTime())) {
+        if (getStock().getItemBatch() == null) {
+            JsfUtil.addErrorMessage("Item batch not found for selected stock");
+            return;
+        }
+        if (getStock().getItemBatch().getDateOfExpire() != null
+                && getStock().getItemBatch().getDateOfExpire().before(CommonFunctions.getCurrentDateTime())) {
             JsfUtil.addErrorMessage("Please not select Expired Items");
             return;
         }

--- a/src/main/java/com/divudi/bean/pharmacy/PharmacyWholeSaleController2.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacyWholeSaleController2.java
@@ -793,6 +793,11 @@ public class PharmacyWholeSaleController2 implements Serializable, ControllerWit
             return;
         }
 
+        if (getStock().getItemBatch() == null) {
+            errorMessage = "Item batch not found for selected stock";
+            JsfUtil.addErrorMessage("Item batch not found for selected stock");
+            return;
+        }
         billItem.getPharmaceuticalBillItem().setQtyInUnit(0 - qty);
         billItem.getPharmaceuticalBillItem().setStock(stock);
         billItem.getPharmaceuticalBillItem().setItemBatch(getStock().getItemBatch());
@@ -1439,6 +1444,7 @@ public class PharmacyWholeSaleController2 implements Serializable, ControllerWit
         }
 
         if (getStock().getItemBatch() == null) {
+            errorMessage = "Item batch not found for selected stock";
             JsfUtil.addErrorMessage("Item batch not found for selected stock");
             return;
         }

--- a/src/main/java/com/divudi/bean/pharmacy/PharmacyWholeSaleController3.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacyWholeSaleController3.java
@@ -1439,7 +1439,12 @@ public class PharmacyWholeSaleController3 implements Serializable, ControllerWit
             return;
         }
 
-        if (getStock().getItemBatch().getDateOfExpire().before(CommonFunctions.getCurrentDateTime())) {
+        if (getStock().getItemBatch() == null) {
+            JsfUtil.addErrorMessage("Item batch not found for selected stock");
+            return;
+        }
+        if (getStock().getItemBatch().getDateOfExpire() != null
+                && getStock().getItemBatch().getDateOfExpire().before(CommonFunctions.getCurrentDateTime())) {
             JsfUtil.addErrorMessage("Please not select Expired Items");
             return;
         }

--- a/src/main/java/com/divudi/bean/pharmacy/PharmacyWholeSaleController3.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacyWholeSaleController3.java
@@ -794,6 +794,11 @@ public class PharmacyWholeSaleController3 implements Serializable, ControllerWit
             return;
         }
 
+        if (getStock().getItemBatch() == null) {
+            errorMessage = "Item batch not found for selected stock";
+            JsfUtil.addErrorMessage("Item batch not found for selected stock");
+            return;
+        }
         billItem.getPharmaceuticalBillItem().setQtyInUnit(0 - qty);
         billItem.getPharmaceuticalBillItem().setStock(stock);
         billItem.getPharmaceuticalBillItem().setItemBatch(getStock().getItemBatch());
@@ -1440,6 +1445,7 @@ public class PharmacyWholeSaleController3 implements Serializable, ControllerWit
         }
 
         if (getStock().getItemBatch() == null) {
+            errorMessage = "Item batch not found for selected stock";
             JsfUtil.addErrorMessage("Item batch not found for selected stock");
             return;
         }


### PR DESCRIPTION
## Summary

- Adds `getItemBatch() == null` guard (with user-facing error message) where it was missing
- Adds `getDateOfExpire() != null &&` before every `.before()` call across 13 sites in 12 controllers
- `RetailSaleNativeSqlController` and both `TransferIssue*` controllers were already correctly guarded — left untouched

## Root Cause

The chained call `getStock().getItemBatch().getDateOfExpire().before(...)` threw an NPE for any stock whose `ItemBatch.dateOfExpire` is `null` (devices, non-expiring consumables). This latent bug was triggered when items without expiry dates were selected in any sale flow.

## Test plan

- [ ] Add a bill item for a stock whose ItemBatch has no expiry date — should proceed without NPE
- [ ] Add a bill item for an expired batch — should still show "Please not select Expired Items" error
- [ ] Add a bill item for a valid non-expired batch — normal flow unaffected
- [ ] Verify in PharmacySaleController, WholeSale, BHT, SimpleRetail, FastRetail, and Optician sale pages

Closes #20564

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced null-safety validation across multiple sales controllers to prevent crashes when processing items without complete batch or expiry information. Added defensive checks to ensure item batch data exists before validating expiration dates. Users now receive appropriate error messages instead of application failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->