### PR TITLE
feat(cashier): refactor handover print pages and add float transaction detail view

### DIFF
--- a/src/main/java/com/divudi/bean/cashTransaction/FinancialTransactionController.java
+++ b/src/main/java/com/divudi/bean/cashTransaction/FinancialTransactionController.java
@@ -2073,7 +2073,7 @@ public class FinancialTransactionController implements Serializable {
             }
         }
 
-        return "/cashier/handover_preview?faces-redirect=true";
+        return "/cashier/handover_view?faces-redirect=true";
     }
 
     public String navigateToHandoverAcceptBillReprintFromReport() {
@@ -6023,7 +6023,7 @@ public class FinancialTransactionController implements Serializable {
 
         createHandoverProofMissingBillIfNeeded(currentBill);
 
-        return "/cashier/handover_creation_bill_print?faces-redirect=true";
+        return "/cashier/handover_creation_print_summary?faces-redirect=true";
     }
 
     private void createHandoverProofMissingBillIfNeeded(Bill handoverCreateBill) {
@@ -7384,6 +7384,26 @@ public class FinancialTransactionController implements Serializable {
 
     public String navigateToHandoverReprint() {
         return "/cashier/handover_reprint?faces-redirect=true";
+    }
+
+    public String navigateToHandoverCreationPrintSummary() {
+        return "/cashier/handover_creation_print_summary?faces-redirect=true";
+    }
+
+    public String navigateToHandoverCreationPrintDetails() {
+        return "/cashier/handover_creation_print_details?faces-redirect=true";
+    }
+
+    public String navigateToHandoverView() {
+        return "/cashier/handover_view?faces-redirect=true";
+    }
+
+    public String navigateToHandoverViewPrintSummary() {
+        return "/cashier/handover_view_print_summary?faces-redirect=true";
+    }
+
+    public String navigateToHandoverViewPrintDetails() {
+        return "/cashier/handover_view_print_details?faces-redirect=true";
     }
 
     public String acceptHandoverBillAndWriteToCashbook() {

--- a/src/main/webapp/cashier/handover_creation_print_details.xhtml
+++ b/src/main/webapp/cashier/handover_creation_print_details.xhtml
@@ -13,30 +13,23 @@
                 <ui:define name="subcontent">
                     <p:panel class="my-1">
                         <f:facet name="header">
-                            <div class="d-flex align-items-center justify-content-between">
-                                <div>
-                                    <h:outputText value="Hand Over Bill Preview" ></h:outputText>
-                                </div>
-                                <div>
-                                    <p:commandButton class="ui-button-info mx-2" icon="fas fa-print" value="Print">
-                                        <p:printer target="depositbill" />
-                                    </p:commandButton>
-                                </div>
-                            </div>
+                            <p:outputLabel value="Handover Details Print" />
+<p:commandButton
+                                value="Print"
+                                styleClass="ui-button-info mx-1"
+                                icon="pi pi-print"
+                                ajax="false"
+                                style="float: right;">
+                                <p:printer target="printArea" />
+                            </p:commandButton>
                         </f:facet>
-                        <h:panelGrid id="depositbill" class="w-100">
+                        <h:panelGrid id="printArea" class="w-100">
                             <div class="d-flex justify-content-center">
-                                <prints:five_five_paper_with_headings_for_handover 
-                                    bundle="#{financialTransactionController.bundle}"/>  
+                                <prints:five_five_paper_with_headings_for_handover_detail
+                                    bundle="#{financialTransactionController.bundle}"/>
                             </div>
                         </h:panelGrid>
                     </p:panel>
-
-
-
-
-
-
                 </ui:define>
             </ui:composition>
         </h:form>

--- a/src/main/webapp/cashier/handover_creation_print_summary.xhtml
+++ b/src/main/webapp/cashier/handover_creation_print_summary.xhtml
@@ -1,0 +1,44 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
+      xmlns:h="http://xmlns.jcp.org/jsf/html"
+      xmlns:p="http://primefaces.org/ui"
+      xmlns:prints="http://xmlns.jcp.org/jsf/composite/ezcomp/prints"
+      xmlns:f="http://xmlns.jcp.org/jsf/core">
+
+    <h:body>
+        <h:form>
+            <ui:composition template="./index.xhtml">
+                <ui:define name="subcontent">
+                    <p:panel class="my-1">
+                        <f:facet name="header">
+                            <p:outputLabel value="Handover Summary Print" />
+<p:commandButton
+                                value="Print"
+                                styleClass="ui-button-info mx-1"
+                                icon="pi pi-print"
+                                ajax="false"
+                                style="float: right;">
+                                <p:printer target="printArea" />
+                            </p:commandButton>
+                            <p:commandButton
+                                value="View Details"
+                                styleClass="ui-button-success mx-1"
+                                icon="pi pi-list"
+                                style="float: right;"
+                                action="#{financialTransactionController.navigateToHandoverCreationPrintDetails()}">
+                            </p:commandButton>
+                        </f:facet>
+                        <h:panelGrid id="printArea" class="w-100">
+                            <div class="d-flex justify-content-center">
+                                <prints:five_five_paper_with_headings_for_handover
+                                    bundle="#{financialTransactionController.bundle}"/>
+                            </div>
+                        </h:panelGrid>
+                    </p:panel>
+                </ui:define>
+            </ui:composition>
+        </h:form>
+    </h:body>
+</html>

--- a/src/main/webapp/cashier/handover_view.xhtml
+++ b/src/main/webapp/cashier/handover_view.xhtml
@@ -1,0 +1,52 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
+      xmlns:h="http://xmlns.jcp.org/jsf/html"
+      xmlns:p="http://primefaces.org/ui"
+      xmlns:prints="http://xmlns.jcp.org/jsf/composite/ezcomp/prints"
+      xmlns:f="http://xmlns.jcp.org/jsf/core">
+
+    <h:body>
+        <ui:composition template="/cashier/index.xhtml">
+            <ui:define name="subcontent">
+                <h:form>
+                    <p:panel class="w-100 m-1">
+                        <f:facet name="header">
+                            <p:outputLabel value="View Handover" />
+                            <p:commandButton
+                                value="Print Summary"
+                                styleClass="ui-button-success mx-1"
+                                icon="pi pi-print"
+                                ajax="false"
+                                style="float: right;"
+                                action="#{financialTransactionController.navigateToHandoverViewPrintSummary()}">
+                            </p:commandButton>
+                            <p:commandButton
+                                value="Print Details"
+                                styleClass="ui-button-info mx-1"
+                                icon="pi pi-print"
+                                ajax="false"
+                                style="float: right;"
+                                action="#{financialTransactionController.navigateToHandoverViewPrintDetails()}">
+                            </p:commandButton>
+                            <p:commandButton
+                                value="Print Accept Bill"
+                                styleClass="ui-button-warning mx-1"
+                                icon="pi pi-print"
+                                ajax="false"
+                                style="float: right;"
+                                rendered="#{financialTransactionController.selectedBill ne null and financialTransactionController.selectedBill.completed and not financialTransactionController.selectedBill.cancelled}"
+                                action="#{financialTransactionController.navigateToHandoverAcceptBillReprintFromReport()}">
+                            </p:commandButton>
+                        </f:facet>
+
+                        <prints:five_five_paper_with_headings_for_handover_reprint
+                            bundle="#{financialTransactionController.bundle}"/>
+
+                    </p:panel>
+                </h:form>
+            </ui:define>
+        </ui:composition>
+    </h:body>
+</html>

--- a/src/main/webapp/cashier/handover_view_print_details.xhtml
+++ b/src/main/webapp/cashier/handover_view_print_details.xhtml
@@ -13,28 +13,31 @@
                 <h:form>
                     <p:panel class="w-100 m-1">
                         <f:facet name="header">
-                            <p:outputLabel value="Reprint Handovers" />
+                            <p:outputLabel value="Handover Details Print" />
                             <p:commandButton
-                                value="To Print"
-                                styleClass="ui-button-success mx-1"
-                                icon="pi pi-check-circle"
-                                ajax="false"
-                                style="float: right;"
-                                action="#{financialTransactionController.navigateToHandoverReprint()}">
-                            </p:commandButton>
-                            <p:commandButton
-                                value="Print Accept Bill"
-                                styleClass="ui-button-warning mx-1"
+                                value="Print"
+                                styleClass="ui-button-info mx-1"
                                 icon="pi pi-print"
                                 ajax="false"
+                                style="float: right;">
+                                <p:printer target="printArea" />
+                            </p:commandButton>
+                            <p:commandButton
+                                value="Back"
+                                styleClass="ui-button-secondary mx-1"
+                                icon="pi pi-arrow-left"
+                                ajax="false"
                                 style="float: right;"
-                                rendered="#{financialTransactionController.selectedBill ne null and financialTransactionController.selectedBill.completed and not financialTransactionController.selectedBill.cancelled}"
-                                action="#{financialTransactionController.navigateToHandoverAcceptBillReprintFromReport()}">
+                                action="#{financialTransactionController.navigateToHandoverView()}">
                             </p:commandButton>
                         </f:facet>
 
-                        <prints:five_five_paper_with_headings_for_handover_reprint
-                            bundle="#{financialTransactionController.bundle}"/>
+                        <h:panelGrid id="printArea" class="w-100">
+                            <div class="d-flex justify-content-center">
+                                <prints:five_five_paper_with_headings_for_handover_detail
+                                    bundle="#{financialTransactionController.bundle}"/>
+                            </div>
+                        </h:panelGrid>
 
                     </p:panel>
                 </h:form>

--- a/src/main/webapp/cashier/handover_view_print_summary.xhtml
+++ b/src/main/webapp/cashier/handover_view_print_summary.xhtml
@@ -1,0 +1,54 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
+      xmlns:h="http://xmlns.jcp.org/jsf/html"
+      xmlns:p="http://primefaces.org/ui"
+      xmlns:prints="http://xmlns.jcp.org/jsf/composite/ezcomp/prints"
+      xmlns:f="http://xmlns.jcp.org/jsf/core">
+
+    <h:body>
+        <ui:composition template="/cashier/index.xhtml">
+            <ui:define name="subcontent">
+                <h:form>
+                    <p:panel class="w-100 m-1">
+                        <f:facet name="header">
+                            <p:outputLabel value="Handover Summary Print" />
+                            <p:commandButton
+                                value="View Details"
+                                styleClass="ui-button-success mx-1"
+                                icon="pi pi-list"
+                                style="float: right;"
+                                action="#{financialTransactionController.navigateToHandoverViewPrintDetails()}">
+                            </p:commandButton>
+                            <p:commandButton
+                                value="Print"
+                                styleClass="ui-button-info mx-1"
+                                icon="pi pi-print"
+                                ajax="false"
+                                style="float: right;">
+                                <p:printer target="printArea" />
+                            </p:commandButton>
+                            <p:commandButton
+                                value="Back"
+                                styleClass="ui-button-secondary mx-1"
+                                icon="pi pi-arrow-left"
+                                ajax="false"
+                                style="float: right;"
+                                action="#{financialTransactionController.navigateToHandoverView()}">
+                            </p:commandButton>
+                        </f:facet>
+
+                        <h:panelGrid id="printArea" class="w-100">
+                            <div class="d-flex justify-content-center">
+                                <prints:five_five_paper_with_headings_for_handover_reprint
+                                    bundle="#{financialTransactionController.bundle}"/>
+                            </div>
+                        </h:panelGrid>
+
+                    </p:panel>
+                </h:form>
+            </ui:define>
+        </ui:composition>
+    </h:body>
+</html>

--- a/src/main/webapp/reports/cashier_reports/handover_status_report.xhtml
+++ b/src/main/webapp/reports/cashier_reports/handover_status_report.xhtml
@@ -154,7 +154,7 @@
 
                             <p:column headerText="Actions" width="16em" styleClass="text-center">
                                 <p:commandButton
-                                    value="View / Create Bill"
+                                    value="View Handover"
                                     action="#{financialTransactionController.navigateToViewHandoverBill()}"
                                     ajax="false"
                                     styleClass="ui-button-info m-1"

--- a/src/main/webapp/resources/ezcomp/prints/five_five_paper_with_headings_for_handover_detail.xhtml
+++ b/src/main/webapp/resources/ezcomp/prints/five_five_paper_with_headings_for_handover_detail.xhtml
@@ -375,6 +375,12 @@
                         <h:outputText value="Shift Shortage"
                             rendered="#{summary.paymentHandover ne null and summary.paymentHandover.name() eq 'FLOATS'}"
                             style="color:#dc3545; font-style:italic;" />
+                        <h:outputText value="Float Sent (Cash)"
+                            rendered="#{summary.floatRow and summary.paymentHandover ne null and summary.paymentHandover.name() eq 'FLOAT_OUT'}"
+                            style="color: red; font-weight: bold;" />
+                        <h:outputText value="Float Received (Cash)"
+                            rendered="#{summary.floatRow and summary.paymentHandover ne null and summary.paymentHandover.name() eq 'FLOAT_IN'}"
+                            style="color: green; font-weight: bold;" />
                     </p:column>
 
                     <p:column headerText="Site" rendered="#{configOptionApplicationController.getBooleanValueByKey('Sites are Managed',true)}">
@@ -396,7 +402,7 @@
                     </p:column>
 
                     <p:column class="text-end" headerText="Cash" rendered="#{cc.attrs.bundle.hasCashTransaction}">
-                        <h:outputText value="#{summary.cashHandoverValue}" rendered="#{!summary.floatRow}"><f:convertNumber pattern="#,##0.00"/></h:outputText>
+                        <h:outputText value="#{summary.cashHandoverValue}"><f:convertNumber pattern="#,##0.00"/></h:outputText>
                         <f:facet name="footer"><h:outputText value="#{cc.attrs.bundle.cashHandoverValue}"><f:convertNumber pattern="#,##0.00"/></h:outputText></f:facet>
                     </p:column>
                     <p:column class="text-end" headerText="Card" rendered="#{cc.attrs.bundle.hasCardTransaction}">
@@ -452,7 +458,7 @@
                         <f:facet name="footer"><h:outputText value="#{cc.attrs.bundle.onCallValue}"><f:convertNumber pattern="#,##0.00"/></h:outputText></f:facet>
                     </p:column>
                     <p:column class="text-end" headerText="Total">
-                        <h:outputText rendered="#{!summary.floatRow}"
+                        <h:outputText
                             value="#{summary.cashHandoverValue + summary.cardHandoverValue + summary.creditHandoverValue + summary.staffWelfareHandoverValue + summary.staffHandoverValue + summary.voucherHandoverValue + summary.iouHandoverValue + summary.agentHandoverValue + summary.chequeHandoverValue + summary.slipHandoverValue + summary.ewalletHandoverValue + summary.patientPointsHandoverValue + summary.onlineSettlementHandoverValue + summary.onCallHandoverValue}">
                             <f:convertNumber pattern="#,##0.00"/>
                         </h:outputText>

--- a/src/main/webapp/resources/ezcomp/prints/five_five_paper_with_headings_for_handover_detail.xhtml
+++ b/src/main/webapp/resources/ezcomp/prints/five_five_paper_with_headings_for_handover_detail.xhtml
@@ -53,7 +53,7 @@
             }
 
             .billBody {
-                min-height: 200px; /* Adjust based on content */
+                min-height: 200px;
             }
 
             .billFooter {
@@ -132,7 +132,6 @@
             }
 
             @media print {
-                /* Adjust colors for print if necessary */
                 .pi {
                     color: black !important;
                 }
@@ -141,8 +140,6 @@
                     background-color: lightgray !important;
                 }
             }
-
-
         </style>
 
         <div class="billDocument w-100">
@@ -160,7 +157,7 @@
                     </div>
                 </div>
                 <div class="headingBillFiveFive" style="text-align: center; font-weight: bold;">
-                    <h:outputLabel value="HAND OVER RECEIPT" />
+                    <h:outputLabel value="HAND OVER RECEIPT - DETAILED" />
                 </div>
             </div>
 
@@ -172,13 +169,11 @@
                     <div class="col-6" >
                         <h:panelGrid columns="2" styleClass="handover-grid" columnClasses="labelColumn,valueColumn">
 
-
                             <h:outputText value="From User:" styleClass="handover-label" style="font-weight: normal"/>
                             <h:outputText value="#{cc.attrs.bundle.user.webUserPerson.nameWithTitle}" styleClass="handover-value" />
 
                             <h:outputText value="To User:" styleClass="handover-label" style="font-weight: normal"/>
                             <h:outputText value="#{cc.attrs.bundle.toUser.webUserPerson.nameWithTitle}" styleClass="handover-value" />
-
 
                             <h:outputText value="Shift Start Bill ID:" styleClass="handover-label" style="font-weight: normal"/>
                             <h:outputText value="#{cc.attrs.bundle.startBill.deptId}" styleClass="handover-value" />
@@ -196,7 +191,6 @@
                                 <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateTimeFormat}" />
                             </h:outputText>
 
-
                             <h:outputText  rendered="#{cc.attrs.bundle.endBill ne null}" value="Shift End Bill ID:" styleClass="handover-label" />
                             <h:outputText  rendered="#{cc.attrs.bundle.endBill ne null}" value="#{cc.attrs.bundle.endBill.deptId}" styleClass="handover-value" />
 
@@ -204,7 +198,6 @@
                             <h:outputText  rendered="#{cc.attrs.bundle.endBill ne null}" value="#{cc.attrs.bundle.endBill.createdAt}">
                                 <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateTimeFormat}" />
                             </h:outputText>
