### PR TITLE
Refactor: Staff salary summary by department page UI improvements

### DIFF
--- a/src/main/webapp/hr/hr_report_staff_salary_by_department.xhtml
+++ b/src/main/webapp/hr/hr_report_staff_salary_by_department.xhtml
@@ -4,281 +4,419 @@
                 template="/resources/template/template.xhtml"
                 xmlns:h="http://xmlns.jcp.org/jsf/html"
                 xmlns:p="http://primefaces.org/ui"
-                xmlns:f="http://xmlns.jcp.org/jsf/core"
-
-                xmlns:hr="http://xmlns.jcp.org/jsf/composite/autocomplete">
+                xmlns:f="http://xmlns.jcp.org/jsf/core">
 
     <ui:define name="content">
-        <h:form>
-            <p:selectOneMenu id="advanced"
-                             value="#{salaryCycleController.current}"
-                             var="t"
-                             filter="true"
-                             filterMatchMode="startsWith">
+        <h:form styleClass="salary-summary-form">
 
-                <f:selectItems value="#{salaryCycleController.salaryCycles}"
-                               var="theme"
-                               itemLabel="#{theme.name}"
-                               itemValue="#{theme}" ></f:selectItems>
+            <h:outputStylesheet>
+                .salary-summary-form {
+                    padding: 2rem 1.75rem;
+                }
 
-                <p:column style="width:10%" headerText="Name">
-                    <h:outputText value="#{t.name}" />
-                </p:column>
+                .page-header {
+                    margin-bottom: 1.75rem;
+                }
 
-                <p:column headerText="Year">
-                    <h:outputText value="#{t.salaryYear}" />
-                </p:column>
-                <p:column headerText="Month">
-                    <h:outputText value="#{t.salaryMonth}" />
-                </p:column>
-            </p:selectOneMenu>
-            <h:panelGrid columns="3">
-                <p:commandButton value="Process" ajax="false" action="#{salaryCycleController.fillStaffSalaryByDepartment()}" ></p:commandButton>
-                <p:commandButton value="Print" ajax="false" action="#" >
-                    <p:printer target="gpBillPreview" ></p:printer>
-                </p:commandButton>
-                <p:commandButton ajax="false" value="Excel" styleClass="noPrintButton"  >
-                    <p:dataExporter type="xlsx" target="tbl" fileName="all_staff_salary_summery_by_department"  />
-                </p:commandButton>
-            </h:panelGrid>
+                .page-title {
+                    font-size: 18px;
+                    font-weight: 600;
+                    margin: 0 0 4px 0;
+                }
 
-            <p:panel id="gpBillPreview" styleClass="noBorder summeryBorder">
+                .page-subtitle {
+                    font-size: 13px;
+                    color: #888;
+                    margin: 0;
+                }
 
-                <p:dataTable id="tbl" value="#{salaryCycleController.salaryByDepartments}" var="scc" >
-                    <f:facet name="header">
-                        <h:outputLabel value="#{sessionController.loggedUser.institution.name}" /><br></br>
-                        <h:outputLabel value="All Staff Salary Summary(By Department)"></h:outputLabel><br></br>
-                        <h:outputLabel value="#{salaryCycleController.current.name}"></h:outputLabel>
-                    </f:facet>
-                    <p:column headerText="Department Name" >
-                        <f:facet name="header">
-                            <h:outputLabel value="Department Name"></h:outputLabel>
-                        </f:facet>
-                        <h:outputLabel value="#{scc.department.name}" ></h:outputLabel>
+                .controls-panel .ui-panel-content {
+                    padding: 1.5rem 1.75rem !important;
+                }
+
+                .controls-grid {
+                    display: flex;
+                    flex-direction: column;
+                    gap: 1.25rem;
+                }
+
+                .field-group {
+                    display: flex;
+                    flex-direction: column;
+                    gap: 6px;
+                }
+
+                .field-label {
+                    font-size: 11.5px !important;
+                    font-weight: 600 !important;
+                    text-transform: uppercase;
+                    letter-spacing: 0.05em;
+                    color: #888 !important;
+                }
+
+                .controls-actions {
+                    display: flex;
+                    gap: 10px;
+                    align-items: center;
+                    flex-wrap: wrap;
+                }
+
+                .btn-action {
+                    height: 36px !important;
+                    padding: 0 18px !important;
+                    font-size: 13px !important;
+                }
+
+                .report-panel {
+                    margin-top: 1.5rem;
+                }
+
+                .report-panel .ui-panel-content {
+                    padding: 0 !important;
+                }
+
+                .report-header-wrap {
+                    text-align: center;
+                    padding: 1.5rem 1.5rem 1rem;
+                    border-bottom: 1px solid #e8e8e8;
+                }
+
+                .report-inst-name {
+                    font-size: 15px;
+                    font-weight: 600;
+                    display: block;
+                    margin-bottom: 2px;
+                }
+
+                .report-title-label {
+                    font-size: 13px;
+                    color: #666;
+                    display: block;
+                    margin-bottom: 2px;
+                }
+
+                .report-cycle-label {
+                    font-size: 13px;
+                    font-weight: 500;
+                    display: block;
+                }
+
+                .salary-table .ui-datatable-tablewrapper {
+                    overflow-x: auto;
+                }
+
+                .salary-table .ui-datatable-data td,
+                .salary-table .ui-datatable-thead th {
+                    padding: 10px 14px !important;
+                    white-space: nowrap;
+                    font-size: 13px !important;
+                }
+
+                .salary-table .ui-datatable-thead th {
+                    font-size: 12px !important;
+                    font-weight: 600 !important;
+                    text-transform: uppercase;
+                    letter-spacing: 0.03em;
+                    color: #888 !important;
+                    background: #f9f9f9 !important;
+                    border-bottom: 1px solid #e8e8e8 !important;
+                }
+
+                .salary-table .ui-datatable-data tr:hover td {
+                    background: #f5f7ff !important;
+                }
+
+                .salary-table .averageNumericColumn {
+                    text-align: right !important;
+                }
+
+                .salary-table .averageNumericColumn .ui-outputlabel {
+                    display: block;
+                    text-align: right;
+                }
+
+                .salary-table .col-text {
+                    text-align: left !important;
+                }
+
+                .salary-table .col-name .ui-outputlabel {
+                    font-weight: 500;
+                }
+
+                .salary-table tfoot td {
+                    background: #f9f9f9 !important;
+                    font-weight: 600 !important;
+                    font-size: 13px !important;
+                    border-top: 2px solid #e0e0e0 !important;
+                    padding: 10px 14px !important;
+                }
+
+                .salary-table tfoot .averageNumericColumn td {
+                    text-align: right !important;
+                }
+
+                .report-table-footer {
+                    display: flex;
+                    justify-content: flex-end;
+                    align-items: center;
+                    gap: 6px;
+                    padding: 0.85rem 1.5rem;
+                    border-top: 1px solid #e8e8e8;
+                    font-size: 12px;
+                    color: #999;
+                }
+            </h:outputStylesheet>
+
+            <div class="page-header">
+                <p class="page-title">Staff salary summary by department</p>
+                <p class="page-subtitle">Select a salary cycle and process to generate the report</p>
+            </div>
+
+            <p:panel styleClass="controls-panel">
+                <div class="controls-grid">
+
+                    <div class="field-group">
+                        <p:outputLabel for="advanced" value="Salary cycle" styleClass="field-label" />
+                        <p:selectOneMenu id="advanced"
+                                         value="#{salaryCycleController.current}"
+                                         var="t"
+                                         filter="true"
+                                         filterMatchMode="startsWith"
+                                         style="width: 320px;">
+                            <f:selectItems value="#{salaryCycleController.salaryCycles}"
+                                           var="theme"
+                                           itemLabel="#{theme.name}"
+                                           itemValue="#{theme}" />
+                            <p:column style="width:10%">
+                                <h:outputText value="#{t.name}" />
+                            </p:column>
+                            <p:column>
+                                <h:outputText value="#{t.salaryYear}" />
+                            </p:column>
+                            <p:column>
+                                <h:outputText value="#{t.salaryMonth}" />
+                            </p:column>
+                        </p:selectOneMenu>
+                    </div>
+
+                    <div class="controls-actions">
+                        <p:commandButton value="Process"
+                                         ajax="false"
+                                         action="#{salaryCycleController.fillStaffSalaryByDepartment()}"
+                                         icon="pi pi-sync"
+                                         styleClass="btn-action" />
+                        <p:commandButton value="Print"
+                                         ajax="false"
+                                         action="#"
+                                         icon="pi pi-print"
+                                         styleClass="btn-action">
+                            <p:printer target="gpBillPreview" />
+                        </p:commandButton>
+                        <p:commandButton value="Export Excel"
+                                         ajax="false"
+                                         icon="pi pi-file-excel"
+                                         styleClass="btn-action noPrintButton">
+                            <p:dataExporter type="xlsx" target="tbl" fileName="all_staff_salary_summary_by_department" />
+                        </p:commandButton>
+                    </div>
+
+                </div>
+            </p:panel>
+
+            <p:panel id="gpBillPreview" styleClass="report-panel noBorder summeryBorder">
+
+                <f:facet name="header">
+                    <div class="report-header-wrap">
+                        <span class="report-inst-name">
+                            <h:outputText value="#{sessionController.loggedUser.institution.name}" />
+                        </span>
+                        <span class="report-title-label">Staff salary summary by department</span>
+                        <span class="report-cycle-label">
+                            <h:outputText value="#{salaryCycleController.current.name}" />
+                        </span>
+                    </div>
+                </f:facet>
+
+                <p:dataTable id="tbl"
+                             value="#{salaryCycleController.salaryByDepartments}"
+                             var="scc"
+                             styleClass="salary-table">
+
+                    <p:column headerText="Department" styleClass="col-text col-name">
+                        <h:outputLabel value="#{scc.department.name}" />
                         <f:facet name="footer">
