### PR TITLE
fix(hr): fix salary advance saving and ETF calculation bug

### DIFF
--- a/src/main/java/com/divudi/bean/hr/StaffSalaryAdvanceController.java
+++ b/src/main/java/com/divudi/bean/hr/StaffSalaryAdvanceController.java
@@ -1254,7 +1254,6 @@ public class StaffSalaryAdvanceController implements Serializable {
             }
             current = stf;
 
-            // Save StaffSalary record first
             current.setInstitution(current.getStaff().getInstitution());
             current.setDepartment(current.getStaff().getWorkingDepartment());
             current.setSalaryCycle(salaryCycle);
@@ -1262,6 +1261,8 @@ public class StaffSalaryAdvanceController implements Serializable {
             current.setCreater(getSessionController().getLoggedUser());
 
             List<StaffSalaryComponant> list = current.getStaffSalaryComponants();
+            // Detach components temporarily so JPA cascade does not try to persist
+            // them before the parent StaffSalary has been assigned an ID.
             current.setStaffSalaryComponants(null);
             getStaffSalaryFacade().create(current);
             current.setStaffSalaryComponants(list);
@@ -1275,7 +1276,8 @@ public class StaffSalaryAdvanceController implements Serializable {
                 }
             }
 
-            current.setStaffSalaryComponants(list);
+            // Removed redundant current.setStaffSalaryComponants(list) here —
+            // list reference was already restored above before the loop.
             getStaffSalaryFacade().edit(current);
 
             save();
@@ -1283,6 +1285,8 @@ public class StaffSalaryAdvanceController implements Serializable {
             current = null;
         }
     }