-
 
                         </h:panelGrid>
                     </div>
@@ -356,29 +349,19 @@
                                 </table>
                             </h:panelGroup>
 
-
                         </h:panelGroup>
                     </div>
 
                 </div>
 
-
-
                 <hr/>
 
-
                 <div class="handoverDetails my-3">
-                    <!-- Existing content ... -->
-
-                    <!-- Payment Details Table -->
-
-
-                    <!-- Additional contents ... -->
                 </div>
 
                 <hr/>
 
-
+                <!-- Department / User summary — float aggregate rows excluded -->
                 <p:dataTable
                     style="padding: 0px!important; margin: 0px!important; font-size: #{pharmacySummaryReportController.fontSizeForPrinting}!important;"
                     styleClass="ui-datatable-borderless ui-datatable-sm compact-datatable"
@@ -387,10 +370,11 @@
                     var="summary">
 
                     <p:column headerText="Institution / Type" style="font-weight: normal">
-                        <h:outputText value="#{summary.department.institution.name}" rendered="#{!summary.floatRow and (summary.paymentHandover == null or summary.paymentHandover.name() != 'FLOATS')}" />
-                        <h:outputText value="Shift Shortage"        rendered="#{summary.paymentHandover ne null and summary.paymentHandover.name() eq 'FLOATS'}" style="color:#dc3545; font-style:italic;" />
-                        <h:outputText value="Float Sent (Cash)"     rendered="#{summary.floatRow and summary.paymentHandover ne null and summary.paymentHandover.name() eq 'FLOAT_OUT'}" style="color: red; font-weight: bold;" />
-                        <h:outputText value="Float Received (Cash)" rendered="#{summary.floatRow and summary.paymentHandover ne null and summary.paymentHandover.name() eq 'FLOAT_IN'}"  style="color: green; font-weight: bold;" />
+                        <h:outputText value="#{summary.department.institution.name}"
+                            rendered="#{!summary.floatRow and (summary.paymentHandover == null or summary.paymentHandover.name() != 'FLOATS')}" />
+                        <h:outputText value="Shift Shortage"
+                            rendered="#{summary.paymentHandover ne null and summary.paymentHandover.name() eq 'FLOATS'}"
+                            style="color:#dc3545; font-style:italic;" />
                     </p:column>
 
                     <p:column headerText="Site" rendered="#{configOptionApplicationController.getBooleanValueByKey('Sites are Managed',true)}">