-                            <h:outputLabel value="Total"></h:outputLabel>
+                            <h:outputLabel value="Total" />
                         </f:facet>
                     </p:column>
 
                     <p:column headerText="Basic" styleClass="averageNumericColumn">
-                        <f:facet name="header">
-                            <h:outputLabel value="Basic"></h:outputLabel>
-                        </f:facet>
-                        <h:outputLabel value="#{scc.basicValue}" >
-                            <f:convertNumber pattern="0.00" />
+                        <h:outputLabel value="#{scc.basicValue}">
+                            <f:convertNumber pattern="#,##0.00" />
                         </h:outputLabel>
                         <f:facet name="footer">
-                            <h:outputLabel style="text-align: right;"
-                                           value="#{salaryCycleController.basicValueTotal}">
+                            <h:outputLabel value="#{salaryCycleController.basicValueTotal}">
                                 <f:convertNumber pattern="#,##0.00" />
                             </h:outputLabel>
                         </f:facet>
                     </p:column>
 
-                    <p:column headerText="Over Time" styleClass="averageNumericColumn">
-                        <f:facet name="header">
-                            <h:outputLabel value="Over Time"></h:outputLabel>
-                        </f:facet>
-                        <h:outputLabel value="#{scc.overTimeValue}" >
-                            <f:convertNumber pattern="0.00" />
+                    <p:column headerText="Over time" styleClass="averageNumericColumn">
+                        <h:outputLabel value="#{scc.overTimeValue}">
+                            <f:convertNumber pattern="#,##0.00" />
                         </h:outputLabel>
                         <f:facet name="footer">
-                            <h:outputLabel style="text-align: right;"
-                                           value="#{salaryCycleController.overTimeValueTotal}">
+                            <h:outputLabel value="#{salaryCycleController.overTimeValueTotal}">
                                 <f:convertNumber pattern="#,##0.00" />
                             </h:outputLabel>
                         </f:facet>
                     </p:column>
 
-                    <p:column headerText="Extra Duty Value" styleClass="averageNumericColumn">
-                        <f:facet name="header">
-                            <h:outputLabel value="Extra Duty Value"></h:outputLabel>
-                        </f:facet>
-                        <h:outputLabel value="#{scc.transExtraDutyValue}" >
-                            <f:convertNumber pattern="0.00" />
+                    <p:column headerText="Extra duty" styleClass="averageNumericColumn">
+                        <h:outputLabel value="#{scc.transExtraDutyValue}">
+                            <f:convertNumber pattern="#,##0.00" />
                         </h:outputLabel>
                         <f:facet name="footer">
-                            <h:outputLabel style="text-align: right;"
-                                           value="#{salaryCycleController.extraDutyValueTotal}">
+                            <h:outputLabel value="#{salaryCycleController.extraDutyValueTotal}">
                                 <f:convertNumber pattern="#,##0.00" />
                             </h:outputLabel>
                         </f:facet>
                     </p:column>
 
-                    <p:column headerText="No Pay" styleClass="averageNumericColumn">
-                        <f:facet name="header">
-                            <h:outputLabel value="No Pay"></h:outputLabel>
-                        </f:facet>
-                        <h:outputLabel value="#{scc.noPay}" >
-                            <f:convertNumber pattern="0.00" />
+                    <p:column headerText="No pay" styleClass="averageNumericColumn">
+                        <h:outputLabel value="#{scc.noPay}">
+                            <f:convertNumber pattern="#,##0.00" />
                         </h:outputLabel>
                         <f:facet name="footer">
-                            <h:outputLabel style="text-align: right;"
-                                           value="#{salaryCycleController.noPayValueTotal}">
+                            <h:outputLabel value="#{salaryCycleController.noPayValueTotal}">
                                 <f:convertNumber pattern="#,##0.00" />
                             </h:outputLabel>
                         </f:facet>
                     </p:column>
 
