### PR TITLE
Fix staff admin listbox not loading, filter not working, and prepareAdd NPE

### DIFF
--- a/src/main/java/com/divudi/bean/hr/StaffController.java
+++ b/src/main/java/com/divudi/bean/hr/StaffController.java
@@ -175,7 +175,7 @@ public class StaffController implements Serializable {
         if (current.getId() == null || current.getId() == 0) {
             JsfUtil.addErrorMessage("Please Select Staff Member");
         }
-        if (getSignatureUrl() == null || getSignatureUrl().trim() == "") {
+        if (getSignatureUrl() == null || getSignatureUrl().trim().isEmpty()) {
             JsfUtil.addErrorMessage("Add Signature Url");
         }
         System.out.println("getStaffController().getCurrent = " + getCurrent());
@@ -1063,7 +1063,7 @@ public class StaffController implements Serializable {
 
     public List<Staff> getSelectedItems() {
         if (selectedItems == null) {
-            selectedItems = new ArrayList<>();
+            fillSelectedItemsWithAllStaff();
         }
         return selectedItems;
     }
@@ -1182,6 +1182,7 @@ public class StaffController implements Serializable {
 
     public void prepareAdd() {
         current = new Staff();
+        current.setPerson(new Person());
         tempRetireDate = null;
         removeResign = false;
     }
@@ -1205,7 +1206,7 @@ public class StaffController implements Serializable {
         getItems();
         current = null;
         getCurrent();
-        fillSelectedItemsWithNonDoctorStaff();
+        fillSelectedItemsWithAllStaff();
     }
 
     public void setSelectedItems(List<Staff> selectedItems) {

--- a/src/main/java/com/divudi/bean/hr/StaffController.java
+++ b/src/main/java/com/divudi/bean/hr/StaffController.java
@@ -1206,7 +1206,7 @@ public class StaffController implements Serializable {
         getItems();
         current = null;
         getCurrent();
-        fillSelectedItemsWithAllStaff();
+        fillSelectedItemsWithNonDoctorStaff();
     }
 
     public void setSelectedItems(List<Staff> selectedItems) {

--- a/src/main/webapp/hr/hr_staff_admin.xhtml
+++ b/src/main/webapp/hr/hr_staff_admin.xhtml
@@ -47,9 +47,9 @@
                                             value="Delete"  >
                                         </p:commandButton>
                                     </div>
-                                    <p:selectOneListbox filter="true" id="lstSelect"   value="#{staffController.current}" style="height: auto;" class="w-100">
+                                    <p:selectOneListbox filter="true" id="lstSelect" value="#{staffController.current}">
                                         <f:selectItems  value="#{staffController.selectedItems}" var="myItem" itemValue="#{myItem}" itemLabel="#{myItem.person.name}(#{myItem.code})" ></f:selectItems>
-                                        <p:ajax event="change" process="lstSelect" update="gpDetail panelPrint" listener="#{staffController.changeStaff()}"/>                                        
+                                        <p:ajax event="change" update="gpDetail panelPrint" listener="#{staffController.changeStaff()}"/>
                                     </p:selectOneListbox>
 
                                     <p:panel rendered="false" >


### PR DESCRIPTION
## Changes

- `getSelectedItems()` now calls `fillSelectedItemsWithAllStaff()` instead of
  returning an empty list, so the listbox populates on page load regardless of
  how the page is reached

- Removed `style="height: auto;"` and `process="lstSelect"` from
  `p:selectOneListbox` so the client-side filter works correctly

- `prepareAdd()` now initialises `current.person` to prevent NPE when the
  General tab renders after clicking Add

- Fixed `saveSignatureUrl()` empty string check from `== ""` (reference
  comparison, always false) to `.isEmpty()`

## No functional regressions
- No business logic or persistence code was changed
- Delete behaviour on `hr_staff_without_doctors_admin.xhtml` is unchanged

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Staff list now displays all available staff members in relevant contexts, improving data visibility.
  * Enhanced staff selector component styling and responsiveness.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hmislk/hmis/pull/20671)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->