### PR TITLE
feat(pharmacy): fast native-SQL view path for transfer, retail and inpatient bills

### DIFF
--- a/src/main/java/com/divudi/bean/common/BillSearch.java
+++ b/src/main/java/com/divudi/bean/common/BillSearch.java
@@ -127,6 +127,10 @@ import com.divudi.bean.pharmacy.PharmacySaleController;
 import com.divudi.bean.pharmacy.PharmacySaleForCashierController;
 import com.divudi.bean.pharmacy.PreReturnController;
 import com.divudi.bean.pharmacy.SaleReturnController;
+import com.divudi.bean.pharmacy.TransferIssueNativeSqlController;
+import com.divudi.bean.pharmacy.TransferReceiveNativeSqlController;
+import com.divudi.bean.pharmacy.InpatientDirectIssueNativeSqlController;
+import com.divudi.bean.pharmacy.RetailSaleNativeSqlController;
 import static com.divudi.core.data.BillTypeAtomic.PHARMACY_RETAIL_SALE_PREBILL_SETTLED_AT_CASHIER;
 import static com.divudi.core.data.BillTypeAtomic.PHARMACY_RETAIL_SALE_PRE_TO_SETTLE_AT_CASHIER;
 import static com.divudi.core.data.BillTypeAtomic.PHARMACY_TRANSFER_REQUEST_PRE;
@@ -312,6 +316,14 @@ public class BillSearch implements Serializable, ControllerWithMultiplePayments 
     BillReturnController billReturnController;
     @Inject
     RequestController requestController;
+    @Inject
+    TransferIssueNativeSqlController transferIssueNativeSqlController;
+    @Inject
+    TransferReceiveNativeSqlController transferReceiveNativeSqlController;
+    @Inject
+    InpatientDirectIssueNativeSqlController inpatientDirectIssueNativeSqlController;
+    @Inject
+    RetailSaleNativeSqlController retailSaleNativeSqlController;
     /**
      * Class Variables
      */
