### PR TITLE
Refactor: Staff Salary Component — composition layout + table cleanup

### DIFF
--- a/src/main/webapp/hr/hr_report_staff_payroll.xhtml
+++ b/src/main/webapp/hr/hr_report_staff_payroll.xhtml
@@ -5,352 +5,446 @@
       xmlns:h="http://xmlns.jcp.org/jsf/html"
       xmlns:p="http://primefaces.org/ui"
       xmlns:f="http://xmlns.jcp.org/jsf/core"
-      xmlns:hr="http://xmlns.jcp.org/jsf/composite/autocomplete" >
-    <head>
-
-    </head>
+      xmlns:hr="http://xmlns.jcp.org/jsf/composite/autocomplete">
+    <head></head>
     <h:body>
-        <ui:composition template="/hr/hr_reports.xhtml" >
+        <ui:composition template="/hr/hr_reports.xhtml">
             <ui:define name="content">
-                <style>
 
-                    table, th, td {
-                        border: 1px solid black;
-                        border-collapse: collapse;
-                        padding: 2px;
-                        /*white-space: nowrap;*/
-                    }
-                </style>
+                <h:form id="print" styleClass="salary-summary-form">
 
+                    <h:outputStylesheet>
+                        .salary-summary-form {
+                            padding: 2rem 1.75rem;
+                        }
 
+                        .page-header {
+                            margin-bottom: 1.75rem;
+                        }
 
+                        .page-title {
+                            font-size: 18px;
+                            font-weight: 600;
+                            margin: 0 0 4px 0;
+                        }
 
+                        .page-subtitle {
+                            font-size: 13px;
+                            color: #888;
+                            margin: 0;
+                        }
 
+                        .controls-panel .ui-panel-content {
+                            padding: 1.5rem 1.75rem !important;
+                        }
 
+                        .controls-grid {
+                            display: flex;
+                            flex-direction: column;
+                            gap: 1.25rem;
+                        }
 
+                        .fields-grid {
+                            display: grid;
+                            grid-template-columns: repeat(2, 1fr);
+                            gap: 1rem 1.5rem;
+                        }
 
-                <h:form id="print">
-                    <h:panelGrid columns="2" styleClass="noPrintButton">
-                        <h:outputLabel value="Salary Cycle"/>
-                        <p:selectOneMenu id="advanced"
-                                         value="#{salaryCycleController.current}"
-                                         var="t"
-                                         filter="true"
-                                         filterMatchMode="startsWith">
+                        .field-group {
+                            display: flex;
+                            flex-direction: column;
+                            gap: 6px;
+                        }
 
-                            <f:selectItems value="#{salaryCycleController.salaryCycles}"
-                                           var="theme"
-                                           itemLabel="#{theme.name}"
-                                           itemValue="#{theme}" ></f:selectItems>
+                        .field-label {
+                            font-size: 11.5px !important;
+                            font-weight: 600 !important;
+                            text-transform: uppercase;
+                            letter-spacing: 0.05em;
+                            color: #888 !important;
+                        }
 
-                            <p:column style="width:10%" headerText="Name">
-                                <h:outputText value="#{t.name}" />
-                            </p:column>
+                        .controls-actions {
+                            display: flex;
+                            gap: 10px;
+                            align-items: center;
+                            flex-wrap: wrap;
+                        }
 
-                            <p:column headerText="Year">
-                                <h:outputText value="#{t.salaryYear}" />
-                            </p:column>
-                            <p:column headerText="Month">
-                                <h:outputText value="#{t.salaryMonth}" />
-                            </p:column>
-                        </p:selectOneMenu>
-                        <h:outputLabel value="Institution"/>
-                        <hr:institution value="#{salaryCycleController.reportKeyWord.institution}"/>
-                        <h:outputLabel value="Department : "/>
-                        <hr:department value="#{salaryCycleController.reportKeyWord.department}"/>
-                        <h:outputLabel value="Employee : "/>
-                        <hr:completeStaff value="#{salaryCycleController.reportKeyWord.staff}"/>
-                        <h:outputLabel value="Staff Category : "/>
-                        <hr:completeStaffCategory value="#{salaryCycleController.reportKeyWord.staffCategory}"/>
-                        <h:outputLabel value="Staff Designation : "/>
-                        <hr:completeDesignation value="#{salaryCycleController.reportKeyWord.designation}"/>
-                        <h:outputLabel value="Staff Roster : "/>
-                        <hr:completeRoster value="#{salaryCycleController.reportKeyWord.roster}"/>
-                    </h:panelGrid>
+                        .btn-action {
+                            height: 36px !important;
+                            padding: 0 18px !important;
+                            font-size: 13px !important;
+                        }
 
-                    <p:commandButton value="Print" ajax="false" action="#" styleClass="noPrintButton" >
-                        <p:printer target="print" ></p:printer>
-                    </p:commandButton>
-                    <p:commandButton value="Process" ajax="false" action="#{salaryCycleController.fillStaffPayRoll()}" styleClass="noPrintButton" ></p:commandButton>
-                    <p:commandButton value="Process Hold List" ajax="false" action="#{salaryCycleController.fillStaffPayRollBlocked()}" styleClass="noPrintButton" ></p:commandButton>
+                        .excel-btn {
+                            display: inline-flex;
+                            align-items: center;
+                            height: 36px;
+                            padding: 0 18px;
+                            font-size: 13px;
+                            text-decoration: none;
+                            border: 1px solid #c0c0c0;
+                            border-radius: 3px;
+                            background: #f4f4f4;
+                            color: #333;
+                        }
 
-                    <h:outputScript library="js" name="excellentexport.js" ></h:outputScript>
+                        .excel-btn:hover {
+                            background: #e8e8e8;
+                        }
 
-                    <a download="staff_payroll.xls" href="#" onclick="return ExcellentExport.excel(this, 'tbl', 'Sheet1');"
-                       style="padding: .3em 1em;  background: #D7D0C0; "
-                       styleClass="ui-button ui-widget ui-state-default ui-corner-all ui-button-text-only ui-button-text ui-c noPrintButton" >Export to Excel</a>
-                    <br></br>
-                    <br></br>
-                    <h:outputLabel value="Staff Payroll" />
-                    <br/>
-                    <h:outputLabel value="#{salaryCycleController.current.name}" />
-                    <br/>
-                    <h:panelGroup rendered="#{salaryCycleController.reportKeyWord.institution ne null}" >
-                        <h:outputLabel value="#{salaryCycleController.reportKeyWord.institution.name}" />
-                        <br/>
-                    </h:panelGroup>
-                    <h:panelGroup rendered="#{salaryCycleController.reportKeyWord.department ne null}" >
-                        <h:outputLabel value="Department : #{salaryCycleController.reportKeyWord.department.name}"/>
-                        <br/>
-                    </h:panelGroup>
-                    <h:panelGroup rendered="#{salaryCycleController.reportKeyWord.roster ne null}" >
-                        <h:outputLabel value="Roster : #{salaryCycleController.reportKeyWord.roster.name}"/>
-                        <br/>
-                    </h:panelGroup>
+                        .report-panel {
+                            margin-top: 1.5rem;
+                        }
 
+                        .report-header-wrap {
+                            margin-bottom: 1rem;
+                        }
 
-                    <table id="tbl" border="1"  style="border: 1px solid black;" >
-                        <thead>
-                            <tr>
-                                <th>Code</th>
-                                <th>EPF</th>
-                                <th>Join</th>
-                                <th>Satff </th>
-                                <th>Des</th>
-                                <th>Basic+BR</th>
-                                <th>Merchan</th>
-                                <th>Poya</th>
-                                <th>Day Off</th>
-                                <th>Basic Adjust</th>
-                                <th>Total Salary</th>
-                                <th>No Pay Basic</th>
-                                <th>EPF/ETF Diductable Salary</th>
-                                <ui:repeat value="#{salaryCycleController.headersAdd}" var="h">
-                                    <th>#{h}</th>
-                                </ui:repeat>
-                                <th>Allowance Adjust</th>
-                                <th>No Pay Allowance</th>
-                                <th>Total Allowance</th>
-                                <th>Gross Salary</th>
-                                <th>EPF Staff</th>
-                                <ui:repeat value="#{salaryCycleController.headersSub}" var="hh">
-                                    <th>#{hh}</th>
-                                </ui:repeat>
-                                <th>Total Diduct</th>
-                                <th>Net Salary </th>
-                                <th>EPF Company</th>
-                                <th>ETF Company</th>
-                            </tr>
-                        </thead>
-                        <tbody>
-                            <ui:repeat value="#{salaryCycleController.staffSalarys}" var="scc">
-                                <tr >
-                                    <td style="white-space: nowrap;" ><h:outputLabel value="#{scc.staff.codeInterger}" /></td>
-                                    <td style="white-space: nowrap;;" ><h:outputLabel value="#{scc.staff.epfNo}" /></td>
-                                    <td style="white-space: nowrap;;" ><h:outputLabel value="#{scc.staff.dateJoined}" >
-                                            <f:convertDateTime pattern="dd MM yy" />
-                                        </h:outputLabel>
-                                    </td>
-                                    <td style="white-space: nowrap;" ><h:outputLabel value="#{scc.staff.person.name}" /></td>
-                                    <td style="white-space: nowrap;;" ><h:outputLabel value="#{scc.staff.roster.name}" /></td>
-                                    <td style="text-align: right;;" ><h:outputText value="#{scc.basicValue}" >
-                                            <f:convertNumber pattern="#,##0.00" />
-                                        </h:outputText>
-                                    </td>
-                                    <td style="text-align: right;;"><h:outputText value="#{scc.merchantileAllowanceValue}" >
-                                            <f:convertNumber pattern="#,##0.00" />
-                                        </h:outputText>
-                                    </td>
-                                    <td style="text-align: right;;"><h:outputText value="#{scc.poyaAllowanceValue}" >
-                                            <f:convertNumber pattern="#,##0.00" />
-                                        </h:outputText>
-                                    </td>
-                                    <td style="text-align: right;;"><h:outputText value="#{scc.dayOffAllowance+scc.sleepingDayAllowance}" >
-                                            <f:convertNumber pattern="#,##0.00" />
-                                        </h:outputText>
-                                    </td>
-                                    <td style="text-align: right;;"><h:outputText value="#{scc.adjustmentToBasic}" >
-                                            <f:convertNumber pattern="#,##0.00" />
-                                        </h:outputText>
-                                    </td>
-                                    <td style="text-align: right;;"><h:outputText value="#{scc.transGrossSalary}" >
-                                            <f:convertNumber pattern="#,##0.00" />
-                                        </h:outputText>
-                                    </td>
-                                    <td style="text-align: right;;"><h:outputText value="#{scc.noPayValueBasic}" >
-                                            <f:convertNumber pattern="#,##0.00" />
-                                        </h:outputText>
-                                    </td>
-                                    <td style="text-align: right;;"><h:outputText value="#{scc.transEpfEtfDiductableSalary}" >
-                                            <f:convertNumber pattern="#,##0.00" />
-                                        </h:outputText>
-                                    </td>
+                        .report-header-wrap .report-inst-name {
+                            font-size: 15px;
+                            font-weight: 600;
+                            display: block;
+                            margin-bottom: 2px;
+                        }
 
