### PR TITLE
Refactor: Align Employee Worked Day Report UI with HR report design system

### DIFF
--- a/src/main/webapp/hr/hr_report_month_end_employee_date.xhtml
+++ b/src/main/webapp/hr/hr_report_month_end_employee_date.xhtml
@@ -1,176 +1,371 @@
 <?xml version='1.0' encoding='UTF-8' ?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml"
-      xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
-      xmlns:h="http://xmlns.jcp.org/jsf/html"
-      xmlns:p="http://primefaces.org/ui"
-      xmlns:f="http://xmlns.jcp.org/jsf/core"
+<!DOCTYPE html>
+<ui:composition xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
+                template="/resources/template/template.xhtml"
+                xmlns:h="http://xmlns.jcp.org/jsf/html"
+                xmlns:p="http://primefaces.org/ui"
+                xmlns:f="http://xmlns.jcp.org/jsf/core"
+                xmlns:hr="http://xmlns.jcp.org/jsf/composite/autocomplete">
 
-      xmlns:hr="http://xmlns.jcp.org/jsf/composite/autocomplete">
+    <ui:define name="content">
 
-    <h:body>
+        <h:form styleClass="ewd-form">
 
-        <ui:composition template="/resources/template/template.xhtml">
+            <h:outputStylesheet>
+                .ewd-form {
+                    padding: 2rem 1.75rem;
+                }
 
-            <ui:define name="content">
+                .page-header {
+                    margin-bottom: 1.75rem;
+                }
 
-                <h:form >
-                    <p:panel >
-                        <f:facet name="header" >
-                            <h:outputLabel value="Employee Worked Day Report" />
-                        </f:facet>
-                        <h:panelGrid columns="2" >
-                            <h:outputLabel value="From : " />
-                            <p:calendar value="#{hrReportController.fromDate}" pattern="#{sessionController.applicationPreference.longDateTimeFormat}"  />
-                            <h:outputLabel value="To : " />
-                            <p:calendar value="#{hrReportController.toDate}" pattern="#{sessionController.applicationPreference.longDateTimeFormat}"  />
-                            <h:outputLabel value="Institution : "/>
-                            <hr:institution value="#{hrReportController.reportKeyWord.institution}"/>
-                            <h:outputLabel value="Department : "/>
-                            <hr:department value="#{hrReportController.reportKeyWord.department}"/>
-                            <h:outputLabel value="Employee : "/>
-                            <hr:completeStaff value="#{hrReportController.reportKeyWord.staff}"/>
-                            <h:outputLabel value="Staff Category : "/>
-                            <hr:completeStaffCategory value="#{hrReportController.reportKeyWord.staffCategory}"/>
-                            <h:outputLabel value="Staff Designation : "/>
-                            <hr:completeDesignation value="#{hrReportController.reportKeyWord.designation}"/>
-                            <h:outputLabel value="Staff Roster : "/>
-                            <hr:completeRoster value="#{hrReportController.reportKeyWord.roster}"/>
-                        </h:panelGrid>
+                .page-title {
+                    font-size: 18px;
+                    font-weight: 600;
+                    margin: 0 0 4px 0;
+                }
 