+
+    
 
     private void updateStaffShift(Staff staff, Date fromDate, Date toDate) {
         List<StaffShift> staffShiftsLiePaymentAllowed = humanResourceBean.fetchStaffShiftLiePaymentAllowed(fromDate, toDate, staff);

--- a/src/main/java/com/divudi/bean/hr/StaffSalaryAdvanceController.java
+++ b/src/main/java/com/divudi/bean/hr/StaffSalaryAdvanceController.java
@@ -131,7 +131,6 @@ public class StaffSalaryAdvanceController implements Serializable {
     }
 
     public void save() {
-
         if (getCurrent().getTransAdvanceSalary() != 0) {
             StaffSalaryComponant ss = fetchSalaryAdvance(getCurrent().getStaff());
 
@@ -140,6 +139,7 @@ public class StaffSalaryAdvanceController implements Serializable {
             }
 
             ss.setStaff(getCurrent().getStaff());
+            ss.setStaffSalary(getCurrent());  // ← add this line
             ss.setComponantValue(getCurrent().getTransAdvanceSalary());
             getHumanResourceBean().setEpf(ss, getHrmVariablesController().getCurrent().getEpfRate(), getHrmVariablesController().getCurrent().getEpfCompanyRate());
             getHumanResourceBean().setEtf(ss, getHrmVariablesController().getCurrent().getEtfRate(), getHrmVariablesController().getCurrent().getEtfCompanyRate());
@@ -150,8 +150,21 @@ public class StaffSalaryAdvanceController implements Serializable {
                 staffSalaryComponantFacade.edit(ss);
             }
         }
-
     }
+
+    public void fetchItems() {
+        if (getSalaryCycle() == null) {
+            JsfUtil.addErrorMessage("Please Select Salary Cycle");
+            return;
+        }
+        String sql = "SELECT ss FROM StaffSalary ss "
+                + " WHERE ss.retired=false "
+                + " and ss.salaryCycle=:sc ";
+        HashMap hm = new HashMap();
+        hm.put("sc", getSalaryCycle());
+        items = getStaffSalaryFacade().findByJpql(sql, hm);
+    }
+
 
 //    private void updateComponent(List<StaffSalaryComponant> list) {
 //        for (StaffSalaryComponant ssc : list) {
@@ -849,10 +862,12 @@ public class StaffSalaryAdvanceController implements Serializable {
         String sql = "select sc from StaffSalaryComponant sc "
                 + " where sc.retired=false "
                 + " and sc.salaryCycle=:sc "
-                + " and sc.staff=:stf";
+                + " and sc.staff=:stf"
+                + " and sc.staffPaysheetComponent.paysheetComponent.componentType=:ct";
         HashMap hm = new HashMap();
         hm.put("sc", getSalaryCycle());
         hm.put("stf", getCurrent().getStaff());
+        hm.put("ct", PaysheetComponentType.Salary_Advance_Deduction);
         StaffSalaryComponant salaryComponant = staffSalaryComponantFacade.findFirstByJpql(sql, hm);
 
         if (salaryComponant != null) {
@@ -866,14 +881,13 @@ public class StaffSalaryAdvanceController implements Serializable {
         String sql = "select sc from StaffSalaryComponant sc "
                 + " where sc.retired=false "
                 + " and sc.salaryCycle=:sc "
-                + " and sc.staff=:stf";
+                + " and sc.staff=:stf"
+                + " and sc.staffPaysheetComponent.paysheetComponent.componentType=:ct";
         HashMap hm = new HashMap();
         hm.put("sc", getSalaryCycle());
         hm.put("stf", staff);
-        StaffSalaryComponant salaryComponant = staffSalaryComponantFacade.findFirstByJpql(sql, hm);
-
-        return salaryComponant;
-
+        hm.put("ct", PaysheetComponentType.Salary_Advance_Deduction);
+        return staffSalaryComponantFacade.findFirstByJpql(sql, hm);
     }
 
     public void deleteAll() {
@@ -1220,36 +1234,54 @@ public class StaffSalaryAdvanceController implements Serializable {
     }
 
     public void saveSalary() {
-        Date startTime = new Date();
-        Date fromDate = null;
-        Date toDate = null;
-
         if (getStaffController().getSelectedList() == null) {
             return;
         }
-
         if (dateCheck()) {
             return;
         }
-
         if (items == null) {
             return;
         }
 
         for (StaffSalary stf : items) {
             if (stf.getId() != null) {
+                getStaffSalaryFacade().edit(stf);
+                current = stf;
+                save();
+                current = null;
                 continue;
             }
             current = stf;
+
+            // Save StaffSalary record first
+            current.setInstitution(current.getStaff().getInstitution());
+            current.setDepartment(current.getStaff().getWorkingDepartment());
+            current.setSalaryCycle(salaryCycle);
+            current.setCreatedAt(new Date());
+            current.setCreater(getSessionController().getLoggedUser());
+
+            List<StaffSalaryComponant> list = current.getStaffSalaryComponants();
+            current.setStaffSalaryComponants(null);
+            getStaffSalaryFacade().create(current);
+            current.setStaffSalaryComponants(list);
+
+            for (StaffSalaryComponant ssc : list) {
+                ssc.setStaffSalary(current);
+                if (ssc.getId() == null) {
+                    getStaffSalaryComponantFacade().create(ssc);
+                } else {
+                    getStaffSalaryComponantFacade().edit(ssc);
+                }
+            }
+
+            current.setStaffSalaryComponants(list);
+            getStaffSalaryFacade().edit(current);
+
             save();
-//            updateStaffShift(stf.getStaff(), getSalaryCycle().getWorkedFromDate(), getSalaryCycle().getWorkedToDate());
+
             current = null;
         }
-
-        //   createStaffSalaryTable();
-
-
-
     }
 
     private void updateStaffShift(Staff staff, Date fromDate, Date toDate) {

--- a/src/main/java/com/divudi/ejb/HumanResourceBean.java
+++ b/src/main/java/com/divudi/ejb/HumanResourceBean.java
@@ -2090,7 +2090,7 @@ public class HumanResourceBean {
     }
 
     public void setEtf(StaffSalaryComponant ssc, double etf, double etfCompany) {
-        if (ssc.getStaffPaysheetComponent().getPaysheetComponent().isIncludedForEpf()) {
+        if (ssc.getStaffPaysheetComponent().getPaysheetComponent().isIncludedForEtf()) {
             double tmp = ssc.getComponantValue() * (etf / 100.0);
             ssc.setEtfValue(tmp);
 

--- a/src/main/webapp/hr/hr_staff_salary_advance.xhtml
+++ b/src/main/webapp/hr/hr_staff_salary_advance.xhtml
@@ -358,7 +358,7 @@
                                     value="Edit"
                                     styleClass="ui-button-info"
                                     style="padding: 0.25rem 0.5rem; font-size: 0.82rem;"
-                                    actionListener="#{staffSalaryAdvanceController.onEditListener(ii)}" />
+                                    actionListener="#{staffSalaryAdvanceController.setCurrent(ii)}" />
                             </p:column>
                             <p:column style="width: 6rem;" exportable="false">
                                 <p:commandButton

--- a/src/main/webapp/hr/hr_staff_salary_advance.xhtml
+++ b/src/main/webapp/hr/hr_staff_salary_advance.xhtml
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='UTF-8' ?>
 <!DOCTYPE composition PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <ui:composition xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
-                template="/resources/template/template.xhtml" 
+                template="/resources/template/template.xhtml"
                 xmlns:h="http://xmlns.jcp.org/jsf/html"
                 xmlns:p="http://primefaces.org/ui"
                 xmlns:f="http://xmlns.jcp.org/jsf/core"
@@ -10,247 +10,374 @@
 
     <ui:define name="content">
         <h:form>
-            <p:panel>
-                <p:commandButton ajax="false" value="Generate Salary Advance" action="#{staffSalaryAdvanceController.generate}"  class="m-2 " />
-                <p:commandButton ajax="false" value="Save Salary Advance" action="#{staffSalaryAdvanceController.saveSalary}"  class="m-2" />
-                <p:commandButton ajax="false" value="Clear" actionListener="#{staffSalaryAdvanceController.clear}"   class="m-2" />
+
+            <style>
+                .ui-autocomplete,
+                .ui-autocomplete-input,
+                .ui-selectonemenu,
+                .ui-inputfield {
+                    width: 100% !important;
+                    box-sizing: border-box !important;
+                }
+            </style>
+
+            <!-- ── Top Action Bar ── -->
+            <p:panel style="margin-bottom: 1.25rem;">
+                <div style="display: flex; gap: 0.5rem;">
+                    <p:commandButton
+                        ajax="false"
+                        value="Generate Salary Advance"
+                        icon="fas fa-cogs"
+                        styleClass="ui-button-success"
+                        action="#{staffSalaryAdvanceController.generate}" />
+                    <p:commandButton
+                        ajax="false"
+                        value="Save Salary Advance"
+                        icon="fas fa-save"
+                        styleClass="ui-button-warning"
+                        action="#{staffSalaryAdvanceController.saveSalary}" />
+                    <p:commandButton
+                        ajax="false"
+                        value="Clear"
+                        icon="fas fa-eraser"
+                        styleClass="ui-button-secondary"
+                        actionListener="#{staffSalaryAdvanceController.clear}" />
+                    <p:commandButton
+                        ajax="false"
+                        value="Fetch Saved"
+                        icon="fas fa-database"
+                        styleClass="ui-button-info"
+                        action="#{staffSalaryAdvanceController.fetchItems}" />
+                </div>
             </p:panel>
 
-            <p:tabView style="min-height:300px;">
+            <!-- ── Main Tab View ── -->
+            <p:tabView style="min-height: 300px;">
+
+                <!-- TAB 1: Cycle -->
                 <p:tab title="Cycle">
-                    <p:selectOneMenu id="advanced" 
-                                     value="#{staffSalaryAdvanceController.salaryCycle}"                                  
-                                     var="t" 
-                                     filter="true" 
-                                     filterMatchMode="startsWith"  >
+                    <div style="display: grid; grid-template-columns: 1fr 1fr; gap: 1.25rem; align-items: start;">
 
-                        <f:selectItem itemLabel="Select Cycle"/>
-                        <f:selectItems value="#{salaryCycleController.salaryCycles}" 
-                                       var="theme" 
-                                       itemLabel="#{theme.name}" 
-                                       itemValue="#{theme}" ></f:selectItems>
+                        <!-- Cycle Selector -->
+                        <p:panel header="Select Salary Cycle">
+                            <div style="margin-bottom: 1rem;">
+                                <h:outputText value="Salary Cycle" style="display: block; margin-bottom: 4px;" />
+                                <p:selectOneMenu
+                                    id="advanced"
+                                    value="#{staffSalaryAdvanceController.salaryCycle}"
+                                    var="t"
+                                    filter="true"
+                                    filterMatchMode="startsWith"
+                                    style="width: 100%;">
+                                    <f:selectItem itemLabel="Select Cycle" />
+                                    <f:selectItems
+                                        value="#{salaryCycleController.salaryCycles}"
+                                        var="theme"
+                                        itemLabel="#{theme.name}"
+                                        itemValue="#{theme}" />
+                                    <p:column style="width: 10%;" headerText="Name">
+                                        <h:outputText value="#{t.name}" />
+                                    </p:column>
+                                    <p:column headerText="Year">
+                                        <h:outputText value="#{t.salaryYear}" />
+                                    </p:column>
+                                    <p:column headerText="Month">
+                                        <h:outputText value="#{t.salaryMonth}" />
+                                    </p:column>
+                                    <p:ajax process="@this" update="cycleDetail" event="change" />
+                                </p:selectOneMenu>
+                            </div>
+                        </p:panel>
 
-                        <p:column style="width:10%" headerText="Name">
-                            <h:outputText value="#{t.name}" />
-                        </p:column>
+                        <!-- Cycle Detail -->
+                        <p:panel header="Cycle Dates">
+                            <h:panelGrid id="cycleDetail" columns="2" style="width: 100%;" columnClasses="col-label,col-value">
 
-                        <p:column headerText="Year">
-                            <h:outputText value="#{t.salaryYear}" />
-                        </p:column>
-                        <p:column headerText="Month">
-                            <h:outputText value="#{t.salaryMonth}" />
-                        </p:column>
-                        <f:ajax execute="@this" render="cycleDetail" event="change" listener="#{salaryCycleController.cycleSelectListener()}" />
-                    </p:selectOneMenu>
-                    <p:commandButton value="Process Salary Cycle" ajax="false" action="#{salaryCycleController.listAllSalaryCycles()}" class="m-2 pb-1" ></p:commandButton>
-                    <h:panelGrid columns="2" id="cycleDetail">
-                        <h:outputLabel value="Salary From Date "/>
-                        <h:outputLabel value="#{staffSalaryAdvanceController.salaryCycle.salaryFromDate}"  >                                                        
-                            <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateFormat}"/>
-                        </h:outputLabel>
-                        <h:outputLabel value="Salary To Date "/>
-                        <h:outputLabel   value="#{staffSalaryAdvanceController.salaryCycle.salaryToDate}" >
-                            <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateFormat}"/>
-                        </h:outputLabel>
-                        <h:outputLabel value="Worked From Date "/>
-                        <h:outputLabel value="#{staffSalaryAdvanceController.salaryCycle.workedFromDate}" >
-                            <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateFormat}"/>
-                        </h:outputLabel>
-                        <h:outputLabel value="Worked To Date "/>
-                        <h:outputLabel   value="#{staffSalaryAdvanceController.salaryCycle.workedToDate}">
-                            <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateFormat}"/>
-                        </h:outputLabel>
-                    </h:panelGrid>
+                                <h:outputText value="Salary From Date" style="font-weight: 600;" />
+                                <h:outputText value="#{staffSalaryAdvanceController.salaryCycle.salaryFromDate}">
+                                    <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateFormat}" />
+                                </h:outputText>
+
+                                <h:outputText value="Salary To Date" style="font-weight: 600;" />
+                                <h:outputText value="#{staffSalaryAdvanceController.salaryCycle.salaryToDate}">
+                                    <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateFormat}" />
+                                </h:outputText>
+
+                                <h:outputText value="Worked From Date" style="font-weight: 600;" />
+                                <h:outputText value="#{staffSalaryAdvanceController.salaryCycle.workedFromDate}">
+                                    <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateFormat}" />
+                                </h:outputText>
+
+                                <h:outputText value="Worked To Date" style="font-weight: 600;" />
+                                <h:outputText value="#{staffSalaryAdvanceController.salaryCycle.workedToDate}">
+                                    <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateFormat}" />
+                                </h:outputText>
+
+                            </h:panelGrid>
+                        </p:panel>
+
+                    </div>
                 </p:tab>