@@ -412,70 +396,127 @@
                     </p:column>
 
                     <p:column class="text-end" headerText="Cash" rendered="#{cc.attrs.bundle.hasCashTransaction}">
-                        <h:outputText value="#{summary.cashHandoverValue}"><f:convertNumber pattern="#,##0.00"/></h:outputText>
+                        <h:outputText value="#{summary.cashHandoverValue}" rendered="#{!summary.floatRow}"><f:convertNumber pattern="#,##0.00"/></h:outputText>
                         <f:facet name="footer"><h:outputText value="#{cc.attrs.bundle.cashHandoverValue}"><f:convertNumber pattern="#,##0.00"/></h:outputText></f:facet>
                     </p:column>
                     <p:column class="text-end" headerText="Card" rendered="#{cc.attrs.bundle.hasCardTransaction}">
-                        <h:outputText value="#{summary.cardHandoverValue}"><f:convertNumber pattern="#,##0.00"/></h:outputText>
+                        <h:outputText value="#{summary.cardHandoverValue}" rendered="#{!summary.floatRow}"><f:convertNumber pattern="#,##0.00"/></h:outputText>
                         <f:facet name="footer"><h:outputText value="#{cc.attrs.bundle.cardHandoverValue}"><f:convertNumber pattern="#,##0.00"/></h:outputText></f:facet>
                     </p:column>
                     <p:column class="text-end" headerText="Credit" rendered="#{cc.attrs.bundle.hasCreditTransaction}">
