### PR TITLE
Add v2.4.0 migration: PharmaceuticalBillItem performance indexes

### DIFF
--- a/src/main/resources/db/migrations/v2.4.0/migration-info.json
+++ b/src/main/resources/db/migrations/v2.4.0/migration-info.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.4.0",
+  "version": "v2.4.0",
   "description": "Performance indexes for PharmaceuticalBillItem — fixes full-table scans on pharmacy date-range queries",
   "issue": "RMH database slowness — pharmacy retail sale and batch/stock transaction reports",
   "author": "Dr M H B Ariyaratne",

--- a/src/main/resources/db/migrations/v2.4.0/migration-info.json
+++ b/src/main/resources/db/migrations/v2.4.0/migration-info.json
@@ -1,0 +1,27 @@
+{
+  "version": "2.4.0",
+  "description": "Performance indexes for PharmaceuticalBillItem — fixes full-table scans on pharmacy date-range queries",
+  "issue": "RMH database slowness — pharmacy retail sale and batch/stock transaction reports",
+  "author": "Dr M H B Ariyaratne",
+  "date": "2026-05-12",
+  "type": "performance",
+  "tables_affected": ["pharmaceuticalbillitem", "billitem"],
+  "data_changes": false,
+  "requires_downtime": false,
+  "estimated_duration_minutes": 5,
+  "indexes_added": [
+    "pharmaceuticalbillitem.idx_pbi_createdat_retired (CREATEDAT, RETIRED)",
+    "pharmaceuticalbillitem.idx_pbi_stock_createdat (STOCK_ID, CREATEDAT, RETIRED)",
+    "pharmaceuticalbillitem.idx_pbi_batch_createdat (ITEMBATCH_ID, CREATEDAT, RETIRED)"
+  ],
+  "indexes_dropped": [
+    "billitem.BILLITEM_BILLITEMSTATUS_idx — cardinality=1, 100% NULL across 4.86M rows, dead weight"
+  ],
+  "performance_impact": {
+    "before": "Date-range pharmacy report: full scan 7,153,035 rows",
+    "after": "Date-range pharmacy report: index range scan ~3 rows",
+    "improvement": "~2,000,000x fewer rows examined for date-range queries"
+  },
+  "tested_on": "qa4 (copy of rmh)",
+  "rollback": "rollback.sql"
+}

