### PR TITLE
Fix drawer handover: cash handover value not updating in UI and print

### DIFF
--- a/src/main/java/com/divudi/bean/cashTransaction/FinancialTransactionController.java
+++ b/src/main/java/com/divudi/bean/cashTransaction/FinancialTransactionController.java
@@ -4433,10 +4433,6 @@ public class FinancialTransactionController implements Serializable {
         List<BillTypeAtomic> btas = new ArrayList<>();
         btas.addAll(BillTypeAtomic.findByFinanceType(BillFinanceType.CASH_IN));
         btas.addAll(BillTypeAtomic.findByFinanceType(BillFinanceType.CASH_OUT));
-        btas.add(BillTypeAtomic.IOU_CASH_ISSUE);
-        btas.add(BillTypeAtomic.IOU_SETTLE);
-        btas.add(BillTypeAtomic.IOU_TO_CASH_CONVERSION);
-        btas.add(BillTypeAtomic.IOU_TO_CASH_CONVERSION_CANCELLED);
         Map<String, Object> m = new HashMap<>();
 
         StringBuilder jpqlBuilder = new StringBuilder("SELECT p ")
@@ -4486,10 +4482,6 @@ public class FinancialTransactionController implements Serializable {
         List<BillTypeAtomic> btas = new ArrayList<>();
         btas.addAll(BillTypeAtomic.findByFinanceType(BillFinanceType.CASH_IN));
         btas.addAll(BillTypeAtomic.findByFinanceType(BillFinanceType.CASH_OUT));
-        btas.add(BillTypeAtomic.IOU_CASH_ISSUE);
-        btas.add(BillTypeAtomic.IOU_SETTLE);
-        btas.add(BillTypeAtomic.IOU_TO_CASH_CONVERSION);
-        btas.add(BillTypeAtomic.IOU_TO_CASH_CONVERSION_CANCELLED);
         Map<String, Object> m = new HashMap<>();
 
         StringBuilder jpqlBuilder = new StringBuilder("SELECT p ")
@@ -4539,10 +4531,6 @@ public class FinancialTransactionController implements Serializable {
         List<BillTypeAtomic> btas = new ArrayList<>();
         btas.addAll(BillTypeAtomic.findByFinanceType(BillFinanceType.CASH_IN));
         btas.addAll(BillTypeAtomic.findByFinanceType(BillFinanceType.CASH_OUT));
-        btas.add(BillTypeAtomic.IOU_CASH_ISSUE);
-        btas.add(BillTypeAtomic.IOU_SETTLE);
-        btas.add(BillTypeAtomic.IOU_TO_CASH_CONVERSION);
-        btas.add(BillTypeAtomic.IOU_TO_CASH_CONVERSION_CANCELLED);
         Map<String, Object> m = new HashMap<>();
 
         StringBuilder jpqlBuilder = new StringBuilder("SELECT p ")
@@ -6017,6 +6005,8 @@ public class FinancialTransactionController implements Serializable {
                 bundle.getReportTemplateRows().add(floatRow);
             }
         }
+
+        bundle.setCashHandoverValue(bundle.getDenominatorValue());
 
         createHandoverProofMissingBillIfNeeded(currentBill);
 

--- a/src/main/java/com/divudi/bean/common/IouBillController.java
+++ b/src/main/java/com/divudi/bean/common/IouBillController.java
@@ -394,7 +394,10 @@ public class IouBillController implements Serializable {
         List<Payment> iouReversals = new ArrayList<>();
         List<Payment> cashPayments = new ArrayList<>();
         for (Payment iouPayment : settlingIuos) {
-            // Create a reversed IOU payment (negative value) to balance out
+            // Create a reversed IOU payment (negative value) to balance out.
+            // This is a pure accounting offset — not a physical payment to hand over.
+            // Mark it handingOverStarted=true and cashbookEntryStated=true so it never
+            // surfaces in the shift handover or cashbook pages.
             Payment iouReversal = new Payment();
             iouReversal.setBill(current);
             iouReversal.setPaymentMethod(PaymentMethod.IOU);
@@ -404,6 +407,8 @@ public class IouBillController implements Serializable {
             iouReversal.setCreatedAt(new Date());
             iouReversal.setCreater(sessionController.getLoggedUser());
             iouReversal.setCurrentHolder(sessionController.getLoggedUser());
+            iouReversal.setHandingOverStarted(true);
+            iouReversal.setCashbookEntryStated(true);
             paymentController.save(iouReversal);
             iouReversals.add(iouReversal);
 
@@ -424,11 +429,14 @@ public class IouBillController implements Serializable {
         drawerController.updateDrawerForOuts(iouReversals);
         drawerController.updateDrawerForIns(cashPayments);
 
-        // Mark original IOU payments as processed by linking to the conversion bill
-        // Using cancelledBill reference (without setting cancelled=true) to indicate
-        // this IOU has been converted, keeping it visible in cashier summaries
+        // Mark original IOU payments as processed. The conversion bill takes over their
+        // accounting role: the -500 IOU reversal and +500 Cash handle the cashbook entry.
+        // Setting handingOverStarted=true and cashbookEntryStated=true prevents the original
+        // IOU from double-appearing in handover alongside the +500 Cash payment.
         for (Payment iouPayment : settlingIuos) {
             iouPayment.setCancelledBill(current);
+            iouPayment.setHandingOverStarted(true);
+            iouPayment.setCashbookEntryStated(true);
             paymentController.save(iouPayment);
         }
 

--- a/src/main/webapp/cashier/handover_start_all.xhtml
+++ b/src/main/webapp/cashier/handover_start_all.xhtml
@@ -542,7 +542,7 @@
                                                         event="blur"
                                                         process="txtDenoQtyHandover" 
                                                         listener="#{financialTransactionController.bundle.calculateTotalHandoverByDenominationQuantities()}"
-                                                        update=":#{p:resolveFirstComponentWithId('txtCashHandover',view).clientId} txtDenoVal :#{p:resolveFirstComponentWithId('tblCashier',view).clientId} " ></p:ajax>
+                                                        update=":#{p:resolveFirstComponentWithId('txtCashHandover',view).clientId} txtDenoVal :#{p:resolveFirstComponentWithId('tblCashier',view).clientId} :#{p:resolveFirstComponentWithId('tblAll',view).clientId}" ></p:ajax>
                                                 </p:inputText>  
                                             </p:column>
                                             <p:column >


### PR DESCRIPTION
## Summary

Fixes #20539 — after entering denominations on the handover page, the Cash Handover column footer and the print preview Total row showed 0.00 instead of the actual counted value.

### Changes

**`handover_start_all.xhtml`**
- Added `tblAll` to the denomination input's `p:ajax` update list. Previously, entering a denomination quantity and tabbing out updated `tblCashier` (the top summary table) but not `tblAll` (the bottom datatable), so its Cash Handover footer stayed at 0.00.

**`FinancialTransactionController.settleHandoverStartBill()`**
- Set `bundle.cashHandoverValue = bundle.getDenominatorValue()` just before navigating to the print page. The `denominatorValue` was correctly calculated from denominations but `cashHandoverValue` was never synced to it before the full-page POST, causing the print Total row's Handing Over column to show 0.00.

**`FinancialTransactionController.fetchPaymentsFromShiftStartToEndByDateAndDepartment()` (all 3 overloads)**
- Removed `IOU_CASH_ISSUE`, `IOU_SETTLE`, `IOU_TO_CASH_CONVERSION`, and `IOU_TO_CASH_CONVERSION_CANCELLED` from the `btas` list. These bill types are `BillFinanceType.FLOAT_CHANGE` (accounting-only) and must not be included in the handover payment fetch — adding them caused IOU reversal payments to surface in subsequent shifts.

**`IouBillController.convertSelectedIousToCash()`**
- Mark the IOU reversal payment (`−500 IOU`) with `handingOverStarted=true` and `cashbookEntryStated=true` at creation — it is a pure accounting offset and must never appear in handover or cashbook pages.
- Mark the original IOU payment with `handingOverStarted=true` and `cashbookEntryStated=true` when linking it to the conversion bill — prevents it from double-appearing alongside the `+500 Cash` payment in the handover bundle.

## Test plan

- [ ] Enter denominations on the handover page — Cash Handover footer in the bottom table updates immediately on blur
- [ ] Complete handover — print preview Total row shows correct Handing Over value (not 0.00)
- [ ] Convert an IOU to cash before handover — only the Cash row appears in handover (not the original IOU alongside it)
- [ ] IOU reversal payment does not appear in any subsequent shift's handover page