-                        <h:outputText value="#{summary.creditHandoverValue}"><f:convertNumber pattern="#,##0.00"/></h:outputText>
+                        <h:outputText value="#{summary.creditHandoverValue}" rendered="#{!summary.floatRow}"><f:convertNumber pattern="#,##0.00"/></h:outputText>
                         <f:facet name="footer"><h:outputText value="#{cc.attrs.bundle.creditHandoverValue}"><f:convertNumber pattern="#,##0.00"/></h:outputText></f:facet>
                     </p:column>
                     <p:column class="text-end" headerText="Staff" rendered="#{cc.attrs.bundle.hasStaffTransaction}">
-                        <h:outputText value="#{summary.staffHandoverValue}"><f:convertNumber pattern="#,##0.00"/></h:outputText>
+                        <h:outputText value="#{summary.staffHandoverValue}" rendered="#{!summary.floatRow}"><f:convertNumber pattern="#,##0.00"/></h:outputText>
                         <f:facet name="footer"><h:outputText value="#{cc.attrs.bundle.staffHandoverValue}"><f:convertNumber pattern="#,##0.00"/></h:outputText></f:facet>
                     </p:column>
                     <p:column class="text-end" headerText="Staff Welfare" rendered="#{cc.attrs.bundle.hasStaffWelfareTransaction}">
