### PR TITLE
hotfix: block GRN Return approval when stock insufficient, stamp departmentType

### DIFF
--- a/src/main/java/com/divudi/bean/pharmacy/GrnReturnWorkflowController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/GrnReturnWorkflowController.java
@@ -30,6 +30,8 @@ import com.divudi.core.facade.BillFacade;
 import com.divudi.core.facade.BillItemFacade;
 import com.divudi.core.facade.ItemFacade;
 import com.divudi.core.facade.PharmaceuticalBillItemFacade;
+import com.divudi.core.facade.StockFacade;
+import com.divudi.core.entity.pharmacy.Stock;
 import com.divudi.core.util.JsfUtil;
 import com.divudi.service.BillService;
 import com.divudi.core.data.PaymentMethod;
@@ -83,6 +85,8 @@ public class GrnReturnWorkflowController implements Serializable {
     private BillItemFacade billItemFacade;
     @EJB
     private PharmaceuticalBillItemFacade pharmaceuticalBillItemFacade;
+    @EJB
+    private StockFacade stockFacade;
     @EJB
     private PharmacyBean pharmacyBean;
     @EJB
@@ -968,6 +972,52 @@ public class GrnReturnWorkflowController implements Serializable {
 
     // Stock handling - only at approval stage. Returns false (and shows an error) if any item fails.
     private boolean updateStock() {
+        // Phase 1: pre-deduction availability check — reads fresh DB stock for every
+        // item and accumulates total requested qty per stock record.  No mutations are
+        // made here, so a failure leaves the database completely unchanged.
+        Map<Long, Double> requestedByStockId = new HashMap<>();
+        Map<Long, String> itemNameByStockId = new HashMap<>();
+        for (BillItem bi : billItems) {
+            if (bi.isRetired()) {
+                continue;
+            }
+            PharmaceuticalBillItem phi = bi.getPharmaceuticalBillItem();
+            if (phi == null || phi.getStock() == null || phi.getStock().getId() == null) {
+                continue;
+            }
+            double absQty = Math.abs(phi.getQty()) + Math.abs(phi.getFreeQty());
+            if (absQty == 0) {
+                continue;
+            }
+            Long stockId = phi.getStock().getId();
+            requestedByStockId.merge(stockId, absQty, Double::sum);
+            itemNameByStockId.putIfAbsent(stockId,
+                    bi.getItem() != null ? bi.getItem().getName() : "Unknown");
+        }
+
+        boolean preCheckPassed = true;
+        for (Map.Entry<Long, Double> entry : requestedByStockId.entrySet()) {
+            Long stockId = entry.getKey();
+            double totalRequested = entry.getValue();
+            Stock freshStock = stockFacade.find(stockId);
+            double available = (freshStock != null && freshStock.getStock() != null)
+                    ? freshStock.getStock() : 0.0;
+            if (available < totalRequested) {
+                String itemName = itemNameByStockId.getOrDefault(stockId, "Unknown");
+                LOGGER.log(Level.WARNING,
+                        "Pre-deduction stock check failed for item: {0}, available: {1}, requested: {2}",
+                        new Object[]{itemName, available, totalRequested});
+                JsfUtil.addErrorMessage("Cannot approve: insufficient stock for \""
+                        + itemName + "\". Available: " + String.format("%.2f", available)
+                        + ", Requested: " + String.format("%.2f", totalRequested) + ".");
+                preCheckPassed = false;
+            }
+        }
+        if (!preCheckPassed) {
+            return false;
+        }
+
+        // Phase 2: all items passed the pre-check — proceed with deductions.
         for (BillItem bi : billItems) {
             if (bi.isRetired()) {
                 continue;
@@ -992,9 +1042,12 @@ public class GrnReturnWorkflowController implements Serializable {
             );
 
             if (!returnFlag) {
+                // Pre-check passed but deductFromStock still failed — concurrent transaction
+                // drained the stock between our check and this deduction.
                 String itemName = bi.getItem() != null ? bi.getItem().getName() : "Unknown";
                 double available = phi.getStock() != null ? phi.getStock().getStock() : 0;
-                LOGGER.log(Level.WARNING, "Stock deduction failed for item: {0}, available: {1}, requested: {2}",
+                LOGGER.log(Level.WARNING,
+                        "Stock deduction failed after pre-check for item: {0}, available: {1}, requested: {2}",
                         new Object[]{itemName, available, absQty});
                 phi.setQty(Math.abs(phi.getQty()));
                 phi.setFreeQty(Math.abs(phi.getFreeQty()));
@@ -1009,7 +1062,6 @@ public class GrnReturnWorkflowController implements Serializable {
         if (currentBill != null && currentBill.getBillFinanceDetails() != null) {
             BillFinanceDetails bfd = currentBill.getBillFinanceDetails();
 
-            // Negate the purchase, cost, and retail values at bill level
             if (bfd.getTotalPurchaseValue() != null) {
                 bfd.setTotalPurchaseValue(bfd.getTotalPurchaseValue().abs().negate());
             }
@@ -1020,7 +1072,6 @@ public class GrnReturnWorkflowController implements Serializable {
                 bfd.setTotalRetailSaleValue(bfd.getTotalRetailSaleValue().abs().negate());
             }
 
-            // Save the updated bill with corrected finance details
             billFacade.edit(currentBill);
         }
         return true;

--- a/src/main/java/com/divudi/bean/pharmacy/GrnReturnWorkflowController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/GrnReturnWorkflowController.java
@@ -708,7 +708,16 @@ public class GrnReturnWorkflowController implements Serializable {
                 return;
             }
 
-            updateStock();  // Stock handling happens only at approval stage
+            if (!updateStock()) {
+                // Roll back completed status — stock deduction failed for one or more items
+                currentBill.setCompleted(false);
+                currentBill.setCompletedBy(null);
+                currentBill.setCompletedAt(null);
+                currentBill.setApproveAt(null);
+                currentBill.setApproveUser(null);
+                billFacade.edit(currentBill);
+                return;
+            }
 
             // Create payment for the return - ALL payment methods require payment records for healthcare compliance
             // Payment validation was performed at method start, so we can proceed with confidence
@@ -847,6 +856,9 @@ public class GrnReturnWorkflowController implements Serializable {
             currentBill.setBillTypeAtomic(BillTypeAtomic.PHARMACY_GRN_RETURN);
             currentBill.setInstitution(sessionController.getInstitution());
             currentBill.setDepartment(sessionController.getDepartment());
+            if (sessionController.getDepartment() != null) {
+                currentBill.setDepartmentType(sessionController.getDepartment().getDepartmentType());
+            }
             currentBill.setCreater(sessionController.getLoggedUser());
             currentBill.setCreatedAt(new Date());
 
@@ -954,31 +966,24 @@ public class GrnReturnWorkflowController implements Serializable {
         }
     }
 
-    // Stock handling - only at approval stage
-    private void updateStock() {
+    // Stock handling - only at approval stage. Returns false (and shows an error) if any item fails.
+    private boolean updateStock() {
         for (BillItem bi : billItems) {
-            // Skip only retired items or items with truly zero quantities
             if (bi.isRetired()) {
                 continue;
             }
 
             PharmaceuticalBillItem phi = bi.getPharmaceuticalBillItem();
-            double totalQty = phi.getQty() + phi.getFreeQty();
+            double absQty = Math.abs(phi.getQty()) + Math.abs(phi.getFreeQty());
 
-            // Skip stock processing for zero quantity items (no stock impact)
-            if (totalQty == 0) {
+            if (absQty == 0) {
                 continue;
             }
 
-            // For returns: make quantities negative before saving, use absolute value for stock deduction
-            double absQty = Math.abs(totalQty);
             phi.setQty(-Math.abs(phi.getQty()));
             phi.setFreeQty(-Math.abs(phi.getFreeQty()));
-
-            // Save the pharmaceutical bill item with negative quantities
             pharmaceuticalBillItemFacade.edit(phi);
 
-            // Deduct from stock for return (use absolute value)
             boolean returnFlag = pharmacyBean.deductFromStock(
                     phi.getStock(),
                     absQty,
@@ -987,11 +992,16 @@ public class GrnReturnWorkflowController implements Serializable {
             );
 
             if (!returnFlag) {
-                LOGGER.log(Level.WARNING, "Unable to deduct stock for item: {0}", bi.getItem().getName());
-                // Reset quantities if stock deduction failed
-                phi.setQty(0);
-                phi.setFreeQty(0);
+                String itemName = bi.getItem() != null ? bi.getItem().getName() : "Unknown";
+                double available = phi.getStock() != null ? phi.getStock().getStock() : 0;
+                LOGGER.log(Level.WARNING, "Stock deduction failed for item: {0}, available: {1}, requested: {2}",
+                        new Object[]{itemName, available, absQty});
+                phi.setQty(Math.abs(phi.getQty()));
+                phi.setFreeQty(Math.abs(phi.getFreeQty()));
                 pharmaceuticalBillItemFacade.edit(phi);
+                JsfUtil.addErrorMessage("Cannot approve: insufficient stock for \"" + itemName
+                        + "\". Available: " + available + ", Requested: " + absQty + ".");
+                return false;
             }
         }
 
@@ -1013,6 +1023,7 @@ public class GrnReturnWorkflowController implements Serializable {
             // Save the updated bill with corrected finance details
             billFacade.edit(currentBill);
         }
+        return true;
     }
 
     // Validation methods
@@ -1921,6 +1932,9 @@ public class GrnReturnWorkflowController implements Serializable {
         currentBill.setCreater(sessionController.getLoggedUser());
         currentBill.setInstitution(sessionController.getInstitution());
         currentBill.setDepartment(sessionController.getDepartment());
+        if (sessionController.getDepartment() != null) {
+            currentBill.setDepartmentType(sessionController.getDepartment().getDepartmentType());
+        }
 
         //Copy Payment Method Details from GRN to GRN Return
         currentBill.setPaymentMethod(originalGrn.getPaymentMethod());


### PR DESCRIPTION
## Hotfix — Ruhunu Production

Cherry-pick of fix commit from `fix/grn-return-silent-approval-20616` (PR #20621) onto `ruhunu-prod`.

## Problem

GRN Return bills were silently completing approval even when available stock had dropped below the return quantity between bill creation and approval. The system zeroed `pharmaceuticalbillitem.QTY`, skipped stock deduction, skipped `StockHistory` creation, and showed a success message. The document then disappeared from the Stock Ledger with no indication of failure.

**Confirmed instance:** R/GRN/RHD/LBK/26/000029 — three returns approved within 90 seconds on 27-Mar-2026; the middle one had insufficient stock at approval time.

## Fix

- `updateStock()` now returns `boolean`. Failure shows a clear error: *"Cannot approve: insufficient stock for [item]. Available: X, Requested: Y."*
- `approve()` rolls back the `completed`/`approved` bill flags and aborts if `updateStock()` returns false.
- `bill.DEPARTMENTTYPE` is now stamped from the session department at bill creation time.

## Scope

Single file: `GrnReturnWorkflowController.java` — 30 insertions, 16 deletions. No schema changes. No other modules affected.

## Related

- Development PR: #20621
- Issues: #20616 (primary), #20615 (secondary)
- Data correction for R/GRN/RHD/LBK/26/000029 pending RH approval (tracked in #20617)
- QA test guide: `tmp/grn-return-bug-20616-qa-testing-guide.md`

## Test Plan

- [ ] TC-01: Approval with sufficient stock succeeds normally
- [ ] TC-02: Approval blocked when stock = 0, error message shown
- [ ] TC-03: Approval blocked when stock < return qty
- [ ] TC-09: Regression — normal GRN Return workflow unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)