-                        <p:commandButton ajax="false" value="Process" action="#{hrReportController.createMonthEndReport()}"/>
-                        <p:commandButton ajax="false" value="Excel" styleClass="noPrintButton"  >
-                            <p:dataExporter type="xlsx" target="tb1" fileName="hr_report_month_end_employee_date"  />
+                .page-subtitle {
+                    font-size: 13px;
+                    color: #888;
+                    margin: 0;
+                }
+
+                .controls-panel .ui-panel-content {
+                    padding: 1.5rem 1.75rem !important;
+                }
+
+                .controls-grid {
+                    display: flex;
+                    flex-direction: column;
+                    gap: 1.25rem;
+                }
+
+                .fields-grid {
+                    display: grid;
+                    grid-template-columns: repeat(2, 1fr);
+                    gap: 1rem 1.5rem;
+                }
+
+                .field-group {
+                    display: flex;
+                    flex-direction: column;
+                    gap: 6px;
+                }
+
+                .field-label {
+                    font-size: 11.5px !important;
+                    font-weight: 600 !important;
+                    text-transform: uppercase;
+                    letter-spacing: 0.05em;
+                    color: #888 !important;
+                }
+
+                .controls-actions {
+                    display: flex;
+                    gap: 10px;
+                    align-items: center;
+                    flex-wrap: wrap;
+                }
+
+                .controls-actions-secondary {
+                    display: flex;
+                    gap: 10px;
+                    align-items: center;
+                    flex-wrap: wrap;
+                    padding-top: 0.75rem;
+                    border-top: 1px solid #e8e8e8;
+                }
+
+                .btn-action {
+                    height: 36px !important;
+                    padding: 0 18px !important;
+                    font-size: 13px !important;
+                }
+
+                .report-panel {
+                    margin-top: 1.5rem;
+                }
+
+                .report-panel .ui-panel-content {
+                    padding: 0 !important;
+                }
+
+                .report-header-wrap {
+                    text-align: center;
+                    padding: 1.5rem 1.5rem 1rem;
+                    border-bottom: 1px solid #e8e8e8;
+                }
+
+                .report-title-label {
+                    font-size: 13px;
+                    color: #666;
+                    display: block;
+                    margin-bottom: 2px;
+                }
+
+                .report-meta {
+                    font-size: 13px;
+                    color: #555;
+                    margin-top: 4px;
+                }
+
+                .ewd-table .ui-datatable-tablewrapper {
+                    overflow-x: auto !important;
+                    width: 100% !important;
+                }
+
+                .ewd-table table {
+                    width: auto !important;
+                    table-layout: auto !important;
+                }
+
+                .ewd-table .ui-datatable-data td,
+                .ewd-table .ui-datatable-thead th {
+                    padding: 10px 14px !important;
+                    white-space: nowrap;
+                    font-size: 13px !important;
+                    width: auto !important;
+                }
+
+                .ewd-table .ui-datatable-thead th {
+                    font-size: 12px !important;
+                    font-weight: 600 !important;
+                    text-transform: uppercase;
+                    letter-spacing: 0.03em;
+                    color: #888 !important;
+                    background: #f9f9f9 !important;
+                    border-bottom: 1px solid #e8e8e8 !important;
+                }
+
+                .ewd-table .ui-datatable-data tr:hover td {
+                    background: #f5f7ff !important;
+                }
+
+                .ewd-table .col-text {
+                    text-align: left !important;
+                }
+
+                .ewd-table .col-num {
+                    text-align: right !important;
+                }
+
+                .ewd-table tfoot td {
+                    background: #f9f9f9 !important;
+                    font-weight: 600 !important;
+                    font-size: 13px !important;
+                    border-top: 2px solid #e0e0e0 !important;
+                    padding: 10px 14px !important;
+                }
+
+                .report-table-footer {
+                    display: flex;
+                    justify-content: flex-end;
+                    align-items: center;
+                    gap: 6px;
+                    padding: 0.85rem 1.5rem;
+                    border-top: 1px solid #e8e8e8;
+                    font-size: 12px;
+                    color: #999;
+                }
+            </h:outputStylesheet>
+
+            <div class="page-header">
+                <p class="page-title"><h:outputText value="Employee Worked Day Report" /></p>
+                <p class="page-subtitle"><h:outputText value="Filter by date range, department or employee, then process" /></p>
+            </div>
+
+            <p:panel styleClass="controls-panel">
+                <div class="controls-grid">
+
+                    <div class="fields-grid">
+                        <div class="field-group">
+                            <p:outputLabel value="From" styleClass="field-label" />
+                            <p:calendar id="fromDate"
+                                        value="#{hrReportController.fromDate}"
+                                        pattern="#{sessionController.applicationPreference.longDateTimeFormat}"
+                                        style="width: 100%;" />
+                        </div>
+
+                        <div class="field-group">
+                            <p:outputLabel value="To" styleClass="field-label" />
+                            <p:calendar id="toDate"
+                                        value="#{hrReportController.toDate}"
+                                        pattern="#{sessionController.applicationPreference.longDateTimeFormat}"
+                                        style="width: 100%;" />
+                        </div>
+
+                        <div class="field-group">
+                            <p:outputLabel value="Institution" styleClass="field-label" />
+                            <hr:institution value="#{hrReportController.reportKeyWord.institution}" />
+                        </div>
+
+                        <div class="field-group">
+                            <p:outputLabel value="Department" styleClass="field-label" />
+                            <hr:department value="#{hrReportController.reportKeyWord.department}" />
+                        </div>
+
+                        <div class="field-group">
+                            <p:outputLabel value="Employee" styleClass="field-label" />
+                            <hr:completeStaff value="#{hrReportController.reportKeyWord.staff}" />
+                        </div>
+
+                        <div class="field-group">
+                            <p:outputLabel value="Staff category" styleClass="field-label" />
+                            <hr:completeStaffCategory value="#{hrReportController.reportKeyWord.staffCategory}" />
+                        </div>
+
+                        <div class="field-group">
+                            <p:outputLabel value="Staff designation" styleClass="field-label" />
+                            <hr:completeDesignation value="#{hrReportController.reportKeyWord.designation}" />
+                        </div>
+
+                        <div class="field-group">
+                            <p:outputLabel value="Staff roster" styleClass="field-label" />
+                            <hr:completeRoster value="#{hrReportController.reportKeyWord.roster}" />
+                        </div>
+                    </div>
+
+                    <div class="controls-actions">
+                        <p:commandButton value="Process"
+                                         ajax="false"
+                                         action="#{hrReportController.createMonthEndReport()}"
+                                         icon="pi pi-filter"
+                                         styleClass="btn-action" />
+                    </div>
+
+                    <div class="controls-actions-secondary">
+                        <p:commandButton value="Print"
+                                         type="button"
+                                         icon="pi pi-print"
+                                         styleClass="btn-action">
+                            <p:printer target="gpBillPreview" />
                         </p:commandButton>
