### PR TITLE
Refactor: Align Employee Salary Detail Report UI with HR report design system

### DIFF
--- a/src/main/webapp/hr/hr_report_month_end_employee_date_1.xhtml
+++ b/src/main/webapp/hr/hr_report_month_end_employee_date_1.xhtml
@@ -1,42 +1,215 @@
 <?xml version='1.0' encoding='UTF-8' ?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml"
-      xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
-      xmlns:h="http://xmlns.jcp.org/jsf/html"
-      xmlns:p="http://primefaces.org/ui"
-      xmlns:f="http://xmlns.jcp.org/jsf/core"
-      
-      xmlns:hr="http://xmlns.jcp.org/jsf/composite/autocomplete">
+<!DOCTYPE html>
+<ui:composition xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
+                template="/resources/template/template.xhtml"
+                xmlns:h="http://xmlns.jcp.org/jsf/html"
+                xmlns:p="http://primefaces.org/ui"
+                xmlns:f="http://xmlns.jcp.org/jsf/core"
+                xmlns:hr="http://xmlns.jcp.org/jsf/composite/autocomplete">
 
-    <h:body>
+    <ui:define name="content">
 
-        <ui:composition template="/resources/template/template.xhtml">
+        <h:form styleClass="esd-form">
 
-            <ui:define name="content">
+            <h:outputStylesheet>
+                .esd-form {
+                    padding: 2rem 1.75rem;
+                }
 
-                <h:form >
-                    <p:panel >
-                        <f:facet name="header" >
-                            <h:outputLabel value="Employee Salary Detail Report" />
-                        </f:facet>
-                        <h:panelGrid columns="2" >
-                            <h:outputLabel value="Salary Cycal" />
-                            <p:selectOneMenu id="advanced" 
-                                             value="#{hrReportController.reportKeyWord.salaryCycle}" 
-                                                                              
-                                             var="t" 
-                                             filter="true" 
-                                             filterMatchMode="startsWith"  >
+                .page-header {
+                    margin-bottom: 1.75rem;
+                }
 
-                                <f:selectItems value="#{salaryCycleController.salaryCycles}" 
-                                               var="theme" 
-                                               itemLabel="#{theme.name}" 
-                                               itemValue="#{theme}" ></f:selectItems>
+                .page-title {
+                    font-size: 18px;
+                    font-weight: 600;
+                    margin: 0 0 4px 0;
+                }
 
+                .page-subtitle {
+                    font-size: 13px;
+                    color: #888;
+                    margin: 0;
+                }
+
+                .controls-panel .ui-panel-content {
+                    padding: 1.5rem 1.75rem !important;
+                }
+
+                .controls-grid {
+                    display: flex;
+                    flex-direction: column;
+                    gap: 1.25rem;
+                }
+
+                .fields-grid {
+                    display: grid;
+                    grid-template-columns: repeat(2, 1fr);
+                    gap: 1rem 1.5rem;
+                }
+
+                .field-group {
+                    display: flex;
+                    flex-direction: column;
+                    gap: 6px;
+                }
+
+                .field-label {
+                    font-size: 11.5px !important;
+                    font-weight: 600 !important;
+                    text-transform: uppercase;
+                    letter-spacing: 0.05em;
+                    color: #888 !important;
+                }
+
+                .controls-actions {
+                    display: flex;
+                    gap: 10px;
+                    align-items: center;
+                    flex-wrap: wrap;
+                }
+
+                .controls-actions-secondary {
+                    display: flex;
+                    gap: 10px;
+                    align-items: center;
+                    flex-wrap: wrap;
+                    padding-top: 0.75rem;
+                    border-top: 1px solid #e8e8e8;
+                }
+
+                .btn-action {
+                    height: 36px !important;
+                    padding: 0 18px !important;
+                    font-size: 13px !important;
+                }
+
+                .report-panel {
+                    margin-top: 1.5rem;
+                }
+
+                .report-panel .ui-panel-content {
+                    padding: 0 !important;
+                }
+
+                .report-header-wrap {
+                    text-align: center;
+                    padding: 1.5rem 1.5rem 1rem;
+                    border-bottom: 1px solid #e8e8e8;
+                }
+
+                .report-title-label {
+                    font-size: 13px;
+                    color: #666;
+                    display: block;
+                    margin-bottom: 2px;
+                }
+
+                .report-meta {
+                    font-size: 13px;
+                    color: #555;
+                    margin-top: 4px;
+                }
+
+                .esd-table .ui-datatable-tablewrapper {
+                    overflow-x: auto !important;
+                    width: 100% !important;
+                }
+
+                .esd-table table {
+                    width: auto !important;
+                    table-layout: auto !important;
+                }
+
+                .esd-table .ui-datatable-data td,
+                .esd-table .ui-datatable-thead th {
+                    padding: 10px 14px !important;
+                    white-space: nowrap;
+                    font-size: 13px !important;
+                    width: auto !important;
+                }
+
+                .esd-table .ui-datatable-thead th {
+                    font-size: 12px !important;
+                    font-weight: 600 !important;
+                    text-transform: uppercase;
+                    letter-spacing: 0.03em;
+                    color: #888 !important;
+                    background: #f9f9f9 !important;
+                    border-bottom: 1px solid #e8e8e8 !important;
+                }
+
+                .esd-table .ui-datatable-data tr:hover td {
+                    background: #f5f7ff !important;
+                }
+
+                .esd-table .col-text {
+                    text-align: left !important;
+                }
+
+                .esd-table .col-num {
+                    text-align: right !important;
+                }
+
+                .esd-table tfoot td {
+                    background: #f9f9f9 !important;
+                    font-weight: 600 !important;
+                    font-size: 13px !important;
+                    border-top: 2px solid #e0e0e0 !important;
+                    padding: 10px 14px !important;
+                }
+
+                .newcomer-panel {
+                    margin-top: 1.5rem;
+                }
+
+                .newcomer-panel table {
+                    width: 100%;
+                    border-collapse: collapse;
+                    font-size: 9px;
+                }
+
+                .newcomer-panel table td {
+                    border: 1px solid black;
+                    padding: 4px;
+                }
+
+                .sign-row {
+                    display: flex;
+                    justify-content: space-between;
+                    padding: 2rem 1rem 0.5rem;
+                }
+
+                .sign-label {
+                    text-decoration: overline;
+                    font-size: 13px;
+                }
+            </h:outputStylesheet>
+
+            <div class="page-header">
+                <p class="page-title"><h:outputText value="Employee Salary Detail Report" /></p>
+                <p class="page-subtitle"><h:outputText value="Filter by salary cycle and employee filters, then process" /></p>
+            </div>
+
+            <p:panel styleClass="controls-panel">
+                <div class="controls-grid">
+
+                    <div class="fields-grid">
+                        <div class="field-group">
+                            <p:outputLabel value="Salary cycle" styleClass="field-label" />
+                            <p:selectOneMenu id="advanced"
+                                             value="#{hrReportController.reportKeyWord.salaryCycle}"
+                                             var="t"
+                                             filter="true"
+                                             filterMatchMode="startsWith"
+                                             style="width: 100%;">
+                                <f:selectItems value="#{salaryCycleController.salaryCycles}"
+                                               var="theme"
+                                               itemLabel="#{theme.name}"
+                                               itemValue="#{theme}" />
                                 <p:column style="width:10%" headerText="Name">
                                     <h:outputText value="#{t.name}" />
                                 </p:column>
