### PR TITLE
feat(cashier): back button, float detail, and shortage detail in handover drill-down (#20556)

### DIFF
--- a/src/main/java/com/divudi/bean/cashTransaction/FinancialTransactionController.java
+++ b/src/main/java/com/divudi/bean/cashTransaction/FinancialTransactionController.java
@@ -1366,11 +1366,48 @@ public class FinancialTransactionController implements Serializable {
         return "/cashier/record_shift_excess?faces-redirect=true";
     }
 
-    public String navigateToViewDetailsOfSelectedBundleDuringHandoverInNewWindow() {
+    public String navigateToViewDetailsOfSelectedBundleDuringHandover() {
         if (selectedBundle == null) {
             return null;
         }
+        if (selectedBundle.isFloatRow()) {
+            populateFloatBundleRows(selectedBundle);
+        } else if (selectedBundle.getPaymentHandover() == PaymentHandover.FLOATS) {
+            // Shortage rows already have reportTemplateRows from generatePaymentBundleForHandovers;
+            // nothing extra needed.
+        }
         return "/cashier/handover_start_all_bill_type_details?faces-redirect=true";
+    }
+
+    private void populateFloatBundleRows(ReportTemplateRowBundle floatBundle) {
+        if (floatBundle == null || bundle == null || bundle.getStartBill() == null) {
+            return;
+        }
+        if (!floatBundle.getReportTemplateRows().isEmpty()) {
+            return;
+        }
+        Bill startBill = bundle.getStartBill();
+        Bill endBill = bundle.getEndBill();
+        List<Payment> fundTransferPayments = fetchFundTransferPaymentsForShift(startBill, endBill, startBill.getCreater());
+        if (fundTransferPayments == null) {
+            return;
+        }
+        boolean isOut = floatBundle.getPaymentHandover() == PaymentHandover.FLOAT_OUT;
+        for (Payment fp : fundTransferPayments) {
+            if (fp.getBill() == null) {
+                continue;
+            }
+            BillTypeAtomic bta = fp.getBill().getBillTypeAtomic();
+            if (isOut && bta == BillTypeAtomic.FUND_TRANSFER_BILL) {
+                ReportTemplateRow row = new ReportTemplateRow();
+                row.setPayment(fp);
+                floatBundle.getReportTemplateRows().add(row);
+            } else if (!isOut && bta == BillTypeAtomic.FUND_TRANSFER_RECEIVED_BILL) {
+                ReportTemplateRow row = new ReportTemplateRow();
+                row.setPayment(fp);
+                floatBundle.getReportTemplateRows().add(row);
+            }
+        }
     }
 
     public String navigateToCashierShiftBillSearch() {

--- a/src/main/webapp/cashier/handover_start_all.xhtml
+++ b/src/main/webapp/cashier/handover_start_all.xhtml
@@ -1183,8 +1183,7 @@
                                             title="View Details"
                                             ajax="false"
                                             styleClass="ui-button-info ui-button-sm"
-                                            action="#{financialTransactionController.navigateToViewDetailsOfSelectedBundleDuringHandoverInNewWindow}"
-                                            target="_blank">
+                                            action="#{financialTransactionController.navigateToViewDetailsOfSelectedBundleDuringHandover}">
                                             <f:setPropertyActionListener value="#{summary}" target="#{financialTransactionController.selectedBundle}" />
                                         </p:commandButton>
                                     </p:column>

--- a/src/main/webapp/cashier/handover_start_all_bill_type_details.xhtml
+++ b/src/main/webapp/cashier/handover_start_all_bill_type_details.xhtml
@@ -51,7 +51,11 @@
 
                     <f:facet name="header" >
                         <h:outputLabel value="Shift Collection Details by Bill Type" ></h:outputLabel>
-                        <p:commandButton value="Close Tab" onclick="closeCurrentTab();" type="button" style="float: right;"/>
+                        <p:commandButton value="Back" icon="pi pi-arrow-left"
+                                         ajax="false"
+                                         styleClass="ui-button-secondary"
+                                         action="#{financialTransactionController.navigateBackToPaymentHandoverCreate}"
+                                         style="float: right;"/>
                     </f:facet>
 
 
@@ -295,15 +299,6 @@
                         </p:column>
 
                     </p:dataTable>
-
-
-                    <script type="text/javascript">
-                        function closeCurrentTab() {
-                            // Attempt to close the tab
-                            window.open('', '_self', '');
-                            window.close();
-                        }
-                    </script>
 
 
 


### PR DESCRIPTION
## Summary

- **Back button**: The 'View Details' button on `handover_start_all.xhtml` now opens the detail page in the same window (removed `target="_blank"`). The detail page header now has a Back button (replaces the old 'Close Tab' JS button) that returns to the handover page via `navigateBackToPaymentHandoverCreate()`.
- **Float row detail**: Clicking View on a FLOAT_OUT or FLOAT_IN row now shows the individual fund-transfer payment rows. Previously the detail table was empty because synthetic float bundles had no `reportTemplateRows`. A new `populateFloatBundleRows()` helper fetches the fund-transfer payments on demand using the existing `fetchFundTransferPaymentsForShift()` and populates the bundle before navigation.
- **Shortage row detail**: Shortage (FLOATS) bundles already carry their payment rows from `generatePaymentBundleForHandovers()`, so no extra fetch is needed — the detail page will now display them correctly once the view opens in the same window.

## Files changed

- `FinancialTransactionController.java` — renamed navigation method, added `populateFloatBundleRows()`
- `handover_start_all.xhtml` — removed `target="_blank"`, updated action name
- `handover_start_all_bill_type_details.xhtml` — replaced Close Tab JS with Back button

## Test plan

- [ ] Open handover page, click View on a normal payment row → detail page opens in same window, Back returns to handover
- [ ] Click View on a FLOAT_OUT row → detail table shows the outgoing fund-transfer payment(s)
- [ ] Click View on a FLOAT_IN row → detail table shows the incoming fund-transfer payment(s)
- [ ] Click View on a Shortage (FLOATS) row → detail table shows shortage bill payment(s)
- [ ] Verify Back button on detail page returns to handover page with state preserved

Closes #20556

🤖 Generated with [Claude Code](https://claude.com/claude-code)