### PR TITLE
fix(handover): guard float rows from recalculation in calculateTotalsByChildBundles

### DIFF
--- a/src/main/java/com/divudi/core/data/ReportTemplateRowBundle.java
+++ b/src/main/java/com/divudi/core/data/ReportTemplateRowBundle.java
@@ -881,7 +881,7 @@ public class ReportTemplateRowBundle implements Serializable {
 
                 if (childBundle.isSelected() || selectAll) {
 
-                    if (forHandover) {
+                    if (forHandover && !childBundle.isFloatRow()) {
                         childBundle.calculateTotalsByPaymentsAndDenominationsForHandover();
                     }
 

--- a/src/main/java/com/divudi/core/data/ReportTemplateRowBundle.java
+++ b/src/main/java/com/divudi/core/data/ReportTemplateRowBundle.java
@@ -881,6 +881,12 @@ public class ReportTemplateRowBundle implements Serializable {
 
                 if (childBundle.isSelected() || selectAll) {
 
+                    // Float rows (FLOAT_OUT / FLOAT_IN) are synthetic bundles with no payment rows —
+                    // their cashValue/cashHandoverValue are set directly in generatePaymentBundleForHandovers()
+                    // and must not be recalculated. calculateTotalsByPaymentsAndDenominationsForHandover()
+                    // starts with resetTotalsAndFlags() which would zero cashValue permanently, since
+                    // there are no reportTemplateRows to re-accumulate from.
+                    // The same guard exists in calculateTotalsByChildBundlesForHandover().
                     if (forHandover && !childBundle.isFloatRow()) {
                         childBundle.calculateTotalsByPaymentsAndDenominationsForHandover();
                     }


### PR DESCRIPTION
## Summary

- Float rows (FLOAT_OUT / FLOAT_IN) in the shift handover were zeroed whenever `calculateTotalsBySelectedChildBundles()` was called — triggered by **Unselect All** on the payment selection page or any row checkbox on the main handover table.
- Root cause: `calculateTotalsByChildBundles(forHandover=true)` called `calculateTotalsByPaymentsAndDenominationsForHandover()` on synthetic float bundles, which have no `reportTemplateRows`, so `resetTotalsAndFlags()` zeroed their `cashValue` permanently.
- Fix: add `&& !childBundle.isFloatRow()` guard — the same protection already present in `calculateTotalsByChildBundlesForHandover()`.

## Change

`ReportTemplateRowBundle.java` — one character change on line ~884:

```java
// Before
if (forHandover) {
    childBundle.calculateTotalsByPaymentsAndDenominationsForHandover();
}

// After
if (forHandover && !childBundle.isFloatRow()) {
    childBundle.calculateTotalsByPaymentsAndDenominationsForHandover();
}
```

## Test plan

- [ ] Open Handover Current Shift for a shift that has float transactions and slips.
- [ ] Enter denominator values; confirm cash difference = 0 and float rows visible.
- [ ] Navigate to slip selection → select slips → Back to Shift Handover → verify floats intact.
- [ ] Navigate to slip selection again → click **Unselect All** → Back to Shift Handover → verify float rows still show correct values.
- [ ] Click **Update** button → verify float rows unchanged.
- [ ] Click any row checkbox on the main handover table → verify float rows unchanged.

Closes #20801

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed incorrect cash total calculations during handover operations that were previously being zeroed.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hmislk/hmis/pull/20802?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->