-                                    <ui:repeat value="#{scc.transStaffSalaryComponantsAddition}"  var="col1">
-                                        <td style="text-align: right;;"><h:outputText value="#{col1.componantValue}" >
-                                                <f:convertNumber pattern="#,##0.00" />
-                                            </h:outputText>
-                                        </td>
+                        .report-header-wrap .report-title-label {
+                            font-size: 13px;
+                            color: #666;
+                            display: block;
+                            margin-bottom: 2px;
+                        }
+
+                        .report-header-wrap .report-cycle-label {
+                            font-size: 13px;
+                            font-weight: 500;
+                            display: block;
+                        }
+
+                        .report-meta {
+                            font-size: 13px;
+                            color: #555;
+                            margin-top: 4px;
+                        }
+
+                        .payroll-table-wrap {
+                            overflow-x: auto;
+                            margin-top: 1rem;
+                        }
+
+                        .payroll-table {
+                            border-collapse: collapse;
+                            font-size: 13px;
+                            min-width: 100%;
+                        }
+
+                        .payroll-table thead tr {
+                            background: #f9f9f9;
+                        }
+
+                        .payroll-table th {
+                            padding: 10px 12px;
+                            text-align: right;
+                            font-size: 12px;
+                            font-weight: 600;
+                            text-transform: uppercase;
+                            letter-spacing: 0.03em;
+                            color: #888;
+                            border-bottom: 2px solid #e0e0e0;
+                            border-right: 1px solid #e8e8e8;
+                            white-space: nowrap;
+                        }
+
+                        .payroll-table th:first-child,
+                        .payroll-table th:nth-child(2),
+                        .payroll-table th:nth-child(3),
+                        .payroll-table th:nth-child(4),
+                        .payroll-table th:nth-child(5) {
+                            text-align: left;
+                        }
+
+                        .payroll-table td {
+                            padding: 9px 12px;
+                            text-align: right;
+                            border-bottom: 1px solid #f0f0f0;
+                            border-right: 1px solid #f0f0f0;
+                            white-space: nowrap;
+                            color: #333;
+                        }
+
+                        .payroll-table td:first-child,
+                        .payroll-table td:nth-child(2),
+                        .payroll-table td:nth-child(3),
+                        .payroll-table td:nth-child(4),
+                        .payroll-table td:nth-child(5) {
+                            text-align: left;
+                        }
+
+                        .payroll-table td:nth-child(4) {
+                            font-weight: 500;
+                        }
+
+                        .payroll-table tbody tr:hover td {
+                            background: #f5f7ff;
+                        }
+
+                        .payroll-table .totals-row td {
+                            background: #f9f9f9;
+                            font-weight: 600;
+                            border-top: 2px solid #e0e0e0;
+                        }
+
+                        .report-table-footer {
+                            display: flex;
+                            justify-content: flex-end;
+                            align-items: center;
+                            gap: 6px;
+                            padding: 0.85rem 0 0;
+                            border-top: 1px solid #e8e8e8;
+                            font-size: 12px;
+                            color: #999;
+                            margin-top: 0.5rem;
+                        }
+                    </h:outputStylesheet>
+
+                    <div class="page-header noPrintButton">
+                        <p class="page-title">Staff payroll</p>
+                        <p class="page-subtitle">Filter by cycle, department, employee or category and process to generate</p>
+                    </div>
+
+                    <p:panel styleClass="controls-panel noPrintButton">
+                        <div class="controls-grid">
+
+                            <div class="fields-grid">
+                                <div class="field-group">
+                                    <p:outputLabel for="advanced" value="Salary cycle" styleClass="field-label" />
+                                    <p:selectOneMenu id="advanced"
+                                                    value="#{salaryCycleController.current}"
+                                                    var="t"
+                                                    filter="true"
+                                                    filterMatchMode="startsWith"
+                                                    appendTo="@body"
+                                                    autoWidth="false"
+                                                    style="width: 100%;">
+                                        <f:selectItems value="#{salaryCycleController.salaryCycles}"
+                                                       var="theme"
+                                                       itemLabel="#{theme.name}"
+                                                       itemValue="#{theme}" />
+                                        <p:column style="width:10%">
+                                            <h:outputText value="#{t.name}" />
+                                        </p:column>
+                                        <p:column>
+                                            <h:outputText value="#{t.salaryYear}" />
+                                        </p:column>
+                                        <p:column>
+                                            <h:outputText value="#{t.salaryMonth}" />
+                                        </p:column>
+                                    </p:selectOneMenu>
+                                </div>
+
+                                <div class="field-group">
+                                    <p:outputLabel value="Institution" styleClass="field-label" />
+                                    <hr:institution value="#{salaryCycleController.reportKeyWord.institution}" />
+                                </div>
+
+                                <div class="field-group">
+                                    <p:outputLabel value="Department" styleClass="field-label" />
+                                    <hr:department value="#{salaryCycleController.reportKeyWord.department}" />
+                                </div>
+
+                                <div class="field-group">
+                                    <p:outputLabel value="Employee" styleClass="field-label" />
+                                    <hr:completeStaff value="#{salaryCycleController.reportKeyWord.staff}" />
+                                </div>
+
+                                <div class="field-group">
+                                    <p:outputLabel value="Staff category" styleClass="field-label" />
+                                    <hr:completeStaffCategory value="#{salaryCycleController.reportKeyWord.staffCategory}" />
+                                </div>
+
+                                <div class="field-group">
+                                    <p:outputLabel value="Staff designation" styleClass="field-label" />
+                                    <hr:completeDesignation value="#{salaryCycleController.reportKeyWord.designation}" />
+                                </div>
+
+                                <div class="field-group">
+                                    <p:outputLabel value="Staff roster" styleClass="field-label" />
+                                    <hr:completeRoster value="#{salaryCycleController.reportKeyWord.roster}" />
+                                </div>
+                            </div>
+
+                            <div class="controls-actions">
+                                <p:commandButton value="Process"
+                                                 ajax="false"
+                                                 action="#{salaryCycleController.fillStaffPayRoll()}"
+                                                 icon="pi pi-sync"
+                                                 styleClass="btn-action" />
+                                <p:commandButton value="Process hold list"
+                                                 ajax="false"
+                                                 action="#{salaryCycleController.fillStaffPayRollBlocked()}"
+                                                 icon="pi pi-sync"
+                                                 styleClass="btn-action" />
+                                <p:commandButton value="Print"
+                                                 ajax="false"
+                                                 action="#"
+                                                 icon="pi pi-print"
+                                                 styleClass="btn-action">
+                                    <p:printer target="print" />
+                                </p:commandButton>
+                                <h:outputScript library="js" name="excellentexport.js" />
+                                <a download="staff_payroll.xls"
+                                   href="#"
+                                   onclick="return ExcellentExport.excel(this, 'tbl', 'Sheet1');"
+                                   class="excel-btn">
+                                    Export Excel
+                                </a>
+                            </div>
+
+                        </div>
+                    </p:panel>
+
+                    <div class="report-panel">
+
+                        <div class="report-header-wrap">
+                            <span class="report-title-label">Staff payroll</span>
+                            <span class="report-cycle-label">
+                                <h:outputText value="#{salaryCycleController.current.name}" />
+                            </span>
+                            <h:panelGroup rendered="#{salaryCycleController.reportKeyWord.institution ne null}">
+                                <p class="report-meta">
+                                    <h:outputText value="#{salaryCycleController.reportKeyWord.institution.name}" />
+                                </p>
+                            </h:panelGroup>
+                            <h:panelGroup rendered="#{salaryCycleController.reportKeyWord.department ne null}">
+                                <p class="report-meta">
+                                    Department: <h:outputText value="#{salaryCycleController.reportKeyWord.department.name}" />
+                                </p>
+                            </h:panelGroup>
+                            <h:panelGroup rendered="#{salaryCycleController.reportKeyWord.roster ne null}">
+                                <p class="report-meta">
+                                    Roster: <h:outputText value="#{salaryCycleController.reportKeyWord.roster.name}" />
+                                </p>
+                            </h:panelGroup>
+                        </div>
+
+                        <div class="payroll-table-wrap">
+                            <table id="tbl" class="payroll-table">
+                                <thead>
+                                    <tr>
+                                        <th>Code</th>
+                                        <th>EPF</th>
+                                        <th>Joined</th>
+                                        <th>Staff</th>
+                                        <th>Roster</th>
+                                        <th>Basic + BR</th>
+                                        <th>Merchan.</th>
+                                        <th>Poya</th>
+                                        <th>Day off</th>
+                                        <th>Basic adj.</th>
+                                        <th>Total salary</th>
+                                        <th>No pay basic</th>
+                                        <th>EPF/ETF deductible</th>
+                                        <ui:repeat value="#{salaryCycleController.headersAdd}" var="h">
+                                            <th>#{h}</th>
+                                        </ui:repeat>
+                                        <th>Allow. adj.</th>
+                                        <th>No pay allow.</th>
+                                        <th>Total allow.</th>
+                                        <th>Gross salary</th>
+                                        <th>EPF staff</th>
+                                        <ui:repeat value="#{salaryCycleController.headersSub}" var="hh">
+                                            <th>#{hh}</th>
+                                        </ui:repeat>
+                                        <th>Total deduct.</th>
+                                        <th>Net salary</th>
+                                        <th>EPF company</th>
+                                        <th>ETF company</th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    <ui:repeat value="#{salaryCycleController.staffSalarys}" var="scc">
+                                        <tr>
+                                            <td><h:outputText value="#{scc.staff.codeInterger}" /></td>
+                                            <td><h:outputText value="#{scc.staff.epfNo}" /></td>
+                                            <td>
+                                                <h:outputText value="#{scc.staff.dateJoined}">
+                                                    <f:convertDateTime pattern="dd MM yy" />
+                                                </h:outputText>
+                                            </td>
+                                            <td><h:outputText value="#{scc.staff.person.name}" /></td>
+                                            <td><h:outputText value="#{scc.staff.roster.name}" /></td>
+                                            <td><h:outputText value="#{scc.basicValue}"><f:convertNumber pattern="#,##0.00" /></h:outputText></td>
+                                            <td><h:outputText value="#{scc.merchantileAllowanceValue}"><f:convertNumber pattern="#,##0.00" /></h:outputText></td>
+                                            <td><h:outputText value="#{scc.poyaAllowanceValue}"><f:convertNumber pattern="#,##0.00" /></h:outputText></td>
+                                            <td><h:outputText value="#{scc.dayOffAllowance+scc.sleepingDayAllowance}"><f:convertNumber pattern="#,##0.00" /></h:outputText></td>
+                                            <td><h:outputText value="#{scc.adjustmentToBasic}"><f:convertNumber pattern="#,##0.00" /></h:outputText></td>
+                                            <td><h:outputText value="#{scc.transGrossSalary}"><f:convertNumber pattern="#,##0.00" /></h:outputText></td>
+                                            <td><h:outputText value="#{scc.noPayValueBasic}"><f:convertNumber pattern="#,##0.00" /></h:outputText></td>
+                                            <td><h:outputText value="#{scc.transEpfEtfDiductableSalary}"><f:convertNumber pattern="#,##0.00" /></h:outputText></td>
+                                            <ui:repeat value="#{scc.transStaffSalaryComponantsAddition}" var="col1">
+                                                <td><h:outputText value="#{col1.componantValue}"><f:convertNumber pattern="#,##0.00" /></h:outputText></td>
+                                            </ui:repeat>
+                                            <td><h:outputText value="#{scc.adjustmentToAllowance}"><f:convertNumber pattern="#,##0.00" /></h:outputText></td>
+                                            <td><h:outputText value="#{scc.noPayValueAllowance}"><f:convertNumber pattern="#,##0.00" /></h:outputText></td>
+                                            <td><h:outputText value="#{scc.transTotalAllowance}"><f:convertNumber pattern="#,##0.00" /></h:outputText></td>
+                                            <td><h:outputText value="#{scc.transTotalAllowance+scc.transEpfEtfDiductableSalary}"><f:convertNumber pattern="#,##0.00" /></h:outputText></td>
+                                            <td><h:outputText value="#{scc.epfStaffValue}"><f:convertNumber pattern="#,##0.00" /></h:outputText></td>
+                                            <ui:repeat value="#{scc.transStaffSalaryComponantsSubtraction}" var="col2">
+                                                <td><h:outputText value="#{col2.componantValue}"><f:convertNumber pattern="#,##0.00" /></h:outputText></td>
+                                            </ui:repeat>
+                                            <td><h:outputText value="#{scc.transTotalDeduction-(scc.noPayValueBasic+scc.noPayValueAllowance)}"><f:convertNumber pattern="#,##0.00" /></h:outputText></td>
+                                            <td><h:outputText value="#{scc.transNetSalry}"><f:convertNumber pattern="#,##0.00" /></h:outputText></td>
+                                            <td><h:outputText value="#{scc.epfCompanyValue}"><f:convertNumber pattern="#,##0.00" /></h:outputText></td>
+                                            <td><h:outputText value="#{scc.etfCompanyValue}"><f:convertNumber pattern="#,##0.00" /></h:outputText></td>
+                                        </tr>
                                     </ui:repeat>
 
-                                    <td style="text-align: right;;"><h:outputText value="#{scc.adjustmentToAllowance}" >
-                                            <f:convertNumber pattern="#,##0.00" />
-                                        </h:outputText>
-                                    </td>
-                                    <td style="text-align: right;;"><h:outputText value="#{scc.noPayValueAllowance}" >
-                                            <f:convertNumber pattern="#,##0.00" />
-                                        </h:outputText>
-                                    </td>
-                                    <td style="text-align: right;;"><h:outputText value="#{scc.transTotalAllowance}" >
-                                            <f:convertNumber pattern="#,##0.00" />
-                                        </h:outputText>
-                                    </td>
-                                    <td style="text-align: right;;"><h:outputText value="#{scc.transTotalAllowance+scc.transEpfEtfDiductableSalary}" >
-                                            <f:convertNumber pattern="#,##0.00" />
-                                        </h:outputText>
-                                    </td>
-                                    <td style="text-align: right;;"><h:outputLabel value="#{scc.epfStaffValue}" >
-                                            <f:convertNumber pattern="#,##0.00" />
-                                        </h:outputLabel>
-                                    </td>
-                                    <ui:repeat value="#{scc.transStaffSalaryComponantsSubtraction}"  var="col2">
-                                        <td style="text-align: right; ;"><h:outputText value="#{col2.componantValue}" >
-                                                <f:convertNumber pattern="#,##0.00" />
-                                            </h:outputText>
-                                        </td>
-                                    </ui:repeat>
-                                    <td style="text-align: right; ;"><h:outputLabel value="#{scc.transTotalDeduction-(scc.noPayValueBasic+scc.noPayValueAllowance)}" >
-                                            <f:convertNumber pattern="#,##0.00" />
-                                        </h:outputLabel>
-                                    </td>
-                                    <td style="text-align: right; ;">
-                                        <h:outputLabel value="#{scc.transNetSalry}" >
-                                            <f:convertNumber pattern="#,##0.00" />
-                                        </h:outputLabel>
+                                    <tr class="totals-row">
+                                        <td colspan="5">Total</td>
+                                        <td><h:outputText value="#{salaryCycleController.basicVal}"><f:convertNumber pattern="#,##0.00" /></h:outputText></td>
+                                        <td><h:outputText value="#{salaryCycleController.mercAll}"><f:convertNumber pattern="#,##0.00" /></h:outputText></td>
+                                        <td><h:outputText value="#{salaryCycleController.poyaAll}"><f:convertNumber pattern="#,##0.00" /></h:outputText></td>
+                                        <td><h:outputText value="#{salaryCycleController.dayOffAll}"><f:convertNumber pattern="#,##0.00" /></h:outputText></td>
+                                        <td><h:outputText value="#{salaryCycleController.adjstBasic}"><f:convertNumber pattern="#,##0.00" /></h:outputText></td>
+                                        <td><h:outputText value="#{salaryCycleController.tranGrossSal}"><f:convertNumber pattern="#,##0.00" /></h:outputText></td>
+                                        <td><h:outputText value="#{salaryCycleController.noPayBasic}"><f:convertNumber pattern="#,##0.00" /></h:outputText></td>
+                                        <td><h:outputText value="#{salaryCycleController.epfDeduct}"><f:convertNumber pattern="#,##0.00" /></h:outputText></td>
+                                        <ui:repeat value="#{salaryCycleController.footerAdd}" var="f">
+                                            <td><h:outputText value="#{f}"><f:convertNumber pattern="#,##0.00" /></h:outputText></td>
+                                        </ui:repeat>
+                                        <td><h:outputText value="#{salaryCycleController.adjustAll}"><f:convertNumber pattern="#,##0.00" /></h:outputText></td>
+                                        <td><h:outputText value="#{salaryCycleController.noPayValAll}"><f:convertNumber pattern="#,##0.00" /></h:outputText></td>
+                                        <td><h:outputText value="#{salaryCycleController.transTotAll}"><f:convertNumber pattern="#,##0.00" /></h:outputText></td>
+                                        <td><h:outputText value="#{salaryCycleController.epfDeduct+salaryCycleController.transTotAll}"><f:convertNumber pattern="#,##0.00" /></h:outputText></td>
+                                        <td><h:outputText value="#{salaryCycleController.epfStaffVal}"><f:convertNumber pattern="#,##0.00" /></h:outputText></td>
+                                        <ui:repeat value="#{salaryCycleController.footerSub}" var="ff">
+                                            <td><h:outputText value="#{ff}"><f:convertNumber pattern="#,##0.00" /></h:outputText></td>
+                                        </ui:repeat>
+                                        <td><h:outputText value="#{salaryCycleController.transTotDeduct-(salaryCycleController.noPayBasic+salaryCycleController.noPayValAll)}"><f:convertNumber pattern="#,##0.00" /></h:outputText></td>
+                                        <td><h:outputText value="#{(salaryCycleController.transTotDeduct-(salaryCycleController.noPayBasic+salaryCycleController.noPayValAll))+(salaryCycleController.epfDeduct+salaryCycleController.transTotAll)}"><f:convertNumber pattern="#,##0.00" /></h:outputText></td>
+                                        <td><h:outputText value="#{salaryCycleController.epfComVal}"><f:convertNumber pattern="#,##0.00" /></h:outputText></td>
+                                        <td><h:outputText value="#{salaryCycleController.etfComVal}"><f:convertNumber pattern="#,##0.00" /></h:outputText></td>
+                                    </tr>
+                                </tbody>
+                            </table>
+                        </div>
 
+                        <div class="report-table-footer">
+                            <h:outputText value="Print by: #{sessionController.loggedUser.webUserPerson.name}" />
+                            <span>·</span>
+                            <p:outputLabel value="#{commonFunctionsProxy.currentDateTime}">
+                                <f:convertDateTime pattern="yyyy MMMM dd hh:mm:ss a" />
+                            </p:outputLabel>
+                            <span>·</span>
+                            <h:outputText value="This is a system generated report." />
+                        </div>
 
-                                    </td>
-                                    <td style="text-align: right;;"><h:outputLabel value="#{scc.epfCompanyValue}" >
-                                            <f:convertNumber pattern="#,##0.00" />
-                                        </h:outputLabel>
-                                    </td>
-                                    <td style="text-align: right;;"><h:outputLabel value="#{scc.etfCompanyValue}" >
-                                            <f:convertNumber pattern="#,##0.00" />
-                                        </h:outputLabel>
-                                    </td>
-                                </tr>
-                            </ui:repeat>
-                            <tr>
-                                <td colspan="5"><h:outputLabel value="Totals"/></td>
-                                <td style="text-align: right;;">
-                                    <h:outputText value="#{salaryCycleController.basicVal}" >
-                                        <f:convertNumber pattern="#,##0.00" />
-                                    </h:outputText>
-                                </td>
-                                <td style="text-align: right;;">
-                                    <h:outputText value="#{salaryCycleController.mercAll}" >
-                                        <f:convertNumber pattern="#,##0.00" />
-                                    </h:outputText>
-                                </td>
-                                <td style="text-align: right;;">
-                                    <h:outputText value="#{salaryCycleController.poyaAll}" >
-                                        <f:convertNumber pattern="#,##0.00" />
-                                    </h:outputText>
-                                </td>
-                                <td style="text-align: right;;">
-                                    <h:outputText value="#{salaryCycleController.dayOffAll}" >
-                                        <f:convertNumber pattern="#,##0.00" />
-                                    </h:outputText>
-                                </td>
-                                <td style="text-align: right;;">
-                                    <h:outputText value="#{salaryCycleController.adjstBasic}" >
-                                        <f:convertNumber pattern="#,##0.00" />
-                                    </h:outputText>
-                                </td>
-                                <td style="text-align: right;;">
-                                    <h:outputText value="#{salaryCycleController.tranGrossSal}" >
-                                        <f:convertNumber pattern="#,##0.00" />
-                                    </h:outputText>
-                                </td>
-                                <td style="text-align: right;;">
-                                    <h:outputText value="#{salaryCycleController.noPayBasic}" >
-                                        <f:convertNumber pattern="#,##0.00" />
-                                    </h:outputText>
-                                </td>
-                                <td style="text-align: right;;">
-                                    <h:outputText value="#{salaryCycleController.epfDeduct}" >
-                                        <f:convertNumber pattern="#,##0.00" />
-                                    </h:outputText>
-                                </td>
-                                <ui:repeat value="#{salaryCycleController.footerAdd}" var="f">
-                                    <td style="text-align: right;;">
-                                        <h:outputLabel value="#{f}" >
-                                            <f:convertNumber pattern="#,##0.00" />
-                                        </h:outputLabel>
-                                    </td>
-                                </ui:repeat>
-                                <td style="text-align: right;;">
-                                    <h:outputLabel value="#{salaryCycleController.adjustAll}" >
-                                        <f:convertNumber pattern="#,##0.00" />
-                                    </h:outputLabel>
-                                </td>
-                                <td style="text-align: right;;">
-                                    <h:outputLabel value="#{salaryCycleController.noPayValAll}" >
-                                        <f:convertNumber pattern="#,##0.00" />
-                                    </h:outputLabel>
-                                </td>
-                                <td style="text-align: right;;">
-                                    <h:outputLabel value="#{salaryCycleController.transTotAll}" >
-                                        <f:convertNumber pattern="#,##0.00" />
-                                    </h:outputLabel>
-                                </td>
-                                <td style="text-align: right;;">
-
-                                    <h:outputLabel value="#{salaryCycleController.epfDeduct+salaryCycleController.transTotAll}" >
-                                        <f:convertNumber pattern="#,##0.00" />
-                                    </h:outputLabel>
-                                </td>
-                                <td style="text-align: right;;">
-                                    <h:outputLabel value="#{salaryCycleController.epfStaffVal}" >
-                                        <f:convertNumber pattern="#,##0.00" />
-                                    </h:outputLabel>
-                                </td>
-                                <ui:repeat value="#{salaryCycleController.footerSub}" var="ff">
-                                    <td style="text-align: right;;">
-                                        <h:outputLabel value="#{ff}" >
-                                            <f:convertNumber pattern="#,##0.00" />
-                                        </h:outputLabel>
-                                    </td>
-                                </ui:repeat>
-                                <td style="text-align: right;;">
-                                    <h:outputLabel value="#{salaryCycleController.transTotDeduct-(salaryCycleController.noPayBasic+salaryCycleController.noPayValAll)}" >
-                                        <f:convertNumber pattern="#,##0.00" />
-                                    </h:outputLabel>
-                                </td>
-                                <td style="text-align: right;;">
-
-                                    <h:outputLabel value="#{(salaryCycleController.transTotDeduct-(salaryCycleController.noPayBasic+salaryCycleController.noPayValAll))+(salaryCycleController.epfDeduct+salaryCycleController.transTotAll)}" >
-                                        <f:convertNumber pattern="#,##0.00" />
-                                    </h:outputLabel>
-                                </td>
-                                <td style="text-align: right;;">
-                                    <h:outputLabel value="#{salaryCycleController.epfComVal}" >
-                                        <f:convertNumber pattern="#,##0.00" />
-                                    </h:outputLabel>
-                                </td>
-                                <td style="text-align: right;;">
-                                    <h:outputLabel value="#{salaryCycleController.etfComVal}" >
-                                        <f:convertNumber pattern="#,##0.00" />
-                                    </h:outputLabel>
-                                </td>
-                            </tr>
-                            <tr>
-                                <td colspan="5">
-                                    <h:outputLabel value="Print By : #{sessionController.loggedUser.webUserPerson.name} - Print At : "/>
-                                    <p:outputLabel value="#{commonFunctionsProxy.currentDateTime}" >
-                                        <f:convertDateTime pattern="yyyy MMMM dd hh:mm:ss a " />
-                                    </p:outputLabel>
-                                    <h:outputLabel value=" - This System Generated Report Does Not Carry A Signature."/>
-                                </td>
-                            </tr>
-                        </tbody>
-                    </table>
-
-
+                    </div>
 
                 </h:form>
