### PR TITLE
Fix expression syntax errors in pharmacy transfer forms

### DIFF
--- a/src/main/webapp/resources/pharmacy/transfeRecieve_detailed.xhtml
+++ b/src/main/webapp/resources/pharmacy/transfeRecieve_detailed.xhtml
@@ -137,7 +137,7 @@
                         <f:facet name="header">
                             <h:outputLabel value="QTY"/>
                         </f:facet>
-                        <h:outputLabel value="#{0-bip.qty}"/>
+                        <h:outputLabel value="#{bip.qty}"/>
                     </p:column>                    
 
                     <p:column style="text-align: right;"
@@ -160,7 +160,7 @@
                             </p:column>
                             <p:column  style="text-align: right;">
                                 <f:facet name="footer">
-                                    <h:outputLabel value="#{-cc.attrs.bill.netTotal}">
+                                    <h:outputLabel value="#{cc.attrs.bill.netTotal}">
                                         <f:convertNumber pattern="#0.00" />
                                     </h:outputLabel>
                                 </f:facet>

--- a/src/main/webapp/resources/pharmacy/transfer_receive_custom_2.xhtml
+++ b/src/main/webapp/resources/pharmacy/transfer_receive_custom_2.xhtml
@@ -137,7 +137,7 @@
                         <f:facet name="header">
                             <h:outputLabel value="QTY"/>
                         </f:facet>
-                        <h:outputLabel value="#{0-bip.qty}"/>
+                        <h:outputLabel value="#{bip.qty}"/>
                     </p:column>                    
 
                     <p:column style="text-align: right;"
@@ -160,7 +160,7 @@
                             </p:column>
                             <p:column  style="text-align: right;">
                                 <f:facet name="footer">
-                                    <h:outputLabel value="#{-cc.attrs.bill.netTotal}">
+                                    <h:outputLabel value="#{cc.attrs.bill.netTotal}">
                                         <f:convertNumber pattern="#0.00" />
                                     </h:outputLabel>
                                 </f:facet>


### PR DESCRIPTION
## Summary
Corrects invalid EL (Expression Language) expressions in two pharmacy transfer/receive XHTML templates that were preventing proper display of quantity and bill total values.

## Changes
- **transfeRecieve_detailed.xhtml**: 
  - Fixed `#{0-bip.qty}` → `#{bip.qty}` (line 140)
  - Fixed `#{-cc.attrs.bill.netTotal}` → `#{cc.attrs.bill.netTotal}` (line 163)

- **transfer_receive_custom_2.xhtml**: 
  - Fixed `#{0-bip.qty}` → `#{bip.qty}` (line 140)
  - Fixed `#{-cc.attrs.bill.netTotal}` → `#{cc.attrs.bill.netTotal}` (line 163)

## Details
The expressions contained erroneous arithmetic operators (`0-` and `-`) that were being evaluated as mathematical operations rather than property access. These have been removed to correctly reference the `qty` and `netTotal` properties from their respective managed beans.

These are JSF/XHTML-only changes with no Java code modifications.

https://claude.ai/code/session_012CxPXAgG4ikDAyBCoYEumM

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed incorrect quantity displays in transfer receive views to show accurate amounts.
  * Corrected net total amounts in transfer receive notes to display proper financial totals.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hmislk/hmis/pull/20779?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->