### PR TITLE
fix(cashier): register ViewAllShiftShortageBills privilege enum

### DIFF
--- a/src/main/java/com/divudi/bean/common/UserPrivilageController.java
+++ b/src/main/java/com/divudi/bean/common/UserPrivilageController.java
@@ -884,6 +884,7 @@ public class UserPrivilageController implements Serializable {
         new DefaultTreeNode(new PrivilegeHolder(Privileges.CancelOwnFundTransfer, "Cancel Own Float Transfer"), floatTransferNode);
         new DefaultTreeNode(new PrivilegeHolder(Privileges.CancelOthersFundTransfer, "Cancel Others Float Transfer"), floatTransferNode);
         new DefaultTreeNode(new PrivilegeHolder(Privileges.ViewFundTransferReports, "View Float Transfer Reports"), floatTransferNode);
+        new DefaultTreeNode(new PrivilegeHolder(Privileges.ViewAllShiftShortageBills, "View All Shift Shortage Bills"), floatTransferNode);
 
         // Request Privileges
         TreeNode nurseNode = new DefaultTreeNode(new PrivilegeHolder(null, "Nursing Work Bench"), allNode);

--- a/src/main/java/com/divudi/core/data/Privileges.java
+++ b/src/main/java/com/divudi/core/data/Privileges.java
@@ -712,6 +712,7 @@ public enum Privileges {
     CancelOwnFundTransfer("Cancel Own Float Transfer"),
     CancelOthersFundTransfer("Cancel Others Float Transfer"),
     ViewFundTransferReports("View Float Transfer Reports"),
+    ViewAllShiftShortageBills("View All Shift Shortage Bills"),
     //</editor-fold>
 
     //<editor-fold defaultstate="collapsed" desc="Developers">
@@ -1034,6 +1035,7 @@ public enum Privileges {
             case CancelOwnFundTransfer:
             case CancelOthersFundTransfer:
             case ViewFundTransferReports:
+            case ViewAllShiftShortageBills:
                 return "Float Transfer";
 
             case NursingWorkBench:


### PR DESCRIPTION
## Summary

Fixes the Codex-identified issue from #20798: the `rendered` check for the "Search All Users" button used `hasPrivilege('ViewAllShiftShortageBills')`, but `hasPrivilege` resolves names via `Privileges.valueOf(...)` and catches `IllegalArgumentException` — returning `false` for any unknown constant. The privilege was never registered so the button was permanently hidden.

**Three required registration steps applied:**
- `Privileges.java` — added `ViewAllShiftShortageBills("View All Shift Shortage Bills")` enum constant in the Float Transfer group
- `Privileges.java` `getCategory()` — added `case ViewAllShiftShortageBills` returning `"Float Transfer"`
- `UserPrivilageController.java` — added tree node under `floatTransferNode` so the privilege appears in the admin UI

## Test plan

- [ ] Assign `ViewAllShiftShortageBills` to a test role in the admin UI — it should now appear under Float Transfer
- [ ] User with that privilege sees the "Search All Users" button on the Shift Shortage Bill Search page
- [ ] User without the privilege does not see the button

🤖 Generated with [Claude Code](https://claude.com/claude-code)