### PR TITLE
fix: clear cash inputs after Add Cash and fix cashbook autocomplete ' - ' on deposit funds page

### DIFF
--- a/src/main/java/com/divudi/bean/cashTransaction/CashBookController.java
+++ b/src/main/java/com/divudi/bean/cashTransaction/CashBookController.java
@@ -78,6 +78,15 @@ public class CashBookController implements Serializable {
         return cb;
     }
 
+    public String getCashBookLabel(CashBook cb) {
+        if (cb == null) {
+            return "";
+        }
+        String dept = (cb.getDepartment() != null && cb.getDepartment().getName() != null) ? cb.getDepartment().getName() : "";
+        String inst = (cb.getInstitution() != null && cb.getInstitution().getName() != null) ? cb.getInstitution().getName() : "";
+        return dept + " - " + inst;
+    }
+
     public List<CashBook> completeCashBook(String qry) {
         String jpql = "select cb from CashBook cb "
                 + " where cb.retired = false "

--- a/src/main/webapp/cashier/deposit_funds.xhtml
+++ b/src/main/webapp/cashier/deposit_funds.xhtml
@@ -34,7 +34,7 @@
                                             icon="fa fa-plus"
                                             class="ui-button-success float-end"
                                             process="btnAddCash txtCashRefNo txtCashValue"
-                                            update="tblPayments txtTotalDepositValue"
+                                            update="tblPayments txtTotalDepositValue txtCashRefNo txtCashValue"
                                             action="#{financialTransactionController.addPaymentToFundDepositBill()}"/>
                                     </f:facet>
 
@@ -148,7 +148,7 @@
                                         value="#{financialTransactionController.depositCashBook}"
                                         var="cb"
                                         forceSelection="true"
-                                        itemLabel="#{cb.department.name} - #{cb.institution.name}"
+                                        itemLabel="#{cashBookController.getCashBookLabel(cb)}"
                                         itemValue="#{cb}"
                                         required="true"
                                         requiredMessage="Please select a cashbook"/>


### PR DESCRIPTION
## Summary

- After clicking **Add Cash**, the Reference and Value input fields now clear because `txtCashRefNo` and `txtCashValue` are added to the AJAX `update` list on the button.
- The **Cashbook** autocomplete no longer shows ` - ` on page load; a new null-safe `getCashBookLabel(CashBook cb)` method in `CashBookController` is used as `itemLabel` so a null selected value renders as empty string instead of ` - `.

## Files Changed

- `src/main/webapp/cashier/deposit_funds.xhtml` — update list + itemLabel fix
- `src/main/java/com/divudi/bean/cashTransaction/CashBookController.java` — added `getCashBookLabel`

## Test plan

- [ ] Open `/cashier/deposit_funds.xhtml`
- [ ] Verify the Cashbook autocomplete input is blank (not ` - `) on page load
- [ ] Enter a reference number and value, click **Add Cash** — verify both fields clear to blank
- [ ] Verify the added entry appears in the Deposits to Submit table with correct value

Closes #20786

🤖 Generated with [Claude Code](https://claude.com/claude-code)