-                <p:tab title="Staff List" >
 
-                    <p:commandButton ajax="false" value="Fill Staff" action="#{staffController.createActiveStaffTable()}"  class="mb-2" />
-                    
-                    <h:panelGrid columns="2"> 
-                        <h:outputLabel value="Employee : "/>
-                        <hr:completeStaff value="#{staffController.reportKeyWord.staff}"/>
-                        <h:outputLabel value="Department : "/>
-                        <hr:department value="#{staffController.reportKeyWord.department}"/>
-                        <h:outputLabel value="Institution : "/>
-                        <hr:institution value="#{staffController.reportKeyWord.institution}"/>
-                        <h:outputLabel value="Staff Category : "/>
-                        <hr:completeStaffCategory value="#{staffController.reportKeyWord.staffCategory}"/>
-                        <h:outputLabel value="Designation : "/>
-                        <hr:completeDesignation value="#{staffController.reportKeyWord.designation}"/>
-                        <h:outputLabel value="Roster : "/>
-                        <hr:completeRoster value="#{staffController.reportKeyWord.roster}"/>    
-                        <br></br>
-                    </h:panelGrid>
+                <!-- TAB 2: Staff List -->
+                <p:tab title="Staff List">
 
-                    <p:dataTable  value="#{staffController.staffWithCode}" 
-                                  var="s" filteredValue="#{staffController.filteredStaff}"  
-                                  rowKey="#{s.id}" 
-                                  selection="#{staffController.selectedList}"
-                                  rowIndexVar="i"
-                                  scrollable="true"
-                                  selectionMode="multiple"
-                                  scrollHeight="250">
-                        <p:column   >                            
+                    <p:panel header="Filters" style="margin-bottom: 1rem;">
+                        <div style="margin-bottom: 1rem;">
+                            <p:commandButton
+                                ajax="false"
+                                value="Fill All Staff"
+                                icon="fas fa-fill"
+                                styleClass="ui-button-warning"
+                                action="#{staffController.createActiveStaffTable()}" />
+                        </div>
+
+                        <div style="display: grid; grid-template-columns: 1fr 1fr; gap: 1rem;">
+                            <div>
+                                <h:outputText value="Employee" style="display: block; margin-bottom: 4px;" />
+                                <hr:completeStaff value="#{staffController.reportKeyWord.staff}" />
+                            </div>
+                            <div>
+                                <h:outputText value="Institution" style="display: block; margin-bottom: 4px;" />
+                                <hr:institution value="#{staffController.reportKeyWord.institution}" />
+                            </div>
+                            <div>
+                                <h:outputText value="Department" style="display: block; margin-bottom: 4px;" />
+                                <hr:department value="#{staffController.reportKeyWord.department}" />
+                            </div>
+                            <div>
+                                <h:outputText value="Staff Category" style="display: block; margin-bottom: 4px;" />
+                                <hr:completeStaffCategory value="#{staffController.reportKeyWord.staffCategory}" />
+                            </div>
+                            <div>
+                                <h:outputText value="Designation" style="display: block; margin-bottom: 4px;" />
+                                <hr:completeDesignation value="#{staffController.reportKeyWord.designation}" />
+                            </div>
+                            <div>
+                                <h:outputText value="Roster" style="display: block; margin-bottom: 4px;" />
+                                <hr:completeRoster value="#{staffController.reportKeyWord.roster}" />
+                            </div>
+                        </div>
+                    </p:panel>
+
+                    <p:dataTable
+                        value="#{staffController.staffWithCode}"
+                        var="s"
+                        filteredValue="#{staffController.filteredStaff}"
+                        rowKey="#{s.id}"
+                        selection="#{staffController.selectedList}"
+                        rowIndexVar="i"
+                        selectionMode="multiple"
+                        scrollable="true"
+                        scrollHeight="300"
+                        scrollWidth="100%"
+                        style="table-layout: fixed; width: 100%;">
+
+                        <p:column style="width: 2.5rem;" />
+                        <p:column headerText="#" style="width: 3rem;">
+                            <h:outputText value="#{i+1}" />
+                        </p:column>
+                        <p:column headerText="Code" filterBy="#{s.codeInterger}" filterMatchMode="contains" style="width: 6rem;">
+                            <h:outputText value="#{s.codeInterger}" />
+                        </p:column>
+                        <p:column headerText="Name" filterBy="#{s.person.nameWithTitle}" filterMatchMode="contains">
+                            <h:outputText value="#{s.person.nameWithTitle}" />
+                        </p:column>
+                        <p:column headerText="Designation" filterBy="#{s.designation.name}" filterMatchMode="contains" style="width: 10rem;">
+                            <h:outputText value="#{s.designation.name}" />
+                        </p:column>
+                        <p:column headerText="Roster" filterBy="#{s.roster.name}" filterMatchMode="contains" style="width: 8rem;">
+                            <h:outputText value="#{s.roster.name}" />
+                        </p:column>
+                        <p:column headerText="Grade" filterBy="#{s.grade}" filterMatchMode="contains" style="width: 6rem;">
+                            <h:outputText value="#{s.grade}" />
+                        </p:column>
+                        <p:column headerText="Category" filterBy="#{s.staffCategory.name}" filterMatchMode="contains" style="width: 9rem;">
+                            <h:outputText value="#{s.staffCategory.name}" />
                         </p:column>
 
