### PR TITLE
Persist pre-bill reference updates in pharmacy settlement

### DIFF
--- a/src/main/java/com/divudi/bean/pharmacy/PharmacyPreSettleController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacyPreSettleController.java
@@ -931,6 +931,7 @@ public class PharmacyPreSettleController implements Serializable, ControllerWith
 
     private void updatePreBill() {
         getPreBill().setReferenceBill(getSaleBill());
+        getBillFacade().editAndCommit(getPreBill());
     }
 
     /**


### PR DESCRIPTION
## Summary
Adds persistence of pre-bill reference updates in the pharmacy pre-settlement workflow. Previously, the reference bill assignment was made in memory but not committed to the database.

## Changes
- **PharmacyPreSettleController.updatePreBill()**: Added `getBillFacade().editAndCommit(getPreBill())` to persist the reference bill assignment to the database after updating the pre-bill entity

## Implementation Details
The `updatePreBill()` method now ensures that when a pre-bill's reference bill is set, the change is immediately committed to the database via the bill facade. This prevents data loss and ensures consistency in the pharmacy settlement process.

https://claude.ai/code/session_01X8oyANch7NjeGZiBweyhmr

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Pre-bill updates in the pharmacy module are now properly saved when modified, ensuring changes are retained and not lost.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hmislk/hmis/pull/20781?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->