### PR TITLE
fix: deposit funds UI issues and BioRadD10 middleware image handling

### DIFF
--- a/src/main/java/com/divudi/bean/cashTransaction/CashBookController.java
+++ b/src/main/java/com/divudi/bean/cashTransaction/CashBookController.java
@@ -130,7 +130,7 @@ public class CashBookController implements Serializable {
                 return null;
             }
             CashBookController controller = (CashBookController) facesContext.getApplication().getELResolver().
-                    getValue(facesContext.getELContext(), null, "CashBookController");
+                    getValue(facesContext.getELContext(), null, "cashBookController");
             return controller.getCashbookFacade().find(getKey(value));
         }
 

--- a/src/main/java/com/divudi/ws/lims/LimsMiddlewareController.java
+++ b/src/main/java/com/divudi/ws/lims/LimsMiddlewareController.java
@@ -327,8 +327,16 @@ public class LimsMiddlewareController {
 
                     if (isImageValue
                             && priv.getInvestigationItem().getIxItemType() == InvestigationItemType.ReportImage) {
+                        byte[] imageBytes;
+                        try {
+                            imageBytes = base64TextToByteArray(observationValueStr);
+                        } catch (IllegalArgumentException e) {
+                            return Response.status(Response.Status.BAD_REQUEST)
+                                    .entity("Invalid image observation value: " + observationValueCode)
+                                    .build();
+                        }
                         priv.setLobValue(observationValueStr);
-                        priv.setBaImage(base64TextToByteArray(observationValueStr));
+                        priv.setBaImage(imageBytes);
                         String fileType = extractImageTypeFromResult(observationValueStr);
                         priv.setFileType(fileType);
                         priv.setFileName(observationValueCode + "_" + sampleId + "." + fileType.toLowerCase());

--- a/src/main/java/com/divudi/ws/lims/LimsMiddlewareController.java
+++ b/src/main/java/com/divudi/ws/lims/LimsMiddlewareController.java
@@ -167,18 +167,20 @@ public class LimsMiddlewareController {
         String observationUnitCode = observation.optString("observationUnitCode");
         String observationValueStr = observation.optString("observationValue");
         Double observationValueDbl = null;
+        boolean isImageValue = observationValueStr != null && observationValueStr.startsWith("^Image^");
         String issuedDate = observation.optString("issuedDate");
         String password = observation.optString("password");
         String username = observation.optString("username");
 
-        // Convert observationValueStr to Double
-        try {
-            observationValueDbl = Double.valueOf(observationValueStr);
-        } catch (NumberFormatException e) {
-            // // System.out.println("Invalid observation value: " + observationValueStr);
-            return Response.status(Response.Status.BAD_REQUEST)
-                    .entity("Invalid observation value: " + observationValueStr)
-                    .build();
+        // Convert observationValueStr to Double (skip for image values)
+        if (!isImageValue) {
+            try {
+                observationValueDbl = Double.valueOf(observationValueStr);
+            } catch (NumberFormatException e) {
+                return Response.status(Response.Status.BAD_REQUEST)
+                        .entity("Invalid observation value: " + observationValueStr)
+                        .build();
+            }
         }
 
         Long sampleIdLong;
@@ -315,13 +317,28 @@ public class LimsMiddlewareController {
                 // // System.out.println("tpr = " + tpr);
 
                 for (PatientReportItemValue priv : tpr.getPatientReportItemValues()) {
-                    // // System.out.println("priv = " + priv);
-                    // // System.out.println("priv.getInvestigationItem().getValueCodeSystem() = " + priv.getInvestigationItem());
-                    if (priv.getInvestigationItem() != null
-                            && priv.getInvestigationItem().getValueCodeSystem() != null
-                            && priv.getInvestigationItem().getValueCodeSystem().equals(observationValueCodingSystem)
-                            && priv.getInvestigationItem().getValueCode() != null
-                            && priv.getInvestigationItem().getValueCode().equals(observationValueCode)) {
+                    if (priv.getInvestigationItem() == null
+                            || priv.getInvestigationItem().getValueCodeSystem() == null
+                            || !priv.getInvestigationItem().getValueCodeSystem().equals(observationValueCodingSystem)
+                            || priv.getInvestigationItem().getValueCode() == null
+                            || !priv.getInvestigationItem().getValueCode().equals(observationValueCode)) {
+                        continue;
+                    }
+
+                    if (isImageValue
+                            && priv.getInvestigationItem().getIxItemType() == InvestigationItemType.ReportImage) {
+                        priv.setLobValue(observationValueStr);
+                        priv.setBaImage(base64TextToByteArray(observationValueStr));
+                        String fileType = extractImageTypeFromResult(observationValueStr);
+                        priv.setFileType(fileType);
+                        priv.setFileName(observationValueCode + "_" + sampleId + "." + fileType.toLowerCase());
+                        if (priv.getId() == null) {
+                            patientReportItemValueFacade.create(priv);
+                        } else {
+                            patientReportItemValueFacade.edit(priv);
+                        }
+                        resultAdded = true;
+                    } else if (!isImageValue) {
                         priv.setStrValue(observationValueStr);
                         priv.setDoubleValue(observationValueDbl);
                         resultAdded = true;

--- a/src/main/java/com/divudi/ws/lims/MiddlewareController.java
+++ b/src/main/java/com/divudi/ws/lims/MiddlewareController.java
@@ -174,10 +174,6 @@ public class MiddlewareController {
                 Analyzer analyzer = Analyzer.valueOf(analyzerDetails.getAnalyzerName().replace(" ", "_")); // Ensuring enum compatibility
                 System.out.println("analyzer = " + analyzer);
                 switch (analyzer) {
-                    case BioRadD10:
-                        return processBioRadD10(dataBundle);
-
-
                     case Dimension_Clinical_Chemistry_System:
                         return processDimensionClinicalChemistrySystem(dataBundle);
                     case Gallery_Indiko:
@@ -188,6 +184,7 @@ public class MiddlewareController {
                         return processBA400(dataBundle);
                     case Sysmex_XS_Series:
 //                         return processSysmexXSSeries(dataBundle);
+                    case BioRadD10:
                     case MaglumiX3HL7:
                     case MindrayBC5150:
                     case IndikoPlus:


### PR DESCRIPTION
## Summary
- Fix deposit funds UI: clear cash input fields after Add Cash and fix cashbook autocomplete blank display
- Fix CDI bean name in CashBookConverter EL lookup
- Fix BioRadD10 middleware: route to `processResultsCommon` instead of stub handler, and enable `/observation` endpoint to accept and store ReportImage data (chromatogram PNG images)

Closes #20786
Closes #20788

## Test plan
- [ ] Verify deposit funds page clears input fields after adding cash
- [ ] Verify cashbook autocomplete displays correctly (not blank)
- [ ] Verify BioRadD10 sends HbA1c value + chromatogram via `/test_results` endpoint and both are stored
- [ ] Verify chromatogram image renders in patient report view

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Image observations are now supported in laboratory results processing, with automatic file type detection and image data persistence.

* **Bug Fixes**
  * Improved analyzer-specific routing for enhanced result processing accuracy.
  * Refined framework-level controller instance binding resolution for improved system stability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hmislk/hmis/pull/20790?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->