-                        <h:outputText value="#{summary.staffWelfareHandoverValue}"><f:convertNumber pattern="#,##0.00"/></h:outputText>
+                        <h:outputText value="#{summary.staffWelfareHandoverValue}" rendered="#{!summary.floatRow}"><f:convertNumber pattern="#,##0.00"/></h:outputText>
                         <f:facet name="footer"><h:outputText value="#{cc.attrs.bundle.staffWelfareHandoverValue}"><f:convertNumber pattern="#,##0.00"/></h:outputText></f:facet>
                     </p:column>
                     <p:column class="text-end" headerText="Voucher" rendered="#{cc.attrs.bundle.hasVoucherTransaction}">
-                        <h:outputText value="#{summary.voucherValue}"><f:convertNumber pattern="#,##0.00"/></h:outputText>
+                        <h:outputText value="#{summary.voucherValue}" rendered="#{!summary.floatRow}"><f:convertNumber pattern="#,##0.00"/></h:outputText>
                         <f:facet name="footer"><h:outputText value="#{cc.attrs.bundle.voucherValue}"><f:convertNumber pattern="#,##0.00"/></h:outputText></f:facet>
                     </p:column>
                     <p:column class="text-end" headerText="IOU" rendered="#{cc.attrs.bundle.hasIouTransaction}">
-                        <h:outputText value="#{summary.iouValue}"><f:convertNumber pattern="#,##0.00"/></h:outputText>
+                        <h:outputText value="#{summary.iouValue}" rendered="#{!summary.floatRow}"><f:convertNumber pattern="#,##0.00"/></h:outputText>
                         <f:facet name="footer"><h:outputText value="#{cc.attrs.bundle.iouValue}"><f:convertNumber pattern="#,##0.00"/></h:outputText></f:facet>
                     </p:column>
                     <p:column class="text-end" headerText="Agent" rendered="#{cc.attrs.bundle.hasAgentTransaction}">
-                        <h:outputText value="#{summary.agentValue}"><f:convertNumber pattern="#,##0.00"/></h:outputText>
+                        <h:outputText value="#{summary.agentValue}" rendered="#{!summary.floatRow}"><f:convertNumber pattern="#,##0.00"/></h:outputText>
                         <f:facet name="footer"><h:outputText value="#{cc.attrs.bundle.agentValue}"><f:convertNumber pattern="#,##0.00"/></h:outputText></f:facet>
                     </p:column>
                     <p:column class="text-end" headerText="Cheque" rendered="#{cc.attrs.bundle.hasChequeTransaction}">
-                        <h:outputText value="#{summary.chequeValue}"><f:convertNumber pattern="#,##0.00"/></h:outputText>
+                        <h:outputText value="#{summary.chequeValue}" rendered="#{!summary.floatRow}"><f:convertNumber pattern="#,##0.00"/></h:outputText>
                         <f:facet name="footer"><h:outputText value="#{cc.attrs.bundle.chequeValue}"><f:convertNumber pattern="#,##0.00"/></h:outputText></f:facet>
                     </p:column>
                     <p:column class="text-end" headerText="Slip" rendered="#{cc.attrs.bundle.hasSlipTransaction}">
