### PR TITLE
Add MindrayCL1000i analyzer enum constant

### DIFF
--- a/src/main/java/com/divudi/core/data/lab/Analyzer.java
+++ b/src/main/java/com/divudi/core/data/lab/Analyzer.java
@@ -17,6 +17,7 @@ public enum Analyzer {
     IndikoPlus("Indiko Plus"),
     BioRadD10("Bio-Rad D10"),
     MindrayBC5150("Mindray BC 5150"),
+    MindrayCL1000i("Mindray CL-1000i"),
     SmartLytePlus("SmartLyte Plus"),
     SwelabLumi("Swelab Lumi"),
     HumaCount5D("HumaCount5D"),


### PR DESCRIPTION
## Summary

- Adds `MindrayCL1000i("Mindray CL-1000i")` enum constant to `com.divudi.core.data.lab.Analyzer`
- Placed immediately after `MindrayBC5150` for logical grouping of Mindray analyzer entries
- Fixes the LIS rejection error: `No enum constant com.divudi.core.data.lab.Analyzer.MindrayCL1000i`

## Motivation

The Mindray CL-1000i analyzer is sending results to the Divudi HMIS LIS, but the system was throwing an `IllegalArgumentException` because the `MindrayCL1000i` constant did not exist in the `Analyzer` enum. This single-line addition resolves the issue.

## Test plan

- [ ] Verify the `Analyzer` enum compiles without errors
- [ ] Confirm `Analyzer.valueOf("MindrayCL1000i")` resolves correctly
- [ ] Confirm `Analyzer.fromString("Mindray CL-1000i")` resolves correctly
- [ ] Send a test result from the Mindray CL-1000i analyzer and confirm the LIS accepts it without the enum error

 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for "Mindray CL-1000i" laboratory analyzer device. The system now recognizes and processes data from this analyzer type.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hmislk/hmis/pull/20819?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->