### PR TITLE
feat(cashier): add payment-type detail columns to handover pages

### DIFF
--- a/src/main/webapp/cashier/handover_accept_row_detail.xhtml
+++ b/src/main/webapp/cashier/handover_accept_row_detail.xhtml
@@ -116,6 +116,78 @@
                                                   rendered="#{row.payment.paymentMethod.name() eq 'Card'}" />
                                 </p:column>
 
+                                <!-- Cheque-specific columns -->
+                                <p:column headerText="Cheque No"
+                                          rendered="#{financialTransactionController.selectedBundle.hasChequeTransaction}">
+                                    <h:outputText value="#{row.payment.chequeRefNo}"
+                                                  rendered="#{row.payment.paymentMethod.name() eq 'Cheque'}" />
+                                </p:column>
+                                <p:column headerText="Cheque Date"
+                                          rendered="#{financialTransactionController.selectedBundle.hasChequeTransaction}">
+                                    <h:outputText value="#{row.payment.chequeDate}"
+                                                  rendered="#{row.payment.paymentMethod.name() eq 'Cheque'}">
+                                        <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateFormat}" />
+                                    </h:outputText>
+                                </p:column>
+                                <p:column headerText="Bank"
+                                          rendered="#{financialTransactionController.selectedBundle.hasChequeTransaction}">
+                                    <h:outputText value="#{row.payment.bank.name}"
+                                                  rendered="#{row.payment.paymentMethod.name() eq 'Cheque'}" />
+                                </p:column>
+
+                                <!-- Slip-specific columns -->
+                                <p:column headerText="Slip No"
+                                          rendered="#{financialTransactionController.selectedBundle.hasSlipTransaction}">
+                                    <h:outputText value="#{row.payment.referenceNo}"
+                                                  rendered="#{row.payment.paymentMethod.name() eq 'Slip'}" />
+                                </p:column>
+                                <p:column headerText="Bank / Institution"
+                                          rendered="#{financialTransactionController.selectedBundle.hasSlipTransaction}">
+                                    <h:outputText value="#{row.payment.bank.name}"
+                                                  rendered="#{row.payment.paymentMethod.name() eq 'Slip'}" />
+                                </p:column>
+
+                                <!-- eWallet-specific columns -->
+                                <p:column headerText="eWallet Provider"
+                                          rendered="#{financialTransactionController.selectedBundle.hasEWalletTransaction}">
+                                    <h:outputText value="#{row.payment.bank.name}"
+                                                  rendered="#{row.payment.paymentMethod.name() eq 'ewallet'}" />
+                                </p:column>
+                                <p:column headerText="Transaction Ref"
+                                          rendered="#{financialTransactionController.selectedBundle.hasEWalletTransaction}">
+                                    <h:outputText value="#{row.payment.referenceNo}"
+                                                  rendered="#{row.payment.paymentMethod.name() eq 'ewallet'}" />
+                                </p:column>
+
+                                <!-- Credit-specific columns -->
+                                <p:column headerText="Company"
+                                          rendered="#{financialTransactionController.selectedBundle.hasCreditTransaction}">
+                                    <h:outputText value="#{row.payment.creditCompany.name}"
+                                                  rendered="#{row.payment.paymentMethod.name() eq 'Credit'}" />
+                                </p:column>
+                                <p:column headerText="Policy No"
+                                          rendered="#{financialTransactionController.selectedBundle.hasCreditTransaction}">
+                                    <h:outputText value="#{row.payment.policyNo}"
+                                                  rendered="#{row.payment.paymentMethod.name() eq 'Credit'}" />
+                                </p:column>
+
+                                <!-- Staff Welfare-specific columns -->
+                                <p:column headerText="Staff Name"
+                                          rendered="#{financialTransactionController.selectedBundle.hasStaffWelfareTransaction}">
+                                    <h:outputText value="#{row.payment.bill.toStaff.person.name}"
+                                                  rendered="#{row.payment.paymentMethod.name() eq 'Staff_Welfare'}" />
+                                </p:column>
+                                <p:column headerText="Staff No"
+                                          rendered="#{financialTransactionController.selectedBundle.hasStaffWelfareTransaction}">
+                                    <h:outputText value="#{row.payment.bill.toStaff.code}"
+                                                  rendered="#{row.payment.paymentMethod.name() eq 'Staff_Welfare'}" />
+                                </p:column>
+                                <p:column headerText="EPF No"
+                                          rendered="#{financialTransactionController.selectedBundle.hasStaffWelfareTransaction}">
+                                    <h:outputText value="#{row.payment.bill.toStaff.epfNo}"
+                                                  rendered="#{row.payment.paymentMethod.name() eq 'Staff_Welfare'}" />
+                                </p:column>
+
                                 <p:column headerText="Value" class="text-end" sortBy="#{row.payment.paidValue}">
                                     <h:outputText value="#{row.payment.paidValue}">
                                         <f:convertNumber pattern="#,##0.00" />

