### PR TITLE
fix(cashier): resolve To User missing in float print via bill.toWebUser fallback

### DIFF
--- a/src/main/java/com/divudi/bean/cashTransaction/FinancialTransactionController.java
+++ b/src/main/java/com/divudi/bean/cashTransaction/FinancialTransactionController.java
@@ -3447,7 +3447,6 @@ public class FinancialTransactionController implements Serializable {
             p.setBill(currentBill);
             p.setCreatedAt(new Date());
             p.setCreater(sessionController.getLoggedUser());
-            p.setFloatRecipient(currentBill.getToWebUser());
             p.setInstitution(null);
             p.setDepartment(null);
             p.setPaidValue(0 - Math.abs(p.getPaidValue()));

--- a/src/main/webapp/resources/ezcomp/prints/five_five_paper_with_headings_for_handover_detail.xhtml
+++ b/src/main/webapp/resources/ezcomp/prints/five_five_paper_with_headings_for_handover_detail.xhtml
@@ -508,7 +508,7 @@
                                         <h:outputText value="#{floatRow.payment.creater.webUserPerson.nameWithTitle}" />
                                     </td>
                                     <td>
-                                        <h:outputText value="#{floatRow.payment.floatRecipient.webUserPerson.nameWithTitle}" />
+                                        <h:outputText value="#{floatRow.payment.floatRecipient ne null ? floatRow.payment.floatRecipient.webUserPerson.nameWithTitle : floatRow.payment.bill.toWebUser.webUserPerson.nameWithTitle}" />
                                     </td>
                                     <td class="text-end">
                                         <h:outputText value="#{floatRow.payment.paidValue}">


### PR DESCRIPTION
## Summary

Follow-up to #20673 addressing a CodeRabbit/Codex review concern.

The previous fix set `floatRecipient` on `FUND_TRANSFER_BILL` payments at creation time. This was reverted because `settleHandoverStartBill()` contains a query scoped by `(creater=:cu OR floatRecipient=:cu)` with `FUND_TRANSFER_BILL` in its bill type list and `handingOverStarted=false`. Setting `floatRecipient` on the sender's payment would cause the **recipient's** handover to incorrectly claim and mark the **sender's** payment, corrupting the sender's shift data.

The correct fix resolves the missing "To User" column entirely in the print template: fall back to `payment.bill.toWebUser` when `floatRecipient` is null. `bill.toWebUser` is always set on `FUND_TRANSFER_BILL` and is never used in shift-scoping queries.

Note: the reviewer cited `fetchShiftFloatsFromShiftStartToEnd` as the affected query — that was incorrect (neither overload includes `FUND_TRANSFER_BILL` in its btas). The real risk was in the marking query inside `settleHandoverStartBill()`.

## Test plan
- [ ] Create a float transfer, then view the handover print details — "To User" column shows the recipient for Float Sent rows
- [ ] Recipient's shift handover totals are not affected by the sender's float transfer payments

Closes #20672

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed payment record creation in fund transfer settlements to ensure accurate transaction tracking
* Improved recipient name display in handover documents with proper fallback rendering

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hmislk/hmis/pull/20686)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->