-
                                 <p:column headerText="Year">
                                     <h:outputText value="#{t.salaryYear}" />
                                 </p:column>
@@ -44,600 +217,538 @@
                                     <h:outputText value="#{t.salaryMonth}" />
                                 </p:column>
                             </p:selectOneMenu>
-                            <h:outputLabel value="Institution : "/>
-                            <hr:institution value="#{hrReportController.reportKeyWord.institution}"/>
-                            <h:outputLabel value="Department : "/>
-                            <hr:department value="#{hrReportController.reportKeyWord.department}"/>
-                            <h:outputLabel value="Employee : "/>
-                            <hr:completeStaff value="#{hrReportController.reportKeyWord.staff}"/>
-                            <h:outputLabel value="Staff Category : "/>
-                            <hr:completeStaffCategory value="#{hrReportController.reportKeyWord.staffCategory}"/>
-                            <h:outputLabel value="Staff Designation : "/>
-                            <hr:completeDesignation value="#{hrReportController.reportKeyWord.designation}"/>
-                            <h:outputLabel value="Staff Roster : "/>
-                            <hr:completeRoster value="#{hrReportController.reportKeyWord.roster}"/>
-                            <h:outputLabel value="Additional Details: "/>
+                        </div>
+
+                        <div class="field-group">
+                            <p:outputLabel value="Institution" styleClass="field-label" />
+                            <hr:institution value="#{hrReportController.reportKeyWord.institution}" />
+                        </div>
+
+                        <div class="field-group">
+                            <p:outputLabel value="Department" styleClass="field-label" />
+                            <hr:department value="#{hrReportController.reportKeyWord.department}" />
+                        </div>
+
+                        <div class="field-group">
+                            <p:outputLabel value="Employee" styleClass="field-label" />
+                            <hr:completeStaff value="#{hrReportController.reportKeyWord.staff}" />
+                        </div>
+
+                        <div class="field-group">
+                            <p:outputLabel value="Staff category" styleClass="field-label" />
+                            <hr:completeStaffCategory value="#{hrReportController.reportKeyWord.staffCategory}" />
+                        </div>
+
+                        <div class="field-group">
+                            <p:outputLabel value="Staff designation" styleClass="field-label" />
+                            <hr:completeDesignation value="#{hrReportController.reportKeyWord.designation}" />
+                        </div>
+
+                        <div class="field-group">
+                            <p:outputLabel value="Staff roster" styleClass="field-label" />
+                            <hr:completeRoster value="#{hrReportController.reportKeyWord.roster}" />
+                        </div>
+
+                        <div class="field-group">
+                            <p:outputLabel value="Additional details" styleClass="field-label" />
                             <p:selectBooleanCheckbox value="#{hrReportController.reportKeyWord.additionalDetails}" />
-                        </h:panelGrid>
+                        </div>
+                    </div>
 
-                        <p:commandButton ajax="false" value="Process" action="#{hrReportController.createMonthEndReportNew()}"/>
-                        <p:commandButton ajax="false" value="Excel" styleClass="noPrintButton"  >
-                            <p:dataExporter type="xlsx" target="tb1" fileName="hr_report_month_end_employee_date_1"  />
+                    <div class="controls-actions">
+                        <p:commandButton value="Process"
+                                         ajax="false"
+                                         action="#{hrReportController.createMonthEndReportNew()}"
+                                         icon="pi pi-filter"
+                                         styleClass="btn-action" />
+                    </div>
+
+                    <div class="controls-actions-secondary">
+                        <p:commandButton value="Print"
+                                         type="button"
+                                         icon="pi pi-print"
+                                         styleClass="btn-action">
+                            <p:printer target="gpBillPreview" />
                         </p:commandButton>
-                        <p:commandButton value="Print" ajax="false" action="#" >
-                            <p:printer target="gpBillPreview" ></p:printer>
+                        <p:commandButton value="Export Excel"
+                                         ajax="false"
+                                         icon="pi pi-file-excel"
+                                         styleClass="btn-action noPrintButton">
+                            <p:dataExporter type="xlsx" target="tb1"
+                                            fileName="hr_report_month_end_employee_date_1" />
                         </p:commandButton>
-                        <p:panel id="gpBillPreview" style="font-size: 12px;"  >                     
-                            <p:dataTable id="tb1" value="#{hrReportController.monthEndRecords}" var="ss" styleClass="noBorder summeryBorder" 
-                                         rowStyleClass="#{ss.workedDays lt 6 ? 'redText':ss.workedDays lt 11 ? 'blueText':''}">
-                                <f:facet name="header">
-                                    <h:outputLabel value="Employee Salary Detail Report"/>
-                                    <br/>
-                                    <p:outputLabel value="Salary Date - From : " />
-                                    <h:outputLabel value="#{hrReportController.reportKeyWord.salaryCycle.salaryFromDate}">
-                                        <f:convertDateTime  timeZone="Asia/Colombo" pattern="#{sessionController.applicationPreference.shortDateFormat}" />
-                                    </h:outputLabel>
-                                    <p:outputLabel value="To : " />
-                                    <h:outputLabel value="#{hrReportController.reportKeyWord.salaryCycle.salaryToDate}">
-                                        <f:convertDateTime  timeZone="Asia/Colombo" pattern="#{sessionController.applicationPreference.shortDateFormat}" />
-                                    </h:outputLabel>
-                                    <br/>
-                                    <p:outputLabel value="OT Date - From : " />
-                                    <h:outputLabel value="#{hrReportController.reportKeyWord.salaryCycle.dayOffPhFromDate}">
-                                        <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateTimeFormat}" />
-                                    </h:outputLabel>
-                                    <p:outputLabel value="To : " />
-                                    <h:outputLabel value="#{hrReportController.reportKeyWord.salaryCycle.dayOffPhToDate}">
-                                        <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateTimeFormat}" />
-                                    </h:outputLabel>
-                                    <h:panelGroup rendered="#{hrReportController.reportKeyWord.roster ne null}">
-                                        <br />
-                                        <h:outputLabel value="#{hrReportController.reportKeyWord.roster.name} Roster" rendered="#{hrReportController.reportKeyWord.roster ne null}"/>
-                                        <br />
-                                    </h:panelGroup>
+                    </div>
 
