### PR TITLE
19540-need-drop-menu-for-institution-and-department-in-inpatient-service-summary

### DIFF
--- a/src/main/webapp/inward/report_md_inward_item.xhtml
+++ b/src/main/webapp/inward/report_md_inward_item.xhtml
@@ -54,14 +54,16 @@
                     </p:selectOneMenu>
 
                     <p:outputLabel for="ins" value="Institution" />
-                    <p:autoComplete class="w-100"
-                                    inputStyleClass="w-100" id="ins" value="#{mdInwardReportController.institution}"
-                                    completeMethod="#{institutionController.completeIns}"
-                                    var="ix" itemLabel="#{ix.name}" itemValue="#{ix}" >
-                        <p:column>
-                            #{ix.name}
-                        </p:column>
-                    </p:autoComplete>
+                    <p:selectOneMenu class="w-100" id="ins"
+                                     value="#{mdInwardReportController.institution}"
+                                     filter="true"
+                                     filterMatchMode="contains"
+                                     autoWidth="false">
+                        <f:selectItem itemLabel="All Institutions" itemValue="#{null}" />
+                        <f:selectItems value="#{institutionController.items}"
+                                       var="ix" itemLabel="#{ix.name}" itemValue="#{ix}" />
+                        <f:ajax event="change" listener="#{mdInwardReportController.makeBillNull}" />
+                    </p:selectOneMenu>
 
                     <h:outputLabel for="siteMenu" value="Site"/>
                     <p:selectOneMenu class="w-100" id="siteMenu"
@@ -73,9 +75,16 @@
                     </p:selectOneMenu>
 
                     <p:outputLabel for="dept" value="Department" />
-                    <p:autoComplete class="w-100"
-                                    inputStyleClass="w-100"  id="dept" completeMethod="#{departmentController.completeDept}" var="dept" itemLabel="#{dept.name}" itemValue="#{dept}" forceSelection="true" value="#{mdInwardReportController.dept}"  >
-                    </p:autoComplete>
+                    <p:selectOneMenu class="w-100" id="dept"
+                                     value="#{mdInwardReportController.dept}"
+                                     filter="true"
+                                     filterMatchMode="contains"
+                                     autoWidth="false">
+                        <f:selectItem itemLabel="All Departments" itemValue="#{null}" />
+                        <f:selectItems value="#{departmentController.items}"
+                                       var="dept" itemLabel="#{dept.name}" itemValue="#{dept}" />
+                        <f:ajax event="change" listener="#{mdInwardReportController.makeBillNull}" />
+                    </p:selectOneMenu>
                     <p:outputLabel for="ct" value="Category" />
                     <p:autoComplete value="#{mdInwardReportController.category}" id="ct"
                                     forceSelection="true"
@@ -140,7 +149,7 @@
                         value="Download Excel"
                         actionListener="#{mdInwardReportController.processInpatientServiceSummary}"
                         class="ui-button-success mx-2">
-                        <p:dataExporter type="xlsx" target="tbl" fileName="report_md_inward_item" />
+                        <p:dataExporter type="xlsx" target="tbl" fileName="service_summary_report" />
                     </p:commandButton>
                     <p:commandButton
                         icon="fas fa-print"


### PR DESCRIPTION
closes #19540 
Added dropdown menu on institution and department in inpatient service summary. Also changed file name of downloaded excel sheet.
changed file -> report_md_inward_item.xhtml 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Institution and Department selectors now use filterable dropdown menus with "All" options for easier selection and filtering.

* **Chores**
  * Updated Excel export report filename.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hmislk/hmis/pull/20613)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->