### PR TITLE
feat(cashier): add same-shift cancellation for shortage bills

### DIFF
--- a/developer_docs/billing/bill-preview-navigation-guide.md
+++ b/developer_docs/billing/bill-preview-navigation-guide.md
@@ -1,760 +1,171 @@
-# Bill Preview and Navigation Implementation Guide
+# Bill Navigation Guide — View, Manage, Admin
 
 ## Overview
 
-This guide explains how to implement bill preview/reprint functionality in HMIS using the atomic bill type routing system. The system automatically routes users to the correct bill preview page based on the bill's atomic type, ensuring consistent navigation across all modules.
+`BillSearch` (bean `billSearch`) provides three families of navigation methods
+that route to the correct page for any bill, based on its `BillTypeAtomic` value.
+Always use these methods — never hardcode a page URL or load the bill yourself in
+the calling page.
 
-## Core Concepts
+---
 
-### 1. Atomic Bill Type Routing
+## Three Navigation Modes
 
-The HMIS system uses `BillTypeAtomic` enum values to determine the correct preview/reprint page for each bill type. This approach:
+| Mode | XHTML method | Purpose |
+|------|-------------|---------|
+| **View** | `billSearch.navigateToViewBillByAtomicBillTypeByBillId(id)` | Read-only / print |
+| **Manage** | `billSearch.navigateToManageBillByAtomicBillTypeByBillId(id)` | Edit / cancel / reprint |
+| **Admin** | `billSearch.navigateToAdminBillByAtomicBillTypeByBillId(id)` | Admin-level corrections |
 
-- **Centralizes navigation logic** in `BillSearch.navigateToViewBillByAtomicBillType()`
-- **Ensures consistency** across all modules
-- **Simplifies maintenance** by having a single source of truth
-- **Supports all bill types** (pharmacy, OPD, channeling, etc.)
+All three accept a `Long` bill ID, look up the `BillTypeAtomic` and route accordingly.
 
-### 2. Navigation Flow
+---
 
