### PR TITLE
fix(startup): remove outbound HTTP call from DatabaseMigrationService

### DIFF
--- a/src/main/java/com/divudi/service/DatabaseMigrationService.java
+++ b/src/main/java/com/divudi/service/DatabaseMigrationService.java
@@ -2,17 +2,10 @@ package com.divudi.service;
 
 import com.divudi.core.data.OptionScope;
 import com.divudi.core.facade.ConfigOptionFacade;
-import java.io.BufferedReader;
-import java.io.InputStreamReader;
-import java.net.HttpURLConnection;
-import java.net.URL;
-import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 import javax.annotation.PostConstruct;
 import javax.annotation.security.PermitAll;
 import javax.ejb.EJB;
@@ -26,10 +19,13 @@ import javax.ejb.TransactionAttributeType;
  *
  * On every deployment/restart, migrationPending starts as true, making the
  * page accessible to anyone. If the stored DATABASE_DDL_VERSION config option
- * matches the current wiki DDL version, migration is automatically marked as
- * not necessary and the banner is suppressed. Otherwise, the banner remains
- * until an admin visits mf.xhtml and marks the migration as complete or not
- * necessary.
+ * is set to "CONFIRMED", migration is automatically marked as not necessary
+ * and the banner is suppressed. Otherwise, the banner remains until an admin
+ * visits mf.xhtml and marks the migration as complete or not necessary.
+ *
+ * The wiki DDL version check has been removed to avoid blocking the deploy
+ * thread with an outbound HTTP request at startup. Admins can confirm the
+ * migration status manually via the admin interface.
  *
  * @author Dr M H B Ariyaratne
  */
@@ -39,7 +35,6 @@ import javax.ejb.TransactionAttributeType;
 public class DatabaseMigrationService {
 
     private static final Logger LOGGER = Logger.getLogger(DatabaseMigrationService.class.getName());
-    private static final String WIKI_DDL_URL = "https://github.com/hmislk/hmis/wiki/Database-Schema-DDL-Generation-Guide";
     private static final String CONFIG_KEY_DDL_VERSION = "DATABASE_DDL_VERSION";
 
     @EJB
@@ -52,23 +47,13 @@ public class DatabaseMigrationService {
     public void init() {
         try {
             String storedVersion = readStoredDdlVersion();
-            if (storedVersion != null && !storedVersion.isEmpty() && !"UNCHECKED".equals(storedVersion)) {
-                String wikiVersion = fetchWikiDdlVersion();
-                if (wikiVersion == null) {
-                    // Wiki unreachable — trust the admin's stored confirmation rather than falsely alarming
-                    migrationPending = false;
-                    LOGGER.info("DatabaseMigrationService: Wiki unreachable at startup; trusting stored confirmation (" + storedVersion + "). No migration pending.");
-                    return;
-                }
-                if (wikiVersion.equals(storedVersion) || "CONFIRMED".equals(storedVersion)) {
-                    migrationPending = false;
-                    LOGGER.info("DatabaseMigrationService: Schema confirmed (wiki=" + wikiVersion + ", stored=" + storedVersion + "). No migration pending.");
-                    return;
-                }
-                LOGGER.info("DatabaseMigrationService: DDL version mismatch (wiki=" + wikiVersion + ", stored=" + storedVersion + "). Migration may be pending.");
+            if ("CONFIRMED".equals(storedVersion)) {
+                migrationPending = false;
+                LOGGER.info("DatabaseMigrationService: stored version is CONFIRMED — no migration pending.");
+                return;
             }
         } catch (Exception e) {
-            LOGGER.log(Level.WARNING, "DatabaseMigrationService: Could not auto-check DDL version at startup.", e);
+            LOGGER.log(Level.WARNING, "DatabaseMigrationService: Could not read stored DDL version at startup.", e);
         }
         LOGGER.info("DatabaseMigrationService: Migration page is open to all users until marked as complete or not necessary.");
     }
@@ -85,37 +70,6 @@ public class DatabaseMigrationService {
             LOGGER.log(Level.WARNING, "DatabaseMigrationService: Could not read stored DDL version.", e);
             return null;
         }
-    }
-
-    private String fetchWikiDdlVersion() {
-        HttpURLConnection conn = null;
-        try {
-            URL url = new URL(WIKI_DDL_URL);
-            conn = (HttpURLConnection) url.openConnection();
-            conn.setRequestMethod("GET");
-            conn.setConnectTimeout(5000);
-            conn.setReadTimeout(10000);
-            conn.setRequestProperty("User-Agent", "HMIS-Schema-Checker/1.0");
-            if (conn.getResponseCode() == 200) {
-                Pattern pattern = Pattern.compile("Last Update\\s*-\\s*(\\d{4}\\.\\d{2}\\.\\d{2}\\s+\\d{2}:\\d{2})");
-                try (BufferedReader reader = new BufferedReader(new InputStreamReader(conn.getInputStream(), StandardCharsets.UTF_8))) {
-                    String line;
-                    while ((line = reader.readLine()) != null) {
-                        Matcher m = pattern.matcher(line);
-                        if (m.find()) {
-                            return m.group(1).trim();
-                        }
-                    }
-                }
-            }
-        } catch (Exception e) {
-            LOGGER.log(Level.WARNING, "DatabaseMigrationService: Could not fetch wiki DDL version.", e);
-        } finally {
-            if (conn != null) {
-                conn.disconnect();
-            }
-        }
-        return null;
     }
 
     @TransactionAttribute(TransactionAttributeType.NOT_SUPPORTED)


### PR DESCRIPTION
## Summary

- Removes the outbound HTTP call to the GitHub wiki from `DatabaseMigrationService.init()`
- The call fetched the DDL version to compare against the stored DB value, but blocked the deploy thread for up to **15 seconds** (5s connect + 10s read timeout) on every deploy
- Simplified: if the stored `DATABASE_DDL_VERSION` config option is `"CONFIRMED"`, migration is suppressed — otherwise the banner stays visible until an admin confirms via the admin interface

## Test plan

- [ ] CI/CD deploys without the 15s startup delay
- [ ] Migration banner still works correctly — visible until admin marks it confirmed

🤖 Generated with [Claude Code](https://claude.com/claude-code)