### PR TITLE
fix(cashier): add missing Slip Date and Credit Ref No to handover accept pages

### DIFF
--- a/src/main/webapp/cashier/handover_accept_row_detail.xhtml
+++ b/src/main/webapp/cashier/handover_accept_row_detail.xhtml
@@ -146,6 +146,13 @@
                                     <h:outputText value="#{row.payment.bank.name}"
                                                   rendered="#{row.payment.paymentMethod.name() eq 'Slip'}" />
                                 </p:column>
+                                <p:column headerText="Slip Date"
+                                          rendered="#{financialTransactionController.selectedBundle.hasSlipTransaction}">
+                                    <h:outputText value="#{row.payment.chequeDate}"
+                                                  rendered="#{row.payment.paymentMethod.name() eq 'Slip'}">
+                                        <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateFormat}" />
+                                    </h:outputText>
+                                </p:column>
 
                                 <!-- eWallet-specific columns -->
                                 <p:column headerText="eWallet Provider"
@@ -168,6 +175,11 @@
                                 <p:column headerText="Policy No"
                                           rendered="#{financialTransactionController.selectedBundle.hasCreditTransaction}">
                                     <h:outputText value="#{row.payment.policyNo}"
+                                                  rendered="#{row.payment.paymentMethod.name() eq 'Credit'}" />
+                                </p:column>
+                                <p:column headerText="Ref No"
+                                          rendered="#{financialTransactionController.selectedBundle.hasCreditTransaction}">
+                                    <h:outputText value="#{row.payment.referenceNo}"
                                                   rendered="#{row.payment.paymentMethod.name() eq 'Credit'}" />
                                 </p:column>
 

--- a/src/main/webapp/cashier/handover_accept_select.xhtml
+++ b/src/main/webapp/cashier/handover_accept_select.xhtml
@@ -115,6 +115,12 @@
                                           rendered="#{financialTransactionController.selectedPaymentMethod eq 'Slip'}">
                                     <h:outputText value="#{row.payment.bank.name}" />
                                 </p:column>
+                                <p:column headerText="Slip Date"
+                                          rendered="#{financialTransactionController.selectedPaymentMethod eq 'Slip'}">
+                                    <h:outputText value="#{row.payment.chequeDate}">
+                                        <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateFormat}" />
+                                    </h:outputText>
+                                </p:column>
 
                                 <!-- eWallet-specific columns -->
                                 <p:column headerText="eWallet Provider"
@@ -134,6 +140,10 @@
                                 <p:column headerText="Policy No"
                                           rendered="#{financialTransactionController.selectedPaymentMethod eq 'Credit'}">
                                     <h:outputText value="#{row.payment.policyNo}" />
+                                </p:column>
+                                <p:column headerText="Ref No"
+                                          rendered="#{financialTransactionController.selectedPaymentMethod eq 'Credit'}">
+                                    <h:outputText value="#{row.payment.referenceNo}" />
                                 </p:column>
 
                                 <!-- Staff Welfare-specific columns -->


### PR DESCRIPTION
## Summary

- Adds **Slip Date** column to both `handover_accept_select.xhtml` and `handover_accept_row_detail.xhtml` for Slip payments (was already present in the `paymentsListSlip.xhtml` composite component on the start-select flow)
- Adds **Ref No** column to both accept-flow pages for Credit payments (was already present in `paymentsListCredit.xhtml` composite component)
- Policy No was already present for credits; only the reference number was missing

## Test plan

- [ ] Open a handover session containing Slip payments — verify "Slip Date" column appears on both the accept-select and accept-row-detail pages
- [ ] Open a handover session containing Credit payments — verify "Ref No" column appears alongside Company and Policy No on both accept pages
- [ ] Confirm no regression for other payment methods (Card, Cheque, eWallet, Staff Welfare)

Closes #20548

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Payment records now display "Slip Date" column for slip transactions with standardized date formatting
  * "Ref No" column added for credit payment transactions
  * Non-cash payments view updated to show "Ref No" instead of "Policy No" for credit payments

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hmislk/hmis/pull/20603)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->