-                        <p:commandButton value="Print" ajax="false" action="#" >
-                            <p:printer target="gpBillPreview" ></p:printer>
+                        <p:commandButton value="Export Excel"
+                                         ajax="false"
+                                         icon="pi pi-file-excel"
+                                         styleClass="btn-action noPrintButton">
+                            <p:dataExporter type="xlsx" target="tb1"
+                                            fileName="hr_report_month_end_employee_date" />
                         </p:commandButton>
-                        <p:panel id="gpBillPreview" styleClass="noBorder summeryBorder">
-                            <p:dataTable id="tb1" value="#{hrReportController.monthEndRecords}" var="ss">
-                                <f:facet name="header">
+                    </div>
 
-                                    <h:panelGroup rendered="#{hrReportController.reportKeyWord.institution ne null}" >
-                                        <h:outputLabel value="#{hrReportController.reportKeyWord.institution.name}" />
-                                        <br/>
-                                    </h:panelGroup>
-                                    <h:panelGroup rendered="#{hrReportController.reportKeyWord.department ne null}" >
-                                        <h:outputLabel value="Department : #{hrReportController.reportKeyWord.department.name}"/>
-                                        <br/>
-                                    </h:panelGroup>
-                                    <h:panelGroup rendered="#{hrReportController.reportKeyWord.roster ne null}" >
-                                        <h:outputLabel value="Roster : #{hrReportController.reportKeyWord.roster.name}"/>
-                                        <br/>
-                                    </h:panelGroup>
-                                    <h:outputLabel value="Employee Worked Date Report"/>
-                                    <br/>
-                                    <h:outputLabel value="#{hrReportController.fromDate}">
-                                        <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateTimeFormat}" />
-                                    </h:outputLabel>
-                                    To
-                                    <h:outputLabel value="#{hrReportController.toDate}">
-                                        <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateTimeFormat}" />
-                                    </h:outputLabel>
+                </div>
+            </p:panel>
 
