### PR TITLE
Remove audit tracking fields from user role entities

### DIFF
--- a/src/main/java/com/divudi/bean/common/UserPrivilageController.java
+++ b/src/main/java/com/divudi/bean/common/UserPrivilageController.java
@@ -24,7 +24,6 @@ import com.divudi.core.entity.WebUserRolePrivilege;
 import com.divudi.core.facade.WebUserRolePrivilegeFacade;
 import com.divudi.service.AuditEventService;
 import com.divudi.core.entity.AuditEvent;
-import com.divudi.core.facade.WebUserRoleFacade;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Date;
@@ -1161,21 +1160,10 @@ public class UserPrivilageController implements Serializable {
         }
         getRoleFacede().batchCreate(newWups);
         getRoleFacede().batchEdit(oldWups);
-        
-        //Save Last Edit Data
-        webUserRole.setLastUpdateAt(new Date());
-        webUserRole.setLastUpdater(sessionController.getLoggedUser());
-        webUserRoleFacade.edit(webUserRole);
-        System.out.println("Update Last Edit by " + webUserRole.getLastUpdater().getName() +" at " + webUserRole.getLastUpdateAt());
-        
-        
         fillUserRolePrivileges();
         JsfUtil.addSuccessMessage("Updated");
     }
     
-    @EJB
-    WebUserRoleFacade webUserRoleFacade;
-
     private static void checkNodes(TreeNode root, List<PrivilegeHolder> privilegesToCheck) {
         if (root == null || privilegesToCheck == null || privilegesToCheck.isEmpty()) {
             return;

--- a/src/main/java/com/divudi/bean/common/WebUserRoleUserController.java
+++ b/src/main/java/com/divudi/bean/common/WebUserRoleUserController.java
@@ -76,40 +76,6 @@ public class WebUserRoleUserController implements Serializable {
             JsfUtil.addErrorMessage("Select Department");
             return;
         }
-//        String jpql = "select ru "
-//                + " from WebUserRoleUser ru "
-//                + " where ru.department=:dept "
-//                + " and ru.webUserRole=:role"
-//                + " and ru.webUser=:user "
-//                + " order by ru.id desc ";
-//        Map params = new HashMap();
-//        params.put("dept", department);
-//        params.put("role", webUserRole);
-//        params.put("user", webUser);
-//        WebUserRoleUser roleUser = getFacade().findFirstByJpql(jpql, params);
-//        
-//
-//        if (roleUser == null) {
-//            roleUser = new WebUserRoleUser();
-//            roleUser.setDepartment(department);
-//            roleUser.setWebUser(webUser);
-//            roleUser.setWebUserRole(webUserRole);
-//            
-//            //Add Creater Details
-//            roleUser.setCreater(sessionController.getLoggedUser());
-//            roleUser.setCreatedAt(new Date());
-//            //Add Last Editer Details
-//            roleUser.setEditer(sessionController.getLoggedUser());
-//            roleUser.setEditedAt(new Date());
-//            getFacade().create(roleUser);
-//        } else {
-//            //Add Last Editer Details
-//            roleUser.setEditer(sessionController.getLoggedUser());
-//            roleUser.setEditedAt(new Date());
-//            roleUser.setRetired(false);
-//            getFacade().edit(roleUser);
-//        }
-        
         updatePrivilegesToUserRole(webUserRole,webUser,department);
         
         JsfUtil.addSuccessMessage("Added Successfully "+ webUserRole.getName() +" Role Privileges to " + department.getName() + "Department.");

--- a/src/main/java/com/divudi/core/entity/WebUserRole.java
+++ b/src/main/java/com/divudi/core/entity/WebUserRole.java
@@ -40,11 +40,6 @@ public class WebUserRole implements Serializable {
     @JsonIgnore
     @Temporal(javax.persistence.TemporalType.TIMESTAMP)
     Date createdAt;
-    //Last Update Properties
-    @Temporal(javax.persistence.TemporalType.TIMESTAMP)
-    private Date lastUpdateAt;
-    @ManyToOne
-    private WebUser lastUpdater;
     //Retairing properties
     @JsonIgnore
     boolean retired;
@@ -194,22 +189,6 @@ public class WebUserRole implements Serializable {
     @Override
     public String toString() {
         return "gov.sp.health.entity.WebUserRole[ id=" + id + " ]";
-    }
-
-    public Date getLastUpdateAt() {
-        return lastUpdateAt;
-    }
-
-    public void setLastUpdateAt(Date lastUpdateAt) {
-        this.lastUpdateAt = lastUpdateAt;
-    }
-
-    public WebUser getLastUpdater() {
-        return lastUpdater;
-    }
-
-    public void setLastUpdater(WebUser lastUpdater) {
-        this.lastUpdater = lastUpdater;
     }
 
 }

--- a/src/main/java/com/divudi/core/entity/WebUserRolePrivilege.java
+++ b/src/main/java/com/divudi/core/entity/WebUserRolePrivilege.java
@@ -48,12 +48,6 @@ public class WebUserRolePrivilege implements Serializable {
     String retireComments;
     String sname;
     String tname;
-    //Last Update Properties
-    @Temporal(javax.persistence.TemporalType.TIMESTAMP)
-    private Date lastUpdateAt;
-    @ManyToOne
-    private WebUser lastUpdater;
-
     public Long getId() {
         return id;
     }
@@ -196,22 +190,6 @@ public class WebUserRolePrivilege implements Serializable {
 
     public void setWebUserRole(WebUserRole webUserRole) {
         this.webUserRole = webUserRole;
-    }
-
-    public Date getLastUpdateAt() {
-        return lastUpdateAt;
-    }
-
-    public void setLastUpdateAt(Date lastUpdateAt) {
-        this.lastUpdateAt = lastUpdateAt;
-    }
-
-    public WebUser getLastUpdater() {
-        return lastUpdater;
-    }
-
-    public void setLastUpdater(WebUser lastUpdater) {
-        this.lastUpdater = lastUpdater;
     }
 
 }

--- a/src/main/java/com/divudi/core/entity/WebUserRoleUser.java
+++ b/src/main/java/com/divudi/core/entity/WebUserRoleUser.java
@@ -44,20 +44,6 @@ public class WebUserRoleUser implements Serializable {
     @Temporal(javax.persistence.TemporalType.TIMESTAMP)
     private Date retiredAt;
     private String retireComments;
-    //Editer Properties
-    @ManyToOne
-
-    private WebUser editer;
-
-    @Temporal(javax.persistence.TemporalType.TIMESTAMP)
-    private Date editedAt;
-
-    //Last Update Properties
-    @Temporal(javax.persistence.TemporalType.TIMESTAMP)
-    private Date lastUpdateAt;
-    @ManyToOne
-    private WebUser lastUpdater;
-
     @Transient
     private Boolean needUpdateUserRole;
 
@@ -151,22 +137,6 @@ public class WebUserRoleUser implements Serializable {
         this.retireComments = retireComments;
     }
 
-    public WebUser getEditer() {
-        return editer;
-    }
-
-    public void setEditer(WebUser editer) {
-        this.editer = editer;
-    }
-
-    public Date getEditedAt() {
-        return editedAt;
-    }
-
-    public void setEditedAt(Date editedAt) {
-        this.editedAt = editedAt;
-    }
-
     public WebUserRole getWebUserRole() {
         return webUserRole;
     }
@@ -184,33 +154,10 @@ public class WebUserRoleUser implements Serializable {
     }
 
     public Boolean getNeedUpdateUserRole() {
-        if (webUserRole == null || webUserRole.getLastUpdateAt() == null) {
-            return false;
-        }
-        if (editedAt == null) {
-            return true;
-        }
-        needUpdateUserRole =  webUserRole.getLastUpdateAt().after(editedAt);
-        return needUpdateUserRole;
+        return webUserRole != null;
     }
 
     public void setNeedUpdateUserRole(Boolean needUpdateUserRole) {
         this.needUpdateUserRole = needUpdateUserRole;
-    }
-
-    public Date getLastUpdateAt() {
-        return lastUpdateAt;
-    }
-
-    public void setLastUpdateAt(Date lastUpdateAt) {
-        this.lastUpdateAt = lastUpdateAt;
-    }
-
-    public WebUser getLastUpdater() {
-        return lastUpdater;
-    }
-
-    public void setLastUpdater(WebUser lastUpdater) {
-        this.lastUpdater = lastUpdater;
     }
 }

--- a/src/main/webapp/admin/users/user_role_privileges.xhtml
+++ b/src/main/webapp/admin/users/user_role_privileges.xhtml
@@ -27,11 +27,6 @@
                             <p:outputLabel  value="User Role" ></p:outputLabel>
                             <p:outputLabel  value=":" class="mx-3"></p:outputLabel>
                             <p:outputLabel class="w-100" value="#{userPrivilageController.webUserRole.name}"></p:outputLabel>
-                            <p:outputLabel  value="Last Update" ></p:outputLabel>
-                            <p:outputLabel  value=":" class="mx-3"></p:outputLabel>
-                            <p:outputLabel class="w-100" value="#{userPrivilageController.webUserRole.lastUpdateAt}">
-                                <f:convertDateTime pattern="yyyy-MM-dd hh:mm a" />
-                            </p:outputLabel>
                         </h:panelGrid>  
 
 

--- a/src/main/webapp/admin/users/user_role_users.xhtml
+++ b/src/main/webapp/admin/users/user_role_users.xhtml
@@ -105,24 +105,6 @@
                             <h:outputText id="role" value="#{user.webUserRole.name}" class="d-flex justify-content-center" style="font-weight: 700;"/>
                         </div>
 
-                        <p:tooltip for="role" showEffect="clip" hideEffect="fold" position="bottom" >
-                            <div style="width: 550px; font-size: 19px;" class="p-2">
-                                <div class="row">
-                                    <h:outputText value="Last Role Update" style="width: 250px;"/>
-                                    <h:outputText value=" : " style="width: 50px;"/>
-                                    <h:outputText value="#{user.webUserRole.lastUpdateAt eq null ? 'N/A' : user.webUserRole.lastUpdateAt}">
-                                        <f:convertDateTime pattern="yyyy-MM-dd hh:mm a" />
-                                    </h:outputText>
-                                </div>
-                                <div class="row">
-                                    <h:outputText value="Last User Role Update" style="width: 250px;"/>
-                                    <h:outputText value=" : " style="width: 50px;"/>
-                                    <h:outputText value="#{user.editedAt eq null ? 'N/A' : user.editedAt}" >
-                                        <f:convertDateTime pattern="yyyy-MM-dd hh:mm a" />
-                                    </h:outputText>
-                                </div>
-                            </div>
-                        </p:tooltip>
                     </p:column>
 
                     <p:column headerText="Actions" class="text-center" style=" padding: 10px; width: 200px; " >


### PR DESCRIPTION
## Summary
This PR removes audit tracking functionality (last update timestamp and updater user references) from user role-related entities and their associated UI components. The changes simplify the data model by eliminating redundant audit fields that were tracking when roles and privileges were last modified.

## Key Changes
- **WebUserRoleUser entity**: Removed `editer`, `editedAt`, `lastUpdater`, and `lastUpdateAt` fields along with their getters/setters. Simplified `getNeedUpdateUserRole()` logic to only check if `webUserRole` is not null.
- **WebUserRole entity**: Removed `lastUpdater` and `lastUpdateAt` fields and their accessors.
- **WebUserRolePrivilege entity**: Removed `lastUpdater` and `lastUpdateAt` fields and their accessors.
- **UserPrivilageController**: Removed code that was setting `lastUpdateAt` and `lastUpdater` when saving role privileges, and removed the unused `WebUserRoleFacade` injection.
- **WebUserRoleUserController**: Removed commented-out legacy code that referenced the removed audit fields.
- **UI Components**: Removed tooltip and display elements from `user_role_users.xhtml` and `user_role_privileges.xhtml` that were showing last update timestamps.

## Implementation Details
The `getNeedUpdateUserRole()` method in `WebUserRoleUser` was significantly simplified from a complex comparison of timestamps to a simple null check, indicating a shift in how role update requirements are determined.

https://claude.ai/code/session_012B8a8ywo3stvxhtC1iFWaE

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Removed "Last Update" audit metadata from user role and privilege management system, including timestamps and user tracking information.
  * Simplified role update detection logic in user role assignments.
  * Updated administration pages to remove "Last Update" information displays.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->