### PR TITLE
Enhance drawer entries API with drawerId, userId filters and extra DTO fields

### DIFF
--- a/src/main/java/com/divudi/core/data/dto/DrawerEntryDTO.java
+++ b/src/main/java/com/divudi/core/data/dto/DrawerEntryDTO.java
@@ -27,6 +27,11 @@ public class DrawerEntryDTO implements Serializable {
     private Long paymentId;
     private Date createdAt;
     private String createrName;
+    private String billTypeAtomic;
+    private Double beforeShortageExcess;
+    private Double afterShortageExcess;
+    private Long webUserId;
+    private String webUserName;
 
     // Constructors
     public DrawerEntryDTO() {
@@ -143,6 +148,46 @@ public class DrawerEntryDTO implements Serializable {
 
     public void setCreaterName(String createrName) {
         this.createrName = createrName;
+    }
+
+    public String getBillTypeAtomic() {
+        return billTypeAtomic;
+    }
+
+    public void setBillTypeAtomic(String billTypeAtomic) {
+        this.billTypeAtomic = billTypeAtomic;
+    }
+
+    public Double getBeforeShortageExcess() {
+        return beforeShortageExcess;
+    }
+
+    public void setBeforeShortageExcess(Double beforeShortageExcess) {
+        this.beforeShortageExcess = beforeShortageExcess;
+    }
+
+    public Double getAfterShortageExcess() {
+        return afterShortageExcess;
+    }
+
+    public void setAfterShortageExcess(Double afterShortageExcess) {
+        this.afterShortageExcess = afterShortageExcess;
+    }
+
+    public Long getWebUserId() {
+        return webUserId;
+    }
+
+    public void setWebUserId(Long webUserId) {
+        this.webUserId = webUserId;
+    }
+
+    public String getWebUserName() {
+        return webUserName;
+    }
+
+    public void setWebUserName(String webUserName) {
+        this.webUserName = webUserName;
     }
 
     @Override

--- a/src/main/java/com/divudi/ws/finance/BalanceHistoryApi.java
+++ b/src/main/java/com/divudi/ws/finance/BalanceHistoryApi.java
@@ -85,6 +85,8 @@ public class BalanceHistoryApi {
     @Produces(MediaType.APPLICATION_JSON)
     public Response getDrawerEntries(
             @QueryParam("billId") Long billId,
+            @QueryParam("drawerId") Long drawerId,
+            @QueryParam("userId") Long userId,
             @QueryParam("fromDate") String fromDateStr,
             @QueryParam("toDate") String toDateStr,
             @QueryParam("paymentMethod") String paymentMethod,
@@ -103,6 +105,16 @@ public class BalanceHistoryApi {
             if (billId != null) {
                 jpql.append(" AND de.bill.id = :billId");
                 params.put("billId", billId);
+            }
+
+            if (drawerId != null) {
+                jpql.append(" AND de.drawer.id = :drawerId");
+                params.put("drawerId", drawerId);
+            }
+
+            if (userId != null) {
+                jpql.append(" AND de.webUser.id = :userId");
+                params.put("userId", userId);
             }
 
             if (paymentMethod != null && !paymentMethod.trim().isEmpty()) {
@@ -400,6 +412,12 @@ public class BalanceHistoryApi {
         dto.setPaymentId(entry.getPayment() != null ? entry.getPayment().getId() : null);
         dto.setCreatedAt(entry.getCreatedAt());
         dto.setCreaterName(entry.getCreater() != null ? entry.getCreater().getName() : null);
+        dto.setBillTypeAtomic(entry.getBill() != null && entry.getBill().getBillTypeAtomic() != null
+                ? entry.getBill().getBillTypeAtomic().getLabel() : null);
+        dto.setBeforeShortageExcess(entry.getBeforeShortageExcess());
+        dto.setAfterShortageExcess(entry.getAfterShortageExcess());
+        dto.setWebUserId(entry.getWebUser() != null ? entry.getWebUser().getId() : null);
+        dto.setWebUserName(entry.getWebUser() != null ? entry.getWebUser().getName() : null);
         return dto;
     }
 


### PR DESCRIPTION
## Summary
- Add `drawerId` and `userId` query parameters to `GET /api/balance_history/drawer_entries` for filtering entries by specific drawer or user
- Add `billTypeAtomic`, `beforeShortageExcess`, `afterShortageExcess`, `webUserId`, and `webUserName` fields to `DrawerEntryDTO` for better investigation context

## Test plan
- [ ] Call `/api/balance_history/drawer_entries?drawerId=<id>` and verify only entries for that drawer are returned
- [ ] Call `/api/balance_history/drawer_entries?userId=<id>` and verify only entries for that user are returned
- [ ] Combine filters: `?drawerId=<id>&paymentMethod=Cash&fromDate=...&toDate=...`
- [ ] Verify new DTO fields (`billTypeAtomic`, `beforeShortageExcess`, `afterShortageExcess`, `webUserId`, `webUserName`) are populated in response
- [ ] Verify existing filters (`billId`, `fromDate`, `toDate`, `paymentMethod`, `limit`) still work correctly

Closes #20919

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Drawer entries endpoint now supports optional filtering by drawer ID and user ID for more targeted data retrieval
  * Drawer entry responses now include additional fields: bill type classification, shortage/excess calculations, and web user identifiers and names

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hmislk/hmis/pull/20920?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->