### PR TITLE
Fix stateful database migration execution

### DIFF
--- a/src/main/java/com/divudi/bean/common/DatabaseMigrationController.java
+++ b/src/main/java/com/divudi/bean/common/DatabaseMigrationController.java
@@ -579,7 +579,10 @@ public class DatabaseMigrationController implements Serializable {
 
             if (usesMysqlConnectionScopedState(executableStatements)) {
                 logBuilder.append("Executing stateful MySQL script on a single JDBC connection\n");
-                migrationFacade.executeNativeSqlStatements(executableStatements);
+                List<String> skipMessages = migrationFacade.executeNativeSqlStatements(executableStatements);
+                for (String skipMessage : skipMessages) {
+                    logBuilder.append(skipMessage).append("\n");
+                }
                 logBuilder.append("Stateful script executed successfully\n");
                 return;
             }

--- a/src/main/java/com/divudi/bean/common/DatabaseMigrationController.java
+++ b/src/main/java/com/divudi/bean/common/DatabaseMigrationController.java
@@ -511,7 +511,9 @@ public class DatabaseMigrationController implements Serializable {
             );
 
             migration.setStatus(MigrationStatus.EXECUTING);
+            migration.setExecutedAt(new Date());
             migration.setExecutedBy(sessionController.getLoggedUser());
+            migration.setErrorMessage(null);
             migration.setRequiresDowntime(migrationInfo.isRequiresDowntime());
             migration.setEstimatedDurationMs(migrationInfo.getEstimatedDurationMs());
             migration.setMigrationMetadata(serializeMigrationInfo(migrationInfo));
@@ -530,6 +532,7 @@ public class DatabaseMigrationController implements Serializable {
             long executionTime = System.currentTimeMillis() - startTime;
             migration.setStatus(MigrationStatus.SUCCESS);
             migration.setExecutionTimeMs(executionTime);
+            migration.setErrorMessage(null);
             migration.setExecutionLog(logBuilder.toString());
             migrationFacade.edit(migration);
 
@@ -572,13 +575,16 @@ public class DatabaseMigrationController implements Serializable {
     private void executeSqlScript(String sql, StringBuilder logBuilder) throws Exception {
         try {
             List<String> statements = splitSqlStatements(sql);
+            List<String> executableStatements = getExecutableSqlStatements(statements);
 
-            for (String stmt : statements) {
-                // Strip leading comment/blank lines to get to the executable SQL
-                String executableStmt = stripLeadingComments(stmt);
-                if (executableStmt.isEmpty()) {
-                    continue;
-                }
+            if (usesMysqlConnectionScopedState(executableStatements)) {
+                logBuilder.append("Executing stateful MySQL script on a single JDBC connection\n");
+                migrationFacade.executeNativeSqlStatements(executableStatements);
+                logBuilder.append("Stateful script executed successfully\n");
+                return;
+            }
+
+            for (String executableStmt : executableStatements) {
                 logBuilder.append("Executing: ").append(executableStmt.substring(0, Math.min(100, executableStmt.length()))).append("...\n");
                 try {
                     if (isDdlStatement(executableStmt)) {
@@ -602,6 +608,17 @@ public class DatabaseMigrationController implements Serializable {
             logBuilder.append("Error executing SQL: ").append(e.getMessage()).append("\n");
             throw e;
         }
+    }
+
+    private List<String> getExecutableSqlStatements(List<String> statements) {
+        List<String> executableStatements = new ArrayList<>();
+        for (String stmt : statements) {
+            String executableStmt = stripLeadingComments(stmt);
+            if (!executableStmt.isEmpty()) {
+                executableStatements.add(executableStmt);
+            }
+        }
+        return executableStatements;
     }
 
     /**
@@ -686,6 +703,17 @@ public class DatabaseMigrationController implements Serializable {
         return upper.startsWith("CREATE") || upper.startsWith("ALTER")
                 || upper.startsWith("DROP") || upper.startsWith("CALL")
                 || upper.startsWith("RENAME") || upper.startsWith("TRUNCATE");
+    }
+
+    private boolean usesMysqlConnectionScopedState(List<String> statements) {
+        for (String statement : statements) {
+            String upper = statement.toUpperCase().trim();
+            if (upper.contains("@") || upper.startsWith("PREPARE ")
+                    || upper.startsWith("EXECUTE ") || upper.startsWith("DEALLOCATE PREPARE")) {
+                return true;
+            }
+        }
+        return false;
     }
 
     /**

--- a/src/main/java/com/divudi/core/facade/DatabaseMigrationFacade.java
+++ b/src/main/java/com/divudi/core/facade/DatabaseMigrationFacade.java
@@ -89,9 +89,10 @@ public class DatabaseMigrationFacade extends AbstractFacade<DatabaseMigration> {
      * full script on a single connection while still running outside JTA.
      */
     @TransactionAttribute(TransactionAttributeType.NOT_SUPPORTED)
-    public void executeNativeSqlStatements(List<String> sqlStatements) throws Exception {
+    public List<String> executeNativeSqlStatements(List<String> sqlStatements) throws Exception {
+        List<String> skipMessages = new ArrayList<>();
         if (sqlStatements == null || sqlStatements.isEmpty()) {
-            return;
+            return skipMessages;
         }
         Connection conn = getRawJdbcConnection();
         try {
@@ -101,8 +102,16 @@ public class DatabaseMigrationFacade extends AbstractFacade<DatabaseMigration> {
                     if (sql == null || sql.trim().isEmpty()) {
                         continue;
                     }
-                    stmt.execute(sql);
-                    drainStatementResults(stmt);
+                    try {
+                        stmt.execute(sql);
+                        drainStatementResults(stmt);
+                    } catch (SQLException e) {
+                        String skipReason = getIdempotentSkipReason(sql, e);
+                        if (skipReason == null) {
+                            throw e;
+                        }
+                        skipMessages.add(skipReason);
+                    }
                 }
             }
         } finally {
@@ -110,12 +119,54 @@ public class DatabaseMigrationFacade extends AbstractFacade<DatabaseMigration> {
             try { conn.setAutoCommit(false); } catch (Exception ignored) { }
             conn.close();
         }
+        return skipMessages;
     }
 
     private void drainStatementResults(Statement stmt) throws SQLException {
         while (stmt.getMoreResults() || stmt.getUpdateCount() != -1) {
             // Consume all result/update counts from statements such as CALL.
         }
+    }
+
+    private String getIdempotentSkipReason(String sql, SQLException e) {
+        String upper = sql.toUpperCase().trim();
+        String msg = collectCauseMessages(e);
+
+        if ((upper.startsWith("CREATE INDEX") || upper.startsWith("CREATE UNIQUE INDEX"))
+                && (msg.contains("1061") || msg.contains("Duplicate key name")
+                    || msg.contains("1146") || msg.contains("doesn't exist"))) {
+            return "Index already exists or target table missing, skipping: " + abbreviateSql(sql);
+        }
+
+        if (upper.startsWith("ALTER TABLE") && upper.contains("ADD COLUMN")
+                && (msg.contains("1060") || msg.contains("Duplicate column name"))) {
+            return "Column already exists, skipping: " + abbreviateSql(sql);
+        }
+
+        if (upper.startsWith("ALTER TABLE")
+                && (upper.contains("DROP FOREIGN KEY") || upper.contains("DROP INDEX") || upper.contains("DROP KEY"))
+                && (msg.contains("1091") || msg.contains("check that column/key exists"))) {
+            return "Foreign key or index already absent, skipping: " + abbreviateSql(sql);
+        }
+
+        return null;
+    }
+
+    private String collectCauseMessages(Throwable e) {
+        StringBuilder sb = new StringBuilder();
+        Throwable cause = e;
+        while (cause != null) {
+            if (cause.getMessage() != null) {
+                sb.append(cause.getMessage()).append('\n');
+            }
+            cause = cause.getCause();
+        }
+        return sb.toString();
+    }
+
+    private String abbreviateSql(String sql) {
+        String oneLine = sql.replaceAll("\\s+", " ").trim();
+        return oneLine.substring(0, Math.min(100, oneLine.length()));
     }
 
     private static final Logger LOGGER = Logger.getLogger(DatabaseMigrationFacade.class.getName());

--- a/src/main/java/com/divudi/core/facade/DatabaseMigrationFacade.java
+++ b/src/main/java/com/divudi/core/facade/DatabaseMigrationFacade.java
@@ -9,6 +9,7 @@ import com.divudi.core.data.MigrationStatus;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
+import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -76,6 +77,44 @@ public class DatabaseMigrationFacade extends AbstractFacade<DatabaseMigration> {
             // java.lang.reflect.UndeclaredThrowableException wrapped in SQLException.
             try { conn.setAutoCommit(false); } catch (Exception ignored) { }
             conn.close();
+        }
+    }
+
+    /**
+     * Execute a migration script on one raw JDBC connection.
+     *
+     * MySQL user variables, PREPARE, and EXECUTE statements are scoped to the
+     * connection. Running those scripts one statement per pooled connection can
+     * lose guard state and execute unsafe dynamic DDL. This method keeps the
+     * full script on a single connection while still running outside JTA.
+     */
+    @TransactionAttribute(TransactionAttributeType.NOT_SUPPORTED)
+    public void executeNativeSqlStatements(List<String> sqlStatements) throws Exception {
+        if (sqlStatements == null || sqlStatements.isEmpty()) {
+            return;
+        }
+        Connection conn = getRawJdbcConnection();
+        try {
+            conn.setAutoCommit(true);
+            try (Statement stmt = conn.createStatement()) {
+                for (String sql : sqlStatements) {
+                    if (sql == null || sql.trim().isEmpty()) {
+                        continue;
+                    }
+                    stmt.execute(sql);
+                    drainStatementResults(stmt);
+                }
+            }
+        } finally {
+            // Restore autoCommit=false before returning connection to Payara's JTA pool.
+            try { conn.setAutoCommit(false); } catch (Exception ignored) { }
+            conn.close();
+        }
+    }
+
+    private void drainStatementResults(Statement stmt) throws SQLException {
+        while (stmt.getMoreResults() || stmt.getUpdateCount() != -1) {
+            // Consume all result/update counts from statements such as CALL.
         }
     }
 

--- a/src/main/resources/db/migrations/v2.1.17/migration.sql
+++ b/src/main/resources/db/migrations/v2.1.17/migration.sql
@@ -27,6 +27,9 @@ SET @ps_table = (
 );
 
 SELECT CONCAT('Detected patientsample table as: ', IFNULL(@ps_table, '(not found)')) AS info;
+SELECT IF(@ps_table IS NULL,
+          'patientsample table not found; v2.1.17 is not applicable and will complete as a successful no-op',
+          'patientsample table found; checking removable FK constraints and indexes') AS applicability;
 
 -- STEP 1: PRE-MIGRATION ANALYSIS
 


### PR DESCRIPTION
## Summary
- Fix migration execution for HMIS databases that differ in physical table-name casing, such as PATIENTSAMPLE on some Linux/case-sensitive instances and patientsample on other instances.
- Execute MySQL migration scripts that use session variables or PREPARE/EXECUTE on a single raw JDBC connection so detected table names like @ps_table remain consistent across statements.
- Preserve existing benign idempotency skips for mixed-case migration probes, and clear stale failure messages when a failed migration is retried successfully.
- Add an explicit v2.1.17 no-op message when neither upper nor lower case patientsample table exists.

## Verification
- Ran git diff --check / git diff --staged --check.
- Did not run Maven compile/build per project instruction; this needs environment DB verification by re-executing v2.1.17 against instances with uppercase, lowercase, and absent patientsample table names.

Closes #20647