--- a/src/main/webapp/cashier/handover_accept_select.xhtml
+++ b/src/main/webapp/cashier/handover_accept_select.xhtml
@@ -90,6 +90,66 @@
                                     <h:outputText value="#{row.payment.creditCardRefNo}" />
                                 </p:column>
 
+                                <!-- Cheque-specific columns -->
+                                <p:column headerText="Cheque No"
+                                          rendered="#{financialTransactionController.selectedPaymentMethod eq 'Cheque'}">
+                                    <h:outputText value="#{row.payment.chequeRefNo}" />
+                                </p:column>
+                                <p:column headerText="Cheque Date"
+                                          rendered="#{financialTransactionController.selectedPaymentMethod eq 'Cheque'}">
+                                    <h:outputText value="#{row.payment.chequeDate}">
+                                        <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateFormat}" />
+                                    </h:outputText>
+                                </p:column>
+                                <p:column headerText="Bank"
+                                          rendered="#{financialTransactionController.selectedPaymentMethod eq 'Cheque'}">
+                                    <h:outputText value="#{row.payment.bank.name}" />
+                                </p:column>
+
+                                <!-- Slip-specific columns -->
+                                <p:column headerText="Slip No"
+                                          rendered="#{financialTransactionController.selectedPaymentMethod eq 'Slip'}">
+                                    <h:outputText value="#{row.payment.referenceNo}" />
+                                </p:column>
+                                <p:column headerText="Bank / Institution"
+                                          rendered="#{financialTransactionController.selectedPaymentMethod eq 'Slip'}">
+                                    <h:outputText value="#{row.payment.bank.name}" />
+                                </p:column>
+
+                                <!-- eWallet-specific columns -->
+                                <p:column headerText="eWallet Provider"
+                                          rendered="#{financialTransactionController.selectedPaymentMethod eq 'ewallet'}">
+                                    <h:outputText value="#{row.payment.bank.name}" />
+                                </p:column>
+                                <p:column headerText="Transaction Ref"
+                                          rendered="#{financialTransactionController.selectedPaymentMethod eq 'ewallet'}">
+                                    <h:outputText value="#{row.payment.referenceNo}" />
+                                </p:column>
+
+                                <!-- Credit-specific columns -->
+                                <p:column headerText="Company"
+                                          rendered="#{financialTransactionController.selectedPaymentMethod eq 'Credit'}">
+                                    <h:outputText value="#{row.payment.creditCompany.name}" />
+                                </p:column>
+                                <p:column headerText="Policy No"
+                                          rendered="#{financialTransactionController.selectedPaymentMethod eq 'Credit'}">
+                                    <h:outputText value="#{row.payment.policyNo}" />
+                                </p:column>
+
+                                <!-- Staff Welfare-specific columns -->
+                                <p:column headerText="Staff Name"
+                                          rendered="#{financialTransactionController.selectedPaymentMethod eq 'Staff_Welfare'}">
+                                    <h:outputText value="#{row.payment.bill.toStaff.person.name}" />
+                                </p:column>
+                                <p:column headerText="Staff No"
+                                          rendered="#{financialTransactionController.selectedPaymentMethod eq 'Staff_Welfare'}">
+                                    <h:outputText value="#{row.payment.bill.toStaff.code}" />
+                                </p:column>
+                                <p:column headerText="EPF No"
+                                          rendered="#{financialTransactionController.selectedPaymentMethod eq 'Staff_Welfare'}">
+                                    <h:outputText value="#{row.payment.bill.toStaff.epfNo}" />
+                                </p:column>
+
                                 <p:column headerText="Value" class="text-end">
                                     <h:outputText value="#{row.payment.paidValue}">
                                         <f:convertNumber pattern="#,##0.00" />

--- a/src/main/webapp/cashier/handover_start_select.xhtml
+++ b/src/main/webapp/cashier/handover_start_select.xhtml
@@ -432,7 +432,7 @@
                                 <payments:paymentsListAny 
                                     rendered="#{financialTransactionController.selectedPaymentMethod eq 'Staff'}"
                                     />