-            </ui:define>
 
+            </ui:define>
         </ui:composition>
     </h:body>
 </html>

--- a/src/main/webapp/hr/hr_report_staff_payroll.xhtml
+++ b/src/main/webapp/hr/hr_report_staff_payroll.xhtml
@@ -5,446 +5,352 @@
       xmlns:h="http://xmlns.jcp.org/jsf/html"
       xmlns:p="http://primefaces.org/ui"
       xmlns:f="http://xmlns.jcp.org/jsf/core"
-      xmlns:hr="http://xmlns.jcp.org/jsf/composite/autocomplete">
-    <head></head>
+      xmlns:hr="http://xmlns.jcp.org/jsf/composite/autocomplete" >
+    <head>
+
+    </head>
     <h:body>
-        <ui:composition template="/hr/hr_reports.xhtml">
+        <ui:composition template="/hr/hr_reports.xhtml" >
             <ui:define name="content">
+                <style>
 
-                <h:form id="print" styleClass="salary-summary-form">
+                    table, th, td {
+                        border: 1px solid black;
+                        border-collapse: collapse;
+                        padding: 2px;
+                        /*white-space: nowrap;*/
+                    }
+                </style>
 
-                    <h:outputStylesheet>
-                        .salary-summary-form {
-                            padding: 2rem 1.75rem;
-                        }
 
-                        .page-header {
-                            margin-bottom: 1.75rem;
-                        }
 
-                        .page-title {
-                            font-size: 18px;
-                            font-weight: 600;
-                            margin: 0 0 4px 0;
-                        }
 
-                        .page-subtitle {
-                            font-size: 13px;
-                            color: #888;
-                            margin: 0;
-                        }
 
-                        .controls-panel .ui-panel-content {
-                            padding: 1.5rem 1.75rem !important;
-                        }
 
-                        .controls-grid {
-                            display: flex;
-                            flex-direction: column;
-                            gap: 1.25rem;
-                        }
 
-                        .fields-grid {
-                            display: grid;
-                            grid-template-columns: repeat(2, 1fr);
-                            gap: 1rem 1.5rem;
-                        }
 
-                        .field-group {
-                            display: flex;
-                            flex-direction: column;
-                            gap: 6px;
-                        }
+                <h:form id="print">
+                    <h:panelGrid columns="2" styleClass="noPrintButton">
+                        <h:outputLabel value="Salary Cycle"/>
+                        <p:selectOneMenu id="advanced"
+                                         value="#{salaryCycleController.current}"
+                                         var="t"
+                                         filter="true"
+                                         filterMatchMode="startsWith">
 
-                        .field-label {
-                            font-size: 11.5px !important;
-                            font-weight: 600 !important;
-                            text-transform: uppercase;
-                            letter-spacing: 0.05em;
-                            color: #888 !important;
-                        }
+                            <f:selectItems value="#{salaryCycleController.salaryCycles}"
+                                           var="theme"
+                                           itemLabel="#{theme.name}"
+                                           itemValue="#{theme}" ></f:selectItems>
 
-                        .controls-actions {
-                            display: flex;
-                            gap: 10px;
-                            align-items: center;
-                            flex-wrap: wrap;
-                        }
+                            <p:column style="width:10%" headerText="Name">
+                                <h:outputText value="#{t.name}" />
+                            </p:column>
 
-                        .btn-action {
-                            height: 36px !important;
-                            padding: 0 18px !important;
-                            font-size: 13px !important;
-                        }
+                            <p:column headerText="Year">
+                                <h:outputText value="#{t.salaryYear}" />
+                            </p:column>
+                            <p:column headerText="Month">
+                                <h:outputText value="#{t.salaryMonth}" />
+                            </p:column>
+                        </p:selectOneMenu>
+                        <h:outputLabel value="Institution"/>
+                        <hr:institution value="#{salaryCycleController.reportKeyWord.institution}"/>
+                        <h:outputLabel value="Department : "/>
+                        <hr:department value="#{salaryCycleController.reportKeyWord.department}"/>
+                        <h:outputLabel value="Employee : "/>
+                        <hr:completeStaff value="#{salaryCycleController.reportKeyWord.staff}"/>
+                        <h:outputLabel value="Staff Category : "/>
+                        <hr:completeStaffCategory value="#{salaryCycleController.reportKeyWord.staffCategory}"/>
+                        <h:outputLabel value="Staff Designation : "/>
+                        <hr:completeDesignation value="#{salaryCycleController.reportKeyWord.designation}"/>
+                        <h:outputLabel value="Staff Roster : "/>
+                        <hr:completeRoster value="#{salaryCycleController.reportKeyWord.roster}"/>
+                    </h:panelGrid>
 
-                        .excel-btn {
-                            display: inline-flex;
-                            align-items: center;
-                            height: 36px;
-                            padding: 0 18px;
-                            font-size: 13px;
-                            text-decoration: none;
-                            border: 1px solid #c0c0c0;
-                            border-radius: 3px;
-                            background: #f4f4f4;
-                            color: #333;
-                        }
+                    <p:commandButton value="Print" ajax="false" action="#" styleClass="noPrintButton" >
+                        <p:printer target="print" ></p:printer>
+                    </p:commandButton>
+                    <p:commandButton value="Process" ajax="false" action="#{salaryCycleController.fillStaffPayRoll()}" styleClass="noPrintButton" ></p:commandButton>
+                    <p:commandButton value="Process Hold List" ajax="false" action="#{salaryCycleController.fillStaffPayRollBlocked()}" styleClass="noPrintButton" ></p:commandButton>
 
-                        .excel-btn:hover {
-                            background: #e8e8e8;
-                        }
+                    <h:outputScript library="js" name="excellentexport.js" ></h:outputScript>
 
-                        .report-panel {
-                            margin-top: 1.5rem;
-                        }
+                    <a download="staff_payroll.xls" href="#" onclick="return ExcellentExport.excel(this, 'tbl', 'Sheet1');"
+                       style="padding: .3em 1em;  background: #D7D0C0; "
+                       styleClass="ui-button ui-widget ui-state-default ui-corner-all ui-button-text-only ui-button-text ui-c noPrintButton" >Export to Excel</a>
+                    <br></br>
+                    <br></br>
+                    <h:outputLabel value="Staff Payroll" />
+                    <br/>
+                    <h:outputLabel value="#{salaryCycleController.current.name}" />
+                    <br/>
+                    <h:panelGroup rendered="#{salaryCycleController.reportKeyWord.institution ne null}" >
+                        <h:outputLabel value="#{salaryCycleController.reportKeyWord.institution.name}" />
+                        <br/>
+                    </h:panelGroup>
+                    <h:panelGroup rendered="#{salaryCycleController.reportKeyWord.department ne null}" >
+                        <h:outputLabel value="Department : #{salaryCycleController.reportKeyWord.department.name}"/>
+                        <br/>
+                    </h:panelGroup>
+                    <h:panelGroup rendered="#{salaryCycleController.reportKeyWord.roster ne null}" >
+                        <h:outputLabel value="Roster : #{salaryCycleController.reportKeyWord.roster.name}"/>
+                        <br/>
+                    </h:panelGroup>
 
-                        .report-header-wrap {
-                            margin-bottom: 1rem;
-                        }
 
-                        .report-header-wrap .report-inst-name {
-                            font-size: 15px;
-                            font-weight: 600;
-                            display: block;
-                            margin-bottom: 2px;
-                        }
+                    <table id="tbl" border="1"  style="border: 1px solid black;" >
+                        <thead>
+                            <tr>
+                                <th>Code</th>
+                                <th>EPF</th>
+                                <th>Join</th>
+                                <th>Satff </th>
+                                <th>Des</th>
+                                <th>Basic+BR</th>
+                                <th>Merchan</th>
+                                <th>Poya</th>
+                                <th>Day Off</th>
+                                <th>Basic Adjust</th>
+                                <th>Total Salary</th>
+                                <th>No Pay Basic</th>
+                                <th>EPF/ETF Diductable Salary</th>
+                                <ui:repeat value="#{salaryCycleController.headersAdd}" var="h">
+                                    <th>#{h}</th>
+                                </ui:repeat>
+                                <th>Allowance Adjust</th>
+                                <th>No Pay Allowance</th>
+                                <th>Total Allowance</th>
+                                <th>Gross Salary</th>
+                                <th>EPF Staff</th>
+                                <ui:repeat value="#{salaryCycleController.headersSub}" var="hh">
+                                    <th>#{hh}</th>
+                                </ui:repeat>
+                                <th>Total Diduct</th>
+                                <th>Net Salary </th>
+                                <th>EPF Company</th>
+                                <th>ETF Company</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            <ui:repeat value="#{salaryCycleController.staffSalarys}" var="scc">
+                                <tr >
+                                    <td style="white-space: nowrap;" ><h:outputLabel value="#{scc.staff.codeInterger}" /></td>
+                                    <td style="white-space: nowrap;;" ><h:outputLabel value="#{scc.staff.epfNo}" /></td>
+                                    <td style="white-space: nowrap;;" ><h:outputLabel value="#{scc.staff.dateJoined}" >
+                                            <f:convertDateTime pattern="dd MM yy" />
+                                        </h:outputLabel>
+                                    </td>
+                                    <td style="white-space: nowrap;" ><h:outputLabel value="#{scc.staff.person.name}" /></td>
+                                    <td style="white-space: nowrap;;" ><h:outputLabel value="#{scc.staff.roster.name}" /></td>
+                                    <td style="text-align: right;;" ><h:outputText value="#{scc.basicValue}" >
+                                            <f:convertNumber pattern="#,##0.00" />
+                                        </h:outputText>
+                                    </td>
+                                    <td style="text-align: right;;"><h:outputText value="#{scc.merchantileAllowanceValue}" >
+                                            <f:convertNumber pattern="#,##0.00" />
+                                        </h:outputText>
+                                    </td>
+                                    <td style="text-align: right;;"><h:outputText value="#{scc.poyaAllowanceValue}" >
+                                            <f:convertNumber pattern="#,##0.00" />
+                                        </h:outputText>
+                                    </td>
+                                    <td style="text-align: right;;"><h:outputText value="#{scc.dayOffAllowance+scc.sleepingDayAllowance}" >
+                                            <f:convertNumber pattern="#,##0.00" />
+                                        </h:outputText>
+                                    </td>
+                                    <td style="text-align: right;;"><h:outputText value="#{scc.adjustmentToBasic}" >
+                                            <f:convertNumber pattern="#,##0.00" />
+                                        </h:outputText>
+                                    </td>
+                                    <td style="text-align: right;;"><h:outputText value="#{scc.transGrossSalary}" >
+                                            <f:convertNumber pattern="#,##0.00" />
+                                        </h:outputText>
+                                    </td>
+                                    <td style="text-align: right;;"><h:outputText value="#{scc.noPayValueBasic}" >
+                                            <f:convertNumber pattern="#,##0.00" />
+                                        </h:outputText>
+                                    </td>
+                                    <td style="text-align: right;;"><h:outputText value="#{scc.transEpfEtfDiductableSalary}" >
+                                            <f:convertNumber pattern="#,##0.00" />
+                                        </h:outputText>
+                                    </td>
 
