### PR TITLE
feat(membership): corporate membership support and always-on VIP/VVIP status

### DIFF
--- a/src/main/java/com/divudi/bean/common/BillPackageController.java
+++ b/src/main/java/com/divudi/bean/common/BillPackageController.java
@@ -2725,12 +2725,6 @@ public class BillPackageController implements Serializable, ControllerWithPatien
             OptionScope.APPLICATION
         ));
 
-        metadata.addConfigOption(new ConfigOptionInfo(
-            "Enable patient specific status management in the system",
-            "Shows patient-specific status badges and management features",
-            "Lines 419-423: Patient specific status badge display",
-            OptionScope.APPLICATION
-        ));
 
 
         // Configuration Options - Package Management

--- a/src/main/java/com/divudi/bean/common/PatientController.java
+++ b/src/main/java/com/divudi/bean/common/PatientController.java
@@ -218,6 +218,7 @@ public class PatientController implements Serializable, ControllerWithPatient {
     Long patientId;
     private FamilyMember familyMember;
     private List<FamilyMember> familyMembers;
+    private List<FamilyMember> filteredFamilyMembers;
     private Family currentFamily;
     private List<Family> families;
     FamilyMember currentFamilyMember;
@@ -2622,6 +2623,10 @@ public class PatientController implements Serializable, ControllerWithPatient {
 
     public String searchCorporateFamilyMember() {
         familyMembers = null;
+        if (searchText == null || searchText.trim().isEmpty()) {
+            JsfUtil.addErrorMessage("Please enter a search term.");
+            return "";
+        }
         String j = "Select fm "
                 + " from FamilyMember fm"
                 + " where fm.retired=false "
@@ -4446,6 +4451,14 @@ public class PatientController implements Serializable, ControllerWithPatient {
 
     public void setFamilyMembers(List<FamilyMember> familyMembers) {
         this.familyMembers = familyMembers;
+    }
+
+    public List<FamilyMember> getFilteredFamilyMembers() {
+        return filteredFamilyMembers;
+    }
+
+    public void setFilteredFamilyMembers(List<FamilyMember> filteredFamilyMembers) {
+        this.filteredFamilyMembers = filteredFamilyMembers;
     }
 
     public ReportKeyWord getReportKeyWord() {

--- a/src/main/java/com/divudi/bean/common/PatientController.java
+++ b/src/main/java/com/divudi/bean/common/PatientController.java
@@ -2821,7 +2821,8 @@ public class PatientController implements Serializable, ControllerWithPatient {
         }
         saveIndividualMembership();
         currentFamily = new Family();
-        current = new Patient();
+        current = null;
+        getCurrent();
         return navigateToAddNewCorporateMembership();
     }
 
@@ -3261,6 +3262,10 @@ public class PatientController implements Serializable, ControllerWithPatient {
     }
 
     public void pseudonymisePatient() {
+        if (!webUserController.hasPrivilege("ClinicalPatientPseudonymise")) {
+            JsfUtil.addErrorMessage("You do not have permission to pseudonymise patient records.");
+            return;
+        }
         if (current == null || current.getId() == null) {
             JsfUtil.addErrorMessage("No patient selected.");
             return;
@@ -3276,20 +3281,18 @@ public class PatientController implements Serializable, ControllerWithPatient {
                 p.getId(),
                 "Patient");
 
-        // Use PHN as the seed so the placeholder is stable and unique per patient.
-        // Name uses only letters/spaces to satisfy name-regex patterns (e.g. [A-Za-z ]+).
-        // Phone uses 10-digit format starting with 0 to satisfy common mobile-regex patterns.
-        String phn = p.getPhn() != null ? p.getPhn() : String.valueOf(p.getId());
-        String namePlaceholder = "Patient " + phn;
-        // Derive a deterministic 10-digit phone from the PHN/ID numeric characters only
-        String digits = phn.replaceAll("[^0-9]", "");
-        // Pad or trim to 9 digits, prefix with 0 → valid 10-digit number (e.g. 0XXXXXXXXX)
+        // Use patient DB ID (not PHN) as seed — ID is a non-reversible surrogate
+        // and does not expose the original identity in visible fields.
+        String seed = String.valueOf(p.getId());
+        String namePlaceholder = "Patient " + seed;
+        // Derive a deterministic 10-digit phone from the ID digits only
+        String digits = seed.replaceAll("[^0-9]", "");
         while (digits.length() < 9) {
             digits = digits + "0";
         }
         String phonePlaceholder = "0" + digits.substring(0, 9);
-        String nicPlaceholder = phn.replaceAll("[^A-Za-z0-9]", "") + "V";
-        String addressPlaceholder = "Address " + phn;
+        String nicPlaceholder = seed + "V";
+        String addressPlaceholder = "Address " + seed;
 
         p.getPerson().setName(namePlaceholder);
         p.getPerson().setFullName(namePlaceholder);

--- a/src/main/java/com/divudi/bean/common/PatientController.java
+++ b/src/main/java/com/divudi/bean/common/PatientController.java
@@ -2393,6 +2393,25 @@ public class PatientController implements Serializable, ControllerWithPatient {
         return "/membership/individual_membership_search?faces-redirect=true";
     }
 
+    public String navigateToAddNewCorporateMembership() {
+        currentFamily = new Family();
+        if (institution == null) {
+            institution = sessionController.getInstitution();
+        }
+        if (department == null) {
+            department = sessionController.getDepartment();
+        }
+        currentFamily.setCreatedInstitution(institution);
+        currentFamily.setCreatedDepartment(department);
+        return "/membership/corporate_membership_new?faces-redirect=true";
+    }
+
+    public String navigateToSearchCorporateMembership() {
+        currentFamily = null;
+        currentFamilyMember = null;
+        return "/membership/corporate_membership_search?faces-redirect=true";
+    }
+
     public String searchFamily() {
         families = null;
         String jpql = "Select f "
@@ -2601,6 +2620,43 @@ public class PatientController implements Serializable, ControllerWithPatient {
         }
     }
 
+    public String searchCorporateFamilyMember() {
+        familyMembers = null;
+        String j = "Select fm "
+                + " from FamilyMember fm"
+                + " where fm.retired=false "
+                + " and fm.family.retired=false "
+                + " and fm.family.membershipScheme.institution is not null "
+                + " and (fm.family.phoneNo=:pn or fm.family.membershipCardNo=:mcn "
+                + "   or fm.patient.person.mobile=:mobile or fm.patient.person.phone=:phone "
+                + "   or fm.patient.person.name like :name or fm.patient.person.nic=:nic) ";
+        Map m = new HashMap();
+        Long mcn;
+        try {
+            mcn = Long.parseLong(searchText);
+        } catch (Exception e) {
+            mcn = 0L;
+        }
+        m.put("pn", searchText);
+        m.put("mcn", mcn);
+        m.put("mobile", searchText);
+        m.put("phone", searchText);
+        m.put("name", "%" + searchText + "%");
+        m.put("nic", searchText);
+
+        List<FamilyMember> fs = familyMemberFacade.findByJpql(j, m);
+        if (fs == null || fs.isEmpty()) {
+            JsfUtil.addErrorMessage("No matches");
+            return "";
+        } else {
+            familyMembers = fs;
+            familyMember = null;
+            current = null;
+            searchText = "";
+            return "";
+        }
+    }
+
     public void saveFamily() {
         if (currentFamily == null) {
             JsfUtil.addErrorMessage("No Family Selected to Save or Update");
@@ -2743,6 +2799,25 @@ public class PatientController implements Serializable, ControllerWithPatient {
         currentFamily = new Family();
         current = new Patient();
         return navigateToAddNewIndividualMembership();
+    }
+
+    public String saveAndClearForNewCorporateMembership() {
+        if (currentFamily == null) {
+            JsfUtil.addErrorMessage("No Membership is Selected to Save or Update");
+            return "";
+        }
+        if (current == null) {
+            JsfUtil.addErrorMessage("No Patient to Save or Update");
+            return "";
+        }
+        if (current.getPerson().getName() == null || current.getPerson().getName().isEmpty()) {
+            JsfUtil.addErrorMessage("No Patient to Save or Update");
+            return "";
+        }
+        saveIndividualMembership();
+        currentFamily = new Family();
+        current = new Patient();
+        return navigateToAddNewCorporateMembership();
     }
 
     //    public String toAddNewFamily() {
@@ -3178,6 +3253,54 @@ public class PatientController implements Serializable, ControllerWithPatient {
             blacklistComment = null;
             JsfUtil.addSuccessMessage("Patient blacklist is reverted.");
         }
+    }
+
+    public void pseudonymisePatient() {
+        if (current == null || current.getId() == null) {
+            JsfUtil.addErrorMessage("No patient selected.");
+            return;
+        }
+        Patient p = getFacade().find(current.getId());
+        if (p == null) {
+            JsfUtil.addErrorMessage("Patient record not found.");
+            return;
+        }
+        AuditEvent auditEvent = auditEventController.createNewAuditEvent(
+                "Pseudonymise Patient",
+                "{\"patientId\":" + p.getId() + ",\"phn\":\"" + p.getPhn() + "\"}",
+                p.getId(),
+                "Patient");
+
+        // Use PHN as the seed so the placeholder is stable and unique per patient.
+        // Name uses only letters/spaces to satisfy name-regex patterns (e.g. [A-Za-z ]+).
+        // Phone uses 10-digit format starting with 0 to satisfy common mobile-regex patterns.
+        String phn = p.getPhn() != null ? p.getPhn() : String.valueOf(p.getId());
+        String namePlaceholder = "Patient " + phn;
+        // Derive a deterministic 10-digit phone from the PHN/ID numeric characters only
+        String digits = phn.replaceAll("[^0-9]", "");
+        // Pad or trim to 9 digits, prefix with 0 → valid 10-digit number (e.g. 0XXXXXXXXX)
+        while (digits.length() < 9) {
+            digits = digits + "0";
+        }
+        String phonePlaceholder = "0" + digits.substring(0, 9);
+        String nicPlaceholder = phn.replaceAll("[^A-Za-z0-9]", "") + "V";
+        String addressPlaceholder = "Address " + phn;
+
+        p.getPerson().setName(namePlaceholder);
+        p.getPerson().setFullName(namePlaceholder);
+        p.getPerson().setNameWithInitials(namePlaceholder);
+        p.getPerson().setNic(nicPlaceholder);
+        p.getPerson().setAddress(addressPlaceholder);
+        p.getPerson().setPhone(phonePlaceholder);
+        p.getPerson().setMobile(phonePlaceholder);
+        p.getPerson().setEmail("");
+        p.setPatientPhoneNumber(null);
+        p.setPatientMobileNumber(null);
+        getFacade().editAndCommit(p);
+        auditEventController.completeAuditEvent(auditEvent,
+                "{\"patientId\":" + p.getId() + ",\"pseudonymised\":true}");
+        this.current = getFacade().findWithoutCache(p.getId());
+        JsfUtil.addSuccessMessage("Patient record has been pseudonymised.");
     }
 
     public String deletePatient() {

--- a/src/main/java/com/divudi/bean/common/UserPrivilageController.java
+++ b/src/main/java/com/divudi/bean/common/UserPrivilageController.java
@@ -499,6 +499,7 @@ public class UserPrivilageController implements Serializable {
         new DefaultTreeNode(new PrivilegeHolder(Privileges.ClinicalPatientNameChange, "Change Patient Name"), clinicalsNode);
         new DefaultTreeNode(new PrivilegeHolder(Privileges.ClinicalPatientPhoneNumberEdit, "Edit Patient Phone Number"), clinicalsNode);
         new DefaultTreeNode(new PrivilegeHolder(Privileges.ClinicalPatientBlacklist, "Blacklist / Unblacklist Patient"), clinicalsNode);
+        new DefaultTreeNode(new PrivilegeHolder(Privileges.ClinicalPatientPseudonymise, "Pseudonymise Patient"), clinicalsNode);
         new DefaultTreeNode(new PrivilegeHolder(Privileges.ClinicalPatientCommentsView, "View Patient Comments"), clinicalsNode);
         new DefaultTreeNode(new PrivilegeHolder(Privileges.ClinicalPatientCommentsEdit, "Edit Patient Comments"), clinicalsNode);
         new DefaultTreeNode(new PrivilegeHolder(Privileges.ClinicalMembershipAdd, "Add Membership"), clinicalsNode);

--- a/src/main/java/com/divudi/bean/membership/MembershipSchemeController.java
+++ b/src/main/java/com/divudi/bean/membership/MembershipSchemeController.java
@@ -236,6 +236,20 @@ public class MembershipSchemeController implements Serializable {
         items = getFacade().findByJpql(j, m);
     }
 
+    public List<MembershipScheme> getPersonalSchemes() {
+        String j = "select s from MembershipScheme s where s.retired=:ret and s.institution is null order by s.name";
+        Map m = new HashMap();
+        m.put("ret", false);
+        return getFacade().findByJpql(j, m);
+    }
+
+    public List<MembershipScheme> getCorporateSchemes() {
+        String j = "select s from MembershipScheme s where s.retired=:ret and s.institution is not null order by s.name";
+        Map m = new HashMap();
+        m.put("ret", false);
+        return getFacade().findByJpql(j, m);
+    }
+
     public Institution getLastInstitution() {
         return lastInstitution;
     }

--- a/src/main/java/com/divudi/core/data/Privileges.java
+++ b/src/main/java/com/divudi/core/data/Privileges.java
@@ -486,6 +486,7 @@ public enum Privileges {
     ClinicalMembershipEdit("Clinical Membership Edit"),
     ClinicalPatientPhoneNumberEdit("Clinical Patient Phone Number Edit"),
     ClinicalPatientBlacklist("Clinical Patient Blacklist"),
+    ClinicalPatientPseudonymise("Clinical Patient Pseudonymise"),
     //</editor-fold>
 
     //<editor-fold defaultstate="collapsed" desc="Pharmacy">

--- a/src/main/java/com/divudi/core/entity/membership/MembershipScheme.java
+++ b/src/main/java/com/divudi/core/entity/membership/MembershipScheme.java
@@ -16,4 +16,8 @@ import javax.persistence.Entity;
 @Entity
 public class MembershipScheme extends Category {
 
+    public boolean isCorporate() {
+        return getInstitution() != null;
+    }
+
 }

--- a/src/main/webapp/channel/channel_booking_by_month.xhtml
+++ b/src/main/webapp/channel/channel_booking_by_month.xhtml
@@ -540,7 +540,7 @@
                                                                     <div class="col-md-4 p-1">
 
                                                                         <div class="input-group">
-                                                                            <p:selectOneMenu title="Patient Specific Status" class="w-100" id="specificStatus" value="#{bookingControllerViewScopeMonth.patient.specificStatus != null and bookingControllerViewScopeMonth.patient.specificStatus.name() != 'NORMAL' ? bookingControllerViewScopeMonth.patient.specificStatus : ''}">
+                                                                            <p:selectOneMenu title="Patient Specific Status" class="w-100" id="specificStatus" value="#{bookingControllerViewScopeMonth.patient.specificStatus}">
                                                                                 <f:selectItems value="#{patientController.getAllPatientSpecificLabels()}"/>
                                                                             </p:selectOneMenu>
 
@@ -585,7 +585,7 @@
                                                                 <h:panelGroup class="d-flex">
 
                                                                     
-                                                                    <p:badge style="transform: translate(110%, -40%);background-color: #{bookingControllerViewScopeMonth.patient.specificStatus != null and bookingControllerViewScopeMonth.patient.specificStatus.name() != 'NORMAL' ? '#FF401F' : 'white'} ; font-style: italic;" value="#{bookingControllerViewScopeMonth.patient.specificStatus != null and bookingControllerViewScopeMonth.patient.specificStatus.name() != 'NORMAL' ? bookingControllerViewScopeMonth.patient.specificStatus : ''}" severity="danger">
+                                                                    <p:badge style="transform: translate(110%, -40%);background-color: #{bookingControllerViewScopeMonth.patient.specificStatus != null and bookingControllerViewScopeMonth.patient.specificStatus.name() != 'NORMAL' ? '#FF401F' : 'white'} ; font-style: italic;" value="#{bookingControllerViewScopeMonth.patient.specificStatus}" severity="danger">
                                                                         <p:outputLabel value="#{bookingControllerViewScopeMonth.patient.person.nameWithTitle}" rendered="#{not empty bookingControllerViewScopeMonth.patient.person.nameWithTitle}" />
                                                                     </p:badge> 
 

--- a/src/main/webapp/channel/channel_booking_by_month.xhtml
+++ b/src/main/webapp/channel/channel_booking_by_month.xhtml
@@ -540,7 +540,7 @@
                                                                     <div class="col-md-4 p-1">
 
                                                                         <div class="input-group">
-                                                                            <p:selectOneMenu title="Patient Specific Status" class="w-100" id="specificStatus" value="#{bookingControllerViewScopeMonth.patient.specificStatus}">
+                                                                            <p:selectOneMenu title="Patient Specific Status" class="w-100" id="specificStatus" value="#{bookingControllerViewScopeMonth.patient.specificStatus != null and bookingControllerViewScopeMonth.patient.specificStatus.name() != 'NORMAL' ? bookingControllerViewScopeMonth.patient.specificStatus : ''}">
                                                                                 <f:selectItems value="#{patientController.getAllPatientSpecificLabels()}"/>
                                                                             </p:selectOneMenu>
 
@@ -584,9 +584,8 @@
                                                                 <h:outputLabel value=" : " class="mx-3"/>
                                                                 <h:panelGroup class="d-flex">
 
-                                                                    <p:outputLabel class="ml-4" value="#{bookingControllerViewScopeMonth.patient.person.nameWithTitle}" rendered="#{not empty bookingControllerViewScopeMonth.patient.person.nameWithTitle and !configOptionApplicationController.getBooleanValueByKey('Enable patient specific status management in the system')}" />
-
-                                                                    <p:badge rendered="#{configOptionApplicationController.getBooleanValueByKey('Enable patient specific status management in the system')}" style="transform: translate(110%, -40%);background-color: #{empty bookingControllerViewScopeMonth.patient.specificStatus ? 'white' : '#FF401F'} ; font-style: italic;" value="#{bookingControllerViewScopeMonth.patient.specificStatus}" severity="danger">
+                                                                    
+                                                                    <p:badge style="transform: translate(110%, -40%);background-color: #{bookingControllerViewScopeMonth.patient.specificStatus != null and bookingControllerViewScopeMonth.patient.specificStatus.name() != 'NORMAL' ? '#FF401F' : 'white'} ; font-style: italic;" value="#{bookingControllerViewScopeMonth.patient.specificStatus != null and bookingControllerViewScopeMonth.patient.specificStatus.name() != 'NORMAL' ? bookingControllerViewScopeMonth.patient.specificStatus : ''}" severity="danger">
                                                                         <p:outputLabel value="#{bookingControllerViewScopeMonth.patient.person.nameWithTitle}" rendered="#{not empty bookingControllerViewScopeMonth.patient.person.nameWithTitle}" />
                                                                     </p:badge> 
 

--- a/src/main/webapp/inward/inward_appointment_edit.xhtml
+++ b/src/main/webapp/inward/inward_appointment_edit.xhtml
@@ -397,7 +397,7 @@
                                                             <div class="col-md-4 p-1">
 
                                                                 <div class="input-group">
-                                                                    <p:selectOneMenu title="Patient Specific Status" class="w-100" id="specificStatus" value="#{appointmentController.patient.specificStatus}">
+                                                                    <p:selectOneMenu title="Patient Specific Status" class="w-100" id="specificStatus" value="#{appointmentController.patient.specificStatus != null and appointmentController.patient.specificStatus.name() != 'NORMAL' ? appointmentController.patient.specificStatus : ''}">
                                                                         <f:selectItems value="#{patientController.getAllPatientSpecificLabels()}"/>
                                                                     </p:selectOneMenu>
 
@@ -441,9 +441,8 @@
 
                                                     <h:panelGroup class="d-flex">
 
-                                                        <p:outputLabel class="ml-4" value="#{appointmentController.patient.person.nameWithTitle}" rendered="#{not empty appointmentController.patient.person.nameWithTitle and !configOptionApplicationController.getBooleanValueByKey('Enable patient specific status management in the system')}" />
-
-                                                        <p:badge rendered="#{configOptionApplicationController.getBooleanValueByKey('Enable patient specific status management in the system')}" style="transform: translate(110%, -40%);background-color: #{empty appointmentController.patient.specificStatus ? 'white' : '#FF401F'} ; font-style: italic;" value="#{appointmentController.patient.specificStatus}" severity="danger">
+                                                        
+                                                        <p:badge style="transform: translate(110%, -40%);background-color: #{appointmentController.patient.specificStatus != null and appointmentController.patient.specificStatus.name() != 'NORMAL' ? '#FF401F' : 'white'} ; font-style: italic;" value="#{appointmentController.patient.specificStatus != null and appointmentController.patient.specificStatus.name() != 'NORMAL' ? appointmentController.patient.specificStatus : ''}" severity="danger">
                                                             <p:outputLabel value="#{appointmentController.patient.person.nameWithTitle}" rendered="#{not empty appointmentController.patient.person.nameWithTitle}" />
                                                         </p:badge> 
 

--- a/src/main/webapp/inward/inward_appointment_edit.xhtml
+++ b/src/main/webapp/inward/inward_appointment_edit.xhtml
@@ -397,7 +397,7 @@
                                                             <div class="col-md-4 p-1">
 
                                                                 <div class="input-group">
-                                                                    <p:selectOneMenu title="Patient Specific Status" class="w-100" id="specificStatus" value="#{appointmentController.patient.specificStatus != null and appointmentController.patient.specificStatus.name() != 'NORMAL' ? appointmentController.patient.specificStatus : ''}">
+                                                                    <p:selectOneMenu title="Patient Specific Status" class="w-100" id="specificStatus" value="#{appointmentController.patient.specificStatus}">
                                                                         <f:selectItems value="#{patientController.getAllPatientSpecificLabels()}"/>
                                                                     </p:selectOneMenu>
 
@@ -442,7 +442,7 @@
                                                     <h:panelGroup class="d-flex">
 
                                                         
-                                                        <p:badge style="transform: translate(110%, -40%);background-color: #{appointmentController.patient.specificStatus != null and appointmentController.patient.specificStatus.name() != 'NORMAL' ? '#FF401F' : 'white'} ; font-style: italic;" value="#{appointmentController.patient.specificStatus != null and appointmentController.patient.specificStatus.name() != 'NORMAL' ? appointmentController.patient.specificStatus : ''}" severity="danger">
+                                                        <p:badge style="transform: translate(110%, -40%);background-color: #{appointmentController.patient.specificStatus != null and appointmentController.patient.specificStatus.name() != 'NORMAL' ? '#FF401F' : 'white'} ; font-style: italic;" value="#{appointmentController.patient.specificStatus}" severity="danger">
                                                             <p:outputLabel value="#{appointmentController.patient.person.nameWithTitle}" rendered="#{not empty appointmentController.patient.person.nameWithTitle}" />
                                                         </p:badge> 
 

--- a/src/main/webapp/inward/inward_change_patient.xhtml
+++ b/src/main/webapp/inward/inward_change_patient.xhtml
@@ -241,9 +241,8 @@
                                         
                                         <h:panelGroup class="d-flex">
 
-                                            <p:outputLabel class="ml-4" value="#{admissionPatientChangeController.current.patient.person.nameWithTitle}" rendered="#{not empty admissionPatientChangeController.current.patient.person.nameWithTitle and !configOptionApplicationController.getBooleanValueByKey('Enable patient specific status management in the system')}" />
-
-                                            <p:badge rendered="#{configOptionApplicationController.getBooleanValueByKey('Enable patient specific status management in the system')}" style="transform: translate(110%, -40%);background-color: #{empty admissionPatientChangeController.current.patient.specificStatus ? 'white' : '#FF401F'} ; font-style: italic;" value="#{admissionPatientChangeController.current.patient.specificStatus}" severity="danger">
+                                            
+                                            <p:badge style="transform: translate(110%, -40%);background-color: #{admissionPatientChangeController.current.patient.specificStatus != null and admissionPatientChangeController.current.patient.specificStatus.name() != 'NORMAL' ? '#FF401F' : 'white'} ; font-style: italic;" value="#{admissionPatientChangeController.current.patient.specificStatus != null and admissionPatientChangeController.current.patient.specificStatus.name() != 'NORMAL' ? admissionPatientChangeController.current.patient.specificStatus : ''}" severity="danger">
                                                 <p:outputLabel value="#{admissionPatientChangeController.current.patient.person.nameWithTitle}" rendered="#{not empty admissionPatientChangeController.current.patient.person.nameWithTitle}" />
                                             </p:badge>
 

--- a/src/main/webapp/membership/corporate_membership_new.xhtml
+++ b/src/main/webapp/membership/corporate_membership_new.xhtml
@@ -16,23 +16,23 @@
                     <na:not_authorize />
                 </h:panelGroup>
 
-                <h:form   rendered="#{webUserController.hasPrivilege('MemberShipAdd')}">
+                <h:form rendered="#{webUserController.hasPrivilege('MemberShipAdd')}">
                     <p:panel class="p-1 m-1">
                         <f:facet name="header">
-                            <h:outputText styleClass="fa-solid fa-people-group" />
-                            <p:outputLabel value="Add Individual Mambership" class="m-2"/>
+                            <h:outputText styleClass="fa-solid fa-building" />
+                            <p:outputLabel value="Add Corporate Membership" class="m-2"/>
                             <div style="float: right;">
-                                <p:commandButton 
-                                    value="Save Member &amp; Manage" 
-                                    action="#{patientController.saveIndividualMembershipAndNavigateToManageIndividual()}" 
-                                    ajax="false" 
+                                <p:commandButton
+                                    value="Save &amp; Manage"
+                                    action="#{patientController.saveIndividualMembershipAndNavigateToManageIndividual()}"
+                                    ajax="false"
                                     class="ui-button-success mx-1"
                                     icon="fas fa-save">
                                 </p:commandButton>
                                 <p:commandButton
-                                    value="Save &amp; Clear for a new Membership" 
-                                    action="#{patientController.saveAndClearForNewIndividual()}" 
-                                    class="ui-button-warning mx-1" 
+                                    value="Save &amp; Clear for New"
+                                    action="#{patientController.saveAndClearForNewCorporateMembership()}"
+                                    class="ui-button-warning mx-1"
                                     icon="fas fa-eraser"
                                     ajax="false">
                                 </p:commandButton>
@@ -46,31 +46,33 @@
                                     controller="#{patientController}"/>
                             </div>
                             <div class="col-6">
-
                                 <p:panelGrid columns="2" class="w-100" layout="tabular">
-                                    <f:facet name="header" >
-                                        <h:outputText value="Membership" ></h:outputText>
+                                    <f:facet name="header">
+                                        <h:outputText value="Corporate Membership" />
                                     </f:facet>
+
                                     <p:outputLabel value="Membership Card No:" for="membershipCardNo" />
                                     <p:inputText class="w-100"
-                                                 autocomplete="off" id="membershipCardNo" value="#{patientController.currentFamily.membershipCardNo}" title="MembershipCardNo" />
+                                                 autocomplete="off" id="membershipCardNo"
+                                                 value="#{patientController.currentFamily.membershipCardNo}" />
 
-
-                                    <p:outputLabel value="Personal Membership Scheme:" for="membershipScheme" />
+                                    <p:outputLabel value="Corporate Scheme:" for="membershipScheme" />
                                     <p:selectOneMenu
                                         id="membershipScheme"
                                         class="w-100"
                                         value="#{patientController.currentFamily.membershipScheme}"
                                         filter="true"
                                         filterMatchMode="contains">
+                                        <f:selectItem itemLabel="Select a corporate scheme" itemValue="#{null}" />
                                         <f:selectItems
-                                            value="#{membershipSchemeController.personalSchemes}"
+                                            value="#{membershipSchemeController.corporateSchemes}"
                                             var="m"
-                                            itemLabel="#{m.name}" itemValue="#{m}"/>
+                                            itemLabel="#{m.name} (#{m.institution.name})"
+                                            itemValue="#{m}"/>
                                     </p:selectOneMenu>
 
                                     <p:outputLabel value="Institution:" for="institution" />
-                                    <p:autoComplete 
+                                    <p:autoComplete
                                         id="institution"
                                         class="w-100"
                                         inputStyleClass="w-100"
@@ -78,30 +80,27 @@
                                         completeMethod="#{institutionController.completeIns}"
                                         var="ins"
                                         itemLabel="#{ins.name}"
-                                        itemValue="#{ins}"
-                                        >
-                                        <p:ajax process="institution" update="department" ></p:ajax>
+                                        itemValue="#{ins}">
+                                        <p:ajax process="institution" update="department" />
                                     </p:autoComplete>
 
-
                                     <p:outputLabel value="Department:" for="department" />
-                                    <p:selectOneMenu 
+                                    <p:selectOneMenu
                                         id="department"
                                         class="w-100"
-                                        value="#{patientController.currentFamily.createdDepartment}"
-                                        >
-                                        <f:selectItem itemLabel="Select" ></f:selectItem>
-                                        <f:selectItems 
+                                        value="#{patientController.currentFamily.createdDepartment}">
+                                        <f:selectItem itemLabel="Select" />
+                                        <f:selectItems
                                             value="#{departmentController.getInstitutionDepatrments(patientController.currentFamily.createdInstitution)}"
                                             var="dept"
                                             itemLabel="#{dept.name}"
-                                            itemValue="#{dept}"></f:selectItems>
+                                            itemValue="#{dept}" />
                                     </p:selectOneMenu>
 
                                     <p:outputLabel value="Comments:" for="comments" />
-                                    <p:inputTextarea rows="4" cols="30" class="w-100" id="comments" value="#{patientController.currentFamily.comments}" title="Comments" />
+                                    <p:inputTextarea rows="4" cols="30" class="w-100" id="comments"
+                                                     value="#{patientController.currentFamily.comments}" />
                                 </p:panelGrid>
-
                             </div>
                         </div>
                     </p:panel>

--- a/src/main/webapp/membership/corporate_membership_search.xhtml
+++ b/src/main/webapp/membership/corporate_membership_search.xhtml
@@ -1,0 +1,118 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
+      xmlns:p="http://primefaces.org/ui"
+      xmlns:h="http://xmlns.jcp.org/jsf/html"
+      xmlns:na="http://xmlns.jcp.org/jsf/composite/template"
+      xmlns:f="http://xmlns.jcp.org/jsf/core">
+
+    <h:head>
+    </h:head>
+
+    <h:body>
+        <ui:composition template="/resources/template/template.xhtml">
+            <ui:define name="content">
+
+                <h:panelGroup rendered="#{!webUserController.hasPrivilege('MemberShipSearch')}">
+                    <na:not_authorize />
+                </h:panelGroup>
+
+                <h:panelGroup rendered="#{webUserController.hasPrivilege('MemberShipSearch')}">
+                    <h:form>
+                        <p:growl />
+                        <p:panel header="Search Corporate Members" class="m-1">
+                            <p:panelGrid columns="3" layout="tabular" class="w-100 m-1">
+                                <p:outputLabel value="Membership Card No / Phone No / Name / NIC" />
+                                <p:inputText value="#{patientController.searchText}" autocomplete="off" class="w-100" />
+                                <p:commandButton
+                                    ajax="false"
+                                    action="#{patientController.searchCorporateFamilyMember()}"
+                                    value="Search" >
+                                </p:commandButton>
+                            </p:panelGrid>
+
+                            <p:dataTable
+                                value="#{patientController.familyMembers}"
+                                var="f"
+                                rowIndexVar="n"
+                                rowKey="#{f.id}"
+                                paginator="true"
+                                rows="10"
+                                rowsPerPageTemplate="5,10,20,50"
+                                paginatorPosition="bottom"
+                                filteredValue="#{patientController.filteredFamilyMembers}"
+                                widgetVar="corporateTable"
+                                emptyMessage="No matching records found">
+
+                                <p:column headerText="Company" sortBy="#{f.family.membershipScheme.institution.name}" filterBy="#{f.family.membershipScheme.institution.name}" filterMatchMode="contains">
+                                    <p:outputLabel value="#{f.family.membershipScheme.institution.name}" style="font-weight: bold;" />
+                                </p:column>
+
+                                <p:column headerText="Scheme" sortBy="#{f.family.membershipScheme.name}" filterBy="#{f.family.membershipScheme.name}" filterMatchMode="contains">
+                                    <p:outputLabel value="#{f.family.membershipScheme.name}" />
+                                </p:column>
+
+                                <p:column headerText="Card No" sortBy="#{f.family.membershipCardNo}" filterBy="#{f.family.membershipCardNo}" filterMatchMode="contains">
+                                    <p:outputLabel value="#{f.family.membershipCardNo}" />
+                                </p:column>
+
+                                <p:column headerText="Name" sortBy="#{f.patient.person.name}" filterBy="#{f.patient.person.name}" filterMatchMode="contains">
+                                    <p:outputLabel value="#{f.patient.person.name}" />
+                                </p:column>
+
+                                <p:column headerText="Phone" sortBy="#{f.patient.person.phone}" filterBy="#{f.patient.person.phone}" filterMatchMode="contains">
+                                    <p:outputLabel value="#{f.patient.person.phone}" class="mx-1"/>
+                                    <p:outputLabel value="#{f.patient.person.mobile}" class="mx-1" />
+                                </p:column>
+
+                                <p:column headerText="Sex" sortBy="#{f.patient.person.sex}" filterBy="#{f.patient.person.sex}" filterMatchMode="exact">
+                                    <p:outputLabel value="#{f.patient.person.sex}" />
+                                </p:column>
+
+                                <p:column headerText="Age" sortBy="#{f.patient.age}">
+                                    <p:outputLabel value="#{f.patient.age}" />
+                                </p:column>
+
+                                <p:column headerText="Actions">
+                                    <p:commandButton
+                                        action="#{patientController.navigateToManageFamily(f.family)}"
+                                        ajax="false"
+                                        class="mx-2"
+                                        icon="fa fa-fw fa-building"
+                                        title="Manage Corporate Membership">
+                                    </p:commandButton>
+
+                                    <p:commandButton
+                                        action="#{opdBillController.navigateToNewOpdBillWithPaymentScheme(f.patient, f.family.membershipScheme.paymentScheme)}"
+                                        ajax="false"
+                                        class="mx-2"
+                                        icon="fa fa-fw fa-file-medical"
+                                        title="OPD Billing">
+                                    </p:commandButton>
+
+                                    <p:commandButton
+                                        action="#{opdPreBillController.navigateToBillingForCashierFromMembership(f.patient, f.family.membershipScheme.paymentScheme)}"
+                                        ajax="false"
+                                        class="mx-2"
+                                        icon="fa fa-fw fa-cash-register"
+                                        title="OPD Billing for Cashier">
+                                    </p:commandButton>
+
+                                    <p:commandButton
+                                        ajax="false"
+                                        action="#{bookingControllerViewScope.navigateToChannelBookingFromMembershipByDate(f.patient, f.family.membershipScheme.paymentScheme)}"
+                                        icon="fa fa-fw fa-calendar-check"
+                                        class="mx-1"
+                                        title="Channelling"
+                                        disabled="#{!webUserController.hasPrivilege('ChannellingChannelBooking')}">
+                                    </p:commandButton>
+                                </p:column>
+                            </p:dataTable>
+                        </p:panel>
+                    </h:form>
+                </h:panelGroup>
+            </ui:define>
+        </ui:composition>
+    </h:body>
+</html>

--- a/src/main/webapp/membership/family_membership_new.xhtml
+++ b/src/main/webapp/membership/family_membership_new.xhtml
@@ -44,16 +44,16 @@
                                                           id="phoneNo" value="#{patientController.currentFamily.phoneNo}" title="MembershipCardNo" />
 
 
-                                            <p:outputLabel value="MembershipScheme:" for="membershipScheme" />
-                                            <p:selectOneMenu 
+                                            <p:outputLabel value="Personal Membership Scheme:" for="membershipScheme" />
+                                            <p:selectOneMenu
                                                 id="membershipScheme"
-                                                class="w-100" 
-                                                value="#{patientController.currentFamily.membershipScheme}" 
+                                                class="w-100"
+                                                value="#{patientController.currentFamily.membershipScheme}"
                                                 filter="true"
                                                 filterMatchMode="contains">
-                                                <f:selectItems 
-                                                    value="#{membershipSchemeController.items}" 
-                                                    var="m" 
+                                                <f:selectItems
+                                                    value="#{membershipSchemeController.personalSchemes}"
+                                                    var="m"
                                                     itemLabel="#{m.name}" itemValue="#{m}"/>
                                             </p:selectOneMenu>
                                             <p:outputLabel value="Comments:" for="comments" />

--- a/src/main/webapp/opd/opd_bill.xhtml
+++ b/src/main/webapp/opd/opd_bill.xhtml
@@ -364,7 +364,7 @@
                                                             <div class="col-md-4 p-1">
 
                                                                 <div class="input-group">
-                                                                    <p:selectOneMenu title="Patient Specific Status" class="w-100" id="specificStatus" value="#{opdBillController.patient.specificStatus != null and opdBillController.patient.specificStatus.name() != 'NORMAL' ? opdBillController.patient.specificStatus : ''}">
+                                                                    <p:selectOneMenu title="Patient Specific Status" class="w-100" id="specificStatus" value="#{opdBillController.patient.specificStatus}">
                                                                         <f:selectItems value="#{patientController.getAllPatientSpecificLabels()}"/>
                                                                     </p:selectOneMenu>
 
@@ -410,7 +410,7 @@
                                                     <h:panelGroup class="d-flex">
 
                                                         
-                                                        <p:badge style="transform: translate(110%, -40%);background-color: #{opdBillController.patient.specificStatus != null and opdBillController.patient.specificStatus.name() != 'NORMAL' ? '#FF401F' : 'white'} ; font-style: italic;" value="#{opdBillController.patient.specificStatus != null and opdBillController.patient.specificStatus.name() != 'NORMAL' ? opdBillController.patient.specificStatus : ''}" severity="danger">
+                                                        <p:badge style="transform: translate(110%, -40%);background-color: #{opdBillController.patient.specificStatus != null and opdBillController.patient.specificStatus.name() != 'NORMAL' ? '#FF401F' : 'white'} ; font-style: italic;" value="#{opdBillController.patient.specificStatus}" severity="danger">
                                                             <p:outputLabel value="#{opdBillController.patient.person.nameWithTitle}" rendered="#{not empty opdBillController.patient.person.nameWithTitle}" />
                                                         </p:badge> 
 

--- a/src/main/webapp/opd/opd_bill.xhtml
+++ b/src/main/webapp/opd/opd_bill.xhtml
@@ -364,7 +364,7 @@
                                                             <div class="col-md-4 p-1">
 
                                                                 <div class="input-group">
-                                                                    <p:selectOneMenu title="Patient Specific Status" class="w-100" id="specificStatus" value="#{opdBillController.patient.specificStatus}">
+                                                                    <p:selectOneMenu title="Patient Specific Status" class="w-100" id="specificStatus" value="#{opdBillController.patient.specificStatus != null and opdBillController.patient.specificStatus.name() != 'NORMAL' ? opdBillController.patient.specificStatus : ''}">
                                                                         <f:selectItems value="#{patientController.getAllPatientSpecificLabels()}"/>
                                                                     </p:selectOneMenu>
 
@@ -409,9 +409,8 @@
                                                     <h:outputLabel value=" : " class="mx-3"/>
                                                     <h:panelGroup class="d-flex">
 
-                                                        <p:outputLabel class="ml-4" value="#{opdBillController.patient.person.nameWithTitle}" rendered="#{not empty opdBillController.patient.person.nameWithTitle and !configOptionApplicationController.getBooleanValueByKey('Enable patient specific status management in the system')}" />
-
-                                                        <p:badge rendered="#{configOptionApplicationController.getBooleanValueByKey('Enable patient specific status management in the system')}" style="transform: translate(110%, -40%);background-color: #{empty opdBillController.patient.specificStatus ? 'white' : '#FF401F'} ; font-style: italic;" value="#{opdBillController.patient.specificStatus}" severity="danger">
+                                                        
+                                                        <p:badge style="transform: translate(110%, -40%);background-color: #{opdBillController.patient.specificStatus != null and opdBillController.patient.specificStatus.name() != 'NORMAL' ? '#FF401F' : 'white'} ; font-style: italic;" value="#{opdBillController.patient.specificStatus != null and opdBillController.patient.specificStatus.name() != 'NORMAL' ? opdBillController.patient.specificStatus : ''}" severity="danger">
                                                             <p:outputLabel value="#{opdBillController.patient.person.nameWithTitle}" rendered="#{not empty opdBillController.patient.person.nameWithTitle}" />
                                                         </p:badge> 
 

--- a/src/main/webapp/opd/opd_bill_ac.xhtml
+++ b/src/main/webapp/opd/opd_bill_ac.xhtml
@@ -372,7 +372,7 @@
                                                             <div class="col-md-4 p-1">
 
                                                                 <div class="input-group">
-                                                                    <p:selectOneMenu title="Patient Specific Status" class="w-100" id="specificStatus" value="#{opdBillController.patient.specificStatus}">
+                                                                    <p:selectOneMenu title="Patient Specific Status" class="w-100" id="specificStatus" value="#{opdBillController.patient.specificStatus != null and opdBillController.patient.specificStatus.name() != 'NORMAL' ? opdBillController.patient.specificStatus : ''}">
                                                                         <f:selectItems value="#{patientController.getAllPatientSpecificLabels()}"/>
                                                                     </p:selectOneMenu>
 
@@ -416,9 +416,8 @@
                                                     <h:outputLabel value=" : " class="mx-3"/>
                                                     <h:panelGroup class="d-flex">
 
-                                                        <p:outputLabel class="ml-4" value="#{opdBillController.patient.person.nameWithTitle}" rendered="#{not empty opdBillController.patient.person.nameWithTitle and !configOptionApplicationController.getBooleanValueByKey('Enable patient specific status management in the system')}" />
-
-                                                        <p:badge rendered="#{configOptionApplicationController.getBooleanValueByKey('Enable patient specific status management in the system')}" style="transform: translate(110%, -40%);background-color: #{empty opdBillController.patient.specificStatus ? 'white' : '#FF401F'} ; font-style: italic;" value="#{opdBillController.patient.specificStatus}" severity="danger">
+                                                        
+                                                        <p:badge style="transform: translate(110%, -40%);background-color: #{opdBillController.patient.specificStatus != null and opdBillController.patient.specificStatus.name() != 'NORMAL' ? '#FF401F' : 'white'} ; font-style: italic;" value="#{opdBillController.patient.specificStatus != null and opdBillController.patient.specificStatus.name() != 'NORMAL' ? opdBillController.patient.specificStatus : ''}" severity="danger">
                                                             <p:outputLabel value="#{opdBillController.patient.person.nameWithTitle}" rendered="#{not empty opdBillController.patient.person.nameWithTitle}" />
                                                         </p:badge> 
 

--- a/src/main/webapp/opd/opd_bill_ac.xhtml
+++ b/src/main/webapp/opd/opd_bill_ac.xhtml
@@ -372,7 +372,7 @@
                                                             <div class="col-md-4 p-1">
 
                                                                 <div class="input-group">
-                                                                    <p:selectOneMenu title="Patient Specific Status" class="w-100" id="specificStatus" value="#{opdBillController.patient.specificStatus != null and opdBillController.patient.specificStatus.name() != 'NORMAL' ? opdBillController.patient.specificStatus : ''}">
+                                                                    <p:selectOneMenu title="Patient Specific Status" class="w-100" id="specificStatus" value="#{opdBillController.patient.specificStatus}">
                                                                         <f:selectItems value="#{patientController.getAllPatientSpecificLabels()}"/>
                                                                     </p:selectOneMenu>
 
@@ -417,7 +417,7 @@
                                                     <h:panelGroup class="d-flex">
 
                                                         
-                                                        <p:badge style="transform: translate(110%, -40%);background-color: #{opdBillController.patient.specificStatus != null and opdBillController.patient.specificStatus.name() != 'NORMAL' ? '#FF401F' : 'white'} ; font-style: italic;" value="#{opdBillController.patient.specificStatus != null and opdBillController.patient.specificStatus.name() != 'NORMAL' ? opdBillController.patient.specificStatus : ''}" severity="danger">
+                                                        <p:badge style="transform: translate(110%, -40%);background-color: #{opdBillController.patient.specificStatus != null and opdBillController.patient.specificStatus.name() != 'NORMAL' ? '#FF401F' : 'white'} ; font-style: italic;" value="#{opdBillController.patient.specificStatus}" severity="danger">
                                                             <p:outputLabel value="#{opdBillController.patient.person.nameWithTitle}" rendered="#{not empty opdBillController.patient.person.nameWithTitle}" />
                                                         </p:badge> 
 

--- a/src/main/webapp/opd/opd_bill_package.xhtml
+++ b/src/main/webapp/opd/opd_bill_package.xhtml
@@ -386,7 +386,7 @@
                                                                 <div class="col-md-4 p-1">
 
                                                                     <div class="input-group">
-                                                                        <p:selectOneMenu title="Patient Specific Status" class="w-100" id="specificStatus" value="#{billPackageController.patient.specificStatus != null and billPackageController.patient.specificStatus.name() != 'NORMAL' ? billPackageController.patient.specificStatus : ''}">
+                                                                        <p:selectOneMenu title="Patient Specific Status" class="w-100" id="specificStatus" value="#{billPackageController.patient.specificStatus}">
                                                                             <f:selectItems value="#{patientController.getAllPatientSpecificLabels()}"/>
                                                                         </p:selectOneMenu>
 
@@ -431,7 +431,7 @@
                                                         <h:panelGroup class="d-flex">
 
                                                             
-                                                            <p:badge style="transform: translate(110%, -40%);background-color: #{billPackageController.patient.specificStatus != null and billPackageController.patient.specificStatus.name() != 'NORMAL' ? '#FF401F' : 'white'} ; font-style: italic;" value="#{billPackageController.patient.specificStatus != null and billPackageController.patient.specificStatus.name() != 'NORMAL' ? billPackageController.patient.specificStatus : ''}" severity="danger">
+                                                            <p:badge style="transform: translate(110%, -40%);background-color: #{billPackageController.patient.specificStatus != null and billPackageController.patient.specificStatus.name() != 'NORMAL' ? '#FF401F' : 'white'} ; font-style: italic;" value="#{billPackageController.patient.specificStatus}" severity="danger">
                                                                 <p:outputLabel value="#{billPackageController.patient.person.nameWithTitle}" rendered="#{not empty billPackageController.patient.person.nameWithTitle}" />
                                                             </p:badge> 
 

--- a/src/main/webapp/opd/opd_bill_package.xhtml
+++ b/src/main/webapp/opd/opd_bill_package.xhtml
@@ -386,7 +386,7 @@
                                                                 <div class="col-md-4 p-1">
 
                                                                     <div class="input-group">
-                                                                        <p:selectOneMenu title="Patient Specific Status" class="w-100" id="specificStatus" value="#{billPackageController.patient.specificStatus}">
+                                                                        <p:selectOneMenu title="Patient Specific Status" class="w-100" id="specificStatus" value="#{billPackageController.patient.specificStatus != null and billPackageController.patient.specificStatus.name() != 'NORMAL' ? billPackageController.patient.specificStatus : ''}">
                                                                             <f:selectItems value="#{patientController.getAllPatientSpecificLabels()}"/>
                                                                         </p:selectOneMenu>
 
@@ -430,9 +430,8 @@
                                                         <h:outputLabel value=" : " class="mx-3"/>
                                                         <h:panelGroup class="d-flex">
 
-                                                            <p:outputLabel class="ml-4" value="#{billPackageController.patient.person.nameWithTitle}" rendered="#{not empty billPackageController.patient.person.nameWithTitle and !configOptionApplicationController.getBooleanValueByKey('Enable patient specific status management in the system')}" />
-
-                                                            <p:badge rendered="#{configOptionApplicationController.getBooleanValueByKey('Enable patient specific status management in the system')}" style="transform: translate(110%, -40%);background-color: #{empty billPackageController.patient.specificStatus ? 'white' : '#FF401F'} ; font-style: italic;" value="#{billPackageController.patient.specificStatus}" severity="danger">
+                                                            
+                                                            <p:badge style="transform: translate(110%, -40%);background-color: #{billPackageController.patient.specificStatus != null and billPackageController.patient.specificStatus.name() != 'NORMAL' ? '#FF401F' : 'white'} ; font-style: italic;" value="#{billPackageController.patient.specificStatus != null and billPackageController.patient.specificStatus.name() != 'NORMAL' ? billPackageController.patient.specificStatus : ''}" severity="danger">
                                                                 <p:outputLabel value="#{billPackageController.patient.person.nameWithTitle}" rendered="#{not empty billPackageController.patient.person.nameWithTitle}" />
                                                             </p:badge> 
 

--- a/src/main/webapp/opd/patient.xhtml
+++ b/src/main/webapp/opd/patient.xhtml
@@ -83,11 +83,9 @@
 
                                                     <h:panelGroup rendered="#{not empty patientController.current.person.nameWithTitle}" layout="block" styleClass="mb-3">
                                                         <strong class="text-muted">Name:</strong><br/>
-                                                        <p:outputLabel class="ml-4" value="#{patientController.current.person.nameWithTitle}" rendered="#{not empty patientController.current.person.nameWithTitle and !configOptionApplicationController.getBooleanValueByKey('Enable patient specific status management in the system')}" />
-
-                                                        <p:badge rendered="#{configOptionApplicationController.getBooleanValueByKey('Enable patient specific status management in the system')}" style="transform: translate(110%, -40%);background-color: #{empty patientController.current.specificStatus ? 'white' : '#FF401F'} ; font-style: italic;" value="#{patientController.current.specificStatus}" severity="danger">
+                                                        <p:badge style="transform: translate(110%, -40%);background-color: #{patientController.current.specificStatus != null and patientController.current.specificStatus.name() != 'NORMAL' ? '#FF401F' : 'white'} ; font-style: italic;" value="#{patientController.current.specificStatus != null and patientController.current.specificStatus.name() != 'NORMAL' ? patientController.current.specificStatus : ''}" severity="danger">
                                                             <p:outputLabel value="#{patientController.current.person.nameWithTitle}" rendered="#{not empty patientController.current.person.nameWithTitle}" />
-                                                        </p:badge> 
+                                                        </p:badge>
 
                                                         <p:badge style="transform: translate(110%, -40%);background-color: #{patientController.current.blacklisted ? '#dc3545' : 'white'} ; font-style: italic; font-size: 15px" value="#{patientController.current.blacklisted ? 'Blacklisted' : 'Active'}" severity="danger">
 
@@ -249,8 +247,7 @@
                                                         <div class="alert alert-danger p-2 mt-1" style="font-size:0.85em;">
                                                             <strong>Reason:</strong> #{patientController.current.reasonForBlacklist}<br/>
                                                             <h:panelGroup rendered="#{not empty patientController.current.blacklistedBy}" layout="block">
-                                                                <strong>By:</strong> <h:outputText value="#{patientController.current.blacklistedBy.person.nameWithTitle}" rendered="#{not empty patientController.current.blacklistedBy.person}"/>
-                                                                <h:outputText value="#{patientController.current.blacklistedBy.username}" rendered="#{empty patientController.current.blacklistedBy.person}"/><br/>
+                                                                <strong>By:</strong> <h:outputText value="#{patientController.current.blacklistedBy.name}"/><br/>
                                                             </h:panelGroup>
                                                             <h:panelGroup rendered="#{not empty patientController.current.blacklistedAt}">
                                                                 <strong>On:</strong> <h:outputText value="#{patientController.current.blacklistedAt}"><f:convertDateTime pattern="#{sessionController.applicationPreference.longDateTimeFormat}" /></h:outputText>

--- a/src/main/webapp/opd/patient_edit.xhtml
+++ b/src/main/webapp/opd/patient_edit.xhtml
@@ -223,7 +223,7 @@
                                         </div>
                                     </div>
                                     
-                                    <div class="row form-group mb-1" style="display: #{configOptionApplicationController.getBooleanValueByKey('Enable patient specific status management in the system') ? 'flex' : 'none'}">
+                                    <div class="row form-group mb-1">
                                         <div class="col-md-3">
                                             <p:outputLabel value="Patient Specific Status:" class="form-label" />
                                             <div class="input-group">

--- a/src/main/webapp/opd/patient_search.xhtml
+++ b/src/main/webapp/opd/patient_search.xhtml
@@ -137,7 +137,7 @@
 
                                 </div>
 
-                                <div class="mb-3" style="display: #{configOptionApplicationController.getBooleanValueByKey('Enable patient specific status management in the system') ? 'block' : 'none'}">
+                                <div class="mb-3">
                                     <h:outputLabel class="form form-label" value="Patient Specific Status" ></h:outputLabel>
                                     <p:selectOneMenu class="w-100" id="specificStatus" value="#{patientController.specificPatientStatus}">
                                         <f:selectItem itemLabel="Select a status" itemValue="#{null}"/>
@@ -191,7 +191,7 @@
                                         <p:outputLabel value="#{p.person.address}"></p:outputLabel>
                                     </p:column>
 
-                                    <p:column style="text-align: center" headerText="Patient Status" width="10%" rendered="#{configOptionApplicationController.getBooleanValueByKey('Enable patient specific status management in the system')}">
+                                    <p:column style="text-align: center" headerText="Patient Status" width="10%">
                                         <p:outputLabel value="X Blacklisted" class="px-3" rendered="#{p.blacklisted}" style="color: #FF401F; font-weight: bold; padding: 5px; border-radius: 15px;"></p:outputLabel>
                                         <p:outputLabel value="Active" class="px-3" rendered="#{!p.blacklisted}" style="color: green; font-weight: bold; padding: 5px; border-radius: 15px;"></p:outputLabel>
                                         <p:outputLabel value="#{p.specificStatus}" class="px-3" rendered="#{not empty p.specificStatus}" style="color: EB7633; font-weight: bold; padding: 5px; border-radius: 15px;"></p:outputLabel>

--- a/src/main/webapp/pharmacy/pharmacy_bill_retail_sale.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_bill_retail_sale.xhtml
@@ -831,7 +831,7 @@
                                                                     <div class="col-md-4 p-1">
                                                                       
                                                                         <div class="input-group">
-                                                                            <p:selectOneMenu title="Patient Specific Status" class="w-100" id="specificStatus" value="#{pharmacySaleController.patient.specificStatus != null and pharmacySaleController.patient.specificStatus.name() != 'NORMAL' ? pharmacySaleController.patient.specificStatus : ''}">
+                                                                            <p:selectOneMenu title="Patient Specific Status" class="w-100" id="specificStatus" value="#{pharmacySaleController.patient.specificStatus}">
                                                                                 <f:selectItems value="#{patientController.getAllPatientSpecificLabels()}"/>
                                                                             </p:selectOneMenu>
 
@@ -877,7 +877,7 @@
                                                             <h:panelGroup class="d-flex">
 
                                                                 
-                                                                <p:badge style="transform: translate(110%, -40%);background-color: #{pharmacySaleController.patient.specificStatus != null and pharmacySaleController.patient.specificStatus.name() != 'NORMAL' ? '#FF401F' : 'white'} ; font-style: italic;" value="#{pharmacySaleController.patient.specificStatus != null and pharmacySaleController.patient.specificStatus.name() != 'NORMAL' ? pharmacySaleController.patient.specificStatus : ''}" severity="danger">
+                                                                <p:badge style="transform: translate(110%, -40%);background-color: #{pharmacySaleController.patient.specificStatus != null and pharmacySaleController.patient.specificStatus.name() != 'NORMAL' ? '#FF401F' : 'white'} ; font-style: italic;" value="#{pharmacySaleController.patient.specificStatus}" severity="danger">
                                                                     <p:outputLabel value="#{pharmacySaleController.patient.person.nameWithTitle}" rendered="#{not empty pharmacySaleController.patient.person.nameWithTitle}" />
                                                                 </p:badge> 
 

--- a/src/main/webapp/pharmacy/pharmacy_bill_retail_sale.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_bill_retail_sale.xhtml
@@ -831,7 +831,7 @@
                                                                     <div class="col-md-4 p-1">
                                                                       
                                                                         <div class="input-group">
-                                                                            <p:selectOneMenu title="Patient Specific Status" class="w-100" id="specificStatus" value="#{pharmacySaleController.patient.specificStatus}">
+                                                                            <p:selectOneMenu title="Patient Specific Status" class="w-100" id="specificStatus" value="#{pharmacySaleController.patient.specificStatus != null and pharmacySaleController.patient.specificStatus.name() != 'NORMAL' ? pharmacySaleController.patient.specificStatus : ''}">
                                                                                 <f:selectItems value="#{patientController.getAllPatientSpecificLabels()}"/>
                                                                             </p:selectOneMenu>
 
@@ -876,9 +876,8 @@
 
                                                             <h:panelGroup class="d-flex">
 
-                                                                <p:outputLabel class="ml-4" value="#{pharmacySaleController.patient.person.nameWithTitle}" rendered="#{not empty pharmacySaleController.patient.person.nameWithTitle and !configOptionApplicationController.getBooleanValueByKey('Enable patient specific status management in the system', false)}" />
-
-                                                                <p:badge rendered="#{configOptionApplicationController.getBooleanValueByKey('Enable patient specific status management in the system', false)}" style="transform: translate(110%, -40%);background-color: #{empty pharmacySaleController.patient.specificStatus ? 'white' : '#FF401F'} ; font-style: italic;" value="#{pharmacySaleController.patient.specificStatus}" severity="danger">
+                                                                
+                                                                <p:badge style="transform: translate(110%, -40%);background-color: #{pharmacySaleController.patient.specificStatus != null and pharmacySaleController.patient.specificStatus.name() != 'NORMAL' ? '#FF401F' : 'white'} ; font-style: italic;" value="#{pharmacySaleController.patient.specificStatus != null and pharmacySaleController.patient.specificStatus.name() != 'NORMAL' ? pharmacySaleController.patient.specificStatus : ''}" severity="danger">
                                                                     <p:outputLabel value="#{pharmacySaleController.patient.person.nameWithTitle}" rendered="#{not empty pharmacySaleController.patient.person.nameWithTitle}" />
                                                                 </p:badge> 
 

--- a/src/main/webapp/pharmacy/pharmacy_bill_retail_sale_1.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_bill_retail_sale_1.xhtml
@@ -829,7 +829,7 @@
                                                                     <div class="col-md-4 p-1">
 
                                                                         <div class="input-group">
-                                                                            <p:selectOneMenu title="Patient Specific Status" class="w-100" id="specificStatus" value="#{pharmacySaleController1.patient.specificStatus}">
+                                                                            <p:selectOneMenu title="Patient Specific Status" class="w-100" id="specificStatus" value="#{pharmacySaleController1.patient.specificStatus != null and pharmacySaleController1.patient.specificStatus.name() != 'NORMAL' ? pharmacySaleController1.patient.specificStatus : ''}">
                                                                                 <f:selectItems value="#{patientController.getAllPatientSpecificLabels()}"/>
                                                                             </p:selectOneMenu>
 
@@ -874,9 +874,8 @@
 
                                                             <h:panelGroup class="d-flex">
 
-                                                                <p:outputLabel class="ml-4" value="#{pharmacySaleController1.patient.person.nameWithTitle}" rendered="#{not empty pharmacySaleController1.patient.person.nameWithTitle and !configOptionApplicationController.getBooleanValueByKey('Enable patient specific status management in the system')}" />
-
-                                                                <p:badge rendered="#{configOptionApplicationController.getBooleanValueByKey('Enable patient specific status management in the system')}" style="transform: translate(110%, -40%);background-color: #{empty pharmacySaleController1.patient.specificStatus ? 'white' : '#FF401F'} ; font-style: italic;" value="#{pharmacySaleController1.patient.specificStatus}" severity="danger">
+                                                                
+                                                                <p:badge style="transform: translate(110%, -40%);background-color: #{pharmacySaleController1.patient.specificStatus != null and pharmacySaleController1.patient.specificStatus.name() != 'NORMAL' ? '#FF401F' : 'white'} ; font-style: italic;" value="#{pharmacySaleController1.patient.specificStatus != null and pharmacySaleController1.patient.specificStatus.name() != 'NORMAL' ? pharmacySaleController1.patient.specificStatus : ''}" severity="danger">
                                                                     <p:outputLabel value="#{pharmacySaleController1.patient.person.nameWithTitle}" rendered="#{not empty pharmacySaleController1.patient.person.nameWithTitle}" />
                                                                 </p:badge> 
 

--- a/src/main/webapp/pharmacy/pharmacy_bill_retail_sale_1.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_bill_retail_sale_1.xhtml
@@ -829,7 +829,7 @@
                                                                     <div class="col-md-4 p-1">
 
                                                                         <div class="input-group">
-                                                                            <p:selectOneMenu title="Patient Specific Status" class="w-100" id="specificStatus" value="#{pharmacySaleController1.patient.specificStatus != null and pharmacySaleController1.patient.specificStatus.name() != 'NORMAL' ? pharmacySaleController1.patient.specificStatus : ''}">
+                                                                            <p:selectOneMenu title="Patient Specific Status" class="w-100" id="specificStatus" value="#{pharmacySaleController1.patient.specificStatus}">
                                                                                 <f:selectItems value="#{patientController.getAllPatientSpecificLabels()}"/>
                                                                             </p:selectOneMenu>
 
@@ -875,7 +875,7 @@
                                                             <h:panelGroup class="d-flex">
 
                                                                 
-                                                                <p:badge style="transform: translate(110%, -40%);background-color: #{pharmacySaleController1.patient.specificStatus != null and pharmacySaleController1.patient.specificStatus.name() != 'NORMAL' ? '#FF401F' : 'white'} ; font-style: italic;" value="#{pharmacySaleController1.patient.specificStatus != null and pharmacySaleController1.patient.specificStatus.name() != 'NORMAL' ? pharmacySaleController1.patient.specificStatus : ''}" severity="danger">
+                                                                <p:badge style="transform: translate(110%, -40%);background-color: #{pharmacySaleController1.patient.specificStatus != null and pharmacySaleController1.patient.specificStatus.name() != 'NORMAL' ? '#FF401F' : 'white'} ; font-style: italic;" value="#{pharmacySaleController1.patient.specificStatus}" severity="danger">
                                                                     <p:outputLabel value="#{pharmacySaleController1.patient.person.nameWithTitle}" rendered="#{not empty pharmacySaleController1.patient.person.nameWithTitle}" />
                                                                 </p:badge> 
 

--- a/src/main/webapp/pharmacy/pharmacy_bill_retail_sale_2.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_bill_retail_sale_2.xhtml
@@ -827,7 +827,7 @@
                                                                     <div class="col-md-4 p-1">
 
                                                                         <div class="input-group">
-                                                                            <p:selectOneMenu title="Patient Specific Status" class="w-100" id="specificStatus" value="#{pharmacySaleController2.patient.specificStatus != null and pharmacySaleController2.patient.specificStatus.name() != 'NORMAL' ? pharmacySaleController2.patient.specificStatus : ''}">
+                                                                            <p:selectOneMenu title="Patient Specific Status" class="w-100" id="specificStatus" value="#{pharmacySaleController2.patient.specificStatus}">
                                                                                 <f:selectItems value="#{patientController.getAllPatientSpecificLabels()}"/>
                                                                             </p:selectOneMenu>
 
@@ -873,7 +873,7 @@
                                                             <h:panelGroup class="d-flex">
 
                                                                 
-                                                                <p:badge style="transform: translate(110%, -40%);background-color: #{pharmacySaleController2.patient.specificStatus != null and pharmacySaleController2.patient.specificStatus.name() != 'NORMAL' ? '#FF401F' : 'white'} ; font-style: italic;" value="#{pharmacySaleController2.patient.specificStatus != null and pharmacySaleController2.patient.specificStatus.name() != 'NORMAL' ? pharmacySaleController2.patient.specificStatus : ''}" severity="danger">
+                                                                <p:badge style="transform: translate(110%, -40%);background-color: #{pharmacySaleController2.patient.specificStatus != null and pharmacySaleController2.patient.specificStatus.name() != 'NORMAL' ? '#FF401F' : 'white'} ; font-style: italic;" value="#{pharmacySaleController2.patient.specificStatus}" severity="danger">
                                                                     <p:outputLabel value="#{pharmacySaleController2.patient.person.nameWithTitle}" rendered="#{not empty pharmacySaleController2.patient.person.nameWithTitle}" />
                                                                 </p:badge> 
 

--- a/src/main/webapp/pharmacy/pharmacy_bill_retail_sale_2.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_bill_retail_sale_2.xhtml
@@ -827,7 +827,7 @@
                                                                     <div class="col-md-4 p-1">
 
                                                                         <div class="input-group">
-                                                                            <p:selectOneMenu title="Patient Specific Status" class="w-100" id="specificStatus" value="#{pharmacySaleController2.patient.specificStatus}">
+                                                                            <p:selectOneMenu title="Patient Specific Status" class="w-100" id="specificStatus" value="#{pharmacySaleController2.patient.specificStatus != null and pharmacySaleController2.patient.specificStatus.name() != 'NORMAL' ? pharmacySaleController2.patient.specificStatus : ''}">
                                                                                 <f:selectItems value="#{patientController.getAllPatientSpecificLabels()}"/>
                                                                             </p:selectOneMenu>
 
@@ -872,9 +872,8 @@
 
                                                             <h:panelGroup class="d-flex">
 
-                                                                <p:outputLabel class="ml-4" value="#{pharmacySaleController2.patient.person.nameWithTitle}" rendered="#{not empty pharmacySaleController2.patient.person.nameWithTitle and !configOptionApplicationController.getBooleanValueByKey('Enable patient specific status management in the system')}" />
-
-                                                                <p:badge rendered="#{configOptionApplicationController.getBooleanValueByKey('Enable patient specific status management in the system')}" style="transform: translate(110%, -40%);background-color: #{empty pharmacySaleController2.patient.specificStatus ? 'white' : '#FF401F'} ; font-style: italic;" value="#{pharmacySaleController2.patient.specificStatus}" severity="danger">
+                                                                
+                                                                <p:badge style="transform: translate(110%, -40%);background-color: #{pharmacySaleController2.patient.specificStatus != null and pharmacySaleController2.patient.specificStatus.name() != 'NORMAL' ? '#FF401F' : 'white'} ; font-style: italic;" value="#{pharmacySaleController2.patient.specificStatus != null and pharmacySaleController2.patient.specificStatus.name() != 'NORMAL' ? pharmacySaleController2.patient.specificStatus : ''}" severity="danger">
                                                                     <p:outputLabel value="#{pharmacySaleController2.patient.person.nameWithTitle}" rendered="#{not empty pharmacySaleController2.patient.person.nameWithTitle}" />
                                                                 </p:badge> 
 

--- a/src/main/webapp/pharmacy/pharmacy_bill_retail_sale_3.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_bill_retail_sale_3.xhtml
@@ -828,7 +828,7 @@
                                                                     <div class="col-md-4 p-1">
 
                                                                         <div class="input-group">
-                                                                            <p:selectOneMenu title="Patient Specific Status" class="w-100" id="specificStatus" value="#{pharmacySaleController3.patient.specificStatus != null and pharmacySaleController3.patient.specificStatus.name() != 'NORMAL' ? pharmacySaleController3.patient.specificStatus : ''}">
+                                                                            <p:selectOneMenu title="Patient Specific Status" class="w-100" id="specificStatus" value="#{pharmacySaleController3.patient.specificStatus}">
                                                                                 <f:selectItems value="#{patientController.getAllPatientSpecificLabels()}"/>
                                                                             </p:selectOneMenu>
 
@@ -875,7 +875,7 @@
                                                             <h:panelGroup class="d-flex">
 
                                                                 
-                                                                <p:badge style="transform: translate(110%, -40%);background-color: #{pharmacySaleController3.patient.specificStatus != null and pharmacySaleController3.patient.specificStatus.name() != 'NORMAL' ? '#FF401F' : 'white'} ; font-style: italic;" value="#{pharmacySaleController3.patient.specificStatus != null and pharmacySaleController3.patient.specificStatus.name() != 'NORMAL' ? pharmacySaleController3.patient.specificStatus : ''}" severity="danger">
+                                                                <p:badge style="transform: translate(110%, -40%);background-color: #{pharmacySaleController3.patient.specificStatus != null and pharmacySaleController3.patient.specificStatus.name() != 'NORMAL' ? '#FF401F' : 'white'} ; font-style: italic;" value="#{pharmacySaleController3.patient.specificStatus}" severity="danger">
                                                                     <p:outputLabel value="#{pharmacySaleController3.patient.person.nameWithTitle}" rendered="#{not empty pharmacySaleController3.patient.person.nameWithTitle}" />
                                                                 </p:badge> 
 

--- a/src/main/webapp/pharmacy/pharmacy_bill_retail_sale_3.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_bill_retail_sale_3.xhtml
@@ -828,7 +828,7 @@
                                                                     <div class="col-md-4 p-1">
 
                                                                         <div class="input-group">
-                                                                            <p:selectOneMenu title="Patient Specific Status" class="w-100" id="specificStatus" value="#{pharmacySaleController3.patient.specificStatus}">
+                                                                            <p:selectOneMenu title="Patient Specific Status" class="w-100" id="specificStatus" value="#{pharmacySaleController3.patient.specificStatus != null and pharmacySaleController3.patient.specificStatus.name() != 'NORMAL' ? pharmacySaleController3.patient.specificStatus : ''}">
                                                                                 <f:selectItems value="#{patientController.getAllPatientSpecificLabels()}"/>
                                                                             </p:selectOneMenu>
 
@@ -874,9 +874,8 @@
 
                                                             <h:panelGroup class="d-flex">
 
-                                                                <p:outputLabel class="ml-4" value="#{pharmacySaleController3.patient.person.nameWithTitle}" rendered="#{not empty pharmacySaleController3.patient.person.nameWithTitle and !configOptionApplicationController.getBooleanValueByKey('Enable patient specific status management in the system')}" />
-
-                                                                <p:badge rendered="#{configOptionApplicationController.getBooleanValueByKey('Enable patient specific status management in the system')}" style="transform: translate(110%, -40%);background-color: #{empty pharmacySaleController3.patient.specificStatus ? 'white' : '#FF401F'} ; font-style: italic;" value="#{pharmacySaleController3.patient.specificStatus}" severity="danger">
+                                                                
+                                                                <p:badge style="transform: translate(110%, -40%);background-color: #{pharmacySaleController3.patient.specificStatus != null and pharmacySaleController3.patient.specificStatus.name() != 'NORMAL' ? '#FF401F' : 'white'} ; font-style: italic;" value="#{pharmacySaleController3.patient.specificStatus != null and pharmacySaleController3.patient.specificStatus.name() != 'NORMAL' ? pharmacySaleController3.patient.specificStatus : ''}" severity="danger">
                                                                     <p:outputLabel value="#{pharmacySaleController3.patient.person.nameWithTitle}" rendered="#{not empty pharmacySaleController3.patient.person.nameWithTitle}" />
                                                                 </p:badge> 
 

--- a/src/main/webapp/pharmacy/pharmacy_fast_retail_sale.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_fast_retail_sale.xhtml
@@ -683,7 +683,7 @@
                                                                         <div class="col-md-4 p-1">
 
                                                                             <div class="input-group">
-                                                                                <p:selectOneMenu title="Patient Specific Status" class="w-100" id="specificStatus" value="#{pharmacyFastRetailSaleController.patient.specificStatus != null and pharmacyFastRetailSaleController.patient.specificStatus.name() != 'NORMAL' ? pharmacyFastRetailSaleController.patient.specificStatus : ''}">
+                                                                                <p:selectOneMenu title="Patient Specific Status" class="w-100" id="specificStatus" value="#{pharmacyFastRetailSaleController.patient.specificStatus}">
                                                                                     <f:selectItems value="#{patientController.getAllPatientSpecificLabels()}"/>
                                                                                 </p:selectOneMenu>
 
@@ -729,7 +729,7 @@
                                                                 <h:panelGroup class="d-flex">
 
                                                                     
-                                                                    <p:badge style="transform: translate(110%, -40%);background-color: #{pharmacyFastRetailSaleController.patient.specificStatus != null and pharmacyFastRetailSaleController.patient.specificStatus.name() != 'NORMAL' ? '#FF401F' : 'white'} ; font-style: italic;" value="#{pharmacyFastRetailSaleController.patient.specificStatus != null and pharmacyFastRetailSaleController.patient.specificStatus.name() != 'NORMAL' ? pharmacyFastRetailSaleController.patient.specificStatus : ''}" severity="danger">
+                                                                    <p:badge style="transform: translate(110%, -40%);background-color: #{pharmacyFastRetailSaleController.patient.specificStatus != null and pharmacyFastRetailSaleController.patient.specificStatus.name() != 'NORMAL' ? '#FF401F' : 'white'} ; font-style: italic;" value="#{pharmacyFastRetailSaleController.patient.specificStatus}" severity="danger">
                                                                         <p:outputLabel value="#{pharmacyFastRetailSaleController.patient.person.nameWithTitle}" rendered="#{not empty pharmacyFastRetailSaleController.patient.person.nameWithTitle}" />
                                                                     </p:badge> 
 

--- a/src/main/webapp/pharmacy/pharmacy_fast_retail_sale.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_fast_retail_sale.xhtml
@@ -683,7 +683,7 @@
                                                                         <div class="col-md-4 p-1">
 
                                                                             <div class="input-group">
-                                                                                <p:selectOneMenu title="Patient Specific Status" class="w-100" id="specificStatus" value="#{pharmacyFastRetailSaleController.patient.specificStatus}">
+                                                                                <p:selectOneMenu title="Patient Specific Status" class="w-100" id="specificStatus" value="#{pharmacyFastRetailSaleController.patient.specificStatus != null and pharmacyFastRetailSaleController.patient.specificStatus.name() != 'NORMAL' ? pharmacyFastRetailSaleController.patient.specificStatus : ''}">
                                                                                     <f:selectItems value="#{patientController.getAllPatientSpecificLabels()}"/>
                                                                                 </p:selectOneMenu>
 
@@ -728,9 +728,8 @@
 
                                                                 <h:panelGroup class="d-flex">
 
-                                                                    <p:outputLabel class="ml-4" value="#{pharmacyFastRetailSaleController.patient.person.nameWithTitle}" rendered="#{not empty pharmacyFastRetailSaleController.patient.person.nameWithTitle and !configOptionApplicationController.getBooleanValueByKey('Enable patient specific status management in the system')}" />
-
-                                                                    <p:badge rendered="#{configOptionApplicationController.getBooleanValueByKey('Enable patient specific status management in the system')}" style="transform: translate(110%, -40%);background-color: #{empty pharmacyFastRetailSaleController.patient.specificStatus ? 'white' : '#FF401F'} ; font-style: italic;" value="#{pharmacyFastRetailSaleController.patient.specificStatus}" severity="danger">
+                                                                    
+                                                                    <p:badge style="transform: translate(110%, -40%);background-color: #{pharmacyFastRetailSaleController.patient.specificStatus != null and pharmacyFastRetailSaleController.patient.specificStatus.name() != 'NORMAL' ? '#FF401F' : 'white'} ; font-style: italic;" value="#{pharmacyFastRetailSaleController.patient.specificStatus != null and pharmacyFastRetailSaleController.patient.specificStatus.name() != 'NORMAL' ? pharmacyFastRetailSaleController.patient.specificStatus : ''}" severity="danger">
                                                                         <p:outputLabel value="#{pharmacyFastRetailSaleController.patient.person.nameWithTitle}" rendered="#{not empty pharmacyFastRetailSaleController.patient.person.nameWithTitle}" />
                                                                     </p:badge> 
 

--- a/src/main/webapp/pharmacy/pharmacy_fast_retail_sale_1.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_fast_retail_sale_1.xhtml
@@ -678,7 +678,7 @@
                                                                         <div class="col-md-4 p-1">
 
                                                                             <div class="input-group">
-                                                                                <p:selectOneMenu title="Patient Specific Status" class="w-100" id="specificStatus" value="#{pharmacyFastRetailSaleController1.patient.specificStatus != null and pharmacyFastRetailSaleController1.patient.specificStatus.name() != 'NORMAL' ? pharmacyFastRetailSaleController1.patient.specificStatus : ''}">
+                                                                                <p:selectOneMenu title="Patient Specific Status" class="w-100" id="specificStatus" value="#{pharmacyFastRetailSaleController1.patient.specificStatus}">
                                                                                     <f:selectItems value="#{patientController.getAllPatientSpecificLabels()}"/>
                                                                                 </p:selectOneMenu>
 
@@ -724,7 +724,7 @@
                                                                 <h:panelGroup class="d-flex">
 
                                                                     
-                                                                    <p:badge style="transform: translate(110%, -40%);background-color: #{pharmacyFastRetailSaleController1.patient.specificStatus != null and pharmacyFastRetailSaleController1.patient.specificStatus.name() != 'NORMAL' ? '#FF401F' : 'white'} ; font-style: italic;" value="#{pharmacyFastRetailSaleController1.patient.specificStatus != null and pharmacyFastRetailSaleController1.patient.specificStatus.name() != 'NORMAL' ? pharmacyFastRetailSaleController1.patient.specificStatus : ''}" severity="danger">
+                                                                    <p:badge style="transform: translate(110%, -40%);background-color: #{pharmacyFastRetailSaleController1.patient.specificStatus != null and pharmacyFastRetailSaleController1.patient.specificStatus.name() != 'NORMAL' ? '#FF401F' : 'white'} ; font-style: italic;" value="#{pharmacyFastRetailSaleController1.patient.specificStatus}" severity="danger">
                                                                         <p:outputLabel value="#{pharmacyFastRetailSaleController1.patient.person.nameWithTitle}" rendered="#{not empty pharmacyFastRetailSaleController1.patient.person.nameWithTitle}" />
                                                                     </p:badge> 
 

--- a/src/main/webapp/pharmacy/pharmacy_fast_retail_sale_1.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_fast_retail_sale_1.xhtml
@@ -678,7 +678,7 @@
                                                                         <div class="col-md-4 p-1">
 
                                                                             <div class="input-group">
-                                                                                <p:selectOneMenu title="Patient Specific Status" class="w-100" id="specificStatus" value="#{pharmacyFastRetailSaleController1.patient.specificStatus}">
+                                                                                <p:selectOneMenu title="Patient Specific Status" class="w-100" id="specificStatus" value="#{pharmacyFastRetailSaleController1.patient.specificStatus != null and pharmacyFastRetailSaleController1.patient.specificStatus.name() != 'NORMAL' ? pharmacyFastRetailSaleController1.patient.specificStatus : ''}">
                                                                                     <f:selectItems value="#{patientController.getAllPatientSpecificLabels()}"/>
                                                                                 </p:selectOneMenu>
 
@@ -723,9 +723,8 @@
 
                                                                 <h:panelGroup class="d-flex">
 
-                                                                    <p:outputLabel class="ml-4" value="#{pharmacyFastRetailSaleController1.patient.person.nameWithTitle}" rendered="#{not empty pharmacyFastRetailSaleController1.patient.person.nameWithTitle and !configOptionApplicationController.getBooleanValueByKey('Enable patient specific status management in the system')}" />
-
-                                                                    <p:badge rendered="#{configOptionApplicationController.getBooleanValueByKey('Enable patient specific status management in the system')}" style="transform: translate(110%, -40%);background-color: #{empty pharmacyFastRetailSaleController1.patient.specificStatus ? 'white' : '#FF401F'} ; font-style: italic;" value="#{pharmacyFastRetailSaleController1.patient.specificStatus}" severity="danger">
+                                                                    
+                                                                    <p:badge style="transform: translate(110%, -40%);background-color: #{pharmacyFastRetailSaleController1.patient.specificStatus != null and pharmacyFastRetailSaleController1.patient.specificStatus.name() != 'NORMAL' ? '#FF401F' : 'white'} ; font-style: italic;" value="#{pharmacyFastRetailSaleController1.patient.specificStatus != null and pharmacyFastRetailSaleController1.patient.specificStatus.name() != 'NORMAL' ? pharmacyFastRetailSaleController1.patient.specificStatus : ''}" severity="danger">
                                                                         <p:outputLabel value="#{pharmacyFastRetailSaleController1.patient.person.nameWithTitle}" rendered="#{not empty pharmacyFastRetailSaleController1.patient.person.nameWithTitle}" />
                                                                     </p:badge> 
 

--- a/src/main/webapp/pharmacy/pharmacy_fast_retail_sale_2.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_fast_retail_sale_2.xhtml
@@ -680,7 +680,7 @@
                                                                         <div class="col-md-4 p-1">
 
                                                                             <div class="input-group">
-                                                                                <p:selectOneMenu title="Patient Specific Status" class="w-100" id="specificStatus" value="#{pharmacyFastRetailSaleController2.patient.specificStatus != null and pharmacyFastRetailSaleController2.patient.specificStatus.name() != 'NORMAL' ? pharmacyFastRetailSaleController2.patient.specificStatus : ''}">
+                                                                                <p:selectOneMenu title="Patient Specific Status" class="w-100" id="specificStatus" value="#{pharmacyFastRetailSaleController2.patient.specificStatus}">
                                                                                     <f:selectItems value="#{patientController.getAllPatientSpecificLabels()}"/>
                                                                                 </p:selectOneMenu>
 
@@ -726,7 +726,7 @@
                                                                 <h:panelGroup class="d-flex">
 
                                                                     
-                                                                    <p:badge style="transform: translate(110%, -40%);background-color: #{pharmacyFastRetailSaleController2.patient.specificStatus != null and pharmacyFastRetailSaleController2.patient.specificStatus.name() != 'NORMAL' ? '#FF401F' : 'white'} ; font-style: italic;" value="#{pharmacyFastRetailSaleController2.patient.specificStatus != null and pharmacyFastRetailSaleController2.patient.specificStatus.name() != 'NORMAL' ? pharmacyFastRetailSaleController2.patient.specificStatus : ''}" severity="danger">
+                                                                    <p:badge style="transform: translate(110%, -40%);background-color: #{pharmacyFastRetailSaleController2.patient.specificStatus != null and pharmacyFastRetailSaleController2.patient.specificStatus.name() != 'NORMAL' ? '#FF401F' : 'white'} ; font-style: italic;" value="#{pharmacyFastRetailSaleController2.patient.specificStatus}" severity="danger">
                                                                         <p:outputLabel value="#{pharmacyFastRetailSaleController2.patient.person.nameWithTitle}" rendered="#{not empty pharmacyFastRetailSaleController2.patient.person.nameWithTitle}" />
                                                                     </p:badge> 
 

--- a/src/main/webapp/pharmacy/pharmacy_fast_retail_sale_2.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_fast_retail_sale_2.xhtml
@@ -680,7 +680,7 @@
                                                                         <div class="col-md-4 p-1">
 
                                                                             <div class="input-group">
-                                                                                <p:selectOneMenu title="Patient Specific Status" class="w-100" id="specificStatus" value="#{pharmacyFastRetailSaleController2.patient.specificStatus}">
+                                                                                <p:selectOneMenu title="Patient Specific Status" class="w-100" id="specificStatus" value="#{pharmacyFastRetailSaleController2.patient.specificStatus != null and pharmacyFastRetailSaleController2.patient.specificStatus.name() != 'NORMAL' ? pharmacyFastRetailSaleController2.patient.specificStatus : ''}">
                                                                                     <f:selectItems value="#{patientController.getAllPatientSpecificLabels()}"/>
                                                                                 </p:selectOneMenu>
 
@@ -725,9 +725,8 @@
 
                                                                 <h:panelGroup class="d-flex">
 
-                                                                    <p:outputLabel class="ml-4" value="#{pharmacyFastRetailSaleController2.patient.person.nameWithTitle}" rendered="#{not empty pharmacyFastRetailSaleController2.patient.person.nameWithTitle and !configOptionApplicationController.getBooleanValueByKey('Enable patient specific status management in the system')}" />
-
-                                                                    <p:badge rendered="#{configOptionApplicationController.getBooleanValueByKey('Enable patient specific status management in the system')}" style="transform: translate(110%, -40%);background-color: #{empty pharmacyFastRetailSaleController2.patient.specificStatus ? 'white' : '#FF401F'} ; font-style: italic;" value="#{pharmacyFastRetailSaleController2.patient.specificStatus}" severity="danger">
+                                                                    
+                                                                    <p:badge style="transform: translate(110%, -40%);background-color: #{pharmacyFastRetailSaleController2.patient.specificStatus != null and pharmacyFastRetailSaleController2.patient.specificStatus.name() != 'NORMAL' ? '#FF401F' : 'white'} ; font-style: italic;" value="#{pharmacyFastRetailSaleController2.patient.specificStatus != null and pharmacyFastRetailSaleController2.patient.specificStatus.name() != 'NORMAL' ? pharmacyFastRetailSaleController2.patient.specificStatus : ''}" severity="danger">
                                                                         <p:outputLabel value="#{pharmacyFastRetailSaleController2.patient.person.nameWithTitle}" rendered="#{not empty pharmacyFastRetailSaleController2.patient.person.nameWithTitle}" />
                                                                     </p:badge> 
 

--- a/src/main/webapp/pharmacy/pharmacy_fast_retail_sale_3.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_fast_retail_sale_3.xhtml
@@ -681,7 +681,7 @@
                                                                         <div class="col-md-4 p-1">
 
                                                                             <div class="input-group">
-                                                                                <p:selectOneMenu title="Patient Specific Status" class="w-100" id="specificStatus" value="#{pharmacyFastRetailSaleController3.patient.specificStatus != null and pharmacyFastRetailSaleController3.patient.specificStatus.name() != 'NORMAL' ? pharmacyFastRetailSaleController3.patient.specificStatus : ''}">
+                                                                                <p:selectOneMenu title="Patient Specific Status" class="w-100" id="specificStatus" value="#{pharmacyFastRetailSaleController3.patient.specificStatus}">
                                                                                     <f:selectItems value="#{patientController.getAllPatientSpecificLabels()}"/>
                                                                                 </p:selectOneMenu>
 
@@ -727,7 +727,7 @@
                                                                 <h:panelGroup class="d-flex">
 
                                                                     
-                                                                    <p:badge style="transform: translate(110%, -40%);background-color: #{pharmacyFastRetailSaleController3.patient.specificStatus != null and pharmacyFastRetailSaleController3.patient.specificStatus.name() != 'NORMAL' ? '#FF401F' : 'white'} ; font-style: italic;" value="#{pharmacyFastRetailSaleController3.patient.specificStatus != null and pharmacyFastRetailSaleController3.patient.specificStatus.name() != 'NORMAL' ? pharmacyFastRetailSaleController3.patient.specificStatus : ''}" severity="danger">
+                                                                    <p:badge style="transform: translate(110%, -40%);background-color: #{pharmacyFastRetailSaleController3.patient.specificStatus != null and pharmacyFastRetailSaleController3.patient.specificStatus.name() != 'NORMAL' ? '#FF401F' : 'white'} ; font-style: italic;" value="#{pharmacyFastRetailSaleController3.patient.specificStatus}" severity="danger">
                                                                         <p:outputLabel value="#{pharmacyFastRetailSaleController3.patient.person.nameWithTitle}" rendered="#{not empty pharmacyFastRetailSaleController3.patient.person.nameWithTitle}" />
                                                                     </p:badge> 
 

--- a/src/main/webapp/pharmacy/pharmacy_fast_retail_sale_3.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_fast_retail_sale_3.xhtml
@@ -681,7 +681,7 @@
                                                                         <div class="col-md-4 p-1">
 
                                                                             <div class="input-group">
-                                                                                <p:selectOneMenu title="Patient Specific Status" class="w-100" id="specificStatus" value="#{pharmacyFastRetailSaleController3.patient.specificStatus}">
+                                                                                <p:selectOneMenu title="Patient Specific Status" class="w-100" id="specificStatus" value="#{pharmacyFastRetailSaleController3.patient.specificStatus != null and pharmacyFastRetailSaleController3.patient.specificStatus.name() != 'NORMAL' ? pharmacyFastRetailSaleController3.patient.specificStatus : ''}">
                                                                                     <f:selectItems value="#{patientController.getAllPatientSpecificLabels()}"/>
                                                                                 </p:selectOneMenu>
 
@@ -726,9 +726,8 @@
 
                                                                 <h:panelGroup class="d-flex">
 
-                                                                    <p:outputLabel class="ml-4" value="#{pharmacyFastRetailSaleController3.patient.person.nameWithTitle}" rendered="#{not empty pharmacyFastRetailSaleController3.patient.person.nameWithTitle and !configOptionApplicationController.getBooleanValueByKey('Enable patient specific status management in the system')}" />
-
-                                                                    <p:badge rendered="#{configOptionApplicationController.getBooleanValueByKey('Enable patient specific status management in the system')}" style="transform: translate(110%, -40%);background-color: #{empty pharmacyFastRetailSaleController3.patient.specificStatus ? 'white' : '#FF401F'} ; font-style: italic;" value="#{pharmacyFastRetailSaleController3.patient.specificStatus}" severity="danger">
+                                                                    
+                                                                    <p:badge style="transform: translate(110%, -40%);background-color: #{pharmacyFastRetailSaleController3.patient.specificStatus != null and pharmacyFastRetailSaleController3.patient.specificStatus.name() != 'NORMAL' ? '#FF401F' : 'white'} ; font-style: italic;" value="#{pharmacyFastRetailSaleController3.patient.specificStatus != null and pharmacyFastRetailSaleController3.patient.specificStatus.name() != 'NORMAL' ? pharmacyFastRetailSaleController3.patient.specificStatus : ''}" severity="danger">
                                                                         <p:outputLabel value="#{pharmacyFastRetailSaleController3.patient.person.nameWithTitle}" rendered="#{not empty pharmacyFastRetailSaleController3.patient.person.nameWithTitle}" />
                                                                     </p:badge> 
 

--- a/src/main/webapp/pharmacy/pharmacy_fast_retail_sale_for_cashier.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_fast_retail_sale_for_cashier.xhtml
@@ -678,7 +678,7 @@
                                                                         <div class="col-md-4 p-1">
 
                                                                             <div class="input-group">
-                                                                                <p:selectOneMenu title="Patient Specific Status" class="w-100" id="specificStatus" value="#{pharmacyFastRetailSaleForCashierController.patient.specificStatus != null and pharmacyFastRetailSaleForCashierController.patient.specificStatus.name() != 'NORMAL' ? pharmacyFastRetailSaleForCashierController.patient.specificStatus : ''}">
+                                                                                <p:selectOneMenu title="Patient Specific Status" class="w-100" id="specificStatus" value="#{pharmacyFastRetailSaleForCashierController.patient.specificStatus}">
                                                                                     <f:selectItems value="#{patientController.getAllPatientSpecificLabels()}"/>
                                                                                 </p:selectOneMenu>
 
@@ -724,7 +724,7 @@
                                                                 <h:panelGroup class="d-flex">
 
                                                                     
-                                                                    <p:badge style="transform: translate(110%, -40%);background-color: #{pharmacyFastRetailSaleForCashierController.patient.specificStatus != null and pharmacyFastRetailSaleForCashierController.patient.specificStatus.name() != 'NORMAL' ? '#FF401F' : 'white'} ; font-style: italic;" value="#{pharmacyFastRetailSaleForCashierController.patient.specificStatus != null and pharmacyFastRetailSaleForCashierController.patient.specificStatus.name() != 'NORMAL' ? pharmacyFastRetailSaleForCashierController.patient.specificStatus : ''}" severity="danger">
+                                                                    <p:badge style="transform: translate(110%, -40%);background-color: #{pharmacyFastRetailSaleForCashierController.patient.specificStatus != null and pharmacyFastRetailSaleForCashierController.patient.specificStatus.name() != 'NORMAL' ? '#FF401F' : 'white'} ; font-style: italic;" value="#{pharmacyFastRetailSaleForCashierController.patient.specificStatus}" severity="danger">
                                                                         <p:outputLabel value="#{pharmacyFastRetailSaleForCashierController.patient.person.nameWithTitle}" rendered="#{not empty pharmacyFastRetailSaleForCashierController.patient.person.nameWithTitle}" />
                                                                     </p:badge> 
 

--- a/src/main/webapp/pharmacy/pharmacy_fast_retail_sale_for_cashier.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_fast_retail_sale_for_cashier.xhtml
@@ -678,7 +678,7 @@
                                                                         <div class="col-md-4 p-1">
 
                                                                             <div class="input-group">
-                                                                                <p:selectOneMenu title="Patient Specific Status" class="w-100" id="specificStatus" value="#{pharmacyFastRetailSaleForCashierController.patient.specificStatus}">
+                                                                                <p:selectOneMenu title="Patient Specific Status" class="w-100" id="specificStatus" value="#{pharmacyFastRetailSaleForCashierController.patient.specificStatus != null and pharmacyFastRetailSaleForCashierController.patient.specificStatus.name() != 'NORMAL' ? pharmacyFastRetailSaleForCashierController.patient.specificStatus : ''}">
                                                                                     <f:selectItems value="#{patientController.getAllPatientSpecificLabels()}"/>
                                                                                 </p:selectOneMenu>
 
@@ -723,9 +723,8 @@
 
                                                                 <h:panelGroup class="d-flex">
 
-                                                                    <p:outputLabel class="ml-4" value="#{pharmacyFastRetailSaleForCashierController.patient.person.nameWithTitle}" rendered="#{not empty pharmacyFastRetailSaleForCashierController.patient.person.nameWithTitle and !configOptionApplicationController.getBooleanValueByKey('Enable patient specific status management in the system')}" />
-
-                                                                    <p:badge rendered="#{configOptionApplicationController.getBooleanValueByKey('Enable patient specific status management in the system')}" style="transform: translate(110%, -40%);background-color: #{empty pharmacyFastRetailSaleForCashierController.patient.specificStatus ? 'white' : '#FF401F'} ; font-style: italic;" value="#{pharmacyFastRetailSaleForCashierController.patient.specificStatus}" severity="danger">
+                                                                    
+                                                                    <p:badge style="transform: translate(110%, -40%);background-color: #{pharmacyFastRetailSaleForCashierController.patient.specificStatus != null and pharmacyFastRetailSaleForCashierController.patient.specificStatus.name() != 'NORMAL' ? '#FF401F' : 'white'} ; font-style: italic;" value="#{pharmacyFastRetailSaleForCashierController.patient.specificStatus != null and pharmacyFastRetailSaleForCashierController.patient.specificStatus.name() != 'NORMAL' ? pharmacyFastRetailSaleForCashierController.patient.specificStatus : ''}" severity="danger">
                                                                         <p:outputLabel value="#{pharmacyFastRetailSaleForCashierController.patient.person.nameWithTitle}" rendered="#{not empty pharmacyFastRetailSaleForCashierController.patient.person.nameWithTitle}" />
                                                                     </p:badge> 
 

--- a/src/main/webapp/resources/ezcomp/common/patient_details.xhtml
+++ b/src/main/webapp/resources/ezcomp/common/patient_details.xhtml
@@ -319,7 +319,7 @@
                                     <div class="col-md-4 p-1">
 
                                         <div class="input-group">
-                                            <p:selectOneMenu title="Patient Specific Status" class="w-100" id="specificStatus" value="#{cc.attrs.controller.patient.specificStatus != null and cc.attrs.controller.patient.specificStatus.name() != 'NORMAL' ? cc.attrs.controller.patient.specificStatus : ''}">
+                                            <p:selectOneMenu title="Patient Specific Status" class="w-100" id="specificStatus" value="#{cc.attrs.controller.patient.specificStatus}">
                                                 <f:selectItems value="#{patientController.getAllPatientSpecificLabels()}"/>
                                             </p:selectOneMenu>
 
@@ -366,7 +366,7 @@
                             <h:panelGroup class="d-flex">
 
                                 
-                                <p:badge style="transform: translate(110%, -40%);background-color: #{cc.attrs.controller.patient.specificStatus != null and cc.attrs.controller.patient.specificStatus.name() != 'NORMAL' ? '#FF401F' : 'white'} ; font-style: italic;" value="#{cc.attrs.controller.patient.specificStatus != null and cc.attrs.controller.patient.specificStatus.name() != 'NORMAL' ? cc.attrs.controller.patient.specificStatus : ''}" severity="danger">
+                                <p:badge style="transform: translate(110%, -40%);background-color: #{cc.attrs.controller.patient.specificStatus != null and cc.attrs.controller.patient.specificStatus.name() != 'NORMAL' ? '#FF401F' : 'white'} ; font-style: italic;" value="#{cc.attrs.controller.patient.specificStatus}" severity="danger">
                                     <p:outputLabel value="#{cc.attrs.controller.patient.person.nameWithTitle}" rendered="#{not empty cc.attrs.controller.patient.person.nameWithTitle}" />
                                 </p:badge> 
 

--- a/src/main/webapp/resources/ezcomp/common/patient_details.xhtml
+++ b/src/main/webapp/resources/ezcomp/common/patient_details.xhtml
@@ -319,7 +319,7 @@
                                     <div class="col-md-4 p-1">
 
                                         <div class="input-group">
-                                            <p:selectOneMenu title="Patient Specific Status" class="w-100" id="specificStatus" value="#{cc.attrs.controller.patient.specificStatus}">
+                                            <p:selectOneMenu title="Patient Specific Status" class="w-100" id="specificStatus" value="#{cc.attrs.controller.patient.specificStatus != null and cc.attrs.controller.patient.specificStatus.name() != 'NORMAL' ? cc.attrs.controller.patient.specificStatus : ''}">
                                                 <f:selectItems value="#{patientController.getAllPatientSpecificLabels()}"/>
                                             </p:selectOneMenu>
 
@@ -365,9 +365,8 @@
 
                             <h:panelGroup class="d-flex">
 
-                                <p:outputLabel class="ml-4" value="#{cc.attrs.controller.patient.person.nameWithTitle}" rendered="#{not empty cc.attrs.controller.patient.person.nameWithTitle and !configOptionApplicationController.getBooleanValueByKey('Enable patient specific status management in the system')}" />
-
-                                <p:badge rendered="#{configOptionApplicationController.getBooleanValueByKey('Enable patient specific status management in the system')}" style="transform: translate(110%, -40%);background-color: #{empty cc.attrs.controller.patient.specificStatus ? 'white' : '#FF401F'} ; font-style: italic;" value="#{cc.attrs.controller.patient.specificStatus}" severity="danger">
+                                
+                                <p:badge style="transform: translate(110%, -40%);background-color: #{cc.attrs.controller.patient.specificStatus != null and cc.attrs.controller.patient.specificStatus.name() != 'NORMAL' ? '#FF401F' : 'white'} ; font-style: italic;" value="#{cc.attrs.controller.patient.specificStatus != null and cc.attrs.controller.patient.specificStatus.name() != 'NORMAL' ? cc.attrs.controller.patient.specificStatus : ''}" severity="danger">
                                     <p:outputLabel value="#{cc.attrs.controller.patient.person.nameWithTitle}" rendered="#{not empty cc.attrs.controller.patient.person.nameWithTitle}" />
                                 </p:badge> 
 

--- a/src/main/webapp/resources/ezcomp/common/patient_details_for_addmission.xhtml
+++ b/src/main/webapp/resources/ezcomp/common/patient_details_for_addmission.xhtml
@@ -297,7 +297,7 @@
                                     <div class="col-md-4 p-1">
 
                                         <div class="input-group">
-                                            <p:selectOneMenu title="Patient Specific Status" class="w-100" id="specificStatus" value="#{cc.attrs.controller.patient.specificStatus}">
+                                            <p:selectOneMenu title="Patient Specific Status" class="w-100" id="specificStatus" value="#{cc.attrs.controller.patient.specificStatus != null and cc.attrs.controller.patient.specificStatus.name() != 'NORMAL' ? cc.attrs.controller.patient.specificStatus : ''}">
                                                 <f:selectItems value="#{patientController.getAllPatientSpecificLabels()}"/>
                                             </p:selectOneMenu>
 
@@ -391,9 +391,8 @@
 
                             <h:panelGroup class="d-flex">
 
-                                <p:outputLabel class="ml-4" value="#{cc.attrs.controller.patient.person.nameWithTitle}" rendered="#{not empty cc.attrs.controller.patient.person.nameWithTitle and !configOptionApplicationController.getBooleanValueByKey('Enable patient specific status management in the system')}" />
-
-                                <p:badge rendered="#{configOptionApplicationController.getBooleanValueByKey('Enable patient specific status management in the system')}" style="transform: translate(110%, -40%);background-color: #{empty cc.attrs.controller.patient.specificStatus ? 'white' : '#FF401F'} ; font-style: italic;" value="#{cc.attrs.controller.patient.specificStatus}" severity="danger">
+                                
+                                <p:badge style="transform: translate(110%, -40%);background-color: #{cc.attrs.controller.patient.specificStatus != null and cc.attrs.controller.patient.specificStatus.name() != 'NORMAL' ? '#FF401F' : 'white'} ; font-style: italic;" value="#{cc.attrs.controller.patient.specificStatus != null and cc.attrs.controller.patient.specificStatus.name() != 'NORMAL' ? cc.attrs.controller.patient.specificStatus : ''}" severity="danger">
                                     <p:outputLabel value="#{cc.attrs.controller.patient.person.nameWithTitle}" rendered="#{not empty cc.attrs.controller.patient.person.nameWithTitle}" />
                                 </p:badge> 
 

--- a/src/main/webapp/resources/ezcomp/common/patient_details_for_addmission.xhtml
+++ b/src/main/webapp/resources/ezcomp/common/patient_details_for_addmission.xhtml
@@ -297,7 +297,7 @@
                                     <div class="col-md-4 p-1">
 
                                         <div class="input-group">
-                                            <p:selectOneMenu title="Patient Specific Status" class="w-100" id="specificStatus" value="#{cc.attrs.controller.patient.specificStatus != null and cc.attrs.controller.patient.specificStatus.name() != 'NORMAL' ? cc.attrs.controller.patient.specificStatus : ''}">
+                                            <p:selectOneMenu title="Patient Specific Status" class="w-100" id="specificStatus" value="#{cc.attrs.controller.patient.specificStatus}">
                                                 <f:selectItems value="#{patientController.getAllPatientSpecificLabels()}"/>
                                             </p:selectOneMenu>
 
@@ -392,7 +392,7 @@
                             <h:panelGroup class="d-flex">
 
                                 
-                                <p:badge style="transform: translate(110%, -40%);background-color: #{cc.attrs.controller.patient.specificStatus != null and cc.attrs.controller.patient.specificStatus.name() != 'NORMAL' ? '#FF401F' : 'white'} ; font-style: italic;" value="#{cc.attrs.controller.patient.specificStatus != null and cc.attrs.controller.patient.specificStatus.name() != 'NORMAL' ? cc.attrs.controller.patient.specificStatus : ''}" severity="danger">
+                                <p:badge style="transform: translate(110%, -40%);background-color: #{cc.attrs.controller.patient.specificStatus != null and cc.attrs.controller.patient.specificStatus.name() != 'NORMAL' ? '#FF401F' : 'white'} ; font-style: italic;" value="#{cc.attrs.controller.patient.specificStatus}" severity="danger">
                                     <p:outputLabel value="#{cc.attrs.controller.patient.person.nameWithTitle}" rendered="#{not empty cc.attrs.controller.patient.person.nameWithTitle}" />
                                 </p:badge> 
 

--- a/src/main/webapp/resources/ezcomp/common/patient_details_for_appoiment.xhtml
+++ b/src/main/webapp/resources/ezcomp/common/patient_details_for_appoiment.xhtml
@@ -341,7 +341,7 @@
                                     <div class="col-md-4 p-1">
 
                                         <div class="input-group">
-                                            <p:selectOneMenu title="Patient Specific Status" class="w-100" id="specificStatus" value="#{cc.attrs.controller.patient.specificStatus != null and cc.attrs.controller.patient.specificStatus.name() != 'NORMAL' ? cc.attrs.controller.patient.specificStatus : ''}">
+                                            <p:selectOneMenu title="Patient Specific Status" class="w-100" id="specificStatus" value="#{cc.attrs.controller.patient.specificStatus}">
                                                 <f:selectItems value="#{patientController.getAllPatientSpecificLabels()}"/>
                                             </p:selectOneMenu>
 
@@ -386,7 +386,7 @@
                             <h:panelGroup class="d-flex">
 
                                 
-                                <p:badge style="transform: translate(110%, -40%);background-color: #{cc.attrs.controller.patient.specificStatus != null and cc.attrs.controller.patient.specificStatus.name() != 'NORMAL' ? '#FF401F' : 'white'} ; font-style: italic;" value="#{cc.attrs.controller.patient.specificStatus != null and cc.attrs.controller.patient.specificStatus.name() != 'NORMAL' ? cc.attrs.controller.patient.specificStatus : ''}" severity="danger">
+                                <p:badge style="transform: translate(110%, -40%);background-color: #{cc.attrs.controller.patient.specificStatus != null and cc.attrs.controller.patient.specificStatus.name() != 'NORMAL' ? '#FF401F' : 'white'} ; font-style: italic;" value="#{cc.attrs.controller.patient.specificStatus}" severity="danger">
                                     <p:outputLabel value="#{cc.attrs.controller.patient.person.nameWithTitle}" rendered="#{not empty cc.attrs.controller.patient.person.nameWithTitle}" />
                                 </p:badge> 
 

--- a/src/main/webapp/resources/ezcomp/common/patient_details_for_appoiment.xhtml
+++ b/src/main/webapp/resources/ezcomp/common/patient_details_for_appoiment.xhtml
@@ -341,7 +341,7 @@
                                     <div class="col-md-4 p-1">
 
                                         <div class="input-group">
-                                            <p:selectOneMenu title="Patient Specific Status" class="w-100" id="specificStatus" value="#{cc.attrs.controller.patient.specificStatus}">
+                                            <p:selectOneMenu title="Patient Specific Status" class="w-100" id="specificStatus" value="#{cc.attrs.controller.patient.specificStatus != null and cc.attrs.controller.patient.specificStatus.name() != 'NORMAL' ? cc.attrs.controller.patient.specificStatus : ''}">
                                                 <f:selectItems value="#{patientController.getAllPatientSpecificLabels()}"/>
                                             </p:selectOneMenu>
 
@@ -385,9 +385,8 @@
 
                             <h:panelGroup class="d-flex">
 
-                                <p:outputLabel class="ml-4" value="#{cc.attrs.controller.patient.person.nameWithTitle}" rendered="#{not empty cc.attrs.controller.patient.person.nameWithTitle and !configOptionApplicationController.getBooleanValueByKey('Enable patient specific status management in the system')}" />
-
-                                <p:badge rendered="#{configOptionApplicationController.getBooleanValueByKey('Enable patient specific status management in the system')}" style="transform: translate(110%, -40%);background-color: #{empty cc.attrs.controller.patient.specificStatus ? 'white' : '#FF401F'} ; font-style: italic;" value="#{cc.attrs.controller.patient.specificStatus}" severity="danger">
+                                
+                                <p:badge style="transform: translate(110%, -40%);background-color: #{cc.attrs.controller.patient.specificStatus != null and cc.attrs.controller.patient.specificStatus.name() != 'NORMAL' ? '#FF401F' : 'white'} ; font-style: italic;" value="#{cc.attrs.controller.patient.specificStatus != null and cc.attrs.controller.patient.specificStatus.name() != 'NORMAL' ? cc.attrs.controller.patient.specificStatus : ''}" severity="danger">
                                     <p:outputLabel value="#{cc.attrs.controller.patient.person.nameWithTitle}" rendered="#{not empty cc.attrs.controller.patient.person.nameWithTitle}" />
                                 </p:badge> 
 

--- a/src/main/webapp/resources/ezcomp/common/patient_details_view_scope.xhtml
+++ b/src/main/webapp/resources/ezcomp/common/patient_details_view_scope.xhtml
@@ -290,7 +290,7 @@
                                     <div class="col-md-4 p-1">
 
                                         <div class="input-group">
-                                            <p:selectOneMenu title="Patient Specific Status" class="w-100" id="specificStatus" value="#{cc.attrs.controller.patient.specificStatus != null and cc.attrs.controller.patient.specificStatus.name() != 'NORMAL' ? cc.attrs.controller.patient.specificStatus : ''}">
+                                            <p:selectOneMenu title="Patient Specific Status" class="w-100" id="specificStatus" value="#{cc.attrs.controller.patient.specificStatus}">
                                                 <f:selectItems value="#{patientController.getAllPatientSpecificLabels()}"/>
                                             </p:selectOneMenu>
 
@@ -337,7 +337,7 @@
                             <h:panelGroup class="d-flex">
 
                                 
-                                <p:badge style="transform: translate(110%, -40%);background-color: #{cc.attrs.controller.patient.specificStatus != null and cc.attrs.controller.patient.specificStatus.name() != 'NORMAL' ? '#FF401F' : 'white'} ; font-style: italic;" value="#{cc.attrs.controller.patient.specificStatus != null and cc.attrs.controller.patient.specificStatus.name() != 'NORMAL' ? cc.attrs.controller.patient.specificStatus : ''}" severity="danger">
+                                <p:badge style="transform: translate(110%, -40%);background-color: #{cc.attrs.controller.patient.specificStatus != null and cc.attrs.controller.patient.specificStatus.name() != 'NORMAL' ? '#FF401F' : 'white'} ; font-style: italic;" value="#{cc.attrs.controller.patient.specificStatus}" severity="danger">
                                     <p:outputLabel value="#{cc.attrs.controller.patient.person.nameWithTitle}" rendered="#{not empty cc.attrs.controller.patient.person.nameWithTitle}" />
                                 </p:badge> 
 

--- a/src/main/webapp/resources/ezcomp/common/patient_details_view_scope.xhtml
+++ b/src/main/webapp/resources/ezcomp/common/patient_details_view_scope.xhtml
@@ -290,7 +290,7 @@
                                     <div class="col-md-4 p-1">
 
                                         <div class="input-group">
-                                            <p:selectOneMenu title="Patient Specific Status" class="w-100" id="specificStatus" value="#{cc.attrs.controller.patient.specificStatus}">
+                                            <p:selectOneMenu title="Patient Specific Status" class="w-100" id="specificStatus" value="#{cc.attrs.controller.patient.specificStatus != null and cc.attrs.controller.patient.specificStatus.name() != 'NORMAL' ? cc.attrs.controller.patient.specificStatus : ''}">
                                                 <f:selectItems value="#{patientController.getAllPatientSpecificLabels()}"/>
                                             </p:selectOneMenu>
 
@@ -336,9 +336,8 @@
 
                             <h:panelGroup class="d-flex">
 
-                                <p:outputLabel class="ml-4" value="#{cc.attrs.controller.patient.person.nameWithTitle}" rendered="#{not empty cc.attrs.controller.patient.person.nameWithTitle and !configOptionApplicationController.getBooleanValueByKey('Enable patient specific status management in the system')}" />
-
-                                <p:badge rendered="#{configOptionApplicationController.getBooleanValueByKey('Enable patient specific status management in the system')}" style="transform: translate(110%, -40%);background-color: #{empty cc.attrs.controller.patient.specificStatus ? 'white' : '#FF401F'} ; font-style: italic;" value="#{cc.attrs.controller.patient.specificStatus}" severity="danger">
+                                
+                                <p:badge style="transform: translate(110%, -40%);background-color: #{cc.attrs.controller.patient.specificStatus != null and cc.attrs.controller.patient.specificStatus.name() != 'NORMAL' ? '#FF401F' : 'white'} ; font-style: italic;" value="#{cc.attrs.controller.patient.specificStatus != null and cc.attrs.controller.patient.specificStatus.name() != 'NORMAL' ? cc.attrs.controller.patient.specificStatus : ''}" severity="danger">
                                     <p:outputLabel value="#{cc.attrs.controller.patient.person.nameWithTitle}" rendered="#{not empty cc.attrs.controller.patient.person.nameWithTitle}" />
                                 </p:badge> 
 

--- a/src/main/webapp/resources/ezcomp/emr/patient.xhtml
+++ b/src/main/webapp/resources/ezcomp/emr/patient.xhtml
@@ -22,9 +22,8 @@
                     <div class="col-md-8">
                     <h:panelGroup class="d-flex">
 
-                        <p:outputLabel class="ml-4" value="#{cc.attrs.patient.person.nameWithTitle}" rendered="#{not empty cc.attrs.patient.person.nameWithTitle and !configOptionApplicationController.getBooleanValueByKey('Enable patient specific status management in the system')}" />
-
-                        <p:badge rendered="#{configOptionApplicationController.getBooleanValueByKey('Enable patient specific status management in the system')}" style="transform: translate(110%, -40%);background-color: #{empty cc.attrs.patient.specificStatus ? 'white' : '#FF401F'} ; font-style: italic;" value="#{cc.attrs.patient.specificStatus}" severity="danger">
+                        
+                        <p:badge style="transform: translate(110%, -40%);background-color: #{cc.attrs.patient.specificStatus != null and cc.attrs.patient.specificStatus.name() != 'NORMAL' ? '#FF401F' : 'white'} ; font-style: italic;" value="#{cc.attrs.patient.specificStatus != null and cc.attrs.patient.specificStatus.name() != 'NORMAL' ? cc.attrs.patient.specificStatus : ''}" severity="danger">
                             <p:outputLabel value="#{cc.attrs.patient.person.nameWithTitle}" rendered="#{not empty cc.attrs.patient.person.nameWithTitle}" />
                         </p:badge> 
 

--- a/src/main/webapp/resources/ezcomp/menu.xhtml
+++ b/src/main/webapp/resources/ezcomp/menu.xhtml
@@ -312,14 +312,28 @@
                         value="Add Family" 
                         rendered="#{webUserController.hasPrivilege('MemberShipAdd')}"
                         icon="fa fa-users"></p:menuitem>
-                    <p:menuitem 
-                        ajax="false" 
+                    <p:menuitem
+                        ajax="false"
                         action="#{patientController.navigateToSearchFamilyMembership()}"
-                        value="Search Families" 
+                        value="Search Families"
                         rendered="#{webUserController.hasPrivilege('MemberShipSearch')}"
                         icon="fa fa-search-plus"></p:menuitem>
-                    <p:menuitem 
-                        ajax="false" 
+                    <p:separator />
+                    <p:menuitem
+                        ajax="false"
+                        action="#{patientController.navigateToAddNewCorporateMembership()}"
+                        value="Add Corporate Member"
+                        rendered="#{webUserController.hasPrivilege('MemberShipAdd')}"
+                        icon="fa fa-building"></p:menuitem>
+                    <p:menuitem
+                        ajax="false"
+                        action="#{patientController.navigateToSearchCorporateMembership()}"
+                        value="Search Corporate Members"
+                        rendered="#{webUserController.hasPrivilege('MemberShipSearch')}"
+                        icon="fa fa-search"></p:menuitem>
+                    <p:separator />
+                    <p:menuitem
+                        ajax="false"
                         id="mnuItemMembershipAnalytics"
                         action="#{membershipController.navigateToMembershipAnalyticsIndex()}"
                         value="Analytics"

--- a/src/main/webapp/resources/ezcomp/pages/membership/membership.xhtml
+++ b/src/main/webapp/resources/ezcomp/pages/membership/membership.xhtml
@@ -101,7 +101,7 @@
                                 <p:selectOneMenu
                                     filter="true"
                                     filterMatchMode="contains"
-                                    id="lstDiscountScheme"   
+                                    id="lstDiscountScheme"
                                     class="w-100 mb-1"
                                     value="#{membershipSchemeController.current.paymentScheme}" >
                                     <f:selectItem itemLabel="Select" ></f:selectItem>
@@ -109,6 +109,20 @@
                                     <f:ajax render="gpDetail" execute="lstSelect" >
                                     </f:ajax>
                                 </p:selectOneMenu>
+
+                                <p:outputLabel for="txtCompany" id="lblCompany" value="Company (blank = personal scheme)" ></p:outputLabel>
+                                <p:autoComplete
+                                    id="txtCompany"
+                                    class="w-100 mb-1"
+                                    inputStyleClass="w-100"
+                                    value="#{membershipSchemeController.current.institution}"
+                                    completeMethod="#{institutionController.completeIns}"
+                                    var="ins"
+                                    itemLabel="#{ins.name}"
+                                    itemValue="#{ins}"
+                                    forceSelection="true" >
+                                    <p:ajax process="txtCompany" update="gpDetailText" />
+                                </p:autoComplete>
                             </p:panelGrid>
                         </p:panel>
 


### PR DESCRIPTION
## Summary

- **Corporate Membership**: A `MembershipScheme` with a linked `Institution` (Company field) is now a corporate scheme — no new DB column needed, `institution` already existed on `Category`. Personal schemes have `institution = null`.
- **New pages**: `corporate_membership_new.xhtml` and `corporate_membership_search.xhtml` for enrolling and searching corporate members
- **Menu**: Added "Add Corporate Member" and "Search Corporate Members" entries under the Membership submenu
- **Personal scheme filtering**: Individual and Family membership pages now only show schemes where `institution = null`
- **Always-on VIP/VVIP/STAFF badge**: Removed `Enable patient specific status management in the system` config gate from 23 XHTML files — the badge is now unconditionally visible system-wide (same pattern as recent blacklist config removal)
- **Pseudonymise privilege**: Added `ClinicalPatientPseudonymise` enum value and tree node (backend ready for pseudonymise button)

## Key technical decisions

- Corporate distinction is purely `MembershipScheme.institution != null` — `isCorporate()` helper added
- `getPersonalSchemes()` / `getCorporateSchemes()` query methods added to `MembershipSchemeController`
- `searchCorporateFamilyMember()` additionally searches by name and NIC (broader than personal member search)
- A patient can belong to multiple corporate schemes simultaneously (multiple `FamilyMember` records)

## Wiki articles published

- [Corporate Membership](https://github.com/hmislk/hmis/wiki/Corporate-Membership)
- [VIP, VVIP and Staff Patient Status](https://github.com/hmislk/hmis/wiki/VIP-VVIP-and-Staff-Patient-Status)
- [Pseudonymisation of Patient Data](https://github.com/hmislk/hmis/wiki/Pseudonymisation-of-Patient-Data)

## Test plan

- [ ] Create a corporate membership scheme (Admin → Membership Schemes → set Company field)
- [ ] Create a personal membership scheme (Company field left blank)
- [ ] Verify personal scheme only appears in Individual/Family membership dropdowns
- [ ] Verify corporate scheme only appears in Corporate membership dropdown, showing company name
- [ ] Enrol a patient via Add Corporate Member; verify saved under correct scheme
- [ ] Search corporate members — verify Company column visible, personal members excluded
- [ ] Enrol same patient in a second corporate scheme — verify both appear in search
- [ ] Verify VIP/VVIP/STAFF badge shows on patient name in OPD, pharmacy, inward, channelling pages
- [ ] Verify badge is absent (white/empty) for NORMAL status patients

Closes #20766

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Corporate membership flows: add/create/search corporate members and dedicated pages.
  * Patient pseudonymisation: UI action to pseudonymise patient records with audit tracking.
  * New privilege and menu entries to manage corporate membership and pseudonymisation.

* **Improvements**
  * Patient status display unified: status badge always shown but only highlighted for non‑NORMAL states.
  * Membership schemes separated into personal vs corporate for clearer selection.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hmislk/hmis/pull/20806?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->