### PR TITLE
fix(migration): split inline PREPARE/EXECUTE/DEALLOCATE onto separate lines in v2.4.0

### DIFF
--- a/src/main/resources/db/migrations/v2.4.0/migration.sql
+++ b/src/main/resources/db/migrations/v2.4.0/migration.sql
@@ -53,7 +53,9 @@ SET @size_sql = CONCAT(
     'FROM INFORMATION_SCHEMA.TABLES ',
     'WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME IN (''', @pbi_table, ''',''', @bi_table, ''')'
 );
-PREPARE stmt FROM @size_sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+PREPARE stmt FROM @size_sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
 
 SELECT COUNT(*) AS pbi_existing_idx FROM INFORMATION_SCHEMA.STATISTICS
 WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = @pbi_table;
@@ -75,7 +77,9 @@ SET @sql = IF(@pbi_table IS NULL OR @idx_exists > 0,
     'SELECT "SKIPPED: table not found or index already exists" AS status',
     CONCAT('CREATE INDEX idx_pbi_createdat_retired ON ', @pbi_table, '(CREATEDAT, RETIRED)')
 );
-PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+PREPARE stmt FROM @sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
 
 SET @idx_exists = (SELECT COUNT(*) FROM INFORMATION_SCHEMA.STATISTICS
     WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = @pbi_table AND INDEX_NAME = 'idx_pbi_createdat_retired');
@@ -97,7 +101,9 @@ SET @sql = IF(@pbi_table IS NULL OR @idx_exists > 0,
     'SELECT "SKIPPED: table not found or index already exists" AS status',
     CONCAT('CREATE INDEX idx_pbi_stock_createdat ON ', @pbi_table, '(STOCK_ID, CREATEDAT, RETIRED)')
 );
-PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+PREPARE stmt FROM @sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
 
 SET @idx_exists = (SELECT COUNT(*) FROM INFORMATION_SCHEMA.STATISTICS
     WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = @pbi_table AND INDEX_NAME = 'idx_pbi_stock_createdat');
@@ -119,7 +125,9 @@ SET @sql = IF(@pbi_table IS NULL OR @idx_exists > 0,
     'SELECT "SKIPPED: table not found or index already exists" AS status',
     CONCAT('CREATE INDEX idx_pbi_batch_createdat ON ', @pbi_table, '(ITEMBATCH_ID, CREATEDAT, RETIRED)')
 );
-PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+PREPARE stmt FROM @sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
 
 SET @idx_exists = (SELECT COUNT(*) FROM INFORMATION_SCHEMA.STATISTICS
     WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = @pbi_table AND INDEX_NAME = 'idx_pbi_batch_createdat');
@@ -142,7 +150,9 @@ SET @sql = IF(@bi_table IS NULL OR @idx_exists = 0,
     'SELECT "SKIPPED: table not found or index already absent" AS status',
     CONCAT('ALTER TABLE ', @bi_table, ' DROP INDEX BILLITEM_BILLITEMSTATUS_idx')
 );
-PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+PREPARE stmt FROM @sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
 
 SET @idx_gone = (SELECT COUNT(*) FROM INFORMATION_SCHEMA.STATISTICS
     WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = @bi_table AND INDEX_NAME = 'BILLITEM_BILLITEMSTATUS_idx');

--- a/src/main/resources/db/migrations/v2.4.0/rollback.sql
+++ b/src/main/resources/db/migrations/v2.4.0/rollback.sql
@@ -14,19 +14,25 @@ SET @idx_exists = (SELECT COUNT(*) FROM INFORMATION_SCHEMA.STATISTICS
     WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = @pbi_table AND INDEX_NAME = 'idx_pbi_createdat_retired');
 SET @sql = IF(@pbi_table IS NULL OR @idx_exists = 0, 'SELECT 1',
     CONCAT('ALTER TABLE ', @pbi_table, ' DROP INDEX idx_pbi_createdat_retired'));
-PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+PREPARE stmt FROM @sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
 
 SET @idx_exists = (SELECT COUNT(*) FROM INFORMATION_SCHEMA.STATISTICS
     WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = @pbi_table AND INDEX_NAME = 'idx_pbi_stock_createdat');
 SET @sql = IF(@pbi_table IS NULL OR @idx_exists = 0, 'SELECT 1',
     CONCAT('ALTER TABLE ', @pbi_table, ' DROP INDEX idx_pbi_stock_createdat'));
-PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+PREPARE stmt FROM @sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
 
 SET @idx_exists = (SELECT COUNT(*) FROM INFORMATION_SCHEMA.STATISTICS
     WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = @pbi_table AND INDEX_NAME = 'idx_pbi_batch_createdat');
 SET @sql = IF(@pbi_table IS NULL OR @idx_exists = 0, 'SELECT 1',
     CONCAT('ALTER TABLE ', @pbi_table, ' DROP INDEX idx_pbi_batch_createdat'));
-PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+PREPARE stmt FROM @sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
 
 SELECT 'Rollback v2.4.0 completed — three idx_pbi_* indexes dropped' AS status;
 SELECT 'NOTE: BILLITEM_BILLITEMSTATUS_idx was 100% NULL and intentionally not restored' AS note;


### PR DESCRIPTION
## Summary

- Migration v2.4.0 failed with `You have an error in your SQL syntax... near 'EXECUTE stmt; DEALLOCATE PREPARE stmt' at line 1`
- Root cause: the migration executor splits SQL on semicolons per line and submits each fragment as a separate JDBC call — placing three statements on one line produced a multi-query string that MySQL rejects without `allowMultiQueries=true`
- Fix: split each `PREPARE stmt FROM ...; EXECUTE stmt; DEALLOCATE PREPARE stmt;` triple onto three separate lines in `migration.sql` (5 occurrences) and `rollback.sql` (3 occurrences)

## Test plan

- [ ] Re-execute migration v2.4.0 via Database Migration Management — should complete without SQL syntax error
- [ ] Verify three indexes created on `PHARMACEUTICALBILLITEM`: `idx_pbi_createdat_retired`, `idx_pbi_stock_createdat`, `idx_pbi_batch_createdat`
- [ ] Verify `BILLITEM_BILLITEMSTATUS_idx` is absent from `BILLITEM`

Closes #20800

🤖 Generated with [Claude Code](https://claude.com/claude-code)