-                        <p:column >
-                            #{i+1}
-                        </p:column>
-                        <p:column headerText="Roster"  filterBy="#{s.roster.name}"  filterMatchMode="contains" >
-                            <h:outputLabel value="#{s.roster.name}"/>
-                        </p:column>
-                        <p:column headerText="Grade"  filterBy="#{s.grade}"  filterMatchMode="contains" >
-                            <h:outputLabel value="#{s.grade}"/>
-                        </p:column>
-                        <p:column headerText="Category" filterBy="#{s.staffCategory.name}"  filterMatchMode="contains">
-                            <h:outputLabel value="#{s.staffCategory.name}"/>
-                        </p:column>
-                        <p:column headerText="Designation" filterBy="#{s.designation.name}"  filterMatchMode="contains">
-                            <h:outputLabel value="#{s.designation.name}"/>
-                        </p:column>                         
-                        <p:column headerText="Code" filterBy="#{s.codeInterger}"  filterMatchMode="contains">
-                            <h:outputLabel value="#{s.codeInterger}"/>
-                        </p:column>
-                        <p:column headerText="Name" filterBy="#{s.person.nameWithTitle}"  filterMatchMode="contains">
-                            <h:outputLabel value="#{s.person.nameWithTitle}"/>
-                        </p:column>
-                    </p:dataTable> 
+                    </p:dataTable>
+
                 </p:tab>
