### PR TITLE
fix(persistence): remove eclipselink.deploy-on-startup from both PUs

### DIFF
--- a/src/main/resources/META-INF/persistence.xml
+++ b/src/main/resources/META-INF/persistence.xml
@@ -49,11 +49,6 @@
             <!-- every cache hit.                                               -->
             <property name="eclipselink.jdbc.result-set-access-optimization" value="true"/>
 
-            <!-- Force full persistence-unit deployment at server startup,    -->
-            <!-- moving descriptor init + session login off the first user    -->
-            <!-- request path. Deployment takes ~20s longer but no user ever  -->
-            <!-- waits for EntityManagerSetupImpl.deploy(). Issue #20138.     -->
-            <property name="eclipselink.deploy-on-startup" value="true"/>
         </properties>
     </persistence-unit>
     <persistence-unit name="hmisAuditPU" transaction-type="JTA">
@@ -62,7 +57,6 @@
         <properties>
             <property name="eclipselink.logging.level.sql" value="SEVERE"/>
             <property name="eclipselink.logging.level" value="SEVERE"/>
-            <property name="eclipselink.deploy-on-startup" value="true"/>
         </properties>
     </persistence-unit>
 </persistence>


### PR DESCRIPTION
## Summary
- Removes `eclipselink.deploy-on-startup=true` from both `hmisPU` and `hmisAuditPU`
- This property forces EclipseLink to initialize the full persistence unit on the Payara deploy thread — against remote/Azure databases this can block for 10+ minutes, causing CI timeouts
- EclipseLink will now initialize lazily on first use, which is the correct behaviour for JTA persistence units on an external connection pool

## Background
Root-caused during RMH production outage: `deploy-on-startup` + Azure DB latency was the primary cause of `asadmin` 600 s timeouts. Removed from `rmh-prod` via the hotfix chain. This PR brings `development` in sync.

## Test plan
- [ ] Local deploy completes without blocking on first-request init
- [ ] No regression in query performance (L2 cache still active via `eclipselink.cache.size.default=1000`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated persistence unit configuration to no longer enforce deployment-on-startup forcing for the main and audit persistence units.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hmislk/hmis/pull/20695)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->