### PR TITLE
Make pharmacy sales history filtering by department configurable

### DIFF
--- a/src/main/java/com/divudi/bean/pharmacy/PharmacyController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacyController.java
@@ -8294,6 +8294,9 @@ public class PharmacyController implements Serializable {
         btas.add(BillTypeAtomic.PHARMACY_RETAIL_SALE_RETURN_ITEMS_ONLY);
         btas.add(BillTypeAtomic.PHARMACY_RETAIL_SALE_RETURN_ITEMS_AND_PAYMENTS);
 
+        boolean listOnlyDepartmentTransactions = configOptionApplicationController.getBooleanValueByKey(
+                "Pharmacy History Lists Only Department Transactions for Sales", true);
+
         String jpql = "SELECT new com.divudi.core.data.dto.PharmacySaleByBillTypeDTO("
                 + "i.bill.billTypeAtomic, "
                 + "sum(i.pharmaceuticalBillItem.qty)) "
@@ -8301,16 +8304,20 @@ public class PharmacyController implements Serializable {
                 + "WHERE (i.bill.retired is null or i.bill.retired=false) "
                 + "AND i.item in :ris "
                 + "AND i.bill.billTypeAtomic in :btas "
-                + "AND i.createdAt between :frm and :to "
-                + "AND i.bill.department=:dep "
-                + "GROUP BY i.bill.billTypeAtomic";
+                + "AND i.createdAt between :frm and :to ";
 
         Map<String, Object> m = new HashMap<>();
         m.put("ris", relatedAmpAndAmpps);
         m.put("frm", getFromDate());
         m.put("to", getToDate());
         m.put("btas", btas);
-        m.put("dep", sessionController.getDepartment());
+
+        if (listOnlyDepartmentTransactions) {
+            jpql += "AND i.bill.department=:dep ";
+            m.put("dep", sessionController.getDepartment());
+        }
+
+        jpql += "GROUP BY i.bill.billTypeAtomic";
 
         salesByBillType = (List<PharmacySaleByBillTypeDTO>) getBillItemFacade().findLightsByJpql(jpql, m, TemporalType.TIMESTAMP);
     }

--- a/src/main/webapp/resources/pharmacy/history.xhtml
+++ b/src/main/webapp/resources/pharmacy/history.xhtml
@@ -195,7 +195,7 @@
                             rendered="#{configOptionApplicationController.getBooleanValueByKey('Pharmacy Item Details Section - Display Sale Block', true)}" >
                             <p:panel>
                                 <div style="background-color: #337357; padding: 10px; font-weight: bold; color: white; text-align: center;">
-                                    Pharmacy Sale
+                                    #{configOptionApplicationController.getBooleanValueByKey('Pharmacy History Lists Only Department Transactions for Sales', true) ? 'Department Sale' : 'All Departments Sale'}
                                 </div>
                                 <h:panelGroup rendered="#{empty pharmacyController.salesByBillType}">
                                     <div class="alert alert-info text-center" style="margin: 20px 0; padding: 15px;">
@@ -735,7 +735,7 @@
                         </p:tab>
 
                         <p:tab
-                            title="Sale"
+                            title="#{configOptionApplicationController.getBooleanValueByKey('Pharmacy History Lists Only Department Transactions for Sales', true) ? 'Department Sale' : 'All Departments Sale'}"
                             id="itemDetailsTabSales"
                             rendered="#{configOptionApplicationController.getBooleanValueByKey('Pharmacy Item Details Section - Display Sale Tab', true)}">
 


### PR DESCRIPTION
## Summary
This change makes the pharmacy sales history filtering behavior configurable through a new application setting, allowing administrators to choose whether sales data should be filtered to only show department-specific transactions or all departments.

## Key Changes
- **Backend Logic**: Modified `PharmacyController.createDepartmentSaleDto()` to conditionally apply department filtering based on a new configuration option `"Pharmacy History Lists Only Department Transactions for Sales"`
  - When enabled (default): filters sales to only the current user's department
  - When disabled: displays sales from all departments
  
- **UI Updates**: Updated pharmacy history view labels to dynamically reflect the filtering mode
  - Panel header in item details section now shows "Department Sale" or "All Departments Sale"
  - Tab title for sales section also updates based on the configuration setting

## Implementation Details
- The configuration option defaults to `true` to maintain backward compatibility with existing behavior
- The JPQL query is conditionally built to include or exclude the department filter clause
- UI labels use EL expressions to read the same configuration key, ensuring consistency between backend filtering and frontend display

https://claude.ai/code/session_01HBYZBSFycWLQjmoMTf9N9k

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new configuration option (`Pharmacy History Lists Only Department Transactions for Sales`) to control pharmacy sales report filtering. When enabled, sales reports display only your department's transactions; when disabled, reports show all departments. Report labels dynamically reflect the current setting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->