### PR TITLE
fix: remove redundant float row and duplicate handover columns from reprint view

### DIFF
--- a/src/main/webapp/cashier/handover_view.xhtml
+++ b/src/main/webapp/cashier/handover_view.xhtml
@@ -15,7 +15,7 @@
                         <f:facet name="header">
                             <p:outputLabel value="View Handover" />
                             <p:commandButton
-                                value="Print Summary"
+                                value="To Print Summary"
                                 styleClass="ui-button-success mx-1"
                                 icon="pi pi-print"
                                 ajax="false"
@@ -23,7 +23,7 @@
                                 action="#{financialTransactionController.navigateToHandoverViewPrintSummary()}">
                             </p:commandButton>
                             <p:commandButton
-                                value="Print Details"
+                                value="To Print Details"
                                 styleClass="ui-button-info mx-1"
                                 icon="pi pi-print"
                                 ajax="false"

--- a/src/main/webapp/resources/ezcomp/prints/five_five_paper_with_headings_for_handover_reprint_view.xhtml
+++ b/src/main/webapp/resources/ezcomp/prints/five_five_paper_with_headings_for_handover_reprint_view.xhtml
@@ -220,12 +220,6 @@
                                                 <td class="text-end"><h:outputText value="#{cc.attrs.bundle.cashHandoverValue}"><f:convertNumber pattern="#,##0.00"/></h:outputText></td>
                                             </tr>
                                         </h:panelGroup>
-                                        <h:panelGroup rendered="#{cc.attrs.bundle.cashFloatInTotal gt 0}">
-                                            <tr>
-                                                <td>Float Received (Cash)</td>
-                                                <td class="text-end" style="color: green;"><h:outputText value="#{cc.attrs.bundle.cashFloatInTotal}"><f:convertNumber pattern="#,##0.00"/></h:outputText></td>
-                                            </tr>
-                                        </h:panelGroup>
                                         <h:panelGroup rendered="#{cc.attrs.bundle.cashFloatOutTotal gt 0}">
                                             <tr>
                                                 <td>Float Sent (Cash)</td>
@@ -366,11 +360,7 @@
                         </h:outputText>
                     </p:column>
 
-                    <p:column class="text-end" headerText="Cash Collected" rendered="#{cc.attrs.bundle.hasCashTransaction}">
-                        <h:outputText value="#{summary.cashValue}"><f:convertNumber pattern="#,##0.00"/></h:outputText>
-                        <f:facet name="footer"><h:outputText value="#{cc.attrs.bundle.cashValue}"><f:convertNumber pattern="#,##0.00"/></h:outputText></f:facet>
-                    </p:column>
-                    <p:column class="text-end" headerText="Cash Handover" rendered="#{cc.attrs.bundle.hasCashTransaction}">
+                    <p:column class="text-end" headerText="Cash" rendered="#{cc.attrs.bundle.hasCashTransaction}">
                         <h:outputText value="#{summary.cashHandoverValue}"><f:convertNumber pattern="#,##0.00"/></h:outputText>
                         <f:facet name="footer"><h:outputText value="#{cc.attrs.bundle.cashHandoverValue}"><f:convertNumber pattern="#,##0.00"/></h:outputText></f:facet>
                     </p:column>
@@ -378,33 +368,17 @@
                         <h:outputText value="#{summary.cardValue}"><f:convertNumber pattern="#,##0.00"/></h:outputText>
                         <f:facet name="footer"><h:outputText value="#{cc.attrs.bundle.cardValue}"><f:convertNumber pattern="#,##0.00"/></h:outputText></f:facet>
                     </p:column>
-                    <p:column class="text-end" headerText="Card Handover" rendered="#{cc.attrs.bundle.hasCardTransaction}">
-                        <h:outputText value="#{summary.cardHandoverValue}"><f:convertNumber pattern="#,##0.00"/></h:outputText>
-                        <f:facet name="footer"><h:outputText value="#{cc.attrs.bundle.cardHandoverValue}"><f:convertNumber pattern="#,##0.00"/></h:outputText></f:facet>
-                    </p:column>
                     <p:column class="text-end" headerText="Credit" rendered="#{cc.attrs.bundle.hasCreditTransaction}">
                         <h:outputText value="#{summary.creditValue}"><f:convertNumber pattern="#,##0.00"/></h:outputText>
                         <f:facet name="footer"><h:outputText value="#{cc.attrs.bundle.creditValue}"><f:convertNumber pattern="#,##0.00"/></h:outputText></f:facet>
