### PR TITLE
feat(patient): blacklist management with privilege gate, always-on, and audit events

### DIFF
--- a/src/main/java/com/divudi/bean/channel/BookingControllerViewScope.java
+++ b/src/main/java/com/divudi/bean/channel/BookingControllerViewScope.java
@@ -4165,13 +4165,10 @@ public class BookingControllerViewScope implements Serializable, ControllerWithP
             return;
         }
         
-        if(configOptionApplicationController.getBooleanValueByKey("Enable blacklist patient management in the system", false) 
-                && configOptionApplicationController.getBooleanValueByKey("Enable blacklist patient management for Channeling from the system", false)){
-            if(patient.isBlacklisted()){
-                JsfUtil.addErrorMessage("This patient is blacklisted from the system. Can't Bill.");
-                settleSucessFully = false;
-                return;
-            }
+        if (patient.isBlacklisted()) {
+            JsfUtil.addErrorMessage("This patient is blacklisted from the system. Can't Bill.");
+            settleSucessFully = false;
+            return;
         }
         
         if (paymentMethodErrorPresent()) {

--- a/src/main/java/com/divudi/bean/channel/BookingControllerViewScopeMonth.java
+++ b/src/main/java/com/divudi/bean/channel/BookingControllerViewScopeMonth.java
@@ -2952,13 +2952,10 @@ public class BookingControllerViewScopeMonth implements Serializable {
             return;
         }
 
-        if (configOptionApplicationController.getBooleanValueByKey("Enable blacklist patient management in the system", false)
-                && configOptionApplicationController.getBooleanValueByKey("Enable blacklist patient management for Channeling from the system", false)) {
-            if (patient.isBlacklisted()) {
-                JsfUtil.addErrorMessage("This patient is blacklisted from the system. Can't Bill.");
-                settleSucessFully = false;
-                return;
-            }
+        if (patient.isBlacklisted()) {
+            JsfUtil.addErrorMessage("This patient is blacklisted from the system. Can't Bill.");
+            settleSucessFully = false;
+            return;
         }
 
         if (paymentMethodErrorPresent()) {

--- a/src/main/java/com/divudi/bean/common/AppointmentController.java
+++ b/src/main/java/com/divudi/bean/common/AppointmentController.java
@@ -547,7 +547,7 @@ public class AppointmentController implements Serializable, ControllerWithPatien
 
     public void settleBill() {
 
-        if (getPatient().getId() != null && getPatient().isBlacklisted() && configOptionApplicationController.getBooleanValueByKey("Enable blacklist patient management for inward from the system", false)) {
+        if (getPatient().getId() != null && getPatient().isBlacklisted()) {
             JsfUtil.addErrorMessage("This patient is blacklisted from the system.");
             return;
         }

--- a/src/main/java/com/divudi/bean/common/BillPackageController.java
+++ b/src/main/java/com/divudi/bean/common/BillPackageController.java
@@ -465,12 +465,9 @@ public class BillPackageController implements Serializable, ControllerWithPatien
             }
         }
         
-        if(configOptionApplicationController.getBooleanValueByKey("Enable blacklist patient management in the system", false) 
-                && configOptionApplicationController.getBooleanValueByKey("Enable blacklist patient management for OPD from the system", false)){
-            if(getPatient().isBlacklisted()){
-                JsfUtil.addErrorMessage("This patient is blacklisted from the system. Can't Bill.");
-                return true;
-            }
+        if (getPatient().isBlacklisted()) {
+            JsfUtil.addErrorMessage("This patient is blacklisted from the system. Can't Bill.");
+            return true;
         }
 
         if (getLstBillEntries().isEmpty()) {
@@ -2735,19 +2732,6 @@ public class BillPackageController implements Serializable, ControllerWithPatien
             OptionScope.APPLICATION
         ));
 
-        metadata.addConfigOption(new ConfigOptionInfo(
-            "Enable blacklist patient management in the system",
-            "Enables blacklist patient management features globally",
-            "Line 425: Blacklist patient badge rendering (combined with OPD-specific setting)",
-            OptionScope.APPLICATION
-        ));
-
-        metadata.addConfigOption(new ConfigOptionInfo(
-            "Enable blacklist patient management for OPD from the system",
-            "Enables blacklist patient management specifically for OPD modules",
-            "Line 425: Combined with global blacklist setting for OPD blacklist badge",
-            OptionScope.APPLICATION
-        ));
 
         // Configuration Options - Package Management
         metadata.addConfigOption(new ConfigOptionInfo(

--- a/src/main/java/com/divudi/bean/common/OpdPreBillController.java
+++ b/src/main/java/com/divudi/bean/common/OpdPreBillController.java
@@ -1092,12 +1092,9 @@ public class OpdPreBillController implements Serializable, ControllerWithPatient
             }
         }
         
-        if(configOptionApplicationController.getBooleanValueByKey("Enable blacklist patient management in the system", false) 
-                && configOptionApplicationController.getBooleanValueByKey("Enable blacklist patient management for OPD from the system", false)){
-            if(getPatient().isBlacklisted()){
-                JsfUtil.addErrorMessage("This patient is blacklisted from the system. Can't Bill.");
-                return true;
-            }
+        if (getPatient().isBlacklisted()) {
+            JsfUtil.addErrorMessage("This patient is blacklisted from the system. Can't Bill.");
+            return true;
         }
 
 //        if (getPaymentMethod() == null) {

--- a/src/main/java/com/divudi/bean/common/PatientController.java
+++ b/src/main/java/com/divudi/bean/common/PatientController.java
@@ -58,6 +58,7 @@ import com.divudi.core.facade.WebUserFacade;
 import com.divudi.core.util.JsfUtil;
 import com.divudi.core.data.BillTypeAtomic;
 import com.divudi.core.data.SpecificPatientStatus;
+import com.divudi.core.entity.AuditEvent;
 import com.divudi.core.entity.CancelledBill;
 import com.divudi.core.entity.Department;
 import com.divudi.core.entity.PatientDeposit;
@@ -195,6 +196,8 @@ public class PatientController implements Serializable, ControllerWithPatient {
     PatientController patientController;
     @Inject
     ConfigOptionApplicationController configOptionApplicationController;
+    @Inject
+    AuditEventController auditEventController;
     @Inject
     PatientDepositController patientDepositController;
     @Inject
@@ -3125,6 +3128,11 @@ public class PatientController implements Serializable, ControllerWithPatient {
                 JsfUtil.addErrorMessage("Please provide a reason for blacklisting. ");
                 return;
             }
+            AuditEvent auditEvent = auditEventController.createNewAuditEvent(
+                    "Blacklist Patient",
+                    "{\"patientId\":" + patient.getId() + ",\"blacklisted\":false}",
+                    patient.getId(),
+                    "Patient");
             Patient newb = getFacade().find(patient.getId());
             newb.setBlacklisted(true);
             newb.setBlacklistedAt(new Date());
@@ -3134,6 +3142,8 @@ public class PatientController implements Serializable, ControllerWithPatient {
 //            getFacade().edit(patient);
 
             getFacade().editAndCommit(newb);
+            auditEventController.completeAuditEvent(auditEvent,
+                    "{\"patientId\":" + newb.getId() + ",\"blacklisted\":true,\"reason\":\"" + blacklistComment + "\"}");
             this.current = getFacade().findWithoutCache(newb.getId());
             blacklistComment = null;
             JsfUtil.addSuccessMessage("Patient is blacklisted.");
@@ -3144,6 +3154,11 @@ public class PatientController implements Serializable, ControllerWithPatient {
                 return;
             }
 
+            AuditEvent auditEvent = auditEventController.createNewAuditEvent(
+                    "Revert Patient Blacklist",
+                    "{\"patientId\":" + patient.getId() + ",\"blacklisted\":true,\"reason\":\"" + patient.getReasonForBlacklist() + "\"}",
+                    patient.getId(),
+                    "Patient");
             Patient newb = getFacade().find(patient.getId());
             newb.setBlacklisted(false);
             getFacade().edit(newb);
@@ -3157,7 +3172,8 @@ public class PatientController implements Serializable, ControllerWithPatient {
             newb.setBlacklistedBy(null);
 
             getFacade().editAndCommit(newb);
-
+            auditEventController.completeAuditEvent(auditEvent,
+                    "{\"patientId\":" + newb.getId() + ",\"blacklisted\":false,\"revertComment\":\"" + blacklistComment + "\"}");
             blacklistComment = null;
             JsfUtil.addSuccessMessage("Patient blacklist is reverted.");
         }

--- a/src/main/java/com/divudi/bean/common/UserPrivilageController.java
+++ b/src/main/java/com/divudi/bean/common/UserPrivilageController.java
@@ -498,6 +498,7 @@ public class UserPrivilageController implements Serializable {
         new DefaultTreeNode(new PrivilegeHolder(Privileges.ClinicalPatientEdit, "Edit Patient"), clinicalsNode);
         new DefaultTreeNode(new PrivilegeHolder(Privileges.ClinicalPatientNameChange, "Change Patient Name"), clinicalsNode);
         new DefaultTreeNode(new PrivilegeHolder(Privileges.ClinicalPatientPhoneNumberEdit, "Edit Patient Phone Number"), clinicalsNode);
+        new DefaultTreeNode(new PrivilegeHolder(Privileges.ClinicalPatientBlacklist, "Blacklist / Unblacklist Patient"), clinicalsNode);
         new DefaultTreeNode(new PrivilegeHolder(Privileges.ClinicalPatientCommentsView, "View Patient Comments"), clinicalsNode);
         new DefaultTreeNode(new PrivilegeHolder(Privileges.ClinicalPatientCommentsEdit, "Edit Patient Comments"), clinicalsNode);
         new DefaultTreeNode(new PrivilegeHolder(Privileges.ClinicalMembershipAdd, "Add Membership"), clinicalsNode);

--- a/src/main/java/com/divudi/bean/inward/AdmissionController.java
+++ b/src/main/java/com/divudi/bean/inward/AdmissionController.java
@@ -287,12 +287,6 @@ public class AdmissionController implements Serializable, ControllerWithPatient 
                 OptionScope.APPLICATION
         ));
 
-        metadata.addConfigOption(new ConfigOptionInfo(
-                "Enable blacklist patient management for inward from the system",
-                "Prevent blacklisted patients from being admitted (default false)",
-                "inward/inward_admission",
-                OptionScope.APPLICATION
-        ));
 
         pageMetadataRegistry.registerPage(metadata);
     }
@@ -1997,7 +1991,7 @@ public class AdmissionController implements Serializable, ControllerWithPatient 
             return;
         }
 
-        if (getPatient() != null && getPatient().getId() != null && getPatient().isBlacklisted() && configOptionApplicationController.getBooleanValueByKey("Enable blacklist patient management for inward from the system", false)) {
+        if (getPatient() != null && getPatient().getId() != null && getPatient().isBlacklisted()) {
             JsfUtil.addErrorMessage("This patient is blacklisted from the system.");
             return;
         }

--- a/src/main/java/com/divudi/bean/opd/OpdBillController.java
+++ b/src/main/java/com/divudi/bean/opd/OpdBillController.java
@@ -761,19 +761,6 @@ public class OpdBillController implements Serializable, ControllerWithPatient, C
         ));
 
         // Patient Management and Security Configurations
-        metadata.addConfigOption(new ConfigOptionInfo(
-                "Enable blacklist patient management in the system",
-                "Enables global blacklist functionality for patients across the entire system",
-                "OpdBillController.java line 3022: Global blacklist check in settleOpdBill()",
-                OptionScope.APPLICATION
-        ));
-
-        metadata.addConfigOption(new ConfigOptionInfo(
-                "Enable blacklist patient management for OPD from the system",
-                "Enables blacklist validation specifically for OPD billing to prevent billing blacklisted patients",
-                "OpdBillController.java line 3023: OPD-specific blacklist check in settleOpdBill()",
-                OptionScope.APPLICATION
-        ));
 
         // Item Listing Strategy Configuration
         metadata.addConfigOption(new ConfigOptionInfo(
@@ -3227,12 +3214,9 @@ public class OpdBillController implements Serializable, ControllerWithPatient, C
             return true;
         }
 
-        if (configOptionApplicationController.getBooleanValueByKey("Enable blacklist patient management in the system", false)
-                && configOptionApplicationController.getBooleanValueByKey("Enable blacklist patient management for OPD from the system", false)) {
-            if (getPatient().isBlacklisted()) {
-                JsfUtil.addErrorMessage("This patient is blacklisted from the system. Can't Bill.");
-                return true;
-            }
+        if (getPatient().isBlacklisted()) {
+            JsfUtil.addErrorMessage("This patient is blacklisted from the system. Can't Bill.");
+            return true;
         }
 
         if (getPatient().getPerson() == null) {

--- a/src/main/java/com/divudi/bean/pharmacy/PharmacyFastRetailSaleController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacyFastRetailSaleController.java
@@ -1652,13 +1652,10 @@ public class PharmacyFastRetailSaleController implements Serializable, Controlle
             }
         }
         
-        if(configOptionApplicationController.getBooleanValueByKey("Enable blacklist patient management in the system", false) 
-                && configOptionApplicationController.getBooleanValueByKey("Enable blacklist patient management for Pharmacy from the system", false)){
-            if(getPatient().isBlacklisted()){
-                JsfUtil.addErrorMessage("This patient is blacklisted from the system. Can't Bill.");
-                billSettlingStarted = false;
-                return;
-            }
+        if (getPatient().isBlacklisted()) {
+            JsfUtil.addErrorMessage("This patient is blacklisted from the system. Can't Bill.");
+            billSettlingStarted = false;
+            return;
         }
 
         if (configOptionApplicationController.getBooleanValueByKey("Check for Allergies during Dispensing")) {

--- a/src/main/java/com/divudi/bean/pharmacy/PharmacyFastRetailSaleForCashierController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacyFastRetailSaleForCashierController.java
@@ -152,12 +152,9 @@ public class PharmacyFastRetailSaleForCashierController extends PharmacyFastReta
             return;
         }
         
-        if(getPatient() != null && getPatient().getId() != null && configOptionApplicationController.getBooleanValueByKey("Enable blacklist patient management in the system", false) 
-                && configOptionApplicationController.getBooleanValueByKey("Enable blacklist patient management for Pharmacy from the system", false)){
-            if(getPatient().isBlacklisted()){
-                JsfUtil.addErrorMessage("This patient is blacklisted from the system. Can't Bill.");
-                return;
-            }
+        if (getPatient() != null && getPatient().getId() != null && getPatient().isBlacklisted()) {
+            JsfUtil.addErrorMessage("This patient is blacklisted from the system. Can't Bill.");
+            return;
         }
         
         for (BillItem bi : getPreBill().getBillItems()) {

--- a/src/main/java/com/divudi/bean/pharmacy/PharmacySaleController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacySaleController.java
@@ -3534,13 +3534,10 @@ public class PharmacySaleController implements Serializable, ControllerWithPatie
             }
         }
         
-        if(configOptionApplicationController.getBooleanValueByKey("Enable blacklist patient management in the system", false) 
-                && configOptionApplicationController.getBooleanValueByKey("Enable blacklist patient management for Pharmacy from the system", false)){
-            if(getPatient().isBlacklisted()){
-                JsfUtil.addErrorMessage("This patient is blacklisted from the system. Can't Bill.");
-                billSettlingStarted = false;
-                return;
-            }
+        if (getPatient().isBlacklisted()) {
+            JsfUtil.addErrorMessage("This patient is blacklisted from the system. Can't Bill.");
+            billSettlingStarted = false;
+            return;
         }
 
         if (configOptionApplicationController.getBooleanValueByKey("Need Patient Title And Gender To Save Patient in Pharmacy Sale", false)) {

--- a/src/main/java/com/divudi/bean/pharmacy/PharmacySaleController1.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacySaleController1.java
@@ -3006,13 +3006,10 @@ public class PharmacySaleController1 implements Serializable, ControllerWithPati
             }
         }
         
-        if(configOptionApplicationController.getBooleanValueByKey("Enable blacklist patient management in the system", false) 
-                && configOptionApplicationController.getBooleanValueByKey("Enable blacklist patient management for Pharmacy from the system", false)){
-            if(getPatient().isBlacklisted()){
-                JsfUtil.addErrorMessage("This patient is blacklisted from the system. Can't Bill.");
-                billSettlingStarted = false;
-                return;
-            }
+        if (getPatient().isBlacklisted()) {
+            JsfUtil.addErrorMessage("This patient is blacklisted from the system. Can't Bill.");
+            billSettlingStarted = false;
+            return;
         }
 
         if (configOptionApplicationController.getBooleanValueByKey("Need Patient Title And Gender To Save Patient in Pharmacy Sale", false)) {

--- a/src/main/java/com/divudi/bean/pharmacy/PharmacySaleController2.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacySaleController2.java
@@ -3006,13 +3006,10 @@ public class PharmacySaleController2 implements Serializable, ControllerWithPati
             }
         }
         
-        if(configOptionApplicationController.getBooleanValueByKey("Enable blacklist patient management in the system", false) 
-                && configOptionApplicationController.getBooleanValueByKey("Enable blacklist patient management for Pharmacy from the system", false)){
-            if(getPatient().isBlacklisted()){
-                JsfUtil.addErrorMessage("This patient is blacklisted from the system. Can't Bill.");
-                billSettlingStarted = false;
-                return;
-            }
+        if (getPatient().isBlacklisted()) {
+            JsfUtil.addErrorMessage("This patient is blacklisted from the system. Can't Bill.");
+            billSettlingStarted = false;
+            return;
         }
 
         if (configOptionApplicationController.getBooleanValueByKey("Need Patient Title And Gender To Save Patient in Pharmacy Sale", false)) {

--- a/src/main/java/com/divudi/bean/pharmacy/PharmacySaleController3.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacySaleController3.java
@@ -3006,13 +3006,10 @@ public class PharmacySaleController3 implements Serializable, ControllerWithPati
             }
         }
         
-        if(configOptionApplicationController.getBooleanValueByKey("Enable blacklist patient management in the system", false) 
-                && configOptionApplicationController.getBooleanValueByKey("Enable blacklist patient management for Pharmacy from the system", false)){
-            if(getPatient().isBlacklisted()){
-                JsfUtil.addErrorMessage("This patient is blacklisted from the system. Can't Bill.");
-                billSettlingStarted = false;
-                return;
-            }
+        if (getPatient().isBlacklisted()) {
+            JsfUtil.addErrorMessage("This patient is blacklisted from the system. Can't Bill.");
+            billSettlingStarted = false;
+            return;
         }
 
         if (configOptionApplicationController.getBooleanValueByKey("Need Patient Title And Gender To Save Patient in Pharmacy Sale", false)) {

--- a/src/main/java/com/divudi/bean/pharmacy/PharmacySaleForCashierController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacySaleForCashierController.java
@@ -560,19 +560,6 @@ public class PharmacySaleForCashierController implements Serializable, Controlle
                 OptionScope.APPLICATION
         ));
 
-        metadata.addConfigOption(new ConfigOptionInfo(
-                "Enable blacklist patient management in the system",
-                "Enables system-wide blacklist patient management functionality",
-                "Controller: Patient blacklist checking",
-                OptionScope.APPLICATION
-        ));
-
-        metadata.addConfigOption(new ConfigOptionInfo(
-                "Enable blacklist patient management for Pharmacy from the system",
-                "Enables blacklist patient management specifically for pharmacy module",
-                "Controller: Pharmacy-specific patient blacklist checking",
-                OptionScope.APPLICATION
-        ));
 
         metadata.addConfigOption(new ConfigOptionInfo(
                 "Referring Doctor is required in Pharmacy Retail Sale",
@@ -3719,13 +3706,10 @@ public class PharmacySaleForCashierController implements Serializable, Controlle
             }
         }
 
-        if (configOptionApplicationController.getBooleanValueByKey("Enable blacklist patient management in the system", false)
-                && configOptionApplicationController.getBooleanValueByKey("Enable blacklist patient management for Pharmacy from the system", false)) {
-            if (getPatient().isBlacklisted()) {
-                JsfUtil.addErrorMessage("This patient is blacklisted from the system. Can't Bill.");
-                billSettlingStarted = false;
-                return null;
-            }
+        if (getPatient().isBlacklisted()) {
+            JsfUtil.addErrorMessage("This patient is blacklisted from the system. Can't Bill.");
+            billSettlingStarted = false;
+            return null;
         }
 
         // Referring Doctor validation

--- a/src/main/java/com/divudi/bean/pharmacy/PharmacySaleForCashierController1.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacySaleForCashierController1.java
@@ -553,19 +553,6 @@ public class PharmacySaleForCashierController1 implements Serializable, Controll
                 OptionScope.APPLICATION
         ));
 
-        metadata.addConfigOption(new ConfigOptionInfo(
-                "Enable blacklist patient management in the system",
-                "Enables system-wide blacklist patient management functionality",
-                "Controller: Patient blacklist checking",
-                OptionScope.APPLICATION
-        ));
-
-        metadata.addConfigOption(new ConfigOptionInfo(
-                "Enable blacklist patient management for Pharmacy from the system",
-                "Enables blacklist patient management specifically for pharmacy module",
-                "Controller: Pharmacy-specific patient blacklist checking",
-                OptionScope.APPLICATION
-        ));
 
         metadata.addConfigOption(new ConfigOptionInfo(
                 "Referring Doctor is required in Pharmacy Retail Sale",
@@ -3732,13 +3719,10 @@ public class PharmacySaleForCashierController1 implements Serializable, Controll
             }
         }
 
-        if (configOptionApplicationController.getBooleanValueByKey("Enable blacklist patient management in the system", false)
-                && configOptionApplicationController.getBooleanValueByKey("Enable blacklist patient management for Pharmacy from the system", false)) {
-            if (getPatient().isBlacklisted()) {
-                JsfUtil.addErrorMessage("This patient is blacklisted from the system. Can't Bill.");
-                billSettlingStarted = false;
-                return null;
-            }
+        if (getPatient().isBlacklisted()) {
+            JsfUtil.addErrorMessage("This patient is blacklisted from the system. Can't Bill.");
+            billSettlingStarted = false;
+            return null;
         }
 
         // Referring Doctor validation

--- a/src/main/java/com/divudi/bean/pharmacy/PharmacySaleForCashierController2.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacySaleForCashierController2.java
@@ -553,19 +553,6 @@ public class PharmacySaleForCashierController2 implements Serializable, Controll
             OptionScope.APPLICATION
         ));
 
-        metadata.addConfigOption(new ConfigOptionInfo(
-            "Enable blacklist patient management in the system",
-            "Enables system-wide blacklist patient management functionality",
-            "Controller: Patient blacklist checking",
-            OptionScope.APPLICATION
-        ));
-
-        metadata.addConfigOption(new ConfigOptionInfo(
-            "Enable blacklist patient management for Pharmacy from the system",
-            "Enables blacklist patient management specifically for pharmacy module",
-            "Controller: Pharmacy-specific patient blacklist checking",
-            OptionScope.APPLICATION
-        ));
 
         metadata.addConfigOption(new ConfigOptionInfo(
             "Referring Doctor is required in Pharmacy Retail Sale",
@@ -3730,13 +3717,10 @@ public class PharmacySaleForCashierController2 implements Serializable, Controll
             }
         }
 
-        if (configOptionApplicationController.getBooleanValueByKey("Enable blacklist patient management in the system", false)
-                && configOptionApplicationController.getBooleanValueByKey("Enable blacklist patient management for Pharmacy from the system", false)) {
-            if (getPatient().isBlacklisted()) {
-                JsfUtil.addErrorMessage("This patient is blacklisted from the system. Can't Bill.");
-                billSettlingStarted = false;
-                return null;
-            }
+        if (getPatient().isBlacklisted()) {
+            JsfUtil.addErrorMessage("This patient is blacklisted from the system. Can't Bill.");
+            billSettlingStarted = false;
+            return null;
         }
 
         // Referring Doctor validation

--- a/src/main/java/com/divudi/bean/pharmacy/PharmacySaleForCashierController3.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacySaleForCashierController3.java
@@ -553,19 +553,6 @@ public class PharmacySaleForCashierController3 implements Serializable, Controll
             OptionScope.APPLICATION
         ));
 
-        metadata.addConfigOption(new ConfigOptionInfo(
-            "Enable blacklist patient management in the system",
-            "Enables system-wide blacklist patient management functionality",
-            "Controller: Patient blacklist checking",
-            OptionScope.APPLICATION
-        ));
-
-        metadata.addConfigOption(new ConfigOptionInfo(
-            "Enable blacklist patient management for Pharmacy from the system",
-            "Enables blacklist patient management specifically for pharmacy module",
-            "Controller: Pharmacy-specific patient blacklist checking",
-            OptionScope.APPLICATION
-        ));
 
         metadata.addConfigOption(new ConfigOptionInfo(
             "Referring Doctor is required in Pharmacy Retail Sale",
@@ -3733,13 +3720,10 @@ public class PharmacySaleForCashierController3 implements Serializable, Controll
             }
         }
 
-        if (configOptionApplicationController.getBooleanValueByKey("Enable blacklist patient management in the system", false)
-                && configOptionApplicationController.getBooleanValueByKey("Enable blacklist patient management for Pharmacy from the system", false)) {
-            if (getPatient().isBlacklisted()) {
-                JsfUtil.addErrorMessage("This patient is blacklisted from the system. Can't Bill.");
-                billSettlingStarted = false;
-                return null;
-            }
+        if (getPatient().isBlacklisted()) {
+            JsfUtil.addErrorMessage("This patient is blacklisted from the system. Can't Bill.");
+            billSettlingStarted = false;
+            return null;
         }
 
         // Referring Doctor validation

--- a/src/main/java/com/divudi/bean/pharmacy/PharmacyWholeSaleController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacyWholeSaleController.java
@@ -1327,12 +1327,9 @@ public class PharmacyWholeSaleController implements Serializable, ControllerWith
         Patient pt = savePatient();
 
         if (pt != null) {
-            if (configOptionApplicationController.getBooleanValueByKey("Enable blacklist patient management in the system", false)
-                    && configOptionApplicationController.getBooleanValueByKey("Enable blacklist patient management for Pharmacy from the system", false)) {
-                if (pt.isBlacklisted()) {
-                    JsfUtil.addErrorMessage("This patient is blacklisted from the system. Can't Bill.");
-                    return;
-                }
+            if (pt.isBlacklisted()) {
+                JsfUtil.addErrorMessage("This patient is blacklisted from the system. Can't Bill.");
+                return;
             }
         }
 
@@ -1454,12 +1451,9 @@ public class PharmacyWholeSaleController implements Serializable, ControllerWith
             }
         }
 
-        if (configOptionApplicationController.getBooleanValueByKey("Enable blacklist patient management in the system", false)
-                && configOptionApplicationController.getBooleanValueByKey("Enable blacklist patient management for Pharmacy from the system", false)) {
-            if (getPatient() != null && getPatient().isBlacklisted()) {
-                JsfUtil.addErrorMessage("This patient is blacklisted from the system. Can't Bill.");
-                return;
-            }
+        if (getPatient() != null && getPatient().isBlacklisted()) {
+            JsfUtil.addErrorMessage("This patient is blacklisted from the system. Can't Bill.");
+            return;
         }
 
         if (configOptionApplicationController.getBooleanValueByKey("Referring Doctor is required in Pharmacy Retail Sale", false)) {

--- a/src/main/java/com/divudi/bean/pharmacy/PharmacyWholeSaleController1.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacyWholeSaleController1.java
@@ -1353,12 +1353,9 @@ public class PharmacyWholeSaleController1 implements Serializable, ControllerWit
             }
         }
         
-        if(configOptionApplicationController.getBooleanValueByKey("Enable blacklist patient management in the system", false) && 
-                configOptionApplicationController.getBooleanValueByKey("Enable blacklist patient management for Pharmacy from the system", false)){
-            if(getPatient() != null && getPatient().isBlacklisted()){
-                JsfUtil.addErrorMessage("This patient is blacklisted from the system. Can't Bill.");
-                return ;
-            }
+        if (getPatient() != null && getPatient().isBlacklisted()) {
+            JsfUtil.addErrorMessage("This patient is blacklisted from the system. Can't Bill.");
+            return;
         }
 
 

--- a/src/main/java/com/divudi/bean/pharmacy/PharmacyWholeSaleController2.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacyWholeSaleController2.java
@@ -1354,12 +1354,9 @@ public class PharmacyWholeSaleController2 implements Serializable, ControllerWit
             }
         }
         
-        if(configOptionApplicationController.getBooleanValueByKey("Enable blacklist patient management in the system", false) && 
-                configOptionApplicationController.getBooleanValueByKey("Enable blacklist patient management for Pharmacy from the system", false)){
-            if(getPatient() != null && getPatient().isBlacklisted()){
-                JsfUtil.addErrorMessage("This patient is blacklisted from the system. Can't Bill.");
-                return ;
-            }
+        if (getPatient() != null && getPatient().isBlacklisted()) {
+            JsfUtil.addErrorMessage("This patient is blacklisted from the system. Can't Bill.");
+            return;
         }
 
 //        if (checkAllBillItem()) {

--- a/src/main/java/com/divudi/bean/pharmacy/PharmacyWholeSaleController3.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacyWholeSaleController3.java
@@ -1354,12 +1354,9 @@ public class PharmacyWholeSaleController3 implements Serializable, ControllerWit
             }
         }
         
