### PR TITLE
feat(cashier): restrict shift shortage bill search to own user with privilege override

### DIFF
--- a/src/main/java/com/divudi/bean/common/SearchController.java
+++ b/src/main/java/com/divudi/bean/common/SearchController.java
@@ -5920,6 +5920,27 @@ public class SearchController implements Serializable {
                 + " b.createdAt between :fromDate and :toDate "
                 + " and b.retired=false "
                 + " and b.billTypeAtomic=:bTA "
+                + " and b.billType=:bT "
+                + " and b.creater=:user ";
+
+        m.put("fromDate", fromDate);
+        m.put("toDate", toDate);
+        m.put("bTA", BillTypeAtomic.FUND_SHIFT_SHORTAGE_BILL);
+        m.put("bT", BillType.ShiftShortage);
+        m.put("user", sessionController.getLoggedUser());
+        bills = getBillFacade().findByJpql(sql, m, TemporalType.TIMESTAMP);
+    }
+
+    public void createAllShiftShortageBillsTable() {
+        bills = null;
+        bills = new ArrayList<>();
+        String sql;
+        Map m = new HashMap();
+
+        sql = "Select b From Bill b where "
+                + " b.createdAt between :fromDate and :toDate "
+                + " and b.retired=false "
+                + " and b.billTypeAtomic=:bTA "
                 + " and b.billType=:bT ";
 
         m.put("fromDate", fromDate);
@@ -5927,11 +5948,6 @@ public class SearchController implements Serializable {
         m.put("bTA", BillTypeAtomic.FUND_SHIFT_SHORTAGE_BILL);
         m.put("bT", BillType.ShiftShortage);
         bills = getBillFacade().findByJpql(sql, m, TemporalType.TIMESTAMP);
-
-        if (bills == null || bills.isEmpty()) {
-        } else {
-        }
-
     }
 
     public void createApprovedPharmacy() {

--- a/src/main/webapp/cashier/cashier_shift_bill_search.xhtml
+++ b/src/main/webapp/cashier/cashier_shift_bill_search.xhtml
@@ -46,9 +46,16 @@
                             </div>
                             <p:commandButton class="ui-button-success"
                                              icon="fas fa-search"
-                                             value="Search"
+                                             value="Search My Bills"
                                              action="#{searchController.createShiftShortageBillsTable()}"
                                              update="tb">
+                            </p:commandButton>
+                            <p:commandButton class="ui-button-warning mx-2"
+                                             icon="fas fa-users"
+                                             value="Search All Users"
+                                             action="#{searchController.createAllShiftShortageBillsTable()}"
+                                             update="tb"
+                                             rendered="#{webUserController.hasPrivilege('ViewAllShiftShortageBills')}">
                             </p:commandButton>
                         </h:panelGroup>
 
@@ -180,7 +187,9 @@
                             </p:column>
 
                             <p:column headerText="Actions">
-                                <p:commandButton icon="pi pi-wallet" styleClass="m-1" ajax="false" title="Manage Bill" action="#{billSearch.navigateToManageBillByAtomicBillType()}">
+                                <p:commandButton icon="pi pi-wallet" styleClass="m-1" ajax="false" title="Manage Bill"
+                                                 action="#{billSearch.navigateToManageBillByAtomicBillType()}"
+                                                 rendered="#{bill.creater.id == sessionController.loggedUser.id}">
                                     <f:setPropertyActionListener value="#{bill}" target="#{billSearch.bill}"/>
                                 </p:commandButton>
                                 <p:commandButton icon="pi pi-search" styleClass="m-1" ajax="false" title="View Bill" action="#{billSearch.navigateToViewBillByAtomicBillType()}">


### PR DESCRIPTION
## Summary

- Default **Search My Bills** button now filters shortage bills to the current logged-in user only
- New **Search All Users** button (privilege: `ViewAllShiftShortageBills`) lets supervisors/managers view all cashiers' shortage bills in a date range
- **Manage Bill** (settle/cancel) action button is now owner-only — hidden for other users' bills even when viewed via the all-users search

## Test plan

- [ ] As a regular cashier, Search My Bills returns only own shortage bills
- [ ] As a regular cashier, "Search All Users" button is not visible
- [ ] As a user with `ViewAllShiftShortageBills` privilege, "Search All Users" button appears and returns all users' bills
- [ ] In the all-users view, the wallet (Manage) button appears only on own bills — not on other cashiers' bills
- [ ] View (search) button works for all rows regardless of owner

🤖 Generated with [Claude Code](https://claude.com/claude-code)