### PR TITLE
19680-patient-name-not-displayed-in-cancelled-professional-fee-bill

### DIFF
--- a/src/main/java/com/divudi/bean/inward/InwardProfessionalBillController.java
+++ b/src/main/java/com/divudi/bean/inward/InwardProfessionalBillController.java
@@ -285,6 +285,9 @@ public class InwardProfessionalBillController implements Serializable {
             bill.setBillDate(new Date());
             bill.setBillTime(new Date());
             bill.setPatientEncounter(getBatchBill().getPatientEncounter());
+            if (getBatchBill().getPatientEncounter() != null) {
+                bill.setPatient(getBatchBill().getPatientEncounter().getPatient());
+            }
             bill.setProcedure(getBatchBill().getProcedure());
             bill.setDepartment(getSessionController().getDepartment());
             bill.setInstitution(getSessionController().getInstitution());

--- a/src/main/java/com/divudi/bean/inward/InwardSearch.java
+++ b/src/main/java/com/divudi/bean/inward/InwardSearch.java
@@ -947,8 +947,15 @@ public class InwardSearch implements Serializable {
                 return;
             }
 
+            if (getBill().getPatient() == null && getBill().getPatientEncounter().getPatient() != null) {
+                getBill().setPatient(getBill().getPatientEncounter().getPatient());
+            }
+
             CancelledBill cb = createCancelBill();
             cb.setBillTypeAtomic(BillTypeAtomic.INWARD_THEATRE_PROFESSIONAL_FEE_BILL_CANCELLATION);
+            if (cb.getPatient() == null && getBill().getPatient() != null) {
+                cb.setPatient(getBill().getPatient());
+            }
             if (cb.getId() == null) {
                 getBillFacade().create(cb);
             }

--- a/src/main/webapp/resources/bill/Inward/surgery_professional_fee_5x5.xhtml
+++ b/src/main/webapp/resources/bill/Inward/surgery_professional_fee_5x5.xhtml
@@ -45,7 +45,7 @@
                     <tr>
                         <td><h:outputLabel value="Patient" class="billDetailsFiveFive"/></td>
                         <td style="width:5px;">:</td>
-                        <td><h:outputLabel value="#{cc.attrs.bill.patient.person.nameWithTitle}" class="billDetailsFiveFive"/></td>
+                        <td><h:outputLabel value="#{empty cc.attrs.bill.patient ? cc.attrs.bill.patientEncounter.patient.person.nameWithTitle : cc.attrs.bill.patient.person.nameWithTitle}" class="billDetailsFiveFive"/></td>
                         <td style="width:30px;"/>
                         <td><h:outputLabel value="Date" class="billDetailsFiveFive"/></td>
                         <td>:</td>

--- a/src/main/webapp/resources/bill/Inward/surgery_professional_fee_a4.xhtml
+++ b/src/main/webapp/resources/bill/Inward/surgery_professional_fee_a4.xhtml
@@ -50,7 +50,7 @@
                             <tr>
                                 <td style="width: 35%;"><h:outputLabel value="Patient Name"/></td>
                                 <td style="width: 5%;">:</td>
-                                <td><h:outputLabel value="#{cc.attrs.bill.patient.person.nameWithTitle}"/></td>
+                                <td><h:outputLabel value="#{empty cc.attrs.bill.patient ? cc.attrs.bill.patientEncounter.patient.person.nameWithTitle : cc.attrs.bill.patient.person.nameWithTitle}"/></td>
                             </tr>
                             <tr>
                                 <td><h:outputLabel value="BHT No"/></td>
@@ -61,8 +61,8 @@
                                 <td><h:outputLabel value="Age / Sex"/></td>
                                 <td>:</td>
                                 <td>
-                                    <h:outputLabel value="#{cc.attrs.bill.patient.age}"/>
-                                    <h:outputLabel value=" / #{cc.attrs.bill.patient.person.sex}"/>
+                                    <h:outputLabel value="#{empty cc.attrs.bill.patient ? cc.attrs.bill.patientEncounter.patient.age : cc.attrs.bill.patient.age}"/>
+                                    <h:outputLabel value=" / #{empty cc.attrs.bill.patient ? cc.attrs.bill.patientEncounter.patient.person.sex : cc.attrs.bill.patient.person.sex}"/>
                                 </td>
                             </tr>
                             <tr>

--- a/src/main/webapp/resources/bill/Inward/surgery_professional_fee_pos.xhtml
+++ b/src/main/webapp/resources/bill/Inward/surgery_professional_fee_pos.xhtml
@@ -46,7 +46,7 @@
                     <tr>
                         <td style="width: 35%;"><h:outputLabel value="Patient"/></td>
                         <td style="width: 5%;">:</td>
-                        <td><h:outputLabel value="#{cc.attrs.bill.patient.person.nameWithTitle}"/></td>
+                        <td><h:outputLabel value="#{empty cc.attrs.bill.patient ? cc.attrs.bill.patientEncounter.patient.person.nameWithTitle : cc.attrs.bill.patient.person.nameWithTitle}"/></td>
                     </tr>
                     <tr>
                         <td><h:outputLabel value="BHT No"/></td>

--- a/src/main/webapp/theater/surgery_professional_fees_cancel.xhtml
+++ b/src/main/webapp/theater/surgery_professional_fees_cancel.xhtml
@@ -51,7 +51,7 @@
                                 <h:panelGrid columns="3" class="w-100" style="font-size: 12pt">
                                     <h:outputLabel value="Patient Name"/>
                                     <h:outputLabel value=":"/>
-                                    <h:outputLabel value="#{inwardSearch.bill.patient.person.nameWithTitle}"/>
+                                    <h:outputLabel value="#{empty inwardSearch.bill.patient ? inwardSearch.bill.patientEncounter.patient.person.nameWithTitle : inwardSearch.bill.patient.person.nameWithTitle}"/>
                                     <h:outputLabel value="BHT No"/>
                                     <h:outputLabel value=":"/>
                                     <h:outputLabel value="#{inwardSearch.bill.patientEncounter.bhtNo}"/>


### PR DESCRIPTION
closes #19680 
Added patient name, age, and sex on professional fee cancel bill.
changed files,
01)inwardProfessionalBillController.java
02)inwardSearch.java
03)surgery_professional_fee_5*5.xhtml
04)surgery_professional_fee_a4.xhtml
05)surgery_professional_pos.xhtml
06)surgery_professional_fees_cancel.xhtml


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed patient information display in professional fee bills when patient data is linked through patient encounters.
  * Improved null-safety in bill creation and cancellation workflows to prevent display errors.
  * Professional fee receipts now correctly render patient details across all formats even when data sources vary.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hmislk/hmis/pull/20751)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->