-                    <p:column headerText="Holiday Allowance" styleClass="averageNumericColumn">
-                        <f:facet name="header">
-                            <h:outputLabel value="Holiday Allowance"></h:outputLabel>
-                        </f:facet>
-                        <h:outputLabel value="#{scc.holidayAllowance}" >
-                            <f:convertNumber pattern="0.00" />
+                    <p:column headerText="Holiday allow." styleClass="averageNumericColumn">
+                        <h:outputLabel value="#{scc.holidayAllowance}">
+                            <f:convertNumber pattern="#,##0.00" />
                         </h:outputLabel>
                         <f:facet name="footer">
-                            <h:outputLabel style="text-align: right;"
-                                           value="#{salaryCycleController.holyDayAllowancesTotal}">
+                            <h:outputLabel value="#{salaryCycleController.holyDayAllowancesTotal}">
                                 <f:convertNumber pattern="#,##0.00" />
                             </h:outputLabel>
                         </f:facet>
                     </p:column>
 
-                    <p:column headerText="Day Off Allownace" styleClass="averageNumericColumn">
-                        <f:facet name="header">
-                            <h:outputLabel value="Day Off Allownace"></h:outputLabel>
-                        </f:facet>
-                        <h:outputLabel value="#{scc.dayOffAllownace}" >
-                            <f:convertNumber pattern="0.00" />
+                    <p:column headerText="Day off allow." styleClass="averageNumericColumn">
+                        <h:outputLabel value="#{scc.dayOffAllownace}">
+                            <f:convertNumber pattern="#,##0.00" />
                         </h:outputLabel>
                         <f:facet name="footer">
-                            <h:outputLabel style="text-align: right;"
-                                           value="#{salaryCycleController.dayOffValueTotal}">
+                            <h:outputLabel value="#{salaryCycleController.dayOffValueTotal}">
                                 <f:convertNumber pattern="#,##0.00" />
                             </h:outputLabel>
                         </f:facet>
                     </p:column>
 
-                    <p:column headerText="Additional Componnet" styleClass="averageNumericColumn">
-                        <f:facet name="header">
-                            <h:outputLabel value="Additional Componnet"></h:outputLabel>
-                        </f:facet>
-                        <h:outputLabel value="#{scc.componentValueAddition}" >
-                            <f:convertNumber pattern="0.00" />
+                    <p:column headerText="Add. component" styleClass="averageNumericColumn">
+                        <h:outputLabel value="#{scc.componentValueAddition}">
+                            <f:convertNumber pattern="#,##0.00" />
                         </h:outputLabel>
                         <f:facet name="footer">
-                            <h:outputLabel style="text-align: right;"
-                                           value="#{salaryCycleController.additionalComponentTotal}">
+                            <h:outputLabel value="#{salaryCycleController.additionalComponentTotal}">
                                 <f:convertNumber pattern="#,##0.00" />
                             </h:outputLabel>
                         </f:facet>
                     </p:column>
 
-                    <p:column headerText="Deductional Componnet" styleClass="averageNumericColumn">
-                        <f:facet name="header">
-                            <h:outputLabel value="Deductional Componnet"></h:outputLabel>
-                        </f:facet>
-                        <h:outputLabel value="#{scc.componentValueSubstraction}" >
-                            <f:convertNumber pattern="0.00" />
+                    <p:column headerText="Ded. component" styleClass="averageNumericColumn">
+                        <h:outputLabel value="#{scc.componentValueSubstraction}">
+                            <f:convertNumber pattern="#,##0.00" />
                         </h:outputLabel>
                         <f:facet name="footer">
-                            <h:outputLabel style="text-align: right;"
-                                           value="#{salaryCycleController.deductionalComponentTotal}">
+                            <h:outputLabel value="#{salaryCycleController.deductionalComponentTotal}">
                                 <f:convertNumber pattern="#,##0.00" />
                             </h:outputLabel>
                         </f:facet>
                     </p:column>
 
-                    <p:column headerText="Adjustment To Basic" styleClass="averageNumericColumn">
-                        <f:facet name="header">
-                            <h:outputLabel value="Adjustment To Basic"></h:outputLabel>
-                        </f:facet>
-                        <h:outputLabel value="#{scc.adjustmentToBasic}" >
-                            <f:convertNumber pattern="0.00" />
+                    <p:column headerText="Adj. to basic" styleClass="averageNumericColumn">
+                        <h:outputLabel value="#{scc.adjustmentToBasic}">
+                            <f:convertNumber pattern="#,##0.00" />
                         </h:outputLabel>
                         <f:facet name="footer">
-                            <h:outputLabel style="text-align: right;"
-                                           value="#{salaryCycleController.adjustmentToBasicTotal}">
+                            <h:outputLabel value="#{salaryCycleController.adjustmentToBasicTotal}">
                                 <f:convertNumber pattern="#,##0.00" />
                             </h:outputLabel>
                         </f:facet>
                     </p:column>
 
-                    <p:column headerText="Adjustment To Allowance" styleClass="averageNumericColumn">
-                        <f:facet name="header">
-                            <h:outputLabel value="Adjustment To Allowance"></h:outputLabel>
-                        </f:facet>
-                        <h:outputLabel value="#{scc.adjustmentToAllowance}" >
-                            <f:convertNumber pattern="0.00" />
+                    <p:column headerText="Adj. to allow." styleClass="averageNumericColumn">
+                        <h:outputLabel value="#{scc.adjustmentToAllowance}">
+                            <f:convertNumber pattern="#,##0.00" />
                         </h:outputLabel>
                         <f:facet name="footer">
-                            <h:outputLabel style="text-align: right;"
-                                           value="#{salaryCycleController.adjustmentToAllowancesTotal}">
+                            <h:outputLabel value="#{salaryCycleController.adjustmentToAllowancesTotal}">
                                 <f:convertNumber pattern="#,##0.00" />
                             </h:outputLabel>
                         </f:facet>
                     </p:column>
 
-                    <p:column headerText="EPF Staff" styleClass="averageNumericColumn">
-                        <f:facet name="header">
-                            <h:outputLabel value="EPF Staff"></h:outputLabel>
-                        </f:facet>
-                        <h:outputLabel value="#{scc.epfStaffValue}" >
-                            <f:convertNumber pattern="0.00" />
+                    <p:column headerText="EPF staff" styleClass="averageNumericColumn">
+                        <h:outputLabel value="#{scc.epfStaffValue}">
+                            <f:convertNumber pattern="#,##0.00" />
                         </h:outputLabel>
                         <f:facet name="footer">
-                            <h:outputLabel style="text-align: right;"
-                                           value="#{salaryCycleController.epfStaffValueTotal}">
+                            <h:outputLabel value="#{salaryCycleController.epfStaffValueTotal}">
                                 <f:convertNumber pattern="#,##0.00" />
                             </h:outputLabel>
                         </f:facet>
                     </p:column>
 
-                    <p:column headerText="EPF Company" styleClass="averageNumericColumn">
-                        <f:facet name="header">
-                            <h:outputLabel value="EPF Company"></h:outputLabel>
-                        </f:facet>
-                        <h:outputLabel value="#{scc.epfCompanyValue}" >
-                            <f:convertNumber pattern="0.00" />
+                    <p:column headerText="EPF company" styleClass="averageNumericColumn">
+                        <h:outputLabel value="#{scc.epfCompanyValue}">
+                            <f:convertNumber pattern="#,##0.00" />
                         </h:outputLabel>
                         <f:facet name="footer">
