### PR TITLE
fix(cashier): show bill comments in handover float transactions table

### DIFF
--- a/src/main/webapp/resources/ezcomp/prints/five_five_paper_with_headings_for_handover_detail.xhtml
+++ b/src/main/webapp/resources/ezcomp/prints/five_five_paper_with_headings_for_handover_detail.xhtml
@@ -516,7 +516,7 @@
                                         </h:outputText>
                                     </td>
                                     <td>
-                                        <h:outputText value="#{floatRow.payment.comments}" />
+                                        <h:outputText value="#{floatRow.payment.bill.comments}" />
                                     </td>
                                 </tr>
                             </ui:repeat>


### PR DESCRIPTION
## Summary
- Float transfer comments are stored on the `Bill` entity, not on `Payment`
- The **Reference / Comments** column in the Float Transactions table was rendering `Payment.comments` (always null for float transfers) instead of `Payment.bill.comments`
- One-line EL fix: `#{floatRow.payment.comments}` → `#{floatRow.payment.bill.comments}`

## Test plan
- [ ] Create a float transfer with a comment entered
- [ ] Open the handover that covers that shift
- [ ] Click **Print Details**
- [ ] Verify the Float Transactions table shows the comment in the Reference / Comments column
- [ ] Verify rows with no comments still render a blank cell (no error)

Closes #20814

🤖 Generated with [Claude Code](https://claude.com/claude-code)