-                                </f:facet>
-                                <p:column headerText="Staff Code" style="text-align: left;">
-                                    <f:facet name="header" >
-                                        <p:outputLabel value="Staff Code" />
-                                    </f:facet>
-                                    <p:outputLabel value="#{ss.staff.codeInterger}" style="font-size: 12px;"/>
-                                </p:column>
-                                <p:column headerText="Staff" style="text-align: left;">
-                                    <f:facet name="header" >
-                                        <p:outputLabel value="Staff" />
-                                    </f:facet>
-                                    <p:outputLabel value="#{ss.staff.person.name}" style="font-size: 12px;"/>
-                                </p:column>
-                                <p:column headerText="Worked Days" style="text-align: right;">
-                                    <f:facet name="header" >
-                                        <p:outputLabel value="Worked Days" />
-                                    </f:facet>
-                                    <p:outputLabel value="#{ss.workedDays}" style="font-size: 12px;"/>
-                                </p:column>
-                                <p:column headerText="Annual Leave" style="text-align: right;">
-                                    <f:facet name="header" >
-                                        <p:outputLabel value="Annual Leave" />
-                                    </f:facet>
-                                    <p:outputLabel value="#{ss.leave_annual}" style="font-size: 12px;"/>
-                                </p:column>
-                                <p:column headerText="Casual Leave" style="text-align: right;">
-                                    <f:facet name="header" >
-                                        <p:outputLabel value="Casual Leave" />
-                                    </f:facet>
-                                    <p:outputLabel value="#{ss.leave_casual}" style="font-size: 12px;"/>
-                                </p:column>
-                                <p:column headerText="Medical Leave" style="text-align: right;">
-                                    <f:facet name="header" >
-                                        <p:outputLabel value="Medical Leave" />
-                                    </f:facet>
-                                    <p:outputLabel value="#{ss.leave_medical}" style="font-size: 12px;"/>
-                                </p:column>
-                                <p:column headerText="No Pay Leave" style="text-align: right;">
-                                    <f:facet name="header" >
-                                        <p:outputLabel value="No Pay Leave" />
-                                    </f:facet>
-                                    <p:outputLabel value="#{ss.leave_nopay-ss.lateNoPays}" style="font-size: 12px;"/>
-                                </p:column>
-                                <p:column headerText="Late No Pay Days" style="text-align: right;">
-                                    <f:facet name="header" >
-                                        <p:outputLabel value="Late No Pay Days" />
-                                    </f:facet>
-                                    <p:outputLabel value="#{ss.lateNoPays}" style="font-size: 12px;"/>
-                                </p:column>
-                                <p:column headerText="Late Days" style="text-align: right;">
-                                    <f:facet name="header" >
-                                        <p:outputLabel value="Late Days" />
-                                    </f:facet>
-                                    <p:outputLabel value="#{ss.latedays}" style="font-size: 12px;"/>
-                                </p:column>
-                                <p:column headerText="Off Days" style="text-align: right;">
-                                    <f:facet name="header" >
-                                        <p:outputLabel value="Off Days" />
-                                    </f:facet>
-                                    <p:outputLabel value="#{ss.dayoff}" style="font-size: 12px;"/>
-                                </p:column>
-                                <p:column headerText="Sleeping Days" style="text-align: right;">
-                                    <f:facet name="header" >
-                                        <p:outputLabel value="Sleeping Days" />
-                                    </f:facet>
-                                    <p:outputLabel value="#{ss.sleepingDays}" style="font-size: 12px;"/>
-                                </p:column>
-                                <p:column headerText="Poya Days" style="text-align: right;">
-                                    <f:facet name="header" >
-                                        <p:outputLabel value="Poya Days" />
-                                    </f:facet>
-                                    <p:outputLabel value="#{ss.poyaDays}" style="font-size: 12px;"/>
-                                </p:column>
-                                <p:column headerText="Merhcantile Days" style="text-align: right;">
-                                    <f:facet name="header" >
-                                        <p:outputLabel value="Merhcantile Days" />
-                                    </f:facet>
-                                    <p:outputLabel value="#{ss.merhchantileDays}" style="font-size: 12px;"/>
-                                </p:column>
-                                <!--                                <p:column headerText="Extra Duty Days">
-                                #{ss.extraDutyDays}
-                            </p:column>-->
-                                <f:facet name="footer">
-                                    <p:outputLabel value="Print By : #{sessionController.loggedUser.webUserPerson.name} - " />
-                                    <p:outputLabel value="Print At : " />
-                                    <p:outputLabel value="#{commonFunctionsProxy.currentDateTime}" >
-                                        <f:convertDateTime pattern="yyyy MMMM dd hh:mm:ss a " />
-                                    </p:outputLabel>
-                                </f:facet>
+            <p:panel id="gpBillPreview" styleClass="report-panel noBorder summeryBorder">
 
-                            </p:dataTable>
-                        </p:panel>
+                <f:facet name="header">
+                    <div class="report-header-wrap">
+                        <span class="report-title-label">
+                            <h:outputText value="Employee Worked Day Report" />
+                        </span>
+                        <p class="report-meta">
+                            <h:outputText value="#{hrReportController.fromDate}">
+                                <f:convertDateTime pattern="dd/MM/yyyy HH:mm" />
+                            </h:outputText>
+                            <h:outputText value=" — " />
+                            <h:outputText value="#{hrReportController.toDate}">
+                                <f:convertDateTime pattern="dd/MM/yyyy HH:mm" />
+                            </h:outputText>
+                        </p>
+                        <h:panelGroup rendered="#{hrReportController.reportKeyWord.institution ne null}">
+                            <p class="report-meta">
+                                <h:outputText value="#{hrReportController.reportKeyWord.institution.name}" />
+                            </p>
+                        </h:panelGroup>
+                        <h:panelGroup rendered="#{hrReportController.reportKeyWord.department ne null}">
+                            <p class="report-meta">
+                                <h:outputText value="Department: " />
+                                <h:outputText value="#{hrReportController.reportKeyWord.department.name}" />
+                            </p>
+                        </h:panelGroup>
+                        <h:panelGroup rendered="#{hrReportController.reportKeyWord.roster ne null}">
+                            <p class="report-meta">
+                                <h:outputText value="Roster: " />
+                                <h:outputText value="#{hrReportController.reportKeyWord.roster.name}" />
+                            </p>
+                        </h:panelGroup>
+                    </div>
+                </f:facet>
 
