### PR TITLE
feat(registration): add Full Name and Name with Initials fields to patient edit

### DIFF
--- a/src/main/webapp/opd/patient_edit.xhtml
+++ b/src/main/webapp/opd/patient_edit.xhtml
@@ -96,6 +96,24 @@
                                         </div>
                                     </div>
                                     <div class="row form-group mb-1">
+                                        <div class="col-md-6">
+                                            <p:outputLabel value="Full Name:" for="txtFullName" class="form-label" />
+                                            <p:inputText
+                                                id="txtFullName"
+                                                value="#{patientController.current.person.fullName}"
+                                                class="w-100 form-control"
+                                                placeholder="Full name as in official documents" />
+                                        </div>
+                                        <div class="col-md-6">
+                                            <p:outputLabel value="Name with Initials:" for="txtNameWithInitials" class="form-label" />
+                                            <p:inputText
+                                                id="txtNameWithInitials"
+                                                value="#{patientController.current.person.nameWithInitials}"
+                                                class="w-100 form-control"
+                                                placeholder="e.g. A.B. Perera" />
+                                        </div>
+                                    </div>
+                                    <div class="row form-group mb-1">
                                         <div class="col-md-2">
                                             <p:outputLabel value="Sex:"  class="form-label" />
                                             <p:selectOneMenu id="somSex" value="#{patientController.current.person.sex}" class="form-control" >


### PR DESCRIPTION
## Summary
- Adds **Full Name** (`person.fullName` / DB column `TNAME`) input to the OPD patient edit page
- Adds **Name with Initials** (`person.nameWithInitials` / DB column `SNAME`) input to the OPD patient edit page
- Both fields are optional — existing patient records without these values remain valid
- No schema change required; columns already exist in the database

## Test plan
- [ ] Open an existing patient's edit page — Full Name and Name with Initials fields appear after the Name field
- [ ] Enter values in both fields and save — values persist on reload
- [ ] Leave both fields blank and save — saves successfully (fields are optional)
- [ ] Existing fields (Name, Sex, Age, NIC, etc.) are unaffected

Closes #20763
Part of #20761

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added two new patient demographic form fields: "Full Name" and "Name with Initials" for enhanced patient record management.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hmislk/hmis/pull/20783?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->