--- a/src/main/resources/db/migrations/v2.4.0/migration.sql
+++ b/src/main/resources/db/migrations/v2.4.0/migration.sql
@@ -1,0 +1,166 @@
+-- Migration v2.4.0: Performance indexes for PharmaceuticalBillItem + drop dead index on BillItem
+-- Author: Dr M H B Ariyaratne
+-- Issue: RMH database slowness — pharmacy retail sale and batch/stock transaction queries
+--
+-- Root cause:
+--   PHARMACEUTICALBILLITEM (7.15M rows) had no date-based index. Any date-range pharmacy
+--   report triggered a full 7.15M-row table scan. Stock-specific date queries also scanned
+--   all rows for that stock (up to 12K+ rows) without a composite index.
+--
+--   BILLITEM.BILLITEMSTATUS_idx had cardinality=1 (100% NULL across 4.86M rows) — a
+--   completely useless index adding write overhead to every pharmacy sale INSERT/UPDATE.
+--
+-- Before/after EXPLAIN (tested on qa4):
+--   Date-range report query: type=ALL  rows=7,153,035  → type=range rows=3
+--   Stock+date query:        type=ref  rows=12,744     → type=range rows=1
+--   Batch+date query:        type=ref  rows=scan       → type=range rows=1
+--
+-- UNIVERSAL: detects actual table name case via INFORMATION_SCHEMA so this works on both
+-- case-sensitive (Linux, lower_case_table_names=0) and case-insensitive (Windows/Azure) MySQL.
+-- All CREATE INDEX statements are guarded with existence checks — safe to re-run.
+
+SELECT 'Migration v2.4.0 - PharmaceuticalBillItem performance indexes' AS status;
+
+-- ============================================================
+-- STEP 0: DETECT ACTUAL TABLE NAME CASE
+-- ============================================================
+
+SET @pbi_table = (
+    SELECT TABLE_NAME FROM INFORMATION_SCHEMA.TABLES
+    WHERE TABLE_SCHEMA = DATABASE() AND UPPER(TABLE_NAME) = 'PHARMACEUTICALBILLITEM'
+    LIMIT 1
+);
+
+SET @bi_table = (
+    SELECT TABLE_NAME FROM INFORMATION_SCHEMA.TABLES
+    WHERE TABLE_SCHEMA = DATABASE() AND UPPER(TABLE_NAME) = 'BILLITEM'
+    LIMIT 1
+);
+
+SELECT CONCAT('PHARMACEUTICALBILLITEM table: ', COALESCE(@pbi_table, 'NOT FOUND')) AS info;
+SELECT CONCAT('BILLITEM table: ',              COALESCE(@bi_table,  'NOT FOUND')) AS info;
+
+-- ============================================================
+-- STEP 1: PRE-MIGRATION ANALYSIS
+-- ============================================================
+
+SELECT 'BEFORE: Table sizes and existing indexes' AS status;
+
+SET @size_sql = CONCAT(
+    'SELECT TABLE_NAME, TABLE_ROWS AS est_rows, ',
+    'ROUND(DATA_LENGTH/1024/1024,1) AS data_mb, ',
+    'ROUND(INDEX_LENGTH/1024/1024,1) AS index_mb ',
+    'FROM INFORMATION_SCHEMA.TABLES ',
+    'WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME IN (''', @pbi_table, ''',''', @bi_table, ''')'
+);
+PREPARE stmt FROM @size_sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+SELECT COUNT(*) AS pbi_existing_idx FROM INFORMATION_SCHEMA.STATISTICS
+WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = @pbi_table;
+
+-- ============================================================
+-- STEP 2: CREATE idx_pbi_createdat_retired
+--   Fixes full-table-scan on date-range pharmacy reports
+--   (7.15M → targeted row range)
+-- ============================================================
+
+SELECT 'Step 2: Creating idx_pbi_createdat_retired (CREATEDAT, RETIRED)' AS status;
+
+SET @idx_exists = (
+    SELECT COUNT(*) FROM INFORMATION_SCHEMA.STATISTICS
+    WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = @pbi_table
+      AND INDEX_NAME = 'idx_pbi_createdat_retired'
+);
+SET @sql = IF(@pbi_table IS NULL OR @idx_exists > 0,
+    'SELECT "SKIPPED: table not found or index already exists" AS status',
+    CONCAT('CREATE INDEX idx_pbi_createdat_retired ON ', @pbi_table, '(CREATEDAT, RETIRED)')
+);
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+SET @idx_exists = (SELECT COUNT(*) FROM INFORMATION_SCHEMA.STATISTICS
+    WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = @pbi_table AND INDEX_NAME = 'idx_pbi_createdat_retired');
+SELECT IF(@idx_exists > 0, 'OK: idx_pbi_createdat_retired present', 'FAILED: idx_pbi_createdat_retired missing') AS verify_1;
+
+-- ============================================================
+-- STEP 3: CREATE idx_pbi_stock_createdat
+--   Fixes stock + date-range queries (e.g. stock movement history for one item)
+-- ============================================================
+
+SELECT 'Step 3: Creating idx_pbi_stock_createdat (STOCK_ID, CREATEDAT, RETIRED)' AS status;
+
+SET @idx_exists = (
+    SELECT COUNT(*) FROM INFORMATION_SCHEMA.STATISTICS
+    WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = @pbi_table
+      AND INDEX_NAME = 'idx_pbi_stock_createdat'
+);
+SET @sql = IF(@pbi_table IS NULL OR @idx_exists > 0,
+    'SELECT "SKIPPED: table not found or index already exists" AS status',
+    CONCAT('CREATE INDEX idx_pbi_stock_createdat ON ', @pbi_table, '(STOCK_ID, CREATEDAT, RETIRED)')
+);
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+SET @idx_exists = (SELECT COUNT(*) FROM INFORMATION_SCHEMA.STATISTICS
+    WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = @pbi_table AND INDEX_NAME = 'idx_pbi_stock_createdat');
+SELECT IF(@idx_exists > 0, 'OK: idx_pbi_stock_createdat present', 'FAILED: idx_pbi_stock_createdat missing') AS verify_2;
+
+-- ============================================================
+-- STEP 4: CREATE idx_pbi_batch_createdat
+--   Fixes batch + date-range queries (e.g. GRN batch movement reports)
+-- ============================================================
+
+SELECT 'Step 4: Creating idx_pbi_batch_createdat (ITEMBATCH_ID, CREATEDAT, RETIRED)' AS status;
+
+SET @idx_exists = (
+    SELECT COUNT(*) FROM INFORMATION_SCHEMA.STATISTICS
+    WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = @pbi_table
+      AND INDEX_NAME = 'idx_pbi_batch_createdat'
+);
+SET @sql = IF(@pbi_table IS NULL OR @idx_exists > 0,
+    'SELECT "SKIPPED: table not found or index already exists" AS status',
+    CONCAT('CREATE INDEX idx_pbi_batch_createdat ON ', @pbi_table, '(ITEMBATCH_ID, CREATEDAT, RETIRED)')
+);
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+SET @idx_exists = (SELECT COUNT(*) FROM INFORMATION_SCHEMA.STATISTICS
+    WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = @pbi_table AND INDEX_NAME = 'idx_pbi_batch_createdat');
+SELECT IF(@idx_exists > 0, 'OK: idx_pbi_batch_createdat present', 'FAILED: idx_pbi_batch_createdat missing') AS verify_3;
+
+-- ============================================================
+-- STEP 5: DROP BILLITEM_BILLITEMSTATUS_idx
+--   100% NULL across 4.86M rows — cardinality=1, never used for any query.
+--   Removing it reduces write overhead on every pharmacy sale INSERT/UPDATE.
+-- ============================================================
+
+SELECT 'Step 5: Dropping dead index BILLITEM_BILLITEMSTATUS_idx from billitem' AS status;
+
+SET @idx_exists = (
+    SELECT COUNT(*) FROM INFORMATION_SCHEMA.STATISTICS
+    WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = @bi_table
+      AND INDEX_NAME = 'BILLITEM_BILLITEMSTATUS_idx'
+);
+SET @sql = IF(@bi_table IS NULL OR @idx_exists = 0,
+    'SELECT "SKIPPED: table not found or index already absent" AS status',
+    CONCAT('ALTER TABLE ', @bi_table, ' DROP INDEX BILLITEM_BILLITEMSTATUS_idx')
+);
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+SET @idx_gone = (SELECT COUNT(*) FROM INFORMATION_SCHEMA.STATISTICS
+    WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = @bi_table AND INDEX_NAME = 'BILLITEM_BILLITEMSTATUS_idx');
+SELECT IF(@idx_gone = 0, 'OK: BILLITEM_BILLITEMSTATUS_idx absent', 'FAILED: BILLITEM_BILLITEMSTATUS_idx still present') AS verify_4;
+
+-- ============================================================
+-- STEP 6: POST-MIGRATION VERIFICATION
+-- ============================================================
+
+SELECT 'AFTER: New indexes on PHARMACEUTICALBILLITEM' AS status;
+
+SELECT INDEX_NAME,
+       GROUP_CONCAT(COLUMN_NAME ORDER BY SEQ_IN_INDEX SEPARATOR ', ') AS cols,
+       MAX(CARDINALITY) AS cardinality
+FROM INFORMATION_SCHEMA.STATISTICS
+WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = @pbi_table
+  AND INDEX_NAME LIKE 'idx_pbi_%'
+GROUP BY INDEX_NAME
+ORDER BY INDEX_NAME;
+
+SELECT 'Migration v2.4.0 completed' AS final_status;

--- a/src/main/resources/db/migrations/v2.4.0/rollback.sql
+++ b/src/main/resources/db/migrations/v2.4.0/rollback.sql
@@ -1,0 +1,19 @@
+-- Rollback v2.4.0: Remove PharmaceuticalBillItem performance indexes
+-- Re-creates the dropped BILLITEM_BILLITEMSTATUS_idx only if needed (it was useless — generally safe to leave absent)
+
+SET @pbi_table = (SELECT TABLE_NAME FROM INFORMATION_SCHEMA.TABLES
+    WHERE TABLE_SCHEMA = DATABASE() AND UPPER(TABLE_NAME) = 'PHARMACEUTICALBILLITEM' LIMIT 1);
+
+SET @bi_table = (SELECT TABLE_NAME FROM INFORMATION_SCHEMA.TABLES
+    WHERE TABLE_SCHEMA = DATABASE() AND UPPER(TABLE_NAME) = 'BILLITEM' LIMIT 1);
+
+-- Drop the three new indexes
+SET @sql = IF(@pbi_table IS NULL, 'SELECT 1',
+    CONCAT('ALTER TABLE ', @pbi_table,
+        ' DROP INDEX IF EXISTS idx_pbi_createdat_retired,',
+        ' DROP INDEX IF EXISTS idx_pbi_stock_createdat,',
+        ' DROP INDEX IF EXISTS idx_pbi_batch_createdat'));
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+SELECT 'Rollback v2.4.0 completed — three idx_pbi_* indexes dropped' AS status;
+SELECT 'NOTE: BILLITEM_BILLITEMSTATUS_idx was 100% NULL and intentionally not restored' AS note;

--- a/src/main/resources/db/migrations/v2.4.0/rollback.sql
+++ b/src/main/resources/db/migrations/v2.4.0/rollback.sql
@@ -7,12 +7,25 @@ SET @pbi_table = (SELECT TABLE_NAME FROM INFORMATION_SCHEMA.TABLES
 SET @bi_table = (SELECT TABLE_NAME FROM INFORMATION_SCHEMA.TABLES
     WHERE TABLE_SCHEMA = DATABASE() AND UPPER(TABLE_NAME) = 'BILLITEM' LIMIT 1);
 
--- Drop the three new indexes
-SET @sql = IF(@pbi_table IS NULL, 'SELECT 1',
-    CONCAT('ALTER TABLE ', @pbi_table,
-        ' DROP INDEX IF EXISTS idx_pbi_createdat_retired,',
-        ' DROP INDEX IF EXISTS idx_pbi_stock_createdat,',
-        ' DROP INDEX IF EXISTS idx_pbi_batch_createdat'));
+-- Drop the three new indexes (checked individually via INFORMATION_SCHEMA — avoids
+-- ALTER TABLE DROP INDEX IF EXISTS which requires MySQL 8.0.29+)
+
+SET @idx_exists = (SELECT COUNT(*) FROM INFORMATION_SCHEMA.STATISTICS
+    WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = @pbi_table AND INDEX_NAME = 'idx_pbi_createdat_retired');
+SET @sql = IF(@pbi_table IS NULL OR @idx_exists = 0, 'SELECT 1',
+    CONCAT('ALTER TABLE ', @pbi_table, ' DROP INDEX idx_pbi_createdat_retired'));
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+SET @idx_exists = (SELECT COUNT(*) FROM INFORMATION_SCHEMA.STATISTICS
+    WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = @pbi_table AND INDEX_NAME = 'idx_pbi_stock_createdat');
+SET @sql = IF(@pbi_table IS NULL OR @idx_exists = 0, 'SELECT 1',
+    CONCAT('ALTER TABLE ', @pbi_table, ' DROP INDEX idx_pbi_stock_createdat'));
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+SET @idx_exists = (SELECT COUNT(*) FROM INFORMATION_SCHEMA.STATISTICS
+    WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = @pbi_table AND INDEX_NAME = 'idx_pbi_batch_createdat');
+SET @sql = IF(@pbi_table IS NULL OR @idx_exists = 0, 'SELECT 1',
+    CONCAT('ALTER TABLE ', @pbi_table, ' DROP INDEX idx_pbi_batch_createdat'));
 PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
 
 SELECT 'Rollback v2.4.0 completed — three idx_pbi_* indexes dropped' AS status;


### PR DESCRIPTION
## Summary

- Adds three composite indexes to `PHARMACEUTICALBILLITEM` (7.15M rows) that were missing date-based coverage, causing full table scans on every pharmacy date-range report
- Drops `BILLITEM_BILLITEMSTATUS_idx` — cardinality=1 (100% NULL across 4.86M rows), pure write overhead with zero query benefit

## Root Cause

`PHARMACEUTICALBILLITEM` had no index on `CREATEDAT`. Any pharmacy report filtering by date range (monthly stock reports, batch movement reports, retail sale history) triggered a full scan of 7.15M rows.

Additionally, the highest-traffic stock had 12K+ rows — even stock-specific date queries scanned all of them without a composite index.

## Indexes Added

| Index | Columns | Fixes |
|---|---|---|
| `idx_pbi_createdat_retired` | `CREATEDAT, RETIRED` | Date-range pharmacy reports |
| `idx_pbi_stock_createdat` | `STOCK_ID, CREATEDAT, RETIRED` | Stock movement history by date |
| `idx_pbi_batch_createdat` | `ITEMBATCH_ID, CREATEDAT, RETIRED` | Batch movement reports by date |

## Indexes Dropped

| Index | Table | Reason |
|---|---|---|
| `BILLITEM_BILLITEMSTATUS_idx` | `billitem` | 100% NULL (cardinality=1), wastes write overhead on every pharmacy sale |

## Test Plan

- [x] Tested on qa4 (copy of rmh production database)
- [x] EXPLAIN before: `type=ALL, rows=7,153,035` (full scan)
- [x] EXPLAIN after: `type=range, rows=3` (~2,000,000x fewer rows examined)
- [x] Migration re-run is idempotent (all steps SKIPPED/OK on second run)
- [x] Migration handles both uppercase and lowercase table names (Linux/Windows/Azure)
- [ ] Run migration on rmh production and verify pharmacy report latency

🤖 Generated with [Claude Code](https://claude.com/claude-code)