### PR TITLE
fix(pharmacy): fix intermittent wrong bill total on cashier sale receipt

### DIFF
--- a/.claude/skills/start-issue/SKILL.md
+++ b/.claude/skills/start-issue/SKILL.md
@@ -1,0 +1,117 @@
+---
+name: start-issue
+description: >
+  Full environment setup when starting work on a GitHub issue. Creates a feature
+  branch from origin/development, swaps persistence.xml to local JNDI settings,
+  assigns the issue, and guides project board setup. Use when beginning work on
+  any new issue: "start issue 20408", "/start-issue 20408", or "prepare env for issue 20408".
+disable-model-invocation: false
+allowed-tools: Bash, Read, Edit, Grep
+argument-hint: "<issue-number> [short-description] [local-jndi-name]"
+---
+
+# Start Issue Workflow
+
+Prepare the local development environment to fix a GitHub issue.
+
+## Arguments
+
+- `$0` — Issue number (required, e.g. `20408`)
+- `$1` — Short kebab-case description (optional; derive from issue title if omitted)
+- `$2` — Local JNDI datasource name (optional; read from `persistence_for_local_testing.xml` if omitted)
+
+## Step 1 — Fetch Issue Title
+
+```bash
+gh issue view $0 --repo hmislk/hmis --json title,body --jq '.title'
+```
+
+Use the title to derive a short kebab-case description if `$1` is not provided.
+Branch name format: `$0-<short-description>` (all lowercase, hyphens only).
+
+## Step 2 — Create Feature Branch from development
+
+```bash
+git fetch origin
+git checkout -b $0-<description> origin/development
+git push -u origin $0-<description>
+```
+
+**Rule**: ALWAYS base on `origin/development`, never on `master`.
+
+## Step 3 — Set persistence.xml to Local JNDI
+
+Read the local JNDI name from:
+`src/main/resources/META-INF/persistence_for_local_testing.xml`
+
+Look for the `<jta-data-source>` values — use those exact names.
+
+Then update `src/main/resources/META-INF/persistence.xml`:
+- Replace `${JDBC_DATASOURCE}` → the local main JNDI (e.g. `jdbc/ruhunu`)
+- Replace `${JDBC_AUDIT_DATASOURCE}` → the local audit JNDI (e.g. `jdbc/ruhunuAudit`)
+
+**Do NOT commit this change.** It stays local only. Before any push, revert to placeholders
+(or use the `verify-persistence` skill which will catch it).
+
+## Step 4 — Assign Issue on GitHub
+
+```bash
+gh issue edit $0 --repo hmislk/hmis --add-assignee buddhika75
+```
+
+If the command fails with a scope error, inform the user that they need to run:
+```
+! gh auth refresh -s project
+```
+
+## Step 5 — Project Board (CareCode: HMIS Board)
+
+Attempt to add the issue to project #11 and set status to **In Progress** via GraphQL:
+
+```bash
+# Get issue node ID
+gh api repos/hmislk/hmis/issues/$0 --jq '.node_id'
+
+# Get project ID (requires 'project' token scope)
+gh api graphql -f query='
+query {
+  organization(login: "hmislk") {
+    projectV2(number: 11) {
+      id
+      fields(first: 20) {
+        nodes {
+          ... on ProjectV2SingleSelectField {
+            id
+            name
+            options { id name }
+          }
+        }
+      }
+    }
+  }
+}'
+```
+
+If the token lacks the `project` scope (error: INSUFFICIENT_SCOPES), tell the user:
+
+> **Action required**: Your GitHub token lacks the `project` scope for board automation.
+> Please add the issue to the board manually:
+> https://github.com/orgs/hmislk/projects/11
+> Set **Status = In Progress**.
+>
+> To enable automation in future, run: `! gh auth refresh -s project`
+
+## Step 6 — Summary
+
+Report what was done:
+- Branch name created and pushed
+- persistence.xml local JNDI set to (name)
+- Issue assigned to buddhika75
+- Project board status (automated or manual instruction given)
+
+Remind the user: **persistence.xml must be reverted to `${JDBC_DATASOURCE}` before any git push.**
+The `verify-persistence` skill or `commit-code` skill will catch this automatically.
+
+## Reference
+
+See [start-issue-workflow.md](../../../developer_docs/git/start-issue-workflow.md) for full details.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -80,6 +80,10 @@
 - Use `/review-pr <pr-url>` skill to automate investigation and fix steps
 - **🚨 AFTER APPLYING ANY CODERABBIT/CODEX FIX**: Always verify method names exist on the actual entity before pushing. Automated tools frequently generate wrong getter names (e.g., `getCompleted()` instead of `isCompleted()` for primitive `boolean` fields). See [PR Review Workflow §4a](developer_docs/git/pr-review-workflow.md).
 
+### When Starting Work on a New Issue
+- [Start Issue Workflow](developer_docs/git/start-issue-workflow.md) - Branch creation, local persistence swap, GitHub assignment, project board setup
+- Use `/start-issue <number>` skill to automate all steps in one command
+
 ### When Committing Code
 - [Commit Conventions](developer_docs/git/commit-conventions.md) - Message format
 