-                            <h:outputLabel style="text-align: right;"
-                                           value="#{salaryCycleController.epfCompanyValueTotal}">
+                            <h:outputLabel value="#{salaryCycleController.epfCompanyValueTotal}">
                                 <f:convertNumber pattern="#,##0.00" />
                             </h:outputLabel>
                         </f:facet>
                     </p:column>
 
-                    <p:column headerText="ETF Satff" styleClass="averageNumericColumn">
-                        <f:facet name="header">
-                            <h:outputLabel value="ETF Satff"></h:outputLabel>
-                        </f:facet>
-                        <h:outputLabel value="#{scc.etfSatffValue}" >
-                            <f:convertNumber pattern="0.00" />
+                    <p:column headerText="ETF staff" styleClass="averageNumericColumn">
+                        <h:outputLabel value="#{scc.etfSatffValue}">
+                            <f:convertNumber pattern="#,##0.00" />
                         </h:outputLabel>
                         <f:facet name="footer">
-                            <h:outputLabel style="text-align: right;"
-                                           value="#{salaryCycleController.etfStaffValueTotal}">
+                            <h:outputLabel value="#{salaryCycleController.etfStaffValueTotal}">
                                 <f:convertNumber pattern="#,##0.00" />
                             </h:outputLabel>
                         </f:facet>
                     </p:column>
 
-                    <p:column headerText="ETF Company" styleClass="averageNumericColumn">
-                        <f:facet name="header">
-                            <h:outputLabel value="ETF Company"></h:outputLabel>
-                        </f:facet>
-                        <h:outputLabel value="#{scc.etfCompanyValue}" >
-                            <f:convertNumber pattern="0.00" />
+                    <p:column headerText="ETF company" styleClass="averageNumericColumn">
+                        <h:outputLabel value="#{scc.etfCompanyValue}">
+                            <f:convertNumber pattern="#,##0.00" />
                         </h:outputLabel>
                         <f:facet name="footer">
-                            <h:outputLabel style="text-align: right;"
-                                           value="#{salaryCycleController.etfCompanValueTotal}">
+                            <h:outputLabel value="#{salaryCycleController.etfCompanValueTotal}">
                                 <f:convertNumber pattern="#,##0.00" />
                             </h:outputLabel>
                         </f:facet>
                     </p:column>
+
                     <f:facet name="footer">
-                        <p:outputLabel value="Print By : #{sessionController.loggedUser.webUserPerson.name} - " />
-                        <p:outputLabel value="Print At : " />
-                        <p:outputLabel value="#{commonFunctionsProxy.currentDateTime}" >
-                            <f:convertDateTime pattern="yyyy MMMM dd hh:mm:ss a " />
-                        </p:outputLabel>
+                        <div class="report-table-footer">
+                            <p:outputLabel value="Print by: #{sessionController.loggedUser.webUserPerson.name}" />
+                            <span>·</span>
+                            <p:outputLabel value="#{commonFunctionsProxy.currentDateTime}">
+                                <f:convertDateTime pattern="yyyy MMMM dd hh:mm:ss a" />
+                            </p:outputLabel>
+                        </div>
                     </f:facet>
+
                 </p:dataTable>
 
             </p:panel>
+
         </h:form>
     </ui:define>
 

--- a/src/main/webapp/hr/hr_report_staff_salary_by_department.xhtml
+++ b/src/main/webapp/hr/hr_report_staff_salary_by_department.xhtml
@@ -102,7 +102,13 @@
                 }
 
                 .salary-table .ui-datatable-tablewrapper {
-                    overflow-x: auto;
+                    overflow-x: auto !important;
+                    width: 100% !important;
+                }
+
+                .salary-table table {
+                    width: auto !important;
+                    table-layout: auto !important;
                 }
 
                 .salary-table .ui-datatable-data td,
@@ -110,6 +116,7 @@
                     padding: 10px 14px !important;
                     white-space: nowrap;
                     font-size: 13px !important;
