### PR TITLE
feat(patient): admin page to view and reactivate inactive patients

### DIFF
--- a/src/main/java/com/divudi/bean/common/PatientController.java
+++ b/src/main/java/com/divudi/bean/common/PatientController.java
@@ -3865,6 +3865,10 @@ public class PatientController implements Serializable, ControllerWithPatient {
     }
 
     public void activePatient(Patient p) {
+        if (!webUserController.hasPrivilege("AdminInactivePatients")) {
+            JsfUtil.addErrorMessage("You do not have permission to activate inactive patients.");
+            return;
+        }
         if (p == null || p.getId() == null) {
             return;
         }
@@ -3886,11 +3890,19 @@ public class PatientController implements Serializable, ControllerWithPatient {
     }
 
     public void searchInactivePatients() {
+        if (!webUserController.hasPrivilege("AdminInactivePatients")) {
+            inactivePatients = new java.util.ArrayList<>();
+            return;
+        }
         String j = "select p from Patient p where p.retired = true order by p.id desc";
         inactivePatients = getFacade().findByJpql(j);
     }
 
     public String navigateToInactivePatients() {
+        if (!webUserController.hasPrivilege("AdminInactivePatients")) {
+            JsfUtil.addErrorMessage("You do not have permission to manage inactive patients.");
+            return null;
+        }
         searchInactivePatients();
         return "/admin/patients/inactive_patients?faces-redirect=true";
     }

--- a/src/main/java/com/divudi/bean/common/PatientController.java
+++ b/src/main/java/com/divudi/bean/common/PatientController.java
@@ -3378,6 +3378,7 @@ public class PatientController implements Serializable, ControllerWithPatient {
     }
 
     List<Patient> patientList;
+    List<Patient> inactivePatients;
 
     public List<Patient> completePatientByNameOrCode(String query) {
         if (query == null) {
@@ -3864,19 +3865,34 @@ public class PatientController implements Serializable, ControllerWithPatient {
     }
 
     public void activePatient(Patient p) {
-//        p.setEditedAt(new Date());
-//        p.setEditer(getSessionController().getLoggedUser());
+        if (p == null || p.getId() == null) {
+            return;
+        }
+        AuditEvent auditEvent = auditEventController.createNewAuditEvent(
+                "Activate Patient",
+                "{\"patientId\":" + p.getId() + ",\"retired\":true}",
+                p.getId(),
+                "Patient");
         p.setRetired(false);
         p.setRetireComments("Re-Activated");
         getFacade().edit(p);
-
-//        p.getPerson().setEditedAt(new Date());
-//        p.getPerson().setEditer(getSessionController().getLoggedUser());
         p.getPerson().setRetired(false);
         p.getPerson().setRetireComments("Re-Activated");
         getPersonFacade().edit(p.getPerson());
-        createPatientList();
+        auditEventController.completeAuditEvent(auditEvent,
+                "{\"patientId\":" + p.getId() + ",\"retired\":false}");
+        searchInactivePatients();
         JsfUtil.addSuccessMessage("Re-Activated");
+    }
+
+    public void searchInactivePatients() {
+        String j = "select p from Patient p where p.retired = true order by p.id desc";
+        inactivePatients = getFacade().findByJpql(j);
+    }
+
+    public String navigateToInactivePatients() {
+        searchInactivePatients();
+        return "/admin/patients/inactive_patients?faces-redirect=true";
     }
 
     public void deActivePatient(Patient p) {
@@ -4481,6 +4497,14 @@ public class PatientController implements Serializable, ControllerWithPatient {
 
     public void setPatientList(List<Patient> patientList) {
         this.patientList = patientList;
+    }
+
+    public List<Patient> getInactivePatients() {
+        return inactivePatients;
+    }
+
+    public void setInactivePatients(List<Patient> inactivePatients) {
+        this.inactivePatients = inactivePatients;
     }
 
     public BillFacade getBillFacade() {

--- a/src/main/java/com/divudi/bean/common/UserPrivilageController.java
+++ b/src/main/java/com/divudi/bean/common/UserPrivilageController.java
@@ -515,6 +515,7 @@ public class UserPrivilageController implements Serializable {
         new DefaultTreeNode(new PrivilegeHolder(Privileges.AdminItems, "Manage Items/Services"), adminNode);
         new DefaultTreeNode(new PrivilegeHolder(Privileges.AdminPrices, "Manage Fees/Prices/Packages"), adminNode);
         new DefaultTreeNode(new PrivilegeHolder(Privileges.AdminPatientRelationships, "Manage Patient Relationships"), adminNode);
+        new DefaultTreeNode(new PrivilegeHolder(Privileges.AdminInactivePatients, "Manage Inactive Patients"), adminNode);
         new DefaultTreeNode(new PrivilegeHolder(Privileges.ManageCreditCompany, "Manage Credit Companies"), adminNode);
         new DefaultTreeNode(new PrivilegeHolder(Privileges.AdminFilterWithoutDepartment, "Filter Without Department"), adminNode);
         new DefaultTreeNode(new PrivilegeHolder(Privileges.SearchAll, "Search All"), adminNode);

--- a/src/main/java/com/divudi/core/data/Privileges.java
+++ b/src/main/java/com/divudi/core/data/Privileges.java
@@ -1055,6 +1055,9 @@ public enum Privileges {
             case InpatientClinicalDischarge:
                 return "Inward";
 
+            case AdminInactivePatients:
+                return "Admin";
+
             default:
                 return this.toString();
         }

--- a/src/main/java/com/divudi/core/data/Privileges.java
+++ b/src/main/java/com/divudi/core/data/Privileges.java
@@ -693,6 +693,7 @@ public enum Privileges {
     AdminItems("Admin Items"),
     AdminPrices("Admin Prices"),
     AdminPatientRelationships("Manage Patient Relationships"),
+    AdminInactivePatients("Manage Inactive Patients"),
     ManageCreditCompany("Manage Credit Company"),
     AdminFilterWithoutDepartment("Admin Filter Without Department"),
     //</editor-fold>

--- a/src/main/webapp/admin/patients/inactive_patients.xhtml
+++ b/src/main/webapp/admin/patients/inactive_patients.xhtml
@@ -1,0 +1,98 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
+      xmlns:p="http://primefaces.org/ui"
+      xmlns:h="http://xmlns.jcp.org/jsf/html"
+      xmlns:f="http://xmlns.jcp.org/jsf/core"
+      xmlns:na="http://xmlns.jcp.org/jsf/composite/template">
+
+    <h:head>
+        <title>Inactive Patients</title>
+    </h:head>
+
+    <h:body>
+        <ui:composition template="/resources/template/template.xhtml">
+            <ui:define name="content">
+
+                <h:panelGroup rendered="#{!webUserController.hasPrivilege('AdminInactivePatients')}">
+                    <na:not_authorize />
+                </h:panelGroup>
+
+                <h:panelGroup rendered="#{webUserController.hasPrivilege('AdminInactivePatients')}">
+                    <h:form id="frm">
+                        <p:growl />
+                        <p:panel>
+                            <f:facet name="header">
+                                <i class="fa fa-user-slash mr-2"/>
+                                <span class="fw-bold">Inactive Patients</span>
+                            </f:facet>
+
+                            <div class="alert alert-info mb-3">
+                                Inactive patients are excluded from all patient searches, billing, admissions,
+                                and clinical workflows. Only users with this administrative privilege can view
+                                and reactivate them.
+                            </div>
+
+                            <p:commandButton
+                                value="Refresh"
+                                icon="fa fa-refresh"
+                                actionListener="#{patientController.searchInactivePatients()}"
+                                update="tblInactive"
+                                styleClass="ui-button-secondary mb-3" />
+
+                            <p:dataTable
+                                id="tblInactive"
+                                value="#{patientController.inactivePatients}"
+                                var="pat"
+                                emptyMessage="No inactive patients found."
+                                paginator="true"
+                                rows="20"
+                                rowsPerPageTemplate="10,20,50"
+                                styleClass="mt-2">
+
+                                <p:column headerText="#" style="width:50px">
+                                    <h:outputText value="#{patientController.inactivePatients.indexOf(pat) + 1}" />
+                                </p:column>
+
+                                <p:column headerText="Patient ID">
+                                    <h:outputText value="#{pat.phn}" />
+                                </p:column>
+
+                                <p:column headerText="Name">
+                                    <h:outputText value="#{pat.person.name}" />
+                                </p:column>
+
+                                <p:column headerText="Date of Birth">
+                                    <h:outputText value="#{pat.person.dob}">
+                                        <f:convertDateTime pattern="yyyy-MM-dd" />
+                                    </h:outputText>
+                                </p:column>
+
+                                <p:column headerText="Phone">
+                                    <h:outputText value="#{pat.patientMobileNumber}" />
+                                </p:column>
+
+                                <p:column headerText="Deactivation Note">
+                                    <h:outputText value="#{pat.retireComments}" />
+                                </p:column>
+
+                                <p:column headerText="Action" style="width:120px">
+                                    <p:commandButton
+                                        value="Activate"
+                                        icon="fa fa-check"
+                                        styleClass="ui-button-success"
+                                        actionListener="#{patientController.activePatient(pat)}"
+                                        update="tblInactive"
+                                        title="Reactivate this patient" />
+                                </p:column>
+
+                            </p:dataTable>
+                        </p:panel>
+                    </h:form>
+                </h:panelGroup>
+
+            </ui:define>
+        </ui:composition>
+    </h:body>
+</html>

--- a/src/main/webapp/resources/ezcomp/menu.xhtml
+++ b/src/main/webapp/resources/ezcomp/menu.xhtml
@@ -2106,12 +2106,19 @@
                         value="Membership Administration" 
                         icon="fa fa-bar-chart"
                         rendered="#{webUserController.hasPrivilege('MembershipAdministration')}" ></p:menuitem>
-                    <p:menuitem  
-                        ajax="false"  
-                        action="#{dataAdministrationController.navigateToAdminDataAdministration()}" 
-                        value="Manage Metadata " 
+                    <p:menuitem
+                        ajax="false"
+                        action="#{dataAdministrationController.navigateToAdminDataAdministration()}"
+                        value="Manage Metadata "
                         icon="fa fa-database"
                         rendered="#{webUserController.hasPrivilege('AdminItems')}" >
+                    </p:menuitem>
+                    <p:menuitem
+                        ajax="false"
+                        action="#{patientController.navigateToInactivePatients()}"
+                        value="Inactive Patients"
+                        icon="fa fa-user-slash"
+                        rendered="#{webUserController.hasPrivilege('AdminInactivePatients')}" >
                     </p:menuitem>
 
                 </p:submenu>


### PR DESCRIPTION
## Summary

- Adds a new **Inactive Patients** page under the Administration menu, listing all patients with `retired = true`
- Each row has an **Activate** button that reactivates the patient and records a full audit event
- Adds `AdminInactivePatients` privilege (enum + role management tree node + menu guard)
- Enhances `activePatient()` in `PatientController` to create an audit event on every reactivation

## Inactive patients are invisible to all normal users

Every patient JPQL query in the system filters by `retired = false`, so inactive patients never appear in:
- Patient search / registration counter
- OPD, inward admissions, channelling, and clinical queue
- Billing and autocomplete fields

Only holders of the **Manage Inactive Patients** (`AdminInactivePatients`) privilege can see and reactivate them via **Administration → Inactive Patients**.

## Wiki

- [Inactive Patients](https://github.com/hmislk/hmis/wiki/Inactive-Patients) — end-user documentation covering visibility rules, how to access the admin page, how to reactivate a patient, and the audit trail format

## Test plan

- [ ] Grant `AdminInactivePatients` privilege to a test role; verify the menu item appears
- [ ] Deactivate a patient from their profile; confirm they vanish from patient search
- [ ] Open Administration → Inactive Patients; confirm the deactivated patient appears
- [ ] Click Activate; confirm patient reappears in normal search and disappears from the inactive list
- [ ] Check audit event log; confirm `Activate Patient` event recorded with correct before/after JSON and acting user
- [ ] Without the privilege, confirm the menu item is hidden and the page shows "not authorized"

Closes #20770

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added inactive patient management capability with a dedicated admin page to view deactivated patients.
  * Patients can now be re-activated directly from the inactive patients list.
  * Added "Inactive Patients" menu item to the Administration menu.

* **Bug Fixes**
  * Patient re-activation now includes audit event tracking and validation checks.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hmislk/hmis/pull/20816?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->