### PR TITLE
fix(cashier): label shortage cancellation rows as Shift Shortage in handover view

### DIFF
--- a/src/main/java/com/divudi/bean/cashTransaction/FinancialTransactionController.java
+++ b/src/main/java/com/divudi/bean/cashTransaction/FinancialTransactionController.java
@@ -1896,9 +1896,17 @@ public class FinancialTransactionController implements Serializable {
             }
 
             childBundle.calculateTotalsByPaymentsAndDenominations();
-            // Shortage component bills have negative cash — mark them so the accept page
-            // can display the "Shift Shortage" label in the Institution/Type column.
-            if (childBundle.getCashValue() < -0.001) {
+            // Mark shortage-related component bills so the accept page displays the
+            // "Shift Shortage" label in the Institution/Type column.  The sign-only
+            // check misses two cases: (a) a cancellation-only row (positive cashValue)
+            // and (b) a merged row where the original shortage and its same-day
+            // cancellation net to zero.  Checking the bill type of any linked payment
+            // covers all three cases reliably.
+            boolean isShortageRelated = payments != null && payments.stream().anyMatch(p ->
+                    p.getBill() != null && (
+                            p.getBill().getBillTypeAtomic() == BillTypeAtomic.FUND_SHIFT_SHORTAGE_BILL
+                            || p.getBill().getBillTypeAtomic() == BillTypeAtomic.FUND_SHIFT_SHORTAGE_BILL_CANCELLED));
+            if (childBundle.getCashValue() < -0.001 || isShortageRelated) {
                 childBundle.setPaymentHandover(PaymentHandover.FLOATS);
             }
             bundle.getBundles().add(childBundle);
@@ -2028,9 +2036,17 @@ public class FinancialTransactionController implements Serializable {
             }
 
             childBundle.calculateTotalsByPaymentsAndDenominations();
-            // Shortage component bills have negative cash — mark them so the reprint
-            // composite can display the "Shift Shortage" label in Institution/Type column.
-            if (childBundle.getCashValue() < -0.001) {
+            // Mark shortage-related component bills so the reprint composite displays
+            // the "Shift Shortage" label in the Institution/Type column.  The sign-only
+            // check misses two cases: (a) a cancellation-only row (positive cashValue)
+            // and (b) a merged row where the original shortage and its same-day
+            // cancellation net to zero.  Checking the bill type of any linked payment
+            // covers all three cases reliably.
+            boolean isShortageRelated = payments != null && payments.stream().anyMatch(p ->
+                    p.getBill() != null && (
+                            p.getBill().getBillTypeAtomic() == BillTypeAtomic.FUND_SHIFT_SHORTAGE_BILL
+                            || p.getBill().getBillTypeAtomic() == BillTypeAtomic.FUND_SHIFT_SHORTAGE_BILL_CANCELLED));
+            if (childBundle.getCashValue() < -0.001 || isShortageRelated) {
                 childBundle.setPaymentHandover(PaymentHandover.FLOATS);
             }
             bundle.getBundles().add(childBundle);


### PR DESCRIPTION
## Summary

- Shift shortage cancellation rows in the handover view/reprint page showed no label in the **Institution / Type** column, when they should display **Shift Shortage**.
- Root cause: the reconstruction code used `cashValue < 0` to detect shortage-related rows, which missed cancellation rows (positive value) and merged rows that net to zero.
- Fix: check the `billTypeAtomic` of linked payments instead — if any payment is `FUND_SHIFT_SHORTAGE_BILL` or `FUND_SHIFT_SHORTAGE_BILL_CANCELLED`, mark the bundle with `paymentHandover = FLOATS` so the label renders correctly.
- Applied identically to both reconstruction paths (view/reprint and accept-page).

Closes #20812
Part of master tracker #17532

## Test plan

- [ ] Create a shift shortage bill and cancel it
- [ ] Open the handover view page for that handover
- [ ] Verify the cancellation row shows **Shift Shortage** in the Institution/Type column (red italic)
- [ ] Open the handover accept page — verify same label appears there
- [ ] Verify regular (non-shortage) rows still show institution name as before
- [ ] Verify float rows (`FLOAT_OUT` / `FLOAT_IN`) still display their labels correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved shift shortage record handling in financial handovers to correctly identify and mark records for float display, including scenarios with cancelled transactions and merged zero-balance cases.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hmislk/hmis/pull/20813?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->