@@ -4896,6 +4908,32 @@ public class BillSearch implements Serializable, ControllerWithMultiplePayments 
     }
 
     public String navigateToViewBillByAtomicBillType() {
+        if (bill == null) {
+            JsfUtil.addErrorMessage("No Bill is Selected");
+            return null;
+        }
+        if (bill.getBillTypeAtomic() == null) {
+            JsfUtil.addErrorMessage("No Bill type");
+            return null;
+        }
+        switch (bill.getBillTypeAtomic()) {
+            case PHARMACY_ISSUE:
+                return transferIssueNativeSqlController.viewByBillId(bill.getId());
+            case PHARMACY_RECEIVE:
+                return transferReceiveNativeSqlController.viewByBillId(bill.getId());
+            case DIRECT_ISSUE_INWARD_MEDICINE:
+                return inpatientDirectIssueNativeSqlController.viewByBillId(bill.getId());
+            case PHARMACY_RETAIL_SALE:
+                return retailSaleNativeSqlController.viewByBillId(bill.getId());
+            case PHARMACY_TRANSFER_REQUEST_PRE:
+            case PHARMACY_TRANSFER_REQUEST:
+                return pharmacyBillSearch.viewRequestByBillId(bill.getId());
+            default:
+                return navigateToViewBillByAtomicBillTypeEntityBased();
+        }
+    }
+
+    public String navigateToViewBillByAtomicBillTypeEntityBased() {
         if (bill == null) {
             JsfUtil.addErrorMessage("No Bill is Selected");
             return null;

--- a/src/main/java/com/divudi/bean/common/BillSearch.java
+++ b/src/main/java/com/divudi/bean/common/BillSearch.java
@@ -4916,6 +4916,10 @@ public class BillSearch implements Serializable, ControllerWithMultiplePayments 
             JsfUtil.addErrorMessage("No Bill type");
             return null;
         }
+        if (bill.getId() == null) {
+            JsfUtil.addErrorMessage("Bill ID is required");
+            return null;
+        }
         switch (bill.getBillTypeAtomic()) {
             case PHARMACY_ISSUE:
                 return transferIssueNativeSqlController.viewByBillId(bill.getId());

--- a/src/main/java/com/divudi/bean/common/SearchController.java
+++ b/src/main/java/com/divudi/bean/common/SearchController.java
@@ -4232,14 +4232,8 @@ public class SearchController implements Serializable {
         params.put("btp", BillTypeAtomic.PHARMACY_RECEIVE);
         params.put("issuedBillIds", issuedBillIds);
         String jpql = "SELECT NEW com.divudi.core.data.dto.PharmacyTransferReceivedListDTO("
-                + "b.id, b.referenceBill.id, b.deptId, b.createdAt, b.cancelled, wup.name, b.netTotal, "
-                + "cbwup.name, cb.createdAt) "
+                + "b.id, b.referenceBill.id, b.deptId, b.cancelled) "
                 + "FROM Bill b "
-                + "LEFT JOIN b.creater wu "
-                + "LEFT JOIN wu.webUserPerson wup "
-                + "LEFT JOIN b.cancelledBill cb "
-                + "LEFT JOIN cb.creater cbwu "
-                + "LEFT JOIN cbwu.webUserPerson cbwup "
                 + "WHERE b.retired = false "
                 + "AND b.billTypeAtomic = :btp "
                 + "AND b.referenceBill.id IN :issuedBillIds";

--- a/src/main/java/com/divudi/bean/pharmacy/InpatientDirectIssueNativeSqlController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/InpatientDirectIssueNativeSqlController.java
@@ -517,6 +517,23 @@ public class InpatientDirectIssueNativeSqlController implements Serializable {
     }
 
     // -----------------------------------------------------------------------
+    // View by bill ID (from BillSearch dispatcher)
+    // -----------------------------------------------------------------------
+
+    @SuppressWarnings("unchecked")
+    public String viewByBillId(Long billId) {
+        if (billId == null) return null;
+        resetAll();
+        Object[] result = nativeSqlService.loadViewDataByBillId(billId);
+        if (result == null) return null;
+        patientEncounter = (PatientEncounter) result[0];
+        printBill = (PrintBillData) result[1];
+        printBillItems = (List<BillItemData>) result[2];
+        billPreview = true;
+        return "/inward/pharmacy_bill_issue_bht_native?faces-redirect=true";
+    }
+
+    // -----------------------------------------------------------------------
     // Clear / reset
     // -----------------------------------------------------------------------
 

--- a/src/main/java/com/divudi/bean/pharmacy/InpatientDirectIssueNativeSqlController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/InpatientDirectIssueNativeSqlController.java
@@ -522,10 +522,16 @@ public class InpatientDirectIssueNativeSqlController implements Serializable {
 
     @SuppressWarnings("unchecked")
     public String viewByBillId(Long billId) {
-        if (billId == null) return null;
+        if (billId == null) {
+            JsfUtil.addErrorMessage("No Bill Selected");
+            return null;
+        }
         resetAll();
         Object[] result = nativeSqlService.loadViewDataByBillId(billId);
-        if (result == null) return null;
+        if (result == null) {
+            JsfUtil.addErrorMessage("Bill not found");
+            return null;
+        }
         patientEncounter = (PatientEncounter) result[0];
         printBill = (PrintBillData) result[1];
         printBillItems = (List<BillItemData>) result[2];

--- a/src/main/java/com/divudi/bean/pharmacy/PharmacyBillSearch.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacyBillSearch.java
@@ -58,6 +58,7 @@ import com.divudi.core.entity.PreBill;
 import com.divudi.core.entity.StockBill;
 import com.divudi.core.util.CommonFunctions;
 import com.divudi.service.BillService;
+import com.divudi.service.pharmacy.TransferIssueNativeSqlService;
 import java.io.BufferedReader;
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
@@ -121,6 +122,8 @@ public class PharmacyBillSearch implements Serializable {
     private EmailFacade emailFacade;
     @EJB
     private EmailManagerEjb emailManagerEjb;
+    @EJB
+    private TransferIssueNativeSqlService transferIssueNativeSqlService;
     // </editor-fold>
     // <editor-fold defaultstate="collapsed" desc="Controllers">
     @Inject
@@ -299,7 +302,12 @@ public class PharmacyBillSearch implements Serializable {
             JsfUtil.addErrorMessage("No Bill Selected");
             return null;
         }
-        bill = billService.reloadBill(billId);
+        return viewRequestByBillId(billId);
+    }
+
+    public String viewRequestByBillId(Long billId) {
+        if (billId == null) return null;
+        bill = transferIssueNativeSqlService.loadRequestBillForView(billId);
         if (bill == null) {
             JsfUtil.addErrorMessage("Bill not found");
             return null;

--- a/src/main/java/com/divudi/bean/pharmacy/PharmacyBillSearch.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacyBillSearch.java
@@ -306,7 +306,10 @@ public class PharmacyBillSearch implements Serializable {
     }
 
     public String viewRequestByBillId(Long billId) {
-        if (billId == null) return null;
+        if (billId == null) {
+            JsfUtil.addErrorMessage("No Bill Selected");
+            return null;
+        }
         bill = transferIssueNativeSqlService.loadRequestBillForView(billId);
         if (bill == null) {
             JsfUtil.addErrorMessage("Bill not found");

--- a/src/main/java/com/divudi/bean/pharmacy/RetailSaleNativeSqlController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/RetailSaleNativeSqlController.java
@@ -151,10 +151,16 @@ public class RetailSaleNativeSqlController implements Serializable, ControllerWi
 
     @SuppressWarnings("unchecked")
     public String viewByBillId(Long billId) {
-        if (billId == null) return null;
+        if (billId == null) {
+            JsfUtil.addErrorMessage("No Bill Selected");
+            return null;
+        }
         resetAll();
         Object[] result = nativeSqlService.loadViewDataByBillId(billId);
-        if (result == null) return null;
+        if (result == null) {
+            JsfUtil.addErrorMessage("Bill not found");
+            return null;
+        }
         printBill = (PrintBillData) result[0];
         printBillItems = (List<BillItemData>) result[1];
         billPreview = true;

--- a/src/main/java/com/divudi/bean/pharmacy/RetailSaleNativeSqlController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/RetailSaleNativeSqlController.java
@@ -149,6 +149,18 @@ public class RetailSaleNativeSqlController implements Serializable, ControllerWi
         return "/pharmacy/pharmacy_bill_retail_sale_native?faces-redirect=true";
     }
 
+    @SuppressWarnings("unchecked")
+    public String viewByBillId(Long billId) {
+        if (billId == null) return null;
+        resetAll();
+        Object[] result = nativeSqlService.loadViewDataByBillId(billId);
+        if (result == null) return null;
+        printBill = (PrintBillData) result[0];
+        printBillItems = (List<BillItemData>) result[1];
+        billPreview = true;
+        return "/pharmacy/pharmacy_bill_retail_sale_native?faces-redirect=true";
+    }
+
     // -----------------------------------------------------------------------
     // Settle
     // -----------------------------------------------------------------------

--- a/src/main/java/com/divudi/bean/pharmacy/TransferIssueNativeSqlController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/TransferIssueNativeSqlController.java
@@ -137,6 +137,19 @@ public class TransferIssueNativeSqlController implements Serializable {
         return "/pharmacy/pharmacy_transfer_request_list?faces-redirect=true";
     }
 
+    public String viewByBillId(Long billId) {
+        if (billId == null) return null;
+        makeNull();
+        printDto = transferIssueNativeSqlService.loadPrintDtoByBillId(billId);
+        if (printDto == null) return null;
+        printDto.setFooterCss(configOptionApplicationController
+                .getLongTextValueByKey("Pharmacy Transfer Issue Bill Footer CSS"));
+        printDto.setFooterText(configOptionApplicationController
+                .getLongTextValueByKey("Pharmacy Transfer Issue Bill Footer Text"));
+        printPreview = true;
+        return "/pharmacy/pharmacy_transfer_issue_native?faces-redirect=true";
+    }
+
     // -----------------------------------------------------------------------
     // Core settlement
     // -----------------------------------------------------------------------

--- a/src/main/java/com/divudi/bean/pharmacy/TransferIssueNativeSqlController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/TransferIssueNativeSqlController.java
@@ -138,10 +138,16 @@ public class TransferIssueNativeSqlController implements Serializable {
     }
 
     public String viewByBillId(Long billId) {
-        if (billId == null) return null;
+        if (billId == null) {
+            JsfUtil.addErrorMessage("No Bill Selected");
+            return null;
+        }
         makeNull();
         printDto = transferIssueNativeSqlService.loadPrintDtoByBillId(billId);
-        if (printDto == null) return null;
+        if (printDto == null) {
+            JsfUtil.addErrorMessage("Bill not found");
+            return null;
+        }
         printDto.setFooterCss(configOptionApplicationController
                 .getLongTextValueByKey("Pharmacy Transfer Issue Bill Footer CSS"));
         printDto.setFooterText(configOptionApplicationController

--- a/src/main/java/com/divudi/bean/pharmacy/TransferReceiveNativeSqlController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/TransferReceiveNativeSqlController.java
@@ -167,10 +167,16 @@ public class TransferReceiveNativeSqlController implements Serializable {
     }
 
     public String viewByBillId(Long billId) {
-        if (billId == null) return null;
+        if (billId == null) {
+            JsfUtil.addErrorMessage("No Bill Selected");
+            return null;
+        }
         makeNull();
         printDto = transferReceiveNativeSqlService.loadPrintDtoByBillId(billId);
-        if (printDto == null) return null;
+        if (printDto == null) {
+            JsfUtil.addErrorMessage("Bill not found");
+            return null;
+        }
         String headerTemplate = configOptionApplicationController
                 .getLongTextValueByKey("Transfer Receive Note Header");
         printDto.setFooterCss(configOptionApplicationController

--- a/src/main/java/com/divudi/bean/pharmacy/TransferReceiveNativeSqlController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/TransferReceiveNativeSqlController.java
@@ -166,6 +166,22 @@ public class TransferReceiveNativeSqlController implements Serializable {
         return "/pharmacy/pharmacy_transfer_receive_native_approval?faces-redirect=true";
     }
 
+    public String viewByBillId(Long billId) {
+        if (billId == null) return null;
+        makeNull();
+        printDto = transferReceiveNativeSqlService.loadPrintDtoByBillId(billId);
+        if (printDto == null) return null;
+        String headerTemplate = configOptionApplicationController
+                .getLongTextValueByKey("Transfer Receive Note Header");
+        printDto.setFooterCss(configOptionApplicationController
+                .getLongTextValueByKey("Pharmacy Transfer Receive Bill Footer CSS"));
+        printDto.setFooterText(configOptionApplicationController
+                .getLongTextValueByKey("Pharmacy Transfer Receive Bill Footer Text"));
+        printDto.setTemplateHeader(fillHeaderDataFromPrintDto(headerTemplate));
+        printPreview = true;
+        return "/pharmacy/pharmacy_transfer_receive_native?faces-redirect=true";
+    }
+
     // -----------------------------------------------------------------------
     // Core settlement
     // -----------------------------------------------------------------------

--- a/src/main/java/com/divudi/core/data/dto/PharmacyTransferReceivedListDTO.java
+++ b/src/main/java/com/divudi/core/data/dto/PharmacyTransferReceivedListDTO.java
@@ -18,6 +18,10 @@ public class PharmacyTransferReceivedListDTO implements Serializable {
     public PharmacyTransferReceivedListDTO() {
     }
 
+    public PharmacyTransferReceivedListDTO(Long billId, Long issuedBillId, String deptId, Boolean cancelled) {
+        this(billId, issuedBillId, deptId, null, cancelled, null, null, null, null);
+    }
+
     public PharmacyTransferReceivedListDTO(Long billId, Long issuedBillId, String deptId,
             Date createdAt, Boolean cancelled, String createrName, Double netTotal,
             String cancelledByName, Date cancelledAt) {

--- a/src/main/java/com/divudi/service/pharmacy/InpatientDirectIssueNativeSqlService.java
+++ b/src/main/java/com/divudi/service/pharmacy/InpatientDirectIssueNativeSqlService.java
@@ -6,13 +6,18 @@
 package com.divudi.service.pharmacy;
 
 import com.divudi.core.data.dto.BillItemData;
+import com.divudi.core.data.dto.PrintBillData;
 import com.divudi.core.data.dto.StockAggregateResult;
 import com.divudi.core.entity.Bill;
 import com.divudi.core.entity.BillFinanceDetails;
 import com.divudi.core.entity.BillItem;
 import com.divudi.core.entity.BillItemFinanceDetails;
+import com.divudi.core.entity.Department;
+import com.divudi.core.entity.Institution;
+import com.divudi.core.entity.PatientEncounter;
 import com.divudi.core.entity.pharmacy.Stock;
 import com.divudi.core.entity.pharmacy.StockHistory;
+import java.util.ArrayList;
 import javax.ejb.Stateless;
 import javax.ejb.TransactionAttribute;
 import javax.ejb.TransactionAttributeType;
@@ -54,6 +59,7 @@ public class InpatientDirectIssueNativeSqlService {
     private volatile String tBill = null;
     private volatile String tBillItem = null;
     private volatile String tPharmBillItem = null;
+    private volatile String tItem = null;
 
     // -----------------------------------------------------------------------
     // Public API
@@ -554,5 +560,90 @@ public class InpatientDirectIssueNativeSqlService {
     private String pharmBillItemTable() {
         if (tPharmBillItem == null) tPharmBillItem = resolveTable("PHARMACEUTICALBILLITEM");
         return tPharmBillItem;
+    }
+
+    private String itemTable() {
+        if (tItem == null) tItem = resolveTable("ITEM");
+        return tItem;
+    }
+
+    private static String safeStr(String s) {
+        return s != null ? s : "";
+    }
+
+    /**
+     * Loads view data for an existing settled inpatient direct issue bill.
+     * Returns Object[]{PatientEncounter, PrintBillData, List&lt;BillItemData&gt;}.
+     * Used by InpatientDirectIssueNativeSqlController.viewByBillId to display
+     * the print preview without triggering a full entity-graph load.
+     */
+    @TransactionAttribute(TransactionAttributeType.REQUIRED)
+    public Object[] loadViewDataByBillId(long billId) {
+        Bill bill = em.find(Bill.class, billId);
+        if (bill == null) {
+            return null;
+        }
+
+        PatientEncounter pe = bill.getPatientEncounter();
+
+        PrintBillData pbd = new PrintBillData();
+        Department dept = bill.getDepartment();
+        if (dept != null) {
+            pbd.setDepartmentName(safeStr(dept.getName()));
+            pbd.setDepartmentPrintingName(dept.getPrintingName() != null
+                    ? dept.getPrintingName() : safeStr(dept.getName()));
+            pbd.setDepartmentTelephone1(safeStr(dept.getTelephone1()));
+            Institution inst = dept.getInstitution();
+            if (inst != null) {
+                pbd.setInstitutionName(safeStr(inst.getName()));
+                pbd.setInstitutionAddress(safeStr(inst.getAddress()));
+            }
+        }
+        if (bill.getPatient() != null && bill.getPatient().getPerson() != null) {
+            pbd.setPatientName(safeStr(bill.getPatient().getPerson().getNameWithTitle()));
+            try {
+                pbd.setPatientAgeSex(safeStr(bill.getPatient().getPerson().getAgeAsShortString())
+                        + " / " + (bill.getPatient().getPerson().getSex() != null
+                                ? bill.getPatient().getPerson().getSex().getLabel() : ""));
+            } catch (Exception ignore) {
+            }
+        }
+        if (pe != null) {
+            pbd.setBhtNo(safeStr(pe.getBhtNo()));
+        }
+        pbd.setBillNo(safeStr(bill.getDeptId()));
+        pbd.setCreatedAt(bill.getCreatedAt());
+        pbd.setNetTotal(Math.abs(bill.getNetTotal()));
+
+        String sql = "SELECT i.name, ABS(bi.qty), COALESCE(bi.rate, bi.netRate, 0),"
+                + " ABS(bi.netRate), ABS(bi.netValue), ABS(bi.grossValue), ib.dateOfExpire"
+                + " FROM " + billItemTable() + " bi"
+                + " JOIN " + pharmBillItemTable() + " pbi ON pbi.billItem_ID = bi.ID"
+                + " JOIN " + itemBatchTable() + " ib ON ib.ID = pbi.itemBatch_ID"
+                + " JOIN " + itemTable() + " i ON i.ID = bi.item_ID"
+                + " WHERE bi.bill_ID = ? AND (bi.retired IS NULL OR bi.retired = 0)"
+                + " ORDER BY bi.ID";
+
+        @SuppressWarnings("unchecked")
+        List<Object[]> rows = em.createNativeQuery(sql)
+                .setParameter(1, billId)
+                .getResultList();
+
+        List<BillItemData> itemList = new ArrayList<>();
+        for (Object[] row : rows) {
+            BillItemData bid = new BillItemData();
+            bid.setItemName(row[0] != null ? row[0].toString() : "");
+            bid.setQty(toDouble(row[1]));
+            bid.setRate(toDouble(row[2]));
+            bid.setNetRate(toDouble(row[3]));
+            bid.setNetValue(toDouble(row[4]));
+            bid.setGrossValue(toDouble(row[5]));
+            bid.setDoe(row[6] instanceof java.sql.Date
+                    ? new java.util.Date(((java.sql.Date) row[6]).getTime())
+                    : (row[6] instanceof java.util.Date ? (java.util.Date) row[6] : null));
+            itemList.add(bid);
+        }
+
+        return new Object[]{pe, pbd, itemList};
     }
 }

--- a/src/main/java/com/divudi/service/pharmacy/RetailSaleNativeSqlService.java
+++ b/src/main/java/com/divudi/service/pharmacy/RetailSaleNativeSqlService.java
@@ -8,15 +8,19 @@ package com.divudi.service.pharmacy;
 import com.divudi.core.data.PaymentMethod;
 import com.divudi.core.data.dataStructure.PaymentMethodData;
 import com.divudi.core.data.dto.BillItemData;
+import com.divudi.core.data.dto.PrintBillData;
 import com.divudi.core.data.dto.StockAggregateResult;
 import com.divudi.core.entity.Bill;
 import com.divudi.core.entity.BillFinanceDetails;
 import com.divudi.core.entity.BillItem;
 import com.divudi.core.entity.BillItemFinanceDetails;
+import com.divudi.core.entity.Department;
+import com.divudi.core.entity.Institution;
 import com.divudi.core.entity.Payment;
 import com.divudi.core.entity.PaymentScheme;
 import com.divudi.core.entity.pharmacy.Stock;
 import com.divudi.core.entity.pharmacy.StockHistory;
+import java.util.ArrayList;
 import javax.ejb.Stateless;
 import javax.ejb.TransactionAttribute;
 import javax.ejb.TransactionAttributeType;
@@ -60,6 +64,7 @@ public class RetailSaleNativeSqlService {
     private volatile String tBill = null;
     private volatile String tBillItem = null;
     private volatile String tPharmBillItem = null;
+    private volatile String tItem = null;
     // -----------------------------------------------------------------------
     // Public API
     // -----------------------------------------------------------------------
@@ -620,5 +625,95 @@ public class RetailSaleNativeSqlService {
     private String pharmBillItemTable() {
         if (tPharmBillItem == null) tPharmBillItem = resolveTable("PHARMACEUTICALBILLITEM");
         return tPharmBillItem;
+    }
+
+    private String itemTable() {
+        if (tItem == null) tItem = resolveTable("ITEM");
+        return tItem;
+    }
+
+    private static String safeStr(String s) {
+        return s != null ? s : "";
+    }
+
+    /**
+     * Loads view data for an existing settled retail sale bill.
+     * Returns Object[]{PrintBillData, List&lt;BillItemData&gt;}.
+     * Used by RetailSaleNativeSqlController.viewByBillId to display
+     * the print preview without triggering a full entity-graph load.
+     */
+    @TransactionAttribute(TransactionAttributeType.REQUIRED)
+    public Object[] loadViewDataByBillId(long billId) {
+        Bill bill = em.find(Bill.class, billId);
+        if (bill == null) {
+            return null;
+        }
+
+        PrintBillData pbd = new PrintBillData();
+        Department dept = bill.getDepartment();
+        if (dept != null) {
+            pbd.setDepartmentName(safeStr(dept.getName()));
+            pbd.setDepartmentPrintingName(dept.getPrintingName() != null
+                    ? dept.getPrintingName() : safeStr(dept.getName()));
+            pbd.setDepartmentTelephone1(safeStr(dept.getTelephone1()));
+            pbd.setDepartmentAddress(safeStr(dept.getAddress()));
+            Institution inst = dept.getInstitution();
+            if (inst != null) {
+                pbd.setInstitutionName(safeStr(inst.getName()));
+                pbd.setInstitutionAddress(safeStr(inst.getAddress()));
+                pbd.setInstitutionEmail(safeStr(inst.getEmail()));
+                pbd.setInstitutionWeb(safeStr(inst.getWeb()));
+            }
+        }
+        pbd.setBillNo(safeStr(bill.getDeptId()));
+        pbd.setCreatedAt(bill.getCreatedAt());
+        if (bill.getCreater() != null) {
+            pbd.setCreatorName(safeStr(bill.getCreater().getName()));
+        }
+        if (bill.getPatient() != null && bill.getPatient().getPerson() != null) {
+            pbd.setPatientName(safeStr(bill.getPatient().getPerson().getNameWithTitle()));
+            pbd.setPatientPhone(safeStr(bill.getPatient().getPerson().getPhone()));
+            pbd.setPatientPhn(safeStr(bill.getPatient().getPhn()));
+        }
+        if (bill.getPaymentMethod() != null) {
+            pbd.setPaymentMethodLabel(bill.getPaymentMethod().getLabel());
+        }
+        if (bill.getPaymentScheme() != null) {
+            pbd.setPaymentSchemePrintingName(bill.getPaymentScheme().getPrintingName() != null
+                    ? bill.getPaymentScheme().getPrintingName() : safeStr(bill.getPaymentScheme().getName()));
+        }
+        pbd.setComment(safeStr(bill.getComments()));
+        pbd.setNetTotal(Math.abs(bill.getNetTotal()));
+
+        String sql = "SELECT i.name, ABS(bi.qty), COALESCE(bi.rate, bi.netRate, 0),"
+                + " ABS(bi.netRate), ABS(bi.netValue), ABS(bi.grossValue), ib.dateOfExpire"
+                + " FROM " + billItemTable() + " bi"
+                + " JOIN " + pharmBillItemTable() + " pbi ON pbi.billItem_ID = bi.ID"
+                + " JOIN " + itemBatchTable() + " ib ON ib.ID = pbi.itemBatch_ID"
+                + " JOIN " + itemTable() + " i ON i.ID = bi.item_ID"
+                + " WHERE bi.bill_ID = ? AND (bi.retired IS NULL OR bi.retired = 0)"
+                + " ORDER BY bi.ID";
+
+        @SuppressWarnings("unchecked")
+        List<Object[]> rows = em.createNativeQuery(sql)
+                .setParameter(1, billId)
+                .getResultList();
+
+        List<BillItemData> itemList = new ArrayList<>();
+        for (Object[] row : rows) {
+            BillItemData bid = new BillItemData();
+            bid.setItemName(row[0] != null ? row[0].toString() : "");
+            bid.setQty(toDouble(row[1]));
+            bid.setRate(toDouble(row[2]));
+            bid.setNetRate(toDouble(row[3]));
+            bid.setNetValue(toDouble(row[4]));
+            bid.setGrossValue(toDouble(row[5]));
+            bid.setDoe(row[6] instanceof java.sql.Date
+                    ? new java.util.Date(((java.sql.Date) row[6]).getTime())
+                    : (row[6] instanceof java.util.Date ? (java.util.Date) row[6] : null));
+            itemList.add(bid);
+        }
+
+        return new Object[]{pbd, itemList};
     }
 }

--- a/src/main/java/com/divudi/service/pharmacy/RetailSaleNativeSqlService.java
+++ b/src/main/java/com/divudi/service/pharmacy/RetailSaleNativeSqlService.java
@@ -683,7 +683,15 @@ public class RetailSaleNativeSqlService {
                     ? bill.getPaymentScheme().getPrintingName() : safeStr(bill.getPaymentScheme().getName()));
         }
         pbd.setComment(safeStr(bill.getComments()));
-        pbd.setNetTotal(Math.abs(bill.getNetTotal()));
+        double net = Math.abs(bill.getNetTotal());
+        double gross = bill.getTotal() > 0 ? bill.getTotal() : net;
+        double disc = Math.max(0, gross - net);
+        pbd.setNetTotal(net);
+        pbd.setTotal(gross);
+        pbd.setDiscount(disc);
+        pbd.setDiscountPercentPharmacy(gross > 0 ? (disc / gross) * 100.0 : 0.0);
+        pbd.setCashPaid(bill.getCashPaid());
+        pbd.setBalance(bill.getCashPaid() - net);
 
         String sql = "SELECT i.name, ABS(bi.qty), COALESCE(bi.rate, bi.netRate, 0),"
                 + " ABS(bi.netRate), ABS(bi.netValue), ABS(bi.grossValue), ib.dateOfExpire"

--- a/src/main/java/com/divudi/service/pharmacy/TransferIssueNativeSqlService.java
+++ b/src/main/java/com/divudi/service/pharmacy/TransferIssueNativeSqlService.java
@@ -13,6 +13,8 @@ import com.divudi.core.entity.Bill;
 import com.divudi.core.entity.BillFinanceDetails;
 import com.divudi.core.entity.BillItem;
 import com.divudi.core.entity.BillItemFinanceDetails;
+import com.divudi.core.entity.Department;
+import com.divudi.core.entity.Institution;
 import com.divudi.core.entity.pharmacy.Stock;
 import com.divudi.core.entity.pharmacy.StockHistory;
 import javax.ejb.Stateless;
@@ -639,6 +641,164 @@ public class TransferIssueNativeSqlService {
         return printDto;
     }
 
+    /**
+     * Loads a TransferIssuePrintDto from an existing settled issue bill.
+     * Used by BillSearch to display the print view without triggering the
+     * full entity-graph load (loadBillDetails) path.
+     */
+    @TransactionAttribute(TransactionAttributeType.REQUIRED)
+    public TransferIssuePrintDto loadPrintDtoByBillId(long billId) {
+        Bill bill = em.find(Bill.class, billId);
+        if (bill == null) {
+            return null;
+        }
+
+        TransferIssuePrintDto dto = new TransferIssuePrintDto();
+        dto.setIssueNo(safeStr(bill.getDeptId()));
+        dto.setIssuedAt(bill.getCreatedAt());
+        dto.setComments(safeStr(bill.getComments()));
+        dto.setNetTotal(Math.abs(bill.getNetTotal()));
+
+        Department fromDept = bill.getFromDepartment() != null ? bill.getFromDepartment() : bill.getDepartment();
+        if (fromDept != null) {
+            dto.setFromDepartmentName(safeStr(fromDept.getName()));
+            dto.setDepartmentPrintingName(fromDept.getPrintingName() != null
+                    ? fromDept.getPrintingName() : safeStr(fromDept.getName()));
+            dto.setDepartmentAddress(safeStr(fromDept.getAddress()));
+            dto.setDepartmentPhone1(safeStr(fromDept.getTelephone1()));
+            dto.setDepartmentPhone2(safeStr(fromDept.getTelephone2()));
+            dto.setDepartmentFax(safeStr(fromDept.getFax()));
+            dto.setDepartmentEmail(safeStr(fromDept.getEmail()));
+            Institution inst = fromDept.getInstitution();
+            if (inst != null) {
+                dto.setInstitutionName(safeStr(inst.getName()));
+                dto.setInstitutionAddress(safeStr(inst.getAddress()));
+                dto.setInstitutionPhone(safeStr(inst.getPhone()));
+                dto.setInstitutionFax(safeStr(inst.getFax()));
+                dto.setInstitutionEmail(safeStr(inst.getEmail()));
+            }
+        }
+
+        Department toDept = bill.getToDepartment();
+        if (toDept != null) {
+            dto.setToDepartmentName(safeStr(toDept.getName()));
+        }
+
+        if (bill.getCreater() != null) {
+            dto.setIssuedByName(bill.getCreater().getWebUserPerson() != null
+                    ? safeStr(bill.getCreater().getWebUserPerson().getName()) : "");
+            dto.setIssuedByStaffCode(bill.getCreater().getStaff() != null
+                    ? safeStr(bill.getCreater().getStaff().getCode()) : "");
+        }
+
+        if (bill.getToStaff() != null && bill.getToStaff().getPerson() != null) {
+            dto.setToStaffName(safeStr(bill.getToStaff().getPerson().getNameWithTitle()));
+            dto.setToStaffCode(safeStr(bill.getToStaff().getCode()));
+        }
+
+        Bill requestBill = bill.getBackwardReferenceBill();
+        if (requestBill != null) {
+            dto.setRequestNo(safeStr(requestBill.getDeptId()));
+            dto.setRequestedAt(requestBill.getCreatedAt());
+            if (toDept == null) {
+                Department reqFromDept = requestBill.getFromDepartment() != null
+                        ? requestBill.getFromDepartment() : requestBill.getDepartment();
+                if (reqFromDept != null) {
+                    dto.setToDepartmentName(safeStr(reqFromDept.getName()));
+                }
+            }
+        }
+
+        String sql = "SELECT COALESCE(bi.searialno, 0), i.name, COALESCE(i.code, ''),"
+                + " ib.batchNo, ib.dateOfExpire,"
+                + " ABS(pbi.qtypacks) AS qty, ABS(pbi.qty) AS qtyInUnits,"
+                + " ABS(bi.rate) AS rate, ABS(bi.netValue) AS netValue,"
+                + " COALESCE(ib.purcahseRate, 0), COALESCE(ib.retailsaleRate, 0),"
+                + " COALESCE(ib.costRate, 0)"
+                + " FROM " + billItemTable() + " bi"
+                + " JOIN " + pharmBillItemTable() + " pbi ON pbi.billItem_ID = bi.ID"
+                + " JOIN " + itemBatchTable() + " ib ON ib.ID = pbi.itemBatch_ID"
+                + " JOIN " + itemTable() + " i ON i.ID = bi.item_ID"
+                + " WHERE bi.bill_ID = ? AND (bi.retired IS NULL OR bi.retired = 0)"
+                + " ORDER BY COALESCE(bi.searialno, 0)";
+
+        @SuppressWarnings("unchecked")
+        List<Object[]> rows = em.createNativeQuery(sql)
+                .setParameter(1, billId)
+                .getResultList();
+
+        List<TransferIssueItemPrintDto> items = new ArrayList<>();
+        int serial = 1;
+        for (Object[] row : rows) {
+            TransferIssueItemPrintDto item = new TransferIssueItemPrintDto();
+            item.setSerialNo(serial++);
+            item.setItemName(row[1] != null ? row[1].toString() : "");
+            item.setItemCode(row[2] != null ? row[2].toString() : "");
+            item.setBatchNo(row[3] != null ? row[3].toString() : "");
+            item.setDateOfExpire(toUtilDate(row[4]));
+            double qty    = toDouble(row[5]);
+            double units  = toDouble(row[6]);
+            double rate   = toDouble(row[7]);
+            double net    = toDouble(row[8]);
+            double prRate = toDouble(row[9]);
+            double rrRate = toDouble(row[10]);
+            double crRate = toDouble(row[11]);
+            item.setQty(qty);
+            item.setQtyInUnits(units);
+            item.setRate(rate);
+            item.setNetRate(rate);
+            item.setNetValue(net);
+            item.setPurchaseRate(prRate);
+            item.setRetailRate(rrRate);
+            item.setCostRate(crRate);
+            BigDecimal unitsBd = BigDecimal.valueOf(units);
+            item.setValueAtPurchaseRate(BigDecimal.valueOf(prRate).multiply(unitsBd));
+            item.setValueAtRetailRate(BigDecimal.valueOf(rrRate).multiply(unitsBd));
+            item.setLineGrossTotal(BigDecimal.valueOf(rate).multiply(BigDecimal.valueOf(qty)));
+            items.add(item);
+        }
+        dto.setItems(items);
+        return dto;
+    }
+
+    /**
+     * Loads a Bill entity for the transfer request view page, eagerly initialising
+     * all lazy associations within the JTA transaction so that the JSF render phase
+     * (which runs without a JPA transaction) can access them on the detached entity.
+     */
+    @TransactionAttribute(TransactionAttributeType.REQUIRED)
+    public Bill loadRequestBillForView(long billId) {
+        Bill bill = em.find(Bill.class, billId);
+        if (bill == null) return null;
+        if (bill.getFromInstitution() != null) bill.getFromInstitution().getName();
+        Department fromDept = bill.getFromDepartment();
+        if (fromDept != null) {
+            fromDept.getName();
+            if (fromDept.getInstitution() != null) fromDept.getInstitution().getName();
+        }
+        if (bill.getToInstitution() != null) bill.getToInstitution().getName();
+        Department toDept = bill.getToDepartment();
+        if (toDept != null) {
+            toDept.getName();
+            if (toDept.getInstitution() != null) toDept.getInstitution().getName();
+        }
+        if (bill.getInstitution() != null) bill.getInstitution().getName();
+        if (bill.getCreater() != null && bill.getCreater().getWebUserPerson() != null) {
+            bill.getCreater().getWebUserPerson().getName();
+        }
+        if (bill.getApproveUser() != null && bill.getApproveUser().getWebUserPerson() != null) {
+            bill.getApproveUser().getWebUserPerson().getName();
+        }
+        if (bill.getForwardReferenceBills() != null) bill.getForwardReferenceBills().size();
+        if (bill.getBillItems() != null) {
+            for (BillItem bi : bill.getBillItems()) {
+                if (bi.getItem() != null) bi.getItem().getName();
+                bi.getPharmaceuticalBillItem();
+            }
+        }
+        return bill;
+    }
+
     // -----------------------------------------------------------------------
     // fullyIssued update
     // -----------------------------------------------------------------------
@@ -1078,6 +1238,10 @@ public class TransferIssueNativeSqlService {
         }
         // grossRate per pack = unitRate * unitsPerPack
         return BigDecimal.valueOf(unitRate * (packSize > 0 ? packSize : 1.0));
+    }
+
+    private static String safeStr(String s) {
+        return s != null ? s : "";
     }
 
     // -----------------------------------------------------------------------

--- a/src/main/java/com/divudi/service/pharmacy/TransferIssueNativeSqlService.java
+++ b/src/main/java/com/divudi/service/pharmacy/TransferIssueNativeSqlService.java
@@ -783,6 +783,7 @@ public class TransferIssueNativeSqlService {
             if (toDept.getInstitution() != null) toDept.getInstitution().getName();
         }
         if (bill.getInstitution() != null) bill.getInstitution().getName();
+        if (bill.getDepartment() != null) bill.getDepartment().getName();
         if (bill.getCreater() != null && bill.getCreater().getWebUserPerson() != null) {
             bill.getCreater().getWebUserPerson().getName();
         }

--- a/src/main/java/com/divudi/service/pharmacy/TransferReceiveNativeSqlService.java
+++ b/src/main/java/com/divudi/service/pharmacy/TransferReceiveNativeSqlService.java
@@ -13,6 +13,8 @@ import com.divudi.core.entity.Bill;
 import com.divudi.core.entity.BillFinanceDetails;
 import com.divudi.core.entity.BillItem;
 import com.divudi.core.entity.BillItemFinanceDetails;
+import com.divudi.core.entity.Department;
+import com.divudi.core.entity.Institution;
 import com.divudi.core.entity.pharmacy.Stock;
 import com.divudi.core.entity.pharmacy.StockHistory;
 import javax.ejb.Stateless;
@@ -515,6 +517,137 @@ public class TransferReceiveNativeSqlService {
         }
         printDto.setItems(printItems);
         return printDto;
+    }
+
+    /**
+     * Loads a TransferReceivePrintDto from an existing settled receive bill.
+     * Used by BillSearch to display the print view without triggering the
+     * full entity-graph load (loadBillDetails) path.
+     */
+    @TransactionAttribute(TransactionAttributeType.REQUIRED)
+    public TransferReceivePrintDto loadPrintDtoByBillId(long billId) {
+        Bill bill = em.find(Bill.class, billId);
+        if (bill == null) {
+            return null;
+        }
+
+        TransferReceivePrintDto dto = new TransferReceivePrintDto();
+        dto.setReceiveNo(safeStr(bill.getDeptId()));
+        dto.setReceivedAt(bill.getCreatedAt());
+        dto.setComments(safeStr(bill.getComments()));
+        dto.setNetTotal(Math.abs(bill.getNetTotal()));
+
+        Department dept = bill.getDepartment() != null ? bill.getDepartment() : bill.getToDepartment();
+        if (dept != null) {
+            dto.setToDepartmentName(safeStr(dept.getName()));
+            dto.setDepartmentPrintingName(dept.getPrintingName() != null
+                    ? dept.getPrintingName() : safeStr(dept.getName()));
+            dto.setDepartmentAddress(safeStr(dept.getAddress()));
+            dto.setDepartmentPhone1(safeStr(dept.getTelephone1()));
+            dto.setDepartmentPhone2(safeStr(dept.getTelephone2()));
+            dto.setDepartmentFax(safeStr(dept.getFax()));
+            dto.setDepartmentEmail(safeStr(dept.getEmail()));
+            String phones = safeStr(dept.getTelephone1());
+            String p2 = safeStr(dept.getTelephone2());
+            if (!p2.isEmpty()) phones += " / " + p2;
+            dto.setInstitutionPhone(phones);
+            Institution inst = dept.getInstitution();
+            if (inst != null) {
+                dto.setInstitutionName(safeStr(inst.getName()));
+                dto.setInstitutionAddress(safeStr(inst.getAddress()));
+                dto.setInstitutionFax(safeStr(inst.getFax()));
+                dto.setInstitutionEmail(safeStr(inst.getEmail()));
+            }
+        }
+
+        if (bill.getCreater() != null) {
+            dto.setReceivedByName(bill.getCreater().getWebUserPerson() != null
+                    ? safeStr(bill.getCreater().getWebUserPerson().getName()) : "");
+            dto.setReceivedByStaffCode(bill.getCreater().getStaff() != null
+                    ? safeStr(bill.getCreater().getStaff().getCode()) : "");
+        }
+
+        if (bill.getApproveUser() != null) {
+            dto.setApprovedByName(bill.getApproveUser().getWebUserPerson() != null
+                    ? safeStr(bill.getApproveUser().getWebUserPerson().getName()) : "");
+            dto.setApprovedAt(bill.getApproveAt());
+        }
+
+        Bill issueBill = bill.getBackwardReferenceBill();
+        if (issueBill != null) {
+            dto.setIssueNo(safeStr(issueBill.getDeptId()));
+            dto.setIssuedAt(issueBill.getCreatedAt());
+            dto.setIssuedNetTotal(Math.abs(issueBill.getNetTotal()));
+            Department fromDept = issueBill.getFromDepartment() != null
+                    ? issueBill.getFromDepartment() : issueBill.getDepartment();
+            if (fromDept != null) {
+                dto.setFromDepartmentName(safeStr(fromDept.getName()));
+            }
+            if (issueBill.getCreater() != null) {
+                dto.setIssuedByName(issueBill.getCreater().getWebUserPerson() != null
+                        ? safeStr(issueBill.getCreater().getWebUserPerson().getName()) : "");
+            }
+            if (issueBill.getToStaff() != null && issueBill.getToStaff().getPerson() != null) {
+                dto.setTransporterName(safeStr(issueBill.getToStaff().getPerson().getNameWithTitle()));
+            }
+        }
+
+        String sql = "SELECT COALESCE(bi.searialNo, 0), i.name, COALESCE(i.code, ''),"
+                + " ib.batchNo, ib.dateOfExpire,"
+                + " ABS(bi.qty) AS qty, ABS(pbi.qty) AS qtyInUnits,"
+                + " ABS(bi.rate) AS rate, ABS(bi.netValue) AS netValue,"
+                + " COALESCE(ib.purcahseRate, 0), COALESCE(ib.retailsaleRate, 0),"
+                + " COALESCE(ib.costRate, 0)"
+                + " FROM " + billItemTable() + " bi"
+                + " JOIN " + pharmBillItemTable() + " pbi ON pbi.billItem_ID = bi.ID"
+                + " JOIN " + itemBatchTable() + " ib ON ib.ID = pbi.itemBatch_ID"
+                + " JOIN " + itemTable() + " i ON i.ID = bi.item_ID"
+                + " WHERE bi.bill_ID = ? AND (bi.retired IS NULL OR bi.retired = 0)"
+                + " ORDER BY COALESCE(bi.searialNo, 0), bi.ID";
+
+        @SuppressWarnings("unchecked")
+        List<Object[]> rows = em.createNativeQuery(sql)
+                .setParameter(1, billId)
+                .getResultList();
+
+        List<TransferReceiveItemPrintDto> items = new ArrayList<>();
+        int serial = 1;
+        for (Object[] row : rows) {
+            TransferReceiveItemPrintDto item = new TransferReceiveItemPrintDto();
+            item.setSerialNo(serial++);
+            item.setItemName(row[1] != null ? row[1].toString() : "");
+            item.setItemCode(row[2] != null ? row[2].toString() : "");
+            item.setBatchNo(row[3] != null ? row[3].toString() : "");
+            item.setDateOfExpire(row[4] instanceof java.sql.Date
+                    ? new Date(((java.sql.Date) row[4]).getTime())
+                    : (row[4] instanceof Date ? (Date) row[4] : null));
+            double qty    = toDouble(row[5]);
+            double units  = toDouble(row[6]);
+            double rate   = toDouble(row[7]);
+            double net    = toDouble(row[8]);
+            double prRate = toDouble(row[9]);
+            double rrRate = toDouble(row[10]);
+            double crRate = toDouble(row[11]);
+            item.setQty(qty);
+            item.setQtyInUnits(units);
+            item.setRate(rate);
+            item.setNetRate(rate);
+            item.setNetValue(net);
+            item.setPurchaseRate(prRate);
+            item.setRetailRate(rrRate);
+            item.setCostRate(crRate);
+            BigDecimal unitsBd = BigDecimal.valueOf(units);
+            item.setValueAtPurchaseRate(BigDecimal.valueOf(prRate).multiply(unitsBd));
+            item.setValueAtRetailRate(BigDecimal.valueOf(rrRate).multiply(unitsBd));
+            item.setLineGrossTotal(BigDecimal.valueOf(rate).multiply(BigDecimal.valueOf(qty)));
+            items.add(item);
+        }
+        dto.setItems(items);
+        return dto;
+    }
+
+    private static String safeStr(String s) {
+        return s != null ? s : "";
     }
 
     // -----------------------------------------------------------------------

--- a/src/main/webapp/pharmacy/pharmacy_transfer_issued_list.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_transfer_issued_list.xhtml
@@ -76,7 +76,11 @@
                             rowsPerPageTemplate="5,10,15"
                             >
                             <p:column headerText="Issue No" width="6em">
-                                <h:outputLabel value="#{p.deptId}"/>
+                                <p:commandLink
+                                    ajax="false"
+                                    value="#{p.deptId}"
+                                    styleClass="#{p.cancelled ? 'text-danger text-decoration-line-through' : ''}"
+                                    action="#{transferIssueNativeSqlController.viewByBillId(p.billId)}"/>
                             </p:column>
                             <p:column headerText="From Department" width="150px">
                                 <h:outputLabel value="#{p.fromDepartmentName}"/>
@@ -134,51 +138,17 @@
 
                             </p:column>
 
-                            <p:column headerText="Received" style="text-align: center">
-                                <p:dataTable var="b" value="#{p.receivedBills}">
-                                    <p:column  >
-                                        <h:outputLabel  value="#{b.deptId}"/>
-                                    </p:column>
-                                    <p:column >
-                                        <h:outputLabel value="#{b.createdAt}" >
-                                            <f:convertDateTime  timeZone="Asia/Colombo" pattern="#{sessionController.applicationPreference.longDateTimeFormat}" />
-                                        </h:outputLabel>
-                                        <br/>
-                                        <h:panelGroup rendered="#{b.cancelled}" >
-                                            <h:outputLabel style="color: red;" value="Cancelled At " />
-                                            <h:outputLabel style="color: red;" value="#{b.cancelledAt}" >
-                                                <f:convertDateTime  timeZone="Asia/Colombo" pattern="#{sessionController.applicationPreference.longDateTimeFormat}" />
-                                            </h:outputLabel>
-                                        </h:panelGroup>
-                                    </p:column>
-                                    <p:column >
-                                        <h:outputLabel value="#{b.createrName}" >
-                                        </h:outputLabel>
-                                        <br/>
-                                        <h:panelGroup rendered="#{b.cancelled}" >
-                                            <h:outputLabel style="color: red;" value="Cancelled By " />
-                                            <h:outputLabel style="color: red;" value="#{b.cancelledByName}" />
-                                        </h:panelGroup>
-                                    </p:column>
-                                    <p:column rendered="#{webUserController.hasPrivilege('PharmacyTransferViewRates')}">
-                                        <h:outputLabel value="#{b.netTotal}">
-                                            <f:convertNumber pattern="#,##0.00" />
-                                        </h:outputLabel>
-                                    </p:column>
-                                    <p:column>
-                                        <p:commandButton
-                                            class="m-1"
-                                            icon="fa fa-eye"
-                                            title="View Recieve Issue"
-                                            ajax="false"
-                                            action="#{transferReceiveController.navigateToReprintRecieveIssue()}"
-                                            disabled="#{b.issuedBillId == null}"
-                                            >
-                                            <f:setPropertyActionListener target="#{pharmacyBillSearch.billId}" value="#{b.billId}"/>
-                                        </p:commandButton>
-                                    </p:column>
-
-                                </p:dataTable>
+                            <p:column headerText="Received">
+                                <ui:repeat value="#{p.receivedBills}" var="b" varStatus="loop">
+                                    <p:commandLink
+                                        ajax="false"
+                                        value="#{b.deptId}"
+                                        styleClass="#{b.cancelled ? 'text-danger text-decoration-line-through' : ''}"
+                                        action="#{billSearch.navigateToViewBillByAtomicBillTypeBySelectedId}">
+                                        <f:setPropertyActionListener value="#{b.billId}" target="#{billSearch.selectedBillId}"/>
+                                    </p:commandLink>
+                                    <h:outputText value=", " rendered="#{!loop.last}"/>
+                                </ui:repeat>
                             </p:column>
 
                         </p:dataTable>


### PR DESCRIPTION
## Summary

- **`BillSearch` dispatcher**: `navigateToViewBillByAtomicBillType()` is now a fast dispatcher. For `PHARMACY_ISSUE`, `PHARMACY_RECEIVE`, `DIRECT_ISSUE_INWARD_MEDICINE`, `PHARMACY_RETAIL_SALE`, `PHARMACY_TRANSFER_REQUEST_PRE`, and `PHARMACY_TRANSFER_REQUEST` it routes directly to the native-SQL path, completely bypassing the expensive `loadBillDetails()` entity-graph load. All other bill types fall through to the renamed `navigateToViewBillByAtomicBillTypeEntityBased()` which preserves the original behaviour.
- **Four native controllers** (`TransferIssueNativeSqlController`, `TransferReceiveNativeSqlController`, `InpatientDirectIssueNativeSqlController`, `RetailSaleNativeSqlController`) each gain a `viewByBillId(Long)` method that populates the print DTO/data within a JTA transaction and navigates to the relevant print page.
- **Four native services** gain the matching load methods: `loadPrintDtoByBillId()` for issue/receive (returns `TransferIssuePrintDto` / `TransferReceivePrintDto`), `loadViewDataByBillId()` for inpatient-direct and retail-sale (returns `Object[]{PrintBillData, List<BillItemData>}`), and `loadRequestBillForView()` in `TransferIssueNativeSqlService` for transfer-request bills (touches all lazy associations within the transaction so the detached entity renders safely).
- **`PharmacyBillSearch`**: `navigateToViewPharmacyTransferRequestById()` now delegates to `viewRequestByBillId(Long)` using the fast service method, removing the slow lazy-load-outside-transaction path for request bill viewing.
- **`pharmacy_transfer_issued_list.xhtml`**: Issue No column changed from a plain label to a `p:commandLink` calling `transferIssueNativeSqlController.viewByBillId(p.billId)` directly.
- Removes duplicate `toDouble()` helper methods that caused compilation errors in `RetailSaleNativeSqlService` and `InpatientDirectIssueNativeSqlService`.

## Test plan

- [ ] Open `pharmacy_transfer_request_list.xhtml` → click **View Request** (eye icon) → verify request print page loads quickly
- [ ] On the same page, click an issued bill link in the **Issued** column → verify transfer issue print view loads quickly
- [ ] Open `pharmacy_transfer_issued_list.xhtml` → click an **Issue No** link → verify transfer issue print page loads quickly
- [ ] On the same page, click a received bill link in the **Received** column → verify transfer receive print page loads quickly
- [ ] Open a retail sale bill from any bill search → verify retail sale print view loads quickly
- [ ] Open a direct inpatient issue bill from any bill search → verify inpatient issue print view loads quickly
- [ ] Verify all other bill types (OPD, channel, GRN, etc.) still navigate correctly via the entity-based fallback

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded pharmacy bill viewing: direct preview/reprint support for inpatient direct issues, retail sales, transfer issues and receives, and pharmacy issue/receive flows.
  * Transfer lists enhanced: issue numbers and received departments are now clickable for fast navigation; cancelled items show strikethrough styling.
  * Improved transfer-receive listing rendering for clearer, comma-separated received entries.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hmislk/hmis/pull/20604)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->