-                        .report-header-wrap .report-title-label {
-                            font-size: 13px;
-                            color: #666;
-                            display: block;
-                            margin-bottom: 2px;
-                        }
-
-                        .report-header-wrap .report-cycle-label {
-                            font-size: 13px;
-                            font-weight: 500;
-                            display: block;
-                        }
-
-                        .report-meta {
-                            font-size: 13px;
-                            color: #555;
-                            margin-top: 4px;
-                        }
-
-                        .payroll-table-wrap {
-                            overflow-x: auto;
-                            margin-top: 1rem;
-                        }
-
-                        .payroll-table {
-                            border-collapse: collapse;
-                            font-size: 13px;
-                            min-width: 100%;
-                        }
-
-                        .payroll-table thead tr {
-                            background: #f9f9f9;
-                        }
-
-                        .payroll-table th {
-                            padding: 10px 12px;
-                            text-align: right;
-                            font-size: 12px;
-                            font-weight: 600;
-                            text-transform: uppercase;
-                            letter-spacing: 0.03em;
-                            color: #888;
-                            border-bottom: 2px solid #e0e0e0;
-                            border-right: 1px solid #e8e8e8;
-                            white-space: nowrap;
-                        }
-
-                        .payroll-table th:first-child,
-                        .payroll-table th:nth-child(2),
-                        .payroll-table th:nth-child(3),
-                        .payroll-table th:nth-child(4),
-                        .payroll-table th:nth-child(5) {
-                            text-align: left;
-                        }
-
-                        .payroll-table td {
-                            padding: 9px 12px;
-                            text-align: right;
-                            border-bottom: 1px solid #f0f0f0;
-                            border-right: 1px solid #f0f0f0;
-                            white-space: nowrap;
-                            color: #333;
-                        }
-
-                        .payroll-table td:first-child,
-                        .payroll-table td:nth-child(2),
-                        .payroll-table td:nth-child(3),
-                        .payroll-table td:nth-child(4),
-                        .payroll-table td:nth-child(5) {
-                            text-align: left;
-                        }
-
-                        .payroll-table td:nth-child(4) {
-                            font-weight: 500;
-                        }
-
-                        .payroll-table tbody tr:hover td {
-                            background: #f5f7ff;
-                        }
-
-                        .payroll-table .totals-row td {
-                            background: #f9f9f9;
-                            font-weight: 600;
-                            border-top: 2px solid #e0e0e0;
-                        }
-
-                        .report-table-footer {
-                            display: flex;
-                            justify-content: flex-end;
-                            align-items: center;
-                            gap: 6px;
-                            padding: 0.85rem 0 0;
-                            border-top: 1px solid #e8e8e8;
-                            font-size: 12px;
-                            color: #999;
-                            margin-top: 0.5rem;
-                        }
-                    </h:outputStylesheet>
-
-                    <div class="page-header noPrintButton">
-                        <p class="page-title">Staff payroll</p>
-                        <p class="page-subtitle">Filter by cycle, department, employee or category and process to generate</p>
-                    </div>
-
-                    <p:panel styleClass="controls-panel noPrintButton">
-                        <div class="controls-grid">
-
-                            <div class="fields-grid">
-                                <div class="field-group">
-                                    <p:outputLabel for="advanced" value="Salary cycle" styleClass="field-label" />
-                                    <p:selectOneMenu id="advanced"
-                                                    value="#{salaryCycleController.current}"
-                                                    var="t"
-                                                    filter="true"
-                                                    filterMatchMode="startsWith"
-                                                    appendTo="@body"
-                                                    autoWidth="false"
-                                                    style="width: 100%;">
-                                        <f:selectItems value="#{salaryCycleController.salaryCycles}"
-                                                       var="theme"
-                                                       itemLabel="#{theme.name}"
-                                                       itemValue="#{theme}" />
-                                        <p:column style="width:10%">
-                                            <h:outputText value="#{t.name}" />
-                                        </p:column>
-                                        <p:column>
-                                            <h:outputText value="#{t.salaryYear}" />
-                                        </p:column>
-                                        <p:column>
-                                            <h:outputText value="#{t.salaryMonth}" />
-                                        </p:column>
-                                    </p:selectOneMenu>
-                                </div>
-
-                                <div class="field-group">
-                                    <p:outputLabel value="Institution" styleClass="field-label" />
-                                    <hr:institution value="#{salaryCycleController.reportKeyWord.institution}" />
-                                </div>
-
-                                <div class="field-group">
-                                    <p:outputLabel value="Department" styleClass="field-label" />
-                                    <hr:department value="#{salaryCycleController.reportKeyWord.department}" />
-                                </div>
-
-                                <div class="field-group">
-                                    <p:outputLabel value="Employee" styleClass="field-label" />
-                                    <hr:completeStaff value="#{salaryCycleController.reportKeyWord.staff}" />
-                                </div>
-
-                                <div class="field-group">
-                                    <p:outputLabel value="Staff category" styleClass="field-label" />
-                                    <hr:completeStaffCategory value="#{salaryCycleController.reportKeyWord.staffCategory}" />
-                                </div>
-
-                                <div class="field-group">
-                                    <p:outputLabel value="Staff designation" styleClass="field-label" />
-                                    <hr:completeDesignation value="#{salaryCycleController.reportKeyWord.designation}" />
-                                </div>
-
-                                <div class="field-group">
-                                    <p:outputLabel value="Staff roster" styleClass="field-label" />
-                                    <hr:completeRoster value="#{salaryCycleController.reportKeyWord.roster}" />
-                                </div>
-                            </div>
-
-                            <div class="controls-actions">
-                                <p:commandButton value="Process"
-                                                 ajax="false"
-                                                 action="#{salaryCycleController.fillStaffPayRoll()}"
-                                                 icon="pi pi-sync"
-                                                 styleClass="btn-action" />
-                                <p:commandButton value="Process hold list"
-                                                 ajax="false"
-                                                 action="#{salaryCycleController.fillStaffPayRollBlocked()}"
-                                                 icon="pi pi-sync"
-                                                 styleClass="btn-action" />
-                                <p:commandButton value="Print"
-                                                 ajax="false"
-                                                 action="#"
-                                                 icon="pi pi-print"
-                                                 styleClass="btn-action">
-                                    <p:printer target="print" />
-                                </p:commandButton>
-                                <h:outputScript library="js" name="excellentexport.js" />
-                                <a download="staff_payroll.xls"
-                                   href="#"
-                                   onclick="return ExcellentExport.excel(this, 'tbl', 'Sheet1');"
-                                   class="excel-btn">
-                                    Export Excel
-                                </a>
-                            </div>
-
-                        </div>
-                    </p:panel>
-
-                    <div class="report-panel">
-
-                        <div class="report-header-wrap">
-                            <span class="report-title-label">Staff payroll</span>
-                            <span class="report-cycle-label">
-                                <h:outputText value="#{salaryCycleController.current.name}" />
-                            </span>
-                            <h:panelGroup rendered="#{salaryCycleController.reportKeyWord.institution ne null}">
-                                <p class="report-meta">
-                                    <h:outputText value="#{salaryCycleController.reportKeyWord.institution.name}" />
-                                </p>
-                            </h:panelGroup>
-                            <h:panelGroup rendered="#{salaryCycleController.reportKeyWord.department ne null}">
-                                <p class="report-meta">
-                                    Department: <h:outputText value="#{salaryCycleController.reportKeyWord.department.name}" />
-                                </p>
-                            </h:panelGroup>
-                            <h:panelGroup rendered="#{salaryCycleController.reportKeyWord.roster ne null}">
-                                <p class="report-meta">
-                                    Roster: <h:outputText value="#{salaryCycleController.reportKeyWord.roster.name}" />
-                                </p>
-                            </h:panelGroup>
-                        </div>
-
-                        <div class="payroll-table-wrap">
-                            <table id="tbl" class="payroll-table">
-                                <thead>
-                                    <tr>
-                                        <th>Code</th>
-                                        <th>EPF</th>
-                                        <th>Joined</th>
-                                        <th>Staff</th>
-                                        <th>Roster</th>
-                                        <th>Basic + BR</th>
-                                        <th>Merchan.</th>
-                                        <th>Poya</th>
-                                        <th>Day off</th>
-                                        <th>Basic adj.</th>
-                                        <th>Total salary</th>
-                                        <th>No pay basic</th>
-                                        <th>EPF/ETF deductible</th>
-                                        <ui:repeat value="#{salaryCycleController.headersAdd}" var="h">
-                                            <th>#{h}</th>
-                                        </ui:repeat>
-                                        <th>Allow. adj.</th>
-                                        <th>No pay allow.</th>
-                                        <th>Total allow.</th>
-                                        <th>Gross salary</th>
-                                        <th>EPF staff</th>
-                                        <ui:repeat value="#{salaryCycleController.headersSub}" var="hh">
-                                            <th>#{hh}</th>
-                                        </ui:repeat>
-                                        <th>Total deduct.</th>
-                                        <th>Net salary</th>
-                                        <th>EPF company</th>
-                                        <th>ETF company</th>
-                                    </tr>
-                                </thead>
-                                <tbody>
-                                    <ui:repeat value="#{salaryCycleController.staffSalarys}" var="scc">
-                                        <tr>
-                                            <td><h:outputText value="#{scc.staff.codeInterger}" /></td>
-                                            <td><h:outputText value="#{scc.staff.epfNo}" /></td>
-                                            <td>
-                                                <h:outputText value="#{scc.staff.dateJoined}">
-                                                    <f:convertDateTime pattern="dd MM yy" />
-                                                </h:outputText>
-                                            </td>
-                                            <td><h:outputText value="#{scc.staff.person.name}" /></td>
-                                            <td><h:outputText value="#{scc.staff.roster.name}" /></td>
-                                            <td><h:outputText value="#{scc.basicValue}"><f:convertNumber pattern="#,##0.00" /></h:outputText></td>
-                                            <td><h:outputText value="#{scc.merchantileAllowanceValue}"><f:convertNumber pattern="#,##0.00" /></h:outputText></td>
-                                            <td><h:outputText value="#{scc.poyaAllowanceValue}"><f:convertNumber pattern="#,##0.00" /></h:outputText></td>
-                                            <td><h:outputText value="#{scc.dayOffAllowance+scc.sleepingDayAllowance}"><f:convertNumber pattern="#,##0.00" /></h:outputText></td>
-                                            <td><h:outputText value="#{scc.adjustmentToBasic}"><f:convertNumber pattern="#,##0.00" /></h:outputText></td>
-                                            <td><h:outputText value="#{scc.transGrossSalary}"><f:convertNumber pattern="#,##0.00" /></h:outputText></td>
-                                            <td><h:outputText value="#{scc.noPayValueBasic}"><f:convertNumber pattern="#,##0.00" /></h:outputText></td>
-                                            <td><h:outputText value="#{scc.transEpfEtfDiductableSalary}"><f:convertNumber pattern="#,##0.00" /></h:outputText></td>
-                                            <ui:repeat value="#{scc.transStaffSalaryComponantsAddition}" var="col1">
-                                                <td><h:outputText value="#{col1.componantValue}"><f:convertNumber pattern="#,##0.00" /></h:outputText></td>
-                                            </ui:repeat>
-                                            <td><h:outputText value="#{scc.adjustmentToAllowance}"><f:convertNumber pattern="#,##0.00" /></h:outputText></td>
-                                            <td><h:outputText value="#{scc.noPayValueAllowance}"><f:convertNumber pattern="#,##0.00" /></h:outputText></td>
-                                            <td><h:outputText value="#{scc.transTotalAllowance}"><f:convertNumber pattern="#,##0.00" /></h:outputText></td>
-                                            <td><h:outputText value="#{scc.transTotalAllowance+scc.transEpfEtfDiductableSalary}"><f:convertNumber pattern="#,##0.00" /></h:outputText></td>
-                                            <td><h:outputText value="#{scc.epfStaffValue}"><f:convertNumber pattern="#,##0.00" /></h:outputText></td>
-                                            <ui:repeat value="#{scc.transStaffSalaryComponantsSubtraction}" var="col2">
-                                                <td><h:outputText value="#{col2.componantValue}"><f:convertNumber pattern="#,##0.00" /></h:outputText></td>
-                                            </ui:repeat>
-                                            <td><h:outputText value="#{scc.transTotalDeduction-(scc.noPayValueBasic+scc.noPayValueAllowance)}"><f:convertNumber pattern="#,##0.00" /></h:outputText></td>
-                                            <td><h:outputText value="#{scc.transNetSalry}"><f:convertNumber pattern="#,##0.00" /></h:outputText></td>
-                                            <td><h:outputText value="#{scc.epfCompanyValue}"><f:convertNumber pattern="#,##0.00" /></h:outputText></td>
-                                            <td><h:outputText value="#{scc.etfCompanyValue}"><f:convertNumber pattern="#,##0.00" /></h:outputText></td>
-                                        </tr>
+                                    <ui:repeat value="#{scc.transStaffSalaryComponantsAddition}"  var="col1">
+                                        <td style="text-align: right;;"><h:outputText value="#{col1.componantValue}" >
+                                                <f:convertNumber pattern="#,##0.00" />
+                                            </h:outputText>
+                                        </td>
                                     </ui:repeat>
 
-                                    <tr class="totals-row">
-                                        <td colspan="5">Total</td>
-                                        <td><h:outputText value="#{salaryCycleController.basicVal}"><f:convertNumber pattern="#,##0.00" /></h:outputText></td>
-                                        <td><h:outputText value="#{salaryCycleController.mercAll}"><f:convertNumber pattern="#,##0.00" /></h:outputText></td>
-                                        <td><h:outputText value="#{salaryCycleController.poyaAll}"><f:convertNumber pattern="#,##0.00" /></h:outputText></td>
-                                        <td><h:outputText value="#{salaryCycleController.dayOffAll}"><f:convertNumber pattern="#,##0.00" /></h:outputText></td>
-                                        <td><h:outputText value="#{salaryCycleController.adjstBasic}"><f:convertNumber pattern="#,##0.00" /></h:outputText></td>
-                                        <td><h:outputText value="#{salaryCycleController.tranGrossSal}"><f:convertNumber pattern="#,##0.00" /></h:outputText></td>
-                                        <td><h:outputText value="#{salaryCycleController.noPayBasic}"><f:convertNumber pattern="#,##0.00" /></h:outputText></td>
-                                        <td><h:outputText value="#{salaryCycleController.epfDeduct}"><f:convertNumber pattern="#,##0.00" /></h:outputText></td>
-                                        <ui:repeat value="#{salaryCycleController.footerAdd}" var="f">
-                                            <td><h:outputText value="#{f}"><f:convertNumber pattern="#,##0.00" /></h:outputText></td>
-                                        </ui:repeat>
-                                        <td><h:outputText value="#{salaryCycleController.adjustAll}"><f:convertNumber pattern="#,##0.00" /></h:outputText></td>
-                                        <td><h:outputText value="#{salaryCycleController.noPayValAll}"><f:convertNumber pattern="#,##0.00" /></h:outputText></td>
-                                        <td><h:outputText value="#{salaryCycleController.transTotAll}"><f:convertNumber pattern="#,##0.00" /></h:outputText></td>
-                                        <td><h:outputText value="#{salaryCycleController.epfDeduct+salaryCycleController.transTotAll}"><f:convertNumber pattern="#,##0.00" /></h:outputText></td>
-                                        <td><h:outputText value="#{salaryCycleController.epfStaffVal}"><f:convertNumber pattern="#,##0.00" /></h:outputText></td>
-                                        <ui:repeat value="#{salaryCycleController.footerSub}" var="ff">
-                                            <td><h:outputText value="#{ff}"><f:convertNumber pattern="#,##0.00" /></h:outputText></td>
-                                        </ui:repeat>
-                                        <td><h:outputText value="#{salaryCycleController.transTotDeduct-(salaryCycleController.noPayBasic+salaryCycleController.noPayValAll)}"><f:convertNumber pattern="#,##0.00" /></h:outputText></td>
-                                        <td><h:outputText value="#{(salaryCycleController.transTotDeduct-(salaryCycleController.noPayBasic+salaryCycleController.noPayValAll))+(salaryCycleController.epfDeduct+salaryCycleController.transTotAll)}"><f:convertNumber pattern="#,##0.00" /></h:outputText></td>
-                                        <td><h:outputText value="#{salaryCycleController.epfComVal}"><f:convertNumber pattern="#,##0.00" /></h:outputText></td>
-                                        <td><h:outputText value="#{salaryCycleController.etfComVal}"><f:convertNumber pattern="#,##0.00" /></h:outputText></td>
-                                    </tr>
-                                </tbody>
-                            </table>
-                        </div>
+                                    <td style="text-align: right;;"><h:outputText value="#{scc.adjustmentToAllowance}" >
+                                            <f:convertNumber pattern="#,##0.00" />
+                                        </h:outputText>
+                                    </td>
+                                    <td style="text-align: right;;"><h:outputText value="#{scc.noPayValueAllowance}" >
+                                            <f:convertNumber pattern="#,##0.00" />
+                                        </h:outputText>
+                                    </td>
+                                    <td style="text-align: right;;"><h:outputText value="#{scc.transTotalAllowance}" >
+                                            <f:convertNumber pattern="#,##0.00" />
+                                        </h:outputText>
+                                    </td>
+                                    <td style="text-align: right;;"><h:outputText value="#{scc.transTotalAllowance+scc.transEpfEtfDiductableSalary}" >
+                                            <f:convertNumber pattern="#,##0.00" />
+                                        </h:outputText>
+                                    </td>
+                                    <td style="text-align: right;;"><h:outputLabel value="#{scc.epfStaffValue}" >
+                                            <f:convertNumber pattern="#,##0.00" />
+                                        </h:outputLabel>
+                                    </td>
+                                    <ui:repeat value="#{scc.transStaffSalaryComponantsSubtraction}"  var="col2">
+                                        <td style="text-align: right; ;"><h:outputText value="#{col2.componantValue}" >
+                                                <f:convertNumber pattern="#,##0.00" />
+                                            </h:outputText>
+                                        </td>
+                                    </ui:repeat>
+                                    <td style="text-align: right; ;"><h:outputLabel value="#{scc.transTotalDeduction-(scc.noPayValueBasic+scc.noPayValueAllowance)}" >
+                                            <f:convertNumber pattern="#,##0.00" />
+                                        </h:outputLabel>
+                                    </td>
+                                    <td style="text-align: right; ;">
+                                        <h:outputLabel value="#{scc.transNetSalry}" >
+                                            <f:convertNumber pattern="#,##0.00" />
+                                        </h:outputLabel>
 
-                        <div class="report-table-footer">
-                            <h:outputText value="Print by: #{sessionController.loggedUser.webUserPerson.name}" />
-                            <span>·</span>
-                            <p:outputLabel value="#{commonFunctionsProxy.currentDateTime}">
-                                <f:convertDateTime pattern="yyyy MMMM dd hh:mm:ss a" />
-                            </p:outputLabel>
-                            <span>·</span>
-                            <h:outputText value="This is a system generated report." />
-                        </div>
 