-                                    <h:panelGroup rendered="#{hrReportController.reportKeyWord.staff ne null}">
-                                        <br />
-                                        <h:outputLabel value="Employee #{hrReportController.reportKeyWord.staff.person.name}" rendered="#{hrReportController.reportKeyWord.staff ne null}"/>
-                                        <br />
-                                    </h:panelGroup>
+                </div>
+            </p:panel>
 
-                                    <h:panelGroup rendered="#{hrReportController.reportKeyWord.institution ne null}">
-                                        <br />
-                                        <h:outputLabel value="#{hrReportController.reportKeyWord.institution.name}" rendered="#{hrReportController.reportKeyWord.institution ne null}"/>
-                                        <br />
-                                    </h:panelGroup>
+            <p:panel id="gpBillPreview" styleClass="report-panel noBorder summeryBorder">
 
-                                    <h:panelGroup rendered="#{hrReportController.reportKeyWord.department ne null}">
-                                        <br />
-                                        <h:outputLabel value="#{hrReportController.reportKeyWord.department.name} Department" rendered="#{hrReportController.reportKeyWord.department ne null}"/>
-                                        <br />
-                                    </h:panelGroup>
+                <f:facet name="header">
+                    <div class="report-header-wrap">
+                        <span class="report-title-label">
+                            <h:outputText value="Employee Salary Detail Report" />
+                        </span>
+                        <p class="report-meta">
+                            <h:outputText value="Salary date: " />
+                            <h:outputText value="#{hrReportController.reportKeyWord.salaryCycle.salaryFromDate}">
+                                <f:convertDateTime timeZone="Asia/Colombo" pattern="#{sessionController.applicationPreference.shortDateFormat}" />
+                            </h:outputText>
+                            <h:outputText value=" — " />
+                            <h:outputText value="#{hrReportController.reportKeyWord.salaryCycle.salaryToDate}">
+                                <f:convertDateTime timeZone="Asia/Colombo" pattern="#{sessionController.applicationPreference.shortDateFormat}" />
+                            </h:outputText>
+                        </p>
+                        <p class="report-meta">
+                            <h:outputText value="OT date: " />
+                            <h:outputText value="#{hrReportController.reportKeyWord.salaryCycle.dayOffPhFromDate}">
+                                <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateTimeFormat}" />
+                            </h:outputText>
+                            <h:outputText value=" — " />
+                            <h:outputText value="#{hrReportController.reportKeyWord.salaryCycle.dayOffPhToDate}">
+                                <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateTimeFormat}" />
+                            </h:outputText>
+                        </p>
+                        <h:panelGroup rendered="#{hrReportController.reportKeyWord.roster ne null}">
+                            <p class="report-meta">
+                                <h:outputText value="Roster: " />
+                                <h:outputText value="#{hrReportController.reportKeyWord.roster.name}" />
+                            </p>
+                        </h:panelGroup>
+                        <h:panelGroup rendered="#{hrReportController.reportKeyWord.staff ne null}">
+                            <p class="report-meta">
+                                <h:outputText value="Employee: " />
+                                <h:outputText value="#{hrReportController.reportKeyWord.staff.person.name}" />
+                            </p>
+                        </h:panelGroup>
+                        <h:panelGroup rendered="#{hrReportController.reportKeyWord.institution ne null}">
+                            <p class="report-meta">
+                                <h:outputText value="#{hrReportController.reportKeyWord.institution.name}" />
+                            </p>
+                        </h:panelGroup>
+                        <h:panelGroup rendered="#{hrReportController.reportKeyWord.department ne null}">
+                            <p class="report-meta">
+                                <h:outputText value="Department: " />
+                                <h:outputText value="#{hrReportController.reportKeyWord.department.name}" />
+                            </p>
+                        </h:panelGroup>
+                        <h:panelGroup rendered="#{hrReportController.reportKeyWord.staffCategory ne null}">
+                            <p class="report-meta">
+                                <h:outputText value="Staff category: " />
+                                <h:outputText value="#{hrReportController.reportKeyWord.staffCategory.name}" />
+                            </p>
+                        </h:panelGroup>
+                        <h:panelGroup rendered="#{hrReportController.reportKeyWord.designation ne null}">
+                            <p class="report-meta">
+                                <h:outputText value="Staff designation: " />
+                                <h:outputText value="#{hrReportController.reportKeyWord.designation.name}" />
+                            </p>
+                        </h:panelGroup>
+                    </div>
+                </f:facet>
 
-                                    <h:panelGroup rendered="#{hrReportController.reportKeyWord.staffCategory ne null}">
-                                        <br />
-                                        <h:outputLabel value="Staff Category #{hrReportController.reportKeyWord.staffCategory.name}" rendered="#{hrReportController.reportKeyWord.staffCategory ne null}"/>
-                                        <br />
-                                    </h:panelGroup>
+                <p:dataTable id="tb1"
+                             value="#{hrReportController.monthEndRecords}"
+                             var="ss"
+                             styleClass="esd-table noBorder summeryBorder"
+                             rowStyleClass="#{ss.workedDays lt 6 ? 'redText':ss.workedDays lt 11 ? 'blueText':''}">
 
