### PR TITLE
fix(cashier): show fund-transfer details for Net Float row in handover accept

### DIFF
--- a/src/main/java/com/divudi/bean/cashTransaction/FinancialTransactionController.java
+++ b/src/main/java/com/divudi/bean/cashTransaction/FinancialTransactionController.java
@@ -4586,6 +4586,12 @@ public class FinancialTransactionController implements Serializable {
 
     public String navigateToViewIndividualShiftForHandover(ReportTemplateRowBundle childBundle) {
         selectedBundle = childBundle;
+        if (selectedBundle.isFloatRow()
+                && selectedBundle.getReportTemplateRows().isEmpty()
+                && bundle != null
+                && !bundle.getReportTemplateRows().isEmpty()) {
+            selectedBundle.getReportTemplateRows().addAll(bundle.getReportTemplateRows());
+        }
         return "/cashier/handover_accept_row_detail?faces-redirect=true";
     }
 

--- a/src/main/webapp/cashier/handover_accept_row_detail.xhtml
+++ b/src/main/webapp/cashier/handover_accept_row_detail.xhtml
@@ -51,30 +51,73 @@
                             </div>
                         </f:facet>
 
-                        <!-- Net Float row: synthetic, no payment records -->
+                        <!-- Float row: show individual fund-transfer payments if available -->
                         <h:panelGroup rendered="#{financialTransactionController.selectedBundle.floatRow}">
-                            <div class="alert alert-info m-2">
-                                This row represents the net cash float received from other cashiers.
-                                No individual payment records are associated with this entry.
-                            </div>
-                            <table class="table table-bordered table-sm w-100">
-                                <thead class="thead-dark">
-                                    <tr>
-                                        <th>Description</th>
-                                        <th class="text-end">Value</th>
-                                    </tr>
-                                </thead>
-                                <tbody>
-                                    <tr>
-                                        <td>Net Float (Cash)</td>
-                                        <td class="text-end">
-                                            <h:outputText value="#{financialTransactionController.selectedBundle.cashValue}">
-                                                <f:convertNumber pattern="#,##0.00" />
-                                            </h:outputText>
-                                        </td>
-                                    </tr>
-                                </tbody>
-                            </table>
+                            <h:panelGroup rendered="#{not empty financialTransactionController.selectedBundle.reportTemplateRows}">
+                                <p:dataTable
+                                    value="#{financialTransactionController.selectedBundle.reportTemplateRows}"
+                                    var="row"
+                                    emptyMessage="No float transfer records found"
+                                    paginator="true"
+                                    paginatorAlwaysVisible="false"
+                                    rows="50"
+                                    paginatorTemplate="{CurrentPageReport}  {FirstPageLink} {PreviousPageLink} {PageLinks} {NextPageLink} {LastPageLink}"
+                                    currentPageReportTemplate="(Page {currentPage} of {totalPages})">
+
+                                    <p:column headerText="Bill No" sortBy="#{row.payment.bill.deptId}">
+                                        <h:outputText value="#{row.payment.bill.deptId}" />
+                                    </p:column>
+
+                                    <p:column headerText="Date" sortBy="#{row.payment.createdAt}">
+                                        <h:outputText value="#{row.payment.createdAt}">
+                                            <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateTimeFormat}" />
+                                        </h:outputText>
+                                    </p:column>
+
+                                    <p:column headerText="Type">
+                                        <h:outputText value="Float Sent"
+                                                      rendered="#{row.payment.bill.billTypeAtomic ne null and row.payment.bill.billTypeAtomic.name() eq 'FUND_TRANSFER_BILL'}"
+                                                      style="color:#dc3545;" />
+                                        <h:outputText value="Float Received"
+                                                      rendered="#{row.payment.bill.billTypeAtomic ne null and row.payment.bill.billTypeAtomic.name() eq 'FUND_TRANSFER_RECEIVED_BILL'}"
+                                                      style="color:#198754;" />
+                                    </p:column>
+
+                                    <p:column headerText="Value" class="text-end" sortBy="#{row.payment.paidValue}">
+                                        <h:outputText value="#{row.payment.paidValue}">
+                                            <f:convertNumber pattern="#,##0.00" />
+                                        </h:outputText>
+                                    </p:column>
+
+                                </p:dataTable>
+                            </h:panelGroup>
+
+                            <h:panelGroup rendered="#{empty financialTransactionController.selectedBundle.reportTemplateRows}">
+                                <div class="alert alert-info m-2">
+                                    No individual float transfer records found for this entry.
+                                </div>
+                            </h:panelGroup>
+
+                            <p:panel class="m-2" header="Summary">
+                                <table class="table table-bordered table-sm w-50">
+                                    <thead class="thead-dark">
+                                        <tr>
+                                            <th>Description</th>
+                                            <th class="text-end">Value</th>
+                                        </tr>
+                                    </thead>
+                                    <tbody>
+                                        <tr>
+                                            <td>Net Float (Cash)</td>
+                                            <td class="text-end">
+                                                <h:outputText value="#{financialTransactionController.selectedBundle.cashValue}">
+                                                    <f:convertNumber pattern="#,##0.00" />
+                                                </h:outputText>
+                                            </td>
+                                        </tr>
+                                    </tbody>
+                                </table>
+                            </p:panel>
                         </h:panelGroup>
 
                         <!-- Normal and shortage rows: list all payment records -->


### PR DESCRIPTION
## Summary

- `navigateToViewIndividualShiftForHandover()`: when the selected child bundle is a float row (`FLOAT_IN`/`FLOAT_OUT`) with empty `reportTemplateRows`, copy the parent bundle's float-transfer rows into it before navigating to the detail page.
- `handover_accept_row_detail.xhtml`: replace the static *"No individual records"* message in the float-row block with a `p:dataTable` showing each fund-transfer payment (Bill No, Date, Type = Float Sent/Received, Value) and a summary panel below for the net float value. Falls back to the info message when no rows are present.

## Root cause

`navigateToReceiveNewHandoverBill()` fetches float-transfer payments (already marked `handingOverStarted=true`) and stores them on the **parent** bundle's `reportTemplateRows`. The synthetic FLOAT_IN child bundle has no rows. The old detail page had only a static message for this case, so "View Details" never showed actual transactions.

## Test plan

- [ ] Open a handover bill to accept that includes a Net Float (Cash) row.
- [ ] Click **View Details** on the Net Float (Cash) row — should now show a table of individual FUND_TRANSFER_BILL / FUND_TRANSFER_RECEIVED_BILL payments with Float Sent / Float Received labels.
- [ ] Net float summary row still appears below the table.
- [ ] Click **View Details** on a Shift Shortage row — unchanged, still shows the shortage payment record as before.
- [ ] Click **View Details** on a normal department row — unchanged.

Closes #20817

🤖 Generated with [Claude Code](https://claude.com/claude-code)