-        if(configOptionApplicationController.getBooleanValueByKey("Enable blacklist patient management in the system", false) && 
-                configOptionApplicationController.getBooleanValueByKey("Enable blacklist patient management for Pharmacy from the system", false)){
-            if(getPatient() != null && getPatient().isBlacklisted()){
-                JsfUtil.addErrorMessage("This patient is blacklisted from the system. Can't Bill.");
-                return ;
-            }
+        if (getPatient() != null && getPatient().isBlacklisted()) {
+            JsfUtil.addErrorMessage("This patient is blacklisted from the system. Can't Bill.");
+            return;
         }
 
 //        if (checkAllBillItem()) {

--- a/src/main/java/com/divudi/bean/pharmacy/RetailSaleNativeSqlController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/RetailSaleNativeSqlController.java
@@ -270,15 +270,10 @@ public class RetailSaleNativeSqlController implements Serializable, ControllerWi
             }
         }
 
-        if (configOptionApplicationController.getBooleanValueByKey(
-                "Enable blacklist patient management in the system", false)
-                && configOptionApplicationController.getBooleanValueByKey(
-                        "Enable blacklist patient management for Pharmacy from the system", false)) {
-            if (getPatient().isBlacklisted()) {
-                billSettlingStarted = false;
-                JsfUtil.addErrorMessage("This patient is blacklisted from the system. Can't Bill.");
-                return null;
-            }
+        if (getPatient().isBlacklisted()) {
+            billSettlingStarted = false;
+            JsfUtil.addErrorMessage("This patient is blacklisted from the system. Can't Bill.");
+            return null;
         }
 
         if (configOptionApplicationController.getBooleanValueByKey(

--- a/src/main/java/com/divudi/core/data/Privileges.java
+++ b/src/main/java/com/divudi/core/data/Privileges.java
@@ -485,6 +485,7 @@ public enum Privileges {
     ClinicalMembershipAdd("Clinical Membership Add"),
     ClinicalMembershipEdit("Clinical Membership Edit"),
     ClinicalPatientPhoneNumberEdit("Clinical Patient Phone Number Edit"),
+    ClinicalPatientBlacklist("Clinical Patient Blacklist"),
     //</editor-fold>
 
     //<editor-fold defaultstate="collapsed" desc="Pharmacy">

--- a/src/main/webapp/channel/channel_booking_by_month.xhtml
+++ b/src/main/webapp/channel/channel_booking_by_month.xhtml
@@ -590,7 +590,7 @@
                                                                         <p:outputLabel value="#{bookingControllerViewScopeMonth.patient.person.nameWithTitle}" rendered="#{not empty bookingControllerViewScopeMonth.patient.person.nameWithTitle}" />
                                                                     </p:badge> 
 
-                                                                    <p:badge rendered="#{configOptionApplicationController.getBooleanValueByKey('Enable blacklist patient management in the system') and configOptionApplicationController.getBooleanValueByKey('Enable blacklist patient management for OPD from the system', false)}" style="transform: translate(110%, -40%);background-color: #{bookingControllerViewScopeMonth.patient.blacklisted ? 'black' : 'white'} ; font-style: italic; font-size: 15px" value="X #{bookingControllerViewScopeMonth.patient.blacklisted ? 'Blacklisted' : 'Active'}" severity="danger">
+                                                                    <p:badge style="transform: translate(110%, -40%);background-color: #{bookingControllerViewScopeMonth.patient.blacklisted ? 'black' : 'white'} ; font-style: italic; font-size: 15px" value="X #{bookingControllerViewScopeMonth.patient.blacklisted ? 'Blacklisted' : 'Active'}" severity="danger">
 
                                                                     </p:badge>
 

--- a/src/main/webapp/inward/inward_appointment_edit.xhtml
+++ b/src/main/webapp/inward/inward_appointment_edit.xhtml
@@ -447,7 +447,7 @@
                                                             <p:outputLabel value="#{appointmentController.patient.person.nameWithTitle}" rendered="#{not empty appointmentController.patient.person.nameWithTitle}" />
                                                         </p:badge> 
 
-                                                        <p:badge rendered="#{configOptionApplicationController.getBooleanValueByKey('Enable blacklist patient management in the system')}" style="transform: translate(110%, -40%);background-color: #{appointmentController.patient.blacklisted ? 'black' : 'white'} ; font-style: italic; font-size: 15px" value="X #{appointmentController.patient.blacklisted ? 'Blacklisted' : 'Active'}" severity="danger">
+                                                        <p:badge style="transform: translate(110%, -40%);background-color: #{appointmentController.patient.blacklisted ? 'black' : 'white'} ; font-style: italic; font-size: 15px" value="X #{appointmentController.patient.blacklisted ? 'Blacklisted' : 'Active'}" severity="danger">
 
                                                         </p:badge>
 

--- a/src/main/webapp/inward/inward_change_patient.xhtml
+++ b/src/main/webapp/inward/inward_change_patient.xhtml
@@ -247,7 +247,7 @@
                                                 <p:outputLabel value="#{admissionPatientChangeController.current.patient.person.nameWithTitle}" rendered="#{not empty admissionPatientChangeController.current.patient.person.nameWithTitle}" />
                                             </p:badge>
 
-                                            <p:badge rendered="#{configOptionApplicationController.getBooleanValueByKey('Enable blacklist patient management in the system') and configOptionApplicationController.getBooleanValueByKey('Enable blacklist patient management for Inward from the system', false)}" style="transform: translate(110%, -40%);background-color: #{admissionPatientChangeController.current.patient.blacklisted ? 'black' : 'white'} ; font-style: italic; font-size: 15px" value="X #{admissionPatientChangeController.current.patient.blacklisted ? 'Blacklisted' : 'Active'}" severity="danger">
+                                            <p:badge style="transform: translate(110%, -40%);background-color: #{admissionPatientChangeController.current.patient.blacklisted ? 'black' : 'white'} ; font-style: italic; font-size: 15px" value="X #{admissionPatientChangeController.current.patient.blacklisted ? 'Blacklisted' : 'Active'}" severity="danger">
 
                                             </p:badge>
 

--- a/src/main/webapp/opd/opd_bill.xhtml
+++ b/src/main/webapp/opd/opd_bill.xhtml
@@ -415,7 +415,7 @@
                                                             <p:outputLabel value="#{opdBillController.patient.person.nameWithTitle}" rendered="#{not empty opdBillController.patient.person.nameWithTitle}" />
                                                         </p:badge> 
 
-                                                        <p:badge rendered="#{configOptionApplicationController.getBooleanValueByKey('Enable blacklist patient management in the system') and configOptionApplicationController.getBooleanValueByKey('Enable blacklist patient management for OPD from the system', false)}" style="transform: translate(110%, -40%);background-color: #{opdBillController.patient.blacklisted ? 'black' : 'white'} ; font-style: italic; font-size: 15px" value="X #{opdBillController.patient.blacklisted ? 'Blacklisted' : 'Active'}" severity="danger">
+                                                        <p:badge style="transform: translate(110%, -40%);background-color: #{opdBillController.patient.blacklisted ? 'black' : 'white'} ; font-style: italic; font-size: 15px" value="X #{opdBillController.patient.blacklisted ? 'Blacklisted' : 'Active'}" severity="danger">
 
                                                         </p:badge>
 

--- a/src/main/webapp/opd/opd_bill_ac.xhtml
+++ b/src/main/webapp/opd/opd_bill_ac.xhtml
@@ -422,7 +422,7 @@
                                                             <p:outputLabel value="#{opdBillController.patient.person.nameWithTitle}" rendered="#{not empty opdBillController.patient.person.nameWithTitle}" />
                                                         </p:badge> 
 
-                                                        <p:badge rendered="#{configOptionApplicationController.getBooleanValueByKey('Enable blacklist patient management in the system') and configOptionApplicationController.getBooleanValueByKey('Enable blacklist patient management for OPD from the system', false)}" style="transform: translate(110%, -40%);background-color: #{opdBillController.patient.blacklisted ? 'black' : 'white'} ; font-style: italic; font-size: 15px" value="X #{opdBillController.patient.blacklisted ? 'Blacklisted' : 'Active'}" severity="danger">
+                                                        <p:badge style="transform: translate(110%, -40%);background-color: #{opdBillController.patient.blacklisted ? 'black' : 'white'} ; font-style: italic; font-size: 15px" value="X #{opdBillController.patient.blacklisted ? 'Blacklisted' : 'Active'}" severity="danger">
 
                                                         </p:badge>
 

--- a/src/main/webapp/opd/opd_bill_package.xhtml
+++ b/src/main/webapp/opd/opd_bill_package.xhtml
@@ -436,7 +436,7 @@
                                                                 <p:outputLabel value="#{billPackageController.patient.person.nameWithTitle}" rendered="#{not empty billPackageController.patient.person.nameWithTitle}" />
                                                             </p:badge> 
 
-                                                            <p:badge rendered="#{configOptionApplicationController.getBooleanValueByKey('Enable blacklist patient management in the system') and configOptionApplicationController.getBooleanValueByKey('Enable blacklist patient management for OPD from the system', false)}" style="transform: translate(110%, -40%);background-color: #{billPackageController.patient.blacklisted ? 'black' : 'white'} ; font-style: italic; font-size: 15px" value="X #{billPackageController.patient.blacklisted ? 'Blacklisted' : 'Active'}" severity="danger">
+                                                            <p:badge style="transform: translate(110%, -40%);background-color: #{billPackageController.patient.blacklisted ? 'black' : 'white'} ; font-style: italic; font-size: 15px" value="X #{billPackageController.patient.blacklisted ? 'Blacklisted' : 'Active'}" severity="danger">
 
                                                             </p:badge>
 

--- a/src/main/webapp/opd/patient.xhtml
+++ b/src/main/webapp/opd/patient.xhtml
@@ -89,7 +89,7 @@
                                                             <p:outputLabel value="#{patientController.current.person.nameWithTitle}" rendered="#{not empty patientController.current.person.nameWithTitle}" />
                                                         </p:badge> 
 
-                                                        <p:badge rendered="#{configOptionApplicationController.getBooleanValueByKey('Enable blacklist patient management in the system')}" style="transform: translate(110%, -40%);background-color: #{patientController.current.blacklisted ? 'black' : 'white'} ; font-style: italic; font-size: 15px" value="X #{patientController.current.blacklisted ? 'Blacklisted' : 'Active'}" severity="danger">
+                                                        <p:badge style="transform: translate(110%, -40%);background-color: #{patientController.current.blacklisted ? 'black' : 'white'} ; font-style: italic; font-size: 15px" value="X #{patientController.current.blacklisted ? 'Blacklisted' : 'Active'}" severity="danger">
 
                                                         </p:badge>
                                                     </h:panelGroup>
@@ -447,7 +447,7 @@
                                         <p:commandButton
                                             value="Blacklist Patient"
                                             ajax="true"
-                                            rendered="#{!patientController.current.blacklisted and configOptionApplicationController.getBooleanValueByKey('Enable blacklist patient management in the system', false)}"
+                                            rendered="#{!patientController.current.blacklisted and webUserController.hasPrivilege('ClinicalPatientBlacklist')}"
                                             styleClass="ui-button-danger"
                                             style="min-width: 180px"
                                             icon="pi pi-ban"
@@ -458,7 +458,7 @@
                                         <p:commandButton
                                             value="Revert Blacklist"
                                             ajax="true"
-                                            rendered="#{patientController.current.blacklisted and configOptionApplicationController.getBooleanValueByKey('Enable blacklist patient management in the system', false)}"
+                                            rendered="#{patientController.current.blacklisted and webUserController.hasPrivilege('ClinicalPatientBlacklist')}"
                                             styleClass="ui-button-warning"
                                             style="min-width: 180px"
                                             icon="pi pi-ban"

--- a/src/main/webapp/opd/patient_search.xhtml
+++ b/src/main/webapp/opd/patient_search.xhtml
@@ -146,7 +146,7 @@
 
                                 </div>
                                 
-                                <div class="mb-3" style="display: #{configOptionApplicationController.getBooleanValueByKey('Enable blacklist patient management in the system') ? 'block' : 'none'}">
+                                <div class="mb-3">
                                     <h:outputLabel class="form form-label" value="Patient Active Status" ></h:outputLabel><br></br>
                                     <p:selectBooleanButton class="w-100" value="#{patientController.blackListStatus}" onLabel="Blacklist" onIcon="pi pi-times" offLabel="Active" offIcon="pi pi-check"/>
 

--- a/src/main/webapp/pharmacy/pharmacy_bill_retail_sale.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_bill_retail_sale.xhtml
@@ -882,7 +882,7 @@
                                                                     <p:outputLabel value="#{pharmacySaleController.patient.person.nameWithTitle}" rendered="#{not empty pharmacySaleController.patient.person.nameWithTitle}" />
                                                                 </p:badge> 
 
-                                                                <p:badge rendered="#{configOptionApplicationController.getBooleanValueByKey('Enable blacklist patient management in the system', false) and configOptionApplicationController.getBooleanValueByKey('Enable blacklist patient management for Pharmacy from the system', false)}" style="transform: translate(110%, -40%);background-color: #{pharmacySaleController.patient.blacklisted ? 'black' : 'white'} ; font-style: italic; font-size: 15px" value="X #{pharmacySaleController.patient.blacklisted ? 'Blacklisted' : 'Active'}" severity="danger">
+                                                                <p:badge style="transform: translate(110%, -40%);background-color: #{pharmacySaleController.patient.blacklisted ? 'black' : 'white'} ; font-style: italic; font-size: 15px" value="X #{pharmacySaleController.patient.blacklisted ? 'Blacklisted' : 'Active'}" severity="danger">
 
                                                                 </p:badge>
 

--- a/src/main/webapp/pharmacy/pharmacy_bill_retail_sale_1.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_bill_retail_sale_1.xhtml
@@ -880,7 +880,7 @@
                                                                     <p:outputLabel value="#{pharmacySaleController1.patient.person.nameWithTitle}" rendered="#{not empty pharmacySaleController1.patient.person.nameWithTitle}" />
                                                                 </p:badge> 
 
-                                                                <p:badge rendered="#{configOptionApplicationController.getBooleanValueByKey('Enable blacklist patient management in the system')}" style="transform: translate(110%, -40%);background-color: #{pharmacySaleController1.patient.blacklisted ? 'black' : 'white'} ; font-style: italic; font-size: 15px" value="X #{pharmacySaleController1.patient.blacklisted ? 'Blacklisted' : 'Active'}" severity="danger">
+                                                                <p:badge style="transform: translate(110%, -40%);background-color: #{pharmacySaleController1.patient.blacklisted ? 'black' : 'white'} ; font-style: italic; font-size: 15px" value="X #{pharmacySaleController1.patient.blacklisted ? 'Blacklisted' : 'Active'}" severity="danger">
 
                                                                 </p:badge>
 

--- a/src/main/webapp/pharmacy/pharmacy_bill_retail_sale_2.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_bill_retail_sale_2.xhtml
@@ -878,7 +878,7 @@
                                                                     <p:outputLabel value="#{pharmacySaleController2.patient.person.nameWithTitle}" rendered="#{not empty pharmacySaleController2.patient.person.nameWithTitle}" />
                                                                 </p:badge> 
 
-                                                                <p:badge rendered="#{configOptionApplicationController.getBooleanValueByKey('Enable blacklist patient management in the system') and configOptionApplicationController.getBooleanValueByKey('Enable blacklist patient management for Pharmacy from the system')}" style="transform: translate(110%, -40%);background-color: #{pharmacySaleController2.patient.blacklisted ? 'black' : 'white'} ; font-style: italic; font-size: 15px" value="X #{pharmacySaleController2.patient.blacklisted ? 'Blacklisted' : 'Active'}" severity="danger">
+                                                                <p:badge style="transform: translate(110%, -40%);background-color: #{pharmacySaleController2.patient.blacklisted ? 'black' : 'white'} ; font-style: italic; font-size: 15px" value="X #{pharmacySaleController2.patient.blacklisted ? 'Blacklisted' : 'Active'}" severity="danger">
 
                                                                 </p:badge>
 

--- a/src/main/webapp/pharmacy/pharmacy_bill_retail_sale_3.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_bill_retail_sale_3.xhtml
@@ -880,7 +880,7 @@
                                                                     <p:outputLabel value="#{pharmacySaleController3.patient.person.nameWithTitle}" rendered="#{not empty pharmacySaleController3.patient.person.nameWithTitle}" />
                                                                 </p:badge> 
 
-                                                                <p:badge rendered="#{configOptionApplicationController.getBooleanValueByKey('Enable blacklist patient management in the system') and configOptionApplicationController.getBooleanValueByKey('Enable blacklist patient management for Pharmacy from the system', false)}" style="transform: translate(110%, -40%);background-color: #{pharmacySaleController3.patient.blacklisted ? 'black' : 'white'} ; font-style: italic; font-size: 15px" value="X #{pharmacySaleController3.patient.blacklisted ? 'Blacklisted' : 'Active'}" severity="danger">
+                                                                <p:badge style="transform: translate(110%, -40%);background-color: #{pharmacySaleController3.patient.blacklisted ? 'black' : 'white'} ; font-style: italic; font-size: 15px" value="X #{pharmacySaleController3.patient.blacklisted ? 'Blacklisted' : 'Active'}" severity="danger">
 
                                                                 </p:badge>
 

--- a/src/main/webapp/pharmacy/pharmacy_fast_retail_sale.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_fast_retail_sale.xhtml
@@ -734,7 +734,7 @@
                                                                         <p:outputLabel value="#{pharmacyFastRetailSaleController.patient.person.nameWithTitle}" rendered="#{not empty pharmacyFastRetailSaleController.patient.person.nameWithTitle}" />
                                                                     </p:badge> 
 
-                                                                    <p:badge rendered="#{configOptionApplicationController.getBooleanValueByKey('Enable blacklist patient management in the system') and configOptionApplicationController.getBooleanValueByKey('Enable blacklist patient management for Pharmacy from the system', false)}" style="transform: translate(110%, -40%);background-color: #{pharmacyFastRetailSaleController.patient.blacklisted ? 'black' : 'white'} ; font-style: italic; font-size: 15px" value="X #{pharmacyFastRetailSaleController.patient.blacklisted ? 'Blacklisted' : 'Active'}" severity="danger">
+                                                                    <p:badge style="transform: translate(110%, -40%);background-color: #{pharmacyFastRetailSaleController.patient.blacklisted ? 'black' : 'white'} ; font-style: italic; font-size: 15px" value="X #{pharmacyFastRetailSaleController.patient.blacklisted ? 'Blacklisted' : 'Active'}" severity="danger">
 
                                                                     </p:badge>
 

--- a/src/main/webapp/pharmacy/pharmacy_fast_retail_sale_1.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_fast_retail_sale_1.xhtml
@@ -729,7 +729,7 @@
                                                                         <p:outputLabel value="#{pharmacyFastRetailSaleController1.patient.person.nameWithTitle}" rendered="#{not empty pharmacyFastRetailSaleController1.patient.person.nameWithTitle}" />
                                                                     </p:badge> 
 
-                                                                    <p:badge rendered="#{configOptionApplicationController.getBooleanValueByKey('Enable blacklist patient management in the system') and configOptionApplicationController.getBooleanValueByKey('Enable blacklist patient management for Pharmacy from the system', false)}" style="transform: translate(110%, -40%);background-color: #{pharmacyFastRetailSaleController1.patient.blacklisted ? 'black' : 'white'} ; font-style: italic; font-size: 15px" value="X #{pharmacyFastRetailSaleController1.patient.blacklisted ? 'Blacklisted' : 'Active'}" severity="danger">
+                                                                    <p:badge style="transform: translate(110%, -40%);background-color: #{pharmacyFastRetailSaleController1.patient.blacklisted ? 'black' : 'white'} ; font-style: italic; font-size: 15px" value="X #{pharmacyFastRetailSaleController1.patient.blacklisted ? 'Blacklisted' : 'Active'}" severity="danger">
 
                                                                     </p:badge>
 

--- a/src/main/webapp/pharmacy/pharmacy_fast_retail_sale_2.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_fast_retail_sale_2.xhtml
@@ -731,7 +731,7 @@
                                                                         <p:outputLabel value="#{pharmacyFastRetailSaleController2.patient.person.nameWithTitle}" rendered="#{not empty pharmacyFastRetailSaleController2.patient.person.nameWithTitle}" />
                                                                     </p:badge> 
 
-                                                                    <p:badge rendered="#{configOptionApplicationController.getBooleanValueByKey('Enable blacklist patient management in the system') and configOptionApplicationController.getBooleanValueByKey('Enable blacklist patient management for Pharmacy from the system', false)}" style="transform: translate(110%, -40%);background-color: #{pharmacyFastRetailSaleController2.patient.blacklisted ? 'black' : 'white'} ; font-style: italic; font-size: 15px" value="X #{pharmacyFastRetailSaleController2.patient.blacklisted ? 'Blacklisted' : 'Active'}" severity="danger">
+                                                                    <p:badge style="transform: translate(110%, -40%);background-color: #{pharmacyFastRetailSaleController2.patient.blacklisted ? 'black' : 'white'} ; font-style: italic; font-size: 15px" value="X #{pharmacyFastRetailSaleController2.patient.blacklisted ? 'Blacklisted' : 'Active'}" severity="danger">
 
                                                                     </p:badge>
 

--- a/src/main/webapp/pharmacy/pharmacy_fast_retail_sale_3.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_fast_retail_sale_3.xhtml
@@ -732,7 +732,7 @@
                                                                         <p:outputLabel value="#{pharmacyFastRetailSaleController3.patient.person.nameWithTitle}" rendered="#{not empty pharmacyFastRetailSaleController3.patient.person.nameWithTitle}" />
                                                                     </p:badge> 
 
-                                                                    <p:badge rendered="#{configOptionApplicationController.getBooleanValueByKey('Enable blacklist patient management in the system') and configOptionApplicationController.getBooleanValueByKey('Enable blacklist patient management for Pharmacy from the system', false)}" style="transform: translate(110%, -40%);background-color: #{pharmacyFastRetailSaleController3.patient.blacklisted ? 'black' : 'white'} ; font-style: italic; font-size: 15px" value="X #{pharmacyFastRetailSaleController3.patient.blacklisted ? 'Blacklisted' : 'Active'}" severity="danger">
+                                                                    <p:badge style="transform: translate(110%, -40%);background-color: #{pharmacyFastRetailSaleController3.patient.blacklisted ? 'black' : 'white'} ; font-style: italic; font-size: 15px" value="X #{pharmacyFastRetailSaleController3.patient.blacklisted ? 'Blacklisted' : 'Active'}" severity="danger">
 
                                                                     </p:badge>
 

--- a/src/main/webapp/pharmacy/pharmacy_fast_retail_sale_for_cashier.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_fast_retail_sale_for_cashier.xhtml
@@ -729,7 +729,7 @@
                                                                         <p:outputLabel value="#{pharmacyFastRetailSaleForCashierController.patient.person.nameWithTitle}" rendered="#{not empty pharmacyFastRetailSaleForCashierController.patient.person.nameWithTitle}" />
                                                                     </p:badge> 
 
-                                                                    <p:badge rendered="#{configOptionApplicationController.getBooleanValueByKey('Enable blacklist patient management in the system') and configOptionApplicationController.getBooleanValueByKey('Enable blacklist patient management for Pharmacy from the system', false)}" style="transform: translate(110%, -40%);background-color: #{pharmacyFastRetailSaleForCashierController.patient.blacklisted ? 'black' : 'white'} ; font-style: italic; font-size: 15px" value="X #{pharmacyFastRetailSaleForCashierController.patient.blacklisted ? 'Blacklisted' : 'Active'}" severity="danger">
+                                                                    <p:badge style="transform: translate(110%, -40%);background-color: #{pharmacyFastRetailSaleForCashierController.patient.blacklisted ? 'black' : 'white'} ; font-style: italic; font-size: 15px" value="X #{pharmacyFastRetailSaleForCashierController.patient.blacklisted ? 'Blacklisted' : 'Active'}" severity="danger">
 
                                                                     </p:badge>
 

--- a/src/main/webapp/resources/ezcomp/common/patient_details.xhtml
+++ b/src/main/webapp/resources/ezcomp/common/patient_details.xhtml
@@ -371,7 +371,7 @@
                                     <p:outputLabel value="#{cc.attrs.controller.patient.person.nameWithTitle}" rendered="#{not empty cc.attrs.controller.patient.person.nameWithTitle}" />
                                 </p:badge> 
 
-                                <p:badge rendered="#{configOptionApplicationController.getBooleanValueByKey('Enable blacklist patient management in the system')}" style="transform: translate(110%, -40%);background-color: #{cc.attrs.controller.patient.blacklisted ? 'black' : 'white'} ; font-style: italic; font-size: 15px" value="X #{cc.attrs.controller.patient.blacklisted ? 'Blacklisted' : 'Active'}" severity="danger">
+                                <p:badge style="transform: translate(110%, -40%);background-color: #{cc.attrs.controller.patient.blacklisted ? 'black' : 'white'} ; font-style: italic; font-size: 15px" value="X #{cc.attrs.controller.patient.blacklisted ? 'Blacklisted' : 'Active'}" severity="danger">
 
                                 </p:badge>
 

--- a/src/main/webapp/resources/ezcomp/common/patient_details_for_addmission.xhtml
+++ b/src/main/webapp/resources/ezcomp/common/patient_details_for_addmission.xhtml
@@ -397,7 +397,7 @@
                                     <p:outputLabel value="#{cc.attrs.controller.patient.person.nameWithTitle}" rendered="#{not empty cc.attrs.controller.patient.person.nameWithTitle}" />
                                 </p:badge> 
 
-                                <p:badge rendered="#{configOptionApplicationController.getBooleanValueByKey('Enable blacklist patient management in the system')}" style="transform: translate(110%, -40%);background-color: #{cc.attrs.controller.patient.blacklisted ? 'black' : 'white'} ; font-style: italic; font-size: 15px" value="X #{cc.attrs.controller.patient.blacklisted ? 'Blacklisted' : 'Active'}" severity="danger">
+                                <p:badge style="transform: translate(110%, -40%);background-color: #{cc.attrs.controller.patient.blacklisted ? 'black' : 'white'} ; font-style: italic; font-size: 15px" value="X #{cc.attrs.controller.patient.blacklisted ? 'Blacklisted' : 'Active'}" severity="danger">
 
                                 </p:badge>
 

--- a/src/main/webapp/resources/ezcomp/common/patient_details_for_appoiment.xhtml
+++ b/src/main/webapp/resources/ezcomp/common/patient_details_for_appoiment.xhtml
@@ -391,7 +391,7 @@
                                     <p:outputLabel value="#{cc.attrs.controller.patient.person.nameWithTitle}" rendered="#{not empty cc.attrs.controller.patient.person.nameWithTitle}" />
                                 </p:badge> 
 
-                                <p:badge rendered="#{configOptionApplicationController.getBooleanValueByKey('Enable blacklist patient management in the system')}" style="transform: translate(110%, -40%);background-color: #{cc.attrs.controller.patient.blacklisted ? 'black' : 'white'} ; font-style: italic; font-size: 15px" value="X #{cc.attrs.controller.patient.blacklisted ? 'Blacklisted' : 'Active'}" severity="danger">
+                                <p:badge style="transform: translate(110%, -40%);background-color: #{cc.attrs.controller.patient.blacklisted ? 'black' : 'white'} ; font-style: italic; font-size: 15px" value="X #{cc.attrs.controller.patient.blacklisted ? 'Blacklisted' : 'Active'}" severity="danger">
 
                                 </p:badge>
 

--- a/src/main/webapp/resources/ezcomp/common/patient_details_view_scope.xhtml
+++ b/src/main/webapp/resources/ezcomp/common/patient_details_view_scope.xhtml
@@ -342,7 +342,7 @@
                                     <p:outputLabel value="#{cc.attrs.controller.patient.person.nameWithTitle}" rendered="#{not empty cc.attrs.controller.patient.person.nameWithTitle}" />
                                 </p:badge> 
 
-                                <p:badge rendered="#{configOptionApplicationController.getBooleanValueByKey('Enable blacklist patient management in the system') and configOptionApplicationController.getBooleanValueByKey('Enable blacklist patient management for Channeling from the system')}" style="transform: translate(110%, -40%);background-color: #{cc.attrs.controller.patient.blacklisted ? 'black' : 'white'} ; font-style: italic; font-size: 15px" value="X #{cc.attrs.controller.patient.blacklisted ? 'Blacklisted' : 'Active'}" severity="danger">
+                                <p:badge style="transform: translate(110%, -40%);background-color: #{cc.attrs.controller.patient.blacklisted ? 'black' : 'white'} ; font-style: italic; font-size: 15px" value="X #{cc.attrs.controller.patient.blacklisted ? 'Blacklisted' : 'Active'}" severity="danger">
 
                                 </p:badge>
 

--- a/src/main/webapp/resources/ezcomp/emr/patient.xhtml
+++ b/src/main/webapp/resources/ezcomp/emr/patient.xhtml
@@ -28,7 +28,7 @@
                             <p:outputLabel value="#{cc.attrs.patient.person.nameWithTitle}" rendered="#{not empty cc.attrs.patient.person.nameWithTitle}" />
                         </p:badge> 
 
-                        <p:badge rendered="#{configOptionApplicationController.getBooleanValueByKey('Enable blacklist patient management in the system') and configOptionApplicationController.getBooleanValueByKey('Enable blacklist patient management for OPD from the system', false)}" style="transform: translate(110%, -40%);background-color: #{cc.attrs.patient.blacklisted ? 'black' : 'white'} ; font-style: italic; font-size: 15px" value="X #{cc.attrs.patient.blacklisted ? 'Blacklisted' : 'Active'}" severity="danger">
+                        <p:badge style="transform: translate(110%, -40%);background-color: #{cc.attrs.patient.blacklisted ? 'black' : 'white'} ; font-style: italic; font-size: 15px" value="X #{cc.attrs.patient.blacklisted ? 'Blacklisted' : 'Active'}" severity="danger">
 
                         </p:badge>
 


### PR DESCRIPTION
## Summary

- **Always-on blacklist**: removed all `configOptionApplicationController.getBooleanValueByKey('Enable blacklist patient management...')` gates across 23 Java controllers and 19 XHTML files — the feature is now unconditionally active across OPD, Pharmacy, Inward, Channeling, and all patient badge displays
- **New privilege `ClinicalPatientBlacklist`**: the "Blacklist Patient" and "Revert Blacklist" buttons on the patient profile page are hidden unless the logged-in user holds this privilege; all other UI (badges, warnings at billing time) remains visible to all users
- **Privilege tree registration**: `ClinicalPatientBlacklist` added to `UserPrivilageController` under the Clinical patient node so administrators can assign it via the User Privileges admin page
- **Audit events**: `PatientController.toggleBlacklistPatient()` now records a "Blacklist Patient" or "Revert Patient Blacklist" audit event with before/after JSON (patient ID + reason), visible in `all_audit_events.xhtml`

## Test plan

- [ ] Log in as a user without `ClinicalPatientBlacklist` — confirm Blacklist/Revert buttons are not visible on patient profile; badges still show correctly
- [ ] Log in as a user with `ClinicalPatientBlacklist` — confirm both buttons appear and the modal works
- [ ] Blacklist a patient, verify warning fires at OPD billing and channeling booking
- [ ] Revert the blacklist, verify billing proceeds normally
- [ ] Check Administration > Audit Events — confirm "Blacklist Patient" and "Revert Patient Blacklist" entries appear with correct user, timestamp, and reason
- [ ] Verify `ClinicalPatientBlacklist` is visible and assignable in Administration > User Privileges > Clinical

Closes #20764

🤖 Generated with [Claude Code](https://claude.com/claude-code)