+
+                <!-- TAB 3: Staff Salary Advance -->
                 <p:tab title="Staff Salary">
-                    <p:dataTable value="#{staffSalaryAdvanceController.items}" var="ii" 
-                                 rowStyleClass="#{ii.exist eq true ? 'exist':null}">
-                        <p:column headerText="From">
-                            <h:outputLabel value="#{ii.salaryCycle.salaryFromDate}">
-                                <f:convertDateTime pattern="dd MMMM" />
-                            </h:outputLabel>                            
-                        </p:column>
-                        <p:column headerText="To">                            
-                            <h:outputLabel value="#{ii.salaryCycle.salaryToDate}">
-                                <f:convertDateTime pattern="dd MMMM" />
-                            </h:outputLabel>
-                        </p:column>
-                        <p:column headerText="Code ">
-                            <h:outputLabel value="#{ii.staff.codeInterger}"/>
-                        </p:column>
-                        <p:column headerText="Staff">
-                            <h:outputLabel value="#{ii.staff.person.nameWithTitle}"/>
-                        </p:column>
-                        <p:column headerText="Gross">
-                            <h:outputLabel value="#{ii.transGrossSalary}">
-                                <f:convertNumber pattern="0.00"/>
-                            </h:outputLabel>
-                        </p:column>
-                        <p:column headerText="EPF">
-                            <h:outputLabel value="#{ii.epfStaffValue}">
-                                <f:convertNumber pattern="0.00"/>
-                            </h:outputLabel>
-                        </p:column>
-                        <p:column headerText="EPF Company">
-                            <h:outputLabel value="#{ii.epfCompanyValue}">
-                                <f:convertNumber pattern="0.00"/>
-                            </h:outputLabel>
-                        </p:column>
-                        <p:column headerText="ETF Company">
-                            <h:outputLabel value="#{ii.etfCompanyValue}">
-                                <f:convertNumber pattern="0.00"/>
-                            </h:outputLabel>
-                        </p:column>
-                        <p:column headerText="Net Salary ">
-                            <h:outputLabel value="#{ii.transNetSalry+ii.transExtraDutyValue+ii.overTimeValue}">
-                                <f:convertNumber pattern="0.00"/>
-                            </h:outputLabel>
-                        </p:column>     
-                        <p:column headerText="Advance Payment ">
-                            <p:inputText value="#{ii.transAdvanceSalary}">
-                                <f:convertNumber pattern="0.00"/>
-                            </p:inputText>
-                        </p:column>   
-                        <p:column>
 