-                    </div>
+                                    </td>
+                                    <td style="text-align: right;;"><h:outputLabel value="#{scc.epfCompanyValue}" >
+                                            <f:convertNumber pattern="#,##0.00" />
+                                        </h:outputLabel>
+                                    </td>
+                                    <td style="text-align: right;;"><h:outputLabel value="#{scc.etfCompanyValue}" >
+                                            <f:convertNumber pattern="#,##0.00" />
+                                        </h:outputLabel>
+                                    </td>
+                                </tr>
+                            </ui:repeat>
+                            <tr>
+                                <td colspan="5"><h:outputLabel value="Totals"/></td>
+                                <td style="text-align: right;;">
+                                    <h:outputText value="#{salaryCycleController.basicVal}" >
+                                        <f:convertNumber pattern="#,##0.00" />
+                                    </h:outputText>
+                                </td>
+                                <td style="text-align: right;;">
+                                    <h:outputText value="#{salaryCycleController.mercAll}" >
+                                        <f:convertNumber pattern="#,##0.00" />
+                                    </h:outputText>
+                                </td>
+                                <td style="text-align: right;;">
+                                    <h:outputText value="#{salaryCycleController.poyaAll}" >
+                                        <f:convertNumber pattern="#,##0.00" />
+                                    </h:outputText>
+                                </td>
+                                <td style="text-align: right;;">
+                                    <h:outputText value="#{salaryCycleController.dayOffAll}" >
+                                        <f:convertNumber pattern="#,##0.00" />
+                                    </h:outputText>
+                                </td>
+                                <td style="text-align: right;;">
+                                    <h:outputText value="#{salaryCycleController.adjstBasic}" >
+                                        <f:convertNumber pattern="#,##0.00" />
+                                    </h:outputText>
+                                </td>
+                                <td style="text-align: right;;">
+                                    <h:outputText value="#{salaryCycleController.tranGrossSal}" >
+                                        <f:convertNumber pattern="#,##0.00" />
+                                    </h:outputText>
+                                </td>
+                                <td style="text-align: right;;">
+                                    <h:outputText value="#{salaryCycleController.noPayBasic}" >
+                                        <f:convertNumber pattern="#,##0.00" />
+                                    </h:outputText>
+                                </td>
+                                <td style="text-align: right;;">
+                                    <h:outputText value="#{salaryCycleController.epfDeduct}" >
+                                        <f:convertNumber pattern="#,##0.00" />
+                                    </h:outputText>
+                                </td>
+                                <ui:repeat value="#{salaryCycleController.footerAdd}" var="f">
+                                    <td style="text-align: right;;">
+                                        <h:outputLabel value="#{f}" >
+                                            <f:convertNumber pattern="#,##0.00" />
+                                        </h:outputLabel>
+                                    </td>
+                                </ui:repeat>
+                                <td style="text-align: right;;">
+                                    <h:outputLabel value="#{salaryCycleController.adjustAll}" >
+                                        <f:convertNumber pattern="#,##0.00" />
+                                    </h:outputLabel>
+                                </td>
+                                <td style="text-align: right;;">
+                                    <h:outputLabel value="#{salaryCycleController.noPayValAll}" >
+                                        <f:convertNumber pattern="#,##0.00" />
+                                    </h:outputLabel>
+                                </td>
+                                <td style="text-align: right;;">
+                                    <h:outputLabel value="#{salaryCycleController.transTotAll}" >
+                                        <f:convertNumber pattern="#,##0.00" />
+                                    </h:outputLabel>
+                                </td>
+                                <td style="text-align: right;;">
+
+                                    <h:outputLabel value="#{salaryCycleController.epfDeduct+salaryCycleController.transTotAll}" >
+                                        <f:convertNumber pattern="#,##0.00" />
+                                    </h:outputLabel>
+                                </td>
+                                <td style="text-align: right;;">
+                                    <h:outputLabel value="#{salaryCycleController.epfStaffVal}" >
+                                        <f:convertNumber pattern="#,##0.00" />
+                                    </h:outputLabel>
+                                </td>
+                                <ui:repeat value="#{salaryCycleController.footerSub}" var="ff">
+                                    <td style="text-align: right;;">
+                                        <h:outputLabel value="#{ff}" >
+                                            <f:convertNumber pattern="#,##0.00" />
+                                        </h:outputLabel>
+                                    </td>
+                                </ui:repeat>
+                                <td style="text-align: right;;">
+                                    <h:outputLabel value="#{salaryCycleController.transTotDeduct-(salaryCycleController.noPayBasic+salaryCycleController.noPayValAll)}" >
+                                        <f:convertNumber pattern="#,##0.00" />
+                                    </h:outputLabel>
+                                </td>
+                                <td style="text-align: right;;">
+
+                                    <h:outputLabel value="#{(salaryCycleController.transTotDeduct-(salaryCycleController.noPayBasic+salaryCycleController.noPayValAll))+(salaryCycleController.epfDeduct+salaryCycleController.transTotAll)}" >
+                                        <f:convertNumber pattern="#,##0.00" />
+                                    </h:outputLabel>
+                                </td>
+                                <td style="text-align: right;;">
+                                    <h:outputLabel value="#{salaryCycleController.epfComVal}" >
+                                        <f:convertNumber pattern="#,##0.00" />
+                                    </h:outputLabel>
+                                </td>
+                                <td style="text-align: right;;">
+                                    <h:outputLabel value="#{salaryCycleController.etfComVal}" >
+                                        <f:convertNumber pattern="#,##0.00" />
+                                    </h:outputLabel>
+                                </td>
+                            </tr>
+                            <tr>
+                                <td colspan="5">
+                                    <h:outputLabel value="Print By : #{sessionController.loggedUser.webUserPerson.name} - Print At : "/>
+                                    <p:outputLabel value="#{commonFunctionsProxy.currentDateTime}" >
+                                        <f:convertDateTime pattern="yyyy MMMM dd hh:mm:ss a " />
+                                    </p:outputLabel>
+                                    <h:outputLabel value=" - This System Generated Report Does Not Carry A Signature."/>
+                                </td>
+                            </tr>
+                        </tbody>
+                    </table>
+
+
 
                 </h:form>
-
             </ui:define>
+
         </ui:composition>
     </h:body>
 </html>

--- a/src/main/webapp/hr/hr_report_staff_salary_component.xhtml
+++ b/src/main/webapp/hr/hr_report_staff_salary_component.xhtml
@@ -1,257 +1,491 @@
 <?xml version='1.0' encoding='UTF-8' ?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml"
-      xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
-      xmlns:h="http://xmlns.jcp.org/jsf/html"
-      xmlns:p="http://primefaces.org/ui"
-      xmlns:f="http://xmlns.jcp.org/jsf/core"
+<!DOCTYPE composition PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<ui:composition xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
+                template="/resources/template/template.xhtml"
+                xmlns:h="http://xmlns.jcp.org/jsf/html"
+                xmlns:p="http://primefaces.org/ui"
+                xmlns:f="http://xmlns.jcp.org/jsf/core"
+                xmlns:hr="http://xmlns.jcp.org/jsf/composite/autocomplete"
+                xmlns:salary="http://xmlns.jcp.org/jsf/composite/hr">
 
-      xmlns:hr="http://xmlns.jcp.org/jsf/composite/autocomplete"
-      xmlns:salary="http://xmlns.jcp.org/jsf/composite/hr">
+    <ui:define name="content">
 
-    <h:body>
+        <h:form styleClass="salary-component-form">
 
-        <ui:composition template="/resources/template/template.xhtml">
+            <h:outputStylesheet>
+                .salary-component-form {
+                    padding: 2rem 1.75rem;
+                }
 
-            <ui:define name="content">
-                <h:form >
-                    <p:panel >
-                        <f:facet name="header" >
-                            <h:outputLabel value="Staff Salary Component" />
-                        </f:facet>
-                        <h:panelGrid columns="2" >
-                            <h:outputLabel value="Salary Cycle"/>
-                            <p:selectOneMenu value="#{hrReportController.reportKeyWord.salaryCycle}"
-                                             var="t">
-                                <f:selectItem itemLabel="Select Salary Cycle" />
+                .page-header {
+                    margin-bottom: 1.75rem;
+                }
+
+                .page-title {
+                    font-size: 18px;
+                    font-weight: 600;
+                    margin: 0 0 4px 0;
+                }
+
+                .page-subtitle {
+                    font-size: 13px;
+                    color: #888;
+                    margin: 0;
+                }
+
+                .controls-panel .ui-panel-content {
+                    padding: 1.5rem 1.75rem !important;
+                }
+
+                .controls-grid {
+                    display: flex;
+                    flex-direction: column;
+                    gap: 1.25rem;
+                }
+
+                .fields-grid {
+                    display: grid;
+                    grid-template-columns: repeat(2, 1fr);
+                    gap: 1rem 1.5rem;
+                }
+
+                .field-group {
+                    display: flex;
+                    flex-direction: column;
+                    gap: 6px;
+                }
+
+                .field-label {
+                    font-size: 11.5px !important;
+                    font-weight: 600 !important;
+                    text-transform: uppercase;
+                    letter-spacing: 0.05em;
+                    color: #888 !important;
+                }
+
+                .checkbox-group {
+                    display: flex;
+                    align-items: center;
+                    gap: 8px;
+                    margin-top: 2px;
+                }
+
+                .controls-actions {
+                    display: flex;
+                    gap: 10px;
+                    align-items: center;
+                    flex-wrap: wrap;
+                }
+
+                .controls-actions-secondary {
+                    display: flex;
+                    gap: 10px;
+                    align-items: center;
+                    flex-wrap: wrap;
+                    padding-top: 0.75rem;
+                    border-top: 1px solid #e8e8e8;
+                }
+
+                .btn-action {
+                    height: 36px !important;
+                    padding: 0 18px !important;
+                    font-size: 13px !important;
+                }
+
+                .report-panel {
+                    margin-top: 1.5rem;
+                }
+
+                .report-panel .ui-panel-content {
+                    padding: 0 !important;
+                }
+
+                .report-header-wrap {
+                    text-align: center;
+                    padding: 1.5rem 1.5rem 1rem;
+                    border-bottom: 1px solid #e8e8e8;
+                }
+
+                .report-title-label {
+                    font-size: 13px;
+                    color: #666;
+                    display: block;
+                    margin-bottom: 2px;
+                }
+
+                .report-cycle-label {
+                    font-size: 13px;
+                    font-weight: 500;
+                    display: block;
+                }
+
+                .report-meta {
+                    font-size: 13px;
+                    color: #555;
+                    margin-top: 4px;
+                }
+
+                .salary-comp-table .ui-datatable-tablewrapper {
+                    overflow-x: auto !important;
+                    width: 100% !important;
+                }
+
+                .salary-comp-table table {
+                    width: auto !important;
+                    table-layout: auto !important;
+                }
+
+                .salary-comp-table .ui-datatable-data td,
+                .salary-comp-table .ui-datatable-thead th {
+                    padding: 10px 14px !important;
+                    white-space: nowrap;
+                    font-size: 13px !important;
+                    width: auto !important;
+                }
+
+                .salary-comp-table .ui-datatable-thead th {
+                    font-size: 12px !important;
+                    font-weight: 600 !important;
+                    text-transform: uppercase;
+                    letter-spacing: 0.03em;
+                    color: #888 !important;
+                    background: #f9f9f9 !important;
+                    border-bottom: 1px solid #e8e8e8 !important;
+                }
+
+                .salary-comp-table .ui-datatable-data tr:hover td {
+                    background: #f5f7ff !important;
+                }
+
+                .salary-comp-table .col-num {
+                    text-align: right !important;
+                }
+
+                .salary-comp-table .col-num .ui-outputlabel {
+                    display: block;
+                    text-align: right;
+                }
+
+                .salary-comp-table .col-text {
+                    text-align: left !important;
+                }
+
+                .salary-comp-table .col-name .ui-outputlabel {
+                    font-weight: 500;
+                }
+
+                .salary-comp-table tfoot td {
+                    background: #f9f9f9 !important;
+                    font-weight: 600 !important;
+                    font-size: 13px !important;
+                    border-top: 2px solid #e0e0e0 !important;
+                    padding: 10px 14px !important;
+                }
+
+                .report-table-footer {
+                    display: flex;
+                    justify-content: flex-end;
+                    align-items: center;
+                    gap: 6px;
+                    padding: 0.85rem 1.5rem;
+                    border-top: 1px solid #e8e8e8;
+                    font-size: 12px;
+                    color: #999;
+                }
+
+                .bank-letter-panel {
+                    margin-top: 1.5rem;
+                }
+
+                .bank-letter-panel .ui-panel-content {
+                    padding: 1rem 1.5rem !important;
+                }
+
+                .bank-letter-actions {
+                    display: flex;
+                    gap: 10px;
+                    margin-bottom: 1rem;
+                }
+            </h:outputStylesheet>
+
+            <div class="page-header">
+                <p class="page-title"><h:outputText value="Staff Salary Component" /></p>
+                <p class="page-subtitle"><h:outputText value="Filter by cycle, component, department or employee and process to generate" /></p>
+            </div>
+
+            <p:panel styleClass="controls-panel">
+                <div class="controls-grid">
+
+                    <div class="fields-grid">
+                        <div class="field-group">
+                            <p:outputLabel for="salaryCycle" value="Salary cycle" styleClass="field-label" />
+                            <p:selectOneMenu id="salaryCycle"
+                                             value="#{hrReportController.reportKeyWord.salaryCycle}"
+                                             var="t"
+                                             appendTo="@body"
+                                             autoWidth="false"
+                                             style="width: 100%;">
+                                <f:selectItem itemLabel="Select salary cycle" />
                                 <f:selectItems value="#{salaryCycleController.salaryCycles}"
                                                var="theme"
                                                itemLabel="#{theme.name}"
-                                               itemValue="#{theme}" ></f:selectItems>
-
-                                <p:column style="width:10%" headerText="Name">
+                                               itemValue="#{theme}" />
+                                <p:column style="width:10%">
                                     <h:outputText value="#{t.name}" />
                                 </p:column>
-
-                                <p:column headerText="Year">
+                                <p:column>
                                     <h:outputText value="#{t.salaryYear}" />
                                 </p:column>
-                                <p:column headerText="Month">
+                                <p:column>
                                     <h:outputText value="#{t.salaryMonth}" />
                                 </p:column>
                             </p:selectOneMenu>
-                            <h:outputLabel value="Institution : "/>
-                            <hr:institution value="#{hrReportController.reportKeyWord.institution}"/>
-                            <h:outputLabel value="Department : "/>
-                            <hr:department value="#{hrReportController.reportKeyWord.department}"/>
-                            <h:outputLabel value="Employee : "/>
-                            <hr:completeStaff value="#{hrReportController.reportKeyWord.staff}"/>
-                            <h:outputLabel value="Staff Category : "/>
-                            <hr:completeStaffCategory value="#{hrReportController.reportKeyWord.staffCategory}"/>
-                            <h:outputLabel value="Staff Designation : "/>
-                            <hr:completeDesignation value="#{hrReportController.reportKeyWord.designation}"/>
-                            <h:outputLabel value="Staff Roster : "/>
-                            <hr:completeRoster value="#{hrReportController.reportKeyWord.roster}"/>
-                            <h:outputLabel value="Staff Paysheet Componet : "/>
-                            <hr:completePaySheetComponent value="#{hrReportController.reportKeyWord.paysheetComponent}"/>
-                            <h:outputLabel value="Bank : "/>
-                            <hr:completeBank value="#{hrReportController.reportKeyWord.institutionBank}"/>
-                            <h:outputLabel value="Adjested Components"/>
-                            <p:selectBooleanCheckbox value="#{hrReportController.reportKeyWord.bool1}" />
-                        </h:panelGrid>
+                        </div>
 
-                        <p:commandButton ajax="false" value="Process" action="#{hrReportController.createStaffSalaryComponent()}"/>
-                        <p:commandButton ajax="false" value="Process Special" action="#{hrReportController.createStaffSalaryComponentSpecial()}"/>
+                        <div class="field-group">
+                            <p:outputLabel value="Institution" styleClass="field-label" />
+                            <hr:institution value="#{hrReportController.reportKeyWord.institution}" />
+                        </div>
 