-                                    <h:panelGroup rendered="#{hrReportController.reportKeyWord.designation ne null}">
-                                        <br />
-                                        <h:outputLabel value="Staff Designation #{hrReportController.reportKeyWord.designation.name}" rendered="#{hrReportController.reportKeyWord.designation ne null}"/>
-                                        <br />
-                                    </h:panelGroup>
-                                </f:facet>
-                                <p:column headerText="Staff Code" style="text-align: left;">
-                                    <f:facet name="header" >
-                                        <p:outputLabel value="Staff Code" />
-                                    </f:facet>
-                                    <p:outputLabel value="#{ss.staff.codeInterger}" style="font-size: 12px;"/>
-                                </p:column>
-                                <p:column headerText="Staff" style="text-align: left;">
-                                    <f:facet name="header" >
-                                        <p:outputLabel value="Staff" />
-                                    </f:facet>
-                                    <p:outputLabel value="#{ss.staff.person.name}" style="font-size: 12px;"/>
-                                </p:column>
-                                <p:column headerText="Worked Days" style="text-align: right;">
-                                    <f:facet name="header" >
-                                        <p:outputLabel value="Worked Days" />
-                                    </f:facet>
-                                    <p:outputLabel value="#{ss.workedDays}" style="font-size: 12px;"/>
-                                </p:column>
-                                <p:column headerText="Worked Days Before" style="text-align: right;">
-                                    <f:facet name="header" >
-                                        <p:outputLabel value="Worked Days Before" />
-                                    </f:facet>
-                                    <p:outputLabel value="#{ss.workedDaysBefore}" style="font-size: 12px;"/>
-                                </p:column>
-                                <p:column headerText="Worked Days This" style="text-align: right;">
-                                    <f:facet name="header" >
-                                        <p:outputLabel value="Worked Days This" />
-                                    </f:facet>
-                                    <p:outputLabel value="#{ss.workedDaysThis}" style="font-size: 12px;"/>
-                                </p:column>
-                                <p:column headerText="Worked Days Aditional" style="text-align: right;">
-                                    <f:facet name="header" >
-                                        <p:outputLabel value="Worked Days Aditional" />
-                                    </f:facet>
-                                    <p:outputLabel value="#{ss.workedDaysAditional}" style="font-size: 12px;"/>
-                                </p:column>
-                                <p:column rendered="#{!hrReportController.reportKeyWord.additionalDetails}" headerText="Annual Leave" style="text-align: right;">
-                                    <f:facet name="header" >
-                                        <p:outputLabel value="Annual Leave" />
-                                    </f:facet>
-                                    <p:outputLabel value="#{ss.leave_annual}" style="font-size: 12px;"/>
-                                </p:column>
-                                <p:column rendered="#{!hrReportController.reportKeyWord.additionalDetails}" headerText="Casual Leave" style="text-align: right;">
-                                    <f:facet name="header" >
-                                        <p:outputLabel value="Casual Leave" />
-                                    </f:facet>
-                                    <p:outputLabel value="#{ss.leave_casual}" style="font-size: 12px;"/>
-                                </p:column>
-                                <p:column rendered="#{!hrReportController.reportKeyWord.additionalDetails}" headerText="Medical Leave" style="text-align: right;">
-                                    <f:facet name="header" >
-                                        <p:outputLabel value="Medical Leave" />
-                                    </f:facet>
-                                    <p:outputLabel value="#{ss.leave_medical}" style="font-size: 12px;"/>
-                                </p:column>
-                                <p:column rendered="#{!hrReportController.reportKeyWord.additionalDetails}" headerText="Medical Leave" style="text-align: right;">
-                                    <f:facet name="header" >
-                                        <p:outputLabel value="Maternity Leave" />
-                                    </f:facet>
-                                    <p:outputLabel value="#{ss.leave_maternity}" style="font-size: 12px;"/>
-                                </p:column>
-                                <p:column headerText="No Pay Leave" style="text-align: right;">
-                                    <f:facet name="header" >
-                                        <p:outputLabel value="No Pay Leave" />
-                                    </f:facet>
-                                    <p:outputLabel value="#{ss.leave_nopay-ss.lateNoPays}" style="font-size: 12px;"/>
-                                </p:column>                             
-                                <p:column headerText="Late No Pay Days" style="text-align: right;">
-                                    <f:facet name="header" >
-                                        <p:outputLabel value="Late No Pay Days" />
-                                    </f:facet>
-                                    <p:outputLabel value="#{ss.lateNoPays}" style="font-size: 12px;"/>
-                                </p:column>
-                                <p:column rendered="#{!hrReportController.reportKeyWord.additionalDetails}" headerText="Late Days" style="text-align: right;">
-                                    <f:facet name="header" >
-                                        <p:outputLabel value="Late Days" />
-                                    </f:facet>
-                                    <p:outputLabel value="#{ss.latedays}" style="font-size: 12px;"/>
-                                </p:column>
-                                <p:column headerText="Merhcantile Days" style="text-align: right;">
-                                    <f:facet name="header" >
-                                        <p:outputLabel value="Merhcantile Days" />
-                                    </f:facet>
-                                    <p:outputLabel value="#{ss.merhchantileDays}" style="font-size: 12px;"/>
-                                </p:column>
-                                <p:column rendered="#{!hrReportController.reportKeyWord.additionalDetails}" headerText="Merhcantile Days(Leave)" style="text-align: right;">
-                                    <f:facet name="header" >
-                                        <p:outputLabel value="Merhcantile Days(Leave)" />
-                                    </f:facet>
-                                    <p:outputLabel value="#{ss.merhchantileDaysLeave}" style="font-size: 12px;"/>
-                                </p:column>
-                                <p:column headerText="Poya Days" style="text-align: right;">
-                                    <f:facet name="header" >
-                                        <p:outputLabel value="Poya Days" />
-                                    </f:facet>
-                                    <p:outputLabel value="#{ss.poyaDays}" style="font-size: 12px;"/>
-                                </p:column>
-                                <p:column rendered="#{!hrReportController.reportKeyWord.additionalDetails}" headerText="Poya Days(Leave)" style="text-align: right;">
-                                    <f:facet name="header" >
-                                        <p:outputLabel value="Poya Days(Leave)" />
-                                    </f:facet>
-                                    <p:outputLabel value="#{ss.poyaDaysLeave}" style="font-size: 12px;"/>
-                                </p:column>
-                                <p:column headerText="Off Days" style="text-align: right;">
-                                    <f:facet name="header" >
-                                        <p:outputLabel value="Off Days" />
-                                    </f:facet>
-                                    <p:outputLabel value="#{ss.dayoff}" style="font-size: 12px;"/>
-                                </p:column>
-                                <p:column rendered="#{!hrReportController.reportKeyWord.additionalDetails}" headerText="Sleeping Days" style="text-align: right;">
-                                    <f:facet name="header" >
-                                        <p:outputLabel value="Sleeping Days" />
-                                    </f:facet>
-                                    <p:outputLabel value="#{ss.sleepingDays}" style="font-size: 12px;"/>
-                                </p:column>
-                                <p:column rendered="#{hrReportController.reportKeyWord.additionalDetails}" headerText="Remarks" style="text-align: right;">
-                                    <f:facet name="header" >
-                                        <p:outputLabel value="Remarks" />
-                                    </f:facet>
-                                    <p:outputLabel value="......................................................................."/>
-                                </p:column>
+                    <p:column headerText="Staff code" styleClass="col-text">
+                        <p:outputLabel value="#{ss.staff.codeInterger}" />
+                    </p:column>
 
