### PR TITLE
20577 - inward bill cancellation per department type permission gating badge clarity and dated UI.

### DIFF
--- a/src/main/java/com/divudi/bean/common/RequestController.java
+++ b/src/main/java/com/divudi/bean/common/RequestController.java
@@ -896,7 +896,7 @@ public class RequestController implements Serializable {
             }
         }
 
-        JsfUtil.addSuccessMessage("Successfully Reject");
+        JsfUtil.addSuccessMessage("Request Process Completed.");
     }
 
     public void cancelRequestbyUser() {

--- a/src/main/java/com/divudi/bean/common/RequestController.java
+++ b/src/main/java/com/divudi/bean/common/RequestController.java
@@ -446,10 +446,8 @@ public class RequestController implements Serializable {
                 b.setCurrentRequest(newlyRequest);
                 billFacade.edit(b);
             }
-
             setCurrentRequest(newlyRequest);
         }
-
         printPreview = true;
     }
 
@@ -498,7 +496,6 @@ public class RequestController implements Serializable {
 
             setCurrentRequest(newlyRequest);
         }
-
         printPreview = true;
     }
 

--- a/src/main/java/com/divudi/bean/common/RequestController.java
+++ b/src/main/java/com/divudi/bean/common/RequestController.java
@@ -454,8 +454,6 @@ public class RequestController implements Serializable {
     }
 
     public void createRequestforPettyCashBillCancellation(Bill pettyCashBill) {
-        System.out.println("pettyCashBill = " + pettyCashBill);
-
         if (pettyCashBill == null) {
             JsfUtil.addErrorMessage("Bill not found for Create Request ");
             return;
@@ -642,13 +640,10 @@ public class RequestController implements Serializable {
 
         Drawer loggedUserDrawer = drawerController.getUsersDrawer(sessionController.getLoggedUser());
 
-        System.out.println("loggedUserDrawer = " + loggedUserDrawer);
-
         if (loggedUserDrawer == null) {
             JsfUtil.addErrorMessage("Your Drawer have a Error.");
             return "";
         }
-        System.out.println("loggedUserDrawer.getCashInHandValue() = " + loggedUserDrawer.getCashInHandValue());
 
         if (loggedUserDrawer != null && (loggedUserDrawer.getCashInHandValue() == null || loggedUserDrawer.getCashInHandValue() == 0)) {
             JsfUtil.addErrorMessage("There is no cash in your drawer.");

--- a/src/main/java/com/divudi/bean/inward/InwardSearch.java
+++ b/src/main/java/com/divudi/bean/inward/InwardSearch.java
@@ -38,6 +38,7 @@ import com.divudi.core.facade.PatientInvestigationFacade;
 import com.divudi.core.facade.PersonFacade;
 import com.divudi.core.util.JsfUtil;
 import com.divudi.core.data.BillTypeAtomic;
+import com.divudi.core.data.DepartmentType;
 import com.divudi.core.data.lab.PatientInvestigationStatus;
 import com.divudi.core.entity.cashTransaction.Drawer;
 import com.divudi.core.facade.PaymentFacade;
@@ -167,7 +168,7 @@ public class InwardSearch implements Serializable {
                 return "inward_cancel_bill_payment?faces-redirect=true";
         }
     }
-    
+
     public void editBillDetails() {
         Bill editedBill = bill;
         if (bill == null) {
@@ -186,23 +187,27 @@ public class InwardSearch implements Serializable {
         JsfUtil.addSuccessMessage("Saved");
         referredBy = null;
     }
-    
+
     @Inject
     RequestController requestController;
     @Inject
     RequestService requestService;
-    
+
     private Doctor referredBy;
 
     private Request currentRequest;
-    
+
     public String navigateToCancelInpatientBill() {
         if (bill == null) {
             JsfUtil.addErrorMessage("No bill is selected");
             return "";
         }
 
-        if (configOptionApplicationController.getBooleanValueByKey("Mandatory permission to cancel bills.", false)) {
+        DepartmentType toBillDepartmentType = bill.getToDepartment().getDepartmentType();
+
+        boolean allowType = configOptionApplicationController.getBooleanValueByKey("Inward Billing - Mandatory permission to cancel " + toBillDepartmentType.getLabel() + " type bills", false);
+
+        if (configOptionApplicationController.getBooleanValueByKey("Mandatory permission to cancel bills.", false) && allowType) {
             currentRequest = requestService.findRequest(bill);
 
             if (currentRequest == null) {
@@ -838,19 +843,17 @@ public class InwardSearch implements Serializable {
             JsfUtil.addSuccessMessage("Cancelled");
 
             getBillBean().updateBatchBill(getBill().getForwardReferenceBill());
-            
+
             if (configOptionApplicationController.getBooleanValueByKey("Mandatory permission to cancel bills.", false)) {
-            Request billRequest = requestService.findRequest(getBill());
-            if (billRequest != null) {
-                
-                requestController.getBills().add(getBill());
-                requestController.complteRequest(billRequest);
-            } else {
-                JsfUtil.addErrorMessage("Related approval request not found to complete.");
+                Request billRequest = requestService.findRequest(getBill());
+                if (billRequest != null) {
+
+                    requestController.getBills().add(getBill());
+                    requestController.complteRequest(billRequest);
+                }
             }
-        }
-            
-        printPreview = true;
+
+            printPreview = true;
 
         } else {
             JsfUtil.addErrorMessage("No Bill to cancel");

--- a/src/main/webapp/common/request/inward_bill_cancel_request.xhtml
+++ b/src/main/webapp/common/request/inward_bill_cancel_request.xhtml
@@ -11,146 +11,190 @@
     <h:body>
         <ui:composition template="/resources/template/template.xhtml">
             <ui:define name="content">
-                <h:form>
+                <h:form id="inwardBillCancelRequestForm">
+
+                    <p:growl id="growl" life="4000"/>
+
+                    <p:confirmDialog 
+                        global="true" 
+                        responsive="true" 
+                        width="780"
+                        showEffect="fade" 
+                        hideEffect="fade">
+                        <p:commandButton 
+                            style="width: 150px;"
+                            value="Yes" 
+                            type="button"
+                            styleClass="ui-confirmdialog-yes ui-button-danger"
+                            icon="fa fa-check">
+                        </p:commandButton>
+                        <p:commandButton 
+                            style="width: 150px;"
+                            value="No" 
+                            type="button"
+                            styleClass="ui-confirmdialog-no ui-button-secondary ui-button-outlined"
+                            icon="fa fa-times">
+                        </p:commandButton>
+                    </p:confirmDialog>
+
                     <h:panelGroup rendered="#{!requestController.printPreview}" styleClass="alignTop">
                         <p:panel>
                             <f:facet name="header">
-                                <div class="d-flex justify-content-between">
-                                    <p:outputLabel value="Bill Cancellation Request" class="mt-2"></p:outputLabel>
-                                    <p:commandButton 
+                                <div class="d-flex justify-content-between align-items-center">
+                                    <p:outputLabel value="Bill Cancellation Request"
+                                                   styleClass="fs-5 fw-semibold m-0"/>
+                                    <p:commandButton
                                         ajax="false"
-                                        value="Back to List" 
+                                        value="Back to List"
                                         icon="fa fa-long-arrow-left"
                                         action="/lab/inward_search_service?faces-redirect=true"
-                                        class="ui-button-warning" >
+                                        title="Return to the inward bill search list"
+                                        styleClass="ui-button-warning">
                                     </p:commandButton>
                                 </div>
-
                             </f:facet>
 
-                            <div class="d-flex justify-content-end gap-5">
-
-                                <p:inputText
-                                    id="commentsMenu"
-                                    value="#{requestController.comment}"
-                                    placeholder="Reason of the Cancel"
-                                    style="float: right; width: 500px;"
-                                    >
-                                </p:inputText>
-
-                                <p:commandButton 
-                                    ajax="false"
-                                    value="Request to Cancel Bill" 
-                                    icon="fa fa-cancel"
-                                    style="float: right"
-                                    class="ui-button-danger" 
-                                    action="#{requestController.createRequestforInpatientServiceBill()}">
-                                </p:commandButton>
+                            <!-- Reason + Submit row -->
+                            <div class="d-flex justify-content-end">
+                                <div class="d-flex align-items-center gap-3 mb-3 flex-wrap">
+                                    <p:outputLabel for="commentsMenu"
+                                                   value="Reason for Cancellation"
+                                                   styleClass="fw-semibold m-0"/>
+                                    <p:inputText id="commentsMenu"
+                                                 value="#{requestController.comment}"
+                                                 placeholder="Enter the reason for cancelling this bill"
+                                                 style="width: 500px;"
+                                                 title="Reason for cancellation (required)"/>
+                                    <p:commandButton
+                                        ajax="false"
+                                        value="Request to Cancel Bill"
+                                        icon="fa fa-ban"
+                                        styleClass="ui-button-danger"
+                                        title="Submit a request to cancel this inward bill"
+                                        action="#{requestController.createRequestforInpatientServiceBill()}">
+                                        <p:confirm header="Confirm Cancellation Request"
+                                                   message="Submit a cancellation request for this inward bill?"
+                                                   icon="fa fa-exclamation-triangle"/>
+                                    </p:commandButton>
+                                </div>
                             </div>
 
-
                             <!-- Patient Details and Bill Details Panels -->
-                            <div class="row mt-3">
-                                <div class="col-6">
-                                    <p:panel>
+                            <div class="row g-3">
+                                <div class="col-12 col-lg-6">
+                                    <p:panel styleClass="h-100">
                                         <f:facet name="header">
-                                            <h:outputText styleClass="fas fa-id-card-alt"></h:outputText>
-                                            <h:outputLabel value="Patient Details" class="mx-2"></h:outputLabel>
+                                            <h:outputText styleClass="fas fa-id-card-alt me-2"/>
+                                            <h:outputText value="Patient Details" styleClass="fw-semibold"/>
                                         </f:facet>
                                         <in:bhtDetail admission="#{requestController.patientEncounter}"/>
                                     </p:panel>
-
                                 </div>
-                                <div class="col-6">
-                                    <p:panel>
+                                <div class="col-12 col-lg-6">
+                                    <p:panel styleClass="h-100">
                                         <f:facet name="header">
-                                            <h:outputText styleClass="fas fa-list-alt"></h:outputText>
-                                            <h:outputLabel value="Batch Bill Detail" class="mx-2"></h:outputLabel>
+                                            <h:outputText styleClass="fas fa-file-invoice me-2"/>
+                                            <h:outputText value="Batch Bill Detail" styleClass="fw-semibold"/>
                                         </f:facet>
-                                        <p:panelGrid columns="2">
-                                            <h:outputLabel value="Bill No :" ></h:outputLabel>
-                                            <h:outputLabel value="#{requestController.batchBill.deptId}" ></h:outputLabel>
-                                            <h:outputLabel value="Bill Type Atomic :" ></h:outputLabel>
-                                            <h:outputLabel value="#{requestController.batchBill.billTypeAtomic}" ></h:outputLabel>
-                                            <h:outputLabel value="Net Total :" ></h:outputLabel>
-                                            <h:outputLabel value="#{requestController.batchBill.netTotal}" >
-                                                <f:convertNumber pattern="#,##0.00" />
-                                            </h:outputLabel>
+                                        <p:panelGrid columns="2" layout="tabular" styleClass="w-100"
+                                                     columnClasses="fw-semibold,text-end">
+                                            <h:outputLabel value="Bill No"/>
+                                            <h:outputText value="#{requestController.batchBill.deptId}"
+                                                          style="display:block; text-align:right;"/>
+
+                                            <h:outputLabel value="Bill Type"/>
+                                            <h:outputText value="#{requestController.batchBill.billTypeAtomic}"
+                                                          style="display:block; text-align:right;"/>
+
+                                            <h:outputLabel value="Net Total"/>
+                                            <h:outputText value="#{requestController.batchBill.netTotal}"
+                                                          style="display:block; text-align:right; font-weight:600;">
+                                                <f:convertNumber pattern="#,##0.00"/>
+                                            </h:outputText>
                                         </p:panelGrid>
                                     </p:panel>
                                 </div>
                             </div>
 
-                            <div class="row mt-3">
-                                <!-- Bill Item Detail Panel -->
-                                <p:panel>
-                                    <f:facet name="header">
-                                        <h:outputText styleClass="fas fa-list-alt"></h:outputText>
-                                        <h:outputLabel value="Cancelling Bills Details" class="mx-2"></h:outputLabel>
-                                    </f:facet>
-                                    <p:dataTable rowIndexVar="rowIndex" value="#{requestController.bills}" var="bill">
-                                        <p:column>
-                                            <f:facet name="header">Bill No</f:facet>
-                                            <h:outputLabel value="#{bill.deptId}"/>
-                                        </p:column>
-                                        <p:column>
-                                            <f:facet name="header">Billed For</f:facet>
-                                            <h:outputLabel value="#{bill.toDepartment.name}"/>
-                                        </p:column>
-                                        <p:column>
-                                            <f:facet name="header">Net Total</f:facet>
-                                            <h:outputLabel value="#{bill.netTotal}">
-                                                <f:convertNumber pattern="#,##0.00" />
-                                            </h:outputLabel>
-                                        </p:column>
-                                    </p:dataTable>
-                                </p:panel>
+                            <!-- Bill Item Detail Panel -->
+                            <div class="row g-3 mt-1">
+                                <div class="col-12">
+                                    <p:panel>
+                                        <f:facet name="header">
+                                            <h:outputText styleClass="fas fa-list-alt me-2"/>
+                                            <h:outputText value="Cancelling Bills Details" styleClass="fw-semibold"/>
+                                        </f:facet>
+                                        <p:dataTable id="cancellingBillsTable"
+                                                     rowIndexVar="rowIndex"
+                                                     value="#{requestController.bills}"
+                                                     var="bill"
+                                                     emptyMessage="No bills available for cancellation."
+                                                     styleClass="w-100"
+                                                     stripedRows="true">
+                                            <p:column headerText="#"
+                                                      style="width: 4rem; text-align:center;">
+                                                <h:outputText value="#{rowIndex + 1}"/>
+                                            </p:column>
+                                            <p:column headerText="Bill No">
+                                                <h:outputText value="#{bill.deptId}"/>
+                                            </p:column>
+                                            <p:column headerText="Billed For">
+                                                <h:outputText value="#{bill.toDepartment.name}"/>
+                                            </p:column>
+                                            <p:column headerText="Net Total"
+                                                      style="text-align:right;">
+                                                <h:outputText value="#{bill.netTotal}">
+                                                    <f:convertNumber pattern="#,##0.00"/>
+                                                </h:outputText>
+                                            </p:column>
+                                        </p:dataTable>
+                                    </p:panel>
+                                </div>
                             </div>
 
                         </p:panel>
                     </h:panelGroup>
 
                     <!-- Print Preview Panel -->
-                    <h:panelGroup rendered="#{requestController.printPreview}" >
+                    <h:panelGroup rendered="#{requestController.printPreview}">
                         <p:panel>
                             <f:facet name="header">
-                                <div class="d-flex justify-content-between">
-                                    <p:outputLabel value="Bill Cancellation Request Note" class="mt-2"></p:outputLabel>
-                                    <div class=" d-flex gap-2">
-                                        <p:commandButton 
+                                <div class="d-flex justify-content-between align-items-center">
+                                    <p:outputLabel value="Bill Cancellation Request Note"
+                                                   styleClass="fs-5 fw-semibold m-0"/>
+                                    <div class="d-flex gap-2">
+                                        <p:commandButton
                                             ajax="false"
-                                            value="Print" 
+                                            value="Print"
                                             icon="fa fa-print"
-                                            class="ui-button-info" >
-                                            <p:printer target="printingView" />
+                                            styleClass="ui-button-success"
+                                            title="Print this cancellation request note">
+                                            <p:printer target="printingView"/>
                                         </p:commandButton>
 
-                                        <p:commandButton 
+                                        <p:commandButton
                                             ajax="false"
-                                            value="Back to List" 
+                                            value="Back to List"
                                             icon="fa fa-long-arrow-left"
                                             action="/lab/inward_search_service?faces-redirect=true"
-                                            class="ui-button-warning" >
-                                        </p:commandButton>
+                                            title="Return to the inward bill search list"
+                                            styleClass="ui-button-info ui-button-outlined"/>
                                     </div>
-
                                 </div>
                             </f:facet>
 
                             <div class="d-flex justify-content-center">
                                 <h:panelGroup id="printingView">
-                                    
-                                    <h:panelGroup rendered="#{sessionController.departmentPreference.opdBillPaperType eq 'FiveEightInchPaper'}" >
-                                        <request:five_eight_bill_cancel_request request="#{requestController.currentRequest}" />                        
-                                    </h:panelGroup>
-                                    
-                                </h:panelGroup>
 
+                                    <h:panelGroup rendered="#{sessionController.departmentPreference.opdBillPaperType eq 'FiveEightInchPaper'}">
+                                        <request:five_eight_bill_cancel_request request="#{requestController.currentRequest}"/>
+                                    </h:panelGroup>
+
+                                </h:panelGroup>
                             </div>
                         </p:panel>
-
                     </h:panelGroup>
-                </h:form>                
+                </h:form>
             </ui:define>
         </ui:composition>
     </h:body>

--- a/src/main/webapp/inward/inward_cancel_bill_service.xhtml
+++ b/src/main/webapp/inward/inward_cancel_bill_service.xhtml
@@ -11,155 +11,239 @@
     <h:body>
         <ui:composition template="/resources/template/template.xhtml">
             <ui:define name="content">
-                <h:form>
-                    <h:panelGroup rendered="#{!inwardSearch.printPreview}" styleClass="alignTop" >
-                        <p:panel  header="Service Cancellation">                            
+                <h:form id="inwardCancelBillServiceForm">
+
+                    <p:growl id="growl" life="4000"/>
+
+                    <p:confirmDialog
+                        global="true"
+                        responsive="true"
+                        width="780"
+                        showEffect="fade"
+                        hideEffect="fade">
+                        <p:commandButton
+                            style="width: 150px;"
+                            value="Yes"
+                            type="button"
+                            styleClass="ui-confirmdialog-yes ui-button-danger"
+                            icon="fa fa-check"/>
+                        <p:commandButton
+                            style="width: 150px;"
+                            value="No"
+                            type="button"
+                            styleClass="ui-confirmdialog-no ui-button-secondary ui-button-outlined"
+                            icon="fa fa-times"/>
+                    </p:confirmDialog>
+
+                    <h:panelGroup rendered="#{!inwardSearch.printPreview}" styleClass="alignTop">
+                        <p:panel>
                             <f:facet name="header">
-                                <div class="d-flex justify-content-between">
-                                    <h:outputLabel value="Service Cancellation" class="mt-2"/>
-                                    <div class="d-flex gap-4">
-                                        <h:outputLabel value="Reason for cancellation" class="mt-2" style="font-weight: 600;"/>
-                                        <p:inputText 
-                                            disabled="#{configOptionApplicationController.getBooleanValueByKey('Mandatory permission to cancel bills.', false)}"
-                                            placeholder="Enter a Reason to Cancel" 
-                                            value="#{inwardSearch.comment}"
-                                            style="float: right; width: 450px;">
-                                        </p:inputText>
-
-                                        <p:commandButton 
-                                            class="ui-button-danger mx-2" 
-                                            icon="fas fa-ban" 
-                                            ajax="false" 
-                                            value="Cancel Service Bill" 
-                                            action="#{inwardSearch.cancelBillService()}" >
-                                        </p:commandButton>
-                                    </div>
+                                <div class="d-flex justify-content-between align-items-center">
+                                    <p:outputLabel value="Service Cancellation"
+                                                   styleClass="fs-5 fw-semibold m-0"/>
+                                    <p:commandButton
+                                        ajax="false"
+                                        value="Back to List"
+                                        icon="fa fa-long-arrow-left"
+                                        action="/lab/inward_search_service?faces-redirect=true"
+                                        title="Return to the inward bill search list"
+                                        styleClass="ui-button-warning"/>
                                 </div>
-                            </f:facet>   
+                            </f:facet>
 
-                            <p:panelGrid columns="2" style="width: 100%;">
-                                <p:panel header="Patient Details">
-                                    <h:panelGrid columns="3" class="w-100" style="font-size: 12pt">
-                                        <h:outputLabel value="Patient ​Name" ></h:outputLabel>
-                                        <h:outputLabel value=":" ></h:outputLabel>
-                                        <h:outputLabel value="#{inwardSearch.bill.patient.person.nameWithTitle}" ></h:outputLabel>
-                                        <h:outputLabel value="BHT No" ></h:outputLabel>
-                                        <h:outputLabel value=":" ></h:outputLabel>
-                                        <h:outputLabel value="#{inwardSearch.bill.patientEncounter.bhtNo}" ></h:outputLabel>
-                                        <h:outputLabel value="Age" />
-                                        <h:outputLabel value=":" ></h:outputLabel>
-                                        <h:outputLabel value="#{inwardSearch.bill.patient.age}"  />
-                                        <h:outputLabel value="Sex" >
-                                        </h:outputLabel>
-                                        <h:outputLabel value=":" ></h:outputLabel>
-                                        <h:outputLabel value="#{inwardSearch.bill.patient.person.sex}" >
-                                        </h:outputLabel>
-                                        <h:outputLabel value="Phone" >
-                                        </h:outputLabel>
-                                        <h:outputLabel value=":" ></h:outputLabel>
-                                        <h:outputLabel value="#{inwardSearch.bill.patient.person.phone}" >
-                                        </h:outputLabel>
-                                    </h:panelGrid>
-                                </p:panel>
-                                <p:panel header="Bill Details">
-                                    <h:panelGrid columns="3" class="w-100" style="font-size: 12pt" >
-                                        <h:outputLabel value="Bill No" ></h:outputLabel>
-                                        <h:outputLabel value=":" ></h:outputLabel>
-                                        <h:outputLabel value="#{inwardSearch.bill.deptId}" ></h:outputLabel>
-                                        <h:outputLabel value="Total" ></h:outputLabel>
-                                        <h:outputLabel value=":" ></h:outputLabel>
-                                        <h:outputLabel value="#{inwardSearch.bill.netTotal}" >
-                                            <f:convertNumber pattern="#,##0.00"/>
-                                        </h:outputLabel>
-                                        <h:outputLabel value="Discount" ></h:outputLabel>
-                                        <h:outputLabel value=":" ></h:outputLabel>
-                                        <h:outputLabel value="#{inwardSearch.bill.discount}" >
-                                            <f:convertNumber pattern="#,##0.00"/>
-                                        </h:outputLabel>
-                                        <h:outputLabel value="Net Total" ></h:outputLabel>
-                                        <h:outputLabel value=":" ></h:outputLabel>
-                                        <h:outputLabel value="#{inwardSearch.bill.netTotal}" >
-                                            <f:convertNumber pattern="#,##0.00"/>
-                                        </h:outputLabel>
-                                        <h:outputLabel value="" ></h:outputLabel>
-                                        <h:outputLabel value="" ></h:outputLabel>
-                                        <h:outputLabel value="" ></h:outputLabel>
-                                    </h:panelGrid>
-                                </p:panel>
-                            </p:panelGrid>
-                            <p:panel header="Bill Item Details" class="my-2">
-                                <p:dataTable rowIndexVar="rowIndex" value="#{inwardSearch.billItems}" var="bip" >
-                                    <p:column>
-                                        <f:facet name="header">No</f:facet>
-                                        <h:outputLabel value="#{rowIndex+1}"/>                                
-                                    </p:column>
-                                    <p:column>
-                                        <f:facet name="header">Item</f:facet>
-                                        <h:outputLabel value="#{bip.item.name}"/>
-                                    </p:column>
-                                    <p:column>
-                                        <f:facet name="header">Fee</f:facet>
-                                        <h:outputLabel value="#{bip.netValue}">
-                                            <f:convertNumber pattern="#,##0.00"/>
-                                        </h:outputLabel>
-                                    </p:column>
-                                </p:dataTable>
-                            </p:panel>
+                            <!-- Reason + Cancel row -->
+                            <div class="d-flex justify-content-end">
+                                <div class="d-flex align-items-center gap-3 mb-3 flex-wrap">
+                                    <p:outputLabel for="cancelReason"
+                                                   value="Reason for Cancellation"
+                                                   styleClass="fw-semibold m-0"/>
+                                    <p:inputText id="cancelReason"
+                                                 disabled="#{inwardSearch.bill.currentRequest ne null}"
+                                                 placeholder="Enter a reason to cancel"
+                                                 value="#{inwardSearch.comment}"
+                                                 style="width: 450px;"
+                                                 title="Reason for cancellation"/>
+                                    <p:commandButton
+                                        ajax="false"
+                                        value="Cancel Service Bill"
+                                        icon="fas fa-ban"
+                                        styleClass="ui-button-danger"
+                                        title="Cancel this inward service bill"
+                                        action="#{inwardSearch.cancelBillService()}">
+                                        <p:confirm header="Confirm Service Bill Cancellation"
+                                                   message="Cancel this inward service bill? This action cannot be undone."
+                                                   icon="fa fa-exclamation-triangle"/>
+                                    </p:commandButton>
+                                </div>
+                            </div>
+
+                            <!-- Patient Details and Bill Details Panels -->
+                            <div class="row g-3">
+                                <div class="col-12 col-lg-6">
+                                    <p:panel styleClass="h-100">
+                                        <f:facet name="header">
+                                            <h:outputText styleClass="fas fa-id-card-alt me-2"/>
+                                            <h:outputText value="Patient Details" styleClass="fw-semibold"/>
+                                        </f:facet>
+                                        <p:panelGrid columns="2" layout="tabular" styleClass="w-100"
+                                                     columnClasses="fw-semibold,text-end">
+                                            <h:outputLabel value="Patient Name"/>
+                                            <h:outputText value="#{inwardSearch.bill.patient.person.nameWithTitle}"
+                                                          style="display:block; text-align:right;"/>
+
+                                            <h:outputLabel value="BHT No"/>
+                                            <h:outputText value="#{inwardSearch.bill.patientEncounter.bhtNo}"
+                                                          style="display:block; text-align:right;"/>
+
+                                            <h:outputLabel value="Age"/>
+                                            <h:outputText value="#{inwardSearch.bill.patient.age}"
+                                                          style="display:block; text-align:right;"/>
+
+                                            <h:outputLabel value="Sex"/>
+                                            <h:outputText value="#{inwardSearch.bill.patient.person.sex}"
+                                                          style="display:block; text-align:right;"/>
+
+                                            <h:outputLabel value="Phone"/>
+                                            <h:outputText value="#{inwardSearch.bill.patient.person.phone}"
+                                                          style="display:block; text-align:right;"/>
+                                        </p:panelGrid>
+                                    </p:panel>
+                                </div>
+                                <div class="col-12 col-lg-6">
+                                    <p:panel styleClass="h-100">
+                                        <f:facet name="header">
+                                            <h:outputText styleClass="fas fa-file-invoice me-2"/>
+                                            <h:outputText value="Bill Details" styleClass="fw-semibold"/>
+                                        </f:facet>
+                                        <p:panelGrid columns="2" layout="tabular" styleClass="w-100"
+                                                     columnClasses="fw-semibold,text-end">
+                                            <h:outputLabel value="Bill No"/>
+                                            <h:outputText value="#{inwardSearch.bill.deptId}"
+                                                          style="display:block; text-align:right;"/>
+
+                                            <h:outputLabel value="Total"/>
+                                            <h:outputText value="#{inwardSearch.bill.netTotal}"
+                                                          style="display:block; text-align:right;">
+                                                <f:convertNumber pattern="#,##0.00"/>
+                                            </h:outputText>
+
+                                            <h:outputLabel value="Discount"/>
+                                            <h:outputText value="#{inwardSearch.bill.discount}"
+                                                          style="display:block; text-align:right;">
+                                                <f:convertNumber pattern="#,##0.00"/>
+                                            </h:outputText>
+
+                                            <h:outputLabel value="Net Total"/>
+                                            <h:outputText value="#{inwardSearch.bill.netTotal}"
+                                                          style="display:block; text-align:right; font-weight:600;">
+                                                <f:convertNumber pattern="#,##0.00"/>
+                                            </h:outputText>
+                                        </p:panelGrid>
+                                    </p:panel>
+                                </div>
+                            </div>
+
+                            <!-- Bill Item Details -->
+                            <div class="row g-3 mt-1">
+                                <div class="col-12">
+                                    <p:panel>
+                                        <f:facet name="header">
+                                            <h:outputText styleClass="fas fa-list-alt me-2"/>
+                                            <h:outputText value="Bill Item Details" styleClass="fw-semibold"/>
+                                        </f:facet>
+                                        <p:dataTable id="billItemsTable"
+                                                     rowIndexVar="rowIndex"
+                                                     value="#{inwardSearch.billItems}"
+                                                     var="bip"
+                                                     emptyMessage="No bill items available."
+                                                     styleClass="w-100"
+                                                     stripedRows="true">
+                                            <p:column headerText="#"
+                                                      style="width: 4rem; text-align:center;">
+                                                <h:outputText value="#{rowIndex + 1}"/>
+                                            </p:column>
+                                            <p:column headerText="Item">
+                                                <h:outputText value="#{bip.item.name}"/>
+                                            </p:column>
+                                            <p:column headerText="Fee"
+                                                      style="text-align:right; width: 12rem;">
+                                                <h:outputText value="#{bip.netValue}">
+                                                    <f:convertNumber pattern="#,##0.00"/>
+                                                </h:outputText>
+                                            </p:column>
+                                        </p:dataTable>
+                                    </p:panel>
+                                </div>
+                            </div>
                         </p:panel>
-
                     </h:panelGroup>
 
 
-                    <p:panel rendered="#{inwardSearch.printPreview}" header="Service Cancellation Bill">
-                        <div >
-                            <p:commandButton 
-                                value="Print" 
-                                ajax="false"
-                                style="float: right;"
-                                icon="fa fa-print"
-                                class="ui-button-info">
-                                <p:printer target="gpBillPreview" ></p:printer>
-                            </p:commandButton>
-                        </div>
+                    <!-- Print Preview Panel -->
+                    <h:panelGroup rendered="#{inwardSearch.printPreview}">
+                        <p:panel>
+                            <f:facet name="header">
+                                <div class="d-flex justify-content-between align-items-center">
+                                    <p:outputLabel value="Service Cancellation Bill"
+                                                   styleClass="fs-5 fw-semibold m-0"/>
+                                    <div class="d-flex gap-2">
+                                        <p:commandButton
+                                            ajax="false"
+                                            value="Print"
+                                            icon="fa fa-print"
+                                            styleClass="ui-button-success"
+                                            title="Print this service cancellation bill">
+                                            <p:printer target="gpBillPreview"/>
+                                        </p:commandButton>
+                                        <p:commandButton
+                                            ajax="false"
+                                            value="Back to List"
+                                            icon="fa fa-long-arrow-left"
+                                            action="/lab/inward_search_service?faces-redirect=true"
+                                            title="Return to the inward bill search list"
+                                            styleClass="ui-button-warning"/>
+                                    </div>
+                                </div>
+                            </f:facet>
 
-                        <div>
-                            <h:panelGroup id="gpBillPreview">
+                            <div class="d-flex justify-content-center">
+                                <h:panelGroup id="gpBillPreview">
 
-                                <h:panelGroup rendered="#{configOptionApplicationController.getBooleanValueByKey('Inward Servise Bill size is POS Paper')}">
-                                    <ui:repeat value="#{inwardSearch.bill.cancelledBill}" var="bill">
-                                        <bi:inwardBillPrintPos bill="#{bill}" duplicate="false" cancelled="true"/>
-                                    </ui:repeat>
+                                    <h:panelGroup rendered="#{configOptionApplicationController.getBooleanValueByKey('Inward Servise Bill size is POS Paper')}">
+                                        <ui:repeat value="#{inwardSearch.bill.cancelledBill}" var="bill">
+                                            <bi:inwardBillPrintPos bill="#{bill}" duplicate="false" cancelled="true"/>
+                                        </ui:repeat>
+                                    </h:panelGroup>
+
+                                    <h:panelGroup rendered="#{configOptionApplicationController.getBooleanValueByKey('Inward Servise Bill size is FiveFive paper',true)}">
+                                        <ui:repeat value="#{inwardSearch.bill.cancelledBill}" var="ffb">
+                                            <div style="page-break-after: always;">
+                                                <print:five_five_paper_with_headings_inward_service bill="#{ffb}" cancelled="true"/>
+                                            </div>
+                                            <br/>
+                                        </ui:repeat>
+                                    </h:panelGroup>
+
+                                    <h:panelGroup rendered="#{configOptionApplicationController.getBooleanValueByKey('Inward Servise Bill size is FiveFiveCustom3 Paper')}">
+                                        <ui:repeat value="#{inwardSearch.bill.cancelledBill}" var="pp">
+                                            <print:five_five_custom_3_inward bill="#{pp}" duplicate="false" payments="#{inwardSearch.bill.cancelledBill.size()}" cancelled="true"/>
+                                            <br/>
+                                        </ui:repeat>
+                                    </h:panelGroup>
+
+                                    <h:panelGroup rendered="#{configOptionApplicationController.getBooleanValueByKey('Inward Servise Bill size is 5x8 inch Paper')}">
+                                        <ui:repeat value="#{inwardSearch.bill.cancelledBill}" var="pp">
+                                            <print:five_eight_opd_bill_inward bill="#{pp}" duplicate="false" payments="#{inwardSearch.bill.cancelledBill.size()}"/>
+                                            <br/>
+                                        </ui:repeat>
+                                    </h:panelGroup>
+
                                 </h:panelGroup>
+                            </div>
+                        </p:panel>
+                    </h:panelGroup>
 
-                                <h:panelGroup rendered="#{configOptionApplicationController.getBooleanValueByKey('Inward Servise Bill size is FiveFive paper',true)}">
-                                    <ui:repeat value="#{inwardSearch.bill.cancelledBill}" var="ffb">
-                                        <div style="page-break-after: always;">
-                                            <print:five_five_paper_with_headings_inward_service bill="#{ffb}" cancelled="true"/>
-                                        </div>
-                                        <br/>
-                                    </ui:repeat>
-                                </h:panelGroup>
-
-                                <h:panelGroup rendered="#{configOptionApplicationController.getBooleanValueByKey('Inward Servise Bill size is FiveFiveCustom3 Paper')}">
-                                    <ui:repeat value="#{inwardSearch.bill.cancelledBill}" var="pp">
-                                        <print:five_five_custom_3_inward bill="#{pp}" duplicate="false" payments="#{inwardSearch.bill.cancelledBill.size()}" cancelled="true"/>
-                                        <br/>
-                                    </ui:repeat>
-                                </h:panelGroup>
-
-                                <h:panelGroup  rendered="#{configOptionApplicationController.getBooleanValueByKey('Inward Servise Bill size is 5x8 inch Paper')}" >
-                                    <ui:repeat value="#{inwardSearch.bill.cancelledBill}" var="pp">
-                                        <print:five_eight_opd_bill_inward bill="#{pp}" duplicate="false" payments="#{inwardSearch.bill.cancelledBill.size()}"/>
-                                        <br/>
-                                    </ui:repeat>
-                                </h:panelGroup>
-
-                            </h:panelGroup>
-                        </div>
-                    </p:panel>
-
-
-                </h:form>                
+                </h:form>
             </ui:define>
         </ui:composition>
     </h:body>

--- a/src/main/webapp/lab/inward_search_service.xhtml
+++ b/src/main/webapp/lab/inward_search_service.xhtml
@@ -136,7 +136,7 @@
                                         </h:panelGroup>
 
                                         <h:panelGroup rendered="#{bill.currentRequest ne null}">
-                                            <p:badge value="#{bill.currentRequest.status.label}" severity="warning" styleClass="mr-2"></p:badge>
+                                            <p:badge value="Request #{bill.currentRequest.status.label}" severity="warning" styleClass="mr-2"></p:badge>
                                         </h:panelGroup>
                                     </p:column>  
 


### PR DESCRIPTION
## Summary
  Adds department-type-aware cancellation permissioning for inward bills, clarifies the cancellation-request badge on the search list, and modernises the two inward bill cancellation pages to match current HMIS UI guidelines.

  Closes #20577

  ## Changes

  ### 1. Backend — `src/main/java/com/divudi/bean/inward/InwardSearch.java`
  - Imported `com.divudi.core.data.DepartmentType`.
  - In `cancelBillService()`, before deciding whether to route the cancel through the request workflow, the bill's billed-department type is read and a per-type config key is consulted: Inward Billing - Mandatory permission to cancel  type bills
  - The request workflow is now triggered only when **both**:
  - `Mandatory permission to cancel bills.` is `true`, **and**
  - The department-type-specific key for the bill's `toDepartment` is `true`.

  This gives each customer the ability to require approval for some department types (e.g. Theatre, Lab) while allowing direct cancellation for others (e.g. Pharmacy returns), without changing the global default.

  ### 2. Search list badge — `src/main/webapp/lab/inward_search_service.xhtml`
  - The warning badge for a bill that has an open cancellation request now reads `Request <status>` instead of just `<status>`, removing ambiguity with bill / payment status badges shown elsewhere on the row.

  ### 3. UI rewrite — `src/main/webapp/common/request/inward_bill_cancel_request.xhtml`
  - Added `p:growl` and a global `p:confirmDialog` (Yes/No, 150 px buttons).
  - Header: flex layout with `align-items-center`, title styled `fs-5 fw-semibold`, **Back to List** button uses `ui-button-warning`.
  - Reason + submit row collapsed into a single inline `d-flex` row (label · 500 px input · red **Request to Cancel Bill** button) with
  `flex-wrap` for narrow screens. Inline `float: right` removed.
  - Replaced broken `fa fa-cancel` with valid `fa fa-ban`.
  - `p:confirm` attached to the destructive submit action.
  - Patient Details / Batch Bill Detail panels switched to responsive `col-lg-6` columns, `h-100` for equal heights, headers use icon + label.
  - Batch Bill Detail uses `p:panelGrid layout="tabular"` with right-aligned values; Net Total is bolded.
  - Cancelling Bills DataTable: numbered `#` column, `emptyMessage`, `stripedRows`, right-aligned Net Total, `h:outputLabel` → `h:outputText`.
  - Print preview header re-aligned, **Print** uses `ui-button-success`,
  **Back to List** button preserved.

  ### 4. UI rewrite — `src/main/webapp/inward/inward_cancel_bill_service.xhtml`
  - Same skeleton as (3): `p:growl`, global `p:confirmDialog`, consistent header, single-line reason row (450 px input).
  - Added missing **Back to List** button (warning) in both edit and print preview headers.
  - `p:confirm` added to **Cancel Service Bill** with destructive wording.
  - Patient Details and Bill Details panels rebuilt with `p:panelGrid columns="2" layout="tabular"` — replaces the old 3-column `label / : / value` grids and removes a stray zero-width-space character inside `PatientName`.
  - Bill Items DataTable: `#` column, `emptyMessage`, `stripedRows`, right-aligned Fee column.
  - Print preview: **Print** styled `ui-button-success`, **Back to List** styled `ui-button-warning`. Inline `float: right` removed.
  - All bill-paper variants (POS / FiveFive / FiveFiveCustom3 / 5x8 inch) left untouched.

  ## Out of Scope / Known Pre-existing Issue
  - In `inward_cancel_bill_service.xhtml`, the *Total* and *Net Total* rows in the Bill Details panel are both bound to `inwardSearch.bill.netTotal`. This pre-dates this PR; the *Total* row is likely meant to read `inwardSearch.bill.total`. **Not changed in this PR** — UI-only — flag separately if a behaviour fix is wanted.

  ## Test Plan
  - [ ] Login as a billing user with rights to cancel inward bills.
  - [ ] **Search list**:
  - [ ] Open a bill with an active cancellation request → badge reads  `Request <status>`.
  - [ ] **Direct cancel page (`inward_cancel_bill_service.xhtml`)** with `Mandatory permission to cancel bills.` = `false`:
  - [ ] Page renders cleanly on desktop (≥ 1280 px) and tablet (~ 768 px).
  - [ ] Reason input + Cancel button appear on a single line; no overflow.
  - [ ] Click *Cancel Service Bill* → confirmation dialog appears; *No* cancels, *Yes* proceeds.
  - [ ] After cancellation, all four print-preview paper variants render as before (toggle each `Inward Servise Bill size is …` config key).
  - [ ] **Request page (`inward_bill_cancel_request.xhtml`)** with  `Mandatory permission to cancel bills.` = `true` **and** the matching `Inward Billing - Mandatory permission to cancel <type>  type bills` key = `true` for the bill's department type:
  - [ ] Page is reached when cancelling.
  - [ ] Reason + *Request to Cancel Bill* row is single-line, button  shows the ban icon.
  - [ ] Confirmation dialog appears before submission.
  - [ ] Submission creates a request and routes to the print preview.
  - [ ] **Department-type gating**:
  - [ ] With global key `true` but the type key `false`, cancellation proceeds directly without going through the request flow.
  - [ ] With both keys `true`, request flow is triggered.
  - [ ] With global key `false`, behaviour is unchanged regardless of  type-specific key.
  - [ ] No regressions on existing inward search / re-print flows.

  ## Notes for Reviewers
  - All XHTML changes are UI-only and do not introduce new controller methods or backing-bean state; only existing properties are bound.
  - Configuration keys created on first read by `configOptionApplicationController.getBooleanValueByKey(..., false)` default to `false`, preserving existing behaviour for hospitals that haven't enabled the new per-type gates.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added confirmation dialogs for bill and service cancellation requests

* **Bug Fixes**
  * Improved permission-based navigation for inpatient bill cancellations
  * Removed internal debug logging
  * Simplified request approval validation flow

* **Style**
  * Redesigned bill cancellation and service cancellation pages with modern layout styling
  * Enhanced bill detail tables with improved formatting and presentation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->