-                        <p:commandButton ajax="false" value="Excel" styleClass="noPrintButton"  >
-                            <p:dataExporter type="xlsx" target="tb1" fileName="staff_salary_component"/>
+                        <div class="field-group">
+                            <p:outputLabel value="Department" styleClass="field-label" />
+                            <hr:department value="#{hrReportController.reportKeyWord.department}" />
+                        </div>
+
+                        <div class="field-group">
+                            <p:outputLabel value="Employee" styleClass="field-label" />
+                            <hr:completeStaff value="#{hrReportController.reportKeyWord.staff}" />
+                        </div>
+
+                        <div class="field-group">
+                            <p:outputLabel value="Staff category" styleClass="field-label" />
+                            <hr:completeStaffCategory value="#{hrReportController.reportKeyWord.staffCategory}" />
+                        </div>
+
+                        <div class="field-group">
+                            <p:outputLabel value="Staff designation" styleClass="field-label" />
+                            <hr:completeDesignation value="#{hrReportController.reportKeyWord.designation}" />
+                        </div>
+
+                        <div class="field-group">
+                            <p:outputLabel value="Staff roster" styleClass="field-label" />
+                            <hr:completeRoster value="#{hrReportController.reportKeyWord.roster}" />
+                        </div>
+
+                        <div class="field-group">
+                            <p:outputLabel value="Paysheet component" styleClass="field-label" />
+                            <hr:completePaySheetComponent value="#{hrReportController.reportKeyWord.paysheetComponent}" />
+                        </div>
+
+                        <div class="field-group">
+                            <p:outputLabel value="Bank" styleClass="field-label" />
+                            <hr:completeBank value="#{hrReportController.reportKeyWord.institutionBank}" />
+                        </div>
+
+                        <div class="field-group">
+                            <p:outputLabel value="Options" styleClass="field-label" />
+                            <div class="checkbox-group">
+                                <p:selectBooleanCheckbox id="adjustedComponents"
+                                                         value="#{hrReportController.reportKeyWord.bool1}" />
+                                <h:outputLabel for="adjustedComponents"
+                                               styleClass="field-label"
+                                               value="Adjusted components" />
+                            </div>
+                        </div>
+                    </div>
+
+                    <div class="controls-actions">
+                        <p:commandButton value="Process"
+                                         ajax="false"
+                                         action="#{hrReportController.createStaffSalaryComponent()}"
+                                         icon="pi pi-sync"
+                                         styleClass="btn-action" />
+                        <p:commandButton value="Process special"
+                                         ajax="false"
+                                         action="#{hrReportController.createStaffSalaryComponentSpecial()}"
+                                         icon="pi pi-sync"
+                                         styleClass="btn-action" />
+                    </div>
+
+                    <div class="controls-actions-secondary">
+                        <p:commandButton value="Print"
+                                         ajax="false"
+                                         action="#"
+                                         icon="pi pi-print"
+                                         styleClass="btn-action">
+                            <p:printer target="gpBillPreview" />
                         </p:commandButton>
-                        <p:commandButton value="Print" ajax="false" action="#">
-                            <p:printer target="gpBillPreview"></p:printer>
+                        <p:commandButton value="Export Excel"
+                                         ajax="false"
+                                         icon="pi pi-file-excel"
+                                         styleClass="btn-action noPrintButton">
+                            <p:dataExporter type="xlsx" target="tb1" fileName="staff_salary_component" />
                         </p:commandButton>
-                        <p:panel id="gpBillPreview" styleClass="noBorder summeryBorder" >
-                            <p:dataTable id="tb1" value="#{hrReportController.staffSalaryComponants}" var="ss">
-                                <f:facet name="header">
+                    </div>
 
-                                    <h:outputLabel value="Staff Salary Component"/>
-                                    <br/>
-                                    <h:outputLabel value="Salary Cycle : #{hrReportController.reportKeyWord.salaryCycle.name}"/>
-                                    <br/>
-                                    <h:outputLabel value="SC Cycle : " />
-                                    <h:outputLabel value="#{hrReportController.reportKeyWord.salaryCycle.workedFromDate}" >
-                                        <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateTimeFormat}"  />
-                                    </h:outputLabel>
-                                    <h:outputLabel value="#{hrReportController.reportKeyWord.salaryCycle.workedToDate}"  >
-                                        <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateTimeFormat}"  />
-                                    </h:outputLabel>
-                                    <br/>
-                                    <h:panelGroup rendered="#{hrReportController.reportKeyWord.institution ne null}" >
-                                        <h:outputLabel value="Institution : #{hrReportController.reportKeyWord.institution.name}"/>
-                                        <br/>
-                                    </h:panelGroup>
-                                    <h:panelGroup rendered="#{hrReportController.reportKeyWord.department ne null}" >
-                                        <h:outputLabel value="Department : #{hrReportController.reportKeyWord.department.name}"/>
-                                        <br/>
-                                    </h:panelGroup>
-                                    <h:panelGroup rendered="#{hrReportController.reportKeyWord.staff.person.name ne null}" >
-                                        <h:outputLabel value="Staff : #{hrReportController.reportKeyWord.staff.person.name}"/>
-                                        <br/>
-                                    </h:panelGroup>
-                                </f:facet>
-                                <p:column headerText="Emp No">
-                                    <f:facet name="header">
-                                        <h:outputLabel value="Emp No"  />
-                                    </f:facet>
-                                    <p:outputLabel value="#{ss.staffSalary.staff.codeInterger}" >
-                                    </p:outputLabel>
-                                </p:column>
-                                <p:column headerText="Emp Name" style="text-wrap: avoid; text-overflow: clip; white-space: nowrap;">
-                                    <f:facet name="header">
-                                        <h:outputLabel value="Emp Name"/>
-                                    </f:facet>
-                                    <p:outputLabel value="#{ss.staffSalary.staff.person.nameWithTitle}">
-                                    </p:outputLabel>
-                                </p:column>
-                                <p:column headerText="Paysheet Component ">
-                                    <f:facet name="header">
-                                        <h:outputLabel value="Paysheet Component"  />
-                                    </f:facet>
-                                    <p:outputLabel value="#{ss.staffPaysheetComponent.paysheetComponent.name}">
-                                    </p:outputLabel>
-                                </p:column>
-                                <p:column headerText="Paysheet Component ">
-                                    <f:facet name="header">
-                                        <h:outputLabel value="ID"  />
-                                    </f:facet>
-                                    <p:outputLabel value="#{ss.staffPaysheetComponent.id}">
-                                    </p:outputLabel>
-                                </p:column>
-                                <p:column headerText="Salary Cycle" rendered="#{hrReportController.reportKeyWord.salaryCycle eq null}">
-                                    <f:facet name="header">
-                                        <h:outputLabel value="Salary Cycle"  />
-                                    </f:facet>
-                                    <p:outputLabel value="#{ss.salaryCycle.name}">
-                                    </p:outputLabel>
-                                </p:column>
-                                <p:column headerText="Opennig Balance" rendered="#{hrReportController.reportKeyWord.salaryCycle eq null}">
-                                    <f:facet name="header">
-                                        <h:outputLabel value="Opennig Balance"  />
-                                    </f:facet>
-                                    <p:outputLabel value="#{ss.staffPaysheetComponent.startingBalance}">
-                                    </p:outputLabel>
-                                </p:column>
-                                <p:column headerText="Bank">
-                                    <f:facet name="header">
-                                        <h:outputLabel value="Bank"  />
-                                    </f:facet>
-                                    <p:outputLabel value="#{ss.staffPaysheetComponent.bankBranch.institution.name}">
-                                    </p:outputLabel>
-                                </p:column>
-                                <p:column headerText="Bank">
-                                    <f:facet name="header">
-                                        <h:outputLabel value="Bank"  />
-                                    </f:facet>
-                                    <p:outputLabel value="#{ss.staffPaysheetComponent.id}">
-                                    </p:outputLabel>
-                                </p:column>
-                                <p:column headerText="Component Value " style="text-align: right;">
-                                    <f:facet name="header">
-                                        <h:outputLabel value="Component Value"  />
-                                    </f:facet>
-                                    <p:outputLabel value="#{ss.componantValue}">
+                </div>
+            </p:panel>
 
-                                        <f:convertNumber pattern="#,##0.00" />
-                                    </p:outputLabel>
-                                    <f:facet name="footer">
-                                        <p:outputLabel value="#{hrReportController.total}" >
-                                            <f:convertNumber pattern="#,##0.00" />
-                                        </p:outputLabel>
-                                    </f:facet>
-                                </p:column>
-                                <p:column headerText="EPF Staff Value " style="text-align: right;">
-                                    <f:facet name="header">
-                                        <h:outputLabel value="EPF Staff Value"  />
-                                    </f:facet>
-                                    <p:outputLabel value="#{ss.epfValue}">
-                                        <f:convertNumber pattern="#,##0.00" />
-                                    </p:outputLabel>
-                                </p:column>
-                                <p:column headerText="EPF Company Value " style="text-align: right;">
-                                    <f:facet name="header">
-                                        <h:outputLabel value="EPF Company Value"  />
-                                    </f:facet>
-                                    <p:outputLabel value="#{ss.epfCompanyValue}">
-                                        <f:convertNumber pattern="#,##0.00" />
-                                    </p:outputLabel>
-                                </p:column>
-                                <p:column headerText="ETF Company Value " style="text-align: right;">
-                                    <f:facet name="header">
-                                        <h:outputLabel value="ETF Company Value"  />
-                                    </f:facet>
-                                    <p:outputLabel value="#{ss.etfCompanyValue}">
-                                        <f:convertNumber pattern="#,##0.00" />
-                                    </p:outputLabel>
-                                </p:column>
+            <!-- Main report table -->
+            <p:panel id="gpBillPreview" styleClass="report-panel noBorder summeryBorder">
 
-                                <p:column headerText="Total" style="text-align: right;">
-                                    <f:facet name="header">
-                                        <h:outputLabel value="Total"  />
-                                    </f:facet>
-                                    <p:outputLabel value="#{ss.etfCompanyValue + ss.epfCompanyValue + ss.epfValue + ss.componantValue}">
-                                        <f:convertNumber pattern="#,##0.00" />
-                                    </p:outputLabel>
-                                </p:column>
-                                <p:column headerText="Editer" rendered="#{hrReportController.reportKeyWord.bool1}" style="text-wrap: avoid; text-overflow: clip; white-space: nowrap;">
-                                    <f:facet name="header">
-                                        <h:outputLabel value="Editer"/>
-                                    </f:facet>
-                                    <p:outputLabel value="#{ss.lastEditor.webUserPerson.name}">
-                                    </p:outputLabel>
-                                </p:column>
-                                <p:column headerText="Comment" rendered="#{hrReportController.reportKeyWord.bool1}" style="text-wrap: avoid; text-overflow: clip; white-space: nowrap;">
-                                    <f:facet name="header">
-                                        <h:outputLabel value="Comment"/>
-                                    </f:facet>
-                                    <p:outputLabel value="#{ss.comments}">
-                                    </p:outputLabel>
-                                </p:column>
-                                <p:column headerText="Edited At" rendered="#{hrReportController.reportKeyWord.bool1}">
-                                    <f:facet name="header">
-                                        <h:outputLabel value="Edited At"/>
-                                    </f:facet>
-                                    <p:outputLabel value="#{ss.lastEditedAt}">
-                                        <f:convertDateTime pattern="yyyy MMM dd" />
-                                    </p:outputLabel>
-                                </p:column>
-                                <f:facet name="footer">
-                                    <p:outputLabel value="Print By : #{sessionController.loggedUser.webUserPerson.name} - " />
-                                    <p:outputLabel value="Print At : " />
-                                    <p:outputLabel value="#{commonFunctionsProxy.currentDateTime}" >
-                                        <f:convertDateTime pattern="yyyy MMMM dd hh:mm:ss a " />
-                                    </p:outputLabel>
-                                </f:facet>
-                            </p:dataTable>
-                        </p:panel>
+                <f:facet name="header">
+                    <div class="report-header-wrap">
+                        <span class="report-title-label">Staff Salary Component</span>
+                        <span class="report-cycle-label">
+                            <h:outputText value="#{hrReportController.reportKeyWord.salaryCycle.name}" />
+                        </span>
+                        <p class="report-meta">
+                            SC cycle:
+                            <h:outputText value="#{hrReportController.reportKeyWord.salaryCycle.workedFromDate}">
+                                <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateTimeFormat}" />
+                            </h:outputText>
+                            —
+                            <h:outputText value="#{hrReportController.reportKeyWord.salaryCycle.workedToDate}">
+                                <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateTimeFormat}" />
+                            </h:outputText>
+                        </p>
+                        <h:panelGroup rendered="#{hrReportController.reportKeyWord.institution ne null}">
+                            <p class="report-meta">
+                                <h:outputText value="#{hrReportController.reportKeyWord.institution.name}" />
+                            </p>
+                        </h:panelGroup>
+                        <h:panelGroup rendered="#{hrReportController.reportKeyWord.department ne null}">
+                            <p class="report-meta">
+                                Department: <h:outputText value="#{hrReportController.reportKeyWord.department.name}" />
+                            </p>
+                        </h:panelGroup>
+                        <h:panelGroup rendered="#{hrReportController.reportKeyWord.staff.person.name ne null}">
+                            <p class="report-meta">
+                                Staff: <h:outputText value="#{hrReportController.reportKeyWord.staff.person.name}" />
+                            </p>
+                        </h:panelGroup>
+                    </div>
+                </f:facet>
 
-                        <p:panel rendered="#{hrReportController.reportKeyWord.institutionBank ne null and hrReportController.reportKeyWord.paysheetComponent ne null}" >
-                            <p:commandButton value="Print" ajax="false" action="#">
-                                <p:printer target="gpBillPreviewPaysheet" ></p:printer>
-                            </p:commandButton>
-                            <h:panelGroup   id="gpBillPreviewPaysheet">
-                                <salary:bank_letter salary="#{hrReportController.staffSalaryComponants}"
-                                                    bank="#{hrReportController.reportKeyWord.institutionBank}"
-                                                    component="#{hrReportController.reportKeyWord.paysheetComponent}"
-                                                    total="#{hrReportController.total}"/>
-                            </h:panelGroup>
-                        </p:panel>
+                <p:dataTable id="tb1"
+                             value="#{hrReportController.staffSalaryComponants}"
+                             var="ss"
+                             styleClass="salary-comp-table">
 
+                    <p:column headerText="Emp no" styleClass="col-text">
+                        <p:outputLabel value="#{ss.staffSalary.staff.codeInterger}" />
+                    </p:column>
 
-                    </p:panel>
+                    <p:column headerText="Emp name" styleClass="col-text col-name" style="min-width: 200px;">
+                        <p:outputLabel value="#{ss.staffSalary.staff.person.nameWithTitle}" />
+                    </p:column>
 
-                </h:form>
-            </ui:define>
+                    <p:column headerText="Paysheet component" styleClass="col-text">
+                        <p:outputLabel value="#{ss.staffPaysheetComponent.paysheetComponent.name}" />
+                    </p:column>
 
-        </ui:composition>
+                    <p:column headerText="ID" styleClass="col-text">
+                        <p:outputLabel value="#{ss.staffPaysheetComponent.id}" />
+                    </p:column>
 
-    </h:body>
-</html>
+                    <p:column headerText="Salary cycle" styleClass="col-text"
+                              rendered="#{hrReportController.reportKeyWord.salaryCycle eq null}">
+                        <p:outputLabel value="#{ss.salaryCycle.name}" />
+                    </p:column>
+
+                    <p:column headerText="Opening balance" styleClass="col-num"
+                              rendered="#{hrReportController.reportKeyWord.salaryCycle eq null}">
+                        <p:outputLabel value="#{ss.staffPaysheetComponent.startingBalance}" />
+                    </p:column>
+
+                    <p:column headerText="Bank" styleClass="col-text">
+                        <p:outputLabel value="#{ss.staffPaysheetComponent.bankBranch.institution.name}" />
+                    </p:column>
+
+                    <p:column headerText="Component value" styleClass="col-num">
+                        <p:outputLabel value="#{ss.componantValue}">
+                            <f:convertNumber pattern="#,##0.00" />
+                        </p:outputLabel>
+                        <f:facet name="footer">
+                            <p:outputLabel value="#{hrReportController.total}">
+                                <f:convertNumber pattern="#,##0.00" />
+                            </p:outputLabel>
+                        </f:facet>
+                    </p:column>
+
+                    <p:column headerText="EPF staff value" styleClass="col-num">
+                        <p:outputLabel value="#{ss.epfValue}">
+                            <f:convertNumber pattern="#,##0.00" />
+                        </p:outputLabel>
+                    </p:column>
+
+                    <p:column headerText="EPF company value" styleClass="col-num">
+                        <p:outputLabel value="#{ss.epfCompanyValue}">
+                            <f:convertNumber pattern="#,##0.00" />
+                        </p:outputLabel>
+                    </p:column>
+
+                    <p:column headerText="ETF company value" styleClass="col-num">
+                        <p:outputLabel value="#{ss.etfCompanyValue}">
+                            <f:convertNumber pattern="#,##0.00" />
+                        </p:outputLabel>
+                    </p:column>
+
+                    <p:column headerText="Total" styleClass="col-num">
+                        <p:outputLabel value="#{ss.etfCompanyValue + ss.epfCompanyValue + ss.epfValue + ss.componantValue}">
+                            <f:convertNumber pattern="#,##0.00" />
+                        </p:outputLabel>
+                    </p:column>
+
+                    <p:column headerText="Editor" styleClass="col-text"
+                              rendered="#{hrReportController.reportKeyWord.bool1}">
+                        <p:outputLabel value="#{ss.lastEditor.webUserPerson.name}" />
+                    </p:column>
+
+                    <p:column headerText="Comment" styleClass="col-text"
+                              rendered="#{hrReportController.reportKeyWord.bool1}">
+                        <p:outputLabel value="#{ss.comments}" />
+                    </p:column>
+
+                    <p:column headerText="Edited at" styleClass="col-text"
+                              rendered="#{hrReportController.reportKeyWord.bool1}">
+                        <p:outputLabel value="#{ss.lastEditedAt}">
+                            <f:convertDateTime pattern="yyyy MMM dd" />
+                        </p:outputLabel>
+                    </p:column>
+
+                    <f:facet name="footer">
+                        <div class="report-table-footer">
+                            <p:outputLabel value="Print by: #{sessionController.loggedUser.webUserPerson.name}" />
+                            <span>·</span>
+                            <p:outputLabel value="#{commonFunctionsProxy.currentDateTime}">
+                                <f:convertDateTime pattern="yyyy MMMM dd hh:mm:ss a" />
+                            </p:outputLabel>
+                        </div>
+                    </f:facet>
+
+                </p:dataTable>
+
+            </p:panel>
+
+            <!-- Bank letter panel — only when bank + component filter applied -->
+            <p:panel styleClass="bank-letter-panel"
+                     rendered="#{hrReportController.reportKeyWord.institutionBank ne null
+                                 and hrReportController.reportKeyWord.paysheetComponent ne null}">
+                <div class="bank-letter-actions">
+                    <p:commandButton value="Print bank letter"
+                                     ajax="false"
+                                     action="#"
+                                     icon="pi pi-print"
+                                     styleClass="btn-action">
+                        <p:printer target="gpBillPreviewPaysheet" />
+                    </p:commandButton>
+                </div>
+                <h:panelGroup id="gpBillPreviewPaysheet">
+                    <salary:bank_letter salary="#{hrReportController.staffSalaryComponants}"
+                                        bank="#{hrReportController.reportKeyWord.institutionBank}"
+                                        component="#{hrReportController.reportKeyWord.paysheetComponent}"
+                                        total="#{hrReportController.total}" />
+                </h:panelGroup>
+            </p:panel>
+
+        </h:form>
+    </ui:define>
+
+</ui:composition>