-```
-User clicks "View Bill" button
-    ↓
-Pass Bill ID to navigation method
-    ↓
-Fetch Bill from database
-    ↓
-Identify BillTypeAtomic
-    ↓
-Route to appropriate reprint page
-    ↓
-Display bill with print options
-```
-
-## Implementation Pattern
-
-### Frontend (XHTML)
-
-#### Basic Implementation
+## Standard XHTML Button Pattern
 
 ```xhtml
-<!-- In a data table action column -->
-<p:column headerText="Action">
-    <p:commandButton
-        id="btnViewBill"
-        title="View Bill"
-        ajax="false"
-        class="mx-1"
-        icon="pi pi-eye"
-        action="#{billSearch.navigateToViewBillByAtomicBillTypeByBillId(row.bill.id)}" />
-</p:column>
-```
-
-#### Using Bill Item ID
-
-When your report displays bill items instead of bills:
-
-```xhtml
+<!-- View (read-only / print) -->
 <p:commandButton
-    id="btnViewBill"
-    title="View Bill"
     ajax="false"
-    icon="pi pi-eye"
-    action="#{billSearch.navigateToViewBillByAtomicBillTypeByBillItemId(row.billItem.id)}" />
-```
-
-
-### Backend (Java)
-
-The navigation system is already implemented in `BillSearch.java`. You don't need to write backend code unless you're:
-1. Adding a new bill type
-2. Creating a new reprint page
-
-#### Entry Point Methods
-
-**Method 1: Navigate by Bill ID**
-```java
-// Location: BillSearch.java:3870
-public String navigateToViewBillByAtomicBillTypeByBillId(Long BillId) {
-    if (BillId == null) {
-        JsfUtil.addErrorMessage("Bill ID is required");
-        return null;
-    }
-
-    Bill foundBill = billFacade.find(BillId);
-    if (foundBill == null) {
-        JsfUtil.addErrorMessage("Bill not found");
-        return null;
-    }
-
-    this.bill = foundBill;
-    return navigateToViewBillByAtomicBillType();
-}
-```
-
-**Method 2: Navigate by Bill Item ID**
-```java
-// Location: BillSearch.java:3886
-public String navigateToViewBillByAtomicBillTypeByBillItemId(Long BillItemId) {
-    if (BillItemId == null) {
-        JsfUtil.addErrorMessage("Bill Item ID is required");
-        return null;
-    }
-
-    BillItem foundBillItem = billItemFacede.find(BillItemId);
-    if (foundBillItem == null) {
-        JsfUtil.addErrorMessage("Bill Item not found");
-        return null;
-    }
-
-    if (foundBillItem.getBill() == null) {
-        JsfUtil.addErrorMessage("Associated Bill not found");
-        return null;
-    }
-
-    this.bill = foundBillItem.getBill();
-    return navigateToViewBillByAtomicBillType();
-}
-```
-
-
-#### Core Routing Logic
-
-```java
-// Location: BillSearch.java:3907
-public String navigateToViewBillByAtomicBillType() {
-    if (bill == null) {
-        JsfUtil.addErrorMessage("No Bill is Selected");
-        return null;
-    }
-    if (bill.getBillTypeAtomic() == null) {
-        JsfUtil.addErrorMessage("No Bill type");
-        return null;
-    }
-
-    BillTypeAtomic billTypeAtomic = bill.getBillTypeAtomic();
-    loadBillDetails(bill);
-
-    switch (billTypeAtomic) {
-        case PHARMACY_RETAIL_SALE:
-            pharmacyBillSearch.setBill(bill);
-            return pharmacyBillSearch.navigatePharmacyReprintRetailBill();
-
-        case PHARMACY_RETAIL_SALE_CANCELLED:
-            pharmacyBillSearch.setBill(bill);
-            return pharmacyBillSearch.navigateToViewPharmacyRetailCancellationBill();
-
-        case PHARMACY_ISSUE:
-        case PHARMACY_DISPOSAL_ISSUE:
-            return navigateToPharmacyIssue();
-
-        case PHARMACY_RECEIVE:
-        case PHARMACY_RECEIVE_CANCELLED:
-            return navigateToPharmayReceive();
-
-        case PHARMACY_DIRECT_PURCHASE:
-            return navigateToDirectPurchaseBillView();
-
-        // ... more cases for different bill types
-
-        default:
-            JsfUtil.addErrorMessage("Unknown Bill Type");
-            return null;
-    }
-}
-```
-
-## Finding Existing Reprint Pages
-
-Before creating a new reprint page, check if one already exists for your bill type:
-
-### Step 1: Find the Bill Type Atomic Value
-
-Check your bill's `BillTypeAtomic` enum value. Common values include:
-- `PHARMACY_RETAIL_SALE`
-- `PHARMACY_ISSUE`
-- `PHARMACY_RECEIVE`
-- `PHARMACY_DIRECT_PURCHASE`
-- `PHARMACY_GRN`
-- `OPD_BILL_WITH_PAYMENT`
-- etc.
-
-### Step 2: Search the Switch Statement
-
-Look in `BillSearch.navigateToViewBillByAtomicBillType()` for your bill type:
-
-```java
-case PHARMACY_RETAIL_SALE:
-    pharmacyBillSearch.setBill(bill);
-    return pharmacyBillSearch.navigatePharmacyReprintRetailBill();
-```
-
-### Step 3: Trace the Navigation Method
-
-Follow the navigation method to find the page path:
-
-```java
-// In PharmacyBillSearch.java:308
-public String navigatePharmacyReprintRetailBill() {
-    if (bill == null) {
-        JsfUtil.addErrorMessage("No Bill Selected");
-    }
-    return "/pharmacy/pharmacy_reprint_bill_sale?faces-redirect=true";
-}
-```
-
-This tells you the reprint page is: `/pharmacy/pharmacy_reprint_bill_sale.xhtml`
-
-## Common Navigation Patterns
-
-### Pattern 1: Direct Navigation
-
-For simple bill types, navigation is direct:
-
-```java
-case PHARMACY_DIRECT_PURCHASE:
-    return navigateToDirectPurchaseBillView();
-
-// Method implementation
-public String navigateToDirectPurchaseBillView() {
-    if (bill == null) {
-        JsfUtil.addErrorMessage("No Bill is Selected");
-        return null;
-    }
-    loadBillDetails(bill);
-    directPurchaseController.setPrintPreview(true);
-    directPurchaseController.setPrintBill(bill);
-    return "/pharmacy/direct_purchase";
-}
-```
-
-**Key Points:**
-- Set `printPreview = true` on the controller
-- Set the bill on the controller (`setPrintBill()`, `setIssuedBill()`, etc.)
-- Return the page path without `.xhtml` extension
-- No redirect needed when returning to same page
-
-### Pattern 2: Module-Specific Controller Navigation
-
-For complex bill types with module-specific logic:
-
-```java
-case PHARMACY_RETAIL_SALE:
-    pharmacyBillSearch.setBill(bill);
-    return pharmacyBillSearch.navigatePharmacyReprintRetailBill();
-
-// In PharmacyBillSearch.java
-public String navigatePharmacyReprintRetailBill() {
-    if (bill == null) {
-        JsfUtil.addErrorMessage("No Bill Selected");
-    }
-    return "/pharmacy/pharmacy_reprint_bill_sale?faces-redirect=true";
-}
-```
-
-**Key Points:**
-- Delegate to module-specific controller (`pharmacyBillSearch`, `pharmacySaleController`, etc.)
-- Use `faces-redirect=true` for clean URLs
-- Module controller handles additional business logic
-
-### Pattern 3: Conditional Navigation Based on Bill Type
-
-Some bills require different pages based on additional criteria:
-
-```java
-public String navigateToPharmacyIssue() {
-    if (bill == null) {
-        JsfUtil.addErrorMessage("No Bill is Selected");
-        return null;
-    }
-    loadBillDetails(bill);
-
-    if (bill.getBillType() == BillType.PharmacyTransferIssue) {
-        transferIssueController.setPrintPreview(true);
-        transferIssueController.setIssuedBill(bill);
-        return "/pharmacy/pharmacy_transfer_issue";
-    } else {
-        pharmacyIssueController.setBillPreview(true);
-        pharmacyIssueController.setPrintBill(bill);
-        return "/pharmacy/pharmacy_issue";
-    }
-}
-```
-
-**Key Points:**
-- Check additional bill properties if needed (`billType`, status, etc.)
-- Route to different pages based on business logic
-- Set appropriate flags on controllers
-
-## Creating New Reprint Pages
-
-If a reprint page doesn't exist for your bill type, follow these steps:
-
-### Step 1: Create the Reprint Page
-
-**File:** `/pharmacy/pharmacy_reprint_[billtype].xhtml`
-
-```xhtml
-<?xml version='1.0' encoding='UTF-8' ?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
-    "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml"
-      xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
-      xmlns:h="http://xmlns.jcp.org/jsf/html"
-      xmlns:p="http://primefaces.org/ui"
-      xmlns:f="http://xmlns.jcp.org/jsf/core"
-      xmlns:ph="http://xmlns.jcp.org/jsf/composite/ezcomp/pharmacy">
-
-    <h:body>
-        <ui:composition template="/pharmacy/index.xhtml">
-            <ui:define name="subcontent">
-                <h:form>
-                    <!-- Header with action buttons -->
-                    <p:panel>
-                        <f:facet name="header">
-                            <div class="d-flex align-items-center justify-content-between">
-                                <div>
-                                    <h:outputText value="Bill Preview - #{yourController.bill.deptId}" />
-                                </div>
-                                <div>
-                                    <p:commandButton
-                                        value="Print"
-                                        ajax="false"
-                                        icon="fas fa-print"
-                                        class="ui-button-info mx-2">
-                                        <p:printer target="printArea" />
-                                    </p:commandButton>
-
-                                    <!-- Settings button for printer configuration -->
-                                    <p:commandButton
-                                        rendered="#{webUserController.hasPrivilege('ChangeReceiptPrintingPaperTypes')}"
-                                        value="Settings"
-                                        icon="fas fa-cog"
-                                        class="ui-button-secondary mx-1"
-                                        type="button"
-                                        onclick="PF('billTypeConfigDialog').show();" />
-
-                                    <p:commandButton
-                                        value="Back"
-                                        ajax="false"
-                                        icon="fas fa-arrow-left"
-                                        action="#{yourController.navigateToList}"
-                                        class="ui-button-secondary mx-2" />
-                                </div>
-                            </div>
-                        </f:facet>
-
-                        <!-- Print area with conditional rendering based on paper type settings -->
-                        <h:panelGroup id="printArea">
-                            <!-- A4 Format -->
-                            <h:panelGroup rendered="#{configOptionController.getBooleanValueByKey('Your Bill Type A4 Paper', true)}">
-                                <ph:yourBillComposite bill="#{yourController.bill}"/>
-                            </h:panelGroup>
-
-                            <!-- POS Format -->
-                            <h:panelGroup rendered="#{configOptionController.getBooleanValueByKey('Your Bill Type POS Paper', false)}">
-                                <ph:yourBillComposite_pos bill="#{yourController.bill}"/>
-                            </h:panelGroup>
-
-                            <!-- Custom Format -->
-                            <h:panelGroup rendered="#{configOptionController.getBooleanValueByKey('Your Bill Type Custom Format', false)}">
-                                <ph:yourBillComposite_custom bill="#{yourController.bill}"/>
-                            </h:panelGroup>
-                        </h:panelGroup>
-                    </p:panel>
-                </h:form>
-
-                <!-- Include printer configuration dialog if needed -->
-                <!-- See: developer_docs/configuration/printer-configuration-system.md -->
-
-            </ui:define>
-        </ui:composition>
-    </h:body>
-</html>
-```
-
-### Step 2: Reuse Existing Composites
-
-**IMPORTANT:** Always reuse existing composite components for bill display. Do NOT create duplicate composites.
-
-**Example:** If you're creating a reprint page for pharmacy transfer issue:
-- Look for existing composite: `resources/pharmacy/transferIssue.xhtml`
-- Use the same composite in your reprint page
-- Only the page structure and navigation differs
-
-**Benefits of Reusing Composites:**
-- Consistent bill formatting across create/edit/reprint pages
-- Single source of truth for bill display logic
-- Automatic updates when composite is improved
-- Printer settings work across all pages
-
-### Step 3: Add Printer Configuration Settings
-
-Follow the printer configuration system to allow users to select paper formats:
-
-```xhtml
-<!-- Settings button -->
+    icon="fa fa-eye"
+    title="View Bill"
+    action="#{billSearch.navigateToViewBillByAtomicBillTypeByBillId(row.id)}" />
+
+<!-- Manage (edit / cancel) -->
 <p:commandButton
-    rendered="#{webUserController.hasPrivilege('ChangeReceiptPrintingPaperTypes')}"
-    value="Settings"
-    icon="fas fa-cog"
-    class="ui-button-secondary mx-1"
-    type="button"
-    onclick="PF('yourBillTypeConfigDialog').show();" />
+    ajax="false"
+    icon="fa fa-file-invoice"
+    title="Manage Bill"
+    action="#{billSearch.navigateToManageBillByAtomicBillTypeByBillId(row.id)}" />
 
-<!-- Configuration dialog -->
-<p:dialog id="yourBillTypeConfigDialog"
-          header="Bill Type Printer Configuration"
-          widgetVar="yourBillTypeConfigDialog"
-          modal="true"
-          width="600">
-    <!-- See: developer_docs/configuration/printer-configuration-system.md -->
-</p:dialog>
+<!-- Admin -->
+<p:commandButton
+    ajax="false"
+    icon="fa fa-tools"
+    title="Admin"
+    action="#{billSearch.navigateToAdminBillByAtomicBillTypeByBillId(row.id)}" />
 ```
 