-                            <f:facet name="header">
-                                <p:commandButton process="@this" 
-                                                 update=":#{p:resolveFirstComponentWithId('lst',view).clientId}" 
-                                                 value="View Detail"  
-                                                 actionListener="#{staffSalaryAdvanceController.onEditListener(ii)}" >                              
-                                </p:commandButton>
-                            </f:facet>
-                            <p:rowEditor /> 
+                    <p:tabView id="lst" style="min-height: 300px;">
 
-                        </p:column>
+                        <!-- Sub-tab: Salary Components -->
+                        <p:tab title="Salary Components">
+                            <p:dataTable
+                                editable="true"
+                                value="#{staffSalaryAdvanceController.current.staffSalaryComponants}"
+                                var="i">
+                                <f:facet name="header">
+                                    <div style="display: flex; justify-content: space-between; align-items: center;">
+                                        <h:outputText value="#{staffSalaryAdvanceController.current.staff.person.nameWithTitle}" />
+                                        <h:outputText value="#{staffSalaryAdvanceController.current.staff.code}"
+                                            style="font-style: italic; font-weight: normal;" />
+                                    </div>
+                                </f:facet>
 
+                                <p:ajax event="rowEdit" listener="#{staffSalaryAdvanceController.onEdit}" />
 
-                    </p:dataTable>
-                </p:tab>
-            </p:tabView>
-
-
-            <p:tabView  id="lst" style="min-height:300px;">
-                <p:tab title="Salary Componenetns">
-                    <p:dataTable   editable="true" value="#{staffSalaryAdvanceController.current.staffSalaryComponants}" var="i" >
-
-                        <p:ajax event="rowEdit" listener="#{staffSalaryAdvanceController.onEdit}" />  
-
-                        <p:column headerText="Compnent Name ">
-                            <h:outputLabel value="#{i.staffPaysheetComponent.paysheetComponent.name}"/>
-                        </p:column>
-                        <p:column headerText="Type">
-                            <h:outputLabel  value="#{i.staffPaysheetComponent.paysheetComponent.componentType}"/>
-                        </p:column>
-                        <p:column headerText="Value">                        
-                            <p:cellEditor>  
-                                <f:facet name="output">
-                                    <h:outputLabel value="#{i.componantValue}">
+                                <p:column headerText="Component Name" style="width: 12rem;">
+                                    <h:outputText value="#{i.staffPaysheetComponent.paysheetComponent.name}" />
+                                </p:column>
+                                <p:column headerText="Type" style="width: 8rem;">
+                                    <h:outputText value="#{i.staffPaysheetComponent.paysheetComponent.componentType}" />
+                                </p:column>
+                                <p:column style="width: 6rem;">
+                                    <f:facet name="header">
+                                        <p:commandButton type="button" value="Process" styleClass="ui-button-info" />
+                                    </f:facet>
+                                    <p:rowEditor />
+                                </p:column>
+                                <p:column headerText="Value" style="width: 8rem;">
+                                    <p:cellEditor>
+                                        <f:facet name="output">
+                                            <h:outputText value="#{i.componantValue}">
+                                                <f:convertNumber pattern="#,##0.00" />
+                                            </h:outputText>
+                                        </f:facet>
+                                        <f:facet name="input">
+                                            <p:inputText autocomplete="off" value="#{i.componantValue}"
+                                                disabled="#{i.staffPaysheetComponent.paysheetComponent.componentType eq 'BasicSalary'}" />
+                                        </f:facet>
+                                    </p:cellEditor>
+                                </p:column>
+                                <p:column headerText="EPF" style="width: 7rem;">
+                                    <h:outputText value="#{i.epfValue}">
                                         <f:convertNumber pattern="#,##0.00" />