--- a/src/main/webapp/hr/hr_reports.xhtml
+++ b/src/main/webapp/hr/hr_reports.xhtml
@@ -9,7 +9,6 @@
 
             <ui:define name="content">
 
-
                 <div class="container-flex" >
                     <div class="row" >
                         <div class="col-2" >
@@ -18,192 +17,190 @@
                                     <p:accordionPanel >
                                         <p:tab title="(1) Salary Report">
                                             <h:panelGrid columns="1">
-                                                <!--                                <p:commandButton value="(1) All Staff Salary Detail" 
-                                                                                                action="/hr/hr_report_all_staff_salary" 
-                                                                                                 class="w-100 my-1" ajax="false"  /> -->
                                                 <p:commandButton value="(2) All Staff Salary Summary" 
-                                                                 action="/hr/hr_report_staff_salary" 
+                                                                 action="/hr/hr_report_staff_salary?faces-redirect=true" 
                                                                  class="w-100 my-1" ajax="false" /> 
                                                 <p:commandButton value="(2.1) All Staff Salary Summary(By Department)" 
-                                                                 action="/hr/hr_report_staff_salary_by_department" 
+                                                                 action="/hr/hr_report_staff_salary_by_department?faces-redirect=true" 
                                                                  class="w-100 my-1" ajax="false" /> 
                                                 <p:commandButton value="(3) Staff Payroll" 
-                                                                 action="/hr/hr_report_staff_payroll" 
+                                                                 action="/hr/hr_report_staff_payroll?faces-redirect=true" 
                                                                  class="w-100 my-1" ajax="false" />
                                                 <p:commandButton value="(3) Staff Payroll(Accountant)" 
-                                                                 action="/hr/hr_report_staff_payroll_1" 
+                                                                 action="/hr/hr_report_staff_payroll_1?faces-redirect=true" 
                                                                  class="w-100 my-1" ajax="false" />
                                                 <p:commandButton value="(3.1) Staff Payrol(By Department)" 
-                                                                 action="/hr/hr_report_staff_payroll_department" 
+                                                                 action="/hr/hr_report_staff_payroll_department?faces-redirect=true" 
                                                                  class="w-100 my-1" ajax="false" />
                                                 <p:commandButton value="(3.2) Staff Payroll(By Roster)" 
-                                                                 action="/hr/hr_report_staff_payroll_roster" 
+                                                                 action="/hr/hr_report_staff_payroll_roster?faces-redirect=true" 
                                                                  class="w-100 my-1" ajax="false" />
                                                 <p:commandButton value="(3.1) Staff Payroll(Selected Staff)" 
-                                                                 action="/hr/hr_staff_salary_1" 
+                                                                 action="/hr/hr_staff_salary_1?faces-redirect=true" 
                                                                  class="w-100 my-1" ajax="false" />
-                                                <p:commandButton value="(4) Staff Over Time " 
-                                                                 action="/hr/hr_report_staff_over_time" 
+                                                <p:commandButton value="(4) Staff Over Time" 
+                                                                 action="/hr/hr_report_staff_over_time?faces-redirect=true" 
                                                                  class="w-100 my-1" ajax="false" />  
-                                                <p:commandButton value="(5)No Pay And Salary Allovance  Report " 
-                                                                 action="/hr/hr_report_staff_no_pay_and_late" 
+                                                <p:commandButton value="(5) No Pay And Salary Allowance Report" 
+                                                                 action="/hr/hr_report_staff_no_pay_and_late?faces-redirect=true" 
                                                                  class="w-100 my-1" ajax="false" />  
                                                 <p:commandButton ajax="false"
-                                                                 action="/hr/hr_staff_paysheet_component_list"
-                                                                 value="(6) Staff Paysheet Component  List" 
+                                                                 action="/hr/hr_staff_paysheet_component_list?faces-redirect=true"
+                                                                 value="(6) Staff Paysheet Component List" 
                                                                  class="w-100 my-1"
                                                                  actionListener="#{staffBasicController.makeItemNul()}"  />
-                                                <p:commandButton ajax="false" action="/hr/hr_report_staff_salary_payment_bank"
+                                                <p:commandButton ajax="false" 
+                                                                 action="/hr/hr_report_staff_salary_payment_bank?faces-redirect=true"
                                                                  value="(7) Staff Salary Payment To Bank" 
                                                                  class="w-100 my-1"
                                                                  actionListener="#{staffBasicController.makeItemNul()}"  />
-                                                <p:commandButton ajax="false" action="/hr/hr_report_staff_salary_payment_bank_summery"
+                                                <p:commandButton ajax="false" 
+                                                                 action="/hr/hr_report_staff_salary_payment_bank_summery?faces-redirect=true"
                                                                  value="(7.1) Staff Salary Bank Vise" 
                                                                  class="w-100 my-1"
                                                                  actionListener="#{staffBasicController.makeItemNul()}"  />
-                                                <p:commandButton ajax="false" action="/hr/hr_Hreport_staff_salary_component"
+                                                <p:commandButton ajax="false" 
+                                                                 action="/hr/hr_Hreport_staff_salary_component?faces-redirect=true"
                                                                  value="(8) Staff Salary Component" 
                                                                  class="w-100 my-1"
                                                                  actionListener="#{staffBasicController.makeItemNul()}"  />
-                                                <p:commandButton ajax="false" action="/hr/hr_report_staff_salary_component_summery_bank_vise"
+                                                <p:commandButton ajax="false" 
+                                                                 action="/hr/hr_report_staff_salary_component_summery_bank_vise?faces-redirect=true"
                                                                  value="(8.1) Staff Salary Component(Bank Vise)" 
                                                                  class="w-100 my-1"
                                                                  actionListener="#{staffBasicController.makeItemNul()}"  />
-                                                <p:commandButton ajax="false" action="/hr/hr_report_staff_epf_etf_1"
+                                                <p:commandButton ajax="false" 
+                                                                 action="/hr/hr_report_staff_epf_etf_1?faces-redirect=true"
                                                                  value="(9) EPF" 
                                                                  class="w-100 my-1"
                                                                  actionListener="#{staffBasicController.makeItemNul()}"  />
-                                                <p:commandButton ajax="false" action="/hr/hr_report_staff_epf_etf"
+                                                <p:commandButton ajax="false" 
+                                                                 action="/hr/hr_report_staff_epf_etf?faces-redirect=true"
                                                                  value="(9.1) ETF" 
                                                                  class="w-100 my-1"
                                                                  actionListener="#{staffBasicController.makeItemNul()}"  />
-                                                <p:commandButton ajax="false" action="/hr/hr_report_staff_epf_etf_to_export"
+                                                <p:commandButton ajax="false" 
+                                                                 action="/hr/hr_report_staff_epf_etf_to_export?faces-redirect=true"
                                                                  value="(9.2) EPF ETF(Export)" 
                                                                  class="w-100 my-1"
                                                                  actionListener="#{staffBasicController.makeItemNul()}"  />
-                                                <p:commandButton ajax="false" action="/hr/hr_report_staff_salary_generate _or_not"
+                                                <p:commandButton ajax="false" 
+                                                                 action="/hr/hr_report_staff_salary_generate_or_not?faces-redirect=true"
                                                                  value="(10) Staff Salary Generate Or Not Report" 
                                                                  class="w-100 my-1"
                                                                  actionListener="#{hrReportController.makeNull()}"  />
-                                                <p:commandButton ajax="false" action="/hr/hr_report_staff_salary_deleted_report"
+                                                <p:commandButton ajax="false" 
+                                                                 action="/hr/hr_report_staff_salary_deleted_report?faces-redirect=true"
                                                                  value="(11) Staff Salary Generate Or Delete Detail Report" 
                                                                  class="w-100 my-1"
                                                                  actionListener="#{hrReportController.makeNull()}"  />
-                                                <p:commandButton ajax="false" action="/hr/hr_report_grativity"
+                                                <p:commandButton ajax="false" 
+                                                                 action="/hr/hr_report_grativity?faces-redirect=true"
                                                                  value="(12) Staff Gratuity" 
                                                                  class="w-100 my-1"
                                                                  actionListener="#{hrReportController.makeNull()}"  />
                                             </h:panelGrid>
-
                                         </p:tab>
 
                                         <p:tab title="(2) Attendance">
                                             <h:panelGrid columns="1">
                                                 <p:commandButton value="(1) Attendance Report" 
-                                                                 action="hr_report_attendance" 
+                                                                 action="/hr/hr_report_attendance?faces-redirect=true" 
                                                                  actionListener="#{hrReportController.makeNull()}" 
                                                                  class="w-100 my-1" ajax="false" /> 
-                                                <p:commandButton value="(2) Early In " 
-                                                                 action="hr_report_attendance_early_in" 
-                                                                 actionListener="#{hrReportController.makeNull()}" 
-                                                                 class="w-100 my-1" ajax="false" rendered="fasle"  /> 
-                                                <p:commandButton value="(3) Early Out " 
-                                                                 action="hr_report_attendance_early_out" 
-                                                                 actionListener="#{hrReportController.makeNull()}" 
-                                                                 class="w-100 my-1" ajax="false" rendered="false"/> 
-                                                <p:commandButton value="(4) Late In " 
-                                                                 action="hr_report_attendance_late_in" 
+                                                <p:commandButton value="(2) Early In" 
+                                                                 action="/hr/hr_report_attendance_early_in?faces-redirect=true" 
                                                                  actionListener="#{hrReportController.makeNull()}" 
                                                                  class="w-100 my-1" ajax="false" rendered="false" /> 
-                                                <p:commandButton value="(5) Late Out " 
-                                                                 action="hr_report_attendance_late_out" 
+                                                <p:commandButton value="(3) Early Out" 
+                                                                 action="/hr/hr_report_attendance_early_out?faces-redirect=true" 
                                                                  actionListener="#{hrReportController.makeNull()}" 
-                                                                 class="w-100 my-1" ajax="false" rendered="false"/> 
-                                                <p:commandButton value="(6) Late In and Early Out " 
-                                                                 action="hr_report_attendance_late_in_early_out" 
+                                                                 class="w-100 my-1" ajax="false" rendered="false" /> 
+                                                <p:commandButton value="(4) Late In" 
+                                                                 action="/hr/hr_report_attendance_late_in?faces-redirect=true" 
+                                                                 actionListener="#{hrReportController.makeNull()}" 
+                                                                 class="w-100 my-1" ajax="false" rendered="false" /> 
+                                                <p:commandButton value="(5) Late Out" 
+                                                                 action="/hr/hr_report_attendance_late_out?faces-redirect=true" 
+                                                                 actionListener="#{hrReportController.makeNull()}" 
+                                                                 class="w-100 my-1" ajax="false" rendered="false" /> 
+                                                <p:commandButton value="(6) Late In and Early Out" 
+                                                                 action="/hr/hr_report_attendance_late_in_early_out?faces-redirect=true" 
                                                                  actionListener="#{hrReportController.makeNull()}" 
                                                                  class="w-100 my-1" ajax="false" />
-
                                                 <p:commandButton value="(8) Staff Shift Detail By Staff" 
-                                                                 action="hr_report_summery_by_staff" 
+                                                                 action="/hr/hr_report_summery_by_staff?faces-redirect=true" 
                                                                  actionListener="#{hrReportController.makeNull()}" 
                                                                  class="w-100 my-1" ajax="false" />
-
                                                 <p:commandButton value="(9) Verified Report" 
-                                                                 action="hr_form_staff_shift_report" 
+                                                                 action="/hr/hr_form_staff_shift_report?faces-redirect=true" 
                                                                  actionListener="#{hrReportController.makeNull()}" 
                                                                  class="w-100 my-1" ajax="false" />
-
                                             </h:panelGrid>
-
                                         </p:tab>
 
                                         <p:tab title="(3) Administration">
                                             <h:panelGrid columns="1">
-                                                <p:commandButton value="(1) Department Report " 
-                                                                 action="hr_report_department" 
+                                                <p:commandButton value="(1) Department Report" 
+                                                                 action="/hr/hr_report_department?faces-redirect=true" 
                                                                  actionListener="#{hrReportController.makeNull()}" 
                                                                  class="w-100 my-1" ajax="false" /> 
-                                                <p:commandButton value="(2) Employee Detail " 
-                                                                 action="hr_report_employee_detail" 
+                                                <p:commandButton value="(2) Employee Detail" 
+                                                                 action="/hr/hr_report_employee_detail?faces-redirect=true" 
                                                                  actionListener="#{hrReportController.makeNull()}" 
                                                                  class="w-100 my-1" ajax="false" />
                                                 <p:commandButton value="(3) Employee Detail Zone Code" 
-                                                                 action="hr_report_employee_detail_zone_code" 
+                                                                 action="/hr/hr_report_employee_detail_zone_code?faces-redirect=true" 
                                                                  actionListener="#{hrReportController.makeNull()}" 
                                                                  class="w-100 my-1" ajax="false" />
-
                                                 <p:commandButton value="(4) Employee EPF Detail" 
-                                                                 action="hr_report_epf_detail" 
+                                                                 action="/hr/hr_report_epf_detail?faces-redirect=true" 
                                                                  actionListener="#{hrReportController.makeNull()}" 
                                                                  class="w-100 my-1" ajax="false" />
                                                 <p:commandButton value="(5) Employee Retierd Details" 
-                                                                 action="hr_report_employee_detail_1" 
+                                                                 action="/hr/hr_report_employee_detail_1?faces-redirect=true" 
                                                                  actionListener="#{hrReportController.makeNull()}" 
                                                                  class="w-100 my-1" ajax="false" />
                                             </h:panelGrid>
-
                                         </p:tab>
 
                                         <p:tab title="(4) Shift">
                                             <h:panelGrid columns="1">
                                                 <p:commandButton value="(1) Staff Shift Report" 
-                                                                 action="hr_report_staff_shift" 
+                                                                 action="/hr/hr_report_staff_shift?faces-redirect=true" 
                                                                  actionListener="#{hrReportController.makeNull()}" 
                                                                  class="w-100 my-1" ajax="false" />
-                                                <p:commandButton value="(2) Staff Extra Shift " 
-                                                                 action="hr_report_staff_shift_extra" 
+                                                <p:commandButton value="(2) Staff Extra Shift" 
+                                                                 action="/hr/hr_report_staff_shift_extra?faces-redirect=true" 
                                                                  actionListener="#{hrReportController.makeNull()}" 
                                                                  class="w-100 my-1" ajax="false" />
                                                 <p:commandButton value="(3) Entered Shift Report" 