-                    </p:column>
-                    <p:column class="text-end" headerText="Credit Handover" rendered="#{cc.attrs.bundle.hasCreditTransaction}">
-                        <h:outputText value="#{summary.creditHandoverValue}"><f:convertNumber pattern="#,##0.00"/></h:outputText>
-                        <f:facet name="footer"><h:outputText value="#{cc.attrs.bundle.creditHandoverValue}"><f:convertNumber pattern="#,##0.00"/></h:outputText></f:facet>
                     </p:column>
                     <p:column class="text-end" headerText="Staff" rendered="#{cc.attrs.bundle.hasStaffTransaction}">
                         <h:outputText value="#{summary.staffValue}"><f:convertNumber pattern="#,##0.00"/></h:outputText>
                         <f:facet name="footer"><h:outputText value="#{cc.attrs.bundle.staffValue}"><f:convertNumber pattern="#,##0.00"/></h:outputText></f:facet>
                     </p:column>
-                    <p:column class="text-end" headerText="Staff Handover" rendered="#{cc.attrs.bundle.hasStaffTransaction}">
-                        <h:outputText value="#{summary.staffHandoverValue}"><f:convertNumber pattern="#,##0.00"/></h:outputText>
-                        <f:facet name="footer"><h:outputText value="#{cc.attrs.bundle.staffHandoverValue}"><f:convertNumber pattern="#,##0.00"/></h:outputText></f:facet>
-                    </p:column>
                     <p:column class="text-end" headerText="Staff Welfare" rendered="#{cc.attrs.bundle.hasStaffWelfareTransaction}">
                         <h:outputText value="#{summary.staffWelfareValue}"><f:convertNumber pattern="#,##0.00"/></h:outputText>
                         <f:facet name="footer"><h:outputText value="#{cc.attrs.bundle.staffWelfareValue}"><f:convertNumber pattern="#,##0.00"/></h:outputText></f:facet>
-                    </p:column>
-                    <p:column class="text-end" headerText="SW Handover" rendered="#{cc.attrs.bundle.hasStaffWelfareTransaction}">
-                        <h:outputText value="#{summary.staffWelfareHandoverValue}"><f:convertNumber pattern="#,##0.00"/></h:outputText>
-                        <f:facet name="footer"><h:outputText value="#{cc.attrs.bundle.staffWelfareHandoverValue}"><f:convertNumber pattern="#,##0.00"/></h:outputText></f:facet>
                     </p:column>
                     <p:column class="text-end" headerText="Voucher" rendered="#{cc.attrs.bundle.hasVoucherTransaction}">
                         <h:outputText value="#{summary.voucherValue}"><f:convertNumber pattern="#,##0.00"/></h:outputText>


### PR DESCRIPTION
## Summary

- Remove the "Float Received (Cash)" row from the handover view print summary — already included in the Cash row
- Remove 5 duplicate handover columns from the datatable: Cash Collected, Card Handover, Credit Handover, Staff Handover, SW Handover
- Rename button labels on handover_view.xhtml for clarity ("Print Summary" → "To Print Summary", "Print Details" → "To Print Details")

Closes #20914

## Test plan

- [ ] Navigate to My Handovers → select a handover → View → To Print Summary
- [ ] Verify "Float Received (Cash)" row is no longer shown in the payment summary table
- [ ] Verify the datatable shows one column per payment method (no duplicate handover columns)
- [ ] Verify totals are still correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Style**
  * Refined print button labels in the handover view for enhanced clarity and consistency
  * Updated the payment summary table to display "Float Sent (Cash)" with visual styling improvements including color indicators for better readability and distinction
  * Restructured and consolidated cash-related reporting columns to provide a cleaner, more organized presentation of financial data in handover documents

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hmislk/hmis/pull/20915?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->