### PR TITLE
feat(patient): blacklist warning dialog on Save in patient edit page

### DIFF
--- a/src/main/java/com/divudi/bean/common/PatientController.java
+++ b/src/main/java/com/divudi/bean/common/PatientController.java
@@ -3326,10 +3326,12 @@ public class PatientController implements Serializable, ControllerWithPatient {
         }
     }
 
-    public void checkBeforeSaveAndGoToAdmission() {
+    public String checkBeforeSaveAndGoToAdmission() {
         if (current != null && current.getId() != null && current.isBlacklisted()) {
             PrimeFaces.current().executeScript("PF('dlgBlacklistSaveAdmissionWarning').show();");
+            return null;
         }
+        return saveAndNavigateToAdmissionProfile();
     }
 
     public String saveAndNavigateToOpdPatientProfile() {

--- a/src/main/java/com/divudi/bean/common/PatientController.java
+++ b/src/main/java/com/divudi/bean/common/PatientController.java
@@ -102,6 +102,7 @@ import net.sourceforge.barbecue.Barcode;
 import net.sourceforge.barbecue.BarcodeFactory;
 import net.sourceforge.barbecue.BarcodeImageHandler;
 import org.apache.commons.lang3.StringUtils;
+import org.primefaces.PrimeFaces;
 import org.primefaces.context.PrimeRequestContext;
 import org.primefaces.event.CaptureEvent;
 import org.primefaces.event.FileUploadEvent;
@@ -3305,6 +3306,30 @@ public class PatientController implements Serializable, ControllerWithPatient {
             return null;
         }
         return "/membership/add_family?faces-redirect=true";
+    }
+
+    public void checkBeforeSavePatient() {
+        if (current != null && current.getId() != null && current.isBlacklisted()) {
+            PrimeFaces.current().executeScript("PF('dlgBlacklistSaveWarning').show();");
+            return;
+        }
+        boolean savedSuccessfully = saveSelected(current);
+        if (!savedSuccessfully) {
+            return;
+        }
+        try {
+            javax.faces.context.ExternalContext ec = FacesContext.getCurrentInstance().getExternalContext();
+            ec.redirect(ec.getRequestContextPath() + "/faces/opd/patient");
+            FacesContext.getCurrentInstance().responseComplete();
+        } catch (java.io.IOException e) {
+            JsfUtil.addErrorMessage("Saved but could not redirect.");
+        }
+    }
+
+    public void checkBeforeSaveAndGoToAdmission() {
+        if (current != null && current.getId() != null && current.isBlacklisted()) {
+            PrimeFaces.current().executeScript("PF('dlgBlacklistSaveAdmissionWarning').show();");
+        }
     }
 
     public String saveAndNavigateToOpdPatientProfile() {

--- a/src/main/webapp/opd/patient_edit.xhtml
+++ b/src/main/webapp/opd/patient_edit.xhtml
@@ -56,7 +56,7 @@
                                                 value="Inpatient Dashboard"
                                                 rendered="#{admissionController.current ne null and admissionController.current.id ne null}"
                                                 action="#{patientController.checkBeforeSaveAndGoToAdmission()}"
-                                                update="@form"
+                                                ajax="false"
                                                 icon="fa fa-hospital-o"
                                                 iconPos="left"
                                                 class="ui-button-info m-1" />

--- a/src/main/webapp/opd/patient_edit.xhtml
+++ b/src/main/webapp/opd/patient_edit.xhtml
@@ -26,21 +26,21 @@
                                         </div>
 
                                         <div class="">
-                                            <p:commandButton 
-                                                value="Save" 
-                                                action="#{patientController.saveAndNavigateToOpdPatientProfile()}"
-                                                ajax="false" 
-                                                icon="pi pi-check" 
-                                                iconPos="left" 
+                                            <p:commandButton
+                                                value="Save"
+                                                action="#{patientController.checkBeforeSavePatient()}"
+                                                update="@form"
+                                                icon="pi pi-check"
+                                                iconPos="left"
                                                 class="ui-button-success m-1 " />
 
-                                            <p:commandButton 
-                                                value="Patient Profile" 
-                                                disabled="#{patientController.current eq null}" 
-                                                action="#{patientController.saveAndNavigateToOpdPatientProfile()}"
-                                                ajax="false" 
+                                            <p:commandButton
+                                                value="Patient Profile"
+                                                disabled="#{patientController.current eq null}"
+                                                action="#{patientController.checkBeforeSavePatient()}"
+                                                update="@form"
                                                 icon="fa fa-user"
-                                                iconPos="left" 
+                                                iconPos="left"
                                                 class="ui-button-warning m-1 " />
 
                                             <p:commandButton
@@ -55,8 +55,8 @@
                                             <p:commandButton
                                                 value="Inpatient Dashboard"
                                                 rendered="#{admissionController.current ne null and admissionController.current.id ne null}"
-                                                action="#{patientController.saveAndNavigateToAdmissionProfile()}"
-                                                ajax="false"
+                                                action="#{patientController.checkBeforeSaveAndGoToAdmission()}"
+                                                update="@form"
                                                 icon="fa fa-hospital-o"
                                                 iconPos="left"
                                                 class="ui-button-info m-1" />
@@ -347,6 +347,76 @@
                                     </div>
                                 </div>
                             </p:panel>
+
+                            <!-- Blacklist Warning Dialog — Save and go to Patient Profile -->
+                            <p:dialog id="dlgBlacklistSaveWarning"
+                                      widgetVar="dlgBlacklistSaveWarning"
+                                      header="&#9888; Patient is Blacklisted"
+                                      modal="true"
+                                      resizable="false"
+                                      closable="true"
+                                      style="width:500px">
+                                <div style="padding:12px">
+                                    <p style="color:#b71c1c; font-weight:bold; font-size:1.1em;">
+                                        &#9888; WARNING: This patient is blacklisted.
+                                    </p>
+                                    <p>
+                                        Reason: <strong>#{patientController.current.reasonForBlacklist}</strong>
+                                    </p>
+                                    <p style="font-weight:bold;">
+                                        Are you sure you want to save changes to this blacklisted patient's record?
+                                    </p>
+                                    <div class="d-flex justify-content-end gap-2 mt-3">
+                                        <p:commandButton
+                                            value="Cancel"
+                                            icon="fa fa-times"
+                                            class="ui-button-secondary"
+                                            onclick="PF('dlgBlacklistSaveWarning').hide(); return false;" />
+                                        <p:commandButton
+                                            value="Yes, Save Anyway"
+                                            icon="fa fa-exclamation-triangle"
+                                            class="ui-button-danger"
+                                            action="#{patientController.saveAndNavigateToOpdPatientProfile()}"
+                                            ajax="false"
+                                            onclick="PF('dlgBlacklistSaveWarning').hide();" />
+                                    </div>
+                                </div>
+                            </p:dialog>
+
+                            <!-- Blacklist Warning Dialog — Save and go to Inpatient Dashboard -->
+                            <p:dialog id="dlgBlacklistSaveAdmissionWarning"
+                                      widgetVar="dlgBlacklistSaveAdmissionWarning"
+                                      header="&#9888; Patient is Blacklisted"
+                                      modal="true"
+                                      resizable="false"
+                                      closable="true"
+                                      style="width:500px">
+                                <div style="padding:12px">
+                                    <p style="color:#b71c1c; font-weight:bold; font-size:1.1em;">
+                                        &#9888; WARNING: This patient is blacklisted.
+                                    </p>
+                                    <p>
+                                        Reason: <strong>#{patientController.current.reasonForBlacklist}</strong>
+                                    </p>
+                                    <p style="font-weight:bold;">
+                                        Are you sure you want to save changes to this blacklisted patient's record?
+                                    </p>
+                                    <div class="d-flex justify-content-end gap-2 mt-3">
+                                        <p:commandButton
+                                            value="Cancel"
+                                            icon="fa fa-times"
+                                            class="ui-button-secondary"
+                                            onclick="PF('dlgBlacklistSaveAdmissionWarning').hide(); return false;" />
+                                        <p:commandButton
+                                            value="Yes, Save Anyway"
+                                            icon="fa fa-exclamation-triangle"
+                                            class="ui-button-danger"
+                                            action="#{patientController.saveAndNavigateToAdmissionProfile()}"
+                                            ajax="false"
+                                            onclick="PF('dlgBlacklistSaveAdmissionWarning').hide();" />
+                                    </div>
+                                </div>
+                            </p:dialog>
 
                         </h:form>
                     </h:panelGroup>


### PR DESCRIPTION
## Summary

- Save, Patient Profile, and Inpatient Dashboard buttons on `patient_edit.xhtml` now intercept the save via AJAX when the patient is blacklisted
- A modal warning dialog is shown with the blacklist reason, requiring the user to explicitly confirm before the save proceeds (matching the pattern used for duplicate admissions on the admission page)
- Non-blacklisted patients are completely unaffected — same behaviour as before

## Test plan

- [ ] Edit a non-blacklisted patient → Save works as before, redirects to patient profile
- [ ] Edit a blacklisted patient → clicking Save shows the warning dialog with the blacklist reason
- [ ] In the dialog, click Cancel → dialog closes, no save, user stays on edit page
- [ ] In the dialog, click "Yes, Save Anyway" → record saved, redirects to patient profile
- [ ] Same dialog behaviour for the Patient Profile button
- [ ] Same dialog behaviour for the Inpatient Dashboard button (when an active admission exists)

Closes #20765

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added blacklist validation with warning dialogs. When attempting to save patient data or navigate to the inpatient dashboard, users now receive a warning if the patient is blacklisted. The dialog displays the blacklist reason and allows users to proceed or cancel the operation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hmislk/hmis/pull/20796?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->