### PR TITLE
Include IOU transactions in handover bundle

### DIFF
--- a/src/main/java/com/divudi/bean/cashTransaction/FinancialTransactionController.java
+++ b/src/main/java/com/divudi/bean/cashTransaction/FinancialTransactionController.java
@@ -4433,6 +4433,9 @@ public class FinancialTransactionController implements Serializable {
         List<BillTypeAtomic> btas = new ArrayList<>();
         btas.addAll(BillTypeAtomic.findByFinanceType(BillFinanceType.CASH_IN));
         btas.addAll(BillTypeAtomic.findByFinanceType(BillFinanceType.CASH_OUT));
+        btas.add(BillTypeAtomic.IOU_CASH_ISSUE);
+        btas.add(BillTypeAtomic.IOU_SETTLE);
+        btas.add(BillTypeAtomic.IOU_TO_CASH_CONVERSION);
         Map<String, Object> m = new HashMap<>();
 
         StringBuilder jpqlBuilder = new StringBuilder("SELECT p ")
@@ -4482,6 +4485,9 @@ public class FinancialTransactionController implements Serializable {
         List<BillTypeAtomic> btas = new ArrayList<>();
         btas.addAll(BillTypeAtomic.findByFinanceType(BillFinanceType.CASH_IN));
         btas.addAll(BillTypeAtomic.findByFinanceType(BillFinanceType.CASH_OUT));
+        btas.add(BillTypeAtomic.IOU_CASH_ISSUE);
+        btas.add(BillTypeAtomic.IOU_SETTLE);
+        btas.add(BillTypeAtomic.IOU_TO_CASH_CONVERSION);
         Map<String, Object> m = new HashMap<>();
 
         StringBuilder jpqlBuilder = new StringBuilder("SELECT p ")
@@ -4531,6 +4537,9 @@ public class FinancialTransactionController implements Serializable {
         List<BillTypeAtomic> btas = new ArrayList<>();
         btas.addAll(BillTypeAtomic.findByFinanceType(BillFinanceType.CASH_IN));
         btas.addAll(BillTypeAtomic.findByFinanceType(BillFinanceType.CASH_OUT));
+        btas.add(BillTypeAtomic.IOU_CASH_ISSUE);
+        btas.add(BillTypeAtomic.IOU_SETTLE);
+        btas.add(BillTypeAtomic.IOU_TO_CASH_CONVERSION);
         Map<String, Object> m = new HashMap<>();
 
         StringBuilder jpqlBuilder = new StringBuilder("SELECT p ")

--- a/src/main/java/com/divudi/bean/cashTransaction/FinancialTransactionController.java
+++ b/src/main/java/com/divudi/bean/cashTransaction/FinancialTransactionController.java
@@ -4436,6 +4436,7 @@ public class FinancialTransactionController implements Serializable {
         btas.add(BillTypeAtomic.IOU_CASH_ISSUE);
         btas.add(BillTypeAtomic.IOU_SETTLE);
         btas.add(BillTypeAtomic.IOU_TO_CASH_CONVERSION);
+        btas.add(BillTypeAtomic.IOU_TO_CASH_CONVERSION_CANCELLED);
         Map<String, Object> m = new HashMap<>();
 
         StringBuilder jpqlBuilder = new StringBuilder("SELECT p ")
@@ -4488,6 +4489,7 @@ public class FinancialTransactionController implements Serializable {
         btas.add(BillTypeAtomic.IOU_CASH_ISSUE);
         btas.add(BillTypeAtomic.IOU_SETTLE);
         btas.add(BillTypeAtomic.IOU_TO_CASH_CONVERSION);
+        btas.add(BillTypeAtomic.IOU_TO_CASH_CONVERSION_CANCELLED);
         Map<String, Object> m = new HashMap<>();
 
         StringBuilder jpqlBuilder = new StringBuilder("SELECT p ")
@@ -4540,6 +4542,7 @@ public class FinancialTransactionController implements Serializable {
         btas.add(BillTypeAtomic.IOU_CASH_ISSUE);
         btas.add(BillTypeAtomic.IOU_SETTLE);
         btas.add(BillTypeAtomic.IOU_TO_CASH_CONVERSION);
+        btas.add(BillTypeAtomic.IOU_TO_CASH_CONVERSION_CANCELLED);
         Map<String, Object> m = new HashMap<>();
 
         StringBuilder jpqlBuilder = new StringBuilder("SELECT p ")

--- a/src/main/webapp/cashier/shift_end_for_handover.xhtml
+++ b/src/main/webapp/cashier/shift_end_for_handover.xhtml
@@ -76,7 +76,7 @@
                                         <f:facet name="header">
                                             <div class="row" >
                                                 <div class="col" >
-                                                    <p:outputLabel value="Collected Payment Summary" class="font-weight-bold text-center" />
+                                                    <p:outputLabel value="Collected Payments to Handover Summary" class="font-weight-bold text-center" />
                                                 </div>
                                                 <div class="col" >
                                                     <h:panelGroup rendered="#{financialTransactionController.handoverRequiredButNotComplete}"

--- a/src/main/webapp/cashier/shift_end_print.xhtml
+++ b/src/main/webapp/cashier/shift_end_print.xhtml
@@ -94,10 +94,28 @@
                                     </div>
                                 </div>
 
+                                <h:panelGroup layout="block"
+                                              rendered="#{financialTransactionController.currentDetailedFinancialBill ne null
+                                                          and (financialTransactionController.currentDetailedFinancialBill.cashValue ne null and financialTransactionController.currentDetailedFinancialBill.cashValue ne 0
+                                                          or financialTransactionController.currentDetailedFinancialBill.cardValue ne null and financialTransactionController.currentDetailedFinancialBill.cardValue ne 0
+                                                          or financialTransactionController.currentDetailedFinancialBill.chequeValue ne null and financialTransactionController.currentDetailedFinancialBill.chequeValue ne 0
+                                                          or financialTransactionController.currentDetailedFinancialBill.slipValue ne null and financialTransactionController.currentDetailedFinancialBill.slipValue ne 0
+                                                          or financialTransactionController.currentDetailedFinancialBill.ewalletValue ne null and financialTransactionController.currentDetailedFinancialBill.ewalletValue ne 0
+                                                          or financialTransactionController.currentDetailedFinancialBill.onCallValue ne null and financialTransactionController.currentDetailedFinancialBill.onCallValue ne 0
+                                                          or financialTransactionController.currentDetailedFinancialBill.multiplePaymentMethodsValue ne null and financialTransactionController.currentDetailedFinancialBill.multiplePaymentMethodsValue ne 0
+                                                          or financialTransactionController.currentDetailedFinancialBill.staffValue ne null and financialTransactionController.currentDetailedFinancialBill.staffValue ne 0
+                                                          or financialTransactionController.currentDetailedFinancialBill.creditValue ne null and financialTransactionController.currentDetailedFinancialBill.creditValue ne 0
+                                                          or financialTransactionController.currentDetailedFinancialBill.staffWelfareValue ne null and financialTransactionController.currentDetailedFinancialBill.staffWelfareValue ne 0
+                                                          or financialTransactionController.currentDetailedFinancialBill.voucherValue ne null and financialTransactionController.currentDetailedFinancialBill.voucherValue ne 0
+                                                          or financialTransactionController.currentDetailedFinancialBill.iouValue ne null and financialTransactionController.currentDetailedFinancialBill.iouValue ne 0
+                                                          or financialTransactionController.currentDetailedFinancialBill.agentValue ne null and financialTransactionController.currentDetailedFinancialBill.agentValue ne 0
+                                                          or financialTransactionController.currentDetailedFinancialBill.patientDepositValue ne null and financialTransactionController.currentDetailedFinancialBill.patientDepositValue ne 0
+                                                          or financialTransactionController.currentDetailedFinancialBill.patientPointsValue ne null and financialTransactionController.currentDetailedFinancialBill.patientPointsValue ne 0
+                                                          or financialTransactionController.currentDetailedFinancialBill.onlineSettlementValue ne null and financialTransactionController.currentDetailedFinancialBill.onlineSettlementValue ne 0)}">
                                 <hr class="my-4"/>
 
                                 <div class="text-center mb-2">
-                                    <h4>Collected Payments</h4>
+                                    <h:outputText value="Collections Not Yet Handed Over" styleClass="h4" />
                                 </div>
                                 <div class="row mb-2">
                                     <div class="col-md-3"><p:outputLabel value="Payment Method" class="font-weight-bold" /></div>
@@ -105,133 +123,134 @@
                                     <div class="col-md-6"></div>
                                 </div>
 
-                                <div class="row mb-2" rendered="#{financialTransactionController.currentDetailedFinancialBill.cashValuePresent}">
+                                <h:panelGroup layout="block" styleClass="row mb-2" rendered="#{financialTransactionController.currentDetailedFinancialBill.cashValue ne null and financialTransactionController.currentDetailedFinancialBill.cashValue ne 0}">
                                     <div class="col-md-3"><p:outputLabel value="Cash" /></div>
                                     <div class="col-md-3 text-end"><p:outputLabel value="#{financialTransactionController.currentDetailedFinancialBill.cashValue}">
                                             <f:convertNumber pattern="#,##0.00" />
                                         </p:outputLabel></div>
                                     <div class="col-md-6"></div>
-                                </div>
+                                </h:panelGroup>
 
-                                <div class="row mb-2" rendered="#{financialTransactionController.currentDetailedFinancialBill.cardValuePresent}">
+                                <h:panelGroup layout="block" styleClass="row mb-2" rendered="#{financialTransactionController.currentDetailedFinancialBill.cardValue ne null and financialTransactionController.currentDetailedFinancialBill.cardValue ne 0}">
                                     <div class="col-md-3"><p:outputLabel value="Card" /></div>
                                     <div class="col-md-3 text-end"><p:outputLabel value="#{financialTransactionController.currentDetailedFinancialBill.cardValue}">
                                             <f:convertNumber pattern="#,##0.00" />
                                         </p:outputLabel></div>
                                     <div class="col-md-6"></div>
-                                </div>
+                                </h:panelGroup>
 
-                                <div class="row mb-2" rendered="#{financialTransactionController.currentDetailedFinancialBill.chequeValuePresent}">
+                                <h:panelGroup layout="block" styleClass="row mb-2" rendered="#{financialTransactionController.currentDetailedFinancialBill.chequeValue ne null and financialTransactionController.currentDetailedFinancialBill.chequeValue ne 0}">
                                     <div class="col-md-3"><p:outputLabel value="Cheque" /></div>
                                     <div class="col-md-3 text-end"><p:outputLabel value="#{financialTransactionController.currentDetailedFinancialBill.chequeValue}">
                                             <f:convertNumber pattern="#,##0.00" />
                                         </p:outputLabel></div>
                                     <div class="col-md-6"></div>
-                                </div>
+                                </h:panelGroup>
 
-                                <div class="row mb-2" rendered="#{financialTransactionController.currentDetailedFinancialBill.slipValuePresent}">
+                                <h:panelGroup layout="block" styleClass="row mb-2" rendered="#{financialTransactionController.currentDetailedFinancialBill.slipValue ne null and financialTransactionController.currentDetailedFinancialBill.slipValue ne 0}">
                                     <div class="col-md-3"><p:outputLabel value="Slip" /></div>
                                     <div class="col-md-3 text-end"><p:outputLabel value="#{financialTransactionController.currentDetailedFinancialBill.slipValue}">
                                             <f:convertNumber pattern="#,##0.00" />
                                         </p:outputLabel></div>
                                     <div class="col-md-6"></div>
-                                </div>
+                                </h:panelGroup>
 
-                                <div class="row mb-2" rendered="#{financialTransactionController.currentDetailedFinancialBill.ewalletValuePresent}">
+                                <h:panelGroup layout="block" styleClass="row mb-2" rendered="#{financialTransactionController.currentDetailedFinancialBill.ewalletValue ne null and financialTransactionController.currentDetailedFinancialBill.ewalletValue ne 0}">
                                     <div class="col-md-3"><p:outputLabel value="E-Wallet" /></div>
                                     <div class="col-md-3 text-end"><p:outputLabel value="#{financialTransactionController.currentDetailedFinancialBill.ewalletValue}">
                                             <f:convertNumber pattern="#,##0.00" />
                                         </p:outputLabel></div>
                                     <div class="col-md-6"></div>
-                                </div>
+                                </h:panelGroup>
 
-                                <div class="row mb-2" rendered="#{financialTransactionController.currentDetailedFinancialBill.onCallValuePresent}">
+                                <h:panelGroup layout="block" styleClass="row mb-2" rendered="#{financialTransactionController.currentDetailedFinancialBill.onCallValue ne null and financialTransactionController.currentDetailedFinancialBill.onCallValue ne 0}">
                                     <div class="col-md-3"><p:outputLabel value="On Call" /></div>
                                     <div class="col-md-3 text-end"><p:outputLabel value="#{financialTransactionController.currentDetailedFinancialBill.onCallValue}">
                                             <f:convertNumber pattern="#,##0.00" />
                                         </p:outputLabel></div>
                                     <div class="col-md-6"></div>
-                                </div>
+                                </h:panelGroup>
 
-                                <div class="row mb-2" rendered="#{financialTransactionController.currentDetailedFinancialBill.multiplePaymentMethodsValuePresent}">
+                                <h:panelGroup layout="block" styleClass="row mb-2" rendered="#{financialTransactionController.currentDetailedFinancialBill.multiplePaymentMethodsValue ne null and financialTransactionController.currentDetailedFinancialBill.multiplePaymentMethodsValue ne 0}">
                                     <div class="col-md-3"><p:outputLabel value="Multiple Payment Methods" /></div>
                                     <div class="col-md-3 text-end"><p:outputLabel value="#{financialTransactionController.currentDetailedFinancialBill.multiplePaymentMethodsValue}">
                                             <f:convertNumber pattern="#,##0.00" />
                                         </p:outputLabel></div>
                                     <div class="col-md-6"></div>
-                                </div>
+                                </h:panelGroup>
 
-                                <div class="row mb-2" rendered="#{financialTransactionController.currentDetailedFinancialBill.staffValuePresent}">
+                                <h:panelGroup layout="block" styleClass="row mb-2" rendered="#{financialTransactionController.currentDetailedFinancialBill.staffValue ne null and financialTransactionController.currentDetailedFinancialBill.staffValue ne 0}">
                                     <div class="col-md-3"><p:outputLabel value="Staff" /></div>
                                     <div class="col-md-3 text-end"><p:outputLabel value="#{financialTransactionController.currentDetailedFinancialBill.staffValue}">
                                             <f:convertNumber pattern="#,##0.00" />
                                         </p:outputLabel></div>
                                     <div class="col-md-6"></div>
-                                </div>
+                                </h:panelGroup>
 
-                                <div class="row mb-2" rendered="#{financialTransactionController.currentDetailedFinancialBill.creditValuePresent}">
+                                <h:panelGroup layout="block" styleClass="row mb-2" rendered="#{financialTransactionController.currentDetailedFinancialBill.creditValue ne null and financialTransactionController.currentDetailedFinancialBill.creditValue ne 0}">
                                     <div class="col-md-3"><p:outputLabel value="Credit" /></div>
                                     <div class="col-md-3 text-end"><p:outputLabel value="#{financialTransactionController.currentDetailedFinancialBill.creditValue}">
                                             <f:convertNumber pattern="#,##0.00" />
                                         </p:outputLabel></div>
                                     <div class="col-md-6"></div>
-                                </div>
+                                </h:panelGroup>
 
-                                <div class="row mb-2" rendered="#{financialTransactionController.currentDetailedFinancialBill.staffWelfareValuePresent}">
+                                <h:panelGroup layout="block" styleClass="row mb-2" rendered="#{financialTransactionController.currentDetailedFinancialBill.staffWelfareValue ne null and financialTransactionController.currentDetailedFinancialBill.staffWelfareValue ne 0}">
                                     <div class="col-md-3"><p:outputLabel value="Staff Welfare" /></div>
                                     <div class="col-md-3 text-end"><p:outputLabel value="#{financialTransactionController.currentDetailedFinancialBill.staffWelfareValue}">
                                             <f:convertNumber pattern="#,##0.00" />
                                         </p:outputLabel></div>
                                     <div class="col-md-6"></div>
-                                </div>
+                                </h:panelGroup>
 
-                                <div class="row mb-2" rendered="#{financialTransactionController.currentDetailedFinancialBill.voucherValuePresent}">
+                                <h:panelGroup layout="block" styleClass="row mb-2" rendered="#{financialTransactionController.currentDetailedFinancialBill.voucherValue ne null and financialTransactionController.currentDetailedFinancialBill.voucherValue ne 0}">
                                     <div class="col-md-3"><p:outputLabel value="Voucher" /></div>
                                     <div class="col-md-3 text-end"><p:outputLabel value="#{financialTransactionController.currentDetailedFinancialBill.voucherValue}">
                                             <f:convertNumber pattern="#,##0.00" />
                                         </p:outputLabel></div>
                                     <div class="col-md-6"></div>
-                                </div>
+                                </h:panelGroup>
 
-                                <div class="row mb-2" rendered="#{financialTransactionController.currentDetailedFinancialBill.iouValuePresent}">
+                                <h:panelGroup layout="block" styleClass="row mb-2" rendered="#{financialTransactionController.currentDetailedFinancialBill.iouValue ne null and financialTransactionController.currentDetailedFinancialBill.iouValue ne 0}">
                                     <div class="col-md-3"><p:outputLabel value="IOU" /></div>
                                     <div class="col-md-3 text-end"><p:outputLabel value="#{financialTransactionController.currentDetailedFinancialBill.iouValue}">
                                             <f:convertNumber pattern="#,##0.00" />
                                         </p:outputLabel></div>
                                     <div class="col-md-6"></div>
-                                </div>
+                                </h:panelGroup>
 
-                                <div class="row mb-2" rendered="#{financialTransactionController.currentDetailedFinancialBill.agentValuePresent}">
+                                <h:panelGroup layout="block" styleClass="row mb-2" rendered="#{financialTransactionController.currentDetailedFinancialBill.agentValue ne null and financialTransactionController.currentDetailedFinancialBill.agentValue ne 0}">
                                     <div class="col-md-3"><p:outputLabel value="Agent" /></div>
                                     <div class="col-md-3 text-end"><p:outputLabel value="#{financialTransactionController.currentDetailedFinancialBill.agentValue}">
                                             <f:convertNumber pattern="#,##0.00" />
                                         </p:outputLabel></div>
                                     <div class="col-md-6"></div>
-                                </div>
+                                </h:panelGroup>
 
-                                <div class="row mb-2" rendered="#{financialTransactionController.currentDetailedFinancialBill.patientDepositValuePresent}">
+                                <h:panelGroup layout="block" styleClass="row mb-2" rendered="#{financialTransactionController.currentDetailedFinancialBill.patientDepositValue ne null and financialTransactionController.currentDetailedFinancialBill.patientDepositValue ne 0}">
                                     <div class="col-md-3"><p:outputLabel value="Patient Deposit" /></div>
                                     <div class="col-md-3 text-end"><p:outputLabel value="#{financialTransactionController.currentDetailedFinancialBill.patientDepositValue}">
                                             <f:convertNumber pattern="#,##0.00" />
                                         </p:outputLabel></div>
                                     <div class="col-md-6"></div>
-                                </div>
+                                </h:panelGroup>
 
-                                <div class="row mb-2" rendered="#{financialTransactionController.currentDetailedFinancialBill.patientPointsValuePresent}">
+                                <h:panelGroup layout="block" styleClass="row mb-2" rendered="#{financialTransactionController.currentDetailedFinancialBill.patientPointsValue ne null and financialTransactionController.currentDetailedFinancialBill.patientPointsValue ne 0}">
                                     <div class="col-md-3"><p:outputLabel value="Patient Points" /></div>
                                     <div class="col-md-3 text-end"><p:outputLabel value="#{financialTransactionController.currentDetailedFinancialBill.patientPointsValue}">
                                             <f:convertNumber pattern="#,##0.00" />
                                         </p:outputLabel></div>
                                     <div class="col-md-6"></div>
-                                </div>
+                                </h:panelGroup>
 
-                                <div class="row mb-2" rendered="#{financialTransactionController.currentDetailedFinancialBill.onlineSettlementValuePresent}">
+                                <h:panelGroup layout="block" styleClass="row mb-2" rendered="#{financialTransactionController.currentDetailedFinancialBill.onlineSettlementValue ne null and financialTransactionController.currentDetailedFinancialBill.onlineSettlementValue ne 0}">
                                     <div class="col-md-3"><p:outputLabel value="Online Settlement" /></div>
                                     <div class="col-md-3 text-end"><p:outputLabel value="#{financialTransactionController.currentDetailedFinancialBill.onlineSettlementValue}">
                                             <f:convertNumber pattern="#,##0.00" />
                                         </p:outputLabel></div>
                                     <div class="col-md-6"></div>
-                                </div>
+                                </h:panelGroup>
+                                </h:panelGroup>
                             </div>
                         </h:panelGroup>
                     </p:panel>


### PR DESCRIPTION
## Summary

- IOU bill types (`IOU_CASH_ISSUE`, `IOU_SETTLE`, `IOU_TO_CASH_CONVERSION`) use `BillFinanceType.FLOAT_CHANGE`, which was excluded from the `btas` filter in all three overloads of `fetchPaymentsFromShiftStartToEndByDateAndDepartment`. This caused IOU activity during a shift to be silently omitted from the handover bundle.
- All three overloads now explicitly add the three IOU atomic types to `btas`, so IOU payments appear in the handover creation and accept flows.
- The existing IOU rows in `handover_start_all.xhtml`, `handover_accept.xhtml`, and both print composites (`five_five_paper_with_headings_for_handover.xhtml` / `_accept.xhtml`) were already fully implemented — they just had no data to show.

## Test plan

- [ ] Start a shift and record at least one IOU payment (issue or settle)
- [ ] Navigate to handover creation (`cashier/handover_start_all`) — confirm IOU row appears with correct amount
- [ ] Create the handover and print — confirm IOU row appears in the printed receipt
- [ ] Accept the handover as the receiving cashier — confirm IOU column is visible in the breakdown table
- [ ] Print the accept receipt — confirm IOU Value and IOU Handover columns appear
- [ ] Verify a shift with zero IOU activity shows no IOU row (guard: `rendered="#{...bundle.hasIouTransaction}"`)

Closes #20538

🤖 Generated with [Claude Code](https://claude.com/claude-code)