-**Reference:** See [Printer Configuration System](../configuration/printer-configuration-system.md) for complete implementation details.
+Pass whatever holds the bill ID in your DTO — `row.id`, `row.billId`,
+`row.referenceBillId`, etc.
 
-### Step 4: Add Navigation Method
+**Never** create a custom navigation method just to reach a specific page — check
+the switch statement first (see below).
 
-Add a navigation method in the appropriate controller:
+---
+
+## How `navigateToViewBillByAtomicBillTypeByBillId` Works
+
+1. Fetches **only** `BILLTYPEATOMIC` from the `bill` table via a single native
+   scalar query (no entity load).
+2. Dispatches to the appropriate native-SQL controller or falls back to the
+   entity-based path for bill types not yet migrated.
 
 ```java
-public String navigateToYourBillTypeReprint() {
-    if (bill == null) {
-        JsfUtil.addErrorMessage("No Bill is Selected");
-        return null;
+// BillSearch.java ~4756
+public String navigateToViewBillByAtomicBillTypeByBillId(Long BillId) {
+    BillTypeAtomic bta = fetchBillTypeAtomicByNativeSql(BillId); // single scalar query
+    switch (bta) {
+        case PHARMACY_ISSUE:              return transferIssueNativeSqlController.viewByBillId(BillId);
+        case PHARMACY_RECEIVE:            return transferReceiveNativeSqlController.viewByBillId(BillId);
+        case DIRECT_ISSUE_INWARD_MEDICINE: return inpatientDirectIssueNativeSqlController.viewByBillId(BillId);
+        case PHARMACY_RETAIL_SALE:        return retailSaleNativeSqlController.viewByBillId(BillId);
+        case PHARMACY_TRANSFER_REQUEST_PRE:
+        case PHARMACY_TRANSFER_REQUEST:   return pharmacyBillSearch.viewRequestByBillId(BillId);
+        default:                          return navigateToViewBillByAtomicBillTypeByBillIdEntityBased(BillId);
     }
-    loadBillDetails(bill);
+}
+```
+
+### Native-SQL-backed bill types (fast path)
+
+These six types load data via DTO / native SQL — no JPA entity graph, no L2
+cache involvement:
+
+| `BillTypeAtomic` | Controller | Target page |
+|-----------------|-----------|-------------|
+| `PHARMACY_RETAIL_SALE` | `RetailSaleNativeSqlController` | `pharmacy_bill_retail_sale_native` |
+| `PHARMACY_ISSUE` | `TransferIssueNativeSqlController` | `pharmacy_bill_transfer_issue_native` |
+| `PHARMACY_RECEIVE` | `TransferReceiveNativeSqlController` | `pharmacy_bill_transfer_receive_native` |
+| `DIRECT_ISSUE_INWARD_MEDICINE` | `InpatientDirectIssueNativeSqlController` | `pharmacy_bill_direct_issue_native` |
+| `PHARMACY_TRANSFER_REQUEST_PRE` | `PharmacyBillSearch` | `pharmacy_reprint_transfer_request` |
+| `PHARMACY_TRANSFER_REQUEST` | `PharmacyBillSearch` | `pharmacy_reprint_transfer_request` |
+
+All other bill types fall through to the entity-based path
+(`navigateToViewBillByAtomicBillTypeByBillIdEntityBased`), which loads the full
+`Bill` entity and calls `navigateToViewBillByAtomicBillType()`.
+
+### Fallback: entity-based path
+
+For bill types not yet on the native path, `BillSearch` loads the full entity
+and routes via a large switch in `navigateToViewBillByAtomicBillType()`. This
+covers OPD bills, channelling, GRN, direct purchase, inward professional bills,
+etc.
+
+---
+
+## Manage and Admin Paths
+
+`navigateToManageBillByAtomicBillType()` handles a different set of types — OPD
+bills, package bills, credit company bills, etc. It currently has no native-SQL
+fast path; it always loads the full entity first.
+
+`navigateToAdminBillByAtomicBillType()` delegates entirely to `navigateToAdminBill()`
+after loading the entity — it has no type-specific switch yet.
+
+---
+
+## Adding Support for a New Bill Type
+
+### View (fast path preferred)
+
+1. Create a `viewByBillId(Long billId)` method in the relevant native controller
+   that loads print data via DTO/native SQL and returns the target page with
+   `faces-redirect=true`.
+2. Add a `case YOUR_TYPE: return yourNativeSqlController.viewByBillId(BillId);`
+   to the switch in `navigateToViewBillByAtomicBillTypeByBillId`.
+
+### View (entity fallback)
+
+If native SQL is not yet needed, add a case to
+`navigateToViewBillByAtomicBillType()`:
+
+```java
+case YOUR_TYPE:
     yourController.setPrintPreview(true);
     yourController.setBill(bill);
-    return "/pharmacy/pharmacy_reprint_your_bill_type?faces-redirect=true";
-}
+    return "/your/module/your_page?faces-redirect=true";
 ```
 
