### PR TITLE
fix(cashier): rename Float Received to Net Float and show all transfers in details

### DIFF
--- a/src/main/java/com/divudi/bean/cashTransaction/FinancialTransactionController.java
+++ b/src/main/java/com/divudi/bean/cashTransaction/FinancialTransactionController.java
@@ -1393,17 +1393,15 @@ public class FinancialTransactionController implements Serializable {
         if (fundTransferPayments == null) {
             return;
         }
-        boolean isOut = floatBundle.getPaymentHandover() == PaymentHandover.FLOAT_OUT;
+        // The net float bundle (FLOAT_IN) represents received minus sent, so both
+        // FUND_TRANSFER_BILL (sent) and FUND_TRANSFER_RECEIVED_BILL (received) rows
+        // must appear so the user can see the full breakdown that produces the net value.
         for (Payment fp : fundTransferPayments) {
             if (fp.getBill() == null) {
                 continue;
             }
             BillTypeAtomic bta = fp.getBill().getBillTypeAtomic();
-            if (isOut && bta == BillTypeAtomic.FUND_TRANSFER_BILL) {
-                ReportTemplateRow row = new ReportTemplateRow();
-                row.setPayment(fp);
-                floatBundle.getReportTemplateRows().add(row);
-            } else if (!isOut && bta == BillTypeAtomic.FUND_TRANSFER_RECEIVED_BILL) {
+            if (bta == BillTypeAtomic.FUND_TRANSFER_BILL || bta == BillTypeAtomic.FUND_TRANSFER_RECEIVED_BILL) {
                 ReportTemplateRow row = new ReportTemplateRow();
                 row.setPayment(fp);
                 floatBundle.getReportTemplateRows().add(row);

--- a/src/main/java/com/divudi/core/data/PaymentHandover.java
+++ b/src/main/java/com/divudi/core/data/PaymentHandover.java
@@ -10,7 +10,7 @@ package com.divudi.core.data;
 public enum PaymentHandover {
     FLOATS("Floats"),
     FLOAT_OUT("Float Sent (Cash)"),
-    FLOAT_IN("Float Received (Cash)"),
+    FLOAT_IN("Net Float (Cash)"),
     USER_COLLECTED("Collected by User"),
     OTHER_USERS_COLLECTED_AND_HANDED_OVER("Collected by Other Users and Handed Over");
 

--- a/src/main/webapp/resources/ezcomp/prints/five_five_paper_with_headings_for_handover.xhtml
+++ b/src/main/webapp/resources/ezcomp/prints/five_five_paper_with_headings_for_handover.xhtml
@@ -390,7 +390,7 @@
                         <h:outputText value="#{summary.department.institution.name}" rendered="#{!summary.floatRow and (summary.paymentHandover == null or summary.paymentHandover.name() != 'FLOATS')}" />
                         <h:outputText value="Shift Shortage"        rendered="#{summary.paymentHandover ne null and summary.paymentHandover.name() eq 'FLOATS'}" style="color:#dc3545; font-style:italic;" />
                         <h:outputText value="Float Sent (Cash)"     rendered="#{summary.floatRow and summary.paymentHandover ne null and summary.paymentHandover.name() eq 'FLOAT_OUT'}" style="color: red; font-weight: bold;" />
-                        <h:outputText value="Float Received (Cash)" rendered="#{summary.floatRow and summary.paymentHandover ne null and summary.paymentHandover.name() eq 'FLOAT_IN'}"  style="color: green; font-weight: bold;" />
+                        <h:outputText value="Net Float (Cash)"      rendered="#{summary.floatRow and summary.paymentHandover ne null and summary.paymentHandover.name() eq 'FLOAT_IN'}"  style="color: green; font-weight: bold;" />
                     </p:column>
 
                     <p:column headerText="Site" rendered="#{configOptionApplicationController.getBooleanValueByKey('Sites are Managed',true)}">

--- a/src/main/webapp/resources/ezcomp/prints/five_five_paper_with_headings_for_handover_detail.xhtml
+++ b/src/main/webapp/resources/ezcomp/prints/five_five_paper_with_headings_for_handover_detail.xhtml
@@ -378,7 +378,7 @@
                         <h:outputText value="Float Sent (Cash)"
                             rendered="#{summary.floatRow and summary.paymentHandover ne null and summary.paymentHandover.name() eq 'FLOAT_OUT'}"
                             style="color: red; font-weight: bold;" />
-                        <h:outputText value="Float Received (Cash)"
+                        <h:outputText value="Net Float (Cash)"
                             rendered="#{summary.floatRow and summary.paymentHandover ne null and summary.paymentHandover.name() eq 'FLOAT_IN'}"
                             style="color: green; font-weight: bold;" />
                     </p:column>


### PR DESCRIPTION
## Summary

- Renames the **Float Received (Cash)** label to **Net Float (Cash)** everywhere it appears — the value has always been the net of received minus sent transfers, so the old label was misleading.
- Fixes the **View Details** drill-down on the Net Float row: previously only `FUND_TRANSFER_RECEIVED_BILL` (received) rows were shown; now both received and sent (`FUND_TRANSFER_BILL`) rows are included so the user can see the full breakdown that produces the net figure.
- Aligns the hardcoded label in the handover print and handover-detail print templates with the already-correct accept page and reprint templates.

## Changes

| File | Change |
|---|---|
| `PaymentHandover.java` | `FLOAT_IN` description: `"Float Received (Cash)"` → `"Net Float (Cash)"` |
| `FinancialTransactionController.java` | `populateFloatBundleRows`: include both `FUND_TRANSFER_BILL` and `FUND_TRANSFER_RECEIVED_BILL` |
| `five_five_paper_with_headings_for_handover.xhtml` | Hardcoded label updated to `Net Float (Cash)` |
| `five_five_paper_with_headings_for_handover_detail.xhtml` | Hardcoded label updated to `Net Float (Cash)` |

## Test plan

- [ ] Open Handover Current Shift — the float row now shows **Net Float (Cash)** instead of Float Received
- [ ] Click the eye icon on the Net Float row — the details page lists both sent and received fund transfers
- [ ] Verify the values of individual rows in the details page sum to the net figure shown in the parent row
- [ ] Print a handover slip — label shows Net Float (Cash) in the float section

Closes #20795

🤖 Generated with [Claude Code](https://claude.com/claude-code)