### PR TITLE
feat(patient): Insurance / payer profile panel per patient with multi-insurance support

### DIFF
--- a/src/main/java/com/divudi/bean/common/PatientController.java
+++ b/src/main/java/com/divudi/bean/common/PatientController.java
@@ -203,6 +203,8 @@ public class PatientController implements Serializable, ControllerWithPatient {
     PatientDepositController patientDepositController;
     @Inject
     WebUserController webUserController;
+    @Inject
+    PatientInsuranceController patientInsuranceController;
 
     /**
      *
@@ -811,6 +813,7 @@ public class PatientController implements Serializable, ControllerWithPatient {
         patientEncounterController.setPatient(current);
         patientEncounterController.fillCurrentPatientLists(current);
         patientEncounterController.fillPatientInvestigations(current);
+        patientInsuranceController.initForPatient(current);
         return "/emr/patient_profile?faces-redirect=true";
     }
 
@@ -3186,6 +3189,7 @@ public class PatientController implements Serializable, ControllerWithPatient {
 
     public String navigateToEmrEditPatient() {
         getCurrent();
+        patientInsuranceController.initForPatient(current);
         return "/emr/patient?faces-redirect=true";
     }
 

--- a/src/main/java/com/divudi/bean/common/PatientInsuranceController.java
+++ b/src/main/java/com/divudi/bean/common/PatientInsuranceController.java
@@ -1,0 +1,183 @@
+package com.divudi.bean.common;
+
+import com.divudi.core.entity.Institution;
+import com.divudi.core.entity.Patient;
+import com.divudi.core.entity.PatientInsurance;
+import com.divudi.core.facade.PatientInsuranceFacade;
+import com.divudi.core.util.JsfUtil;
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import javax.ejb.EJB;
+import javax.enterprise.context.SessionScoped;
+import javax.inject.Inject;
+import javax.inject.Named;
+
+/**
+ * Manages PatientInsurance profiles for a patient.
+ * Used on the patient profile and registration pages.
+ *
+ * @author Dr M H B Ariyaratne <buddhika.ari at gmail.com>
+ */
+@Named
+@SessionScoped
+public class PatientInsuranceController implements Serializable {
+
+    @EJB
+    private PatientInsuranceFacade patientInsuranceFacade;
+
+    @Inject
+    private SessionController sessionController;
+
+    private Patient patient;
+    private List<PatientInsurance> insuranceProfiles;
+    private PatientInsurance newInsurance;
+
+    public void initForPatient(Patient p) {
+        this.patient = p;
+        newInsurance = new PatientInsurance();
+        loadProfiles();
+    }
+
+    private void loadProfiles() {
+        if (patient == null || patient.getId() == null) {
+            insuranceProfiles = new ArrayList<>();
+            return;
+        }
+        String jpql = "select pi from PatientInsurance pi "
+                + "where pi.patient = :pt "
+                + "and pi.retired = false "
+                + "order by pi.primary desc, pi.id desc";
+        HashMap<String, Object> params = new HashMap<>();
+        params.put("pt", patient);
+        insuranceProfiles = patientInsuranceFacade.findByJpql(jpql, params);
+    }
+
+    public void addInsurance() {
+        if (patient == null) {
+            JsfUtil.addErrorMessage("No patient selected");
+            return;
+        }
+        if (newInsurance.getCreditCompany() == null) {
+            JsfUtil.addErrorMessage("Please select a credit company / insurer");
+            return;
+        }
+        newInsurance.setPatient(patient);
+        newInsurance.setActive(true);
+        newInsurance.setCreatedAt(new Date());
+        newInsurance.setCreater(sessionController.getLoggedUser());
+        patientInsuranceFacade.create(newInsurance);
+        newInsurance = new PatientInsurance();
+        loadProfiles();
+        JsfUtil.addSuccessMessage("Insurance profile added");
+    }
+
+    public void saveInsurance(PatientInsurance pi) {
+        pi.setEditedAt(new Date());
+        pi.setEditer(sessionController.getLoggedUser());
+        patientInsuranceFacade.edit(pi);
+        JsfUtil.addSuccessMessage("Insurance profile saved");
+    }
+
+    public void deactivateInsurance(PatientInsurance pi) {
+        pi.setActive(false);
+        pi.setEditedAt(new Date());
+        pi.setEditer(sessionController.getLoggedUser());
+        patientInsuranceFacade.edit(pi);
+        loadProfiles();
+        JsfUtil.addSuccessMessage("Insurance profile deactivated");
+    }
+
+    public void retireInsurance(PatientInsurance pi) {
+        pi.setRetired(true);
+        pi.setRetiredAt(new Date());
+        pi.setRetirer(sessionController.getLoggedUser());
+        patientInsuranceFacade.edit(pi);
+        loadProfiles();
+    }
+
+    /**
+     * Returns active, non-retired profiles for the given patient.
+     * Used by AdmissionController to auto-populate credit companies.
+     */
+    public List<PatientInsurance> findActiveProfiles(Patient p) {
+        if (p == null || p.getId() == null) {
+            return new ArrayList<>();
+        }
+        String jpql = "select pi from PatientInsurance pi "
+                + "where pi.patient = :pt "
+                + "and pi.retired = false "
+                + "and pi.active = true "
+                + "order by pi.primary desc, pi.id desc";
+        HashMap<String, Object> params = new HashMap<>();
+        params.put("pt", p);
+        return patientInsuranceFacade.findByJpql(jpql, params);
+    }
+
+    /**
+     * Upserts a PatientInsurance record from an EncounterCreditCompany snapshot.
+     * Matches on patient + institution. Creates a new profile if none exists.
+     */
+    public void upsertFromEncounter(Patient p, Institution institution,
+            String policyNo, String referenceNo, double creditLimit) {
+        if (p == null || institution == null) {
+            return;
+        }
+        String jpql = "select pi from PatientInsurance pi "
+                + "where pi.patient = :pt "
+                + "and pi.creditCompany = :cc "
+                + "and pi.retired = false";
+        HashMap<String, Object> params = new HashMap<>();
+        params.put("pt", p);
+        params.put("cc", institution);
+        PatientInsurance existing = patientInsuranceFacade.findFirstByJpql(jpql, params);
+        if (existing != null) {
+            existing.setPolicyNo(policyNo);
+            existing.setReferenceNo(referenceNo);
+            existing.setCreditLimit(creditLimit);
+            existing.setEditedAt(new Date());
+            existing.setEditer(sessionController.getLoggedUser());
+            patientInsuranceFacade.edit(existing);
+        } else {
+            PatientInsurance pi = new PatientInsurance();
+            pi.setPatient(p);
+            pi.setCreditCompany(institution);
+            pi.setPolicyNo(policyNo);
+            pi.setReferenceNo(referenceNo);
+            pi.setCreditLimit(creditLimit);
+            pi.setActive(true);
+            pi.setCreatedAt(new Date());
+            pi.setCreater(sessionController.getLoggedUser());
+            patientInsuranceFacade.create(pi);
+        }
+    }
+
+    public Patient getPatient() {
+        return patient;
+    }
+
+    public void setPatient(Patient patient) {
+        this.patient = patient;
+    }
+
+    public List<PatientInsurance> getInsuranceProfiles() {
+        return insuranceProfiles;
+    }
+
+    public void setInsuranceProfiles(List<PatientInsurance> insuranceProfiles) {
+        this.insuranceProfiles = insuranceProfiles;
+    }
+
+    public PatientInsurance getNewInsurance() {
+        if (newInsurance == null) {
+            newInsurance = new PatientInsurance();
+        }
+        return newInsurance;
+    }
+
+    public void setNewInsurance(PatientInsurance newInsurance) {
+        this.newInsurance = newInsurance;
+    }
+}

--- a/src/main/java/com/divudi/bean/inward/AdmissionController.java
+++ b/src/main/java/com/divudi/bean/inward/AdmissionController.java
@@ -14,6 +14,7 @@ import com.divudi.bean.common.ConfigOptionApplicationController;
 import com.divudi.bean.common.ConfigOptionController;
 import com.divudi.bean.common.ControllerWithPatient;
 import com.divudi.bean.common.PageMetadataRegistry;
+import com.divudi.bean.common.PatientInsuranceController;
 import com.divudi.bean.common.SessionController;
 import com.divudi.core.data.OptionScope;
 import com.divudi.core.data.admin.ConfigOptionInfo;
@@ -39,8 +40,10 @@ import com.divudi.core.entity.inward.PatientRoom;
 import com.divudi.core.facade.AdmissionFacade;
 import com.divudi.core.facade.AppointmentFacade;
 import com.divudi.core.facade.BillFacade;
+import com.divudi.core.entity.PatientInsurance;
 import com.divudi.core.facade.EncounterCreditCompanyFacade;
 import com.divudi.core.facade.PatientEncounterFacade;
+import com.divudi.core.facade.PatientInsuranceFacade;
 import com.divudi.core.facade.PatientFacade;
 import com.divudi.core.facade.PatientRoomFacade;
 import com.divudi.core.facade.PatientTransferRequestFacade;
@@ -131,6 +134,8 @@ public class AdmissionController implements Serializable, ControllerWithPatient 
     @EJB
     private EncounterCreditCompanyFacade encounterCreditCompanyFacade;
     @EJB
+    private PatientInsuranceFacade patientInsuranceFacade;
+    @EJB
     ClinicalFindingValueFacade clinicalFindingValueFacade;
     @EJB
     ReservationFacade reservationFacade;
@@ -147,6 +152,8 @@ public class AdmissionController implements Serializable, ControllerWithPatient 
     AppointmentController appointmentController;
     @Inject
     private ConfigOptionController configOptionController;
+    @Inject
+    private PatientInsuranceController patientInsuranceController;
 
     ////////////////////////////
     ///////////////////////
@@ -500,6 +507,29 @@ public class AdmissionController implements Serializable, ControllerWithPatient 
         if (configOptionApplicationController.getBooleanValueByKey("Inward Admission - Auto Mark Claimable for Credit Admissions", false)) {
             if (current.getPaymentMethod() == PaymentMethod.Credit) {
                 current.setClaimable(true);
+            }
+        }
+        if (current.getPaymentMethod() == PaymentMethod.Credit && current.getPatient() != null) {
+            // Prefer PatientInsurance profiles over last-admission lookup
+            List<PatientInsurance> profiles = patientInsuranceController.findActiveProfiles(current.getPatient());
+            if (!profiles.isEmpty()) {
+                encounterCreditCompanies = new ArrayList<>();
+                for (PatientInsurance pi : profiles) {
+                    EncounterCreditCompany ecc = new EncounterCreditCompany();
+                    ecc.setPatientEncounter(current);
+                    ecc.setInstitution(pi.getCreditCompany());
+                    ecc.setCreditLimit(pi.getCreditLimit());
+                    ecc.setPolicyNo(pi.getPolicyNo());
+                    ecc.setReferanceNo(pi.getReferenceNo());
+                    ecc.setDescreption(pi.getDescription());
+                    current.setCreditLimit(current.getCreditLimit() + ecc.getCreditLimit());
+                    encounterCreditCompanies.add(ecc);
+                    if (pi.isExpired() && configOptionApplicationController.getBooleanValueByKey("Patient Insurance - Show Expiry Alert on Admission", false)) {
+                        JsfUtil.addWarningMessage("Insurance policy for " + pi.getCreditCompany().getName() + " expired on " + pi.getValidTo());
+                    }
+                }
+                encounterCreditCompany = new EncounterCreditCompany();
+                return;
             }
         }
         if (configOptionApplicationController.getBooleanValueByKey("Inward Admission - Find And Fill Last Used Credit Companies of a Patient", false)) {
@@ -2227,6 +2257,13 @@ public class AdmissionController implements Serializable, ControllerWithPatient 
                 ecc.setCreater(sessionController.getLoggedUser());
                 if (ecc.getInstitution() != null) {
                     getEncounterCreditCompanyFacade().create(ecc);
+                    // Upsert back to patient-level insurance profile
+                    patientInsuranceController.upsertFromEncounter(
+                            current.getPatient(),
+                            ecc.getInstitution(),
+                            ecc.getPolicyNo(),
+                            ecc.getReferanceNo(),
+                            ecc.getCreditLimit());
                 } else {
                     getEncounterCreditCompanyFacade().edit(ecc);
                 }

--- a/src/main/java/com/divudi/core/entity/PatientInsurance.java
+++ b/src/main/java/com/divudi/core/entity/PatientInsurance.java
@@ -1,0 +1,257 @@
+package com.divudi.core.entity;
+
+import java.io.Serializable;
+import java.util.Date;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.ManyToOne;
+import javax.persistence.Temporal;
+
+/**
+ * Stores a patient-level insurance / credit payer profile.
+ * One patient may hold multiple profiles (multi-payer support).
+ * Per-encounter snapshots are stored separately in EncounterCreditCompany.
+ *
+ * @author Dr M H B Ariyaratne <buddhika.ari at gmail.com>
+ */
+@Entity
+public class PatientInsurance implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne
+    private Patient patient;
+
+    @ManyToOne
+    private Institution creditCompany;
+
+    private String memberId;
+    private String policyNo;
+    private String referenceNo;
+    private double creditLimit;
+    private String description;
+
+    @Temporal(javax.persistence.TemporalType.TIMESTAMP)
+    private Date validFrom;
+
+    @Temporal(javax.persistence.TemporalType.TIMESTAMP)
+    private Date validTo;
+
+    private boolean primary;
+    private boolean active;
+
+    // Audit fields
+    @ManyToOne
+    private WebUser creater;
+    @Temporal(javax.persistence.TemporalType.TIMESTAMP)
+    private Date createdAt;
+    @ManyToOne
+    private WebUser editer;
+    @Temporal(javax.persistence.TemporalType.TIMESTAMP)
+    private Date editedAt;
+
+    // Retire fields
+    private boolean retired;
+    @ManyToOne
+    private WebUser retirer;
+    @Temporal(javax.persistence.TemporalType.TIMESTAMP)
+    private Date retiredAt;
+    private String retireComments;
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public Patient getPatient() {
+        return patient;
+    }
+
+    public void setPatient(Patient patient) {
+        this.patient = patient;
+    }
+
+    public Institution getCreditCompany() {
+        return creditCompany;
+    }
+
+    public void setCreditCompany(Institution creditCompany) {
+        this.creditCompany = creditCompany;
+    }
+
+    public String getMemberId() {
+        return memberId;
+    }
+
+    public void setMemberId(String memberId) {
+        this.memberId = memberId;
+    }
+
+    public String getPolicyNo() {
+        return policyNo;
+    }
+
+    public void setPolicyNo(String policyNo) {
+        this.policyNo = policyNo;
+    }
+
+    public String getReferenceNo() {
+        return referenceNo;
+    }
+
+    public void setReferenceNo(String referenceNo) {
+        this.referenceNo = referenceNo;
+    }
+
+    public double getCreditLimit() {
+        return creditLimit;
+    }
+
+    public void setCreditLimit(double creditLimit) {
+        this.creditLimit = creditLimit;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    public Date getValidFrom() {
+        return validFrom;
+    }
+
+    public void setValidFrom(Date validFrom) {
+        this.validFrom = validFrom;
+    }
+
+    public Date getValidTo() {
+        return validTo;
+    }
+
+    public void setValidTo(Date validTo) {
+        this.validTo = validTo;
+    }
+
+    public boolean isPrimary() {
+        return primary;
+    }
+
+    public void setPrimary(boolean primary) {
+        this.primary = primary;
+    }
+
+    public boolean isActive() {
+        return active;
+    }
+
+    public void setActive(boolean active) {
+        this.active = active;
+    }
+
+    public WebUser getCreater() {
+        return creater;
+    }
+
+    public void setCreater(WebUser creater) {
+        this.creater = creater;
+    }
+
+    public Date getCreatedAt() {
+        return createdAt;
+    }
+
+    public void setCreatedAt(Date createdAt) {
+        this.createdAt = createdAt;
+    }
+
+    public WebUser getEditer() {
+        return editer;
+    }
+
+    public void setEditer(WebUser editer) {
+        this.editer = editer;
+    }
+
+    public Date getEditedAt() {
+        return editedAt;
+    }
+
+    public void setEditedAt(Date editedAt) {
+        this.editedAt = editedAt;
+    }
+
+    public boolean isRetired() {
+        return retired;
+    }
+
+    public void setRetired(boolean retired) {
+        this.retired = retired;
+    }
+
+    public WebUser getRetirer() {
+        return retirer;
+    }
+
+    public void setRetirer(WebUser retirer) {
+        this.retirer = retirer;
+    }
+
+    public Date getRetiredAt() {
+        return retiredAt;
+    }
+
+    public void setRetiredAt(Date retiredAt) {
+        this.retiredAt = retiredAt;
+    }
+
+    public String getRetireComments() {
+        return retireComments;
+    }
+
+    public void setRetireComments(String retireComments) {
+        this.retireComments = retireComments;
+    }
+
+    public boolean isExpired() {
+        if (validTo == null) {
+            return false;
+        }
+        return validTo.before(new Date());
+    }
+
+    @Override
+    public int hashCode() {
+        int hash = 0;
+        hash += (id != null ? id.hashCode() : 0);
+        return hash;
+    }
+
+    @Override
+    public boolean equals(Object object) {
+        if (!(object instanceof PatientInsurance)) {
+            return false;
+        }
+        PatientInsurance other = (PatientInsurance) object;
+        if ((this.id == null && other.id != null) || (this.id != null && !this.id.equals(other.id))) {
+            return false;
+        }
+        return true;
+    }
+
+    @Override
+    public String toString() {
+        return "com.divudi.core.entity.PatientInsurance[ id=" + id + " ]";
+    }
+}

--- a/src/main/java/com/divudi/core/facade/PatientInsuranceFacade.java
+++ b/src/main/java/com/divudi/core/facade/PatientInsuranceFacade.java
@@ -1,0 +1,25 @@
+package com.divudi.core.facade;
+
+import com.divudi.core.entity.PatientInsurance;
+import javax.ejb.Stateless;
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+
+/**
+ * @author Dr M H B Ariyaratne <buddhika.ari at gmail.com>
+ */
+@Stateless
+public class PatientInsuranceFacade extends AbstractFacade<PatientInsurance> {
+
+    @PersistenceContext(unitName = "hmisPU")
+    private EntityManager em;
+
+    @Override
+    protected EntityManager getEntityManager() {
+        return em;
+    }
+
+    public PatientInsuranceFacade() {
+        super(PatientInsurance.class);
+    }
+}

--- a/src/main/webapp/emr/patient.xhtml
+++ b/src/main/webapp/emr/patient.xhtml
@@ -7,6 +7,7 @@
       xmlns:f="http://xmlns.jcp.org/jsf/core"
       xmlns:pt="http://xmlns.jcp.org/jsf/passthrough"
       xmlns:emr="http://xmlns.jcp.org/jsf/composite/ezcomp/emr"
+      xmlns:common="http://xmlns.jcp.org/jsf/composite/ezcomp/common"
       xmlns:c="http://java.sun.com/jsp/jstl/core">
     <h:body>
         <ui:composition template="/resources/template/template.xhtml">
@@ -247,6 +248,9 @@
                             </div>
                         </p:panel>
 
+                    </h:form>
+                    <h:form>
+                        <common:patientInsurancePanel/>
                     </h:form>
                 </h:panelGroup>
             </ui:define>

--- a/src/main/webapp/emr/patient_profile.xhtml
+++ b/src/main/webapp/emr/patient_profile.xhtml
@@ -6,6 +6,7 @@
       xmlns:h="http://xmlns.jcp.org/jsf/html"
       xmlns:f="http://xmlns.jcp.org/jsf/core"
       xmlns:emr="http://xmlns.jcp.org/jsf/composite/ezcomp/emr"
+      xmlns:common="http://xmlns.jcp.org/jsf/composite/ezcomp/common"
       >
     <h:body>
         <ui:composition template="/resources/template/template.xhtml">
@@ -560,6 +561,11 @@
                                                         </p:dataTable>
                                                     </div>
                                                 </div>
+                                            </h:form>
+                                        </p:tab>
+                                        <p:tab title="Insurance Profiles">
+                                            <h:form>
+                                                <common:patientInsurancePanel/>
                                             </h:form>
                                         </p:tab>
                                         <p:tab title="Past Data" >

--- a/src/main/webapp/resources/ezcomp/common/patientInsurancePanel.xhtml
+++ b/src/main/webapp/resources/ezcomp/common/patientInsurancePanel.xhtml
@@ -1,0 +1,164 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
+    "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:cc="http://xmlns.jcp.org/jsf/composite"
+      xmlns:h="http://xmlns.jcp.org/jsf/html"
+      xmlns:p="http://primefaces.org/ui"
+      xmlns:f="http://xmlns.jcp.org/jsf/core">
+
+    <cc:interface>
+        <!-- No attributes needed — uses patientInsuranceController directly -->
+    </cc:interface>
+
+    <cc:implementation>
+        <p:panel id="insurancePanel">
+            <f:facet name="header">
+                <h:outputText styleClass="fa fa-shield-alt me-2"/>
+                <h:outputLabel value="Insurance Profiles"/>
+            </f:facet>
+
+            <!-- Add new profile form -->
+            <h:panelGroup id="gpAddInsurance" layout="block" class="mb-3">
+                <div class="row g-2 align-items-end">
+                    <div class="col-12 col-md-3">
+                        <h:outputLabel value="Insurer / Credit Company" styleClass="form-label"/>
+                        <p:autoComplete
+                            id="acInsurer"
+                            class="w-100"
+                            inputStyleClass="w-100"
+                            forceSelection="true"
+                            value="#{patientInsuranceController.newInsurance.creditCompany}"
+                            completeMethod="#{creditCompanyController.completeCredit}"
+                            var="ix"
+                            itemLabel="#{ix.name}"
+                            itemValue="#{ix}"/>
+                    </div>
+                    <div class="col-6 col-md-2">
+                        <h:outputLabel value="Member ID" styleClass="form-label"/>
+                        <p:inputText class="w-100" autocomplete="off"
+                                     value="#{patientInsuranceController.newInsurance.memberId}"/>
+                    </div>
+                    <div class="col-6 col-md-2">
+                        <h:outputLabel value="Policy No" styleClass="form-label"/>
+                        <p:inputText class="w-100" autocomplete="off"
+                                     value="#{patientInsuranceController.newInsurance.policyNo}"/>
+                    </div>
+                    <div class="col-6 col-md-2">
+                        <h:outputLabel value="Reference No" styleClass="form-label"/>
+                        <p:inputText class="w-100" autocomplete="off"
+                                     value="#{patientInsuranceController.newInsurance.referenceNo}"/>
+                    </div>
+                    <div class="col-6 col-md-1">
+                        <h:outputLabel value="Credit Limit" styleClass="form-label"/>
+                        <p:inputText class="w-100" autocomplete="off" onclick="this.select();"
+                                     value="#{patientInsuranceController.newInsurance.creditLimit}"/>
+                    </div>
+                    <div class="col-6 col-md-2">
+                        <h:outputLabel value="Valid From" styleClass="form-label"/>
+                        <p:datePicker class="w-100"
+                                      value="#{patientInsuranceController.newInsurance.validFrom}"
+                                      pattern="dd/MM/yyyy"/>
+                    </div>
+                    <div class="col-6 col-md-2">
+                        <h:outputLabel value="Valid To" styleClass="form-label"/>
+                        <p:datePicker class="w-100"
+                                      value="#{patientInsuranceController.newInsurance.validTo}"
+                                      pattern="dd/MM/yyyy"/>
+                    </div>
+                    <div class="col-6 col-md-1 d-flex align-items-end">
+                        <div>
+                            <h:outputLabel value="Primary" styleClass="form-label d-block"/>
+                            <h:selectBooleanCheckbox
+                                value="#{patientInsuranceController.newInsurance.primary}"/>
+                        </div>
+                    </div>
+                    <div class="col-12 col-md-2">
+                        <p:commandButton
+                            value="Add"
+                            icon="fa fa-plus"
+                            class="w-100 ui-button-success"
+                            process="gpAddInsurance"
+                            update="gpAddInsurance tblInsurance"
+                            action="#{patientInsuranceController.addInsurance()}"/>
+                    </div>
+                </div>
+            </h:panelGroup>
+
+            <!-- Profiles table -->
+            <p:dataTable id="tblInsurance"
+                         value="#{patientInsuranceController.insuranceProfiles}"
+                         var="pi"
+                         emptyMessage="No insurance profiles recorded for this patient"
+                         rowStyleClass="#{pi.expired ? 'ui-state-error' : ''}">
+                <p:column headerText="Insurer" style="min-width:140px;">
+                    <h:outputText value="#{pi.creditCompany.name}"/>
+                </p:column>
+                <p:column headerText="Member ID" style="width:120px;">
+                    <p:inputText class="w-100" autocomplete="off"
+                                 value="#{pi.memberId}"/>
+                </p:column>
+                <p:column headerText="Policy No" style="width:120px;">
+                    <p:inputText class="w-100" autocomplete="off"
+                                 value="#{pi.policyNo}"/>
+                </p:column>
+                <p:column headerText="Reference No" style="width:120px;">
+                    <p:inputText class="w-100" autocomplete="off"
+                                 value="#{pi.referenceNo}"/>
+                </p:column>
+                <p:column headerText="Credit Limit" style="width:100px;text-align:right;">
+                    <p:inputText class="w-100" autocomplete="off" onclick="this.select();"
+                                 style="text-align:right;"
+                                 value="#{pi.creditLimit}">
+                        <f:convertNumber pattern="#,##0.00"/>
+                    </p:inputText>
+                </p:column>
+                <p:column headerText="Valid From" style="width:110px;">
+                    <p:datePicker class="w-100"
+                                  value="#{pi.validFrom}"
+                                  pattern="dd/MM/yyyy"/>
+                </p:column>
+                <p:column headerText="Valid To" style="width:110px;">
+                    <h:panelGroup>
+                        <p:datePicker class="w-100"
+                                      value="#{pi.validTo}"
+                                      pattern="dd/MM/yyyy"/>
+                        <h:outputText value=" (Expired)"
+                                      rendered="#{pi.expired}"
+                                      styleClass="text-danger small fw-bold"/>
+                    </h:panelGroup>
+                </p:column>
+                <p:column headerText="Primary" style="width:60px;text-align:center;">
+                    <h:selectBooleanCheckbox value="#{pi.primary}"/>
+                </p:column>
+                <p:column headerText="Active" style="width:60px;text-align:center;">
+                    <h:outputText value="#{pi.active ? 'Yes' : 'No'}"
+                                  styleClass="#{pi.active ? 'text-success' : 'text-muted'}"/>
+                </p:column>
+                <p:column headerText="Actions" style="width:100px;">
+                    <div class="d-flex gap-1">
+                        <p:commandButton
+                            icon="fa fa-save"
+                            title="Save changes"
+                            class="ui-button-success"
+                            process="tblInsurance"
+                            update="tblInsurance"
+                            action="#{patientInsuranceController.saveInsurance(pi)}"/>
+                        <p:commandButton
+                            icon="fa fa-ban"
+                            title="Deactivate"
+                            class="ui-button-warning"
+                            rendered="#{pi.active}"
+                            process="@this"
+                            update="tblInsurance"
+                            action="#{patientInsuranceController.deactivateInsurance(pi)}">
+                            <p:confirm header="Deactivate Profile"
+                                       message="Deactivate this insurance profile? It will no longer be auto-suggested."
+                                       icon="pi pi-exclamation-triangle"/>
+                        </p:commandButton>
+                    </div>
+                </p:column>
+            </p:dataTable>
+        </p:panel>
+    </cc:implementation>
+</html>


### PR DESCRIPTION
## Summary

- New `PatientInsurance` entity (multi-insurance profiles per patient: company, member ID, policy no, reference no, credit limit, valid from/to, primary flag, active flag) + `PatientInsuranceFacade`
- New `PatientInsuranceController` with add, save, deactivate, and upsert-from-encounter operations
- New composite component `ezcomp/common/patientInsurancePanel.xhtml` — inline add form + editable table with expired-policy row highlighting
- **Insurance Profiles tab** added to `emr/patient_profile.xhtml`
- **Insurance Profiles panel** added to `emr/patient.xhtml` (registration / edit page)
- `PatientController` calls `patientInsuranceController.initForPatient()` on navigation to both pages
- `AdmissionController.findLastUsedCreditCompanies()`: when payment method = Credit, active `PatientInsurance` profiles are loaded first; the existing last-admission lookup is used as fallback when no profiles exist
- `AdmissionController.saveEncounterCreditCompanies()`: after each `EncounterCreditCompany` is persisted, upserts back to `PatientInsurance` (matches on patient + institution; creates new record if none exists)
- Config key `Patient Insurance - Show Expiry Alert on Admission` gates expiry warnings at admission time

## Out of scope (deferred)
- OPD billing auto-suggest — deferred to a follow-up issue (touches the large `OpdBillController`)

## Test plan
- [ ] Create a new patient, navigate to EMR profile → Insurance Profiles tab appears
- [ ] Add an insurance profile; verify it persists and appears in the table
- [ ] Set Valid To to a past date; verify the row is highlighted as expired
- [ ] Deactivate a profile; verify it disappears from the list
- [ ] Open a new admission for the patient, set payment method to Credit; verify profiles auto-populate the credit companies list
- [ ] On the admission form, edit the credit limit or policy number, then save the admission; verify the PatientInsurance record is updated accordingly
- [ ] With config key `Patient Insurance - Show Expiry Alert on Admission` = true, admit a patient with an expired profile; verify the warning growl appears
- [ ] Patient with no PatientInsurance profiles: verify fallback to last-admission lookup still works when config `Inward Admission - Find And Fill Last Used Credit Companies of a Patient` is enabled
- [ ] Navigate to `emr/patient.xhtml` (Edit); verify Insurance Profiles panel is present

Closes #20768

🤖 Generated with [Claude Code](https://claude.com/claude-code)