-### Step 5: Add Case to Switch Statement
+### Manage / Admin
 
-In `BillSearch.navigateToViewBillByAtomicBillType()`, add your bill type:
+Add a case to `navigateToManageBillByAtomicBillType()` or `navigateToAdminBill()`
+as appropriate.
 
-```java
-case YOUR_BILL_TYPE_ATOMIC:
-    return navigateToYourBillTypeReprint();
-```
+---
 
-## Best Practices
-
-### 1. Always Use Atomic Bill Type Routing
-
-✅ **DO:**
-```xhtml
-<p:commandButton
-    action="#{billSearch.navigateToViewBillByAtomicBillTypeByBillId(row.bill.id)}" />
-```
-
-❌ **DON'T:**
-```xhtml
-<p:commandButton
-    action="/pharmacy/pharmacy_reprint_bill_sale?faces-redirect=true" />
-```
-
-**Why:** Atomic routing ensures you navigate to the correct page even if bill types change or business logic evolves.
-
-### 2. Check for Existing Reprint Pages
-
-Before creating a new page:
-1. Search the switch statement in `BillSearch.navigateToViewBillByAtomicBillType()`
-2. Check if your bill type is already handled
-3. Verify the target page exists and works correctly
-4. Reuse existing pages when possible
-
-### 3. Reuse Existing Composites
-
-✅ **DO:**
-```xhtml
-<!-- Reuse existing composite -->
-<ph:transferIssue bill="#{transferIssueController.issuedBill}"/>
-```
-
-❌ **DON'T:**
-```xhtml
-<!-- Create duplicate composite -->
-<ph:transferIssue_reprint bill="#{transferIssueController.issuedBill}"/>
-```
-
-**Why:** Duplicating composites creates maintenance burden and inconsistencies.
-
-### 4. Set Print Preview Flags
-
-Always set the `printPreview` flag when navigating to reprint pages:
-
-```java
-yourController.setPrintPreview(true);
-```
-
-This flag tells the page to:
-- Show print buttons instead of save buttons
-- Hide editing functionality
-- Display the bill in read-only mode
-- Show printer configuration settings
-
-### 5. Include Printer Settings
-
-For all pharmacy bill reprint pages, include printer configuration:
+## What NOT to Do
 
 ```xhtml
-<p:commandButton
-    rendered="#{webUserController.hasPrivilege('ChangeReceiptPrintingPaperTypes')}"
-    value="Settings"
-    icon="fas fa-cog"
-    class="ui-button-secondary mx-1"
-    type="button"
-    onclick="PF('configDialog').show();" />
-```
+<!-- BAD: hardcoded page -->
+<p:commandButton action="/pharmacy/pharmacy_reprint_bill_sale?faces-redirect=true" />
 
