### PR TITLE
fix(cashier): handover total stale, self-handover allowed, float recipient missing in print

### DIFF
--- a/src/main/java/com/divudi/bean/cashTransaction/FinancialTransactionController.java
+++ b/src/main/java/com/divudi/bean/cashTransaction/FinancialTransactionController.java
@@ -3447,6 +3447,7 @@ public class FinancialTransactionController implements Serializable {
             p.setBill(currentBill);
             p.setCreatedAt(new Date());
             p.setCreater(sessionController.getLoggedUser());
+            p.setFloatRecipient(currentBill.getToWebUser());
             p.setInstitution(null);
             p.setDepartment(null);
             p.setPaidValue(0 - Math.abs(p.getPaidValue()));
@@ -5938,6 +5939,10 @@ public class FinancialTransactionController implements Serializable {
         try {
         if (user == null) {
             JsfUtil.addErrorMessage("Please select a user to handover the shift.");
+            return null;
+        }
+        if (user.equals(sessionController.getLoggedUser())) {
+            JsfUtil.addErrorMessage("Cannot handover to yourself. Please select a different user.");
             return null;
         }
         if (bundle == null) {

--- a/src/main/webapp/cashier/handover_start_all.xhtml
+++ b/src/main/webapp/cashier/handover_start_all.xhtml
@@ -109,7 +109,7 @@
                                             <i class="pi pi-dollar" style="margin-right:5px; color: #17a2b8;"></i>
                                             <p:outputLabel value="Total Handed over Value" />
                                         </h:panelGroup>
-                                        <p:outputLabel value="#{financialTransactionController.bundle.handoverTotal}">
+                                        <p:outputLabel id="lblHandoverTotal" value="#{financialTransactionController.bundle.handoverTotal}">
                                             <f:convertNumber pattern="#,##0.00" />
                                         </p:outputLabel>
                                     </p:panelGrid>
@@ -542,7 +542,7 @@
                                                         event="blur"
                                                         process="txtDenoQtyHandover" 
                                                         listener="#{financialTransactionController.bundle.calculateTotalHandoverByDenominationQuantities()}"
-                                                        update=":#{p:resolveFirstComponentWithId('txtCashHandover',view).clientId} txtDenoVal :#{p:resolveFirstComponentWithId('tblCashier',view).clientId} :#{p:resolveFirstComponentWithId('tblAll',view).clientId}" ></p:ajax>
+                                                        update=":#{p:resolveFirstComponentWithId('txtCashHandover',view).clientId} txtDenoVal :#{p:resolveFirstComponentWithId('tblCashier',view).clientId} :#{p:resolveFirstComponentWithId('tblAll',view).clientId} :#{p:resolveFirstComponentWithId('lblHandoverTotal',view).clientId}" ></p:ajax>
                                                 </p:inputText>  
                                             </p:column>
                                             <p:column >


### PR DESCRIPTION
## Summary

- **Total Handed over Value** on `handover_start_all.xhtml` was stale after denomination entry — only updated when the Update button was clicked. Fixed by adding the label to the denomination AJAX update targets.
- **Self-handover** was not prevented — a cashier could hand over a shift to themselves. Fixed with a server-side guard in `settleHandoverStartBill()`.
- **To User missing** in Float Transactions on the handover print details page for all "Float Sent" rows. `floatRecipient` was never set on `FUND_TRANSFER_BILL` payments at creation time. Fixed by setting it from `currentBill.getToWebUser()`.

A backfill script is needed for existing records on any deployed database:
```sql
UPDATE PAYMENT p JOIN BILL b ON p.bill_id = b.id SET p.floatRecipient_id = b.toWebUser_id WHERE b.billTypeAtomic = 'FUND_TRANSFER_BILL' AND b.toWebUser_id IS NOT NULL AND p.floatRecipient_id IS NULL AND b.retired = 0 AND p.retired = 0;
```

## Test plan
- [ ] Enter denomination quantities on handover page — Total Handed over Value updates immediately on blur without clicking Update
- [ ] Select yourself as handover recipient — error message shown, handover blocked
- [ ] Create a float transfer, then view the handover print details — To User column shows the recipient for Float Sent rows

Closes #20672

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
- Added server-side validation preventing users from initiating shift handovers to their own account, improving shift management controls
- Enhanced the handover total display to refresh correctly when entering denomination quantities during cashier fund handling operations
- Improved payment accuracy in fund transfer operations by ensuring proper recipient-side information is maintained throughout all transaction flows

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hmislk/hmis/pull/20673)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->