--- a/developer_docs/git/start-issue-workflow.md
+++ b/developer_docs/git/start-issue-workflow.md
@@ -1,0 +1,62 @@
+# Start Issue Workflow
+
+Complete environment setup when beginning work on a GitHub issue.
+
+## Overview
+
+Before fixing an issue, the local development environment must be prepared:
+1. Create a feature branch from `origin/development`
+2. Set `persistence.xml` to local JNDI settings
+3. Assign the issue on GitHub
+4. Add the issue to the project board and set status to **In Progress**
+
+Use the `/start-issue` skill to automate all of these steps.
+
+## Branch Naming
+
+Format: `<issueNumber>-<short-kebab-case-description>`
+
+Examples:
+- `20408-fix-cashier-bill-total-calculation`
+- `19887-collection-center-receipt-pdf`
+
+## Persistence.xml Swap
+
+The `persistence.xml` committed on `development` uses CI/CD placeholders:
+- `${JDBC_DATASOURCE}` → replace with local JNDI (e.g. `jdbc/ruhunu`)
+- `${JDBC_AUDIT_DATASOURCE}` → replace with local audit JNDI (e.g. `jdbc/ruhunuAudit`)
+
+The correct local JNDI names are stored in:
+`src/main/resources/META-INF/persistence_for_local_testing.xml`
+
+**Before pushing to remote**, revert `persistence.xml` back to placeholders (or use `/commit-code` / `verify-persistence` skill which checks this automatically).
+
+Reference: [persistence-workflow.md](../persistence/persistence-workflow.md)
+
+## GitHub Steps (requires `project` scope on token)
+
+```bash
+# Assign issue
+gh issue edit <number> --repo hmislk/hmis --add-assignee <github-username>
+
+# Add to project board and set In Progress — requires GraphQL with project scope
+# If token lacks the scope, do it manually at:
+# https://github.com/orgs/hmislk/projects/11
+```
+
+### Token Scope Note
+
+Project board manipulation requires the `project` OAuth scope. If the `gh` CLI returns a scope error:
+
+1. Run `! gh auth refresh -s project` in the Claude Code prompt to re-authenticate with the extra scope, **or**
+2. Add the item and set status manually on the board at https://github.com/orgs/hmislk/projects/11
+
+## Quick Reference
+
+| Step | Command / Action |
+|------|-----------------|
+| Fetch & branch | `git checkout -b <branch> origin/development` |
+| Push branch | `git push -u origin <branch>` |
+| Local persistence | Replace `${JDBC_DATASOURCE}` → `jdbc/ruhunu` in `persistence.xml` |
+| Assign issue | `gh issue edit <N> --repo hmislk/hmis --add-assignee <user>` |
+| Project board | https://github.com/orgs/hmislk/projects/11 (manual if no token scope) |

--- a/src/main/java/com/divudi/bean/pharmacy/PharmacySaleForCashierController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacySaleForCashierController.java
@@ -3292,10 +3292,14 @@ public class PharmacySaleForCashierController implements Serializable, Controlle
         }
 
         for (BillItem tbi : list) {
-            if (execureOnEditActions(tbi)) {
-                // If any issue in Stock Bill Item will not save & not include for total
-                // continue;
-            }
+            // Stock validation is handled upstream by lockAndValidateStocks() before this
+            // method is called. Calling execureOnEditActions() here was redundant and caused
+            // a mid-loop side effect: onEditCalculation() → calculateBillItemsAndBillTotalsOfPreBill()
+            // recalculated the bill total before the current item was added to preBill.getBillItems(),
+            // which could leave preBill.total set to the sum of only the previously-added items.
+            // The final calculateRatesForAllBillItemsInPreBill() below corrects the total in most
+            // cases, but if it failed (e.g. stale proxy on a specific item) the wrong total
+            // remained. Removed to fix intermittent wrong bill total (Closes #20408).
 
             tbi.setInwardChargeType(InwardChargeType.Medicine);
             tbi.setBill(getPreBill());


### PR DESCRIPTION
## Summary

- Removes the redundant `execureOnEditActions()` call inside `savePreBillItemsFinallyWithLockedStocks()` in `PharmacySaleForCashierController`
- Stock validation is already performed upstream by `lockAndValidateStocks()` before this method runs, making the call unnecessary
- The call caused a mid-loop side effect: for an N-item bill, when item N was being processed, `onEditCalculation()` → `calculateBillItemsAndBillTotalsOfPreBill()` recalculated the bill total using only items 1…N-1 (item N not yet added to the list). In the normal path the final `calculateRatesForAllBillItemsInPreBill()` at the end of the loop corrects this; but if it encountered a stale JPA proxy on a specific item the correction was skipped, leaving `preBill.total` set to the partial sum and producing the wrong total on the printed cashier receipt

## Root cause

`PharmacySaleForCashierController.savePreBillItemsFinallyWithLockedStocks()` — `execureOnEditActions(tbi)` → `onEditCalculation()` → `calculateBillItemsAndBillTotalsOfPreBill()` was called inside the item-save loop **before** `tbi` was appended to `preBill.getBillItems()`, causing a transient under-count of the bill total.

## Test plan

- [ ] Create a cashier retail sale bill with 3+ items
- [ ] Settle the bill and verify the printed receipt total equals the sum of all item values
- [ ] Confirm no regression in stock deduction (each item's stock is reduced correctly)
- [ ] Test with cash, credit, and staff payment methods

Closes #20408

🤖 Generated with [Claude Code](https://claude.com/claude-code)