### PR TITLE
Add code field search to AMP autocomplete query

### DIFF
--- a/src/main/java/com/divudi/bean/pharmacy/AmpController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/AmpController.java
@@ -479,7 +479,7 @@ public class AmpController implements Serializable {
         if (qry == null || qry.trim().isEmpty()) {
             suggestions = new ArrayList<>();
         } else {
-            String jpql = "SELECT c FROM Amp c WHERE c.retired = false AND LOWER(c.name) LIKE :query ORDER BY c.name";
+            String jpql = "SELECT c FROM Amp c WHERE c.retired = false AND (LOWER(c.name) LIKE :query OR LOWER(c.code) LIKE :query) ORDER BY c.name";
             Map<String, Object> parameters = new HashMap<>();
             parameters.put("query", "%" + qry.trim().toLowerCase() + "%");
             suggestions = getFacade().findByJpqlWithoutCache(jpql, parameters);


### PR DESCRIPTION
## Summary
Enhanced the AMP (Active Medicinal Product) autocomplete search functionality to include code field matching in addition to name field matching.

## Key Changes
- Modified the JPQL query in `completeAmpAny()` method to search both `name` and `code` fields
- Updated WHERE clause to use OR condition: `LOWER(c.name) LIKE :query OR LOWER(c.code) LIKE :query`
- Maintains existing functionality for name-based search while adding code-based search capability

## Implementation Details
- The same query parameter is used for both name and code fields, allowing users to find AMPs by either field
- Search remains case-insensitive through the LOWER() function
- Results are still ordered by name for consistent presentation
- No changes to the parameter binding or result processing logic

https://claude.ai/code/session_01EEwtjcnPbb5TwVDYmPxBtJ