-                            </p:dataTable>
-                            <p:panel header="New Comer" >
-                                <table rendered="#{hrReportController.reportKeyWord.additionalDetails}" border="1px solid black" align="center" >
-                                    <tr>
-                                        <td width="50" style="font-size: 9px">E.No</td>
-                                        <td width="50" style="font-size: 9px">EPF No</td>
-                                        <td width="60" style="font-size: 9px">Date Of Join</td>
-                                        <td style="font-size: 9px">Basic Salary+BR</td>
-                                        <td style="font-size: 9px">T. Allowance </td>
-                                        <td style="font-size: 9px">Per. Allowance</td>
-                                        <td width="350" style="font-size: 9px">Name</td>
-                                        <td width="100" style="font-size: 9px">Designation</td>
-                                    </tr>
-                                    <tr>
-                                        <td>&nbsp;</td>
-                                        <td></td>
-                                        <td></td>
-                                        <td></td>
-                                        <td></td>
-                                        <td></td>
-                                        <td></td>
-                                        <td></td>
-                                    </tr>
-                                    <tr>
-                                        <td>&nbsp;</td>
-                                        <td></td>
-                                        <td></td>
-                                        <td></td>
-                                        <td></td>
-                                        <td></td>
-                                        <td></td>
-                                        <td></td>
-                                    </tr>
-                                    <tr>
-                                        <td>&nbsp;</td>
-                                        <td></td>
-                                        <td></td>
-                                        <td></td>
-                                        <td></td>
-                                        <td></td>
-                                        <td></td>
-                                        <td></td>
-                                    </tr>
-                                    <tr>
-                                        <td>&nbsp;</td>
-                                        <td></td>
-                                        <td></td>
-                                        <td></td>
-                                        <td></td>
-                                        <td></td>
-                                        <td></td>
-                                        <td></td>
-                                    </tr>
-                                    <tr>
-                                        <td>&nbsp;</td>
-                                        <td></td>
-                                        <td></td>
-                                        <td></td>
-                                        <td></td>
-                                        <td></td>
-                                        <td></td>
-                                        <td></td>
-                                    </tr>
-                                    <tr>
-                                        <td>&nbsp;</td>
-                                        <td></td>
-                                        <td></td>
-                                        <td></td>
-                                        <td></td>
-                                        <td></td>
-                                        <td></td>
-                                        <td></td>
-                                    </tr>
-                                    <tr>
-                                        <td>&nbsp;</td>
-                                        <td></td>
-                                        <td></td>
-                                        <td></td>
-                                        <td></td>
-                                        <td></td>
-                                        <td></td>
-                                        <td></td>
-                                    </tr>
-                                    <tr>
-                                        <td>&nbsp;</td>
-                                        <td></td>
-                                        <td></td>
-                                        <td></td>
-                                        <td></td>
-                                        <td></td>
-                                        <td></td>
-                                        <td></td>
-                                    </tr>
-                                    <tr>
-                                        <td>&nbsp;</td>
-                                        <td></td>
-                                        <td></td>
-                                        <td></td>
-                                        <td></td>
-                                        <td></td>
-                                        <td></td>
-                                        <td></td>
-                                    </tr>
-                                    <tr>
-                                        <td>&nbsp;</td>
-                                        <td></td>
-                                        <td></td>
-                                        <td></td>
-                                        <td></td>
-                                        <td></td>
-                                        <td></td>
-                                        <td></td>
-                                    </tr>
-                                    <!--                                    <tr>
-                                                                            <td>&nbsp;</td>
-                                                                            <td></td>
-                                                                            <td></td>
-                                                                            <td></td>
-                                                                            <td></td>
-                                                                            <td></td>
-                                                                            <td></td>
-                                                                            <td></td>
-                                                                        </tr>
-                                                                        <tr>
-                                                                            <td>&nbsp;</td>
-                                                                            <td></td>
-                                                                            <td></td>
-                                                                            <td></td>
-                                                                            <td></td>
-                                                                            <td></td>
-                                                                            <td></td>
-                                                                            <td></td>
-                                                                        </tr>
-                                                                        <tr>
-                                                                            <td>&nbsp;</td>
-                                                                            <td></td>
-                                                                            <td></td>
-                                                                            <td></td>
-                                                                            <td></td>
-                                                                            <td></td>
-                                                                            <td></td>
-                                                                            <td></td>
-                                                                        </tr>
-                                                                        <tr>
-                                                                            <td>&nbsp;</td>
-                                                                            <td></td>
-                                                                            <td></td>
-                                                                            <td></td>
-                                                                            <td></td>
-                                                                            <td></td>
-                                                                            <td></td>
-                                                                            <td></td>
-                                                                        </tr>
-                                                                        <tr>
-                                                                            <td>&nbsp;</td>
-                                                                            <td></td>
-                                                                            <td></td>
-                                                                            <td></td>
-                                                                            <td></td>
-                                                                            <td></td>
-                                                                            <td></td>
-                                                                            <td></td>
-                                                                        </tr>
-                                                                        <tr>
-                                                                            <td>&nbsp;</td>
-                                                                            <td></td>
-                                                                            <td></td>
-                                                                            <td></td>
-                                                                            <td></td>
-                                                                            <td></td>
-                                                                            <td></td>
-                                                                            <td></td>
-                                                                        </tr>
-                                                                        <tr>
-                                                                            <td>&nbsp;</td>
-                                                                            <td></td>
-                                                                            <td></td>
-                                                                            <td></td>
-                                                                            <td></td>
-                                                                            <td></td>
-                                                                            <td></td>
-                                                                            <td></td>
-                                                                        </tr>
-                                                                        <tr>
-                                                                            <td>&nbsp;</td>
-                                                                            <td></td>
-                                                                            <td></td>
-                                                                            <td></td>
-                                                                            <td></td>
-                                                                            <td></td>
-                                                                            <td></td>
-                                                                            <td></td>
-                                                                        </tr>
-                                                                        <tr>
-                                                                            <td>&nbsp;</td>
-                                                                            <td></td>
-                                                                            <td></td>
-                                                                            <td></td>
-                                                                            <td></td>
-                                                                            <td></td>
-                                                                            <td></td>
-                                                                            <td></td>
-                                                                        </tr>
-                                                                        <tr>
-                                                                            <td>&nbsp;</td>
-                                                                            <td></td>
-                                                                            <td></td>
-                                                                            <td></td>
-                                                                            <td></td>
-                                                                            <td></td>
-                                                                            <td></td>
-                                                                            <td></td>
-                                                                        </tr>
-                                                                        <tr>
-                                                                            <td>&nbsp;</td>
-                                                                            <td></td>
-                                                                            <td></td>
-                                                                            <td></td>
-                                                                            <td></td>
-                                                                            <td></td>
-                                                                            <td></td>
-                                                                            <td></td>
-                                                                        </tr>
-                                                                        <tr>
-                                                                            <td>&nbsp;</td>
-                                                                            <td></td>
-                                                                            <td></td>
-                                                                            <td></td>
-                                                                            <td></td>
-                                                                            <td></td>
-                                                                            <td></td>
-                                                                            <td></td>
-                                                                        </tr>
-                                                                        <tr>
-                                                                            <td>&nbsp;</td>
-                                                                            <td></td>
-                                                                            <td></td>
-                                                                            <td></td>
-                                                                            <td></td>
-                                                                            <td></td>
-                                                                            <td></td>
-                                                                            <td></td>
-                                                                        </tr>
-                                                                        <tr>
-                                                                            <td>&nbsp;</td>
-                                                                            <td></td>
-                                                                            <td></td>
-                                                                            <td></td>
-                                                                            <td></td>
-                                                                            <td></td>
-                                                                            <td></td>
-                                                                            <td></td>
-                                                                        </tr>
-                                                                        <tr>
-                                                                            <td>&nbsp;</td>
-                                                                            <td></td>
-                                                                            <td></td>
-                                                                            <td></td>
-                                                                            <td></td>
-                                                                            <td></td>
-                                                                            <td></td>
-                                                                            <td></td>
-                                                                        </tr>
-                                                                        <tr>
-                                                                            <td>&nbsp;</td>
-                                                                            <td></td>
-                                                                            <td></td>
-                                                                            <td></td>
-                                                                            <td></td>
-                                                                            <td></td>
-                                                                            <td></td>
-                                                                            <td></td>
-                                                                        </tr>
-                                                                        <tr>
-                                                                            <td>&nbsp;</td>
-                                                                            <td></td>
-                                                                            <td></td>
-                                                                            <td></td>
-                                                                            <td></td>
-                                                                            <td></td>
-                                                                            <td></td>
-                                                                            <td></td>
-                                                                        </tr>
-                                                                        <tr>
-                                                                            <td>&nbsp;</td>
-                                                                            <td></td>
-                                                                            <td></td>
-                                                                            <td></td>
-                                                                            <td></td>
-                                                                            <td></td>
-                                                                            <td></td>
-                                                                            <td></td>
-                                                                        </tr>
-                                                                        <tr>
-                                                                            <td>&nbsp;</td>
-                                                                            <td></td>
-                                                                            <td></td>
-                                                                            <td></td>
-                                                                            <td></td>
-                                                                            <td></td>
-                                                                            <td></td>
-                                                                            <td></td>
-                                                                        </tr>
-                                                                        <tr>
-                                                                            <td>&nbsp;</td>
-                                                                            <td></td>
-                                                                            <td></td>
-                                                                            <td></td>
-                                                                            <td></td>
-                                                                            <td></td>
-                                                                            <td></td>
-                                                                            <td></td>
-                                                                        </tr>
-                                                                        <tr>
-                                                                            <td>&nbsp;</td>
-                                                                            <td></td>
-                                                                            <td></td>
-                                                                            <td></td>
-                                                                            <td></td>
-                                                                            <td></td>
-                                                                            <td></td>
-                                                                            <td></td>
-                                                                        </tr>
-                                                                        <tr>
-                                                                            <td>&nbsp;</td>
-                                                                            <td></td>
-                                                                            <td></td>
-                                                                            <td></td>
-                                                                            <td></td>
-                                                                            <td></td>
-                                                                            <td></td>
-                                                                            <td></td>
-                                                                        </tr>
-                                                                        <tr>
-                                                                            <td>&nbsp;</td>
-                                                                            <td></td>
-                                                                            <td></td>
-                                                                            <td></td>
-                                                                            <td></td>
-                                                                            <td></td>
-                                                                            <td></td>
-                                                                            <td></td>
-                                                                        </tr>
-                                                                        <tr>
-                                                                            <td>&nbsp;</td>
-                                                                            <td></td>
-                                                                            <td></td>
-                                                                            <td></td>
-                                                                            <td></td>
-                                                                            <td></td>
-                                                                            <td></td>
-                                                                            <td></td>
-                                                                        </tr>
-                                                                        <tr>
-                                                                            <td>&nbsp;</td>
-                                                                            <td></td>
-                                                                            <td></td>
-                                                                            <td></td>
-                                                                            <td></td>
-                                                                            <td></td>
-                                                                            <td></td>
-                                                                            <td></td>
-                                                                        </tr>
-                                                                        <tr>
-                                                                            <td>&nbsp;</td>
-                                                                            <td></td>
-                                                                            <td></td>
-                                                                            <td></td>
-                                                                            <td></td>
-                                                                            <td></td>
-                                                                            <td></td>
-                                                                            <td></td>
-                                                                        </tr>-->
-                                </table>
+                    <p:column headerText="Staff" styleClass="col-text">
+                        <p:outputLabel value="#{ss.staff.person.name}" />
+                    </p:column>
 
