### PR TITLE
20611 - OPD Batch Bill Cancellation: per-department-type approval gating and NPE guard.

### DIFF
--- a/src/main/java/com/divudi/bean/common/OpdBatchBillCancellationController.java
+++ b/src/main/java/com/divudi/bean/common/OpdBatchBillCancellationController.java
@@ -1143,8 +1143,8 @@ public class OpdBatchBillCancellationController implements Serializable, Control
         hash.put("val", 0.1);
         hash.put("company", institution);
         hash.put("ins", getSessionController().getInstitution());
-      //hash.put("dep", getSessionController().getDepartment());
-      //hash.put("pm", PaymentMethod.Credit);
+        //hash.put("dep", getSessionController().getDepartment());
+        //hash.put("pm", PaymentMethod.Credit);
         List<Bill> bill = getFacade().findByJpql(sql, hash);
 
         if (bill == null) {
@@ -1958,7 +1958,29 @@ public class OpdBatchBillCancellationController implements Serializable, Control
             return "";
         }
 
-        if (configOptionApplicationController.getBooleanValueByKey("Mandatory permission to cancel bills.", false)) {
+        boolean needPermissionToCancel = false;
+
+        for (Bill b : bills) {
+            DepartmentType toBillDepartmentType = b.getToDepartment().getDepartmentType();
+
+            if (toBillDepartmentType == null) {
+                System.out.println("To Bill Department Type is Null. Now Assign Other Department Type to it.");
+                toBillDepartmentType = DepartmentType.Other;
+            }
+
+            boolean allowType = configOptionApplicationController.getBooleanValueByKey("OPD Billing - Mandatory permission to cancel " + toBillDepartmentType.getLabel() + " type bills", false);
+
+            System.out.println(b.getDeptId() + " --> " + toBillDepartmentType.getLabel() + " --> " + allowType);
+
+            if (allowType == true) {
+                needPermissionToCancel = true;
+                continue;
+            }
+        }
+
+        System.out.println("Need Permission to Cancel = " + needPermissionToCancel);
+
+        if (configOptionApplicationController.getBooleanValueByKey("Mandatory permission to cancel bills.", false) && needPermissionToCancel) {
             currentRequest = requestService.findRequest(batchBill);
 
             if (currentRequest == null) {
@@ -2278,9 +2300,10 @@ public class OpdBatchBillCancellationController implements Serializable, Control
     }
 
     /**
-     * Creates a deep copy of the current paymentMethodData to store as originalPaymentMethodData.
-     * This allows restoration of original payment details if user changes payment method and then
-     * switches back to the original payment method.
+     * Creates a deep copy of the current paymentMethodData to store as
+     * originalPaymentMethodData. This allows restoration of original payment
+     * details if user changes payment method and then switches back to the
+     * original payment method.
      */
     private void captureOriginalPaymentMethodData() {
         if (paymentMethodData == null) {
@@ -2292,8 +2315,9 @@ public class OpdBatchBillCancellationController implements Serializable, Control
     }
 
     /**
-     * Creates a deep copy of PaymentMethodData including all ComponentDetail objects.
-     * This ensures that modifications to the copy don't affect the original and vice versa.
+     * Creates a deep copy of PaymentMethodData including all ComponentDetail
+     * objects. This ensures that modifications to the copy don't affect the
+     * original and vice versa.
      */
     private PaymentMethodData deepCopyPaymentMethodData(PaymentMethodData source) {
         if (source == null) {
@@ -2345,14 +2369,15 @@ public class OpdBatchBillCancellationController implements Serializable, Control
     }
 
     /**
-     * Creates a deep copy of a ComponentDetail object including all its properties and
-     * nested ComponentDetail lists for multiple payment methods.
+     * Creates a deep copy of a ComponentDetail object including all its
+     * properties and nested ComponentDetail lists for multiple payment methods.
      *
-     * Note: This method intentionally does NOT deep copy the nested PaymentMethodData
-     * to avoid infinite recursion, since PaymentMethodData contains ComponentDetail
-     * objects which in turn can have PaymentMethodData. The nested PaymentMethodData
-     * in ComponentDetail is used for multiple payment methods and is handled separately
-     * through the multiplePaymentMethodComponentDetails list.
+     * Note: This method intentionally does NOT deep copy the nested
+     * PaymentMethodData to avoid infinite recursion, since PaymentMethodData
+     * contains ComponentDetail objects which in turn can have
+     * PaymentMethodData. The nested PaymentMethodData in ComponentDetail is
+     * used for multiple payment methods and is handled separately through the
+     * multiplePaymentMethodComponentDetails list.
      */
     private ComponentDetail deepCopyComponentDetail(ComponentDetail source) {
         if (source == null) {
@@ -2378,7 +2403,6 @@ public class OpdBatchBillCancellationController implements Serializable, Control
         // Note: We intentionally skip deep copying paymentMethodData here to avoid
         // infinite recursion. The ComponentDetail's paymentMethodData is only used
         // for nested multiple payment methods, which are handled below.
-
         // Deep copy multiple payment method component details
         if (source.getMultiplePaymentMethodComponentDetails() != null
                 && !source.getMultiplePaymentMethodComponentDetails().isEmpty()) {
@@ -3860,7 +3884,6 @@ public class OpdBatchBillCancellationController implements Serializable, Control
         if (omitPaymentGeneratedBills != null && omitPaymentGeneratedBills) {
             jpql += " AND (b.paymentGenerated = false OR b.paymentGenerated = 0 OR b.paymentGenerated IS NULL)";
         }
-        
 
         return getBillFacade().findByJpql(jpql, params, TemporalType.TIMESTAMP);
     }
@@ -5877,10 +5900,9 @@ public class OpdBatchBillCancellationController implements Serializable, Control
     }
 
     // ============= Original Payment Details Methods =============
-
     /**
-     * Load and store original payment details from batch bill
-     * This ensures payment details are available throughout the cancellation process
+     * Load and store original payment details from batch bill This ensures
+     * payment details are available throughout the cancellation process
      */
     public void loadOriginalPaymentDetails() {
         System.out.println("=== loadOriginalPaymentDetails() CALLED (Batch Bill) ===");
@@ -5953,11 +5975,13 @@ public class OpdBatchBillCancellationController implements Serializable, Control
     /**
      * Get the actual payment method from Payment entity.
      *
-     * The payment method is ALWAYS stored correctly in the Payment.paymentMethod field.
+     * The payment method is ALWAYS stored correctly in the
+     * Payment.paymentMethod field.
      *
      * Note: Even for bills with bill.paymentMethod = 'MultiplePaymentMethods',
-     * each individual Payment record stores its actual method (Cash, Card, Cheque, etc.)
-     * This was verified in production database - NO Payment records have paymentMethod = 'MultiplePaymentMethods'.
+     * each individual Payment record stores its actual method (Cash, Card,
+     * Cheque, etc.) This was verified in production database - NO Payment
+     * records have paymentMethod = 'MultiplePaymentMethods'.
      *
      * @param payment The payment entity
      * @return The actual payment method stored in the database
@@ -6040,7 +6064,6 @@ public class OpdBatchBillCancellationController implements Serializable, Control
     }
 
     // ======== Getter and Setter Methods for Original Payment Details ========
-
     /**
      * Get stored original payment details loaded during navigation
      *
@@ -6080,10 +6103,10 @@ public class OpdBatchBillCancellationController implements Serializable, Control
     }
 
     // ============= Payment Data Copy Methods =============
-
     /**
-     * Copy payment method data from an original payment component detail
-     * Used by UI payment pickers to populate fields when user selects an original payment
+     * Copy payment method data from an original payment component detail Used
+     * by UI payment pickers to populate fields when user selects an original
+     * payment
      *
      * @param originalPm The original payment component detail to copy from
      */

--- a/src/main/java/com/divudi/bean/common/OpdBatchBillCancellationController.java
+++ b/src/main/java/com/divudi/bean/common/OpdBatchBillCancellationController.java
@@ -1961,10 +1961,12 @@ public class OpdBatchBillCancellationController implements Serializable, Control
         boolean needPermissionToCancel = false;
 
         for (Bill b : bills) {
-            DepartmentType toBillDepartmentType = b.getToDepartment().getDepartmentType();
-            if (toBillDepartmentType == null) {
-                toBillDepartmentType = DepartmentType.Other;
+            DepartmentType toBillDepartmentType = DepartmentType.Other;
+            
+            if(b.getToDepartment() != null && b.getToDepartment().getDepartmentType() != null){
+                toBillDepartmentType = b.getToDepartment().getDepartmentType();
             }
+
             boolean allowType = configOptionApplicationController.getBooleanValueByKey("OPD Billing - Mandatory permission to cancel " + toBillDepartmentType.getLabel() + " type bills", false);
 
             if (allowType == true) {

--- a/src/main/java/com/divudi/bean/common/OpdBatchBillCancellationController.java
+++ b/src/main/java/com/divudi/bean/common/OpdBatchBillCancellationController.java
@@ -1962,23 +1962,16 @@ public class OpdBatchBillCancellationController implements Serializable, Control
 
         for (Bill b : bills) {
             DepartmentType toBillDepartmentType = b.getToDepartment().getDepartmentType();
-
             if (toBillDepartmentType == null) {
-                System.out.println("To Bill Department Type is Null. Now Assign Other Department Type to it.");
                 toBillDepartmentType = DepartmentType.Other;
             }
-
             boolean allowType = configOptionApplicationController.getBooleanValueByKey("OPD Billing - Mandatory permission to cancel " + toBillDepartmentType.getLabel() + " type bills", false);
-
-            System.out.println(b.getDeptId() + " --> " + toBillDepartmentType.getLabel() + " --> " + allowType);
 
             if (allowType == true) {
                 needPermissionToCancel = true;
                 continue;
             }
         }
-
-        System.out.println("Need Permission to Cancel = " + needPermissionToCancel);
 
         if (configOptionApplicationController.getBooleanValueByKey("Mandatory permission to cancel bills.", false) && needPermissionToCancel) {
             currentRequest = requestService.findRequest(batchBill);

--- a/src/main/java/com/divudi/bean/inward/InwardSearch.java
+++ b/src/main/java/com/divudi/bean/inward/InwardSearch.java
@@ -203,10 +203,10 @@ public class InwardSearch implements Serializable {
             return "";
         }
 
-        DepartmentType toBillDepartmentType = bill.getToDepartment().getDepartmentType();
-        
-        if(toBillDepartmentType == null){
-            toBillDepartmentType = DepartmentType.Other;
+        DepartmentType toBillDepartmentType = DepartmentType.Other;
+
+        if (bill.getToDepartment() != null && bill.getToDepartment().getDepartmentType() != null) {
+            toBillDepartmentType = bill.getToDepartment().getDepartmentType();
         }
 
         boolean allowType = configOptionApplicationController.getBooleanValueByKey("Inward Billing - Mandatory permission to cancel " + toBillDepartmentType.getLabel() + " type bills", false);

--- a/src/main/java/com/divudi/bean/inward/InwardSearch.java
+++ b/src/main/java/com/divudi/bean/inward/InwardSearch.java
@@ -204,6 +204,10 @@ public class InwardSearch implements Serializable {
         }
 
         DepartmentType toBillDepartmentType = bill.getToDepartment().getDepartmentType();
+        
+        if(toBillDepartmentType == null){
+            toBillDepartmentType = DepartmentType.Other;
+        }
 
         boolean allowType = configOptionApplicationController.getBooleanValueByKey("Inward Billing - Mandatory permission to cancel " + toBillDepartmentType.getLabel() + " type bills", false);
 

--- a/src/main/webapp/opd/batch_bill_cancel.xhtml
+++ b/src/main/webapp/opd/batch_bill_cancel.xhtml
@@ -25,7 +25,7 @@
                                             id="commentsMenu"
                                             value="#{opdBatchBillCancellationController.comment}"
                                             editable="true"
-                                            disabled="#{configOptionApplicationController.getBooleanValueByKey('Mandatory permission to cancel bills.', false)}"
+                                            disabled="#{opdBatchBillCancellationController.batchBill.currentRequest ne null}"
                                             filter="true"
                                             placeholder="Select or enter a comment"
                                             filterMatchMode="contains"

--- a/src/main/webapp/opd/opd_batch_bill_print.xhtml
+++ b/src/main/webapp/opd/opd_batch_bill_print.xhtml
@@ -251,9 +251,9 @@
                                                     disabled="#{opdBillController.batchBill.cancelled or opdBillController.batchBill.refunded}"
                                                     action="#{opdBatchBillCancellationController.navigateToCancelOpdBatchBill()}" 
                                                     styleClass="ui-button-danger">
-                                                    <f:setPropertyActionListener 
-                                                        value="#{opdBillController.batchBill}" 
-                                                        target="#{opdBatchBillCancellationController.batchBill}" />
+                                                    <f:setPropertyActionListener value="#{opdBillController.batchBill}" target="#{opdBatchBillCancellationController.batchBill}" />
+                                                    <f:setPropertyActionListener value="#{opdBillController.bills}" target="#{opdBatchBillCancellationController.bills}" />
+
                                                 </p:commandButton>
                                             </div>
                                         </div>


### PR DESCRIPTION
## Summary
  Aligns OPD batch bill cancellation approval logic with the existing Inward pattern, adds a null-safety guard for `DepartmentType`, fixes the disabled state of the cancellation comment field, and passes the batch's child bills from the print screen so the new per-bill evaluation has data to operate on.

  ## Changes

  ### `OpdBatchBillCancellationController.java`
  - `navigateToCancelOpdBatchBill()` now iterates the batch's `bills` and, for each bill, reads the per-type config key `OPD Billing - Mandatory permission to cancel <DepartmentType.label> type bills`.
  - A new local `needPermissionToCancel` flag is set to `true` only if at least one bill's department type has its per-type key enabled.
  - The request/approval path is now triggered only when **both** the global `Mandatory permission to cancel bills.` flag **and** `needPermissionToCancel` are true.
  - Adds null-safe defaulting of `DepartmentType` to `DepartmentType.Other` before constructing the config key.
  - Minor Javadoc/whitespace reflows in unrelated helper methods (no behaviour change).

  ### `InwardSearch.java`
  - Adds the same null-safe guard: when `bill.getToDepartment().getDepartmentType()` is `null`, it is treated as `DepartmentType.Other` so the subsequent `.getLabel()` lookup cannot NPE.

  ### `batch_bill_cancel.xhtml`
  - The cancellation comment dropdown's `disabled` attribute is changed from the global config flag to  `#{opdBatchBillCancellationController.batchBill.currentRequest ne null}`,  so the comment is editable until an approval request actually exists for the  batch bill.

  ### `opd_batch_bill_print.xhtml`
  - The "Cancel Batch Bill" command button now also propagates the batch's `bills` collection to the cancellation controller via an additional `f:setPropertyActionListener`. Without this, the new per-bill evaluation in the controller would operate on a null/empty list.

  ## Files Changed
  - `src/main/java/com/divudi/bean/common/OpdBatchBillCancellationController.java`
  - `src/main/java/com/divudi/bean/inward/InwardSearch.java`
  - `src/main/webapp/opd/batch_bill_cancel.xhtml`
  - `src/main/webapp/opd/opd_batch_bill_print.xhtml`

  ## Why
  - Brings the OPD batch cancellation flow in line with the existing Inward pattern (`Inward Billing - Mandatory permission to cancel <Type> type bills`), so sites can selectively require approval per department type instead of an  all-or-nothing global flag.
  - Prevents an NPE on `DepartmentType.getLabel()` when a department is configured without a department type.
  - Restores the cashier's ability to pick a cancellation reason on the cancellation screen.

  ## Backward Compatibility
  - Default state of every new `OPD Billing - Mandatory permission to cancel <Type> type bills` key is `false`. If a site does not configure any per-type keys, `needPermissionToCancel` evaluates to `false` and the approval flow is **not** triggered, even with the global flag on. Sites must opt in.
  - No DB schema changes. No DTO/entity changes. No new privileges.

  ## Configuration
  New (per-type, OPD): `OPD Billing - Mandatory permission to cancel <DepartmentType.label> type bills`  (e.g., `OPD Billing - Mandatory permission to cancel Pharmacy type bills`).

  Created on demand by `configOptionApplicationController.getBooleanValueByKey(..., false)` - no migration script needed.

  ## Test Plan
  - [ ] Global flag ON, no per-type keys → cancel OPD batch bill → proceeds without entering the request flow.
  - [ ] Global flag ON, per-type key for a department in the batch set to TRUE  → cancel OPD batch bill → request flow is triggered.
  - [ ] Global flag OFF, per-type keys set to TRUE → cancel OPD batch bill →  proceeds without entering the request flow (global flag still gates).
  - [ ] Bill in batch with `toDepartment.departmentType = null` → no NPE; the  bill is evaluated as `Other`.
  - [ ] Inward service bill cancellation with `departmentType = null` → no NPE.
  - [ ] Comment dropdown on `batch_bill_cancel.xhtml` is editable until a  `Request` is created; read-only afterwards.
  - [ ] Navigation from `opd_batch_bill_print.xhtml` → cancellation screen  shows the batch's child bills (`bills` populated on the controller).

  ## Related Issue
  Closes #20611