-                        <h:outputText value="#{summary.slipValue}"><f:convertNumber pattern="#,##0.00"/></h:outputText>
+                        <h:outputText value="#{summary.slipValue}" rendered="#{!summary.floatRow}"><f:convertNumber pattern="#,##0.00"/></h:outputText>
                         <f:facet name="footer"><h:outputText value="#{cc.attrs.bundle.slipValue}"><f:convertNumber pattern="#,##0.00"/></h:outputText></f:facet>
                     </p:column>
                     <p:column class="text-end" headerText="eWallet" rendered="#{cc.attrs.bundle.hasEWalletTransaction}">
-                        <h:outputText value="#{summary.ewalletValue}"><f:convertNumber pattern="#,##0.00"/></h:outputText>
+                        <h:outputText value="#{summary.ewalletValue}" rendered="#{!summary.floatRow}"><f:convertNumber pattern="#,##0.00"/></h:outputText>
                         <f:facet name="footer"><h:outputText value="#{cc.attrs.bundle.ewalletValue}"><f:convertNumber pattern="#,##0.00"/></h:outputText></f:facet>
                     </p:column>
                     <p:column class="text-end" headerText="Pt Points" rendered="#{cc.attrs.bundle.hasPatientPointsTransaction}">
-                        <h:outputText value="#{summary.patientPointsValue}"><f:convertNumber pattern="#,##0.00"/></h:outputText>
+                        <h:outputText value="#{summary.patientPointsValue}" rendered="#{!summary.floatRow}"><f:convertNumber pattern="#,##0.00"/></h:outputText>
                         <f:facet name="footer"><h:outputText value="#{cc.attrs.bundle.patientPointsValue}"><f:convertNumber pattern="#,##0.00"/></h:outputText></f:facet>
                     </p:column>
                     <p:column class="text-end" headerText="Online" rendered="#{cc.attrs.bundle.hasOnlineSettlementTransaction}">
-                        <h:outputText value="#{summary.onlineSettlementValue}"><f:convertNumber pattern="#,##0.00"/></h:outputText>
+                        <h:outputText value="#{summary.onlineSettlementValue}" rendered="#{!summary.floatRow}"><f:convertNumber pattern="#,##0.00"/></h:outputText>
                         <f:facet name="footer"><h:outputText value="#{cc.attrs.bundle.onlineSettlementValue}"><f:convertNumber pattern="#,##0.00"/></h:outputText></f:facet>
                     </p:column>
                     <p:column class="text-end" headerText="On Call" rendered="#{cc.attrs.bundle.hasOnCallTransaction}">
-                        <h:outputText value="#{summary.onCallValue}"><f:convertNumber pattern="#,##0.00"/></h:outputText>
+                        <h:outputText value="#{summary.onCallValue}" rendered="#{!summary.floatRow}"><f:convertNumber pattern="#,##0.00"/></h:outputText>
                         <f:facet name="footer"><h:outputText value="#{cc.attrs.bundle.onCallValue}"><f:convertNumber pattern="#,##0.00"/></h:outputText></f:facet>
                     </p:column>
                     <p:column class="text-end" headerText="Total">
-                        <h:outputText value="#{summary.cashHandoverValue + summary.cardHandoverValue + summary.creditHandoverValue + summary.staffWelfareHandoverValue + summary.staffHandoverValue + summary.voucherHandoverValue + summary.iouHandoverValue + summary.agentHandoverValue + summary.chequeHandoverValue + summary.slipHandoverValue + summary.ewalletHandoverValue + summary.patientPointsHandoverValue + summary.onlineSettlementHandoverValue + summary.onCallHandoverValue}"><f:convertNumber pattern="#,##0.00"/></h:outputText>
+                        <h:outputText rendered="#{!summary.floatRow}"
+                            value="#{summary.cashHandoverValue + summary.cardHandoverValue + summary.creditHandoverValue + summary.staffWelfareHandoverValue + summary.staffHandoverValue + summary.voucherHandoverValue + summary.iouHandoverValue + summary.agentHandoverValue + summary.chequeHandoverValue + summary.slipHandoverValue + summary.ewalletHandoverValue + summary.patientPointsHandoverValue + summary.onlineSettlementHandoverValue + summary.onCallHandoverValue}">
+                            <f:convertNumber pattern="#,##0.00"/>
+                        </h:outputText>
                         <f:facet name="footer">
