### PR TITLE
fix(pharmacy): use generic bill-type router for view button on return-item-only search page

### DIFF
--- a/src/main/resources/META-INF/persistence.xml
+++ b/src/main/resources/META-INF/persistence.xml
@@ -2,7 +2,7 @@
 <persistence version="2.2" xmlns="http://java.sun.com/xml/ns/persistence" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/persistence http://xmlns.jcp.org/xml/ns/persistence/persistence_2_2.xsd">
     <persistence-unit name="hmisPU" transaction-type="JTA">
         <provider>org.eclipse.persistence.jpa.PersistenceProvider</provider>
-        <jta-data-source>jdbc/coop</jta-data-source>
+        <jta-data-source>${JDBC_DATASOURCE}</jta-data-source>
         <exclude-unlisted-classes>false</exclude-unlisted-classes>
         <properties>
             <property name="eclipselink.logging.level.sql" value="SEVERE"/>
@@ -57,7 +57,7 @@
         </properties>
     </persistence-unit>
     <persistence-unit name="hmisAuditPU" transaction-type="JTA">
-        <jta-data-source>jdbc/ruhunuAudit</jta-data-source>
+        <jta-data-source>${JDBC_AUDIT_DATASOURCE}</jta-data-source>
         <exclude-unlisted-classes>false</exclude-unlisted-classes>
         <properties>
             <property name="eclipselink.logging.level.sql" value="SEVERE"/>

--- a/src/main/resources/META-INF/persistence.xml
+++ b/src/main/resources/META-INF/persistence.xml
@@ -2,7 +2,7 @@
 <persistence version="2.2" xmlns="http://java.sun.com/xml/ns/persistence" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/persistence http://xmlns.jcp.org/xml/ns/persistence/persistence_2_2.xsd">
     <persistence-unit name="hmisPU" transaction-type="JTA">
         <provider>org.eclipse.persistence.jpa.PersistenceProvider</provider>
-        <jta-data-source>${JDBC_DATASOURCE}</jta-data-source>
+        <jta-data-source>jdbc/coop</jta-data-source>
         <exclude-unlisted-classes>false</exclude-unlisted-classes>
         <properties>
             <property name="eclipselink.logging.level.sql" value="SEVERE"/>
@@ -57,7 +57,7 @@
         </properties>
     </persistence-unit>
     <persistence-unit name="hmisAuditPU" transaction-type="JTA">
-        <jta-data-source>${JDBC_AUDIT_DATASOURCE}</jta-data-source>
+        <jta-data-source>jdbc/ruhunuAudit</jta-data-source>
         <exclude-unlisted-classes>false</exclude-unlisted-classes>
         <properties>
             <property name="eclipselink.logging.level.sql" value="SEVERE"/>

--- a/src/main/webapp/pharmacy/pharmacy_search_pre_bill_for_return_item_only.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_search_pre_bill_for_return_item_only.xhtml
@@ -101,9 +101,7 @@
                                             ajax="false"
                                             id="viewBill"
                                             icon="fas fa-file-invoice"
-                                            action="pharmacy_reprint_bill_sale">
-                                            <f:setPropertyActionListener value="#{searchController.loadBillById(bill.referenceBillId)}"
-                                                                         target="#{pharmacyBillSearch.bill}"/>
+                                            action="#{billSearch.navigateToViewBillByAtomicBillTypeByBillId(bill.referenceBillId)}">
                                         </p:commandButton>
                                         <p:tooltip for="viewBill" value="View Bill"  showDelay="0" hideDelay="0"></p:tooltip>
                                         <p:commandButton


### PR DESCRIPTION
## Summary

- Replaces the hardcoded `pharmacy_reprint_bill_sale` navigation on the return-item-only search page with `billSearch.navigateToViewBillByAtomicBillTypeByBillId(bill.referenceBillId)`, routing retail sale bills to `pharmacy_bill_retail_sale_native`
- Updates `developer_docs/billing/bill-preview-navigation-guide.md` to document the three navigation modes (view/manage/admin), the six native-SQL-backed bill types, and anti-patterns to avoid

Closes #20696

## Test plan

- [ ] Open `pharmacy_search_pre_bill_for_return_item_only.xhtml`, search for bills
- [ ] Click the View button — should navigate to `pharmacy_bill_retail_sale_native` displaying the retail sale bill correctly
- [ ] Verify the "Return Item Only" button still works as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)