-                                    </h:outputLabel>
-                                </f:facet>
-                                <f:facet name="input">
-                                    <p:inputText autocomplete="off" value="#{i.componantValue}" disabled="#{i.staffPaysheetComponent.paysheetComponent.componentType eq 'BasicSalary'}"/>
-                                </f:facet>
-                            </p:cellEditor>                         
-                        </p:column>
-                        <p:column headerText="EPF">
-                            <h:outputLabel  value="#{i.epfValue}">
-                                <f:convertNumber pattern="#,##0.00" />
-                            </h:outputLabel>
-                            <f:facet name="footer">
-                                <h:outputLabel value="#{staffSalaryAdvanceController.current.epfStaffValue}">
-                                    <f:convertNumber pattern="#,##0.00" />
-                                </h:outputLabel>
-                            </f:facet>
-                        </p:column>       
-                        <p:column headerText="EPF Company">
-                            <h:outputLabel value="#{i.epfCompanyValue}">
-                                <f:convertNumber pattern="#,##0.00" />
-                            </h:outputLabel>
-                            <f:facet name="footer">
-                                <h:outputLabel value="#{staffSalaryAdvanceController.current.epfCompanyValue}">
-                                    <f:convertNumber pattern="#,##0.00" />
-                                </h:outputLabel>
-                            </f:facet>
-                        </p:column>
-                        <p:column headerText="ETF Company">
-                            <h:outputLabel value="#{i.etfCompanyValue}">
-                                <f:convertNumber pattern="#,##0.00" />
-                            </h:outputLabel>
-                            <f:facet name="footer">
-                                <h:outputLabel value="#{staffSalaryAdvanceController.current.etfCompanyValue}">
-                                    <f:convertNumber pattern="#,##0.00" />
-                                </h:outputLabel>
-                            </f:facet>
-                        </p:column>      
-                        <p:column style="width:6%">  
-                            <f:facet name="header">
-                                <p:commandButton ajax="false" value="Process"  />
-                            </f:facet>
-                            <p:rowEditor />  
-                        </p:column>  
-                    </p:dataTable>
-                </p:tab>
+                                    </h:outputText>
+                                    <f:facet name="footer">
+                                        <h:outputText value="#{staffSalaryAdvanceController.current.epfStaffValue}">
+                                            <f:convertNumber pattern="#,##0.00" />
+                                        </h:outputText>
+                                    </f:facet>
+                                </p:column>
+                                <p:column headerText="EPF Company" style="width: 8rem;">
+                                    <h:outputText value="#{i.epfCompanyValue}">
+                                        <f:convertNumber pattern="#,##0.00" />
+                                    </h:outputText>
+                                    <f:facet name="footer">
+                                        <h:outputText value="#{staffSalaryAdvanceController.current.epfCompanyValue}">
+                                            <f:convertNumber pattern="#,##0.00" />
+                                        </h:outputText>
+                                    </f:facet>
+                                </p:column>
+                                <p:column headerText="ETF Company" style="width: 8rem;">
+                                    <h:outputText value="#{i.etfCompanyValue}">
+                                        <f:convertNumber pattern="#,##0.00" />
+                                    </h:outputText>
+                                    <f:facet name="footer">
+                                        <h:outputText value="#{staffSalaryAdvanceController.current.etfCompanyValue}">
+                                            <f:convertNumber pattern="#,##0.00" />
+                                        </h:outputText>
+                                    </f:facet>
+                                </p:column>
 
+                            </p:dataTable>
+                        </p:tab>
+
+                    </p:tabView>
+
+                    <!-- Salary Advance Table -->
+                    <p:panel style="margin-top: 1rem;">
+                        <f:facet name="header">
+                            <div style="display: flex; justify-content: space-between; align-items: center;">
+                                <div>
+                                    <h:outputText value="Salary Advance — " />
+                                    <h:outputText value="#{staffSalaryAdvanceController.salaryCycle.salaryFromDate}">
+                                        <f:convertDateTime pattern="dd MMMM" />
+                                    </h:outputText>
+                                    <h:outputText value=" to " />
+                                    <h:outputText value="#{staffSalaryAdvanceController.salaryCycle.salaryToDate}">
+                                        <f:convertDateTime pattern="dd MMMM" />
+                                    </h:outputText>
+                                </div>
+                            </div>
+                        </f:facet>
+
+                        <p:dataTable
+                            value="#{staffSalaryAdvanceController.items}"
+                            var="ii"
+                            scrollable="true"
+                            scrollWidth="100%"
+                            style="table-layout: fixed; width: 100%;"
+                            rowStyleClass="#{ii.exist eq true ? 'exist' : null}">
+
+                            <p:column headerText="From" style="width: 6rem;">
+                                <h:outputText value="#{ii.salaryCycle.salaryFromDate}">
+                                    <f:convertDateTime pattern="dd MMM" />
+                                </h:outputText>
+                            </p:column>
+                            <p:column headerText="To" style="width: 6rem;">
+                                <h:outputText value="#{ii.salaryCycle.salaryToDate}">
+                                    <f:convertDateTime pattern="dd MMM" />
+                                </h:outputText>
+                            </p:column>
+                            <p:column headerText="Code" style="width: 5rem;">
+                                <h:outputText value="#{ii.staff.codeInterger}" />
+                            </p:column>
+                            <p:column headerText="Staff" style="width: 12rem;">
+                                <h:outputText value="#{ii.staff.person.nameWithTitle}" />
+                            </p:column>
+                            <p:column headerText="Gross Salary" style="width: 8rem;">
+                                <h:outputText value="#{ii.transGrossSalary}">
+                                    <f:convertNumber pattern="0.00" />
+                                </h:outputText>
+                            </p:column>
+                            <p:column headerText="EPF" style="width: 6rem;">
+                                <h:outputText value="#{ii.epfStaffValue}">
+                                    <f:convertNumber pattern="0.00" />
+                                </h:outputText>
+                            </p:column>
+                            <p:column headerText="EPF Company" style="width: 7rem;">
+                                <h:outputText value="#{ii.epfCompanyValue}">
+                                    <f:convertNumber pattern="0.00" />
+                                </h:outputText>
+                            </p:column>
+                            <p:column headerText="ETF Company" style="width: 7rem;">
+                                <h:outputText value="#{ii.etfCompanyValue}">
+                                    <f:convertNumber pattern="0.00" />
+                                </h:outputText>
+                            </p:column>
+                            <p:column headerText="Net Salary" style="width: 7rem;">
+                                <h:outputText value="#{ii.transNetSalry + ii.transExtraDutyValue + ii.overTimeValue}">
+                                    <f:convertNumber pattern="0.00" />
+                                </h:outputText>
+                            </p:column>
+                            <p:column headerText="Advance Payment" style="width: 9rem;">
+                                <p:inputText value="#{ii.transAdvanceSalary}" style="width: 100%;" />
+                            </p:column>
+                            <p:column style="width: 5rem;" exportable="false">
+                                <p:commandButton
+                                    process="@this"
+                                    update=":#{p:resolveFirstComponentWithId('lst', view).clientId}"
+                                    value="Edit"
+                                    styleClass="ui-button-info"
+                                    style="padding: 0.25rem 0.5rem; font-size: 0.82rem;"
+                                    actionListener="#{staffSalaryAdvanceController.onEditListener(ii)}" />
+                            </p:column>
+                            <p:column style="width: 6rem;" exportable="false">
+                                <p:commandButton
+                                    process="@this"
+                                    update="@all"
+                                    value="Delete"
+                                    styleClass="ui-button-danger"
+                                    style="padding: 0.25rem 0.5rem; font-size: 0.82rem;"
+                                    actionListener="#{staffSalaryAdvanceController.deleteSalaryComponent(ii)}"
+                                    onclick="if (!confirm('Are you sure you want to delete this record?')) return false;" />
+                            </p:column>
+                        </p:dataTable>
+                    </p:panel>
+
+                </p:tab>
 
             </p:tabView>
 