-                            <h:outputText value="#{cc.attrs.bundle.cashHandoverValue + cc.attrs.bundle.cardHandoverValue + cc.attrs.bundle.creditHandoverValue + cc.attrs.bundle.staffWelfareHandoverValue + cc.attrs.bundle.staffHandoverValue + cc.attrs.bundle.voucherHandoverValue + cc.attrs.bundle.iouHandoverValue + cc.attrs.bundle.agentHandoverValue + cc.attrs.bundle.chequeHandoverValue + cc.attrs.bundle.slipHandoverValue + cc.attrs.bundle.ewalletHandoverValue + cc.attrs.bundle.patientPointsHandoverValue + cc.attrs.bundle.onlineSettlementHandoverValue + cc.attrs.bundle.onCallHandoverValue}"><f:convertNumber pattern="#,##0.00"/></h:outputText>
+                            <h:outputText value="#{cc.attrs.bundle.cashHandoverValue + cc.attrs.bundle.cardHandoverValue + cc.attrs.bundle.creditHandoverValue + cc.attrs.bundle.staffWelfareHandoverValue + cc.attrs.bundle.staffHandoverValue + cc.attrs.bundle.voucherHandoverValue + cc.attrs.bundle.iouHandoverValue + cc.attrs.bundle.agentHandoverValue + cc.attrs.bundle.chequeHandoverValue + cc.attrs.bundle.slipHandoverValue + cc.attrs.bundle.ewalletHandoverValue + cc.attrs.bundle.patientPointsHandoverValue + cc.attrs.bundle.onlineSettlementHandoverValue + cc.attrs.bundle.onCallHandoverValue}">
+                                <f:convertNumber pattern="#,##0.00"/>
+                            </h:outputText>
                         </f:facet>
                     </p:column>
 
                 </p:dataTable>
 
+                <!-- Float transactions — individual rows from reportTemplateRows -->
+                <h:panelGroup rendered="#{not empty cc.attrs.bundle.reportTemplateRows}">
+                    <hr/>
+                    <div style="font-weight: bold; margin: 8px 0 4px 0;">Float Transactions</div>
+                    <table class="table table-bordered table-sm">
+                        <thead>
+                            <tr>
+                                <th>Date / Time</th>
+                                <th>Direction</th>
+                                <th>From User</th>
+                                <th>To User</th>
+                                <th class="text-end">Amount</th>
+                                <th>Reference / Comments</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            <ui:repeat value="#{cc.attrs.bundle.reportTemplateRows}" var="floatRow">
+                                <tr>
+                                    <td>
+                                        <h:outputText value="#{floatRow.payment.createdAt}">
+                                            <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateTimeFormat}" />
+                                        </h:outputText>
+                                    </td>
+                                    <td>
+                                        <h:outputText
+                                            value="Float Sent"
+                                            rendered="#{floatRow.payment.bill.billTypeAtomic ne null and floatRow.payment.bill.billTypeAtomic.name() eq 'FUND_TRANSFER_BILL'}"
+                                            style="color: red; font-weight: bold;" />
+                                        <h:outputText
+                                            value="Float Received"
+                                            rendered="#{floatRow.payment.bill.billTypeAtomic ne null and floatRow.payment.bill.billTypeAtomic.name() eq 'FUND_TRANSFER_RECEIVED_BILL'}"
+                                            style="color: green; font-weight: bold;" />
+                                    </td>
+                                    <td>
+                                        <h:outputText value="#{floatRow.payment.creater.webUserPerson.nameWithTitle}" />
+                                    </td>
+                                    <td>
+                                        <h:outputText value="#{floatRow.payment.floatRecipient.webUserPerson.nameWithTitle}" />
+                                    </td>
+                                    <td class="text-end">
+                                        <h:outputText value="#{floatRow.payment.paidValue}">
+                                            <f:convertNumber pattern="#,##0.00"/>
+                                        </h:outputText>
+                                    </td>
+                                    <td>
+                                        <h:outputText value="#{floatRow.payment.comments}" />
+                                    </td>
+                                </tr>
+                            </ui:repeat>
+                        </tbody>
+                    </table>
+                </h:panelGroup>
 
             </div>
 

--- a/src/main/webapp/resources/ezcomp/prints/five_five_paper_with_headings_for_handover_reprint.xhtml
+++ b/src/main/webapp/resources/ezcomp/prints/five_five_paper_with_headings_for_handover_reprint.xhtml
@@ -216,22 +216,12 @@
                                         </tr>
                                     </thead>
                                     <tbody>
-                                        <!-- Cash row: reprint bundle does not aggregate float net into cashValue,
-                                             so we add cashFloatNetTotal explicitly here. -->
                                         <h:panelGroup rendered="#{cc.attrs.bundle.hasCashTransaction}">
                                             <tr>
-                                                <td>Cash</td>
+                                                <td>Cash Including Floats</td>
                                                 <td class="text-end"><h:outputText value="#{cc.attrs.bundle.cashValue + cc.attrs.bundle.cashFloatNetTotal}"><f:convertNumber pattern="#,##0.00"/></h:outputText></td>
                                                 <td class="text-end"><h:outputText value="#{cc.attrs.bundle.cashHandoverValue}"><f:convertNumber pattern="#,##0.00"/></h:outputText></td>
                                                 <td class="text-end"><h:outputText value="#{cc.attrs.bundle.cashValue + cc.attrs.bundle.cashFloatNetTotal - cc.attrs.bundle.cashHandoverValue}"><f:convertNumber pattern="#,##0.00"/></h:outputText></td>
-                                            </tr>
-                                        </h:panelGroup>
-                                        <h:panelGroup rendered="#{cc.attrs.bundle.cashFloatNetTotal != 0}">
-                                            <tr>
-                                                <td>Net Float (Cash)</td>
-                                                <td class="text-end"><h:outputText value="#{cc.attrs.bundle.cashFloatNetTotal}"><f:convertNumber pattern="#,##0.00"/></h:outputText></td>
-                                                <td class="text-end"><h:outputText value="#{cc.attrs.bundle.cashFloatNetTotal}"><f:convertNumber pattern="#,##0.00"/></h:outputText></td>
-                                                <td class="text-end"><h:outputText value="#{0}"><f:convertNumber pattern="#,##0.00"/></h:outputText></td>
                                             </tr>
                                         </h:panelGroup>
                                         <h:panelGroup rendered="#{cc.attrs.bundle.hasCardTransaction}">
