### PR TITLE
fix: bank account and banking branch management page issues

### DIFF
--- a/src/main/java/com/divudi/bean/common/BankAccountController.java
+++ b/src/main/java/com/divudi/bean/common/BankAccountController.java
@@ -8,6 +8,8 @@
  */
 package com.divudi.bean.common;
 
+import com.divudi.core.data.BankAccountType;
+import com.divudi.core.entity.Institution;
 import com.divudi.core.util.JsfUtil;
 import com.divudi.core.entity.hr.BankAccount;
 import com.divudi.core.facade.BankAccountFacade;
@@ -41,6 +43,7 @@ public class BankAccountController implements Serializable {
     private BankAccountFacade ejbFacade;
     private BankAccount current;
     private List<BankAccount> items = null;
+    private Institution filterBank;
 
     public String manageBankAccounts() {
         current = new BankAccount();
@@ -81,6 +84,7 @@ public class BankAccountController implements Serializable {
 
     public void prepareAdd() {
         current = new BankAccount();
+        current.setBankAccountType(BankAccountType.BANK_ACCOUNT);
     }
 
     public void recreateModel() {
@@ -88,10 +92,23 @@ public class BankAccountController implements Serializable {
     }
 
     public void saveSelected() {
-        if (getCurrent().getAccountNo().isEmpty() || getCurrent().getAccountNo() == null) {
+        if (getCurrent().getInstitution() == null) {
+            JsfUtil.addErrorMessage("Please select an Institution");
+            return;
+        }
+        if (getCurrent().getBank() == null) {
+            JsfUtil.addErrorMessage("Please select a Bank");
+            return;
+        }
+        if (getCurrent().getBankBranch() == null) {
+            JsfUtil.addErrorMessage("Please select a Bank Branch");
+            return;
+        }
+        if (getCurrent().getAccountNo() == null || getCurrent().getAccountNo().trim().isEmpty()) {
             JsfUtil.addErrorMessage("Please enter Account Number");
             return;
         }
+        getCurrent().setBankAccountType(BankAccountType.BANK_ACCOUNT);
 
         if (getCurrent().getId() != null && getCurrent().getId() > 0) {
             getFacade().edit(current);
@@ -157,10 +174,29 @@ public class BankAccountController implements Serializable {
         return ejbFacade;
     }
 
+    public void onFilterBankChange() {
+        recreateModel();
+    }
+
+    public Institution getFilterBank() {
+        return filterBank;
+    }
+
+    public void setFilterBank(Institution filterBank) {
+        this.filterBank = filterBank;
+    }
+
     public List<BankAccount> getItems() {
         if (items == null || items.isEmpty()) {
-            String j = "SELECT ba FROM BankAccount ba WHERE ba.retired = false ORDER BY ba.accountNo";
-            items = getFacade().findByJpql(j);
+            String j;
+            HashMap params = new HashMap();
+            if (filterBank != null) {
+                j = "SELECT ba FROM BankAccount ba WHERE ba.retired = false AND ba.bank = :bank ORDER BY ba.accountNo";
+                params.put("bank", filterBank);
+            } else {
+                j = "SELECT ba FROM BankAccount ba WHERE ba.retired = false ORDER BY ba.accountNo";
+            }
+            items = getFacade().findByJpql(j, params);
             if (items == null) {
                 items = new ArrayList<>();
             }

--- a/src/main/java/com/divudi/bean/common/InstitutionController.java
+++ b/src/main/java/com/divudi/bean/common/InstitutionController.java
@@ -440,7 +440,15 @@ public class InstitutionController implements Serializable {
     }
 
     public List<Institution> getBranches(Institution bank) {
-        return completeInstitution(null, InstitutionType.branch, bank);
+        if (bank == null) {
+            return new ArrayList<>();
+        }
+        String jpql = "select c from Institution c where c.retired = false"
+                + " and c.institutionType = :tp and c.institution = :bank order by c.name";
+        HashMap<String, Object> params = new HashMap<>();
+        params.put("tp", InstitutionType.branch);
+        params.put("bank", bank);
+        return getFacade().findByJpql(jpql, params);
     }
 
     public Institution getInstitutionByName(String name, InstitutionType type) {

--- a/src/main/java/com/divudi/bean/common/InstitutionConverter.java
+++ b/src/main/java/com/divudi/bean/common/InstitutionConverter.java
@@ -6,12 +6,10 @@
 package com.divudi.bean.common;
 
 import com.divudi.core.entity.Institution;
-import com.divudi.core.facade.InstitutionFacade;
 import javax.faces.component.UIComponent;
 import javax.faces.context.FacesContext;
 import javax.faces.convert.Converter;
 import javax.faces.convert.FacesConverter;
-import javax.inject.Inject;
 
 /**
  * JSF converter for Institution entities, enabling safe use in select
@@ -19,11 +17,8 @@ import javax.inject.Inject;
  *
  * @author Dr M H B Ariyaratne
  */
-@FacesConverter(value = "institutionConverter", managed = true)
+@FacesConverter(value = "institutionConverter")
 public class InstitutionConverter implements Converter {
-
-    @Inject
-    private InstitutionFacade institutionFacade;
 
     @Override
     public Object getAsObject(FacesContext context, UIComponent component, String value) {
@@ -32,7 +27,9 @@ public class InstitutionConverter implements Converter {
         }
         try {
             Long id = Long.valueOf(value.trim());
-            return institutionFacade.find(id);
+            InstitutionController controller = (InstitutionController) context.getApplication()
+                    .getELResolver().getValue(context.getELContext(), null, "institutionController");
+            return controller.getEjbFacade().find(id);
         } catch (NumberFormatException e) {
             return null;
         }

--- a/src/main/webapp/admin/institutions/bank_account.xhtml
+++ b/src/main/webapp/admin/institutions/bank_account.xhtml
@@ -21,7 +21,13 @@
                 <p:panel header="Manage Bank Account" >
                     <div class="row">
                         <div class="col-md-5">
-                            <p:commandButton id="btnAdd" value="Add New" 
+                            <p:selectOneMenu id="cmbFilterBank" value="#{bankAccountController.filterBank}"
+                                             styleClass="w-100 mb-2" >
+                                <f:selectItem itemLabel="All Banks" itemValue="#{null}" noSelectionOption="true"/>
+                                <f:selectItems value="#{institutionController.banks}" var="b" itemLabel="#{b.name}" itemValue="#{b}" />
+                                <p:ajax process="cmbFilterBank" update="lstSelect" listener="#{bankAccountController.onFilterBankChange()}"/>
+                            </p:selectOneMenu>
+                            <p:commandButton id="btnAdd" value="Add New"
                                              icon="fas fa-plus"
                                              action="#{bankAccountController.prepareAdd()}" class="ui-button-success" process="btnAdd"
                                              update="lstSelect gpDetail" >
@@ -45,16 +51,6 @@
                                 <p:panelGrid id="gpDetailText" columns="2" class="w-100" layout="tabular">
                                     <h:outputText  value="Name" ></h:outputText>
                                     <p:inputText autocomplete="off"  value="#{bankAccountController.current.accountName}"  class="w-100"  ></p:inputText>
-                                    <h:outputText  value="Type" ></h:outputText>
-                                    <p:selectOneMenu value="#{bankAccountController.current.bankAccountType}" >
-                                        <f:selectItem itemLabel="Select" ></f:selectItem>
-                                        <f:selectItems 
-                                            value="#{enumController.bankAccountTypes}"
-                                            var="bankAccountType"
-                                            itemLabel="#{bankAccountType.label}"
-                                            itemValue="#{bankAccountType}"></f:selectItems>
-                                    </p:selectOneMenu>
-
                                     <h:outputText  value="Account Number" ></h:outputText>
                                     <p:inputText autocomplete="off"  value="#{bankAccountController.current.accountNo}"  class="w-100"  ></p:inputText>
 

--- a/src/main/webapp/admin/institutions/banking_branch.xhtml
+++ b/src/main/webapp/admin/institutions/banking_branch.xhtml
@@ -83,8 +83,7 @@
                                                      icon="fas fa-save"
                                                      styleClass="ui-button-warning"
                                                      action="#{institutionBranchController.saveSelected()}"
-                                                     process="btnSave gpDetail"
-                                                     update="lstSelect gpDetail msg"/>
+                                                     ajax="false"/>
                                 </div>
                                 <p:defaultCommand target="btnSave"/>
                             </p:panel>


### PR DESCRIPTION
## Summary

- Removed the Type selector from `bank_account.xhtml`; `BankAccountType.BANK_ACCOUNT` is now fixed in the backend on save
- Added required-field validation for Institution, Bank, Branch, and Account Number before saving a bank account
- Fixed NPE bug: null check now comes before `isEmpty()` call
- Added a Bank filter dropdown above the account list (AJAX, updates list on change)
- Fixed `InstitutionConverter` to use the EL resolver pattern instead of broken CDI `@Inject` inside `@FacesConverter`
- Switched banking_branch.xhtml Save button to `ajax="false"` to avoid AJAX processing failures
- Fixed `InstitutionController.getBranches()` to query `c.institution` instead of `c.parentInstitution`, matching how branches are persisted

## Test plan

- [ ] Open Bank Accounts page — Type selector is gone
- [ ] Try saving without Institution / Bank / Branch — error messages appear
- [ ] Select a bank in the filter dropdown — list updates to show only accounts for that bank
- [ ] Open Banking Branches page — Save button works and new branch appears in list
- [ ] Open Bank Accounts page, select a Bank — Branch dropdown populates with that bank's branches

Closes #20784

🤖 Generated with [Claude Code](https://claude.com/claude-code)