### PR TITLE
Remove 'Shift Shortage Bills are enabled' config gate

### DIFF
--- a/src/main/java/com/divudi/bean/cashTransaction/FinancialTransactionController.java
+++ b/src/main/java/com/divudi/bean/cashTransaction/FinancialTransactionController.java
@@ -10251,12 +10251,6 @@ public class FinancialTransactionController implements Serializable {
         ));
 
         fundTransferMetadata.addConfigOption(new ConfigOptionInfo(
-                "Shift Shortage Bills are enabled",
-                "When enabled, allows recording and tracking of shift shortage bills in cashier operations.",
-                OptionScope.APPLICATION
-        ));
-
-        fundTransferMetadata.addConfigOption(new ConfigOptionInfo(
                 "Shift Excess Bills are enabled",
                 "When enabled, allows recording and tracking of shift excess bills in cashier operations.",
                 OptionScope.APPLICATION
@@ -10324,12 +10318,6 @@ public class FinancialTransactionController implements Serializable {
         ));
 
         receiveTransferMetadata.addConfigOption(new ConfigOptionInfo(
-                "Shift Shortage Bills are enabled",
-                "When enabled, allows recording and tracking of shift shortage bills, affecting overall cashier workflow including fund transfer receiving.",
-                OptionScope.APPLICATION
-        ));
-
-        receiveTransferMetadata.addConfigOption(new ConfigOptionInfo(
                 "Shift Excess Bills are enabled",
                 "When enabled, allows recording and tracking of shift excess bills, affecting overall cashier workflow including fund transfer receiving.",
                 OptionScope.APPLICATION
@@ -10385,12 +10373,6 @@ public class FinancialTransactionController implements Serializable {
         cashierIndexMetadata.addConfigOption(new ConfigOptionInfo(
                 "Completed Shift Handover is enabled",
                 "When enabled, shows 'My Shifts' button in the Shift Management tab to view completed shift handovers.",
-                OptionScope.APPLICATION
-        ));
-
-        cashierIndexMetadata.addConfigOption(new ConfigOptionInfo(
-                "Shift Shortage Bills are enabled",
-                "When enabled, shows 'Record Shift Shortage' and 'Shift Shortage Bill Search' buttons in the Shift Management tab for tracking cash shortages.",
                 OptionScope.APPLICATION
         ));
 
@@ -10598,12 +10580,6 @@ public class FinancialTransactionController implements Serializable {
         shiftEndMetadata.addConfigOption(new ConfigOptionInfo(
                 "Recording Shift End Cash is Required Before Viewing Shift Reports",
                 "When enabled, affects the overall shift ending workflow requiring cash recording steps before accessing reports from this page.",
-                OptionScope.APPLICATION
-        ));
-
-        shiftEndMetadata.addConfigOption(new ConfigOptionInfo(
-                "Shift Shortage Bills are enabled",
-                "When enabled, allows tracking of cash shortage transactions that may be identified during the shift ending process.",
                 OptionScope.APPLICATION
         ));
 

--- a/src/main/webapp/cashier/index.xhtml
+++ b/src/main/webapp/cashier/index.xhtml
@@ -90,7 +90,6 @@
                                         class="my-1 w-100 ui-button-warning"
                                         value="Record Shift Shortage"
                                         icon="pi pi-minus"
-                                        rendered="#{configOptionApplicationController.getBooleanValueByKey('Shift Shortage Bills are enabled')}"
                                         ajax="false"
                                         action="#{financialTransactionController.navigateToRecordShiftShortage()}">
                                     </p:commandButton>
@@ -108,7 +107,6 @@
                                     <p:commandButton
                                         class="my-1 w-100 ui-button-info"
                                         value="Shift Shortage Bill Search"
-                                        rendered="#{configOptionApplicationController.getBooleanValueByKey('Shift Shortage Bills are enabled')}"
                                         icon="fa fa-search"
                                         ajax="false"
                                         action="#{financialTransactionController.navigateToCashierShiftBillSearch()}">


### PR DESCRIPTION
## Summary

- Removed `rendered="#{configOptionApplicationController.getBooleanValueByKey('Shift Shortage Bills are enabled')}"` from **Record Shift Shortage** and **Shift Shortage Bill Search** buttons in `cashier/index.xhtml` — they are now always visible
- Removed all four `ConfigOptionInfo` registrations for `"Shift Shortage Bills are enabled"` from `FinancialTransactionController.java` (page metadata for: fund transfer bill, fund transfer bills to receive, cashier index, shift end summary)

## Test plan

- [ ] Open `cashier/index.xhtml` — both **Record Shift Shortage** and **Shift Shortage Bill Search** buttons appear in the Shift tab without needing any config entry
- [ ] Verify no regression in other Shift tab buttons

Closes #20722

🤖 Generated with [Claude Code](https://claude.com/claude-code)