### PR TITLE
fix(pharmacy): replace entity load with scalar JPQL in onEdit to prevent L2 cache deadlock

### DIFF
--- a/src/main/java/com/divudi/bean/pharmacy/RetailSaleNativeSqlController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/RetailSaleNativeSqlController.java
@@ -748,6 +748,21 @@ public class RetailSaleNativeSqlController implements Serializable, ControllerWi
         }
     }
 
+    private Double fetchCurrentStockQty(Long stockId) {
+        if (stockId == null) {
+            return null;
+        }
+        Map<String, Object> params = new HashMap<>();
+        params.put("id", stockId);
+        List<?> result = stockFacade.findLightsByJpql(
+                "SELECT s.stock FROM Stock s WHERE s.id = :id",
+                params, TemporalType.DATE, 1);
+        if (result == null || result.isEmpty() || result.get(0) == null) {
+            return null;
+        }
+        return ((Number) result.get(0)).doubleValue();
+    }
+
     private long resolveAmpItemId(Long itemId) {
         if (itemId == null) return 0L;
         try {
@@ -783,12 +798,11 @@ public class RetailSaleNativeSqlController implements Serializable, ControllerWi
         }
         if (bid.getStockId() != null) {
             try {
-                com.divudi.core.entity.pharmacy.Stock currentStock = stockFacade.find(bid.getStockId());
-                if (currentStock != null && currentStock.getStock() != null
-                        && bid.getQty() > currentStock.getStock()) {
-                    bid.setQty(currentStock.getStock());
+                Double availableQty = fetchCurrentStockQty(bid.getStockId());
+                if (availableQty != null && bid.getQty() > availableQty) {
+                    bid.setQty(availableQty);
                     JsfUtil.addErrorMessage("Quantity cannot exceed available stock ("
-                            + currentStock.getStock().intValue() + "). Quantity has been set to the maximum available.");
+                            + availableQty.intValue() + "). Quantity has been set to the maximum available.");
                 }
             } catch (Exception e) {
                 LOGGER.log(Level.WARNING, "Could not verify stock qty for stockId={0}", bid.getStockId());


### PR DESCRIPTION
## Summary

- `onEdit()` in `RetailSaleNativeSqlController` called `stockFacade.find(stockId)` to validate the quantity cap, which loaded a full `Stock` entity and triggered the `Stock → ItemBatch → Item` EAGER chain
- This acquired EclipseLink deferred object-building locks at depth-4 on `ItemBatch`, creating cross-thread lock contention when a concurrent settle or second qty edit held a related `Stock` lock
- The result was a permanent deadlock requiring a server redeploy to recover (observed 89 min hang on qa4, 2026-05-12)
- Replaced the entity load with `fetchCurrentStockQty()` — a scalar JPQL projection `SELECT s.stock FROM Stock s WHERE s.id = :id` that returns only the `Double` quantity, acquiring no L2 cache locks

## Test plan

- [ ] Edit qty of an item in native retail sale — stock cap validation still works (capped to available qty with error message)
- [ ] Settle a native retail sale bill normally — no regression
- [ ] Concurrent qty edits no longer cause thread hang on qa4

Closes #20665

🤖 Generated with [Claude Code](https://claude.com/claude-code)