### PR TITLE
19799-improper-validation-message-when-saving-without-adding-vocabularies

### DIFF
--- a/src/main/webapp/emr/admin/vocabularies.xhtml
+++ b/src/main/webapp/emr/admin/vocabularies.xhtml
@@ -12,7 +12,7 @@
 
         <h:panelGroup >
             <h:form  >
-                <p:growl id="growlMsg"/>
+                <p:growl id="growlMsg" showDetail="true" showSummary="false"/>
                 <p:focus id="selectFocus" context="gpSelect" />
                 <p:focus id="detailFocus" context="gpDetail" />
                 <p:panel header="Manage Vocabularies" >
@@ -64,7 +64,6 @@
                                 <p:panelGrid id="gpDetailText" columns="2" class="w-100">
                                     <p:outputLabel id="lblName" value="Name"></p:outputLabel>
                                     <p:inputText 
-                                        required="true"
                                         autocomplete="off" 
                                         id="txtName" 
                                         class="w-100" 


### PR DESCRIPTION
closes #19799
Added a valid message when the save button is clicked with empty values.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Updated feedback display for vocabulary operations to show detailed messages.
  * Made vocabulary name field optional in the vocabulary management interface.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hmislk/hmis/pull/20624)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->