+                    width: auto !important;
                 }
 
                 .salary-table .ui-datatable-thead th {
@@ -137,6 +144,10 @@
 
                 .salary-table .col-text {
                     text-align: left !important;
+                }
+
+                .salary-table .col-name {
+                    min-width: 200px !important;
                 }
 
                 .salary-table .col-name .ui-outputlabel {
@@ -242,7 +253,7 @@
                              var="scc"
                              styleClass="salary-table">
 
-                    <p:column headerText="Department" styleClass="col-text col-name">
+                    <p:column headerText="Department" styleClass="col-text col-name" style="min-width: 200px;">
                         <h:outputLabel value="#{scc.department.name}" />
                         <f:facet name="footer">
                             <h:outputLabel value="Total" />

--- a/src/main/webapp/hr/hr_reports.xhtml
+++ b/src/main/webapp/hr/hr_reports.xhtml
@@ -9,7 +9,6 @@
 
             <ui:define name="content">
 
-
                 <div class="container-flex" >
                     <div class="row" >
                         <div class="col-2" >
@@ -18,192 +17,190 @@
                                     <p:accordionPanel >
                                         <p:tab title="(1) Salary Report">
                                             <h:panelGrid columns="1">
-                                                <!--                                <p:commandButton value="(1) All Staff Salary Detail" 
-                                                                                                action="/hr/hr_report_all_staff_salary" 
-                                                                                                 class="w-100 my-1" ajax="false"  /> -->
                                                 <p:commandButton value="(2) All Staff Salary Summary" 
-                                                                 action="/hr/hr_report_staff_salary" 
+                                                                 action="/hr/hr_report_staff_salary?faces-redirect=true" 
                                                                  class="w-100 my-1" ajax="false" /> 
                                                 <p:commandButton value="(2.1) All Staff Salary Summary(By Department)" 
-                                                                 action="/hr/hr_report_staff_salary_by_department" 
+                                                                 action="/hr/hr_report_staff_salary_by_department?faces-redirect=true" 
                                                                  class="w-100 my-1" ajax="false" /> 
                                                 <p:commandButton value="(3) Staff Payroll" 
-                                                                 action="/hr/hr_report_staff_payroll" 
+                                                                 action="/hr/hr_report_staff_payroll?faces-redirect=true" 
                                                                  class="w-100 my-1" ajax="false" />
                                                 <p:commandButton value="(3) Staff Payroll(Accountant)" 
-                                                                 action="/hr/hr_report_staff_payroll_1" 
+                                                                 action="/hr/hr_report_staff_payroll_1?faces-redirect=true" 
                                                                  class="w-100 my-1" ajax="false" />
                                                 <p:commandButton value="(3.1) Staff Payrol(By Department)" 
-                                                                 action="/hr/hr_report_staff_payroll_department" 
+                                                                 action="/hr/hr_report_staff_payroll_department?faces-redirect=true" 
                                                                  class="w-100 my-1" ajax="false" />
                                                 <p:commandButton value="(3.2) Staff Payroll(By Roster)" 
-                                                                 action="/hr/hr_report_staff_payroll_roster" 
+                                                                 action="/hr/hr_report_staff_payroll_roster?faces-redirect=true" 
                                                                  class="w-100 my-1" ajax="false" />
                                                 <p:commandButton value="(3.1) Staff Payroll(Selected Staff)" 
-                                                                 action="/hr/hr_staff_salary_1" 
+                                                                 action="/hr/hr_staff_salary_1?faces-redirect=true" 
                                                                  class="w-100 my-1" ajax="false" />
-                                                <p:commandButton value="(4) Staff Over Time " 
-                                                                 action="/hr/hr_report_staff_over_time" 
+                                                <p:commandButton value="(4) Staff Over Time" 
+                                                                 action="/hr/hr_report_staff_over_time?faces-redirect=true" 
                                                                  class="w-100 my-1" ajax="false" />  
-                                                <p:commandButton value="(5)No Pay And Salary Allovance  Report " 
-                                                                 action="/hr/hr_report_staff_no_pay_and_late" 
+                                                <p:commandButton value="(5) No Pay And Salary Allowance Report" 
+                                                                 action="/hr/hr_report_staff_no_pay_and_late?faces-redirect=true" 
                                                                  class="w-100 my-1" ajax="false" />  
                                                 <p:commandButton ajax="false"
-                                                                 action="/hr/hr_staff_paysheet_component_list"
-                                                                 value="(6) Staff Paysheet Component  List" 
+                                                                 action="/hr/hr_staff_paysheet_component_list?faces-redirect=true"
+                                                                 value="(6) Staff Paysheet Component List" 
                                                                  class="w-100 my-1"
                                                                  actionListener="#{staffBasicController.makeItemNul()}"  />
-                                                <p:commandButton ajax="false" action="/hr/hr_report_staff_salary_payment_bank"
+                                                <p:commandButton ajax="false" 
+                                                                 action="/hr/hr_report_staff_salary_payment_bank?faces-redirect=true"
                                                                  value="(7) Staff Salary Payment To Bank" 
                                                                  class="w-100 my-1"
                                                                  actionListener="#{staffBasicController.makeItemNul()}"  />
-                                                <p:commandButton ajax="false" action="/hr/hr_report_staff_salary_payment_bank_summery"
+                                                <p:commandButton ajax="false" 
+                                                                 action="/hr/hr_report_staff_salary_payment_bank_summery?faces-redirect=true"
                                                                  value="(7.1) Staff Salary Bank Vise" 
                                                                  class="w-100 my-1"
                                                                  actionListener="#{staffBasicController.makeItemNul()}"  />
-                                                <p:commandButton ajax="false" action="/hr/hr_Hreport_staff_salary_component"
+                                                <p:commandButton ajax="false" 
+                                                                 action="/hr/hr_Hreport_staff_salary_component?faces-redirect=true"
                                                                  value="(8) Staff Salary Component" 
                                                                  class="w-100 my-1"
                                                                  actionListener="#{staffBasicController.makeItemNul()}"  />
-                                                <p:commandButton ajax="false" action="/hr/hr_report_staff_salary_component_summery_bank_vise"
+                                                <p:commandButton ajax="false" 
+                                                                 action="/hr/hr_report_staff_salary_component_summery_bank_vise?faces-redirect=true"
                                                                  value="(8.1) Staff Salary Component(Bank Vise)" 
                                                                  class="w-100 my-1"
                                                                  actionListener="#{staffBasicController.makeItemNul()}"  />
-                                                <p:commandButton ajax="false" action="/hr/hr_report_staff_epf_etf_1"
+                                                <p:commandButton ajax="false" 
+                                                                 action="/hr/hr_report_staff_epf_etf_1?faces-redirect=true"
                                                                  value="(9) EPF" 
                                                                  class="w-100 my-1"
                                                                  actionListener="#{staffBasicController.makeItemNul()}"  />
-                                                <p:commandButton ajax="false" action="/hr/hr_report_staff_epf_etf"
+                                                <p:commandButton ajax="false" 
+                                                                 action="/hr/hr_report_staff_epf_etf?faces-redirect=true"
                                                                  value="(9.1) ETF" 
                                                                  class="w-100 my-1"
                                                                  actionListener="#{staffBasicController.makeItemNul()}"  />
-                                                <p:commandButton ajax="false" action="/hr/hr_report_staff_epf_etf_to_export"
+                                                <p:commandButton ajax="false" 
+                                                                 action="/hr/hr_report_staff_epf_etf_to_export?faces-redirect=true"
                                                                  value="(9.2) EPF ETF(Export)" 
                                                                  class="w-100 my-1"
                                                                  actionListener="#{staffBasicController.makeItemNul()}"  />
-                                                <p:commandButton ajax="false" action="/hr/hr_report_staff_salary_generate _or_not"
+                                                <p:commandButton ajax="false" 
+                                                                 action="/hr/hr_report_staff_salary_generate_or_not?faces-redirect=true"
                                                                  value="(10) Staff Salary Generate Or Not Report" 
                                                                  class="w-100 my-1"
                                                                  actionListener="#{hrReportController.makeNull()}"  />
-                                                <p:commandButton ajax="false" action="/hr/hr_report_staff_salary_deleted_report"
+                                                <p:commandButton ajax="false" 
+                                                                 action="/hr/hr_report_staff_salary_deleted_report?faces-redirect=true"
                                                                  value="(11) Staff Salary Generate Or Delete Detail Report" 
                                                                  class="w-100 my-1"
                                                                  actionListener="#{hrReportController.makeNull()}"  />
-                                                <p:commandButton ajax="false" action="/hr/hr_report_grativity"
+                                                <p:commandButton ajax="false" 
+                                                                 action="/hr/hr_report_grativity?faces-redirect=true"
                                                                  value="(12) Staff Gratuity" 
                                                                  class="w-100 my-1"
                                                                  actionListener="#{hrReportController.makeNull()}"  />
                                             </h:panelGrid>
-
                                         </p:tab>
 
                                         <p:tab title="(2) Attendance">
                                             <h:panelGrid columns="1">
                                                 <p:commandButton value="(1) Attendance Report" 
-                                                                 action="hr_report_attendance" 
+                                                                 action="/hr/hr_report_attendance?faces-redirect=true" 
                                                                  actionListener="#{hrReportController.makeNull()}" 
                                                                  class="w-100 my-1" ajax="false" /> 
-                                                <p:commandButton value="(2) Early In " 
-                                                                 action="hr_report_attendance_early_in" 
-                                                                 actionListener="#{hrReportController.makeNull()}" 
-                                                                 class="w-100 my-1" ajax="false" rendered="fasle"  /> 
-                                                <p:commandButton value="(3) Early Out " 
-                                                                 action="hr_report_attendance_early_out" 
-                                                                 actionListener="#{hrReportController.makeNull()}" 
-                                                                 class="w-100 my-1" ajax="false" rendered="false"/> 
-                                                <p:commandButton value="(4) Late In " 
-                                                                 action="hr_report_attendance_late_in" 
+                                                <p:commandButton value="(2) Early In" 
+                                                                 action="/hr/hr_report_attendance_early_in?faces-redirect=true" 
                                                                  actionListener="#{hrReportController.makeNull()}" 
                                                                  class="w-100 my-1" ajax="false" rendered="false" /> 
-                                                <p:commandButton value="(5) Late Out " 
-                                                                 action="hr_report_attendance_late_out" 
+                                                <p:commandButton value="(3) Early Out" 
+                                                                 action="/hr/hr_report_attendance_early_out?faces-redirect=true" 
                                                                  actionListener="#{hrReportController.makeNull()}" 
-                                                                 class="w-100 my-1" ajax="false" rendered="false"/> 
-                                                <p:commandButton value="(6) Late In and Early Out " 
-                                                                 action="hr_report_attendance_late_in_early_out" 
+                                                                 class="w-100 my-1" ajax="false" rendered="false" /> 
+                                                <p:commandButton value="(4) Late In" 
+                                                                 action="/hr/hr_report_attendance_late_in?faces-redirect=true" 
+                                                                 actionListener="#{hrReportController.makeNull()}" 
+                                                                 class="w-100 my-1" ajax="false" rendered="false" /> 
+                                                <p:commandButton value="(5) Late Out" 
+                                                                 action="/hr/hr_report_attendance_late_out?faces-redirect=true" 
+                                                                 actionListener="#{hrReportController.makeNull()}" 
+                                                                 class="w-100 my-1" ajax="false" rendered="false" /> 
+                                                <p:commandButton value="(6) Late In and Early Out" 
+                                                                 action="/hr/hr_report_attendance_late_in_early_out?faces-redirect=true" 
                                                                  actionListener="#{hrReportController.makeNull()}" 
                                                                  class="w-100 my-1" ajax="false" />
-
                                                 <p:commandButton value="(8) Staff Shift Detail By Staff" 
-                                                                 action="hr_report_summery_by_staff" 
+                                                                 action="/hr/hr_report_summery_by_staff?faces-redirect=true" 
                                                                  actionListener="#{hrReportController.makeNull()}" 
                                                                  class="w-100 my-1" ajax="false" />
-
                                                 <p:commandButton value="(9) Verified Report" 
-                                                                 action="hr_form_staff_shift_report" 
+                                                                 action="/hr/hr_form_staff_shift_report?faces-redirect=true" 
                                                                  actionListener="#{hrReportController.makeNull()}" 
                                                                  class="w-100 my-1" ajax="false" />
-
                                             </h:panelGrid>
-
                                         </p:tab>
 
                                         <p:tab title="(3) Administration">
                                             <h:panelGrid columns="1">
-                                                <p:commandButton value="(1) Department Report " 
-                                                                 action="hr_report_department" 
+                                                <p:commandButton value="(1) Department Report" 
+                                                                 action="/hr/hr_report_department?faces-redirect=true" 
                                                                  actionListener="#{hrReportController.makeNull()}" 
                                                                  class="w-100 my-1" ajax="false" /> 
-                                                <p:commandButton value="(2) Employee Detail " 
-                                                                 action="hr_report_employee_detail" 
+                                                <p:commandButton value="(2) Employee Detail" 
+                                                                 action="/hr/hr_report_employee_detail?faces-redirect=true" 
                                                                  actionListener="#{hrReportController.makeNull()}" 
                                                                  class="w-100 my-1" ajax="false" />
                                                 <p:commandButton value="(3) Employee Detail Zone Code" 
-                                                                 action="hr_report_employee_detail_zone_code" 
+                                                                 action="/hr/hr_report_employee_detail_zone_code?faces-redirect=true" 
                                                                  actionListener="#{hrReportController.makeNull()}" 
                                                                  class="w-100 my-1" ajax="false" />
-
                                                 <p:commandButton value="(4) Employee EPF Detail" 
-                                                                 action="hr_report_epf_detail" 
+                                                                 action="/hr/hr_report_epf_detail?faces-redirect=true" 
                                                                  actionListener="#{hrReportController.makeNull()}" 
                                                                  class="w-100 my-1" ajax="false" />
                                                 <p:commandButton value="(5) Employee Retierd Details" 
-                                                                 action="hr_report_employee_detail_1" 
+                                                                 action="/hr/hr_report_employee_detail_1?faces-redirect=true" 
                                                                  actionListener="#{hrReportController.makeNull()}" 
                                                                  class="w-100 my-1" ajax="false" />
                                             </h:panelGrid>
-
                                         </p:tab>
 
                                         <p:tab title="(4) Shift">
                                             <h:panelGrid columns="1">
                                                 <p:commandButton value="(1) Staff Shift Report" 
-                                                                 action="hr_report_staff_shift" 
+                                                                 action="/hr/hr_report_staff_shift?faces-redirect=true" 
                                                                  actionListener="#{hrReportController.makeNull()}" 
                                                                  class="w-100 my-1" ajax="false" />
-                                                <p:commandButton value="(2) Staff Extra Shift " 
-                                                                 action="hr_report_staff_shift_extra" 
+                                                <p:commandButton value="(2) Staff Extra Shift" 
+                                                                 action="/hr/hr_report_staff_shift_extra?faces-redirect=true" 
                                                                  actionListener="#{hrReportController.makeNull()}" 
                                                                  class="w-100 my-1" ajax="false" />
                                                 <p:commandButton value="(3) Entered Shift Report" 
-                                                                 action="hr_shift_report" 
+                                                                 action="/hr/hr_shift_report?faces-redirect=true" 
                                                                  actionListener="#{hrReportController.makeNull()}" 
                                                                  class="w-100 my-1" ajax="false" />
                                                 <p:commandButton value="(4) Roster Table and verify Time" 
-                                                                 action="hr_report_shift_table" 
+                                                                 action="/hr/hr_report_shift_table?faces-redirect=true" 
                                                                  actionListener="#{shiftTableController.makeTableNull()}"
                                                                  class="w-100 my-1" ajax="false" />
-
                                             </h:panelGrid>
-
                                         </p:tab>
 
                                         <p:tab title="(5) Finger Print Records">
                                             <h:panelGrid columns="1">
                                                 <p:commandButton value="(1) Finger Print Record By Logged" 
-                                                                 action="hr_report_finger_print_record_logged" 
+                                                                 action="/hr/hr_report_finger_print_record_logged?faces-redirect=true" 
                                                                  actionListener="#{hrReportController.makeNull()}" 
                                                                  class="w-100 my-1" ajax="false" /> 
                                                 <p:commandButton value="(2) Finger Print Record By Verified" 
-                                                                 action="hr_report_finger_print_record_verified" 
+                                                                 action="/hr/hr_report_finger_print_record_verified?faces-redirect=true" 
                                                                  actionListener="#{hrReportController.makeNull()}" 
                                                                  class="w-100 my-1" ajax="false" /> 
                                                 <p:commandButton value="(3) Finger Print Record No Shift Setted" 
-                                                                 action="hr_report_finger_print_record_no_shift_setted" 
+                                                                 action="/hr/hr_report_finger_print_record_no_shift_setted?faces-redirect=true" 
                                                                  actionListener="#{hrReportController.makeNull()}" 
                                                                  class="w-100 my-1" ajax="false" /> 
                                                 <p:commandButton value="(4) Finger Print Approve" 
-                                                                 action="hr_report_finger_print_record_approved" 
+                                                                 action="/hr/hr_report_finger_print_record_approved?faces-redirect=true" 
                                                                  actionListener="#{hrReportController.makeNull()}" 
                                                                  class="w-100 my-1" ajax="false" /> 
                                             </h:panelGrid>
@@ -211,91 +208,87 @@
 
                                         <p:tab title="(6) Summary">
                                             <h:panelGrid columns="1">
-                                                <p:commandButton value="(1) Head Count " 
-                                                                 action="hr_report_head_count" 
+                                                <p:commandButton value="(1) Head Count" 
+                                                                 action="/hr/hr_report_head_count?faces-redirect=true" 
                                                                  actionListener="#{hrReportController.makeNull()}" 
                                                                  class="w-100 my-1" ajax="false" /> 
                                                 <p:commandButton value="(2) Employee Worked Day Report" 
-                                                                 action="hr_report_month_end_employee_date" 
+                                                                 action="/hr/hr_report_month_end_employee_date?faces-redirect=true" 
                                                                  actionListener="#{hrReportController.makeNull()}" 
                                                                  class="w-100 my-1" ajax="false" /> 
                                                 <p:commandButton value="(2.1) Employee Worked Day Report(New)" 
-                                                                 action="hr_report_month_end_employee_date_1" 
+                                                                 action="/hr/hr_report_month_end_employee_date_1?faces-redirect=true" 
                                                                  actionListener="#{hrReportController.makeNull()}" 
                                                                  class="w-100 my-1" ajax="false" />
-                                                <p:commandButton value="(3) Month End Employee Working Time + 
-                                                                 Over Time Report-By Minute " 
-                                                                 action="hr_report_month_end_work_time" 
+                                                <p:commandButton value="(3) Month End Employee Working Time + Over Time Report-By Minute" 
+                                                                 action="/hr/hr_report_month_end_work_time?faces-redirect=true" 
                                                                  actionListener="#{hrReportController.makeNull()}" 
                                                                  class="w-100 my-1" ajax="false" /> 
-                                                <p:commandButton value="(3.1) Month End Employee Working Time + 
-                                                                 Over Time Report-By Minute(Minute) " 
-                                                                 action="hr_report_month_end_work_time_miniuts" 
+                                                <p:commandButton value="(3.1) Month End Employee Working Time + Over Time Report-By Minute(Minute)" 
+                                                                 action="/hr/hr_report_month_end_work_time_miniuts?faces-redirect=true" 
                                                                  actionListener="#{hrReportController.makeNull()}" 
                                                                  class="w-100 my-1" ajax="false" />
-                                                <p:commandButton value="(3.2) Month End Employee Working Time + 
-                                                                 Over Time Report-By Minute(Minute) Summary (New)" 
-                                                                 action="hr_report_month_end_work_time_miniuts_summery" 
+                                                <p:commandButton value="(3.2) Month End Employee Working Time + Over Time Report-By Minute(Minute) Summary (New)" 
+                                                                 action="/hr/hr_report_month_end_work_time_miniuts_summery?faces-redirect=true" 
                                                                  actionListener="#{hrReportController.makeNull()}" 
                                                                  class="w-100 my-1" ajax="false" />
-                                                <p:commandButton value="(4) Month End Employee (No Pay) Report-By Minute " 
-                                                                 action="hr_report_month_end_work_time_no_pay" 
+                                                <p:commandButton value="(4) Month End Employee (No Pay) Report-By Minute" 
+                                                                 action="/hr/hr_report_month_end_work_time_no_pay?faces-redirect=true" 
                                                                  actionListener="#{hrReportController.makeNull()}" 
                                                                  class="w-100 my-1" ajax="false" /> 
-                                                <p:commandButton value="(5) Month End Employee Summary " 
-                                                                 action="hr_report_month_end_staff_shift_data" 
+                                                <p:commandButton value="(5) Month End Employee Summary" 
+                                                                 action="/hr/hr_report_month_end_staff_shift_data?faces-redirect=true" 
                                                                  actionListener="#{hrReportController.makeNull()}" 
                                                                  class="w-100 my-1" ajax="false" /> 
-
                                             </h:panelGrid>
                                         </p:tab>
 
                                         <p:tab title="(7) Leave">
                                             <h:panelGrid columns="1">
-                                                <p:commandButton value="(1) Leave Report " 
-                                                                 action="hr_report_leave" 
+                                                <p:commandButton value="(1) Leave Report" 
+                                                                 action="/hr/hr_report_leave?faces-redirect=true" 
                                                                  actionListener="#{hrReportController.makeNull()}" 
                                                                  class="w-100 my-1" ajax="false" /> 
-                                                <p:commandButton value="(2) Leave Report Summary " 
-                                                                 action="hr_report_leave_summery" 
+                                                <p:commandButton value="(2) Leave Report Summary" 
+                                                                 action="/hr/hr_report_leave_summery?faces-redirect=true" 
                                                                  actionListener="#{hrReportController.makeNull()}" 
                                                                  class="w-100 my-1" ajax="false" /> 
-                                                <p:commandButton value="(3) Leave Report Detail By Staff " 
-                                                                 action="hr_report_leave_summery_by_staff" 
+                                                <p:commandButton value="(3) Leave Report Detail By Staff" 
+                                                                 action="/hr/hr_report_leave_summery_by_staff?faces-redirect=true" 
                                                                  actionListener="#{hrReportController.makeNull()}" 
                                                                  class="w-100 my-1" ajax="false" />
                                                 <p:commandButton value="(4) Late Leave" 
-                                                                 action="hr_report_leave_system" 
+                                                                 action="/hr/hr_report_leave_system?faces-redirect=true" 
                                                                  actionListener="#{hrReportController.makeNull()}" 
                                                                  class="w-100 my-1" ajax="false" />
                                                 <p:commandButton value="(4) Late Leave(Detail)" 
-                                                                 action="hr_report_leave_system_1" 
+                                                                 action="/hr/hr_report_leave_system_1?faces-redirect=true" 
                                                                  actionListener="#{hrReportController.makeNull()}" 
                                                                  class="w-100 my-1" ajax="false" />
                                             </h:panelGrid>
                                         </p:tab>
+
                                         <p:tab title="(8) Working Time">
                                             <h:panelGrid columns="1">
                                                 <p:commandButton value="(1) Worked Time" 
-                                                                 action="hr_report_staff_shift_detail" 
+                                                                 action="/hr/hr_report_staff_shift_detail?faces-redirect=true" 
                                                                  actionListener="#{hrReportController.makeNull()}" 
                                                                  class="w-100 my-1" ajax="false" /> 
                                                 <p:commandButton value="(2) Over Time" 
-                                                                 action="hr_report_over_time" 
+                                                                 action="/hr/hr_report_over_time?faces-redirect=true" 
                                                                  actionListener="#{hrReportController.makeNull()}" 
                                                                  class="w-100 my-1" ajax="false" />
                                             </h:panelGrid>
                                         </p:tab>
 
                                         <p:tab title="(9) History">
-                                                <!--rendered="#{webUserController.hasPrivilege('EmployeeHistoryReport')}" >-->
                                             <h:panelGrid columns="1">
                                                 <p:commandButton value="(1) Staff Shift History" 
-                                                                 action="hr_report_staff_shift_history" 
+                                                                 action="/hr/hr_report_staff_shift_history?faces-redirect=true" 
                                                                  actionListener="#{hrReportController.makeNull()}" 
                                                                  class="w-100 my-1" ajax="false" /> 
-                                                <p:commandButton value="(2)Finger Print History" 
-                                                                 action="hr_report_finger_print_history" 
+                                                <p:commandButton value="(2) Finger Print History" 
+                                                                 action="/hr/hr_report_finger_print_history?faces-redirect=true" 
                                                                  actionListener="#{hrReportController.makeNull()}" 
                                                                  class="w-100 my-1" ajax="false" />
                                             </h:panelGrid>
@@ -303,20 +296,20 @@
 
                                         <p:tab title="(10) Form">
                                             <h:panelGrid columns="1">
-                                                <p:commandButton value="(1)Additional Form Report" 
-                                                                 action="hr_form_staff_additional_report_1" 
+                                                <p:commandButton value="(1) Additional Form Report" 
+                                                                 action="/hr/hr_form_staff_additional_report_1?faces-redirect=true" 
                                                                  actionListener="#{hrReportController.makeNull()}" 
                                                                  class="w-100 my-1" ajax="false" />
-                                                <p:commandButton value="(2)Leave Form Report" 
-                                                                 action="hr_form_staff_leave_report" 
+                                                <p:commandButton value="(2) Leave Form Report" 
+                                                                 action="/hr/hr_form_staff_leave_report?faces-redirect=true" 
                                                                  actionListener="#{hrReportController.makeNull()}" 
                                                                  class="w-100 my-1" ajax="false" />
-                                                <p:commandButton value="(3)Additional Form Report Varification" 
-                                                                 action="hr_form_staff_additional_report" 
+                                                <p:commandButton value="(3) Additional Form Report Varification" 
+                                                                 action="/hr/hr_form_staff_additional_report?faces-redirect=true" 
                                                                  actionListener="#{hrReportController.makeNull()}" 
                                                                  class="w-100 my-1" ajax="false" />
-                                                <p:commandButton value="(4)Form Report That Not Comes To Analysed" 
-                                                                 action="hr_form_staff_form_report" 
+                                                <p:commandButton value="(4) Form Report That Not Comes To Analysed" 
+                                                                 action="/hr/hr_form_staff_form_report?faces-redirect=true" 
                                                                  actionListener="#{hrReportController.makeNull()}" 
                                                                  class="w-100 my-1" ajax="false" />
                                             </h:panelGrid>
@@ -325,13 +318,13 @@
                                         <p:tab title="(11) Hr Edit">
                                             <h:panelGrid columns="1">
                                                 <p:commandButton value="Edit Leave" 
-                                                                 action="hr_staff_leave_edit_search" 
+                                                                 action="/hr/hr_staff_leave_edit_search?faces-redirect=true" 
                                                                  class="w-100 my-1" ajax="false" />
                                                 <p:commandButton value="Edit Shift" 
-                                                                 action="hr_shift_staff_edit_search" 
+                                                                 action="/hr/hr_shift_staff_edit_search?faces-redirect=true" 
                                                                  class="w-100 my-1" ajax="false" />
                                                 <p:commandButton value="Edit Finger Print Record" 
-                                                                 action="hr_staff_finger_edit_search" 
+                                                                 action="/hr/hr_staff_finger_edit_search?faces-redirect=true" 
                                                                  class="w-100 my-1" ajax="false" />
                                             </h:panelGrid>
                                         </p:tab>
@@ -339,17 +332,19 @@
                                         <p:tab title="(12) Hr Holydays">
                                             <h:panelGrid columns="1">
                                                 <p:commandButton value="Holyday Report" 
-                                                                 action="hr_report_ph_date" 
+                                                                 action="/hr/hr_report_ph_date?faces-redirect=true" 
                                                                  class="w-100 my-1" ajax="false" />
                                             </h:panelGrid>
                                         </p:tab>
+
                                         <p:tab title="(13) Staff Reports">
                                             <h:panelGrid columns="1">
                                                 <p:commandButton value="Staff Details" 
-                                                                 action="/hr/report_staff_details" 
+                                                                 action="/hr/report_staff_details?faces-redirect=true" 
                                                                  class="w-100 my-1" ajax="false" />
                                             </h:panelGrid>
                                         </p:tab>
+
                                     </p:accordionPanel>
                                 </p:panel>
                             </h:form>
@@ -363,8 +358,6 @@
                     </div>
 
                 </div>
-
-
 
             </ui:define>
 

--- a/src/main/webapp/resources/ezcomp/menu.xhtml
+++ b/src/main/webapp/resources/ezcomp/menu.xhtml
@@ -1921,7 +1921,7 @@
                         icon="fa fa-cogs" value="Processes"  />
                     <p:menuitem  
                         ajax="false"  
-                        action="/hr/hr_reports" 
+                        action="/hr/hr_reports?faces-redirect=true" 
                         icon="fa fa-chart-bar" value="HR Analytics" 
                         rendered="#{webUserController.hasPrivilege('HrReports')}" />
 


### PR DESCRIPTION
## Summary
UI refactor of the staff salary summary by department page, consistent with the all staff salary summary page styling.

## Changes
- Replaced raw `h:panelGrid` controls layout with structured panel using stacked label + select and a separate actions row
- Applied consistent page title, subtitle, controls panel, and report panel structure matching the all staff salary summary page
- Removed duplicate `f:facet name="header"` inside each `p:column` — `headerText` attribute is sufficient
- Fixed number format from `0.00` to `#,##0.00` consistently across all data cells
- Fixed print footer layout using flex with `justify-content: flex-end`
- Removed unused `xmlns:hr` namespace declaration
- Fixed filename typo: `all_staff_salary_summery_by_department` → `all_staff_salary_summary_by_department`
- Shortened verbose column headers to abbreviated forms matching the reference page (e.g. `Holiday Allowance` → `Holiday allow.`, `Additional Componnet` → `Add. component`)

## No functional changes
All bean bindings, action methods, converters, and data export behaviour are unchanged.