### PR TITLE
fix(persistence): remove eclipselink.deploy-on-startup

### DIFF
--- a/src/main/resources/META-INF/persistence.xml
+++ b/src/main/resources/META-INF/persistence.xml
@@ -49,11 +49,6 @@
             <!-- every cache hit.                                               -->
             <property name="eclipselink.jdbc.result-set-access-optimization" value="true"/>
 
-            <!-- Force full persistence-unit deployment at server startup,    -->
-            <!-- moving descriptor init + session login off the first user    -->
-            <!-- request path. Deployment takes ~20s longer but no user ever  -->
-            <!-- waits for EntityManagerSetupImpl.deploy(). Issue #20138.     -->
-            <property name="eclipselink.deploy-on-startup" value="true"/>
         </properties>
     </persistence-unit>
     <persistence-unit name="hmisAuditPU" transaction-type="JTA">
@@ -62,7 +57,6 @@
         <properties>
             <property name="eclipselink.logging.level.sql" value="SEVERE"/>
             <property name="eclipselink.logging.level" value="SEVERE"/>
-            <property name="eclipselink.deploy-on-startup" value="true"/>
         </properties>
     </persistence-unit>
 </persistence>


### PR DESCRIPTION
## Summary

- Removes `eclipselink.deploy-on-startup=true` from both `hmisPU` and `hmisAuditPU` in `persistence.xml`
- This property forced EclipseLink to fully initialise (connect to DB + build descriptors for 200+ entities) **on the deploy thread**, before Payara could acknowledge the `asadmin deploy` command
- Against the Azure-hosted RMH database the initialisation consistently took **>10 minutes**, causing `asadmin` to hit its 600s read timeout → `rmh` left undeployed every time
- `rh` deployed fine on the same server because it uses a lower-latency local DB

Removing it restores default lazy-init: EclipseLink initialises on the first user request, keeping the admin port responsive during deployment.

## Test plan

- [ ] CI/CD completes without "Read timed out"
- [ ] `rmh` appears in `list-applications`
- [ ] Site reachable at https://rmh.carecode.org/rmh

🤖 Generated with [Claude Code](https://claude.com/claude-code)