-                                <h:panelGrid columns="3" styleClass="noBorder" >
-                                    <p:outputLabel value="Checked By" style="text-decoration: overline;" />
-                                    <p:spacer width="400px" height="100px"/>
-                                    <p:outputLabel value="Authorized By" style="text-decoration: overline; " />
-                                </h:panelGrid>
-                            </p:panel>
+                    <p:column headerText="Worked days" styleClass="col-num">
+                        <p:outputLabel value="#{ss.workedDays}" />
+                    </p:column>
 
-                        </p:panel>
+                    <p:column headerText="Worked days before" styleClass="col-num">
+                        <p:outputLabel value="#{ss.workedDaysBefore}" />
+                    </p:column>
 
+                    <p:column headerText="Worked days this" styleClass="col-num">
+                        <p:outputLabel value="#{ss.workedDaysThis}" />
+                    </p:column>
 
-                    </p:panel>
+                    <p:column headerText="Worked days additional" styleClass="col-num">
+                        <p:outputLabel value="#{ss.workedDaysAditional}" />
+                    </p:column>
 
-                </h:form>
-            </ui:define>
+                    <p:column rendered="#{!hrReportController.reportKeyWord.additionalDetails}"
+                              headerText="Annual leave" styleClass="col-num">
+                        <p:outputLabel value="#{ss.leave_annual}" />
+                    </p:column>
 
-        </ui:composition>
+                    <p:column rendered="#{!hrReportController.reportKeyWord.additionalDetails}"
+                              headerText="Casual leave" styleClass="col-num">
+                        <p:outputLabel value="#{ss.leave_casual}" />
+                    </p:column>
 