-                                <payments:paymentsListAny 
+                                <payments:paymentsListStaffWelfare
                                     rendered="#{financialTransactionController.selectedPaymentMethod eq 'Staff_Welfare'}"
                                     />
                                 <payments:paymentsListAny 

--- a/src/main/webapp/resources/ezcomp/reports/paymentsListStaffWelfare.xhtml
+++ b/src/main/webapp/resources/ezcomp/reports/paymentsListStaffWelfare.xhtml
@@ -1,0 +1,58 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:cc="http://xmlns.jcp.org/jsf/composite"
+      xmlns:f="http://xmlns.jcp.org/jsf/core"
+      xmlns:h="http://xmlns.jcp.org/jsf/html"
+      xmlns:p="http://primefaces.org/ui">
+
+    <!-- INTERFACE -->
+    <cc:interface>
+    </cc:interface>
+
+    <!-- IMPLEMENTATION -->
+    <cc:implementation>
+
+        <p:dataTable
+            value="#{financialTransactionController.selectedBundle.getPaymentRows(financialTransactionController.selectedPaymentMethod)}" var="swPayment" >
+            <p:column headerText="Select to Handover" width="3em">
+                <p:selectBooleanCheckbox id="checkSwSelected" value="#{swPayment.payment.selectedForHandover}">
+                    <p:ajax process="checkSwSelected" update="@all"/>
+                </p:selectBooleanCheckbox>
+            </p:column>
+            <p:column headerText="Proof Missing" width="3em">
+                <p:selectBooleanCheckbox id="checkSwProofMissing" value="#{swPayment.payment.handoverProofMissing}"
+                                         disabled="#{not swPayment.payment.selectedForHandover}">
+                    <p:ajax process="checkSwProofMissing" update="@all"/>
+                </p:selectBooleanCheckbox>
+                <p:badge rendered="#{swPayment.payment.handoverProofMissing}" value="Missing" severity="warn"/>
+            </p:column>
+            <p:column headerText="Bill Number">
+                <h:outputText value="#{swPayment.payment.bill.deptId}" />
+            </p:column>
+            <p:column headerText="Bill Type">
+                <h:outputText value="#{swPayment.payment.bill.billTypeAtomic.label}" />
+            </p:column>
+            <p:column headerText="Bill Date">
+                <h:outputText value="#{swPayment.payment.bill.createdAt}">
+                    <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateTimeFormat}" />
+                </h:outputText>
+            </p:column>
+            <p:column headerText="Staff Name">
+                <h:outputText value="#{swPayment.payment.bill.toStaff.person.name}" />
+            </p:column>
+            <p:column headerText="Staff No">
+                <h:outputText value="#{swPayment.payment.bill.toStaff.code}" />
+            </p:column>
+            <p:column headerText="EPF No">
+                <h:outputText value="#{swPayment.payment.bill.toStaff.epfNo}" />
+            </p:column>
+            <p:column headerText="Value" class="text-end">
+                <h:outputText value="#{swPayment.payment.paidValue}">
+                    <f:convertNumber pattern="#,##0.00" />
+                </h:outputText>
+            </p:column>
+        </p:dataTable>
+
+    </cc:implementation>
+</html>


### PR DESCRIPTION
## Summary

- Add payment-type-specific columns to the handover **start** (select), **accept-select**, and **accept-row-detail** pages so each payment type shows its key details, matching what the daily return report already displays
- New `paymentsListStaffWelfare.xhtml` composite component with Staff Name, Staff No, EPF No columns
- All five payment types now show their relevant detail columns:
  - **Staff Welfare**: Staff Name, Staff No (code), EPF No
  - **Cheque**: Cheque No, Cheque Date, Bank
  - **Slip**: Slip No, Bank / Institution
  - **eWallet**: eWallet Provider, Transaction Ref
  - **Credit**: Company, Policy No

## Issues Closed

Closes #20544
Closes #20545
Closes #20546
Closes #20547
Closes #20548

## Test plan

- [ ] Open handover start page, select Staff Welfare — verify Staff Name, Staff No, EPF No columns appear
- [ ] Open handover start page, select Cheque — verify Cheque No, Cheque Date, Bank columns appear
- [ ] Open handover start page, select Slip — verify Slip No, Bank/Institution columns appear
- [ ] Open handover start page, select eWallet — verify eWallet Provider, Transaction Ref columns appear
- [ ] Open handover start page, select Credit — verify Company, Policy No columns appear
- [ ] Open handover accept-select page for each above payment method — confirm same extra columns show
- [ ] Open handover accept-row-detail page for a row with mixed payments — confirm columns only appear when that payment type is present in the bundle
- [ ] Card columns still render correctly (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)