-**Reference:** [Printer Configuration System](../configuration/printer-configuration-system.md)
-
-### 6. Handle Navigation Errors Gracefully
-
-```java
-if (bill == null) {
-    JsfUtil.addErrorMessage("No Bill is Selected");
-    return null; // Stay on current page
-}
-
-if (bill.getBillTypeAtomic() == null) {
-    JsfUtil.addErrorMessage("Bill type not found");
-    return null;
-}
-```
-
-### 7. Use Faces Redirect for Clean URLs
-
-```java
-return "/pharmacy/pharmacy_reprint_bill_sale?faces-redirect=true";
-```
-
-**Why:**
-- Creates bookmarkable URLs
-- Prevents duplicate form submissions
-- Provides better user experience
-
-## Real-World Examples
-
-### Example 1: Goods in Transit Report
-
-**File:** `reports/inventoryReports/good_in_transit.xhtml:487`
-
-```xhtml
-<p:column headerText="Action">
-    <p:commandButton
-        id="btnViewBill"
-        title="View"
-        ajax="false"
-        class="mx-1"
-        icon="pi pi-eye"
-        action="#{billSearch.navigateToViewBillByAtomicBillTypeByBillId(bi.billItem.bill.id)}" >
-    </p:commandButton>
-</p:column>
-```
-
-**What happens:**
-1. User clicks "View" button for a row
-2. System gets the bill ID from `bi.billItem.bill.id`
-3. `BillSearch` loads the bill and checks its atomic type
-4. If bill type is `PHARMACY_ISSUE`, navigates to `/pharmacy/pharmacy_transfer_issue`
-5. If bill type is `PHARMACY_RECEIVE`, navigates to `/pharmacy/pharmacy_transfer_receive`
-6. Page displays with `printPreview = true` flag
-7. User can print using configured paper format
-
-### Example 2: Pharmacy Transfer Issue
-
-**Navigation Method:** `BillSearch.navigateToPharmacyIssue():4492`
-
-```java
-public String navigateToPharmacyIssue() {
-    if (bill == null) {
-        JsfUtil.addErrorMessage("No Bill is Selected");
-        return null;
-    }
-    loadBillDetails(bill);
-
-    if (bill.getBillType() == BillType.PharmacyTransferIssue) {
-        transferIssueController.setPrintPreview(true);
-        transferIssueController.setIssuedBill(bill);
-        return "/pharmacy/pharmacy_transfer_issue";
-    } else {
-        pharmacyIssueController.setBillPreview(true);
-        pharmacyIssueController.setPrintBill(bill);
-        return "/pharmacy/pharmacy_issue";
-    }
-}
-```
-
-**Key Points:**
-- Checks bill type to determine correct page
-- Sets `printPreview = true` flag
-- Loads bill into appropriate controller
-- Returns to the same page used for creating bills (just in view mode)
-
-### Example 3: Pharmacy Retail Sale Reprint
-
-**Navigation Method:** `PharmacyBillSearch.navigatePharmacyReprintRetailBill():308`
-
-```java
-public String navigatePharmacyReprintRetailBill() {
-    if (bill == null) {
-        JsfUtil.addErrorMessage("No Bill Selected");
-    }
-    return "/pharmacy/pharmacy_reprint_bill_sale?faces-redirect=true";
-}
-```
-
-**Reprint Page:** `pharmacy/pharmacy_reprint_bill_sale.xhtml`
-
-Features:
-- Multiple paper format options (POS, 5.5", Custom)
-- Printer configuration dialog
-- Print button with `<p:printer>` tag
-- Reuses existing bill composites
-- Settings button for paper type selection
-
-## Troubleshooting
-
-### Issue 1: "Bill not found" Error
-
-**Symptom:** Error message when clicking view button
-
-**Causes:**
-- Incorrect bill ID being passed
-- Bill was deleted from database
-- Permission issues preventing access
-
-**Solution:**
-```xhtml
-<!-- Verify correct property path -->
-<p:commandButton
-    action="#{billSearch.navigateToViewBillByAtomicBillTypeByBillId(row.billItem.bill.id)}" />
-
-<!-- Check bill exists in debug -->
-<h:outputText value="Bill ID: #{row.billItem.bill.id}" />
-```
-
-### Issue 2: "Unknown Bill Type" Error
-
-**Symptom:** Error message after bill is loaded
-
-**Causes:**
-- Bill type atomic not set in database
-- Bill type not handled in switch statement
-
-**Solution:**
-1. Check database: `SELECT bill_type_atomic FROM bill WHERE id = ?`
-2. Add case to switch statement in `BillSearch.navigateToViewBillByAtomicBillType()`
-
-```java
-case YOUR_BILL_TYPE_ATOMIC:
-    return navigateToYourBillTypeReprint();
-```
-
-### Issue 3: Navigation Returns to Wrong Page
-
-**Symptom:** Clicking view navigates to incorrect page
-
-**Causes:**
-- Wrong bill type atomic value
-- Incorrect case in switch statement
-- Controller state not properly set
-
-**Solution:**
-1. Verify bill type atomic in database
-2. Check switch statement mapping
-3. Verify controller flags are set correctly:
-
-```java
-yourController.setPrintPreview(true); // Important!
-yourController.setBill(bill);
-```
-
-### Issue 4: Bill Displays in Edit Mode Instead of View Mode
-
-**Symptom:** Reprint page shows save/edit buttons instead of print buttons
-
-**Causes:**
-- `printPreview` flag not set
-- Page doesn't check printPreview flag
-
-**Solution:**
-```java
-// In navigation method
-yourController.setPrintPreview(true);
-```
-
-```xhtml
-<!-- In XHTML page -->
-<p:commandButton
-    rendered="#{yourController.printPreview}"
-    value="Print"
-    icon="fas fa-print">
-    <p:printer target="printArea" />
+<!-- BAD: custom entity load + direct navigation -->
+<p:commandButton action="pharmacy_reprint_bill_sale">
+    <f:setPropertyActionListener value="#{searchController.loadBillById(bill.id)}"
+                                 target="#{pharmacyBillSearch.bill}"/>
 </p:commandButton>
-
-<p:commandButton
-    rendered="#{not yourController.printPreview}"
-    value="Save"
-    action="#{yourController.save}" />
 ```
 
-### Issue 5: Printer Settings Not Showing
+Both patterns bypass the routing layer, break when bill types evolve, and in the
+case of entity load may trigger L2 cache issues. Use the `billSearch` methods
+instead.
 
-**Symptom:** Settings button not visible on reprint page
+---
 
-**Causes:**
-- User doesn't have required privilege
-- Settings button not implemented
-- Configuration dialog missing
+## Related
 
-**Solution:**
-1. Verify user has privilege: `ChangeReceiptPrintingPaperTypes`
-2. Add settings button to page header
-3. Implement configuration dialog
-
-**Reference:** [Printer Configuration System](../configuration/printer-configuration-system.md)
-
-## Related Documentation
-
-- [Printer Configuration System](../configuration/printer-configuration-system.md) - How to implement printer settings
-- [Page Break Implementation](../ui/page-break-implementation-guide.md) - How to handle page breaks for printing
-- [Bill Number Generation Strategy](bill-number-generation-strategy-guide.md) - Understanding bill numbering
-- [UI Styling Guidelines](../ui/ui-styling-guidelines.md) - UI standards for pages
-
-## Summary
-
-**To implement bill preview functionality:**
-
-1. **Check if reprint page exists** by searching `BillSearch.navigateToViewBillByAtomicBillType()`
-2. **If exists:** Use the navigation methods with bill ID/item ID/dept ID
-3. **If not exists:**
-   - Create new reprint page
-   - Reuse existing composites
-   - Add printer configuration
-   - Add navigation method
-   - Update switch statement
-
-**Key principles:**
-- Always use atomic bill type routing
-- Reuse existing composites and pages
-- Set `printPreview = true` flag
-- Include printer configuration settings
-- Handle errors gracefully
-- Use `faces-redirect=true` for clean URLs
-
-**Example button implementation:**
-```xhtml
-<p:commandButton
-    id="btnViewBill"
-    title="View Bill"
-    ajax="false"
-    icon="pi pi-eye"
-    action="#{billSearch.navigateToViewBillByAtomicBillTypeByBillId(row.bill.id)}" />
-```
-
-This pattern ensures consistent, maintainable bill preview functionality across the entire HMIS system.
+- `BillSearch.java` — all routing logic
+- `RetailSaleNativeSqlController.java`, `TransferIssueNativeSqlController.java`, etc. — native controllers
+- [Printer Configuration System](../configuration/printer-configuration-system.md)
+- [DTO Implementation Guidelines](../dto/implementation-guidelines.md)

--- a/src/main/java/com/divudi/bean/cashTransaction/FinancialTransactionController.java
+++ b/src/main/java/com/divudi/bean/cashTransaction/FinancialTransactionController.java
@@ -285,6 +285,9 @@ public class FinancialTransactionController implements Serializable {
     private List<Payment> fundTransferAvailablePayments;
     private List<Payment> depositableNonCashPayments;
 
+    // Shortage Bill Cancellation Properties
+    private String shortageCancellationComment;
+
     // Float Out Cancellation Properties
     private List<Bill> myFundTransferBillsOut;
     private Bill fundTransferBillToCancel;
@@ -8518,6 +8521,136 @@ public class FinancialTransactionController implements Serializable {
 
     public double getShortageOutstanding() {
         return shortageOutstanding;
+    }
+
+    public boolean isShortageInCurrentShift(Bill bill) {
+        if (bill == null || bill.getCreatedAt() == null) {
+            return false;
+        }
+        if (nonClosedShiftStartFundBill == null) {
+            findNonClosedShiftStartFundBillIsAvailable();
+        }
+        if (nonClosedShiftStartFundBill == null || nonClosedShiftStartFundBill.getCreatedAt() == null) {
+            return false;
+        }
+        if (bill.getFromWebUser() == null
+                || !bill.getFromWebUser().getId().equals(sessionController.getLoggedUser().getId())) {
+            return false;
+        }
+        return !bill.getCreatedAt().before(nonClosedShiftStartFundBill.getCreatedAt());
+    }
+
+    public String cancelShiftShortageBill() {
+        if (selectedBill == null || selectedBill.getId() == null) {
+            JsfUtil.addErrorMessage("No shortage bill selected.");
+            return "";
+        }
+        Bill freshBill = billFacade.find(selectedBill.getId());
+        if (freshBill == null) {
+            JsfUtil.addErrorMessage("Shortage bill no longer exists.");
+            return "";
+        }
+        if (freshBill.getBillTypeAtomic() != BillTypeAtomic.FUND_SHIFT_SHORTAGE_BILL) {
+            JsfUtil.addErrorMessage("Only shortage bills can be cancelled.");
+            return "";
+        }
+        if (freshBill.isCancelled()) {
+            JsfUtil.addErrorMessage("This shortage bill has already been cancelled.");
+            return "";
+        }
+        if (freshBill.isPaid()) {
+            JsfUtil.addErrorMessage("Cannot cancel a fully settled shortage bill.");
+            return "";
+        }
+        if (freshBill.getFromWebUser() == null
+                || !freshBill.getFromWebUser().getId().equals(sessionController.getLoggedUser().getId())) {
+            JsfUtil.addErrorMessage("You can only cancel your own shortage bills.");
+            return "";
+        }
+        if (!isShortageInCurrentShift(freshBill)) {
+            JsfUtil.addErrorMessage("Shortage bills can only be cancelled within the shift they were created.");
+            return "";
+        }
+        if (shortageCancellationComment == null || shortageCancellationComment.trim().isEmpty()) {
+            JsfUtil.addErrorMessage("Please provide a reason for cancellation.");
+            return "";
+        }
+
+        CancelledBill cancellationBill = new CancelledBill();
+        cancellationBill.setBillType(BillType.ShiftShortage);
+        cancellationBill.setBillTypeAtomic(BillTypeAtomic.FUND_SHIFT_SHORTAGE_BILL_CANCELLED);
+        cancellationBill.setBillClassType(BillClassType.CancelledBill);
+        cancellationBill.setBillDate(new Date());
+        cancellationBill.setBillTime(new Date());
+        cancellationBill.setCreatedAt(new Date());
+        cancellationBill.setCreater(sessionController.getLoggedUser());
+        cancellationBill.setFromDepartment(freshBill.getFromDepartment());
+        cancellationBill.setFromInstitution(freshBill.getFromInstitution());
+        cancellationBill.setFromStaff(freshBill.getFromStaff());
+        cancellationBill.setFromWebUser(freshBill.getFromWebUser());
+        cancellationBill.setDepartment(freshBill.getDepartment());
+        cancellationBill.setInstitution(freshBill.getInstitution());
+        cancellationBill.setComments(shortageCancellationComment);
+        cancellationBill.setBilledBill(freshBill);
+        cancellationBill.setBackwardReferenceBill(freshBill);
+
+        String deptId = billNumberGenerator.departmentBillNumberGeneratorYearly(
+                sessionController.getDepartment(),
+                BillTypeAtomic.FUND_SHIFT_SHORTAGE_BILL_CANCELLED);
+        cancellationBill.setDeptId(deptId);
+        cancellationBill.setInsId(deptId);
+
+        List<Payment> originalPayments = findPaymentsForBill(freshBill);
+        List<Payment> cancellationPayments = new ArrayList<>();
+        double totalValue = 0.0;
+
+        try {
+            billController.save(cancellationBill);
+
+            for (Payment originalPayment : originalPayments) {
+                Payment cancellationPayment = new Payment();
+                cancellationPayment.setBill(cancellationBill);
+                cancellationPayment.setPaymentMethod(originalPayment.getPaymentMethod());
+                cancellationPayment.setCreatedAt(new Date());
+                cancellationPayment.setCreater(sessionController.getLoggedUser());
+                cancellationPayment.setCurrentHolder(sessionController.getLoggedUser());
+                // Original paidValue is negative (shortage deducted from drawer);
+                // reversal payment is positive to restore the drawer.
+                cancellationPayment.setPaidValue(Math.abs(originalPayment.getPaidValue()));
+                totalValue += cancellationPayment.getPaidValue();
+                paymentController.save(cancellationPayment);
+                cancellationPayments.add(cancellationPayment);
+            }
+
+            cancellationBill.setTotal(totalValue);
+            cancellationBill.setNetTotal(totalValue);
+            billController.save(cancellationBill);
+
+            freshBill.setCancelled(true);
+            freshBill.setCancelledBill(cancellationBill);
+            billController.save(freshBill);
+        } catch (Exception e) {
+            JsfUtil.addErrorMessage("Failed to cancel shortage bill: " + e.getMessage());
+            return "";
+        }
+
+        // Restore drawer: add back the amount the shortage had deducted.
+        drawerController.updateDrawerForIns(cancellationPayments, sessionController.getLoggedUser());
+
+        currentBill = cancellationBill;
+        currentBillPayments = cancellationPayments;
+        selectedBill = freshBill;
+        shortageCancellationComment = null;
+        JsfUtil.addSuccessMessage("Shortage bill cancelled successfully.");
+        return "/cashier/shift_shortage_bill_cancellation_print?faces-redirect=true";
+    }
+
+    public String getShortageCancellationComment() {
+        return shortageCancellationComment;
+    }
+
+    public void setShortageCancellationComment(String shortageCancellationComment) {
+        this.shortageCancellationComment = shortageCancellationComment;
     }
 
     private void calculateShortageBillTotal() {

--- a/src/main/java/com/divudi/bean/cashTransaction/FinancialTransactionController.java
+++ b/src/main/java/com/divudi/bean/cashTransaction/FinancialTransactionController.java
@@ -287,6 +287,7 @@ public class FinancialTransactionController implements Serializable {
 
     // Shortage Bill Cancellation Properties
     private String shortageCancellationComment;
+    private boolean shortageCancellationSubmitting = false;
 
     // Float Out Cancellation Properties
     private List<Bill> myFundTransferBillsOut;
@@ -8523,24 +8524,35 @@ public class FinancialTransactionController implements Serializable {
         return shortageOutstanding;
     }
 
-    public boolean isShortageInCurrentShift(Bill bill) {
+    public boolean shortageInCurrentShift(Bill bill) {
         if (bill == null || bill.getCreatedAt() == null) {
             return false;
         }
-        if (nonClosedShiftStartFundBill == null) {
-            findNonClosedShiftStartFundBillIsAvailable();
-        }
-        if (nonClosedShiftStartFundBill == null || nonClosedShiftStartFundBill.getCreatedAt() == null) {
+        // Always fetch fresh from DB to avoid stale session-cached shift state.
+        Bill activeShift = findNonClosedShiftStartFundBill(sessionController.getLoggedUser());
+        if (activeShift == null || activeShift.getCreatedAt() == null) {
             return false;
         }
         if (bill.getFromWebUser() == null
                 || !bill.getFromWebUser().getId().equals(sessionController.getLoggedUser().getId())) {
             return false;
         }
-        return !bill.getCreatedAt().before(nonClosedShiftStartFundBill.getCreatedAt());
+        return !bill.getCreatedAt().before(activeShift.getCreatedAt());
     }
 
     public String cancelShiftShortageBill() {
+        if (shortageCancellationSubmitting) {
+            return "";
+        }
+        shortageCancellationSubmitting = true;
+        try {
+            return doCancelShiftShortageBill();
+        } finally {
+            shortageCancellationSubmitting = false;
+        }
+    }
+
+    private String doCancelShiftShortageBill() {
         if (selectedBill == null || selectedBill.getId() == null) {
             JsfUtil.addErrorMessage("No shortage bill selected.");
             return "";
@@ -8562,12 +8574,17 @@ public class FinancialTransactionController implements Serializable {
             JsfUtil.addErrorMessage("Cannot cancel a fully settled shortage bill.");
             return "";
         }
+        computeShortageSettlementSummary(freshBill);
+        if (shortageSettledSoFar > 0.001) {
+            JsfUtil.addErrorMessage("Cannot cancel a shortage bill that already has settlements.");
+            return "";
+        }
         if (freshBill.getFromWebUser() == null
                 || !freshBill.getFromWebUser().getId().equals(sessionController.getLoggedUser().getId())) {
             JsfUtil.addErrorMessage("You can only cancel your own shortage bills.");
             return "";
         }
-        if (!isShortageInCurrentShift(freshBill)) {
+        if (!shortageInCurrentShift(freshBill)) {
             JsfUtil.addErrorMessage("Shortage bills can only be cancelled within the shift they were created.");
             return "";
         }

--- a/src/main/java/com/divudi/bean/cashTransaction/FinancialTransactionController.java
+++ b/src/main/java/com/divudi/bean/cashTransaction/FinancialTransactionController.java
@@ -5547,7 +5547,6 @@ public class FinancialTransactionController implements Serializable {
     }
 
     public Bill findNonClosedShiftStartFundBill(WebUser user) {
-        nonClosedShiftStartFundBill = null;
         String jpql = "select b "
                 + " from Bill b "
                 + " where b.creater=:user "
@@ -5558,7 +5557,8 @@ public class FinancialTransactionController implements Serializable {
         m.put("user", user);
         m.put("ret", false);
         m.put("ofb", BillType.ShiftStartFundBill);
-        return billFacade.findFirstByJpql(jpql, m);
+        nonClosedShiftStartFundBill = billFacade.findFirstByJpql(jpql, m);
+        return nonClosedShiftStartFundBill;
     }
 
     public void listBillsFromInitialFundBillUpToNow() {
@@ -8647,6 +8647,13 @@ public class FinancialTransactionController implements Serializable {
             freshBill.setCancelledBill(cancellationBill);
             billController.save(freshBill);
         } catch (Exception e) {
+            if (cancellationBill.getId() != null) {
+                try {
+                    cancellationBill.setCancelled(true);
+                    billController.save(cancellationBill);
+                } catch (Exception ignore) {
+                }
+            }
             JsfUtil.addErrorMessage("Failed to cancel shortage bill: " + e.getMessage());
             return "";
         }

--- a/src/main/webapp/cashier/shift_shortage_bill_cancellation_print.xhtml
+++ b/src/main/webapp/cashier/shift_shortage_bill_cancellation_print.xhtml
@@ -1,0 +1,103 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
+      xmlns:p="http://primefaces.org/ui"
+      xmlns:h="http://xmlns.jcp.org/jsf/html"
+      xmlns:f="http://xmlns.jcp.org/jsf/core">
+    <h:body>
+        <ui:composition template="./index.xhtml">
+            <ui:define name="subcontent">
+                <h:form>
+                    <p:panel>
+                        <f:facet name="header">
+                            <div class="d-flex align-items-center justify-content-between">
+                                <div>
+                                    <i class="fa fa-ban me-2" style="color:#dc3545;"/>
+                                    <h:outputText value="Shift Shortage Bill Cancelled" style="color:#dc3545;"/>
+                                </div>
+                                <div class="d-flex gap-2">
+                                    <p:commandButton
+                                        value="View Shortage Bills"
+                                        icon="fa fa-search"
+                                        styleClass="ui-button-info"
+                                        ajax="false"
+                                        action="#{financialTransactionController.navigateToCashierShiftBillSearchWithTodayResults()}"/>
+                                    <p:commandButton
+                                        value="Print"
+                                        icon="fa fa-print"
+                                        styleClass="ui-button-secondary">
+                                        <p:printer target="cancellationNote"/>
+                                    </p:commandButton>
+                                </div>
+                            </div>
+                        </f:facet>
+
+                        <h:panelGroup id="cancellationNote">
+                            <div class="row g-3">
+                                <div class="col-md-4">
+                                    <p:panel header="Cancellation Details">
+                                        <p:panelGrid columns="2" layout="tabular" class="w-100"
+                                                     columnClasses="fw-medium, text-end">
+                                            <h:outputText value="Cancellation Bill No"/>
+                                            <h:outputText value="#{financialTransactionController.currentBill.deptId}"/>
+
+                                            <h:outputText value="Cancelled At"/>
+                                            <h:outputText value="#{financialTransactionController.currentBill.createdAt}">
+                                                <f:convertDateTime timeZone="Asia/Colombo"
+                                                                   pattern="#{sessionController.applicationPreference.longDateTimeFormat}"/>
+                                            </h:outputText>
+
+                                            <h:outputText value="Cancelled By"/>
+                                            <h:outputText value="#{financialTransactionController.currentBill.creater.name}"/>
+
+                                            <h:outputText value="Reason"/>
+                                            <h:outputText value="#{financialTransactionController.currentBill.comments}"/>
+                                        </p:panelGrid>
+                                    </p:panel>
+                                </div>
+                                <div class="col-md-4">
+                                    <p:panel header="Original Shortage Bill">
+                                        <p:panelGrid columns="2" layout="tabular" class="w-100"
+                                                     columnClasses="fw-medium, text-end">
+                                            <h:outputText value="Original Bill No"/>
+                                            <h:outputText value="#{financialTransactionController.currentBill.billedBill.deptId}"/>
+
+                                            <h:outputText value="Shortage Amount"/>
+                                            <h:outputText value="#{financialTransactionController.currentBill.billedBill.total}">
+                                                <f:convertNumber pattern="#,##0.00"/>
+                                            </h:outputText>
+
+                                            <h:outputText value="Recorded At"/>
+                                            <h:outputText value="#{financialTransactionController.currentBill.billedBill.createdAt}">
+                                                <f:convertDateTime timeZone="Asia/Colombo"
+                                                                   pattern="#{sessionController.applicationPreference.longDateTimeFormat}"/>
+                                            </h:outputText>
+
+                                            <h:outputText value="Recorded By"/>
+                                            <h:outputText value="#{financialTransactionController.currentBill.billedBill.fromWebUser.webUserPerson.name}"/>
+                                        </p:panelGrid>
+                                    </p:panel>
+                                </div>
+                                <div class="col-md-4">
+                                    <p:panel header="Drawer Impact">
+                                        <p:panelGrid columns="2" layout="tabular" class="w-100"
+                                                     columnClasses="fw-medium, text-end">
+                                            <h:outputText value="Amount Restored"/>
+                                            <h:outputText value="#{financialTransactionController.currentBill.total}">
+                                                <f:convertNumber pattern="#,##0.00"/>
+                                            </h:outputText>
+                                        </p:panelGrid>
+                                        <p:outputLabel styleClass="text-muted small d-block mt-2"
+                                                       value="The shortage amount has been added back to your drawer."/>
+                                    </p:panel>
+                                </div>
+                            </div>
+                        </h:panelGroup>
+
+                    </p:panel>
+                </h:form>
+            </ui:define>
+        </ui:composition>
+    </h:body>
+</html>

--- a/src/main/webapp/cashier/shift_shortage_bill_cancellation_print.xhtml
+++ b/src/main/webapp/cashier/shift_shortage_bill_cancellation_print.xhtml
@@ -88,8 +88,8 @@
                                                 <f:convertNumber pattern="#,##0.00"/>
                                             </h:outputText>
                                         </p:panelGrid>
-                                        <p:outputLabel styleClass="text-muted small d-block mt-2"
-                                                       value="The shortage amount has been added back to your drawer."/>
+                                        <h:outputText styleClass="text-muted small d-block mt-2"
+                                                      value="The shortage amount has been added back to your drawer."/>
                                     </p:panel>
                                 </div>
                             </div>

--- a/src/main/webapp/cashier/shift_shortage_bill_reprint.xhtml
+++ b/src/main/webapp/cashier/shift_shortage_bill_reprint.xhtml
@@ -33,7 +33,7 @@
                                         styleClass="ui-button-success"
                                         ajax="false"
                                         action="#{financialTransactionController.navigateToSettleShiftShortageBill()}"
-                                        rendered="#{!billSearch.bill.paid and !billSearch.bill.cancelled}"/>
+                                        rendered="#{!billSearch.bill.paid and !billSearch.bill.cancelled and !financialTransactionController.shortageInCurrentShift(billSearch.bill)}"/>
                                     <p:commandButton
                                         value="Back to Search"
                                         icon="fa fa-arrow-left"
@@ -68,6 +68,30 @@
                                 <h:outputText value="#{billSearch.bill.fromWebUser.webUserPerson.name}"/>
                             </div>
                         </div>
+
+                        <h:panelGroup rendered="#{!billSearch.bill.paid and !billSearch.bill.cancelled and financialTransactionController.shortageInCurrentShift(billSearch.bill)}"
+                                      layout="block" styleClass="row g-3 mb-3 p-2 border border-danger rounded">
+                            <div class="col-12">
+                                <h:outputText value="Cancel This Shortage" styleClass="fw-bold text-danger d-block mb-2"/>
+                                <h:outputText value="This shortage was created in your current shift. You may cancel it if it was recorded in error." styleClass="text-muted small d-block mb-2"/>
+                            </div>
+                            <div class="col-md-8">
+                                <p:inputTextarea
+                                    rows="2"
+                                    styleClass="w-100"
+                                    placeholder="Enter reason for cancellation (required)"
+                                    value="#{financialTransactionController.shortageCancellationComment}"/>
+                            </div>
+                            <div class="col-md-4 d-flex align-items-end">
+                                <p:commandButton
+                                    value="Cancel This Shortage"
+                                    icon="fa fa-ban"
+                                    styleClass="ui-button-danger"
+                                    ajax="false"
+                                    onclick="return confirm('Are you sure you want to cancel this shortage bill? This will reverse the drawer deduction.');"
+                                    action="#{financialTransactionController.cancelShiftShortageBill()}"/>
+                            </div>
+                        </h:panelGroup>
 
                         <div class="row">
                             <div class="col-lg-6">


### PR DESCRIPTION
## Summary
- Shortage bills created in the current shift can now be cancelled within that shift — reverses the drawer deduction so the handover nets to zero
- "Settle This Shortage" button is now hidden while the shortage is in the active shift (cashier can only settle it in a subsequent shift)
- New cancellation print page (`shift_shortage_bill_cancellation_print.xhtml`) shown after cancel

## How it works
1. When a cashier opens a shortage bill from the current shift, a **Cancel This Shortage** section appears (reason input + danger button)
2. On confirm, `cancelShiftShortageBill()` creates a `FUND_SHIFT_SHORTAGE_BILL_CANCELLED` bill with a positive reversal payment
3. The drawer is restored via `drawerController.updateDrawerForIns`
4. The original bill is marked `cancelled = true`
5. Net handover impact: shortage (negative) + cancellation (positive) = 0

## Shift detection logic (`isShortageInCurrentShift`)
- Looks up `nonClosedShiftStartFundBill` for the logged-in user
- Returns `true` if the shortage's `createdAt ≥ shiftStart.createdAt` AND `fromWebUser` matches the current user

## Test plan
- [ ] Record a shortage (e.g. LKR 11) in an active shift
- [ ] Open it via Shift Shortage Bill Search → Manage → confirm Cancel section is visible and Settle button is hidden
- [ ] Cancel with a reason → verify drawer balance restored, bill shows Cancelled badge
- [ ] In a new shift, open the same bill → confirm Settle button appears, Cancel section is hidden
- [ ] Attempt cancel on a paid/cancelled bill → verify it is blocked with error message
- [ ] Attempt cancel by a different user → verify it is blocked

Closes #17940

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added ability for cashiers to cancel shift-shortage bills with a required cancellation reason.
  * Cancellation blocked for bills already paid, already cancelled, or with existing settlements.
  * Only the logged-in bill owner can cancel shortages and only for the current shift.
  * New cancellation confirmation/print page shows original bill, cancellation metadata, and drawer restoration details.
* **UI**
  * Reprint view now shows a cancellation section when the shortage is in the current shift.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hmislk/hmis/pull/20698)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->