-    </h:body>
-</html>
+                    <p:column rendered="#{!hrReportController.reportKeyWord.additionalDetails}"
+                              headerText="Medical leave" styleClass="col-num">
+                        <p:outputLabel value="#{ss.leave_medical}" />
+                    </p:column>
+
+                    <p:column rendered="#{!hrReportController.reportKeyWord.additionalDetails}"
+                              headerText="Maternity leave" styleClass="col-num">
+                        <p:outputLabel value="#{ss.leave_maternity}" />
+                    </p:column>
+
+                    <p:column headerText="No pay leave" styleClass="col-num">
+                        <p:outputLabel value="#{ss.leave_nopay-ss.lateNoPays}" />
+                    </p:column>
+
+                    <p:column headerText="Late no pay days" styleClass="col-num">
+                        <p:outputLabel value="#{ss.lateNoPays}" />
+                    </p:column>
+
+                    <p:column rendered="#{!hrReportController.reportKeyWord.additionalDetails}"
+                              headerText="Late days" styleClass="col-num">
+                        <p:outputLabel value="#{ss.latedays}" />
+                    </p:column>
+
+                    <p:column headerText="Mercantile days" styleClass="col-num">
+                        <p:outputLabel value="#{ss.merhchantileDays}" />
+                    </p:column>
+
+                    <p:column rendered="#{!hrReportController.reportKeyWord.additionalDetails}"
+                              headerText="Mercantile days (leave)" styleClass="col-num">
+                        <p:outputLabel value="#{ss.merhchantileDaysLeave}" />
+                    </p:column>
+
+                    <p:column headerText="Poya days" styleClass="col-num">
+                        <p:outputLabel value="#{ss.poyaDays}" />
+                    </p:column>
+
+                    <p:column rendered="#{!hrReportController.reportKeyWord.additionalDetails}"
+                              headerText="Poya days (leave)" styleClass="col-num">
+                        <p:outputLabel value="#{ss.poyaDaysLeave}" />
+                    </p:column>
+
+                    <p:column headerText="Off days" styleClass="col-num">
+                        <p:outputLabel value="#{ss.dayoff}" />
+                    </p:column>
+
+                    <p:column rendered="#{!hrReportController.reportKeyWord.additionalDetails}"
+                              headerText="Sleeping days" styleClass="col-num">
+                        <p:outputLabel value="#{ss.sleepingDays}" />
+                    </p:column>
+
+                    <p:column rendered="#{hrReportController.reportKeyWord.additionalDetails}"
+                              headerText="Remarks" styleClass="col-text">
+                        <p:outputLabel value="......................................................................." />
+                    </p:column>
+
+                </p:dataTable>
+
+                <p:panel header="New Comer" styleClass="newcomer-panel">
+                    <table rendered="#{hrReportController.reportKeyWord.additionalDetails}" border="1px solid black" align="center">
+                        <tr>
+                            <td width="50" style="font-size: 9px">E.No</td>
+                            <td width="50" style="font-size: 9px">EPF No</td>
+                            <td width="60" style="font-size: 9px">Date Of Join</td>
+                            <td style="font-size: 9px">Basic Salary+BR</td>
+                            <td style="font-size: 9px">T. Allowance </td>
+                            <td style="font-size: 9px">Per. Allowance</td>
+                            <td width="350" style="font-size: 9px">Name</td>
+                            <td width="100" style="font-size: 9px">Designation</td>
+                        </tr>
+                        <tr><td>&#160;</td><td></td><td></td><td></td><td></td><td></td><td></td><td></td></tr>
+                        <tr><td>&#160;</td><td></td><td></td><td></td><td></td><td></td><td></td><td></td></tr>
+                        <tr><td>&#160;</td><td></td><td></td><td></td><td></td><td></td><td></td><td></td></tr>
+                        <tr><td>&#160;</td><td></td><td></td><td></td><td></td><td></td><td></td><td></td></tr>
+                        <tr><td>&#160;</td><td></td><td></td><td></td><td></td><td></td><td></td><td></td></tr>
+                        <tr><td>&#160;</td><td></td><td></td><td></td><td></td><td></td><td></td><td></td></tr>
+                        <tr><td>&#160;</td><td></td><td></td><td></td><td></td><td></td><td></td><td></td></tr>
+                        <tr><td>&#160;</td><td></td><td></td><td></td><td></td><td></td><td></td><td></td></tr>
+                        <tr><td>&#160;</td><td></td><td></td><td></td><td></td><td></td><td></td><td></td></tr>
+                        <tr><td>&#160;</td><td></td><td></td><td></td><td></td><td></td><td></td><td></td></tr>
+                        <tr><td>&#160;</td><td></td><td></td><td></td><td></td><td></td><td></td><td></td></tr>
+                        <!--                                    <tr>
+                                                                <td>&#160;</td>
+                                                                <td></td>
+                                                                <td></td>
+                                                                <td></td>
+                                                                <td></td>
+                                                                <td></td>
+                                                                <td></td>
+                                                                <td></td>
+                                                            </tr>
+                                                            <tr>
+                                                                <td>&#160;</td>
+                                                                <td></td>
+                                                                <td></td>
+                                                                <td></td>
+                                                                <td></td>
+                                                                <td></td>
+                                                                <td></td>
+                                                                <td></td>
+                                                            </tr>
+                                                            <tr>
+                                                                <td>&#160;</td>
+                                                                <td></td>
+                                                                <td></td>
+                                                                <td></td>
+                                                                <td></td>
+                                                                <td></td>
+                                                                <td></td>
+                                                                <td></td>
+                                                            </tr>
+                                                            <tr>
+                                                                <td>&#160;</td>
+                                                                <td></td>
+                                                                <td></td>
+                                                                <td></td>
+                                                                <td></td>
+                                                                <td></td>
+                                                                <td></td>
+                                                                <td></td>
+                                                            </tr>
+                                                            <tr>
+                                                                <td>&#160;</td>
+                                                                <td></td>
+                                                                <td></td>
+                                                                <td></td>
+                                                                <td></td>
+                                                                <td></td>
+                                                                <td></td>
+                                                                <td></td>
+                                                            </tr>
+                                                            <tr>
+                                                                <td>&#160;</td>
+                                                                <td></td>
+                                                                <td></td>
+                                                                <td></td>
+                                                                <td></td>
+                                                                <td></td>
+                                                                <td></td>
+                                                                <td></td>
+                                                            </tr>
+                                                            <tr>
+                                                                <td>&#160;</td>
+                                                                <td></td>
+                                                                <td></td>
+                                                                <td></td>
+                                                                <td></td>
+                                                                <td></td>
+                                                                <td></td>
+                                                                <td></td>
+                                                            </tr>
+                                                            <tr>
+                                                                <td>&#160;</td>
+                                                                <td></td>
+                                                                <td></td>
+                                                                <td></td>
+                                                                <td></td>
+                                                                <td></td>
+                                                                <td></td>
+                                                                <td></td>
+                                                            </tr>
+                                                            <tr>
+                                                                <td>&#160;</td>
+                                                                <td></td>
+                                                                <td></td>
+                                                                <td></td>
+                                                                <td></td>
+                                                                <td></td>
+                                                                <td></td>
+                                                                <td></td>
+                                                            </tr>
+                                                            <tr>
+                                                                <td>&#160;</td>
+                                                                <td></td>
+                                                                <td></td>
+                                                                <td></td>
+                                                                <td></td>
+                                                                <td></td>
+                                                                <td></td>
+                                                                <td></td>
+                                                            </tr>
+                                                            <tr>
+                                                                <td>&#160;</td>
+                                                                <td></td>
+                                                                <td></td>
+                                                                <td></td>
+                                                                <td></td>
+                                                                <td></td>
+                                                                <td></td>
+                                                                <td></td>
+                                                            </tr>
+                                                            <tr>
+                                                                <td>&#160;</td>
+                                                                <td></td>
+                                                                <td></td>
+                                                                <td></td>
+                                                                <td></td>
+                                                                <td></td>
+                                                                <td></td>
+                                                                <td></td>
+                                                            </tr>
+                                                            <tr>
+                                                                <td>&#160;</td>
+                                                                <td></td>
+                                                                <td></td>
+                                                                <td></td>
+                                                                <td></td>
+                                                                <td></td>
+                                                                <td></td>
+                                                                <td></td>
+                                                            </tr>
+                                                            <tr>
+                                                                <td>&#160;</td>
+                                                                <td></td>
+                                                                <td></td>
+                                                                <td></td>
+                                                                <td></td>
+                                                                <td></td>
+                                                                <td></td>
+                                                                <td></td>
+                                                            </tr>
+                                                            <tr>
+                                                                <td>&#160;</td>
+                                                                <td></td>
+                                                                <td></td>
+                                                                <td></td>
+                                                                <td></td>
+                                                                <td></td>
+                                                                <td></td>
+                                                                <td></td>
+                                                            </tr>
+                                                            <tr>
+                                                                <td>&#160;</td>
+                                                                <td></td>
+                                                                <td></td>
+                                                                <td></td>
+                                                                <td></td>
+                                                                <td></td>
+                                                                <td></td>
+                                                                <td></td>
+                                                            </tr>
+                                                            <tr>
+                                                                <td>&#160;</td>
+                                                                <td></td>
+                                                                <td></td>
+                                                                <td></td>
+                                                                <td></td>
+                                                                <td></td>
+                                                                <td></td>
+                                                                <td></td>
+                                                            </tr>
+                                                            <tr>
+                                                                <td>&#160;</td>
+                                                                <td></td>
+                                                                <td></td>
+                                                                <td></td>
+                                                                <td></td>
+                                                                <td></td>
+                                                                <td></td>
+                                                                <td></td>
+                                                            </tr>
+                                                            <tr>
+                                                                <td>&#160;</td>
+                                                                <td></td>
+                                                                <td></td>
+                                                                <td></td>
+                                                                <td></td>
+                                                                <td></td>
+                                                                <td></td>
+                                                                <td></td>
+                                                            </tr>
+                                                            <tr>
+                                                                <td>&#160;</td>
+                                                                <td></td>
+                                                                <td></td>
+                                                                <td></td>
+                                                                <td></td>
+                                                                <td></td>
+                                                                <td></td>
+                                                                <td></td>
+                                                            </tr>
+                                                            <tr>
+                                                                <td>&#160;</td>
+                                                                <td></td>
+                                                                <td></td>
+                                                                <td></td>
+                                                                <td></td>
+                                                                <td></td>
+                                                                <td></td>
+                                                                <td></td>
+                                                            </tr>
+                                                            <tr>
+                                                                <td>&#160;</td>
+                                                                <td></td>
+                                                                <td></td>
+                                                                <td></td>
+                                                                <td></td>
+                                                                <td></td>
+                                                                <td></td>
+                                                                <td></td>
+                                                            </tr>
+                                                            <tr>
+                                                                <td>&#160;</td>
+                                                                <td></td>
+                                                                <td></td>
+                                                                <td></td>
+                                                                <td></td>
+                                                                <td></td>
+                                                                <td></td>
+                                                                <td></td>
+                                                            </tr>
+                                                            <tr>
+                                                                <td>&#160;</td>
+                                                                <td></td>
+                                                                <td></td>
+                                                                <td></td>
+                                                                <td></td>
+                                                                <td></td>
+                                                                <td></td>
+                                                                <td></td>
+                                                            </tr>
+                                                            <tr>
+                                                                <td>&#160;</td>
+                                                                <td></td>
+                                                                <td></td>
+                                                                <td></td>
+                                                                <td></td>
+                                                                <td></td>
+                                                                <td></td>
+                                                                <td></td>
+                                                            </tr>
+                                                            <tr>
+                                                                <td>&#160;</td>
+                                                                <td></td>
+                                                                <td></td>
+                                                                <td></td>
+                                                                <td></td>
+                                                                <td></td>
+                                                                <td></td>
+                                                                <td></td>
+                                                            </tr>
+                                                            <tr>
+                                                                <td>&#160;</td>
+                                                                <td></td>
+                                                                <td></td>
+                                                                <td></td>
+                                                                <td></td>
+                                                                <td></td>
+                                                                <td></td>
+                                                                <td></td>
+                                                            </tr>-->
+                    </table>
+
+                    <h:panelGrid columns="3" styleClass="noBorder">
+                        <p:outputLabel value="Checked By" style="text-decoration: overline;" />
+                        <p:spacer width="400px" height="100px" />
+                        <p:outputLabel value="Authorized By" style="text-decoration: overline;" />
+                    </h:panelGrid>
+                </p:panel>
+
+            </p:panel>
+
+        </h:form>
+    </ui:define>
+
+</ui:composition>