-        </h:form>        
+        </h:form>
     </ui:define>
 
 </ui:composition>


### PR DESCRIPTION
## Summary

This PR fixes multiple bugs in the HR salary advance module that
prevented advance salary records from being correctly persisted to
the database, and fixes an incorrect flag check in ETF calculation
that affected all salary components.

## Problems Fixed

### 1. Salary advance component not linked to parent record
`save()` was creating the `Salary_Advance_Deduction` component without
setting the `staffSalary` FK, leaving `STAFFSALARY_ID` null in the DB.

### 2. StaffSalary and components never persisted
`saveSalary()` called the old `save()` which only handled the advance
component but never persisted the `StaffSalary` parent record or its
salary components (basic, OT, allowances etc.).

### 3. Advance amount not saved on re-save
When clicking Save Salary Advance on already-saved records,
`saveSalary()` skipped directly to `continue` without calling `save()`,
so any advance amount entered after initial save was silently ignored.

### 4. Wrong component fetched for advance
`fetchAndSetSalaryAdvance()` and `fetchSalaryAdvance()` queried by
staff and cycle only, with no component type filter. This caused them
to fetch the first matching component (e.g. `FixedAllowance`) instead
of `Salary_Advance_Deduction`, overwriting unrelated component values.

### 5. ETF calculated using wrong flag
`HumanResourceBean.setEtf()` was checking `isIncludedForEpf()` instead
of `isIncludedForEtf()`. This caused incorrect ETF behavior for any
component where the two flags differ.

## Changes

### `StaffSalaryAdvanceController.java`
- `save()` — added `ss.setStaffSalary(getCurrent())` to link advance
  component to parent salary record
- `saveSalary()` — rewrote to correctly persist `StaffSalary` and all
  components; now calls `save()` for both new and existing records
- `fetchAndSetSalaryAdvance()` — added `componentType` filter
- `fetchSalaryAdvance()` — added `componentType` filter
- `fetchItems()` — new method to reload saved records from DB by cycle

### `HumanResourceBean.java`
- `setEtf()` — changed `isIncludedForEpf()` to `isIncludedForEtf()`

## Testing
- Generated advance salary, saved, verified `STAFFSALARY_ID` populated
- Verified `Salary_Advance_Deduction` component saved with correct value
- Verified advance amount deducted correctly in net salary calculation
- Verified ETF company value calculated correctly on Basic Salary

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added dedicated salary advance table and editable salary components with footer totals.
  * Improved save/fetch workflow: validates cycle selection, preserves advance items across existing and new salary records, and ensures components remain correctly linked to their parent salary.

* **Bug Fixes**
  * Corrected ETF inclusion logic to use the proper inclusion flag.

* **Refactor**
  * Modernized UI with reorganized tabs, updated filters, and streamlined action controls.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hmislk/hmis/pull/20702)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->