### PR TITLE
feat(cashier): pre-populate denominations from request and cap issue amount

### DIFF
--- a/src/main/java/com/divudi/bean/cashTransaction/FinancialTransactionController.java
+++ b/src/main/java/com/divudi/bean/cashTransaction/FinancialTransactionController.java
@@ -2553,6 +2553,38 @@ public class FinancialTransactionController implements Serializable {
         prepareToAddNewFundTransferBill();
         currentBill.setToWebUser(requestBill.getFromWebUser());
         currentBill.setComments(requestBill.getComments());
+        // Pre-populate denominations from the request so the issuer sees the
+        // requested breakdown by default (they may still adjust quantities).
+        Map<String, Object> reqDenoParams = new HashMap<>();
+        reqDenoParams.put("ret", false);
+        reqDenoParams.put("refBill", requestBill);
+        reqDenoParams.put("btype", BillTypeAtomic.FUND_TRANSFER_REQUEST_DENOMINATION_BILL);
+        List<Bill> reqDenoBills = billFacade.findByJpql(
+                "select b from Bill b where b.retired=:ret and b.referenceBill=:refBill and b.billTypeAtomic=:btype",
+                reqDenoParams, TemporalType.TIMESTAMP);
+        if (reqDenoBills != null && !reqDenoBills.isEmpty()) {
+            List<DenominationTransaction> savedDenos = billService.fetchDenominationTransactionFromBill(reqDenoBills.get(0));
+            if (savedDenos != null && !savedDenos.isEmpty()) {
+                Map<Long, Long> reqDenoQtyMap = new HashMap<>();
+                for (DenominationTransaction dt : savedDenos) {
+                    if (dt.getDenomination() != null && dt.getDenominationQty() != null) {
+                        reqDenoQtyMap.put(dt.getDenomination().getId(), dt.getDenominationQty());
+                    }
+                }
+                for (DenominationTransaction dt : fundTransferDenominationTransactions) {
+                    if (dt.getDenomination() != null) {
+                        Long savedQty = reqDenoQtyMap.get(dt.getDenomination().getId());
+                        if (savedQty != null && savedQty > 0) {
+                            dt.setDenominationQty(savedQty);
+                            if (dt.getDenomination().getDenominationValue() != null) {
+                                dt.setDenominationValue(savedQty * dt.getDenomination().getDenominationValue());
+                            }
+                        }
+                    }
+                }
+                calculateFundTransferDenominationTotal();
+            }
+        }
         floatTransferStarted = false;
         currentBillPayments = new ArrayList<>();
         return "/cashier/fund_transfer_bill?faces-redirect=true";
@@ -2960,6 +2992,18 @@ public class FinancialTransactionController implements Serializable {
             }
             if (cumulativeCash > drawerBalance) {
                 JsfUtil.addErrorMessage("Transfer amount cannot exceed available drawer balance (" + drawerBalance + ").");
+                return;
+            }
+        }
+
+        if (selectedFundTransferRequest != null) {
+            double remaining = getRemainingAmountForRequest(selectedFundTransferRequest);
+            double alreadyAdded = 0.0;
+            for (Payment p : getCurrentBillPayments()) {
+                alreadyAdded += Math.abs(p.getPaidValue());
+            }
+            if (alreadyAdded + Math.abs(currentPayment.getPaidValue()) > remaining + 0.001) {
+                JsfUtil.addErrorMessage("Payment would exceed the remaining request balance of " + remaining + ".");
                 return;
             }
         }


### PR DESCRIPTION
## Summary
- When issuing a float transfer against a request, the denomination breakdown entered by the requester is now pre-loaded automatically — the issuer sees the requested quantities by default and can adjust them as needed
- `addPaymentToFundTransferBill()` now validates each newly added payment against the remaining request balance, giving immediate feedback before the final settlement check

## Changes
- `navigateToFundTransferBillFromRequest()`: after preparing the blank transfer bill, looks up the `FUND_TRANSFER_REQUEST_DENOMINATION_BILL` child of the request and copies denomination quantities into the default denomination list, then recalculates the total
- `addPaymentToFundTransferBill()`: when `selectedFundTransferRequest != null`, guards against adding a payment that would push the cumulative total over the remaining unfulfilled amount

## Test plan
- [ ] Make a float request with specific denomination breakdown (e.g. 3×1000, 2×500)
- [ ] Log in as the recipient user, open "Requests for Me" and click Initiate Transfer
- [ ] Verify the denomination table on `fund_transfer_bill.xhtml` shows the pre-filled quantities (3×1000, 2×500) and the denomination total matches
- [ ] Verify the issuer can adjust quantities freely
- [ ] Try adding a cash payment that exceeds the remaining request balance — verify an error message is shown immediately
- [ ] Complete a valid transfer and verify settlement succeeds and the request is marked fulfilled

Closes #20551

🤖 Generated with [Claude Code](https://claude.com/claude-code)