-                                                                 action="hr_shift_report" 
+                                                                 action="/hr/hr_shift_report?faces-redirect=true" 
                                                                  actionListener="#{hrReportController.makeNull()}" 
                                                                  class="w-100 my-1" ajax="false" />
                                                 <p:commandButton value="(4) Roster Table and verify Time" 
-                                                                 action="hr_report_shift_table" 
+                                                                 action="/hr/hr_report_shift_table?faces-redirect=true" 
                                                                  actionListener="#{shiftTableController.makeTableNull()}"
                                                                  class="w-100 my-1" ajax="false" />
-
                                             </h:panelGrid>
-
                                         </p:tab>
 
                                         <p:tab title="(5) Finger Print Records">
                                             <h:panelGrid columns="1">
                                                 <p:commandButton value="(1) Finger Print Record By Logged" 
-                                                                 action="hr_report_finger_print_record_logged" 
+                                                                 action="/hr/hr_report_finger_print_record_logged?faces-redirect=true" 
                                                                  actionListener="#{hrReportController.makeNull()}" 
                                                                  class="w-100 my-1" ajax="false" /> 
                                                 <p:commandButton value="(2) Finger Print Record By Verified" 
-                                                                 action="hr_report_finger_print_record_verified" 
+                                                                 action="/hr/hr_report_finger_print_record_verified?faces-redirect=true" 
                                                                  actionListener="#{hrReportController.makeNull()}" 
                                                                  class="w-100 my-1" ajax="false" /> 
                                                 <p:commandButton value="(3) Finger Print Record No Shift Setted" 
-                                                                 action="hr_report_finger_print_record_no_shift_setted" 
+                                                                 action="/hr/hr_report_finger_print_record_no_shift_setted?faces-redirect=true" 
                                                                  actionListener="#{hrReportController.makeNull()}" 
                                                                  class="w-100 my-1" ajax="false" /> 
                                                 <p:commandButton value="(4) Finger Print Approve" 
-                                                                 action="hr_report_finger_print_record_approved" 
+                                                                 action="/hr/hr_report_finger_print_record_approved?faces-redirect=true" 
                                                                  actionListener="#{hrReportController.makeNull()}" 
                                                                  class="w-100 my-1" ajax="false" /> 
                                             </h:panelGrid>
@@ -211,91 +208,87 @@
 
                                         <p:tab title="(6) Summary">
                                             <h:panelGrid columns="1">
-                                                <p:commandButton value="(1) Head Count " 
-                                                                 action="hr_report_head_count" 
+                                                <p:commandButton value="(1) Head Count" 
+                                                                 action="/hr/hr_report_head_count?faces-redirect=true" 
                                                                  actionListener="#{hrReportController.makeNull()}" 
                                                                  class="w-100 my-1" ajax="false" /> 
                                                 <p:commandButton value="(2) Employee Worked Day Report" 
-                                                                 action="hr_report_month_end_employee_date" 
+                                                                 action="/hr/hr_report_month_end_employee_date?faces-redirect=true" 
                                                                  actionListener="#{hrReportController.makeNull()}" 
                                                                  class="w-100 my-1" ajax="false" /> 
                                                 <p:commandButton value="(2.1) Employee Worked Day Report(New)" 
-                                                                 action="hr_report_month_end_employee_date_1" 
+                                                                 action="/hr/hr_report_month_end_employee_date_1?faces-redirect=true" 
                                                                  actionListener="#{hrReportController.makeNull()}" 
                                                                  class="w-100 my-1" ajax="false" />
-                                                <p:commandButton value="(3) Month End Employee Working Time + 
-                                                                 Over Time Report-By Minute " 
-                                                                 action="hr_report_month_end_work_time" 
+                                                <p:commandButton value="(3) Month End Employee Working Time + Over Time Report-By Minute" 
+                                                                 action="/hr/hr_report_month_end_work_time?faces-redirect=true" 
                                                                  actionListener="#{hrReportController.makeNull()}" 
                                                                  class="w-100 my-1" ajax="false" /> 
-                                                <p:commandButton value="(3.1) Month End Employee Working Time + 
-                                                                 Over Time Report-By Minute(Minute) " 
-                                                                 action="hr_report_month_end_work_time_miniuts" 
+                                                <p:commandButton value="(3.1) Month End Employee Working Time + Over Time Report-By Minute(Minute)" 
+                                                                 action="/hr/hr_report_month_end_work_time_miniuts?faces-redirect=true" 
                                                                  actionListener="#{hrReportController.makeNull()}" 
                                                                  class="w-100 my-1" ajax="false" />
-                                                <p:commandButton value="(3.2) Month End Employee Working Time + 
-                                                                 Over Time Report-By Minute(Minute) Summary (New)" 
-                                                                 action="hr_report_month_end_work_time_miniuts_summery" 
+                                                <p:commandButton value="(3.2) Month End Employee Working Time + Over Time Report-By Minute(Minute) Summary (New)" 
+                                                                 action="/hr/hr_report_month_end_work_time_miniuts_summery?faces-redirect=true" 
                                                                  actionListener="#{hrReportController.makeNull()}" 
                                                                  class="w-100 my-1" ajax="false" />
-                                                <p:commandButton value="(4) Month End Employee (No Pay) Report-By Minute " 
-                                                                 action="hr_report_month_end_work_time_no_pay" 
+                                                <p:commandButton value="(4) Month End Employee (No Pay) Report-By Minute" 
+                                                                 action="/hr/hr_report_month_end_work_time_no_pay?faces-redirect=true" 
                                                                  actionListener="#{hrReportController.makeNull()}" 
                                                                  class="w-100 my-1" ajax="false" /> 
-                                                <p:commandButton value="(5) Month End Employee Summary " 
-                                                                 action="hr_report_month_end_staff_shift_data" 
+                                                <p:commandButton value="(5) Month End Employee Summary" 
+                                                                 action="/hr/hr_report_month_end_staff_shift_data?faces-redirect=true" 
                                                                  actionListener="#{hrReportController.makeNull()}" 
                                                                  class="w-100 my-1" ajax="false" /> 
-
                                             </h:panelGrid>
                                         </p:tab>
 
                                         <p:tab title="(7) Leave">
                                             <h:panelGrid columns="1">
-                                                <p:commandButton value="(1) Leave Report " 
-                                                                 action="hr_report_leave" 
+                                                <p:commandButton value="(1) Leave Report" 
+                                                                 action="/hr/hr_report_leave?faces-redirect=true" 
                                                                  actionListener="#{hrReportController.makeNull()}" 
                                                                  class="w-100 my-1" ajax="false" /> 
-                                                <p:commandButton value="(2) Leave Report Summary " 
-                                                                 action="hr_report_leave_summery" 
+                                                <p:commandButton value="(2) Leave Report Summary" 
+                                                                 action="/hr/hr_report_leave_summery?faces-redirect=true" 
                                                                  actionListener="#{hrReportController.makeNull()}" 
                                                                  class="w-100 my-1" ajax="false" /> 
-                                                <p:commandButton value="(3) Leave Report Detail By Staff " 
-                                                                 action="hr_report_leave_summery_by_staff" 
+                                                <p:commandButton value="(3) Leave Report Detail By Staff" 
+                                                                 action="/hr/hr_report_leave_summery_by_staff?faces-redirect=true" 
                                                                  actionListener="#{hrReportController.makeNull()}" 
                                                                  class="w-100 my-1" ajax="false" />
                                                 <p:commandButton value="(4) Late Leave" 
-                                                                 action="hr_report_leave_system" 
+                                                                 action="/hr/hr_report_leave_system?faces-redirect=true" 
                                                                  actionListener="#{hrReportController.makeNull()}" 
                                                                  class="w-100 my-1" ajax="false" />
                                                 <p:commandButton value="(4) Late Leave(Detail)" 
-                                                                 action="hr_report_leave_system_1" 
+                                                                 action="/hr/hr_report_leave_system_1?faces-redirect=true" 
                                                                  actionListener="#{hrReportController.makeNull()}" 
                                                                  class="w-100 my-1" ajax="false" />
                                             </h:panelGrid>
                                         </p:tab>
+
                                         <p:tab title="(8) Working Time">
                                             <h:panelGrid columns="1">
                                                 <p:commandButton value="(1) Worked Time" 
-                                                                 action="hr_report_staff_shift_detail" 
+                                                                 action="/hr/hr_report_staff_shift_detail?faces-redirect=true" 
                                                                  actionListener="#{hrReportController.makeNull()}" 
                                                                  class="w-100 my-1" ajax="false" /> 
                                                 <p:commandButton value="(2) Over Time" 
-                                                                 action="hr_report_over_time" 
+                                                                 action="/hr/hr_report_over_time?faces-redirect=true" 
                                                                  actionListener="#{hrReportController.makeNull()}" 
                                                                  class="w-100 my-1" ajax="false" />
                                             </h:panelGrid>
                                         </p:tab>
 
                                         <p:tab title="(9) History">
-                                                <!--rendered="#{webUserController.hasPrivilege('EmployeeHistoryReport')}" >-->
                                             <h:panelGrid columns="1">
                                                 <p:commandButton value="(1) Staff Shift History" 
-                                                                 action="hr_report_staff_shift_history" 
+                                                                 action="/hr/hr_report_staff_shift_history?faces-redirect=true" 
                                                                  actionListener="#{hrReportController.makeNull()}" 
                                                                  class="w-100 my-1" ajax="false" /> 
-                                                <p:commandButton value="(2)Finger Print History" 
-                                                                 action="hr_report_finger_print_history" 
+                                                <p:commandButton value="(2) Finger Print History" 
+                                                                 action="/hr/hr_report_finger_print_history?faces-redirect=true" 
                                                                  actionListener="#{hrReportController.makeNull()}" 
                                                                  class="w-100 my-1" ajax="false" />
                                             </h:panelGrid>
@@ -303,20 +296,20 @@
 
                                         <p:tab title="(10) Form">
                                             <h:panelGrid columns="1">
-                                                <p:commandButton value="(1)Additional Form Report" 
-                                                                 action="hr_form_staff_additional_report_1" 
+                                                <p:commandButton value="(1) Additional Form Report" 
+                                                                 action="/hr/hr_form_staff_additional_report_1?faces-redirect=true" 
                                                                  actionListener="#{hrReportController.makeNull()}" 
                                                                  class="w-100 my-1" ajax="false" />
-                                                <p:commandButton value="(2)Leave Form Report" 
-                                                                 action="hr_form_staff_leave_report" 
+                                                <p:commandButton value="(2) Leave Form Report" 
+                                                                 action="/hr/hr_form_staff_leave_report?faces-redirect=true" 
                                                                  actionListener="#{hrReportController.makeNull()}" 
                                                                  class="w-100 my-1" ajax="false" />
-                                                <p:commandButton value="(3)Additional Form Report Varification" 
-                                                                 action="hr_form_staff_additional_report" 
+                                                <p:commandButton value="(3) Additional Form Report Varification" 
+                                                                 action="/hr/hr_form_staff_additional_report?faces-redirect=true" 
                                                                  actionListener="#{hrReportController.makeNull()}" 
                                                                  class="w-100 my-1" ajax="false" />
-                                                <p:commandButton value="(4)Form Report That Not Comes To Analysed" 
-                                                                 action="hr_form_staff_form_report" 
+                                                <p:commandButton value="(4) Form Report That Not Comes To Analysed" 
+                                                                 action="/hr/hr_form_staff_form_report?faces-redirect=true" 
                                                                  actionListener="#{hrReportController.makeNull()}" 
                                                                  class="w-100 my-1" ajax="false" />
                                             </h:panelGrid>
@@ -325,13 +318,13 @@
                                         <p:tab title="(11) Hr Edit">
                                             <h:panelGrid columns="1">
                                                 <p:commandButton value="Edit Leave" 
-                                                                 action="hr_staff_leave_edit_search" 
+                                                                 action="/hr/hr_staff_leave_edit_search?faces-redirect=true" 
                                                                  class="w-100 my-1" ajax="false" />
                                                 <p:commandButton value="Edit Shift" 
-                                                                 action="hr_shift_staff_edit_search" 
+                                                                 action="/hr/hr_shift_staff_edit_search?faces-redirect=true" 
                                                                  class="w-100 my-1" ajax="false" />
                                                 <p:commandButton value="Edit Finger Print Record" 
-                                                                 action="hr_staff_finger_edit_search" 
+                                                                 action="/hr/hr_staff_finger_edit_search?faces-redirect=true" 
                                                                  class="w-100 my-1" ajax="false" />
                                             </h:panelGrid>
                                         </p:tab>
@@ -339,17 +332,19 @@
                                         <p:tab title="(12) Hr Holydays">
                                             <h:panelGrid columns="1">
                                                 <p:commandButton value="Holyday Report" 
-                                                                 action="hr_report_ph_date" 
+                                                                 action="/hr/hr_report_ph_date?faces-redirect=true" 
                                                                  class="w-100 my-1" ajax="false" />
                                             </h:panelGrid>
                                         </p:tab>
+
                                         <p:tab title="(13) Staff Reports">
                                             <h:panelGrid columns="1">
                                                 <p:commandButton value="Staff Details" 
-                                                                 action="/hr/report_staff_details" 
+                                                                 action="/hr/report_staff_details?faces-redirect=true" 
                                                                  class="w-100 my-1" ajax="false" />
                                             </h:panelGrid>
                                         </p:tab>
+
                                     </p:accordionPanel>
                                 </p:panel>
                             </h:form>
@@ -363,8 +358,6 @@
                     </div>
 
                 </div>
-
-
 
             </ui:define>
 

--- a/src/main/webapp/hr/hr_reports.xhtml
+++ b/src/main/webapp/hr/hr_reports.xhtml
@@ -60,7 +60,7 @@
                                                                  class="w-100 my-1"
                                                                  actionListener="#{staffBasicController.makeItemNul()}"  />
                                                 <p:commandButton ajax="false" 
-                                                                 action="/hr/hr_Hreport_staff_salary_component?faces-redirect=true"
+                                                                 action="/hr/hr_report_staff_salary_component?faces-redirect=true"
                                                                  value="(8) Staff Salary Component" 
                                                                  class="w-100 my-1"
                                                                  actionListener="#{staffBasicController.makeItemNul()}"  />

--- a/src/main/webapp/resources/ezcomp/menu.xhtml
+++ b/src/main/webapp/resources/ezcomp/menu.xhtml
@@ -1921,7 +1921,7 @@
                         icon="fa fa-cogs" value="Processes"  />
                     <p:menuitem  
                         ajax="false"  
-                        action="/hr/hr_reports" 
+                        action="/hr/hr_reports?faces-redirect=true" 
                         icon="fa fa-chart-bar" value="HR Analytics" 
                         rendered="#{webUserController.hasPrivilege('HrReports')}" />
 


### PR DESCRIPTION
## Summary

Migrated the Staff Salary Component view from a legacy full-HTML JSF page to the
standard `ui:composition` pattern used across the HR reports module.

## Changes

### Layout
- Replaced `html`/`h:body` root with `ui:composition` + `ui:define name="content"`
- Replaced `h:panelGrid` filter layout with a CSS `fields-grid` (2-col) using
  `field-group` + `field-label` pattern
- Moved inline styles to `h:outputStylesheet` with a scoped form class
  (`.salary-component-form`)
- Split action bar into two logical rows:
  - **Process actions** — Process, Process special
  - **Secondary actions** — Print, Export Excel
- Bank letter panel extracted into a clearly scoped `.bank-letter-panel` section with
  its own `bank-letter-actions` button bar
- Added PrimeFaces Icons (`pi-sync`, `pi-print`, `pi-file-excel`) to all buttons
- Replaced flat report header with a centred `.report-header-wrap` facet including
  SC cycle date range, matching the overtime report pattern
- Replaced print footer label chain with `.report-table-footer` flex row

### Table
- Added `table-layout: auto` + `white-space: nowrap` via `.salary-comp-table` for
  auto-width columns; removed per-column `style="text-wrap: avoid..."` overrides
- Removed `style="text-align: right"` from columns; alignment handled via `.col-num` /
  `.col-text` utility classes
- Removed duplicate `Bank` column (`ss.staffPaysheetComponent.id` was incorrectly
  labelled "Bank" — the ID is already shown in the `ID` column)
- Fixed typos: `Opennig` → `Opening`, `Editer` → `Editor`, `Componet` → `Component`

### Inputs
- Added `id`, `appendTo="@body"`, `autoWidth="false"` to salary cycle `p:selectOneMenu`
- Adjusted components checkbox converted to `p:selectBooleanCheckbox` with `id` +
  `h:outputLabel for=` for accessibility

## No functional changes

All bean bindings, EL expressions, conditional column rendering, `salary:bank_letter`
composite, footer totals, and export targets are unchanged.