### PR TITLE
fix(cashier): fix doubled rows in handover print Float Transactions table

### DIFF
--- a/src/main/java/com/divudi/bean/cashTransaction/FinancialTransactionController.java
+++ b/src/main/java/com/divudi/bean/cashTransaction/FinancialTransactionController.java
@@ -1911,21 +1911,19 @@ public class FinancialTransactionController implements Serializable {
         // display them. Same query as navigateToViewHandoverBill.
         Bill shiftStartBill = selectedBill.getReferenceBill();
         if (shiftStartBill != null && shiftStartBill.getId() != null) {
-            List<BillTypeAtomic> floatBtas = new ArrayList<>();
-            floatBtas.add(BillTypeAtomic.FUND_TRANSFER_BILL);
-            floatBtas.add(BillTypeAtomic.FUND_TRANSFER_RECEIVED_BILL);
             Map<String, Object> floatParams = new HashMap<>();
             String floatJpql = "SELECT p FROM Payment p JOIN p.bill b "
-                    + "WHERE (p.creater = :cu OR p.floatRecipient = :cu) "
+                    + "WHERE ((b.billTypeAtomic = :ftBill AND p.creater = :cu) "
+                    + "OR (b.billTypeAtomic = :ftRecv AND p.floatRecipient = :cu)) "
                     + "AND p.retired = false "
                     + "AND p.cancelled = false "
                     + "AND p.handingOverStarted = true "
-                    + "AND b.billTypeAtomic IN :btas "
                     + "AND b.id > :sid "
                     + "AND b.id <= :hid "
                     + "ORDER BY b.id";
             floatParams.put("cu", selectedBill.getFromWebUser());
-            floatParams.put("btas", floatBtas);
+            floatParams.put("ftBill", BillTypeAtomic.FUND_TRANSFER_BILL);
+            floatParams.put("ftRecv", BillTypeAtomic.FUND_TRANSFER_RECEIVED_BILL);
             floatParams.put("sid", shiftStartBill.getId());
             floatParams.put("hid", selectedBill.getId());
             List<Payment> floatPayments = paymentFacade.findByJpql(floatJpql, floatParams);
@@ -2054,21 +2052,19 @@ public class FinancialTransactionController implements Serializable {
         // handover bill, for this user as creator or recipient.
         Bill shiftStartBill = selectedBill.getReferenceBill();
         if (shiftStartBill != null && shiftStartBill.getId() != null) {
-            List<BillTypeAtomic> floatBtas = new ArrayList<>();
-            floatBtas.add(BillTypeAtomic.FUND_TRANSFER_BILL);
-            floatBtas.add(BillTypeAtomic.FUND_TRANSFER_RECEIVED_BILL);
             Map<String, Object> floatParams = new HashMap<>();
             String floatJpql = "SELECT p FROM Payment p JOIN p.bill b "
-                    + "WHERE (p.creater = :cu OR p.floatRecipient = :cu) "
+                    + "WHERE ((b.billTypeAtomic = :ftBill AND p.creater = :cu) "
+                    + "OR (b.billTypeAtomic = :ftRecv AND p.floatRecipient = :cu)) "
                     + "AND p.retired = false "
                     + "AND p.cancelled = false "
                     + "AND p.handingOverStarted = true "
-                    + "AND b.billTypeAtomic IN :btas "
                     + "AND b.id > :sid "
                     + "AND b.id <= :hid "
                     + "ORDER BY b.id";
             floatParams.put("cu", selectedBill.getFromWebUser());
-            floatParams.put("btas", floatBtas);
+            floatParams.put("ftBill", BillTypeAtomic.FUND_TRANSFER_BILL);
+            floatParams.put("ftRecv", BillTypeAtomic.FUND_TRANSFER_RECEIVED_BILL);
             floatParams.put("sid", shiftStartBill.getId());
             floatParams.put("hid", selectedBill.getId());
             List<Payment> floatPayments = paymentFacade.findByJpql(floatJpql, floatParams);
@@ -6170,20 +6166,18 @@ public class FinancialTransactionController implements Serializable {
         // at this point (validated at the start of this method).
         Bill shiftStartBillForFloats = bundle.getStartBill();
         if (shiftStartBillForFloats != null && shiftStartBillForFloats.getId() != null) {
-            List<BillTypeAtomic> floatTransferBtas = new ArrayList<>();
-            floatTransferBtas.add(BillTypeAtomic.FUND_TRANSFER_BILL);
-            floatTransferBtas.add(BillTypeAtomic.FUND_TRANSFER_RECEIVED_BILL);
             Map<String, Object> floatParams = new HashMap<>();
             String floatJpql = "SELECT p FROM Payment p JOIN p.bill b "
-                    + "WHERE (p.creater = :cu OR p.floatRecipient = :cu) "
+                    + "WHERE ((b.billTypeAtomic = :ftBill AND p.creater = :cu) "
+                    + "OR (b.billTypeAtomic = :ftRecv AND p.floatRecipient = :cu)) "
                     + "AND p.retired = false "
                     + "AND p.cancelled = false "
                     + "AND p.handingOverStarted = false "
                     + "AND p.cashbookEntryStated = false "
-                    + "AND b.billTypeAtomic IN :btas "
                     + "AND b.id > :sid";
             floatParams.put("cu", sessionController.getLoggedUser());
-            floatParams.put("btas", floatTransferBtas);
+            floatParams.put("ftBill", BillTypeAtomic.FUND_TRANSFER_BILL);
+            floatParams.put("ftRecv", BillTypeAtomic.FUND_TRANSFER_RECEIVED_BILL);
             floatParams.put("sid", shiftStartBillForFloats.getId());
             List<Payment> floatPaymentsToMark = paymentFacade.findByJpql(floatJpql, floatParams);
             for (Payment ftp : floatPaymentsToMark) {


### PR DESCRIPTION
## Summary

- Each float transfer was appearing twice in the **Float Transactions** table on the Handover Detail Print page
- Root cause: JPQL queries used `(p.creater = :cu OR p.floatRecipient = :cu)` across both `FUND_TRANSFER_BILL` and `FUND_TRANSFER_RECEIVED_BILL` types — a single float event produces one record of each type, so both matched the OR
- Fix: apply type-specific conditions so only one record per transfer is fetched: `(FUND_TRANSFER_BILL AND creater=cu) OR (FUND_TRANSFER_RECEIVED_BILL AND floatRecipient=cu)`
- Applied to three JPQL queries in `FinancialTransactionController` (accept flow, view/reprint flow, submit flow)

Closes #20703

## Test plan

- [ ] Perform a shift with at least one float sent and one float received
- [ ] Complete handover and open the Handover Details Print page
- [ ] Verify each float transfer appears exactly once in the Float Transactions table
- [ ] Verify the total in the Float Transactions table matches the net float shown in the header

🤖 Generated with [Claude Code](https://claude.com/claude-code)