+                <p:dataTable id="tb1"
+                             value="#{hrReportController.monthEndRecords}"
+                             var="ss"
+                             styleClass="ewd-table">
 
-                    </p:panel>
+                    <p:column headerText="Staff code" styleClass="col-text">
+                        <p:outputLabel value="#{ss.staff.codeInterger}" />
+                    </p:column>
 
-                </h:form>
-            </ui:define>
+                    <p:column headerText="Staff" styleClass="col-text">
+                        <p:outputLabel value="#{ss.staff.person.name}" />
+                    </p:column>
 
-        </ui:composition>
+                    <p:column headerText="Worked days" styleClass="col-num">
+                        <p:outputLabel value="#{ss.workedDays}" />
+                    </p:column>
 
-    </h:body>
-</html>
+                    <p:column headerText="Annual leave" styleClass="col-num">
+                        <p:outputLabel value="#{ss.leave_annual}" />
+                    </p:column>
+
+                    <p:column headerText="Casual leave" styleClass="col-num">
+                        <p:outputLabel value="#{ss.leave_casual}" />
+                    </p:column>
+
+                    <p:column headerText="Medical leave" styleClass="col-num">
+                        <p:outputLabel value="#{ss.leave_medical}" />
+                    </p:column>
+
+                    <p:column headerText="No pay leave" styleClass="col-num">
+                        <p:outputLabel value="#{ss.leave_nopay-ss.lateNoPays}" />
+                    </p:column>
+
+                    <p:column headerText="Late no pay days" styleClass="col-num">
+                        <p:outputLabel value="#{ss.lateNoPays}" />
+                    </p:column>
+
+                    <p:column headerText="Late days" styleClass="col-num">
+                        <p:outputLabel value="#{ss.latedays}" />
+                    </p:column>
+
+                    <p:column headerText="Off days" styleClass="col-num">
+                        <p:outputLabel value="#{ss.dayoff}" />
+                    </p:column>
+
+                    <p:column headerText="Sleeping days" styleClass="col-num">
+                        <p:outputLabel value="#{ss.sleepingDays}" />
+                    </p:column>
+
+                    <p:column headerText="Poya days" styleClass="col-num">
+                        <p:outputLabel value="#{ss.poyaDays}" />
+                    </p:column>
+
+                    <p:column headerText="Mercantile days" styleClass="col-num">
+                        <p:outputLabel value="#{ss.merhchantileDays}" />
+                    </p:column>
+
+                    <!--                                <p:column headerText="Extra Duty Days">
+                        #{ss.extraDutyDays}
+                    </p:column>-->
+
+                    <f:facet name="footer">
+                        <div class="report-table-footer">
+                            <p:outputLabel value="Print by: #{sessionController.loggedUser.webUserPerson.name}" />
+                            <span>·</span>
+                            <p:outputLabel value="#{commonFunctionsProxy.currentDateTime}">
+                                <f:convertDateTime pattern="yyyy MMMM dd hh:mm:ss a" />
+                            </p:outputLabel>
+                        </div>
+                    </f:facet>
+
+                </p:dataTable>
+
+            </p:panel>
+
+        </h:form>
+    </ui:define>
+
+</ui:composition>


### PR DESCRIPTION
## Summary
Restyled `hr_report_month_end_employee_date.xhtml` to match the established layout and CSS conventions used across the HR report views.

## Changes

### UI / Layout
- Migrated composition root from `html/h:body` wrapper to direct `ui:composition`
- DOCTYPE fixed to `<!DOCTYPE html>`
- Replaced `h:panelGrid` filter section with responsive `fields-grid` CSS grid
- Unified field labels to uppercase spaced style via `.field-label`
- Process button moved to `controls-actions` row with icon
- Print and Export Excel moved to `controls-actions-secondary` row with border separator
- Print button: `ajax="false" action="#"` → `type="button"`
- Applied `ewd-table` datatable styles: uppercase headers, right-aligned numeric columns via `col-num`, hover highlight, bold footer rule, horizontal scroll
- Rebuilt report panel header using `report-header-wrap` / `report-meta` structure with institution, department, and roster filter guards
- Removed redundant `f:facet name="header"` blocks inside each `p:column`
- Fixed typo in "Mercantile days" column header (`Merhcantile` → `Mercantile`)

## Notes
- Commented-out Extra Duty Days column preserved as-is
- No backend/bean changes — all EL expressions preserved as-is
- No functional regressions