### PR TITLE
feat(shift-guard): enforce shift-start check on inward payment pages

### DIFF
--- a/src/main/java/com/divudi/bean/cashTransaction/FinancialTransactionController.java
+++ b/src/main/java/com/divudi/bean/cashTransaction/FinancialTransactionController.java
@@ -357,17 +357,21 @@ public class FinancialTransactionController implements Serializable {
         if (!sessionController.getPaymentManagementAfterShiftStart()) {
             return;
         }
+        FacesContext fc = FacesContext.getCurrentInstance();
+        // Skip the check on postbacks — the shift was already verified on initial load
+        if (fc.isPostback()) {
+            return;
+        }
         findNonClosedShiftStartFundBillIsAvailable();
         if (nonClosedShiftStartFundBill != null) {
             return;
         }
         try {
+            // Preserve the error message across the redirect
+            fc.getExternalContext().getFlash().setKeepMessages(true);
             JsfUtil.addErrorMessage("Start Your Shift First !");
-            FacesContext.getCurrentInstance()
-                    .getExternalContext()
-                    .redirect(FacesContext.getCurrentInstance()
-                            .getExternalContext()
-                            .getRequestContextPath() + "/cashier/index.xhtml");
+            fc.getExternalContext().redirect(
+                    fc.getExternalContext().getRequestContextPath() + "/faces/cashier/index.xhtml");
         } catch (java.io.IOException e) {
             // redirect failed — nothing further we can do at render time
         }

--- a/src/main/java/com/divudi/bean/cashTransaction/FinancialTransactionController.java
+++ b/src/main/java/com/divudi/bean/cashTransaction/FinancialTransactionController.java
@@ -346,6 +346,33 @@ public class FinancialTransactionController implements Serializable {
         }
     }
 
+    /**
+     * Page-level shift guard. Call from f:event type="preRenderView" on any
+     * financial transaction page. When the config is enabled and no active
+     * shift bill exists for the current user, shows an error and redirects to
+     * the cashier index. Safe to call on every page load — does nothing when
+     * the config is disabled.
+     */
+    public void redirectIfShiftNotStarted() {
+        if (!sessionController.getPaymentManagementAfterShiftStart()) {
+            return;
+        }
+        findNonClosedShiftStartFundBillIsAvailable();
+        if (nonClosedShiftStartFundBill != null) {
+            return;
+        }
+        try {
+            JsfUtil.addErrorMessage("Start Your Shift First !");
+            FacesContext.getCurrentInstance()
+                    .getExternalContext()
+                    .redirect(FacesContext.getCurrentInstance()
+                            .getExternalContext()
+                            .getRequestContextPath() + "/cashier/index.xhtml");
+        } catch (java.io.IOException e) {
+            // redirect failed — nothing further we can do at render time
+        }
+    }
+
     public String navigateToNewIncomeBill() {
         resetClassVariables();
         currentBill = new Bill();

--- a/src/main/webapp/credit/credit_compnay_bill_inward.xhtml
+++ b/src/main/webapp/credit/credit_compnay_bill_inward.xhtml
@@ -12,6 +12,7 @@
         xmlns:pa="http://xmlns.jcp.org/jsf/composite/paymentMethod">
 
     <ui:define name="admin">
+        <f:event type="preRenderView" listener="#{financialTransactionController.redirectIfShiftNotStarted()}"/>
         <h:panelGroup >
             <h:form  >
                 <p:growl id="growl" showDetail="true" />

--- a/src/main/webapp/credit/credit_compnay_bill_payment_inward.xhtml
+++ b/src/main/webapp/credit/credit_compnay_bill_payment_inward.xhtml
@@ -10,6 +10,7 @@
                 xmlns:pa="http://xmlns.jcp.org/jsf/composite/paymentMethod">
 
     <ui:define name="admin">
+        <f:event type="preRenderView" listener="#{financialTransactionController.redirectIfShiftNotStarted()}"/>
         <h:panelGroup >
             <h:form  >
                 <p:panel rendered="#{!cashRecieveBillController.printPreview}" >

--- a/src/main/webapp/credit/inward_patient_copay_payment.xhtml
+++ b/src/main/webapp/credit/inward_patient_copay_payment.xhtml
@@ -13,6 +13,7 @@
         xmlns:bill="http://xmlns.jcp.org/jsf/composite/inward/bill/payment">
 
     <ui:define name="admin">
+        <f:event type="preRenderView" listener="#{financialTransactionController.redirectIfShiftNotStarted()}"/>
         <h:panelGroup rendered="#{webUserController.hasPrivilege('InwardBilling')}">
         <h:panelGroup>
             <h:form id="copayForm">

--- a/src/main/webapp/inward/inward_bill_payment.xhtml
+++ b/src/main/webapp/inward/inward_bill_payment.xhtml
@@ -14,6 +14,7 @@
 
 
     <ui:define name="content">
+        <f:event type="preRenderView" listener="#{financialTransactionController.redirectIfShiftNotStarted()}"/>
         <h:panelGroup rendered="#{inwardPaymentController.current.patientEncounter eq null}">
             <h:form>
                 <p:panel>

--- a/src/main/webapp/patient_deposit/receive.xhtml
+++ b/src/main/webapp/patient_deposit/receive.xhtml
@@ -14,7 +14,7 @@
                 xmlns:pt="http://xmlns.jcp.org/jsf/composite/ezcomp/patient_transactions">
 
     <ui:define name="subcontent">
-
+        <f:event type="preRenderView" listener="#{financialTransactionController.redirectIfShiftNotStarted()}"/>
 
         <h:panelGroup rendered="#{!patientDepositController.printPreview}" >
             <h:form  >


### PR DESCRIPTION
## Summary

- Adds `FinancialTransactionController.redirectIfShiftNotStarted()` — a single reusable page-level shift guard callable from any XHTML page via `<f:event type="preRenderView">`
- Guards 5 inward financial transaction pages that previously had no shift check, allowing users to process payments without starting a shift
- The guard is a no-op when the `"Payment Management can be done after shift start"` config is disabled — zero impact on hospitals not using shift management

## Pages now protected

| Page | Transaction type |
|---|---|
| `inward/inward_bill_payment.xhtml` | Inward patient payment collection |
| `credit/credit_compnay_bill_inward.xhtml` | Credit company inward payment by BHT |
| `credit/credit_compnay_bill_payment_inward.xhtml` | Credit company inward payment by company |
| `credit/inward_patient_copay_payment.xhtml` | Inward patient co-payment |
| `patient_deposit/receive.xhtml` | Patient deposit receipt |

## Why page-level guard

Previous guards lived in individual navigation methods — meaning any new entry point (menu item, hub button, direct URL) would bypass them. Placing the guard on the destination page ensures it fires regardless of how the user arrives.

## Test plan

- [ ] Enable `"Payment Management can be done after shift start"` config option
- [ ] Without starting a shift, attempt to navigate to each of the 5 guarded pages — verify redirect to cashier index with "Start Your Shift First!" error
- [ ] Start a shift, then navigate to each page — verify normal access
- [ ] Disable the config — verify all pages load normally without any shift check

Closes #20851

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added shift verification to payment-related pages. Users attempting to access payment management features without an active shift will now be automatically redirected to the cashier dashboard and shown an error message.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hmislk/hmis/pull/20885?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->