@@ -494,9 +484,9 @@
                         <f:facet name="footer"><h:outputText value="#{cc.attrs.bundle.onCallValue}"><f:convertNumber pattern="#,##0.00"/></h:outputText></f:facet>
                     </p:column>
                     <p:column class="text-end" headerText="Total">
-                        <h:outputText value="#{summary.cashValue + summary.cardValue + summary.creditValue + summary.staffWelfareValue + summary.staffValue + summary.voucherValue + summary.iouValue + summary.agentValue + summary.chequeValue + summary.slipValue + summary.ewalletValue + summary.patientPointsValue + summary.onlineSettlementValue + summary.onCallValue}"><f:convertNumber pattern="#,##0.00"/></h:outputText>
+                        <h:outputText value="#{summary.cashHandoverValue + summary.cardHandoverValue + summary.creditHandoverValue + summary.staffWelfareHandoverValue + summary.staffHandoverValue + summary.voucherHandoverValue + summary.iouHandoverValue + summary.agentHandoverValue + summary.chequeHandoverValue + summary.slipHandoverValue + summary.ewalletHandoverValue + summary.patientPointsHandoverValue + summary.onlineSettlementHandoverValue + summary.onCallHandoverValue}"><f:convertNumber pattern="#,##0.00"/></h:outputText>
                         <f:facet name="footer">
-                            <h:outputText value="#{cc.attrs.bundle.cashValue + cc.attrs.bundle.cardValue + cc.attrs.bundle.creditValue + cc.attrs.bundle.staffWelfareValue + cc.attrs.bundle.staffValue + cc.attrs.bundle.voucherValue + cc.attrs.bundle.iouValue + cc.attrs.bundle.agentValue + cc.attrs.bundle.chequeValue + cc.attrs.bundle.slipValue + cc.attrs.bundle.ewalletValue + cc.attrs.bundle.patientPointsValue + cc.attrs.bundle.onlineSettlementValue + cc.attrs.bundle.onCallValue}"><f:convertNumber pattern="#,##0.00"/></h:outputText>
+                            <h:outputText value="#{cc.attrs.bundle.cashHandoverValue + cc.attrs.bundle.cardHandoverValue + cc.attrs.bundle.creditHandoverValue + cc.attrs.bundle.staffWelfareHandoverValue + cc.attrs.bundle.staffHandoverValue + cc.attrs.bundle.voucherHandoverValue + cc.attrs.bundle.iouHandoverValue + cc.attrs.bundle.agentHandoverValue + cc.attrs.bundle.chequeHandoverValue + cc.attrs.bundle.slipHandoverValue + cc.attrs.bundle.ewalletHandoverValue + cc.attrs.bundle.patientPointsHandoverValue + cc.attrs.bundle.onlineSettlementHandoverValue + cc.attrs.bundle.onCallHandoverValue}"><f:convertNumber pattern="#,##0.00"/></h:outputText>
                         </f:facet>
                     </p:column>
 


### PR DESCRIPTION
## Summary

- **Renamed pages**: `handover_preview.xhtml` → `handover_view.xhtml`; `handover_creation_bill_print.xhtml` → `handover_creation_print_summary.xhtml`
- **New pages**: Separate summary/detail print pages for both creation (`handover_creation_print_summary`, `handover_creation_print_details`) and view (`handover_view_print_summary`, `handover_view_print_details`) flows, each with appropriate Back/Print/View Details buttons
- **New composite** `five_five_paper_with_headings_for_handover_detail`: lists individual float transactions one per row (date/time, direction, from user, to user, amount, comments) instead of a single net float aggregate row
- **Fix From/To User** in float detail table: use `payment.creater` / `payment.floatRecipient` instead of `bill.fromWebUser` / `bill.toWebUser` — `FUND_TRANSFER_RECEIVED_BILL` rows have null from/to web user in the DB
- **Summary table fixes**: remove redundant Net Float (Cash) row; rename Cash → Cash Including Floats; fix Handing Over and Difference columns in both composites
- **Bottom table fix** in reprint composite: Total column now uses handover values (was incorrectly summing collected values)
- **Status report**: rename button from "View / Create Bill" → "View Handover"
- **Navigation methods** added to `FinancialTransactionController` for all new pages

## Test plan

- [ ] Handover creation flow: complete a handover → lands on summary print page → "View Details" navigates to detail print → float transactions listed with correct from/to users and amounts
- [ ] Handover view flow: open a past handover from status report → "Print Summary" and "Print Details" buttons both navigate correctly with Back buttons returning to view page
- [ ] Float transactions section only appears when floats exist during the shift
- [ ] From User and To User columns show names (not blank) for both sent and received float rows
- [ ] Summary table shows Cash Including Floats (no separate Net Float row); Handing Over and Difference columns are correct
- [ ] Print button triggers browser print on all print pages

Closes #20541

🤖 Generated with [Claude Code](https://claude.com/claude-code)