### PR TITLE
feat(pharmacy): archive old StockHistory records to reduce table bloat

### DIFF
--- a/src/main/java/com/divudi/bean/common/ConfigOptionApplicationController.java
+++ b/src/main/java/com/divudi/bean/common/ConfigOptionApplicationController.java
@@ -118,6 +118,7 @@ public class ConfigOptionApplicationController implements Serializable {
             loadPettyCashBillingConfigurationDefaults();
             loadDatabaseVersionConfigurationDefaults();
             loadAiChatConfigurationDefaults();
+            loadStockHistoryArchiveConfigurationDefaults();
             enumController.resetPaymentMethods();
         } finally {
             isLoadingApplicationOptions = false;
@@ -1160,6 +1161,12 @@ public class ConfigOptionApplicationController implements Serializable {
     private String buildAllCashierCollectionOptionKey(PaymentMethod paymentMethod) {
         String label = paymentMethod != null ? paymentMethod.getLabel() : "Unknown";
         return "Include " + label + " in Collection Total";
+    }
+
+    private void loadStockHistoryArchiveConfigurationDefaults() {
+        getIntegerValueByKey("StockHistory Archive - Retention Days", 730);
+        getIntegerValueByKey("StockHistory Archive - Batch Size", 2000);
+        getIntegerValueByKey("StockHistory Archive - Max Batches Per Run", 50);
     }
 
     public ConfigOption getApplicationOption(String key) {

--- a/src/main/java/com/divudi/bean/common/UserPrivilageController.java
+++ b/src/main/java/com/divudi/bean/common/UserPrivilageController.java
@@ -790,6 +790,8 @@ public class UserPrivilageController implements Serializable {
         TreeNode PharmacyStockTakeApprove = new DefaultTreeNode(new PrivilegeHolder(Privileges.PharmacyStockTakeApprove, "Pharmacy Stock Take Approve"), PharmacyAdjustment);
         // Create New Batch privilege
         new DefaultTreeNode(new PrivilegeHolder(Privileges.PharmacyAdjustmentCreateBatch, "Pharmacy Adjustment Create Batch"), PharmacyAdjustment);
+        // Archive Old StockHistory Records (issue #20726)
+        new DefaultTreeNode(new PrivilegeHolder(Privileges.ArchiveOldStockHistory, "Archive Old StockHistory Records"), PharmacyAdjustment);
 
         TreeNode pharmacyDisposalNode = new DefaultTreeNode(new PrivilegeHolder(null, "Pharmacy Disposal"), pharmacyNode);
         new DefaultTreeNode(new PrivilegeHolder(Privileges.PharmacyDisposalMenue, "Pharmacy Disposal Menu"), pharmacyDisposalNode);

--- a/src/main/java/com/divudi/bean/pharmacy/StockHistoryArchivalController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/StockHistoryArchivalController.java
@@ -11,6 +11,8 @@ import com.divudi.service.archival.StockHistoryArchivalService;
 import java.io.Serializable;
 import java.util.Calendar;
 import java.util.Date;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import javax.ejb.EJB;
 import javax.enterprise.context.SessionScoped;
 import javax.inject.Inject;
@@ -29,6 +31,8 @@ import javax.inject.Named;
 public class StockHistoryArchivalController implements Serializable {
 
     private static final long serialVersionUID = 1L;
+
+    private static final Logger LOGGER = Logger.getLogger(StockHistoryArchivalController.class.getName());
 
     @EJB
     private StockHistoryArchivalService archivalService;
@@ -51,17 +55,21 @@ public class StockHistoryArchivalController implements Serializable {
     }
 
     private void resetDefaults() {
-        int retentionDays = configOptionController.getIntegerValueByKey(
-                "StockHistory Archive - Retention Days", 730);
+        int retentionDays = sanitisePositive(configOptionController.getIntegerValueByKey(
+                "StockHistory Archive - Retention Days", 730), 730);
         Calendar cal = Calendar.getInstance();
         cal.add(Calendar.DATE, -retentionDays);
         cutoffDate = cal.getTime();
 
-        batchSize = configOptionController.getIntegerValueByKey(
-                "StockHistory Archive - Batch Size", 2000);
-        maxBatches = configOptionController.getIntegerValueByKey(
-                "StockHistory Archive - Max Batches Per Run", 50);
+        batchSize = sanitisePositive(configOptionController.getIntegerValueByKey(
+                "StockHistory Archive - Batch Size", 2000), 2000);
+        maxBatches = sanitisePositive(configOptionController.getIntegerValueByKey(
+                "StockHistory Archive - Max Batches Per Run", 50), 50);
         dryRun = true;
+    }
+
+    private static int sanitisePositive(Integer raw, int fallback) {
+        return (raw == null || raw <= 0) ? fallback : raw;
     }
 
     public void preview() {
@@ -73,7 +81,8 @@ public class StockHistoryArchivalController implements Serializable {
             JsfUtil.addSuccessMessage(candidateCount + " row(s) eligible for archival before "
                     + cutoffDate);
         } catch (Exception ex) {
-            JsfUtil.addErrorMessage("Preview failed: " + ex.getMessage());
+            LOGGER.log(Level.SEVERE, "StockHistory archival preview failed", ex);
+            JsfUtil.addErrorMessage("Preview failed. Please check server logs for details.");
         }
     }
 
@@ -90,7 +99,8 @@ public class StockHistoryArchivalController implements Serializable {
                 JsfUtil.addSuccessMessage(lastResult.getMessage());
             }
         } catch (Exception ex) {
-            JsfUtil.addErrorMessage("Archive run failed: " + ex.getMessage());
+            LOGGER.log(Level.SEVERE, "StockHistory archive run failed", ex);
+            JsfUtil.addErrorMessage("Archive run failed. Please check server logs for details.");
         }
     }
 

--- a/src/main/java/com/divudi/bean/pharmacy/StockHistoryArchivalController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/StockHistoryArchivalController.java
@@ -1,0 +1,131 @@
+/*
+ * Dr M H B Ariyaratne
+ * buddhika.ari@gmail.com
+ */
+package com.divudi.bean.pharmacy;
+
+import com.divudi.bean.common.ConfigOptionApplicationController;
+import com.divudi.core.data.dto.ArchiveResult;
+import com.divudi.core.util.JsfUtil;
+import com.divudi.service.archival.StockHistoryArchivalService;
+import java.io.Serializable;
+import java.util.Calendar;
+import java.util.Date;
+import javax.ejb.EJB;
+import javax.enterprise.context.SessionScoped;
+import javax.inject.Inject;
+import javax.inject.Named;
+
+/**
+ * Backing bean for the manual StockHistory archive admin page.
+ *
+ * Lets an authorised user pick a cutoff date, batch size and dry-run flag,
+ * and run a one-off archive pass without waiting for the scheduled job.
+ *
+ * Issue #20726.
+ */
+@Named
+@SessionScoped
+public class StockHistoryArchivalController implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    @EJB
+    private StockHistoryArchivalService archivalService;
+
+    @Inject
+    private ConfigOptionApplicationController configOptionController;
+
+    private Date cutoffDate;
+    private int batchSize;
+    private int maxBatches;
+    private boolean dryRun;
+    private ArchiveResult lastResult;
+    private Long candidateCount;
+
+    public String navigateToArchiveStockHistory() {
+        resetDefaults();
+        lastResult = null;
+        candidateCount = null;
+        return "/dataAdmin/archive_stock_history?faces-redirect=true";
+    }
+
+    private void resetDefaults() {
+        int retentionDays = configOptionController.getIntegerValueByKey(
+                "StockHistory Archive - Retention Days", 730);
+        Calendar cal = Calendar.getInstance();
+        cal.add(Calendar.DATE, -retentionDays);
+        cutoffDate = cal.getTime();
+
+        batchSize = configOptionController.getIntegerValueByKey(
+                "StockHistory Archive - Batch Size", 2000);
+        maxBatches = configOptionController.getIntegerValueByKey(
+                "StockHistory Archive - Max Batches Per Run", 50);
+        dryRun = true;
+    }
+
+    public void preview() {
+        if (!validateInputs()) {
+            return;
+        }
+        try {
+            candidateCount = archivalService.countOlderThan(cutoffDate);
+            JsfUtil.addSuccessMessage(candidateCount + " row(s) eligible for archival before "
+                    + cutoffDate);
+        } catch (Exception ex) {
+            JsfUtil.addErrorMessage("Preview failed: " + ex.getMessage());
+        }
+    }
+
+    public void run() {
+        if (!validateInputs()) {
+            return;
+        }
+        try {
+            lastResult = archivalService.archive(cutoffDate, batchSize, maxBatches, dryRun);
+            if (dryRun) {
+                JsfUtil.addSuccessMessage("Dry run: " + lastResult.getCandidateCount()
+                        + " row(s) would be archived");
+            } else {
+                JsfUtil.addSuccessMessage(lastResult.getMessage());
+            }
+        } catch (Exception ex) {
+            JsfUtil.addErrorMessage("Archive run failed: " + ex.getMessage());
+        }
+    }
+
+    private boolean validateInputs() {
+        if (cutoffDate == null) {
+            JsfUtil.addErrorMessage("Cutoff date is required");
+            return false;
+        }
+        if (cutoffDate.after(new Date())) {
+            JsfUtil.addErrorMessage("Cutoff date cannot be in the future");
+            return false;
+        }
+        if (batchSize <= 0 || batchSize > 50000) {
+            JsfUtil.addErrorMessage("Batch size must be between 1 and 50000");
+            return false;
+        }
+        if (maxBatches <= 0 || maxBatches > 1000) {
+            JsfUtil.addErrorMessage("Max batches must be between 1 and 1000");
+            return false;
+        }
+        return true;
+    }
+
+    public Date getCutoffDate() { return cutoffDate; }
+    public void setCutoffDate(Date cutoffDate) { this.cutoffDate = cutoffDate; }
+
+    public int getBatchSize() { return batchSize; }
+    public void setBatchSize(int batchSize) { this.batchSize = batchSize; }
+
+    public int getMaxBatches() { return maxBatches; }
+    public void setMaxBatches(int maxBatches) { this.maxBatches = maxBatches; }
+
+    public boolean isDryRun() { return dryRun; }
+    public void setDryRun(boolean dryRun) { this.dryRun = dryRun; }
+
+    public ArchiveResult getLastResult() { return lastResult; }
+    public Long getCandidateCount() { return candidateCount; }
+}

--- a/src/main/java/com/divudi/core/data/Privileges.java
+++ b/src/main/java/com/divudi/core/data/Privileges.java
@@ -555,6 +555,7 @@ public enum Privileges {
     PharmacyAdjustmentCreateBatch("Pharmacy Adjustment Create Batch"),
     PharmacyPhysicalCountApprove("Pharmacy Physical Count Approve"),
     PharmacyStockTakeApprove("Pharmacy Stock Take Approve"),
+    ArchiveOldStockHistory("Archive Old StockHistory Records"),
     // Pharmacy Dealer Payments
     PharmacyDealerPaymentMenue("Pharmacy Dealer Payment Menu"),
     PharmacyDealerDueSearch("Pharmacy Dealer Due Search"),
@@ -966,6 +967,7 @@ public enum Privileges {
             case PharmacyAdjustmentCreateBatch:
             case PharmacyPhysicalCountApprove:
             case PharmacyStockTakeApprove:
+            case ArchiveOldStockHistory:
 
             // Pharmacy Dealer Payments
             case PharmacyDealerDueSearch:

--- a/src/main/java/com/divudi/core/data/ScheduledProcess.java
+++ b/src/main/java/com/divudi/core/data/ScheduledProcess.java
@@ -8,7 +8,8 @@ public enum ScheduledProcess {
     Record_Pharmacy_Stock_Values("Record Pharmacy Stock Values"),
     All_Drawer_Balances("All Drawer Balances"),
     All_Collection_Centre_Balances("All Collection Centre Balances"),
-    All_Credit_Company_Balances("All Credit Company Balances");
+    All_Credit_Company_Balances("All Credit Company Balances"),
+    Archive_Old_StockHistory_Records("Archive Old StockHistory Records");
 
     private final String label;
 

--- a/src/main/java/com/divudi/core/data/dto/ArchiveResult.java
+++ b/src/main/java/com/divudi/core/data/dto/ArchiveResult.java
@@ -1,0 +1,56 @@
+/*
+ * Dr M H B Ariyaratne
+ * buddhika.ari@gmail.com
+ */
+package com.divudi.core.data.dto;
+
+import java.io.Serializable;
+import java.util.Date;
+
+/**
+ * Result of an archival run.
+ *
+ * Used by ArchivalServiceBase (issue #20726) and the manual admin trigger
+ * so the caller can see how much was moved without having to query the
+ * archive table directly.
+ */
+public class ArchiveResult implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    private final boolean dryRun;
+    private final long candidateCount;
+    private final long archivedCount;
+    private final int batchesRun;
+    private final boolean reachedBatchLimit;
+    private final Date startedAt;
+    private final Date endedAt;
+    private final String message;
+
+    public ArchiveResult(boolean dryRun, long candidateCount, long archivedCount,
+                         int batchesRun, boolean reachedBatchLimit,
+                         Date startedAt, Date endedAt, String message) {
+        this.dryRun = dryRun;
+        this.candidateCount = candidateCount;
+        this.archivedCount = archivedCount;
+        this.batchesRun = batchesRun;
+        this.reachedBatchLimit = reachedBatchLimit;
+        this.startedAt = startedAt;
+        this.endedAt = endedAt;
+        this.message = message;
+    }
+
+    public boolean isDryRun() { return dryRun; }
+    public long getCandidateCount() { return candidateCount; }
+    public long getArchivedCount() { return archivedCount; }
+    public int getBatchesRun() { return batchesRun; }
+    public boolean isReachedBatchLimit() { return reachedBatchLimit; }
+    public Date getStartedAt() { return startedAt; }
+    public Date getEndedAt() { return endedAt; }
+    public String getMessage() { return message; }
+
+    public long getDurationMillis() {
+        if (startedAt == null || endedAt == null) return 0;
+        return endedAt.getTime() - startedAt.getTime();
+    }
+}

--- a/src/main/java/com/divudi/core/entity/pharmacy/StockHistoryArchive.java
+++ b/src/main/java/com/divudi/core/entity/pharmacy/StockHistoryArchive.java
@@ -1,0 +1,299 @@
+/*
+ * Dr M H B Ariyaratne
+ * buddhika.ari@gmail.com
+ */
+package com.divudi.core.entity.pharmacy;
+
+import com.divudi.core.entity.RetirableEntity;
+import com.divudi.core.data.HistoryType;
+import com.divudi.core.entity.Department;
+import com.divudi.core.entity.Institution;
+import com.divudi.core.entity.Item;
+import com.divudi.core.entity.Staff;
+import com.divudi.core.entity.WebUser;
+import java.io.Serializable;
+import java.util.Date;
+import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
+import javax.persistence.FetchType;
+import javax.persistence.Id;
+import javax.persistence.ManyToOne;
+import javax.persistence.OneToOne;
+import javax.persistence.Table;
+import javax.persistence.Temporal;
+
+/**
+ * Archive table for old StockHistory rows.
+ *
+ * Same schema as StockHistory but used for long-term retention. Rows older
+ * than the configured retention window are moved here by the archival job
+ * (issue #20726).
+ *
+ * Notes:
+ * - No @GeneratedValue on id: rows keep their original StockHistory id so
+ *   downstream references (e.g. audit logs, exported reports) remain stable.
+ * - Same field order/types as StockHistory so a column-list-based
+ *   INSERT...SELECT lines up reliably.
+ */
+@Entity
+@Table(name = "STOCKHISTORYARCHIVE")
+public class StockHistoryArchive implements Serializable, RetirableEntity {
+
+    private static final long serialVersionUID = 1L;
+    @Id
+    private Long id;
+
+    @Temporal(javax.persistence.TemporalType.DATE)
+    Date stockAt;
+    @OneToOne(fetch = FetchType.LAZY)
+    PharmaceuticalBillItem pbItem;
+
+    double retailRate;
+    double wholesaleRate;
+    double purchaseRate;
+    double costRate;
+
+    @ManyToOne
+    ItemBatch itemBatch;
+    @ManyToOne
+    Institution institution;
+    @ManyToOne
+    Department department;
+    @ManyToOne
+    Staff staff;
+
+    @ManyToOne
+    Item item;
+    @Enumerated(EnumType.STRING)
+    HistoryType historyType;
+
+    @Temporal(javax.persistence.TemporalType.TIMESTAMP)
+    Date fromDate;
+    @Temporal(javax.persistence.TemporalType.TIMESTAMP)
+    Date toDate;
+
+    private double stockSaleValue;
+    private Double institutionBatchStockValueAtSaleRate;
+    private Double totalBatchStockValueAtSaleRate;
+
+    private double stockPurchaseValue;
+    private Double institutionBatchStockValueAtPurchaseRate;
+    private Double totalBatchStockValueAtPurchaseRate;
+
+    private double stockCostValue;
+    private Double institutionBatchStockValueAtCostRate;
+    private Double totalBatchStockValueAtCostRate;
+
+    long hxYear;
+    int hxMonth;
+    int hxDate;
+    int hxWeek;
+
+    double stockQty;
+    private double instituionBatchQty;
+    private double totalBatchQty;
+
+    private Double itemStock;
+    private Double institutionItemStock;
+    private Double totalItemStock;
+
+    private Double itemStockValueAtSaleRate;
+    private Double institutionItemStockValueAtSaleRate;
+    private Double totalItemStockValueAtSaleRate;
+
+    private Double itemStockValueAtPurchaseRate;
+    private Double institutionItemStockValueAtPurchaseRate;
+    private Double totalItemStockValueAtPurchaseRate;
+
+    private Double itemStockValueAtCostRate;
+    private Double institutionItemStockValueAtCostRate;
+    private Double totalItemStockValueAtCostRate;
+
+    @ManyToOne
+    private WebUser creater;
+    @Temporal(javax.persistence.TemporalType.TIMESTAMP)
+    private Date createdAt;
+    private boolean retired;
+    @ManyToOne
+    private WebUser retirer;
+    @Temporal(javax.persistence.TemporalType.TIMESTAMP)
+    private Date retiredAt;
+    private String retireComments;
+
+    @Temporal(javax.persistence.TemporalType.TIMESTAMP)
+    private Date archivedAt;
+
+    public Long getId() { return id; }
+    public void setId(Long id) { this.id = id; }
+
+    public Date getStockAt() { return stockAt; }
+    public void setStockAt(Date stockAt) { this.stockAt = stockAt; }
+
+    public PharmaceuticalBillItem getPbItem() { return pbItem; }
+    public void setPbItem(PharmaceuticalBillItem pbItem) { this.pbItem = pbItem; }
+
+    public double getRetailRate() { return retailRate; }
+    public void setRetailRate(double retailRate) { this.retailRate = retailRate; }
+
+    public double getWholesaleRate() { return wholesaleRate; }
+    public void setWholesaleRate(double wholesaleRate) { this.wholesaleRate = wholesaleRate; }
+
+    public double getPurchaseRate() { return purchaseRate; }
+    public void setPurchaseRate(double purchaseRate) { this.purchaseRate = purchaseRate; }
+
+    public double getCostRate() { return costRate; }
+    public void setCostRate(double costRate) { this.costRate = costRate; }
+
+    public ItemBatch getItemBatch() { return itemBatch; }
+    public void setItemBatch(ItemBatch itemBatch) { this.itemBatch = itemBatch; }
+
+    public Institution getInstitution() { return institution; }
+    public void setInstitution(Institution institution) { this.institution = institution; }
+
+    public Department getDepartment() { return department; }
+    public void setDepartment(Department department) { this.department = department; }
+
+    public Staff getStaff() { return staff; }
+    public void setStaff(Staff staff) { this.staff = staff; }
+
+    public Item getItem() { return item; }
+    public void setItem(Item item) { this.item = item; }
+
+    public HistoryType getHistoryType() { return historyType; }
+    public void setHistoryType(HistoryType historyType) { this.historyType = historyType; }
+
+    public Date getFromDate() { return fromDate; }
+    public void setFromDate(Date fromDate) { this.fromDate = fromDate; }
+
+    public Date getToDate() { return toDate; }
+    public void setToDate(Date toDate) { this.toDate = toDate; }
+
+    public double getStockSaleValue() { return stockSaleValue; }
+    public void setStockSaleValue(double stockSaleValue) { this.stockSaleValue = stockSaleValue; }
+
+    public Double getInstitutionBatchStockValueAtSaleRate() { return institutionBatchStockValueAtSaleRate; }
+    public void setInstitutionBatchStockValueAtSaleRate(Double v) { this.institutionBatchStockValueAtSaleRate = v; }
+
+    public Double getTotalBatchStockValueAtSaleRate() { return totalBatchStockValueAtSaleRate; }
+    public void setTotalBatchStockValueAtSaleRate(Double v) { this.totalBatchStockValueAtSaleRate = v; }
+
+    public double getStockPurchaseValue() { return stockPurchaseValue; }
+    public void setStockPurchaseValue(double stockPurchaseValue) { this.stockPurchaseValue = stockPurchaseValue; }
+
+    public Double getInstitutionBatchStockValueAtPurchaseRate() { return institutionBatchStockValueAtPurchaseRate; }
+    public void setInstitutionBatchStockValueAtPurchaseRate(Double v) { this.institutionBatchStockValueAtPurchaseRate = v; }
+
+    public Double getTotalBatchStockValueAtPurchaseRate() { return totalBatchStockValueAtPurchaseRate; }
+    public void setTotalBatchStockValueAtPurchaseRate(Double v) { this.totalBatchStockValueAtPurchaseRate = v; }
+
+    public double getStockCostValue() { return stockCostValue; }
+    public void setStockCostValue(double stockCostValue) { this.stockCostValue = stockCostValue; }
+
+    public Double getInstitutionBatchStockValueAtCostRate() { return institutionBatchStockValueAtCostRate; }
+    public void setInstitutionBatchStockValueAtCostRate(Double v) { this.institutionBatchStockValueAtCostRate = v; }
+
+    public Double getTotalBatchStockValueAtCostRate() { return totalBatchStockValueAtCostRate; }
+    public void setTotalBatchStockValueAtCostRate(Double v) { this.totalBatchStockValueAtCostRate = v; }
+
+    public long getHxYear() { return hxYear; }
+    public void setHxYear(long hxYear) { this.hxYear = hxYear; }
+
+    public int getHxMonth() { return hxMonth; }
+    public void setHxMonth(int hxMonth) { this.hxMonth = hxMonth; }
+
+    public int getHxDate() { return hxDate; }
+    public void setHxDate(int hxDate) { this.hxDate = hxDate; }
+
+    public int getHxWeek() { return hxWeek; }
+    public void setHxWeek(int hxWeek) { this.hxWeek = hxWeek; }
+
+    public double getStockQty() { return stockQty; }
+    public void setStockQty(double stockQty) { this.stockQty = stockQty; }
+
+    public double getInstituionBatchQty() { return instituionBatchQty; }
+    public void setInstituionBatchQty(double instituionBatchQty) { this.instituionBatchQty = instituionBatchQty; }
+
+    public double getTotalBatchQty() { return totalBatchQty; }
+    public void setTotalBatchQty(double totalBatchQty) { this.totalBatchQty = totalBatchQty; }
+
+    public Double getItemStock() { return itemStock; }
+    public void setItemStock(Double itemStock) { this.itemStock = itemStock; }
+
+    public Double getInstitutionItemStock() { return institutionItemStock; }
+    public void setInstitutionItemStock(Double institutionItemStock) { this.institutionItemStock = institutionItemStock; }
+
+    public Double getTotalItemStock() { return totalItemStock; }
+    public void setTotalItemStock(Double totalItemStock) { this.totalItemStock = totalItemStock; }
+
+    public Double getItemStockValueAtSaleRate() { return itemStockValueAtSaleRate; }
+    public void setItemStockValueAtSaleRate(Double v) { this.itemStockValueAtSaleRate = v; }
+
+    public Double getInstitutionItemStockValueAtSaleRate() { return institutionItemStockValueAtSaleRate; }
+    public void setInstitutionItemStockValueAtSaleRate(Double v) { this.institutionItemStockValueAtSaleRate = v; }
+
+    public Double getTotalItemStockValueAtSaleRate() { return totalItemStockValueAtSaleRate; }
+    public void setTotalItemStockValueAtSaleRate(Double v) { this.totalItemStockValueAtSaleRate = v; }
+
+    public Double getItemStockValueAtPurchaseRate() { return itemStockValueAtPurchaseRate; }
+    public void setItemStockValueAtPurchaseRate(Double v) { this.itemStockValueAtPurchaseRate = v; }
+
+    public Double getInstitutionItemStockValueAtPurchaseRate() { return institutionItemStockValueAtPurchaseRate; }
+    public void setInstitutionItemStockValueAtPurchaseRate(Double v) { this.institutionItemStockValueAtPurchaseRate = v; }
+
+    public Double getTotalItemStockValueAtPurchaseRate() { return totalItemStockValueAtPurchaseRate; }
+    public void setTotalItemStockValueAtPurchaseRate(Double v) { this.totalItemStockValueAtPurchaseRate = v; }
+
+    public Double getItemStockValueAtCostRate() { return itemStockValueAtCostRate; }
+    public void setItemStockValueAtCostRate(Double v) { this.itemStockValueAtCostRate = v; }
+
+    public Double getInstitutionItemStockValueAtCostRate() { return institutionItemStockValueAtCostRate; }
+    public void setInstitutionItemStockValueAtCostRate(Double v) { this.institutionItemStockValueAtCostRate = v; }
+
+    public Double getTotalItemStockValueAtCostRate() { return totalItemStockValueAtCostRate; }
+    public void setTotalItemStockValueAtCostRate(Double v) { this.totalItemStockValueAtCostRate = v; }
+
+    public WebUser getCreater() { return creater; }
+    public void setCreater(WebUser creater) { this.creater = creater; }
+
+    public Date getCreatedAt() { return createdAt; }
+    public void setCreatedAt(Date createdAt) { this.createdAt = createdAt; }
+
+    @Override
+    public boolean isRetired() { return retired; }
+    @Override
+    public void setRetired(boolean retired) { this.retired = retired; }
+
+    public WebUser getRetirer() { return retirer; }
+    public void setRetirer(WebUser retirer) { this.retirer = retirer; }
+
+    public Date getRetiredAt() { return retiredAt; }
+    public void setRetiredAt(Date retiredAt) { this.retiredAt = retiredAt; }
+
+    public String getRetireComments() { return retireComments; }
+    public void setRetireComments(String retireComments) { this.retireComments = retireComments; }
+
+    public Date getArchivedAt() { return archivedAt; }
+    public void setArchivedAt(Date archivedAt) { this.archivedAt = archivedAt; }
+
+    @Override
+    public int hashCode() {
+        int hash = 0;
+        hash += (id != null ? id.hashCode() : 0);
+        return hash;
+    }
+
+    @Override
+    public boolean equals(Object object) {
+        if (!(object instanceof StockHistoryArchive)) {
+            return false;
+        }
+        StockHistoryArchive other = (StockHistoryArchive) object;
+        return !((this.id == null && other.id != null) || (this.id != null && !this.id.equals(other.id)));
+    }
+
+    @Override
+    public String toString() {
+        return "com.divudi.core.entity.pharmacy.StockHistoryArchive[ id=" + id + " ]";
+    }
+}

--- a/src/main/java/com/divudi/core/facade/StockHistoryArchiveFacade.java
+++ b/src/main/java/com/divudi/core/facade/StockHistoryArchiveFacade.java
@@ -1,0 +1,26 @@
+/*
+ * Dr M H B Ariyaratne
+ * buddhika.ari@gmail.com
+ */
+package com.divudi.core.facade;
+
+import com.divudi.core.entity.pharmacy.StockHistoryArchive;
+import javax.ejb.Stateless;
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+
+@Stateless
+public class StockHistoryArchiveFacade extends AbstractFacade<StockHistoryArchive> {
+
+    @PersistenceContext(unitName = "hmisPU")
+    private EntityManager em;
+
+    @Override
+    protected EntityManager getEntityManager() {
+        return em;
+    }
+
+    public StockHistoryArchiveFacade() {
+        super(StockHistoryArchive.class);
+    }
+}

--- a/src/main/java/com/divudi/service/ScheduledProcessService.java
+++ b/src/main/java/com/divudi/service/ScheduledProcessService.java
@@ -1,7 +1,9 @@
 package com.divudi.service;
 
+import com.divudi.bean.common.ConfigOptionApplicationController;
 import com.divudi.core.data.HistoricalRecordType;
 import com.divudi.core.data.ScheduledFrequency;
+import com.divudi.core.data.dto.ArchiveResult;
 import com.divudi.core.entity.Department;
 import com.divudi.core.entity.HistoricalRecord;
 import com.divudi.core.entity.Institution;
@@ -9,15 +11,21 @@ import com.divudi.core.entity.ScheduledProcessConfiguration;
 import com.divudi.core.facade.ScheduledProcessConfigurationFacade;
 import com.divudi.service.HistoricalRecordService;
 import com.divudi.service.StockService;
+import com.divudi.service.archival.StockHistoryArchivalService;
 import com.divudi.core.data.StockValueRow;
 import java.util.Calendar;
 import java.util.Date;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import javax.ejb.Asynchronous;
 import javax.ejb.EJB;
 import javax.ejb.Stateless;
+import javax.inject.Inject;
 
 @Stateless
 public class ScheduledProcessService {
+
+    private static final Logger LOGGER = Logger.getLogger(ScheduledProcessService.class.getName());
 
     @EJB
     private ScheduledProcessConfigurationFacade configFacade;
@@ -27,6 +35,12 @@ public class ScheduledProcessService {
 
     @EJB
     private StockService stockService;
+
+    @EJB
+    private StockHistoryArchivalService stockHistoryArchivalService;
+
+    @Inject
+    private ConfigOptionApplicationController configOptionController;
 
     @Asynchronous
     public void executeScheduledProcess(ScheduledProcessConfiguration config) {
@@ -132,7 +146,43 @@ public class ScheduledProcessService {
             case All_Credit_Company_Balances:
                 // TODO: implement process
                 break;
+            case Archive_Old_StockHistory_Records:
+                archiveOldStockHistoryRecords();
+                break;
             default:
+        }
+    }
+
+    /**
+     * Scheduled handler for {@code Archive_Old_StockHistory_Records}.
+     *
+     * Reads the retention/batch/max-batches knobs from
+     * {@link ConfigOptionApplicationController} (defaults: 730 days, 2000,
+     * 50) and runs one archival pass. The pass is capped at
+     * {@code batchSize * maxBatches} rows so a scheduled invocation can't
+     * monopolize the database; subsequent scheduled runs drain the
+     * remaining backlog.
+     */
+    private void archiveOldStockHistoryRecords() {
+        int retentionDays = configOptionController.getIntegerValueByKey(
+                "StockHistory Archive - Retention Days", 730);
+        int batchSize = configOptionController.getIntegerValueByKey(
+                "StockHistory Archive - Batch Size", 2000);
+        int maxBatches = configOptionController.getIntegerValueByKey(
+                "StockHistory Archive - Max Batches Per Run", 50);
+
+        Calendar cal = Calendar.getInstance();
+        cal.add(Calendar.DATE, -retentionDays);
+        Date cutoff = cal.getTime();
+
+        try {
+            ArchiveResult result = stockHistoryArchivalService.archive(cutoff, batchSize, maxBatches, false);
+            LOGGER.log(Level.INFO,
+                    "StockHistory archive run: cutoff={0}, archived={1}, batches={2}, durationMs={3}, message={4}",
+                    new Object[]{cutoff, result.getArchivedCount(), result.getBatchesRun(),
+                            result.getDurationMillis(), result.getMessage()});
+        } catch (Exception ex) {
+            LOGGER.log(Level.SEVERE, "StockHistory archive run failed", ex);
         }
     }
 

--- a/src/main/java/com/divudi/service/ScheduledProcessService.java
+++ b/src/main/java/com/divudi/service/ScheduledProcessService.java
@@ -164,12 +164,12 @@ public class ScheduledProcessService {
      * remaining backlog.
      */
     private void archiveOldStockHistoryRecords() {
-        int retentionDays = configOptionController.getIntegerValueByKey(
-                "StockHistory Archive - Retention Days", 730);
-        int batchSize = configOptionController.getIntegerValueByKey(
-                "StockHistory Archive - Batch Size", 2000);
-        int maxBatches = configOptionController.getIntegerValueByKey(
-                "StockHistory Archive - Max Batches Per Run", 50);
+        int retentionDays = sanitisePositive(configOptionController.getIntegerValueByKey(
+                "StockHistory Archive - Retention Days", 730), 730);
+        int batchSize = sanitisePositive(configOptionController.getIntegerValueByKey(
+                "StockHistory Archive - Batch Size", 2000), 2000);
+        int maxBatches = sanitisePositive(configOptionController.getIntegerValueByKey(
+                "StockHistory Archive - Max Batches Per Run", 50), 50);
 
         Calendar cal = Calendar.getInstance();
         cal.add(Calendar.DATE, -retentionDays);
@@ -183,7 +183,14 @@ public class ScheduledProcessService {
                             result.getDurationMillis(), result.getMessage()});
         } catch (Exception ex) {
             LOGGER.log(Level.SEVERE, "StockHistory archive run failed", ex);
+            // Rethrow so executeScheduledProcess() does not mark
+            // lastProcessCompleted=true when the archive actually failed.
+            throw new RuntimeException("StockHistory archive run failed", ex);
         }
+    }
+
+    private static int sanitisePositive(Integer raw, int fallback) {
+        return (raw == null || raw <= 0) ? fallback : raw;
     }
 
     public Date calculateNextSupposedAt(ScheduledFrequency frequency, Date from) {

--- a/src/main/java/com/divudi/service/archival/ArchivalBatchTx.java
+++ b/src/main/java/com/divudi/service/archival/ArchivalBatchTx.java
@@ -1,0 +1,67 @@
+/*
+ * Dr M H B Ariyaratne
+ * buddhika.ari@gmail.com
+ */
+package com.divudi.service.archival;
+
+import java.util.List;
+import javax.ejb.Stateless;
+import javax.ejb.TransactionAttribute;
+import javax.ejb.TransactionAttributeType;
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+import javax.persistence.Query;
+
+/**
+ * Transaction-bounded executor for a single archival batch.
+ *
+ * Each invocation of {@link #copyAndDelete} runs in its own transaction
+ * (REQUIRES_NEW) so the row-locks acquired by the INSERT and DELETE are held
+ * only for the duration of one batch, not the entire archival run. This is
+ * what makes the archival job safe to run concurrently with normal pharmacy
+ * write traffic against STOCKHISTORY.
+ *
+ * Issue #20726.
+ */
+@Stateless
+public class ArchivalBatchTx {
+
+    @PersistenceContext(unitName = "hmisPU")
+    private EntityManager em;
+
+    /**
+     * Copy the rows identified by {@code ids} from {@code sourceTable} to
+     * {@code archiveTable}, then delete them from {@code sourceTable}. All
+     * within one new transaction.
+     *
+     * Table/column names come from concrete archival services (compile-time
+     * constants), never from user input, so the direct string concatenation
+     * is safe from injection.
+     *
+     * @param archiveTable   archive table name (e.g. STOCKHISTORYARCHIVE)
+     * @param sourceTable    source table name (e.g. STOCKHISTORY)
+     * @param columnList     comma-separated column list common to both tables,
+     *                       excluding ARCHIVEDAT (which is set to NOW() here)
+     * @param ids            primary-key IDs to move; must be non-null and non-empty
+     * @return number of rows deleted from the source
+     */
+    @TransactionAttribute(TransactionAttributeType.REQUIRES_NEW)
+    public int copyAndDelete(String archiveTable, String sourceTable,
+                             String columnList, List<Long> ids) {
+        if (ids == null || ids.isEmpty()) {
+            return 0;
+        }
+
+        String insertSql = "INSERT INTO " + archiveTable + " (" + columnList + ", ARCHIVEDAT) "
+                + "SELECT " + columnList + ", NOW() FROM " + sourceTable
+                + " WHERE ID IN (:ids)";
+        Query insertQ = em.createNativeQuery(insertSql);
+        insertQ.setParameter("ids", ids);
+        insertQ.executeUpdate();
+
+        String deleteSql = "DELETE FROM " + sourceTable + " WHERE ID IN (:ids)";
+        Query deleteQ = em.createNativeQuery(deleteSql);
+        deleteQ.setParameter("ids", ids);
+        return deleteQ.executeUpdate();
+    }
+}

--- a/src/main/java/com/divudi/service/archival/ArchivalServiceBase.java
+++ b/src/main/java/com/divudi/service/archival/ArchivalServiceBase.java
@@ -88,19 +88,26 @@ public abstract class ArchivalServiceBase {
     /**
      * Resolve the list of column names common to both source and archive
      * tables (excluding {@code ARCHIVEDAT}, which the batch executor sets
-     * to {@code NOW()}). Uses INFORMATION_SCHEMA so the column list stays
-     * in sync as the schema evolves.
+     * to {@code NOW()}). Uses an INFORMATION_SCHEMA intersection so any
+     * future schema drift between the two tables — a column added to one
+     * but not the other — yields a safe subset rather than a runtime
+     * "column unknown" failure inside the INSERT…SELECT batch.
      */
     @SuppressWarnings("unchecked")
     protected List<String> resolveCommonColumns() {
         String sql =
-                "SELECT COLUMN_NAME FROM INFORMATION_SCHEMA.COLUMNS "
-              + "WHERE TABLE_SCHEMA = DATABASE() "
-              + "  AND UPPER(TABLE_NAME) = UPPER(?) "
-              + "  AND UPPER(COLUMN_NAME) <> 'ARCHIVEDAT' "
-              + "ORDER BY ORDINAL_POSITION";
+                "SELECT a.COLUMN_NAME FROM INFORMATION_SCHEMA.COLUMNS a "
+              + "JOIN INFORMATION_SCHEMA.COLUMNS s "
+              + "  ON s.TABLE_SCHEMA = a.TABLE_SCHEMA "
+              + " AND UPPER(s.TABLE_NAME) = UPPER(?) "
+              + " AND UPPER(s.COLUMN_NAME) = UPPER(a.COLUMN_NAME) "
+              + "WHERE a.TABLE_SCHEMA = DATABASE() "
+              + "  AND UPPER(a.TABLE_NAME) = UPPER(?) "
+              + "  AND UPPER(a.COLUMN_NAME) <> 'ARCHIVEDAT' "
+              + "ORDER BY a.ORDINAL_POSITION";
         Query q = em().createNativeQuery(sql);
-        q.setParameter(1, archiveTable());
+        q.setParameter(1, sourceTable());
+        q.setParameter(2, archiveTable());
         List<?> raw = q.getResultList();
         List<String> cols = new ArrayList<>(raw.size());
         for (Object o : raw) {

--- a/src/main/java/com/divudi/service/archival/ArchivalServiceBase.java
+++ b/src/main/java/com/divudi/service/archival/ArchivalServiceBase.java
@@ -1,0 +1,167 @@
+/*
+ * Dr M H B Ariyaratne
+ * buddhika.ari@gmail.com
+ */
+package com.divudi.service.archival;
+
+import com.divudi.core.data.dto.ArchiveResult;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+import javax.persistence.EntityManager;
+import javax.persistence.Query;
+
+/**
+ * Reusable batched-archival skeleton.
+ *
+ * Concrete subclasses provide:
+ * <ul>
+ *   <li>the source and archive table names</li>
+ *   <li>a JPA entity name to count and id-scan against</li>
+ *   <li>a cutoff predicate (default: {@code e.createdAt < :cutoff})</li>
+ *   <li>the EntityManager and the {@link ArchivalBatchTx} executor</li>
+ * </ul>
+ *
+ * The base orchestrates: count → scan IDs → copyAndDelete per batch → repeat
+ * until either no more candidate rows remain or {@code maxBatches} is hit.
+ * Each batch's INSERT+DELETE runs in its own transaction so concurrent
+ * writers to the source table are not blocked across the full run.
+ *
+ * Designed to be reused for #20724 (ItemBatch archive) by overriding the
+ * cutoff predicate / id-scan method.
+ *
+ * Issue #20726.
+ */
+public abstract class ArchivalServiceBase {
+
+    protected abstract EntityManager em();
+
+    protected abstract ArchivalBatchTx batchTx();
+
+    /** Physical name of the archive table, e.g. {@code STOCKHISTORYARCHIVE}. */
+    protected abstract String archiveTable();
+
+    /** Physical name of the source table, e.g. {@code STOCKHISTORY}. */
+    protected abstract String sourceTable();
+
+    /** JPA entity name used in JPQL, e.g. {@code StockHistory}. */
+    protected abstract String sourceEntityName();
+
+    /**
+     * JPQL predicate applied to the source entity (alias {@code e}) to identify
+     * archivable rows. The default targets a {@code createdAt} field. Override
+     * for more complex eligibility checks (e.g. ItemBatch expired + zero-stock).
+     * The implementation must use the named parameter {@code :cutoff} typed
+     * as a {@link Date}.
+     */
+    protected String cutoffWhereJpql() {
+        return "e.createdAt < :cutoff";
+    }
+
+    /**
+     * Count of rows eligible for archival at the given cutoff. Default uses
+     * {@link #cutoffWhereJpql()}; override if the cutoff needs custom params.
+     */
+    public long countOlderThan(Date cutoff) {
+        String jpql = "SELECT COUNT(e) FROM " + sourceEntityName() + " e WHERE " + cutoffWhereJpql();
+        Query q = em().createQuery(jpql);
+        q.setParameter("cutoff", cutoff);
+        Object result = q.getSingleResult();
+        return result == null ? 0L : ((Number) result).longValue();
+    }
+
+    /**
+     * Fetch the next batch of source IDs to archive. Default uses
+     * {@link #cutoffWhereJpql()} ordered by id ascending. Override for
+     * non-trivial selection criteria.
+     */
+    @SuppressWarnings("unchecked")
+    protected List<Long> fetchNextBatchIds(Date cutoff, int batchSize) {
+        String jpql = "SELECT e.id FROM " + sourceEntityName() + " e WHERE "
+                + cutoffWhereJpql() + " ORDER BY e.id";
+        Query q = em().createQuery(jpql);
+        q.setParameter("cutoff", cutoff);
+        q.setMaxResults(batchSize);
+        return q.getResultList();
+    }
+
+    /**
+     * Resolve the list of column names common to both source and archive
+     * tables (excluding {@code ARCHIVEDAT}, which the batch executor sets
+     * to {@code NOW()}). Uses INFORMATION_SCHEMA so the column list stays
+     * in sync as the schema evolves.
+     */
+    @SuppressWarnings("unchecked")
+    protected List<String> resolveCommonColumns() {
+        String sql =
+                "SELECT COLUMN_NAME FROM INFORMATION_SCHEMA.COLUMNS "
+              + "WHERE TABLE_SCHEMA = DATABASE() "
+              + "  AND UPPER(TABLE_NAME) = UPPER(?) "
+              + "  AND UPPER(COLUMN_NAME) <> 'ARCHIVEDAT' "
+              + "ORDER BY ORDINAL_POSITION";
+        Query q = em().createNativeQuery(sql);
+        q.setParameter(1, archiveTable());
+        List<?> raw = q.getResultList();
+        List<String> cols = new ArrayList<>(raw.size());
+        for (Object o : raw) {
+            cols.add(o.toString());
+        }
+        return cols;
+    }
+
+    /**
+     * Run an archival pass.
+     *
+     * @param cutoff           rows with createdAt strictly before this are eligible
+     * @param batchSize        rows per transactional batch (recommended: 1000-5000)
+     * @param maxBatches       upper bound on batches in this invocation; protects
+     *                         the system from one runaway run that holds resources
+     *                         for too long. Use a sensible cap (e.g. 50 = 100k rows
+     *                         at batch size 2000) for scheduled invocations.
+     * @param dryRun           if true, only count candidates; do not move any rows
+     */
+    public ArchiveResult archive(Date cutoff, int batchSize, int maxBatches, boolean dryRun) {
+        Date startedAt = new Date();
+        long candidates = countOlderThan(cutoff);
+
+        if (dryRun || candidates == 0) {
+            String msg = dryRun
+                    ? "Dry run: " + candidates + " row(s) would be archived"
+                    : "No rows older than cutoff";
+            return new ArchiveResult(dryRun, candidates, 0L, 0, false,
+                    startedAt, new Date(), msg);
+        }
+
+        String columnList = String.join(", ", resolveCommonColumns());
+        if (columnList.isEmpty()) {
+            return new ArchiveResult(false, candidates, 0L, 0, false,
+                    startedAt, new Date(),
+                    "Aborted: could not resolve column list from " + archiveTable());
+        }
+
+        long totalArchived = 0;
+        int batchesRun = 0;
+        boolean reachedLimit = false;
+
+        for (int b = 0; b < maxBatches; b++) {
+            List<Long> ids = fetchNextBatchIds(cutoff, batchSize);
+            if (ids.isEmpty()) {
+                break;
+            }
+            int moved = batchTx().copyAndDelete(archiveTable(), sourceTable(), columnList, ids);
+            totalArchived += moved;
+            batchesRun++;
+            if (ids.size() < batchSize) {
+                break;
+            }
+            if (b == maxBatches - 1) {
+                reachedLimit = true;
+            }
+        }
+
+        String msg = "Archived " + totalArchived + " row(s) across " + batchesRun + " batch(es)"
+                + (reachedLimit ? " (batch limit reached; more rows remain)" : "");
+        return new ArchiveResult(false, candidates, totalArchived, batchesRun,
+                reachedLimit, startedAt, new Date(), msg);
+    }
+}

--- a/src/main/java/com/divudi/service/archival/StockHistoryArchivalService.java
+++ b/src/main/java/com/divudi/service/archival/StockHistoryArchivalService.java
@@ -1,0 +1,65 @@
+/*
+ * Dr M H B Ariyaratne
+ * buddhika.ari@gmail.com
+ */
+package com.divudi.service.archival;
+
+import javax.ejb.EJB;
+import javax.ejb.Stateless;
+import javax.ejb.TransactionAttribute;
+import javax.ejb.TransactionAttributeType;
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+
+/**
+ * Archives old {@code StockHistory} rows to {@code STOCKHISTORYARCHIVE}.
+ *
+ * Eligible rows are those whose {@code createdAt} timestamp is strictly
+ * before the configured cutoff. The default retention is 2 years for all
+ * history types (transaction rows and {@code MonthlyRecord} summary rows
+ * are treated the same way for v1; can be split later if needed).
+ *
+ * Each batch is INSERT…SELECT then DELETE inside its own transaction
+ * (via {@link ArchivalBatchTx}), so we don't hold row-locks across the
+ * full multi-million-row run.
+ *
+ * Top-level methods run with {@code NOT_SUPPORTED} so this bean itself
+ * doesn't open a long-running transaction — only each batch does.
+ *
+ * Issue #20726.
+ */
+@Stateless
+@TransactionAttribute(TransactionAttributeType.NOT_SUPPORTED)
+public class StockHistoryArchivalService extends ArchivalServiceBase {
+
+    @PersistenceContext(unitName = "hmisPU")
+    private EntityManager em;
+
+    @EJB
+    private ArchivalBatchTx batchTx;
+
+    @Override
+    protected EntityManager em() {
+        return em;
+    }
+
+    @Override
+    protected ArchivalBatchTx batchTx() {
+        return batchTx;
+    }
+
+    @Override
+    protected String archiveTable() {
+        return "STOCKHISTORYARCHIVE";
+    }
+
+    @Override
+    protected String sourceTable() {
+        return "STOCKHISTORY";
+    }
+
+    @Override
+    protected String sourceEntityName() {
+        return "StockHistory";
+    }
+}

--- a/src/main/resources/db/migrations/v2.1.18/migration-info.json
+++ b/src/main/resources/db/migrations/v2.1.18/migration-info.json
@@ -1,0 +1,43 @@
+{
+    "version": "v2.1.18",
+    "description": "Create STOCKHISTORYARCHIVE table for archiving old StockHistory records",
+    "author": "Dr M H B Ariyaratne",
+    "estimatedDurationMinutes": 2,
+    "requiresDowntime": false,
+    "affectedTables": ["stockhistory", "stockhistoryarchive"],
+    "affectedModules": ["Pharmacy"],
+    "preRequisites": [
+        "Database backup completed",
+        "STOCKHISTORY table must exist (it is the source of cloned schema)"
+    ],
+    "migrationSteps": [
+        {
+            "description": "Detect actual table name case for STOCKHISTORY and STOCKHISTORYARCHIVE"
+        },
+        {
+            "description": "CREATE TABLE STOCKHISTORYARCHIVE LIKE STOCKHISTORY (clones columns and indexes, no FKs)"
+        },
+        {
+            "description": "Remove AUTO_INCREMENT from ID column so archived rows keep their original StockHistory IDs"
+        },
+        {
+            "description": "Add ARCHIVEDAT DATETIME column for tracking when each row was archived"
+        },
+        {
+            "description": "Add index on CREATEDAT for efficient archive cutoff and lookup queries"
+        },
+        {
+            "description": "Verify schema, column count and presence of ID/CREATEDAT/ARCHIVEDAT columns"
+        }
+    ],
+    "expectedOutcome": {
+        "primaryFix": "STOCKHISTORYARCHIVE table available for the archival job to move rows older than the configured retention window",
+        "impact": "Empty table created; no data movement yet. Archival itself is performed by the application's scheduled or manual archive job.",
+        "tablesAdded": 1
+    },
+    "rollbackNotes": [
+        "Rollback DROPs STOCKHISTORYARCHIVE. If the table has been populated, archived data will be lost.",
+        "Take a backup of STOCKHISTORYARCHIVE before rollback if its rows are still needed."
+    ],
+    "relatedIssue": "#20726 - perf: archive old StockHistory records to reduce 850MB table bloat"
+}

--- a/src/main/resources/db/migrations/v2.1.18/migration.sql
+++ b/src/main/resources/db/migrations/v2.1.18/migration.sql
@@ -90,7 +90,7 @@ SET @has_auto_inc = (
       AND EXTRA LIKE '%auto_increment%'
 );
 
-SET @sql = IF(@has_auto_inc > 0,
+SET @sql = IF(@archive_table IS NOT NULL AND @has_auto_inc > 0,
               CONCAT('ALTER TABLE ', @archive_table, ' MODIFY ID BIGINT NOT NULL'),
               'SELECT 1');
 PREPARE stmt FROM @sql;
@@ -110,7 +110,7 @@ SET @has_archivedat = (
       AND UPPER(COLUMN_NAME) = 'ARCHIVEDAT'
 );
 
-SET @sql = IF(@has_archivedat = 0,
+SET @sql = IF(@archive_table IS NOT NULL AND @has_archivedat = 0,
               CONCAT('ALTER TABLE ', @archive_table, ' ADD COLUMN ARCHIVEDAT DATETIME NULL'),
               'SELECT 1');
 PREPARE stmt FROM @sql;
@@ -131,7 +131,7 @@ SET @has_createdat_idx = (
       AND INDEX_NAME = 'idx_stockhistoryarchive_createdat'
 );
 
-SET @sql = IF(@has_createdat_idx = 0,
+SET @sql = IF(@archive_table IS NOT NULL AND @has_createdat_idx = 0,
               CONCAT('ALTER TABLE ', @archive_table, ' ADD INDEX idx_stockhistoryarchive_createdat (CREATEDAT)'),
               'SELECT 1');
 PREPARE stmt FROM @sql;

--- a/src/main/resources/db/migrations/v2.1.18/migration.sql
+++ b/src/main/resources/db/migrations/v2.1.18/migration.sql
@@ -1,0 +1,168 @@
+-- Migration v2.1.18: Create STOCKHISTORYARCHIVE table for old StockHistory records
+-- Issue: #20726 - Archive old StockHistory records to reduce 850MB table bloat
+-- Author: Dr M H B Ariyaratne
+-- Date: 2026-05-14
+-- Database: main HMIS database (hmisPU)
+--
+-- Purpose: Create a sibling archive table with the same schema as STOCKHISTORY,
+-- where old rows (default: older than 2 years by CREATEDAT) will be moved by
+-- the archival job (StockHistoryArchivalService).
+--
+-- Strategy:
+-- 1. CREATE TABLE ... LIKE clones columns + indexes (NOT foreign keys, NOT auto-increment behaviour we need to keep, NOT triggers).
+-- 2. Remove AUTO_INCREMENT from the ID column so archived rows keep their original IDs.
+-- 3. Add ARCHIVEDAT timestamp column to record when each row was archived.
+-- 4. Add an index on CREATEDAT for the archive job's range queries and for any future archive lookups.
+--
+-- UNIVERSAL: Detects actual table name case (STOCKHISTORY vs stockhistory) so this
+-- script works on both case-sensitive (Linux, lower_case_table_names=0) and
+-- case-insensitive (Windows) MySQL instances. All DDL is built with prepared
+-- statements against the real table name from INFORMATION_SCHEMA.
+--
+-- IDEMPOTENT: All statements check for existence first, so this migration can
+-- be safely re-run without error.
+
+SELECT 'Migration v2.1.18 - Create STOCKHISTORYARCHIVE table' AS status;
+
+-- ==========================================
+-- STEP 0: DETECT ACTUAL TABLE NAME CASE
+-- ==========================================
+
+SET @sh_table = (
+    SELECT TABLE_NAME
+    FROM INFORMATION_SCHEMA.TABLES
+    WHERE TABLE_SCHEMA = DATABASE()
+      AND UPPER(TABLE_NAME) = 'STOCKHISTORY'
+    LIMIT 1
+);
+
+SET @archive_table = (
+    SELECT TABLE_NAME
+    FROM INFORMATION_SCHEMA.TABLES
+    WHERE TABLE_SCHEMA = DATABASE()
+      AND UPPER(TABLE_NAME) = 'STOCKHISTORYARCHIVE'
+    LIMIT 1
+);
+
+SELECT CONCAT('Detected stockhistory table as: ', IFNULL(@sh_table, '(not found)')) AS info;
+SELECT CONCAT('Detected stockhistoryarchive table as: ', IFNULL(@archive_table, '(not found - will be created)')) AS info;
+
+SELECT IF(@sh_table IS NULL,
+          'STOCKHISTORY table not found; cannot create archive. Migration aborted.',
+          'STOCKHISTORY table found; proceeding with archive table creation') AS applicability;
+
+-- ==========================================
+-- STEP 1: CREATE STOCKHISTORYARCHIVE TABLE
+-- ==========================================
+
+-- Only create if it does not already exist. CREATE TABLE LIKE clones the full
+-- schema (columns, primary key, KEY indexes) but not foreign keys.
+SET @sql = IF(@archive_table IS NULL AND @sh_table IS NOT NULL,
+              CONCAT('CREATE TABLE STOCKHISTORYARCHIVE LIKE ', @sh_table),
+              'SELECT 1');
+PREPARE stmt FROM @sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+-- Re-detect after creation (the cloned table will be in the same case as the source)
+SET @archive_table = (
+    SELECT TABLE_NAME
+    FROM INFORMATION_SCHEMA.TABLES
+    WHERE TABLE_SCHEMA = DATABASE()
+      AND UPPER(TABLE_NAME) = 'STOCKHISTORYARCHIVE'
+    LIMIT 1
+);
+
+SELECT CONCAT('Archive table is now: ', IFNULL(@archive_table, '(creation failed)')) AS info;
+
+-- ==========================================
+-- STEP 2: REMOVE AUTO_INCREMENT FROM ID COLUMN
+-- ==========================================
+-- We preserve the original StockHistory.id when archiving so historical
+-- references stay valid. AUTO_INCREMENT on the archive would clash with that.
+
+SET @has_auto_inc = (
+    SELECT COUNT(*)
+    FROM INFORMATION_SCHEMA.COLUMNS
+    WHERE TABLE_SCHEMA = DATABASE()
+      AND TABLE_NAME = @archive_table
+      AND COLUMN_NAME = 'ID'
+      AND EXTRA LIKE '%auto_increment%'
+);
+
+SET @sql = IF(@has_auto_inc > 0,
+              CONCAT('ALTER TABLE ', @archive_table, ' MODIFY ID BIGINT NOT NULL'),
+              'SELECT 1');
+PREPARE stmt FROM @sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+-- ==========================================
+-- STEP 3: ADD ARCHIVEDAT COLUMN
+-- ==========================================
+-- Records the timestamp at which each row was moved to the archive.
+
+SET @has_archivedat = (
+    SELECT COUNT(*)
+    FROM INFORMATION_SCHEMA.COLUMNS
+    WHERE TABLE_SCHEMA = DATABASE()
+      AND TABLE_NAME = @archive_table
+      AND UPPER(COLUMN_NAME) = 'ARCHIVEDAT'
+);
+
+SET @sql = IF(@has_archivedat = 0,
+              CONCAT('ALTER TABLE ', @archive_table, ' ADD COLUMN ARCHIVEDAT DATETIME NULL'),
+              'SELECT 1');
+PREPARE stmt FROM @sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+-- ==========================================
+-- STEP 4: ADD INDEX ON CREATEDAT
+-- ==========================================
+-- The archive job's cutoff query and any future archive lookups both filter
+-- on CREATEDAT, so we want it indexed independently of any cloned indexes.
+
+SET @has_createdat_idx = (
+    SELECT COUNT(*)
+    FROM INFORMATION_SCHEMA.STATISTICS
+    WHERE TABLE_SCHEMA = DATABASE()
+      AND TABLE_NAME = @archive_table
+      AND INDEX_NAME = 'idx_stockhistoryarchive_createdat'
+);
+
+SET @sql = IF(@has_createdat_idx = 0,
+              CONCAT('ALTER TABLE ', @archive_table, ' ADD INDEX idx_stockhistoryarchive_createdat (CREATEDAT)'),
+              'SELECT 1');
+PREPARE stmt FROM @sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+-- ==========================================
+-- STEP 5: POST-MIGRATION VERIFICATION
+-- ==========================================
+
+SELECT 'STOCKHISTORYARCHIVE table schema' AS status;
+
+SELECT
+    ROUND(DATA_LENGTH/1024/1024, 1) AS data_mb,
+    ROUND(INDEX_LENGTH/1024/1024, 1) AS index_mb,
+    TABLE_ROWS
+FROM INFORMATION_SCHEMA.TABLES
+WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = @archive_table;
+
+SELECT COUNT(*) AS column_count
+FROM INFORMATION_SCHEMA.COLUMNS
+WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = @archive_table;
+
+SELECT
+    COLUMN_NAME,
+    COLUMN_TYPE,
+    IS_NULLABLE,
+    EXTRA
+FROM INFORMATION_SCHEMA.COLUMNS
+WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = @archive_table
+  AND COLUMN_NAME IN ('ID', 'CREATEDAT', 'ARCHIVEDAT')
+ORDER BY ORDINAL_POSITION;
+
+SELECT 'Migration v2.1.18 completed - STOCKHISTORYARCHIVE table ready' AS final_status;

--- a/src/main/resources/db/migrations/v2.1.18/rollback.sql
+++ b/src/main/resources/db/migrations/v2.1.18/rollback.sql
@@ -20,11 +20,12 @@ SET @archive_table = (
 
 SELECT CONCAT('Detected stockhistoryarchive table as: ', IFNULL(@archive_table, '(not found - nothing to drop)')) AS info;
 
-SET @row_count = (
-    SELECT IFNULL(TABLE_ROWS, 0)
+SET @row_count = COALESCE((
+    SELECT TABLE_ROWS
     FROM INFORMATION_SCHEMA.TABLES
     WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = @archive_table
-);
+    LIMIT 1
+), 0);
 
 SELECT CONCAT('Approximate rows in archive (will be lost): ', @row_count) AS warning;
 

--- a/src/main/resources/db/migrations/v2.1.18/rollback.sql
+++ b/src/main/resources/db/migrations/v2.1.18/rollback.sql
@@ -1,0 +1,38 @@
+-- Rollback v2.1.18: Drop STOCKHISTORYARCHIVE table
+-- Issue: #20726
+--
+-- WARNING: This is destructive. If the archive has been populated, ALL
+-- archived rows will be lost. Before rolling back, ensure either:
+--   (a) the archive is still empty, OR
+--   (b) you have a backup of the archive data you can restore later.
+--
+-- UNIVERSAL: handles both case-sensitive and case-insensitive MySQL.
+
+SELECT 'Rollback v2.1.18 - Drop STOCKHISTORYARCHIVE table' AS status;
+
+SET @archive_table = (
+    SELECT TABLE_NAME
+    FROM INFORMATION_SCHEMA.TABLES
+    WHERE TABLE_SCHEMA = DATABASE()
+      AND UPPER(TABLE_NAME) = 'STOCKHISTORYARCHIVE'
+    LIMIT 1
+);
+
+SELECT CONCAT('Detected stockhistoryarchive table as: ', IFNULL(@archive_table, '(not found - nothing to drop)')) AS info;
+
+SET @row_count = (
+    SELECT IFNULL(TABLE_ROWS, 0)
+    FROM INFORMATION_SCHEMA.TABLES
+    WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = @archive_table
+);
+
+SELECT CONCAT('Approximate rows in archive (will be lost): ', @row_count) AS warning;
+
+SET @sql = IF(@archive_table IS NOT NULL,
+              CONCAT('DROP TABLE ', @archive_table),
+              'SELECT 1');
+PREPARE stmt FROM @sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+SELECT 'Rollback v2.1.18 completed' AS final_status;

--- a/src/main/webapp/dataAdmin/admin_data_administration.xhtml
+++ b/src/main/webapp/dataAdmin/admin_data_administration.xhtml
@@ -149,6 +149,13 @@
                                                 ajax="false"
                                                 styleClass="w-100 ui-button-success"
                                                 icon="fa fa-database" />
+                                            <p:commandButton
+                                                value="Archive Old StockHistory"
+                                                action="#{stockHistoryArchivalController.navigateToArchiveStockHistory()}"
+                                                ajax="false"
+                                                styleClass="w-100 ui-button-warning"
+                                                icon="fa fa-archive"
+                                                rendered="#{webUserController.hasPrivilege('ArchiveOldStockHistory')}" />
                                         </div>
                                     </p:tab>
 

--- a/src/main/webapp/dataAdmin/archive_stock_history.xhtml
+++ b/src/main/webapp/dataAdmin/archive_stock_history.xhtml
@@ -1,0 +1,112 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
+      xmlns:h="http://xmlns.jcp.org/jsf/html"
+      xmlns:p="http://primefaces.org/ui"
+      xmlns:f="http://xmlns.jcp.org/jsf/core">
+    <h:head>
+        <title>Archive Old StockHistory Records</title>
+    </h:head>
+    <h:body>
+        <ui:composition template="/dataAdmin/admin_data_administration.xhtml">
+            <ui:define name="subcontent">
+                <h:form id="archiveForm" rendered="#{webUserController.hasPrivilege('ArchiveOldStockHistory')}">
+                    <p:panel>
+                        <f:facet name="header">
+                            <h:outputLabel value="Archive Old StockHistory Records" />
+                        </f:facet>
+
+                        <p:messages id="messages" showDetail="true" closable="true" />
+
+                        <div class="row">
+                            <div class="col-md-7">
+                                <p:panel header="Archive Settings">
+                                    <p:panelGrid columns="2" layout="tabular" class="w-100">
+                                        <p:outputLabel for="cutoff" value="Cutoff Date (archive rows created before this)" />
+                                        <p:calendar id="cutoff" value="#{stockHistoryArchivalController.cutoffDate}"
+                                                    pattern="#{sessionController.applicationPreference.longDateTimeFormat}"
+                                                    navigator="true" showOn="button" class="w-100" inputStyleClass="w-100" />
+
+                                        <p:outputLabel for="batch" value="Batch Size (rows per transaction)" />
+                                        <p:inputNumber id="batch" value="#{stockHistoryArchivalController.batchSize}"
+                                                       minValue="1" maxValue="50000" decimalPlaces="0" thousandSeparator=""
+                                                       class="w-100" />
+
+                                        <p:outputLabel for="maxBatches" value="Max Batches Per Run" />
+                                        <p:inputNumber id="maxBatches" value="#{stockHistoryArchivalController.maxBatches}"
+                                                       minValue="1" maxValue="1000" decimalPlaces="0" thousandSeparator=""
+                                                       class="w-100" />
+
+                                        <p:outputLabel for="dry" value="Dry Run (count only, do not move rows)" />
+                                        <p:selectBooleanCheckbox id="dry" value="#{stockHistoryArchivalController.dryRun}" />
+                                    </p:panelGrid>
+
+                                    <f:facet name="footer">
+                                        <p:commandButton id="previewBtn" value="Preview Count" icon="fa fa-search"
+                                                         class="ui-button-info m-1"
+                                                         action="#{stockHistoryArchivalController.preview}"
+                                                         update="archiveForm" />
+                                        <p:commandButton id="runBtn" value="Run" icon="fa fa-play"
+                                                         class="ui-button-success m-1"
+                                                         action="#{stockHistoryArchivalController.run}"
+                                                         update="archiveForm"
+                                                         onclick="return confirm('Run archive now? Non-dry-run moves rows out of STOCKHISTORY.');" />
+                                    </f:facet>
+                                </p:panel>
+                            </div>
+
+                            <div class="col-md-5">
+                                <p:panel header="Last Result"
+                                         rendered="#{stockHistoryArchivalController.lastResult ne null}">
+                                    <p:panelGrid columns="2" layout="tabular" class="w-100">
+                                        <h:outputLabel value="Mode" />
+                                        <h:outputText value="#{stockHistoryArchivalController.lastResult.dryRun ? 'Dry run' : 'Live run'}" />
+
+                                        <h:outputLabel value="Candidates" />
+                                        <h:outputText value="#{stockHistoryArchivalController.lastResult.candidateCount}" />
+
+                                        <h:outputLabel value="Archived" />
+                                        <h:outputText value="#{stockHistoryArchivalController.lastResult.archivedCount}" />
+
+                                        <h:outputLabel value="Batches Run" />
+                                        <h:outputText value="#{stockHistoryArchivalController.lastResult.batchesRun}" />
+
+                                        <h:outputLabel value="Reached Batch Limit" />
+                                        <h:outputText value="#{stockHistoryArchivalController.lastResult.reachedBatchLimit ? 'Yes' : 'No'}" />
+
+                                        <h:outputLabel value="Started" />
+                                        <h:outputText value="#{stockHistoryArchivalController.lastResult.startedAt}">
+                                            <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateTimeFormat}" />
+                                        </h:outputText>
+
+                                        <h:outputLabel value="Ended" />
+                                        <h:outputText value="#{stockHistoryArchivalController.lastResult.endedAt}">
+                                            <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateTimeFormat}" />
+                                        </h:outputText>
+
+                                        <h:outputLabel value="Duration (ms)" />
+                                        <h:outputText value="#{stockHistoryArchivalController.lastResult.durationMillis}" />
+
+                                        <h:outputLabel value="Message" />
+                                        <h:outputText value="#{stockHistoryArchivalController.lastResult.message}" />
+                                    </p:panelGrid>
+                                </p:panel>
+
+                                <p:panel header="Preview"
+                                         rendered="#{stockHistoryArchivalController.candidateCount ne null and stockHistoryArchivalController.lastResult eq null}">
+                                    <h:outputText value="#{stockHistoryArchivalController.candidateCount} row(s) eligible for archival" />
+                                </p:panel>
+                            </div>
+                        </div>
+                    </p:panel>
+                </h:form>
+
+                <h:panelGroup rendered="#{not webUserController.hasPrivilege('ArchiveOldStockHistory')}">
+                    <p:messages />
+                    <h:outputText value="You do not have permission to access this page." />
+                </h:panelGroup>
+            </ui:define>
+        </ui:composition>
+    </h:body>
+</html>


### PR DESCRIPTION
## Summary

Closes #20726.

Adds an archive table, batched archival service, manual admin page, and scheduled-process integration so `StockHistory` rows older than the configured retention window (default: **2 years**) can be moved out of the live `STOCKHISTORY` table into a sibling `STOCKHISTORYARCHIVE` table.

The archive job processes rows in small per-transaction batches (default **2000 rows**, `REQUIRES_NEW`) so it does not hold row locks across the full multi-million-row run and remains safe to execute alongside live pharmacy write traffic.

## What's new

**Database**
- New entity `StockHistoryArchive` mirroring `StockHistory` schema, with extra `ARCHIVEDAT` column and no auto-increment on `ID` (archived rows keep their original IDs).
- Migration `v2.1.18` creates `STOCKHISTORYARCHIVE` via `CREATE TABLE LIKE` so the schema stays bit-for-bit aligned with `STOCKHISTORY`. Idempotent and case-insensitive (works on both Windows and Linux MySQL).

**Service layer**
- `ArchivalServiceBase` — generic batched-archival skeleton. Subclasses provide source/archive table names and an optional custom cutoff predicate.
- `ArchivalBatchTx` — per-batch `REQUIRES_NEW` executor: each batch's `INSERT…SELECT` + `DELETE` runs in its own transaction. Designed so #20724 (`ItemBatch` archive) can reuse the same skeleton.
- `StockHistoryArchivalService` — concrete implementation, runs with `TransactionAttributeType.NOT_SUPPORTED` at top level so the orchestration loop doesn't open a long-running transaction.
- `ArchiveResult` DTO returns candidate count, archived count, batches run, duration, and a message.

**Scheduled process**
- New `ScheduledProcess.Archive_Old_StockHistory_Records` enum value + case branch in `ScheduledProcessService.processScheduledTask`.
- Reads retention/batch/max-batches from `ConfigOptionApplicationController`.
- Each scheduled invocation is capped at `batchSize * maxBatches` rows (default = 100k) so it can't monopolize the database; subsequent runs drain the backlog.

**Config defaults** (seeded on first boot)
- `StockHistory Archive - Retention Days` = 730 (2 years)
- `StockHistory Archive - Batch Size` = 2000
- `StockHistory Archive - Max Batches Per Run` = 50

**Privilege**
- New `ArchiveOldStockHistory` privilege registered in all 3 required locations: `Privileges` enum, `getCategory()` (Pharmacy), and `UserPrivilageController` tree node under Pharmacy Adjustment.

**Manual admin page**
- `/dataAdmin/archive_stock_history.xhtml` with cutoff date picker, batch size, max-batches, dry-run toggle, **Preview Count** and **Run** actions.
- Launched from **Administration → Manage Metadata → Data tab → Archive Old StockHistory** button (privilege-gated).
- New backing bean `StockHistoryArchivalController`.

**End-user docs**
- Wiki page: https://github.com/hmislk/hmis/wiki/Archive-Old-StockHistory-Records — plain-English walkthrough for administrators.

## Test plan

Manual development testing on local DB (small dataset) before merging. Production cut-over rehearsal is tracked separately as **#20730**.

- [ ] Build / deploy on local Payara
- [ ] **Privilege gating**
  - [ ] Log in WITHOUT `ArchiveOldStockHistory` privilege — confirm the **Archive Old StockHistory** button is hidden from the Data tab and the page shows "You do not have permission" if URL is hit directly
  - [ ] Log in WITH `ArchiveOldStockHistory` privilege — button is visible and page loads
- [ ] **Migration**
  - [ ] Run `v2.1.18` migration via Administration → Manage Metadata → Database Migration. Confirm `STOCKHISTORYARCHIVE` is created, has same column count as `STOCKHISTORY`, contains `ARCHIVEDAT` column, has index `idx_stockhistoryarchive_createdat`, and `ID` has no AUTO_INCREMENT
  - [ ] Re-run the migration — confirm it is idempotent (no errors)
- [ ] **Preview count**
  - [ ] Open Archive Old StockHistory page. Confirm cutoff defaults to 2 years ago, batch size 2000, max batches 50, Dry Run ticked
  - [ ] Click **Preview Count** — verify candidate count matches a manual `SELECT COUNT(*) FROM STOCKHISTORY WHERE CREATEDAT < ?`
- [ ] **Dry run**
  - [ ] With Dry Run ticked, click **Run** — confirm Last Result shows Mode = Dry run, Archived = 0, Candidates matches preview, no rows actually moved
- [ ] **Small live run**
  - [ ] Untick Dry Run, set max batches to 1. Click **Run** — confirm up to 2000 rows move from `STOCKHISTORY` to `STOCKHISTORYARCHIVE`, IDs preserved, `ARCHIVEDAT` populated with current timestamp
  - [ ] Confirm row count in `STOCKHISTORY` decreased by the archived count
- [ ] **Batch-limit messaging**
  - [ ] Configure a run that exceeds the cap — confirm "batch limit reached; more rows remain" appears in Last Result message
- [ ] **Validation**
  - [ ] Submit empty cutoff → error message
  - [ ] Submit future cutoff → error message
  - [ ] Submit batch size 0 or > 50000 → error message
- [ ] **Scheduled process**
  - [ ] Add a new `Archive_Old_StockHistory_Records` schedule with Hourly frequency, set Next Supposed At to a few minutes from now. Confirm it runs at the scheduled time, logs the result, and `lastProcessCompleted` becomes true
- [ ] **Concurrency**
  - [ ] Run a manual archive while triggering a pharmacy sale that writes to `StockHistory` — both should complete (only old rows are archived, new rows are unaffected)

## Follow-ups

- #20729 — audit which StockHistory reports/queries need archived-row visibility
- #20730 — production rollout runbook (prod backup → dry-run rehearsal → scheduled job)
- Reuse note posted on #20724 (ItemBatch archive) for plugging into `ArchivalServiceBase`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Stock history archival feature enables manual and automated archival of old records
  * Preview functionality allows users to count eligible records before running archival
  * Configurable retention days, batch size, and maximum batches per run
  * New privilege restricts access to authorized administrators
  * Dry-run capability to test operations without permanently archiving data

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hmislk/hmis/pull/20732)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->