### PR DESCRIPTION
## Summary
Restyled `hr_report_month_end_employee_date_1.xhtml` to match the established layout and CSS conventions used across the HR report views.

## Changes

### UI / Layout
- Migrated composition root from `html/h:body` wrapper to direct `ui:composition`
- DOCTYPE fixed to `<!DOCTYPE html>`
- Replaced `h:panelGrid` filter section with responsive `fields-grid` CSS grid
- Unified field labels to uppercase spaced style via `.field-label`
- Salary cycle `p:selectOneMenu` and Additional details checkbox moved into proper `field-group` entries
- Process button moved to `controls-actions` row with icon
- Print and Export Excel moved to `controls-actions-secondary` row with border separator
- Print button: `ajax="false" action="#"` → `type="button"`
- Applied `esd-table` datatable styles: uppercase headers, right-aligned numeric columns via `col-num`, hover highlight, horizontal scroll
- Rebuilt report panel header using `report-header-wrap` / `report-meta` structure with salary date range, OT date range, and all filter guards (roster, staff, institution, department, staff category, designation)
- Removed redundant `f:facet name="header"` blocks inside each `p:column`
- Fixed typo in "Mercantile days" column headers (`Merhcantile` → `Mercantile`)
- New Comer panel and signature row preserved as-is including all commented-out rows

## Notes
- `rowStyleClass` conditional colouring (`redText`, `blueText`) preserved as-is
- All `rendered` conditions on columns preserved exactly
- Commented-out newcomer table rows preserved as-is
- No backend/bean changes — all EL expressions preserved as-is
- No functional regressions