### PR TITLE
feat: native SQL print preview for Purchase Orders

### DIFF
--- a/developer_docs/billing/native-sql-print-page-guide.md
+++ b/developer_docs/billing/native-sql-print-page-guide.md
@@ -123,7 +123,7 @@ not the field name. Several are non-obvious:
 | `Department.site` | `Institution` | `institution` | `department` |
 | `Item.issueUnit` | `MeasurementUnit extends Category` | `category` | `item` |
 | `Item.category` | `Category` | `category` | — |
-| `WebUser.person` (EL: `webUserPerson`) | `Person` | `person` | — |
+| `WebUser.webUserPerson` | `Person` | `person` | FK column is `webUserPerson_ID` not `person_ID` |
 | `Department.institution` | `Institution` | `institution` | — |
 
 To verify: grep the entity class for the field, then check the Java type.

--- a/developer_docs/billing/native-sql-print-page-guide.md
+++ b/developer_docs/billing/native-sql-print-page-guide.md
@@ -103,7 +103,33 @@ resolve which bill is which before querying, e.g.:
 String atomicSql = "SELECT billTypeAtomic, referenceBill_ID FROM bill WHERE ID = ?1 AND retired = 0 LIMIT 1";
 em.createNativeQuery(atomicSql).setParameter(1, billId).getResultList();
 ```
-Then branch on the atomic value to get the approval bill ID before the main query.
+Fail fast on unsupported atomics and missing links — do **not** fall back to `billId`:
+```java
+if ("PHARMACY_ORDER_APPROVAL".equals(billTypeAtomic)) {
+    approvalBillId = billId;
+} else if ("PHARMACY_ORDER".equals(billTypeAtomic)) {
+    if (atomicRow[1] == null) { return null; }  // not yet approved
+    approvalBillId = ((Number) atomicRow[1]).longValue();
+} else {
+    return null;  // unsupported type — do not guess
+}
+```
+
+**Verify entity field types before writing JOINs** — the Java field type determines the DB table,
+not the field name. Several are non-obvious:
+
+| Entity field | Java type | DB table | Common wrong join |
+|---|---|---|---|
+| `Department.site` | `Institution` | `institution` | `department` |
+| `Item.issueUnit` | `MeasurementUnit extends Category` | `category` | `item` |
+| `Item.category` | `Category` | `category` | — |
+| `WebUser.person` (EL: `webUserPerson`) | `Person` | `person` | — |
+| `Department.institution` | `Institution` | `institution` | — |
+
+To verify: grep the entity class for the field, then check the Java type.
+```bash
+grep -n "private.*fieldName" src/main/java/com/divudi/core/entity/SomeEntity.java
+```
 
 Reference: `PurchaseOrderNativeSqlService.java`.
 
@@ -247,7 +273,28 @@ load incorrectly initially when rendered inside a dialog. See `jsf-ajax` skill.
 
 Always call `makeNull()` at the start of `viewByBillId()` to clear stale state.
 
-### 6. Named parameters in native queries cause a SQL syntax error
+### 6. Joining the wrong table for a relation field
+
+The Java field name looks like one table but the actual type maps to another. Silent — LEFT JOIN
+returns null columns rather than an error, so the bug only shows up as blank data on the print page.
+
+```sql
+-- WRONG: Department.site is Institution, not Department
+LEFT JOIN department orderSite ON orderSite.ID = orderDept.site_ID
+
+-- CORRECT
+LEFT JOIN institution orderSite ON orderSite.ID = orderDept.site_ID
+
+-- WRONG: Item.issueUnit is MeasurementUnit extends Category, not Item
+LEFT JOIN item iu ON iu.ID = i.issueUnit_ID
+
+-- CORRECT
+LEFT JOIN category iu ON iu.ID = i.issueUnit_ID
+```
+
+Always grep the entity field to confirm its Java type before writing the JOIN.
+
+### 7. Named parameters in native queries cause a SQL syntax error
 
 EclipseLink's `createNativeQuery` does **not** support named parameters (`:name`). Use positional
 parameters `?1`, `?2`, ... and set them with `.setParameter(1, value)`.

--- a/developer_docs/billing/native-sql-print-page-guide.md
+++ b/developer_docs/billing/native-sql-print-page-guide.md
@@ -1,0 +1,275 @@
+# Native SQL Print Page Development Guide
+
+**Reference implementation**: Purchase Order print page (Issue #20923)  
+**Last updated**: 2026-05-21
+
+---
+
+## Why Native SQL for Print Pages?
+
+The standard entity-based print flow loads a full JPA entity graph on every view:
+`bill → referenceBill → creater → institution / department`, `billItems → item → billItemFinanceDetails`, etc.
+
+For a read-only print page this is wasteful. Native SQL replaces all of that with two queries
+(header + items), each returning flat rows into a DTO. The JSF page binds to the DTO — no
+lazy-loading, no L2 cache involvement.
+
+---
+
+## Step 0 — Identify the Existing Page and Print Formats
+
+1. Find the current print/view XHTML page (e.g. `pharmacy_reprint_po.xhtml`).
+2. Note whether it uses an **old dropdown paper-size selector** or the modern
+   **config-button / gear-icon pattern**.
+   - If it uses a dropdown: add a print config button first following
+     `developer_docs/admin/config-button-implementation-guide.md`, then continue.
+3. List all paper format composite components rendered on the page and read each one fully.
+   Record every entity EL expression used.
+
+---
+
+## Step 1 — Catalogue All Entity References
+
+Go through every composite template and the host XHTML page. For each EL expression, note:
+- Which entity it comes from (`bill`, `bill.referenceBill`, `bill.creater`, etc.)
+- Which field is accessed
+- Whether the FK could be null in production data
+
+Typical sources for pharmacy bills:
+
+| Source | Example fields |
+|---|---|
+| `bill` (approval/main) | `deptId`, `paymentMethod`, `creditDuration`, `createdAt`, `consignment`, `comments`, `netTotal`, `approveAt`, `cancelled` |
+| `bill.referenceBill` (pre-bill) | `createdAt`, `comments`, `checkeAt` |
+| `bill.creater` (WebUser → Person) | `webUserPerson.name` |
+| `bill.referenceBill.checkedBy` (WebUser → Person) | `webUserPerson.name` |
+| `bill.referenceBill.creater` (WebUser → Department → Institution) | `institution.name`, `institution.phone`, `institution.fax`, `department.telephone1`, `department.email` |
+| `bill.department` | `name`, `address`, `telephone1`, `telephone2`, `fax`, `site.name` |
+| `bill.institution` | `name`, `email` |
+| `bill.toInstitution` (supplier) | `name`, `code` |
+| `bill.billItems[]` | `item.name`, `item.code`, `item.issueUnit.name`, `retired` |
+| `billItem.billItemFinanceDetails` | `lineGrossRate`, `quantity`, `freeQuantity`, `lineGrossTotal` |
+| Stock / ItemBatch / StockHistory | Only for bills that affect stock (GRN, retail sale, transfers) |
+
+---
+
+## Step 2 — Create DTOs
+
+Create two DTO classes in `com.divudi.core.data.dto.pharmacy`:
+
+- **`<Module>PrintDto`** — header-level fields (one per bill)
+- **`<Module>ItemPrintDto`** — line-item fields (one per bill item)
+
+Rules:
+- Use primitive types (`double`, `boolean`, `int`) rather than boxed types for numeric fields.
+- Use `String` (never null from the service — default to `""`) for text fields.
+- Use `Date` for timestamps.
+- Add a `List<ItemDto> items = new ArrayList<>()` field on the header DTO.
+- No JPA annotations. No `@Entity`. Plain Java beans with getters/setters only.
+
+Reference: `PurchaseOrderPrintDto` + `PurchaseOrderItemPrintDto`.
+
+---
+
+## Step 3 — Create the Native SQL Service
+
+Create `<Module>NativeSqlService` in `com.divudi.service.pharmacy`:
+- Annotate `@Stateless`.
+- Inject `@PersistenceContext(unitName = "hmisPU") EntityManager em`.
+- One public method: `<ModulePrintDto> loadPrintDtoByBillId(long billId)`.
+- Wrap the body in a try/catch — return `null` on any exception (caller shows error message).
+
+### Query design rules
+
+**Always use LEFT JOIN** for every FK — never INNER JOIN. Any null FK (e.g. a bill with no
+`checkedBy` user, or a bill item with no `billItemFinanceDetails`) must **not** drop the row.
+
+**Two-query pattern**:
+1. Header query — one row joining bill → referenceBill → users → persons → departments → institutions.
+2. Item query — one row per non-retired bill item, joining billitem → item → issueUnit → billitemfinancedetails.
+
+**Null safety in Java**:
+- Use a `str(Object o)` helper: `return o != null ? o.toString().trim() : "";`
+- Use a `toDate(Object o)` helper that handles both `Timestamp` and `java.util.Date`.
+- For numbers: `r[col] != null ? ((Number) r[col]).doubleValue() : 0.0`.
+- For booleans: `r[col] != null && ((Number) r[col]).intValue() != 0`.
+
+**Column ordering**: list columns in the SELECT in the same order as you read them in Java
+(sequential `col++` index). Keep them in sync — a shifted column is a silent bug.
+
+**Bill resolution** — some BillTypeAtomics come in pairs (request/approval). The service must
+resolve which bill is which before querying, e.g.:
+```java
+String atomicSql = "SELECT billTypeAtomic, referenceBill_ID FROM bill WHERE ID = :id AND retired = 0 LIMIT 1";
+```
+Then branch on the atomic value to get the approval bill ID before the main query.
+
+Reference: `PurchaseOrderNativeSqlService.java`.
+
+---
+
+## Step 4 — Create the Controller
+
+Create `<Module>NativeSqlController` in `com.divudi.bean.pharmacy`:
+- Annotate `@Named @SessionScoped`.
+- Fields: `private <ModulePrintDto> printDto` and `private boolean printPreview`.
+- Inject `SessionController` and `@EJB <Module>NativeSqlService`.
+- One public navigation method:
+
+```java
+public String viewByBillId(Long billId) {
+    if (billId == null) { JsfUtil.addErrorMessage("No Bill Selected"); return null; }
+    makeNull();
+    printDto = service.loadPrintDtoByBillId(billId);
+    if (printDto == null) { JsfUtil.addErrorMessage("Bill not found"); return null; }
+    printPreview = true;
+    return "/pharmacy/pharmacy_reprint_<module>_native?faces-redirect=true";
+}
+
+public void makeNull() { printDto = null; printPreview = false; }
+```
+
+Reference: `PurchaseOrderNativeSqlController.java`.
+
+---
+
+## Step 5 — Create the Native Print Page
+
+Copy the original XHTML page to a new file named `pharmacy_reprint_<module>_native.xhtml`.
+
+Changes to make:
+1. **Remove all composite component includes** (`xmlns:ph=...`, `<ph:xxx .../>`).
+2. **Inline each format section** as a `<h:panelGroup rendered="#{configOptionController.getBooleanValueByKey(...)}">` block.
+3. **Replace every entity EL** `#{pharmacyBillSearch.bill.someField}` with the flat DTO field
+   `#{<module>NativeSqlController.printDto.someField}`.
+4. **Keep the config dialog** — reuse the same `purchaseOrderConfigController` (or equivalent)
+   and the same config keys. Use `h:selectBooleanCheckbox` (not `p:selectBooleanCheckbox`) to
+   avoid dialog initialisation issues.
+5. **Add a small Legacy View button** pointing back to the original page:
+
+```xhtml
+<p:commandButton
+    ajax="false"
+    value="Legacy View"
+    title="Open original entity-based print page"
+    action="#{pharmacyBillSearch.navigatePharmacyReprintPo}"
+    class="ui-button-secondary ms-3"
+    icon="fas fa-history"
+    style="font-size: 0.75rem; padding: 0.2rem 0.5rem;"/>
+```
+
+6. **Keep the original page untouched** — do not modify it.
+
+---
+
+## Step 6 — Review Agent Check
+
+After creating the native page, run a review to verify no entity references remain.
+Look for:
+- `#{pharmacyBillSearch.bill.` or any `#{<controller>.bill.` (entity EL chain)
+- Any `ui:repeat value="#{...bill.billItems}"` (iterating entity collection)
+- Any `#{bip.item.name}` style access (entity traversal inside the loop)
+
+Also check whether any controller method called from the page internally loads a JPA entity
+and exposes fields via getters. If so, those fields must also move to the DTO.
+
+---
+
+## Step 7 — Wire Navigation in BillSearch
+
+In `BillSearch.java`:
+
+1. Add an import: `import com.divudi.bean.pharmacy.<Module>NativeSqlController;`
+2. Add an `@Inject` field near the other native controllers (~line 338).
+3. In `navigateToViewBillByAtomicBillTypeByBillId()` (the native fast-path switch at ~line 4786),
+   add cases for the active BillTypeAtomics **before** the `default:` fallthrough:
+
+```java
+case PHARMACY_ORDER:
+case PHARMACY_ORDER_APPROVAL:
+    return purchaseOrderNativeSqlController.viewByBillId(BillId);
+```
+
+4. In `navigateToViewBillByAtomicBillTypeByBillIdEntityBased()` (the entity-based fallback at
+   ~line 5134), replace the unified block with split cases:
+   - Active atomics → delegate to native controller
+   - Cancelled/pre atomics → keep existing entity path
+
+**Do not** add cases to `navigateToManageBillByAtomicBillType()` or
+`navigateToAdminBillByAtomicBillType()` — those flows still use entities and are out of scope.
+
+---
+
+## Step 8 — QA Checklist
+
+- [ ] All enabled paper formats render correctly.
+- [ ] Null FKs (e.g. bill with no `checkedBy`) do not cause NPE or blank page — fields show empty string.
+- [ ] `preparedByName` and `approvedByName` display correct names.
+- [ ] PO Date comes from the request pre-bill; PO Time from the approval bill.
+- [ ] Item list shows all non-retired items with correct quantities and rates.
+- [ ] Net total matches the bill total in the DB.
+- [ ] Legacy View button navigates to the old entity-based page.
+- [ ] Cancelled POs (`PHARMACY_ORDER_CANCELLED`, `PHARMACY_ORDER_APPROVAL_CANCELLED`) still
+      route to the old page.
+- [ ] Settings dialog saves and reloads config correctly.
+
+---
+
+## Common Mistakes
+
+### 1. INNER JOIN drops bills with null FKs
+
+```sql
+-- WRONG: any bill with no checkedBy user silently disappears
+JOIN webuser checkedByWU ON checkedByWU.ID = rb.checkedBy_ID
+
+-- CORRECT
+LEFT JOIN webuser checkedByWU ON checkedByWU.ID = rb.checkedBy_ID
+```
+
+### 2. Column index off-by-one
+
+If the Java column reader skips or double-reads a column (sequential `col++` drift), all
+subsequent values are wrong. Keep SELECT column order and Java read order perfectly in sync.
+
+### 3. Iterating entity collection in the native page
+
+`<ui:repeat value="#{controller.printDto.items}">` is correct.  
+`<ui:repeat value="#{pharmacyBillSearch.bill.billItems}">` loads the JPA entity — remove it.
+
+### 4. p:selectBooleanCheckbox in config dialog
+
+Use `h:selectBooleanCheckbox` not `p:selectBooleanCheckbox` in dialogs. PrimeFaces checkboxes
+load incorrectly initially when rendered inside a dialog. See `jsf-ajax` skill.
+
+### 5. Native controller is SessionScoped but printDto from a prior navigation bleeds in
+
+Always call `makeNull()` at the start of `viewByBillId()` to clear stale state.
+
+### 6. Named parameters in native queries cause a SQL syntax error
+
+EclipseLink's `createNativeQuery` does **not** support named parameters (`:name`). Use positional
+parameters `?1`, `?2`, ... and set them with `.setParameter(1, value)`.
+
+```java
+// WRONG — EclipseLink throws SQLSyntaxErrorException at runtime
+em.createNativeQuery("SELECT ... WHERE ID = :id").setParameter("id", billId)
+
+// CORRECT
+em.createNativeQuery("SELECT ... WHERE ID = ?1").setParameter(1, billId)
+```
+
+---
+
+## Reference Files
+
+| File | Purpose |
+|---|---|
+| `com/divudi/core/data/dto/pharmacy/PurchaseOrderPrintDto.java` | Reference header DTO |
+| `com/divudi/core/data/dto/pharmacy/PurchaseOrderItemPrintDto.java` | Reference item DTO |
+| `com/divudi/service/pharmacy/PurchaseOrderNativeSqlService.java` | Reference native service |
+| `com/divudi/bean/pharmacy/PurchaseOrderNativeSqlController.java` | Reference controller |
+| `src/main/webapp/pharmacy/pharmacy_reprint_po_native.xhtml` | Reference native page |
+| `developer_docs/billing/bill-preview-navigation-guide.md` | BillSearch routing overview |
+| `developer_docs/pharmacy/native-sql-bill-migration-guide.md` | Settlement (write) side native SQL guide |
+| `developer_docs/admin/config-button-implementation-guide.md` | Config button / gear icon pattern |

--- a/developer_docs/billing/native-sql-print-page-guide.md
+++ b/developer_docs/billing/native-sql-print-page-guide.md
@@ -100,7 +100,8 @@ Create `<Module>NativeSqlService` in `com.divudi.service.pharmacy`:
 **Bill resolution** — some BillTypeAtomics come in pairs (request/approval). The service must
 resolve which bill is which before querying, e.g.:
 ```java
-String atomicSql = "SELECT billTypeAtomic, referenceBill_ID FROM bill WHERE ID = :id AND retired = 0 LIMIT 1";
+String atomicSql = "SELECT billTypeAtomic, referenceBill_ID FROM bill WHERE ID = ?1 AND retired = 0 LIMIT 1";
+em.createNativeQuery(atomicSql).setParameter(1, billId).getResultList();
 ```
 Then branch on the atomic value to get the approval bill ID before the main query.
 

--- a/developer_docs/billing/native-sql-print-page-guide.md
+++ b/developer_docs/billing/native-sql-print-page-guide.md
@@ -92,7 +92,17 @@ Create `<Module>NativeSqlService` in `com.divudi.service.pharmacy`:
 - Use a `str(Object o)` helper: `return o != null ? o.toString().trim() : "";`
 - Use a `toDate(Object o)` helper that handles both `Timestamp` and `java.util.Date`.
 - For numbers: `r[col] != null ? ((Number) r[col]).doubleValue() : 0.0`.
-- For booleans: `r[col] != null && ((Number) r[col]).intValue() != 0`.
+- For booleans: use a `toBool(Object o)` helper — MySQL JDBC returns `BIT(1)` columns as
+  `Boolean`, not `Number`, so casting to `Number` throws `ClassCastException` at runtime:
+  ```java
+  private boolean toBool(Object o) {
+      if (o == null) return false;
+      if (o instanceof Boolean) return (Boolean) o;
+      if (o instanceof Number) return ((Number) o).intValue() != 0;
+      return false;
+  }
+  ```
+  Never use `((Number) r[col]).intValue() != 0` for boolean columns.
 
 **Column ordering**: list columns in the SELECT in the same order as you read them in Java
 (sequential `col++` index). Keep them in sync — a shifted column is a silent bug.

--- a/src/main/java/com/divudi/bean/common/BillSearch.java
+++ b/src/main/java/com/divudi/bean/common/BillSearch.java
@@ -133,6 +133,7 @@ import com.divudi.bean.pharmacy.TransferIssueNativeSqlController;
 import com.divudi.bean.pharmacy.TransferReceiveNativeSqlController;
 import com.divudi.bean.pharmacy.InpatientDirectIssueNativeSqlController;
 import com.divudi.bean.pharmacy.RetailSaleNativeSqlController;
+import com.divudi.bean.pharmacy.PurchaseOrderNativeSqlController;
 import static com.divudi.core.data.BillTypeAtomic.DIRECT_ISSUE_INWARD_MEDICINE;
 import static com.divudi.core.data.BillTypeAtomic.PHARMACY_ISSUE;
 import static com.divudi.core.data.BillTypeAtomic.PHARMACY_RECEIVE;
@@ -336,6 +337,8 @@ public class BillSearch implements Serializable, ControllerWithMultiplePayments 
     InpatientDirectIssueNativeSqlController inpatientDirectIssueNativeSqlController;
     @Inject
     RetailSaleNativeSqlController retailSaleNativeSqlController;
+    @Inject
+    PurchaseOrderNativeSqlController purchaseOrderNativeSqlController;
     /**
      * Class Variables
      */
@@ -4792,6 +4795,9 @@ public class BillSearch implements Serializable, ControllerWithMultiplePayments 
             case PHARMACY_TRANSFER_REQUEST_PRE:
             case PHARMACY_TRANSFER_REQUEST:
                 return pharmacyBillSearch.viewRequestByBillId(BillId);
+            case PHARMACY_ORDER:
+            case PHARMACY_ORDER_APPROVAL:
+                return purchaseOrderNativeSqlController.viewByBillId(BillId);
             default:
                 return navigateToViewBillByAtomicBillTypeByBillIdEntityBased(BillId);
         }
@@ -5126,9 +5132,11 @@ public class BillSearch implements Serializable, ControllerWithMultiplePayments 
                 return pharmacyBillSearch.navigateToViewPharmacyBill();
 
             case PHARMACY_ORDER:
+            case PHARMACY_ORDER_APPROVAL:
+                return purchaseOrderNativeSqlController.viewByBillId(bill.getId());
+
             case PHARMACY_ORDER_PRE:
             case PHARMACY_ORDER_CANCELLED:
-            case PHARMACY_ORDER_APPROVAL:
             case PHARMACY_ORDER_APPROVAL_CANCELLED:
                 pharmacyBillSearch.setBill(bill);
                 return pharmacyBillSearch.navigatePharmacyReprintPo();

--- a/src/main/java/com/divudi/bean/pharmacy/PurchaseOrderNativeSqlController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PurchaseOrderNativeSqlController.java
@@ -1,0 +1,77 @@
+/*
+ * Open Hospital Management Information System
+ * Dr M H B Ariyaratne
+ * buddhika.ari@gmail.com
+ */
+package com.divudi.bean.pharmacy;
+
+import com.divudi.bean.common.SessionController;
+import com.divudi.core.data.dto.pharmacy.PurchaseOrderPrintDto;
+import com.divudi.core.util.JsfUtil;
+import com.divudi.service.pharmacy.PurchaseOrderNativeSqlService;
+import java.io.Serializable;
+import javax.ejb.EJB;
+import javax.enterprise.context.SessionScoped;
+import javax.inject.Inject;
+import javax.inject.Named;
+
+/**
+ * SessionScoped controller for the native-SQL Purchase Order print preview.
+ *
+ * Entry point: viewByBillId(Long billId) — called by BillSearch routing.
+ * Stores the loaded DTO and navigates to pharmacy_reprint_po_native.xhtml.
+ * Related issue: #20923
+ */
+@Named
+@SessionScoped
+public class PurchaseOrderNativeSqlController implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    private PurchaseOrderPrintDto printDto;
+    private boolean printPreview;
+
+    @Inject
+    private SessionController sessionController;
+
+    @EJB
+    private PurchaseOrderNativeSqlService purchaseOrderNativeSqlService;
+
+    // -----------------------------------------------------------------------
+    // Navigation entry point (called by BillSearch)
+    // -----------------------------------------------------------------------
+
+    public String viewByBillId(Long billId) {
+        if (billId == null) {
+            JsfUtil.addErrorMessage("No Bill Selected");
+            return null;
+        }
+        makeNull();
+        printDto = purchaseOrderNativeSqlService.loadPrintDtoByBillId(billId);
+        if (printDto == null) {
+            JsfUtil.addErrorMessage("Purchase Order not found");
+            return null;
+        }
+        printPreview = true;
+        return "/pharmacy/pharmacy_reprint_po_native?faces-redirect=true";
+    }
+
+    // -----------------------------------------------------------------------
+    // State
+    // -----------------------------------------------------------------------
+
+    public void makeNull() {
+        printDto = null;
+        printPreview = false;
+    }
+
+    // -----------------------------------------------------------------------
+    // Getters / setters
+    // -----------------------------------------------------------------------
+
+    public PurchaseOrderPrintDto getPrintDto() { return printDto; }
+    public void setPrintDto(PurchaseOrderPrintDto printDto) { this.printDto = printDto; }
+
+    public boolean isPrintPreview() { return printPreview; }
+    public void setPrintPreview(boolean printPreview) { this.printPreview = printPreview; }
+}

--- a/src/main/java/com/divudi/bean/pharmacy/PurchaseOrderNativeSqlController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PurchaseOrderNativeSqlController.java
@@ -30,6 +30,7 @@ public class PurchaseOrderNativeSqlController implements Serializable {
 
     private PurchaseOrderPrintDto printDto;
     private boolean printPreview;
+    private Long currentBillId;
 
     @Inject
     private SessionController sessionController;
@@ -47,6 +48,7 @@ public class PurchaseOrderNativeSqlController implements Serializable {
             return null;
         }
         makeNull();
+        currentBillId = billId;
         printDto = purchaseOrderNativeSqlService.loadPrintDtoByBillId(billId);
         if (printDto == null) {
             JsfUtil.addErrorMessage("Purchase Order not found");
@@ -63,6 +65,7 @@ public class PurchaseOrderNativeSqlController implements Serializable {
     public void makeNull() {
         printDto = null;
         printPreview = false;
+        currentBillId = null;
     }
 
     // -----------------------------------------------------------------------
@@ -74,4 +77,7 @@ public class PurchaseOrderNativeSqlController implements Serializable {
 
     public boolean isPrintPreview() { return printPreview; }
     public void setPrintPreview(boolean printPreview) { this.printPreview = printPreview; }
+
+    public Long getCurrentBillId() { return currentBillId; }
+    public void setCurrentBillId(Long currentBillId) { this.currentBillId = currentBillId; }
 }

--- a/src/main/java/com/divudi/core/data/dto/pharmacy/PurchaseOrderItemPrintDto.java
+++ b/src/main/java/com/divudi/core/data/dto/pharmacy/PurchaseOrderItemPrintDto.java
@@ -1,0 +1,47 @@
+/*
+ * Open Hospital Management Information System
+ * Dr M H B Ariyaratne
+ * buddhika.ari@gmail.com
+ */
+package com.divudi.core.data.dto.pharmacy;
+
+import java.io.Serializable;
+
+/**
+ * One line item on a Purchase Order print.
+ * Populated by PurchaseOrderNativeSqlService.loadPrintDtoByBillId().
+ * Related issue: #20923
+ */
+public class PurchaseOrderItemPrintDto implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    private String itemName;
+    private String itemCode;
+    private String issueUnitName;
+    private double purchaseRate;
+    private double quantity;
+    private double freeQuantity;
+    private double lineTotal;
+
+    public String getItemName() { return itemName; }
+    public void setItemName(String itemName) { this.itemName = itemName; }
+
+    public String getItemCode() { return itemCode; }
+    public void setItemCode(String itemCode) { this.itemCode = itemCode; }
+
+    public String getIssueUnitName() { return issueUnitName; }
+    public void setIssueUnitName(String issueUnitName) { this.issueUnitName = issueUnitName; }
+
+    public double getPurchaseRate() { return purchaseRate; }
+    public void setPurchaseRate(double purchaseRate) { this.purchaseRate = purchaseRate; }
+
+    public double getQuantity() { return quantity; }
+    public void setQuantity(double quantity) { this.quantity = quantity; }
+
+    public double getFreeQuantity() { return freeQuantity; }
+    public void setFreeQuantity(double freeQuantity) { this.freeQuantity = freeQuantity; }
+
+    public double getLineTotal() { return lineTotal; }
+    public void setLineTotal(double lineTotal) { this.lineTotal = lineTotal; }
+}

--- a/src/main/java/com/divudi/core/data/dto/pharmacy/PurchaseOrderPrintDto.java
+++ b/src/main/java/com/divudi/core/data/dto/pharmacy/PurchaseOrderPrintDto.java
@@ -1,0 +1,155 @@
+/*
+ * Open Hospital Management Information System
+ * Dr M H B Ariyaratne
+ * buddhika.ari@gmail.com
+ */
+package com.divudi.core.data.dto.pharmacy;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+
+/**
+ * Print DTO for a native Purchase Order print page.
+ * Populated by PurchaseOrderNativeSqlService.loadPrintDtoByBillId().
+ * Related issue: #20923
+ */
+public class PurchaseOrderPrintDto implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    // ---- Approval bill fields ----
+    private String poNumber;
+    private String paymentMethod;
+    private int creditDuration;
+    private Date poTime;
+    private boolean consignment;
+    private String approveComments;
+    private Date approvedAt;
+    private String approvedByName;
+    private double netTotal;
+    private boolean cancelled;
+
+    // ---- Request (pre-bill) fields ----
+    private Date poDate;
+    private String requestComments;
+    private String preparedByName;
+    private Date preparedAt;
+
+    // ---- Institution / department (from request creater) ----
+    private String institutionName;
+    private String institutionPhone;
+    private String institutionFax;
+    private String departmentTelephone1;
+    private String departmentEmail;
+
+    // ---- Approval bill department ----
+    private String orderDepartmentName;
+    private String orderDepartmentAddress;
+    private String orderDepartmentTelephone1;
+    private String orderDepartmentTelephone2;
+    private String orderDepartmentFax;
+    private String orderInstitutionName;
+    private String orderInstitutionEmail;
+    private String orderSiteName;
+
+    // ---- Supplier (toInstitution) ----
+    private String supplierName;
+    private String supplierCode;
+
+    // ---- Line items ----
+    private List<PurchaseOrderItemPrintDto> items = new ArrayList<>();
+
+    // ---- Getters / setters ----
+
+    public String getPoNumber() { return poNumber; }
+    public void setPoNumber(String poNumber) { this.poNumber = poNumber; }
+
+    public String getPaymentMethod() { return paymentMethod; }
+    public void setPaymentMethod(String paymentMethod) { this.paymentMethod = paymentMethod; }
+
+    public int getCreditDuration() { return creditDuration; }
+    public void setCreditDuration(int creditDuration) { this.creditDuration = creditDuration; }
+
+    public Date getPoTime() { return poTime; }
+    public void setPoTime(Date poTime) { this.poTime = poTime; }
+
+    public boolean isConsignment() { return consignment; }
+    public void setConsignment(boolean consignment) { this.consignment = consignment; }
+
+    public String getApproveComments() { return approveComments; }
+    public void setApproveComments(String approveComments) { this.approveComments = approveComments; }
+
+    public Date getApprovedAt() { return approvedAt; }
+    public void setApprovedAt(Date approvedAt) { this.approvedAt = approvedAt; }
+
+    public String getApprovedByName() { return approvedByName; }
+    public void setApprovedByName(String approvedByName) { this.approvedByName = approvedByName; }
+
+    public double getNetTotal() { return netTotal; }
+    public void setNetTotal(double netTotal) { this.netTotal = netTotal; }
+
+    public boolean isCancelled() { return cancelled; }
+    public void setCancelled(boolean cancelled) { this.cancelled = cancelled; }
+
+    public Date getPoDate() { return poDate; }
+    public void setPoDate(Date poDate) { this.poDate = poDate; }
+
+    public String getRequestComments() { return requestComments; }
+    public void setRequestComments(String requestComments) { this.requestComments = requestComments; }
+
+    public String getPreparedByName() { return preparedByName; }
+    public void setPreparedByName(String preparedByName) { this.preparedByName = preparedByName; }
+
+    public Date getPreparedAt() { return preparedAt; }
+    public void setPreparedAt(Date preparedAt) { this.preparedAt = preparedAt; }
+
+    public String getInstitutionName() { return institutionName; }
+    public void setInstitutionName(String institutionName) { this.institutionName = institutionName; }
+
+    public String getInstitutionPhone() { return institutionPhone; }
+    public void setInstitutionPhone(String institutionPhone) { this.institutionPhone = institutionPhone; }
+
+    public String getInstitutionFax() { return institutionFax; }
+    public void setInstitutionFax(String institutionFax) { this.institutionFax = institutionFax; }
+
+    public String getDepartmentTelephone1() { return departmentTelephone1; }
+    public void setDepartmentTelephone1(String departmentTelephone1) { this.departmentTelephone1 = departmentTelephone1; }
+
+    public String getDepartmentEmail() { return departmentEmail; }
+    public void setDepartmentEmail(String departmentEmail) { this.departmentEmail = departmentEmail; }
+
+    public String getOrderDepartmentName() { return orderDepartmentName; }
+    public void setOrderDepartmentName(String orderDepartmentName) { this.orderDepartmentName = orderDepartmentName; }
+
+    public String getOrderDepartmentAddress() { return orderDepartmentAddress; }
+    public void setOrderDepartmentAddress(String orderDepartmentAddress) { this.orderDepartmentAddress = orderDepartmentAddress; }
+
+    public String getOrderDepartmentTelephone1() { return orderDepartmentTelephone1; }
+    public void setOrderDepartmentTelephone1(String orderDepartmentTelephone1) { this.orderDepartmentTelephone1 = orderDepartmentTelephone1; }
+
+    public String getOrderDepartmentTelephone2() { return orderDepartmentTelephone2; }
+    public void setOrderDepartmentTelephone2(String orderDepartmentTelephone2) { this.orderDepartmentTelephone2 = orderDepartmentTelephone2; }
+
+    public String getOrderDepartmentFax() { return orderDepartmentFax; }
+    public void setOrderDepartmentFax(String orderDepartmentFax) { this.orderDepartmentFax = orderDepartmentFax; }
+
+    public String getOrderInstitutionName() { return orderInstitutionName; }
+    public void setOrderInstitutionName(String orderInstitutionName) { this.orderInstitutionName = orderInstitutionName; }
+
+    public String getOrderInstitutionEmail() { return orderInstitutionEmail; }
+    public void setOrderInstitutionEmail(String orderInstitutionEmail) { this.orderInstitutionEmail = orderInstitutionEmail; }
+
+    public String getOrderSiteName() { return orderSiteName; }
+    public void setOrderSiteName(String orderSiteName) { this.orderSiteName = orderSiteName; }
+
+    public String getSupplierName() { return supplierName; }
+    public void setSupplierName(String supplierName) { this.supplierName = supplierName; }
+
+    public String getSupplierCode() { return supplierCode; }
+    public void setSupplierCode(String supplierCode) { this.supplierCode = supplierCode; }
+
+    public List<PurchaseOrderItemPrintDto> getItems() { return items; }
+    public void setItems(List<PurchaseOrderItemPrintDto> items) { this.items = items; }
+}

--- a/src/main/java/com/divudi/service/pharmacy/PurchaseOrderNativeSqlService.java
+++ b/src/main/java/com/divudi/service/pharmacy/PurchaseOrderNativeSqlService.java
@@ -170,6 +170,10 @@ public class PurchaseOrderNativeSqlService {
         if (rows == null || rows.isEmpty()) {
             return null;
         }
+        if (!rows.isEmpty()) {
+            Object[] dbg = rows.get(0);
+            System.out.println(">>>PO_NATIVE_SERVICE: col[4]=createdAt=" + dbg[4] + " col[7]=approveAt=" + dbg[7] + " col[22]=rb.createdAt=" + dbg[22] + " col[23]=rb.comments=" + dbg[23] + " col[24]=rb.checkeAt=" + dbg[24]);
+        }
         Object[] r = rows.get(0);
         int col = 0;
 

--- a/src/main/java/com/divudi/service/pharmacy/PurchaseOrderNativeSqlService.java
+++ b/src/main/java/com/divudi/service/pharmacy/PurchaseOrderNativeSqlService.java
@@ -46,9 +46,13 @@ public class PurchaseOrderNativeSqlService {
      */
     @TransactionAttribute(TransactionAttributeType.SUPPORTS)
     public PurchaseOrderPrintDto loadPrintDtoByBillId(long billId) {
+        System.out.println(">>>PO_NATIVE_SERVICE: loadPrintDtoByBillId called, billId=" + billId);
         try {
-            return doLoad(billId);
+            PurchaseOrderPrintDto result = doLoad(billId);
+            System.out.println(">>>PO_NATIVE_SERVICE: result=" + (result == null ? "NULL" : "OK"));
+            return result;
         } catch (Exception e) {
+            System.out.println(">>>PO_NATIVE_SERVICE: EXCEPTION " + e.getMessage());
             LOGGER.log(Level.SEVERE, "Failed to load PO print DTO for billId=" + billId, e);
             return null;
         }
@@ -69,27 +73,40 @@ public class PurchaseOrderNativeSqlService {
         // and get the approval bill ID either way.
         String resolveAtomicSql =
             "SELECT billTypeAtomic, referenceBill_ID FROM bill WHERE ID = ?1 AND retired = 0 LIMIT 1";
+        System.out.println(">>>PO_NATIVE_SERVICE: resolve SQL=" + resolveAtomicSql + " param=" + billId);
         List<Object[]> atomicRows;
         try {
             atomicRows = em.createNativeQuery(resolveAtomicSql)
                     .setParameter(1, billId)
                     .getResultList();
         } catch (Exception e) {
+            System.out.println(">>>PO_NATIVE_SERVICE: resolve EXCEPTION " + e.getMessage());
             LOGGER.log(Level.WARNING, "Could not resolve bill atomic for billId=" + billId, e);
             return null;
         }
+        System.out.println(">>>PO_NATIVE_SERVICE: atomicRows size=" + (atomicRows == null ? "null" : atomicRows.size()));
         if (atomicRows == null || atomicRows.isEmpty()) {
             return null;
         }
         Object[] atomicRow = atomicRows.get(0);
         String billTypeAtomic = atomicRow[0] != null ? atomicRow[0].toString() : "";
+        System.out.println(">>>PO_NATIVE_SERVICE: billTypeAtomic=" + billTypeAtomic + " referenceBill_ID=" + atomicRow[1]);
         long approvalBillId;
         if ("PHARMACY_ORDER_APPROVAL".equals(billTypeAtomic)) {
             approvalBillId = billId;
+        } else if ("PHARMACY_ORDER".equals(billTypeAtomic)) {
+            if (atomicRow[1] == null) {
+                LOGGER.log(Level.WARNING, "No approval bill linked for request billId=" + billId);
+                System.out.println(">>>PO_NATIVE_SERVICE: no approval bill linked, returning null");
+                return null;
+            }
+            approvalBillId = ((Number) atomicRow[1]).longValue();
         } else {
-            // PHARMACY_ORDER — get the approval sibling via referenceBill_ID
-            approvalBillId = atomicRow[1] != null ? ((Number) atomicRow[1]).longValue() : billId;
+            LOGGER.log(Level.WARNING, "Unsupported billTypeAtomic for native PO print: " + billTypeAtomic + ", billId=" + billId);
+            System.out.println(">>>PO_NATIVE_SERVICE: unsupported billTypeAtomic=" + billTypeAtomic);
+            return null;
         }
+        System.out.println(">>>PO_NATIVE_SERVICE: approvalBillId=" + approvalBillId);
 
         String sql =
             "SELECT " +
@@ -129,7 +146,7 @@ public class PurchaseOrderNativeSqlService {
             "LEFT JOIN person  approverPerson  ON approverPerson.ID = approverWU.person_ID " +
             "LEFT JOIN department orderDept    ON orderDept.ID = ab.department_ID " +
             "LEFT JOIN institution orderInst   ON orderInst.ID = orderDept.institution_ID " +
-            "LEFT JOIN department  orderSite   ON orderSite.ID = orderDept.site_ID " +
+            "LEFT JOIN institution orderSite    ON orderSite.ID = orderDept.site_ID " +
             "LEFT JOIN institution supplier    ON supplier.ID = ab.toInstitution_ID " +
             "LEFT JOIN webuser checkedByWU     ON checkedByWU.ID = rb.checkedBy_ID " +
             "LEFT JOIN person  preparerPerson  ON preparerPerson.ID = checkedByWU.person_ID " +
@@ -145,9 +162,11 @@ public class PurchaseOrderNativeSqlService {
                     .setParameter(1, approvalBillId)
                     .getResultList();
         } catch (Exception e) {
+            System.out.println(">>>PO_NATIVE_SERVICE: header query EXCEPTION " + e.getMessage());
             LOGGER.log(Level.SEVERE, "Header query failed for approvalBillId=" + approvalBillId, e);
             return null;
         }
+        System.out.println(">>>PO_NATIVE_SERVICE: header rows size=" + (rows == null ? "null" : rows.size()));
         if (rows == null || rows.isEmpty()) {
             return null;
         }
@@ -210,7 +229,7 @@ public class PurchaseOrderNativeSqlService {
             "  COALESCE(bifd.lineGrossTotal, 0)   AS lineTotal " +
             "FROM billitem bi " +
             "LEFT JOIN item i                    ON i.ID = bi.item_ID " +
-            "LEFT JOIN item iu                   ON iu.ID = i.issueUnit_ID " +
+            "LEFT JOIN category iu               ON iu.ID = i.issueUnit_ID " +
             "LEFT JOIN billitemfinancedetails bifd ON bifd.ID = bi.BILLITEMFINANCEDETAILS_ID " +
             "WHERE bi.bill_ID = ?1 " +
             "  AND bi.retired = 0 " +

--- a/src/main/java/com/divudi/service/pharmacy/PurchaseOrderNativeSqlService.java
+++ b/src/main/java/com/divudi/service/pharmacy/PurchaseOrderNativeSqlService.java
@@ -179,11 +179,11 @@ public class PurchaseOrderNativeSqlService {
         dto.setPaymentMethod(str(r[col++]));
         dto.setCreditDuration(r[col] != null ? ((Number) r[col]).intValue() : 0); col++;
         dto.setPoTime(toDate(r[col++]));
-        dto.setConsignment(r[col] != null && ((Number) r[col]).intValue() != 0); col++;
+        dto.setConsignment(toBool(r[col++]));
         dto.setApproveComments(str(r[col++]));
         dto.setApprovedAt(toDate(r[col++]));
         dto.setNetTotal(r[col] != null ? ((Number) r[col]).doubleValue() : 0.0); col++;
-        dto.setCancelled(r[col] != null && ((Number) r[col]).intValue() != 0); col++;
+        dto.setCancelled(toBool(r[col++]));
 
         dto.setApprovedByName(str(r[col++]));
 
@@ -268,6 +268,13 @@ public class PurchaseOrderNativeSqlService {
 
     private String str(Object o) {
         return o != null ? o.toString().trim() : "";
+    }
+
+    private boolean toBool(Object o) {
+        if (o == null) return false;
+        if (o instanceof Boolean) return (Boolean) o;
+        if (o instanceof Number) return ((Number) o).intValue() != 0;
+        return false;
     }
 
     private Date toDate(Object o) {

--- a/src/main/java/com/divudi/service/pharmacy/PurchaseOrderNativeSqlService.java
+++ b/src/main/java/com/divudi/service/pharmacy/PurchaseOrderNativeSqlService.java
@@ -1,0 +1,260 @@
+/*
+ * Open Hospital Management Information System
+ * Dr M H B Ariyaratne
+ * buddhika.ari@gmail.com
+ */
+package com.divudi.service.pharmacy;
+
+import com.divudi.core.data.dto.pharmacy.PurchaseOrderItemPrintDto;
+import com.divudi.core.data.dto.pharmacy.PurchaseOrderPrintDto;
+import javax.ejb.Stateless;
+import javax.ejb.TransactionAttribute;
+import javax.ejb.TransactionAttributeType;
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+import java.sql.Timestamp;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * Loads Purchase Order print data via native SQL.
+ * No JPA entity graph inflation — all data fetched in two queries (header + items).
+ * LEFT JOINs throughout so null FKs never drop the bill from the result set.
+ * Related issue: #20923
+ */
+@Stateless
+public class PurchaseOrderNativeSqlService {
+
+    private static final Logger LOGGER = Logger.getLogger(PurchaseOrderNativeSqlService.class.getName());
+
+    @PersistenceContext(unitName = "hmisPU")
+    private EntityManager em;
+
+    /**
+     * Loads the full print DTO for a PO approval bill.
+     * Works for both PHARMACY_ORDER and PHARMACY_ORDER_APPROVAL atomics —
+     * caller may pass either the approval bill ID or a request bill ID.
+     * When a request bill ID is given (PHARMACY_ORDER), the query finds the
+     * corresponding approval bill via referenceBill_ID.
+     *
+     * @param billId  ID of the approval bill (PHARMACY_ORDER_APPROVAL) or request
+     *                bill (PHARMACY_ORDER). Must not be null.
+     * @return populated DTO, or null if no bill found.
+     */
+    @TransactionAttribute(TransactionAttributeType.SUPPORTS)
+    public PurchaseOrderPrintDto loadPrintDtoByBillId(long billId) {
+        try {
+            return doLoad(billId);
+        } catch (Exception e) {
+            LOGGER.log(Level.SEVERE, "Failed to load PO print DTO for billId=" + billId, e);
+            return null;
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Private
+    // -----------------------------------------------------------------------
+
+    private PurchaseOrderPrintDto doLoad(long billId) {
+        return loadHeader(billId);
+    }
+
+
+    @SuppressWarnings("unchecked")
+    private PurchaseOrderPrintDto loadHeader(long billId) {
+        // First resolve whether this is an approval bill or request bill,
+        // and get the approval bill ID either way.
+        String resolveAtomicSql =
+            "SELECT billTypeAtomic, referenceBill_ID FROM bill WHERE ID = ?1 AND retired = 0 LIMIT 1";
+        List<Object[]> atomicRows;
+        try {
+            atomicRows = em.createNativeQuery(resolveAtomicSql)
+                    .setParameter(1, billId)
+                    .getResultList();
+        } catch (Exception e) {
+            LOGGER.log(Level.WARNING, "Could not resolve bill atomic for billId=" + billId, e);
+            return null;
+        }
+        if (atomicRows == null || atomicRows.isEmpty()) {
+            return null;
+        }
+        Object[] atomicRow = atomicRows.get(0);
+        String billTypeAtomic = atomicRow[0] != null ? atomicRow[0].toString() : "";
+        long approvalBillId;
+        if ("PHARMACY_ORDER_APPROVAL".equals(billTypeAtomic)) {
+            approvalBillId = billId;
+        } else {
+            // PHARMACY_ORDER — get the approval sibling via referenceBill_ID
+            approvalBillId = atomicRow[1] != null ? ((Number) atomicRow[1]).longValue() : billId;
+        }
+
+        String sql =
+            "SELECT " +
+            "  ab.ID, ab.deptId, ab.paymentMethod, ab.creditDuration, " +
+            "  ab.createdAt, ab.consignment, ab.comments, ab.approveAt, " +
+            "  ab.netTotal, ab.cancelled, " +
+            // approver
+            "  approverPerson.name            AS approvedByName, " +
+            // order dept
+            "  orderDept.name                 AS orderDeptName, " +
+            "  orderDept.address              AS orderDeptAddress, " +
+            "  orderDept.telephone1           AS orderDeptTel1, " +
+            "  orderDept.telephone2           AS orderDeptTel2, " +
+            "  orderDept.fax                  AS orderDeptFax, " +
+            // order institution
+            "  orderInst.name                 AS orderInstName, " +
+            "  orderInst.email                AS orderInstEmail, " +
+            // order site
+            "  orderSite.name                 AS orderSiteName, " +
+            // supplier
+            "  supplier.name                  AS supplierName, " +
+            "  supplier.code                  AS supplierCode, " +
+            // request pre-bill
+            "  rb.createdAt                   AS poDate, " +
+            "  rb.comments                    AS requestComments, " +
+            "  rb.checkeAt                    AS preparedAt, " +
+            "  preparerPerson.name            AS preparedByName, " +
+            // institution from request creater
+            "  reqCreaterInst.name            AS instName, " +
+            "  reqCreaterInst.phone           AS instPhone, " +
+            "  reqCreaterInst.fax             AS instFax, " +
+            "  reqCreaterDept.telephone1      AS reqDeptTel1, " +
+            "  reqCreaterDept.email           AS reqDeptEmail " +
+            "FROM bill ab " +
+            "LEFT JOIN bill rb                ON rb.ID = ab.referenceBill_ID " +
+            "LEFT JOIN webuser approverWU      ON approverWU.ID = ab.creater_ID " +
+            "LEFT JOIN person  approverPerson  ON approverPerson.ID = approverWU.person_ID " +
+            "LEFT JOIN department orderDept    ON orderDept.ID = ab.department_ID " +
+            "LEFT JOIN institution orderInst   ON orderInst.ID = orderDept.institution_ID " +
+            "LEFT JOIN department  orderSite   ON orderSite.ID = orderDept.site_ID " +
+            "LEFT JOIN institution supplier    ON supplier.ID = ab.toInstitution_ID " +
+            "LEFT JOIN webuser checkedByWU     ON checkedByWU.ID = rb.checkedBy_ID " +
+            "LEFT JOIN person  preparerPerson  ON preparerPerson.ID = checkedByWU.person_ID " +
+            "LEFT JOIN webuser reqCreaterWU    ON reqCreaterWU.ID = rb.creater_ID " +
+            "LEFT JOIN department reqCreaterDept ON reqCreaterDept.ID = reqCreaterWU.department_ID " +
+            "LEFT JOIN institution reqCreaterInst ON reqCreaterInst.ID = reqCreaterDept.institution_ID " +
+            "WHERE ab.ID = ?1 AND ab.retired = 0 " +
+            "LIMIT 1";
+
+        List<Object[]> rows;
+        try {
+            rows = em.createNativeQuery(sql)
+                    .setParameter(1, approvalBillId)
+                    .getResultList();
+        } catch (Exception e) {
+            LOGGER.log(Level.SEVERE, "Header query failed for approvalBillId=" + approvalBillId, e);
+            return null;
+        }
+        if (rows == null || rows.isEmpty()) {
+            return null;
+        }
+        Object[] r = rows.get(0);
+        int col = 0;
+
+        PurchaseOrderPrintDto dto = new PurchaseOrderPrintDto();
+        col++; // ab.ID — skip, just used for routing
+        dto.setPoNumber(str(r[col++]));
+        dto.setPaymentMethod(str(r[col++]));
+        dto.setCreditDuration(r[col] != null ? ((Number) r[col]).intValue() : 0); col++;
+        dto.setPoTime(toDate(r[col++]));
+        dto.setConsignment(r[col] != null && ((Number) r[col]).intValue() != 0); col++;
+        dto.setApproveComments(str(r[col++]));
+        dto.setApprovedAt(toDate(r[col++]));
+        dto.setNetTotal(r[col] != null ? ((Number) r[col]).doubleValue() : 0.0); col++;
+        dto.setCancelled(r[col] != null && ((Number) r[col]).intValue() != 0); col++;
+
+        dto.setApprovedByName(str(r[col++]));
+
+        dto.setOrderDepartmentName(str(r[col++]));
+        dto.setOrderDepartmentAddress(str(r[col++]));
+        dto.setOrderDepartmentTelephone1(str(r[col++]));
+        dto.setOrderDepartmentTelephone2(str(r[col++]));
+        dto.setOrderDepartmentFax(str(r[col++]));
+        dto.setOrderInstitutionName(str(r[col++]));
+        dto.setOrderInstitutionEmail(str(r[col++]));
+        dto.setOrderSiteName(str(r[col++]));
+
+        dto.setSupplierName(str(r[col++]));
+        dto.setSupplierCode(str(r[col++]));
+
+        dto.setPoDate(toDate(r[col++]));
+        dto.setRequestComments(str(r[col++]));
+        dto.setPreparedAt(toDate(r[col++]));
+        dto.setPreparedByName(str(r[col++]));
+
+        dto.setInstitutionName(str(r[col++]));
+        dto.setInstitutionPhone(str(r[col++]));
+        dto.setInstitutionFax(str(r[col++]));
+        dto.setDepartmentTelephone1(str(r[col++]));
+        dto.setDepartmentEmail(str(r[col]));
+
+        // Store approval bill ID on DTO for item loading
+        dto.getItems(); // ensure list initialised
+        loadItems(dto, approvalBillId);
+        return dto;
+    }
+
+    @SuppressWarnings("unchecked")
+    private void loadItems(PurchaseOrderPrintDto dto, long approvalBillId) {
+        String sql =
+            "SELECT " +
+            "  i.name               AS itemName, " +
+            "  i.code               AS itemCode, " +
+            "  iu.name              AS issueUnitName, " +
+            "  COALESCE(bifd.lineGrossRate, 0)   AS purchaseRate, " +
+            "  COALESCE(bifd.quantity, 0)         AS quantity, " +
+            "  COALESCE(bifd.freeQuantity, 0)     AS freeQuantity, " +
+            "  COALESCE(bifd.lineGrossTotal, 0)   AS lineTotal " +
+            "FROM billitem bi " +
+            "LEFT JOIN item i                    ON i.ID = bi.item_ID " +
+            "LEFT JOIN item iu                   ON iu.ID = i.issueUnit_ID " +
+            "LEFT JOIN billitemfinancedetails bifd ON bifd.ID = bi.BILLITEMFINANCEDETAILS_ID " +
+            "WHERE bi.bill_ID = ?1 " +
+            "  AND bi.retired = 0 " +
+            "ORDER BY bi.ID";
+
+        List<Object[]> rows;
+        try {
+            rows = em.createNativeQuery(sql)
+                    .setParameter(1, approvalBillId)
+                    .getResultList();
+        } catch (Exception e) {
+            LOGGER.log(Level.SEVERE, "Item query failed for approvalBillId=" + approvalBillId, e);
+            return;
+        }
+
+        List<PurchaseOrderItemPrintDto> items = new ArrayList<>();
+        if (rows != null) {
+            for (Object[] r : rows) {
+                PurchaseOrderItemPrintDto item = new PurchaseOrderItemPrintDto();
+                item.setItemName(str(r[0]));
+                item.setItemCode(str(r[1]));
+                item.setIssueUnitName(str(r[2]));
+                item.setPurchaseRate(r[3] != null ? ((Number) r[3]).doubleValue() : 0.0);
+                item.setQuantity(r[4] != null ? ((Number) r[4]).doubleValue() : 0.0);
+                item.setFreeQuantity(r[5] != null ? ((Number) r[5]).doubleValue() : 0.0);
+                item.setLineTotal(r[6] != null ? ((Number) r[6]).doubleValue() : 0.0);
+                items.add(item);
+            }
+        }
+        dto.setItems(items);
+    }
+
+    // -----------------------------------------------------------------------
+    // Helpers
+    // -----------------------------------------------------------------------
+
+    private String str(Object o) {
+        return o != null ? o.toString().trim() : "";
+    }
+
+    private Date toDate(Object o) {
+        if (o == null) return null;
+        if (o instanceof Timestamp) return new java.util.Date(((Timestamp) o).getTime());
+        if (o instanceof java.util.Date) return (java.util.Date) o;
+        return null;
+    }
+}

--- a/src/main/java/com/divudi/service/pharmacy/PurchaseOrderNativeSqlService.java
+++ b/src/main/java/com/divudi/service/pharmacy/PurchaseOrderNativeSqlService.java
@@ -46,13 +46,9 @@ public class PurchaseOrderNativeSqlService {
      */
     @TransactionAttribute(TransactionAttributeType.SUPPORTS)
     public PurchaseOrderPrintDto loadPrintDtoByBillId(long billId) {
-        System.out.println(">>>PO_NATIVE_SERVICE: loadPrintDtoByBillId called, billId=" + billId);
         try {
-            PurchaseOrderPrintDto result = doLoad(billId);
-            System.out.println(">>>PO_NATIVE_SERVICE: result=" + (result == null ? "NULL" : "OK"));
-            return result;
+            return doLoad(billId);
         } catch (Exception e) {
-            System.out.println(">>>PO_NATIVE_SERVICE: EXCEPTION " + e.getMessage());
             LOGGER.log(Level.SEVERE, "Failed to load PO print DTO for billId=" + billId, e);
             return null;
         }
@@ -73,40 +69,33 @@ public class PurchaseOrderNativeSqlService {
         // and get the approval bill ID either way.
         String resolveAtomicSql =
             "SELECT billTypeAtomic, referenceBill_ID FROM bill WHERE ID = ?1 AND retired = 0 LIMIT 1";
-        System.out.println(">>>PO_NATIVE_SERVICE: resolve SQL=" + resolveAtomicSql + " param=" + billId);
         List<Object[]> atomicRows;
         try {
             atomicRows = em.createNativeQuery(resolveAtomicSql)
                     .setParameter(1, billId)
                     .getResultList();
         } catch (Exception e) {
-            System.out.println(">>>PO_NATIVE_SERVICE: resolve EXCEPTION " + e.getMessage());
             LOGGER.log(Level.WARNING, "Could not resolve bill atomic for billId=" + billId, e);
             return null;
         }
-        System.out.println(">>>PO_NATIVE_SERVICE: atomicRows size=" + (atomicRows == null ? "null" : atomicRows.size()));
         if (atomicRows == null || atomicRows.isEmpty()) {
             return null;
         }
         Object[] atomicRow = atomicRows.get(0);
         String billTypeAtomic = atomicRow[0] != null ? atomicRow[0].toString() : "";
-        System.out.println(">>>PO_NATIVE_SERVICE: billTypeAtomic=" + billTypeAtomic + " referenceBill_ID=" + atomicRow[1]);
         long approvalBillId;
         if ("PHARMACY_ORDER_APPROVAL".equals(billTypeAtomic)) {
             approvalBillId = billId;
         } else if ("PHARMACY_ORDER".equals(billTypeAtomic)) {
             if (atomicRow[1] == null) {
                 LOGGER.log(Level.WARNING, "No approval bill linked for request billId=" + billId);
-                System.out.println(">>>PO_NATIVE_SERVICE: no approval bill linked, returning null");
                 return null;
             }
             approvalBillId = ((Number) atomicRow[1]).longValue();
         } else {
             LOGGER.log(Level.WARNING, "Unsupported billTypeAtomic for native PO print: " + billTypeAtomic + ", billId=" + billId);
-            System.out.println(">>>PO_NATIVE_SERVICE: unsupported billTypeAtomic=" + billTypeAtomic);
             return null;
         }
-        System.out.println(">>>PO_NATIVE_SERVICE: approvalBillId=" + approvalBillId);
 
         String sql =
             "SELECT " +
@@ -162,17 +151,11 @@ public class PurchaseOrderNativeSqlService {
                     .setParameter(1, approvalBillId)
                     .getResultList();
         } catch (Exception e) {
-            System.out.println(">>>PO_NATIVE_SERVICE: header query EXCEPTION " + e.getMessage());
             LOGGER.log(Level.SEVERE, "Header query failed for approvalBillId=" + approvalBillId, e);
             return null;
         }
-        System.out.println(">>>PO_NATIVE_SERVICE: header rows size=" + (rows == null ? "null" : rows.size()));
         if (rows == null || rows.isEmpty()) {
             return null;
-        }
-        if (!rows.isEmpty()) {
-            Object[] dbg = rows.get(0);
-            System.out.println(">>>PO_NATIVE_SERVICE: col[4]=createdAt=" + dbg[4] + " col[7]=approveAt=" + dbg[7] + " col[22]=rb.createdAt=" + dbg[22] + " col[23]=rb.comments=" + dbg[23] + " col[24]=rb.checkeAt=" + dbg[24]);
         }
         Object[] r = rows.get(0);
         int col = 0;

--- a/src/main/java/com/divudi/service/pharmacy/PurchaseOrderNativeSqlService.java
+++ b/src/main/java/com/divudi/service/pharmacy/PurchaseOrderNativeSqlService.java
@@ -143,13 +143,13 @@ public class PurchaseOrderNativeSqlService {
             "FROM bill ab " +
             "LEFT JOIN bill rb                ON rb.ID = ab.referenceBill_ID " +
             "LEFT JOIN webuser approverWU      ON approverWU.ID = ab.creater_ID " +
-            "LEFT JOIN person  approverPerson  ON approverPerson.ID = approverWU.person_ID " +
+            "LEFT JOIN person  approverPerson  ON approverPerson.ID = approverWU.webUserPerson_ID " +
             "LEFT JOIN department orderDept    ON orderDept.ID = ab.department_ID " +
             "LEFT JOIN institution orderInst   ON orderInst.ID = orderDept.institution_ID " +
             "LEFT JOIN institution orderSite    ON orderSite.ID = orderDept.site_ID " +
             "LEFT JOIN institution supplier    ON supplier.ID = ab.toInstitution_ID " +
             "LEFT JOIN webuser checkedByWU     ON checkedByWU.ID = rb.checkedBy_ID " +
-            "LEFT JOIN person  preparerPerson  ON preparerPerson.ID = checkedByWU.person_ID " +
+            "LEFT JOIN person  preparerPerson  ON preparerPerson.ID = checkedByWU.webUserPerson_ID " +
             "LEFT JOIN webuser reqCreaterWU    ON reqCreaterWU.ID = rb.creater_ID " +
             "LEFT JOIN department reqCreaterDept ON reqCreaterDept.ID = reqCreaterWU.department_ID " +
             "LEFT JOIN institution reqCreaterInst ON reqCreaterInst.ID = reqCreaterDept.institution_ID " +

--- a/src/main/java/com/divudi/service/pharmacy/PurchaseOrderNativeSqlService.java
+++ b/src/main/java/com/divudi/service/pharmacy/PurchaseOrderNativeSqlService.java
@@ -111,7 +111,7 @@ public class PurchaseOrderNativeSqlService {
         String sql =
             "SELECT " +
             "  ab.ID, ab.deptId, ab.paymentMethod, ab.creditDuration, " +
-            "  ab.createdAt, ab.consignment, ab.comments, ab.approveAt, " +
+            "  ab.createdAt AS approvalCreatedAt, ab.consignment, ab.comments AS approvalComments, ab.approveAt, " +
             "  ab.netTotal, ab.cancelled, " +
             // approver
             "  approverPerson.name            AS approvedByName, " +
@@ -130,8 +130,8 @@ public class PurchaseOrderNativeSqlService {
             "  supplier.name                  AS supplierName, " +
             "  supplier.code                  AS supplierCode, " +
             // request pre-bill
-            "  rb.createdAt                   AS poDate, " +
-            "  rb.comments                    AS requestComments, " +
+            "  rb.createdAt                   AS rbCreatedAt, " +
+            "  rb.comments                    AS rbComments, " +
             "  rb.checkeAt                    AS preparedAt, " +
             "  preparerPerson.name            AS preparedByName, " +
             // institution from request creater

--- a/src/main/webapp/pharmacy/pharmacy_purhcase_order_list_to_approve_dto.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_purhcase_order_list_to_approve_dto.xhtml
@@ -278,15 +278,14 @@
                                             disabled="#{dto.checkedById eq null or dto.approved or dto.cancelled eq true or !webUserController.hasPrivilege('PurchaseOrdersApprovel')}">
                                             <f:setPropertyActionListener target="#{purchaseOrderController.requestedBillId}" value="#{dto.billId}"/>
                                         </p:commandButton>
-                                        <p:commandButton 
+                                        <p:commandButton
                                             id="btnViewApproved"
                                             ajax="false"
                                             icon="pi pi-eye"
                                             class="ui-button-info ui-button-sm"
                                             title="View Approved Purchase Order"
-                                            action="#{pharmacyBillSearch.navigateToReprintPharmacyPurchaseOrderFromDto}" 
+                                            action="#{billSearch.navigateToViewBillByAtomicBillTypeByBillId(dto.referenceBillId)}"
                                             disabled="#{not dto.approved}">
-                                            <f:setPropertyActionListener target="#{pharmacyBillSearch.billId}" value="#{dto.referenceBillId}"/>
                                         </p:commandButton>
                                         <p:commandButton 
                                             id="btnViewRequest"

--- a/src/main/webapp/pharmacy/pharmacy_reprint_po_native.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_reprint_po_native.xhtml
@@ -53,7 +53,7 @@
                                         ajax="false"
                                         value="Legacy View"
                                         title="Open original entity-based print page"
-                                        action="#{pharmacyBillSearch.navigatePharmacyReprintPo}"
+                                        action="#{billSearch.navigateToViewBillByAtomicBillTypeByBillIdEntityBased(purchaseOrderNativeSqlController.currentBillId)}"
                                         class="ui-button-secondary ms-3"
                                         icon="fas fa-history"
                                         style="font-size: 0.75rem; padding: 0.2rem 0.5rem;"/>

--- a/src/main/webapp/pharmacy/pharmacy_reprint_po_native.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_reprint_po_native.xhtml
@@ -1,5 +1,4 @@
-<?xml version='1.0' encoding='UTF-8' ?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml"
       xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
       xmlns:p="http://primefaces.org/ui"

--- a/src/main/webapp/pharmacy/pharmacy_reprint_po_native.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_reprint_po_native.xhtml
@@ -1,0 +1,990 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
+      xmlns:p="http://primefaces.org/ui"
+      xmlns:h="http://xmlns.jcp.org/jsf/html"
+      xmlns:f="http://xmlns.jcp.org/jsf/core">
+    <h:body>
+        <ui:composition template="/resources/template/template.xhtml">
+
+            <ui:define name="content">
+                <h:form>
+                    <p:panel>
+                        <f:facet name="header">
+                            <div class="d-flex align-items-center justify-content-between">
+                                <div>
+                                    <h:outputLabel value="Purchase Order"/>
+                                </div>
+                                <div>
+                                    <p:commandButton
+                                        ajax="false"
+                                        value="Back To PO List"
+                                        rendered="#{webUserController.hasPrivilege('Pharmacy')}"
+                                        action="pharmacy_purhcase_order_list_to_approve_dto?faces-redirect=true"
+                                        class="ui-button-warning" icon="fas fa-arrow-left"/>
+                                    <p:commandButton
+                                        ajax="false"
+                                        value="Back To Good Receipt"
+                                        rendered="#{webUserController.hasPrivilege('PharmacyGoodReceive')}"
+                                        action="/pharmacy/pharmacy_purchase_order_list_for_recieve?faces-redirect=true"
+                                        class="ui-button-warning mx-2" icon="fas fa-arrow-left"/>
+                                    <p:commandButton
+                                        rendered="#{webUserController.hasPrivilege('ChangeReceiptPrintingPaperTypes')}"
+                                        value="Settings"
+                                        icon="fas fa-cog"
+                                        class="ui-button-secondary m-1"
+                                        type="button"
+                                        onclick="PF('poNativeConfigDialog').show();"/>
+                                    <p:commandButton
+                                        class="ui-button-info"
+                                        icon="fas fa-print"
+                                        value="Reprint" ajax="false">
+                                        <p:printer target="gpBillPreview"/>
+                                    </p:commandButton>
+                                    <p:commandButton
+                                        class="ui-button-success mx-1"
+                                        icon="fas fa-print"
+                                        rendered="#{webUserController.hasPrivilege('PrintOriginalPoBillFromReprint')}"
+                                        value="Print Original" ajax="false">
+                                        <p:printer target="gpOriginalBillPreview"/>
+                                    </p:commandButton>
+                                    <!-- Small non-prominent fallback to legacy entity-based page -->
+                                    <p:commandButton
+                                        ajax="false"
+                                        value="Legacy View"
+                                        title="Open original entity-based print page"
+                                        action="#{pharmacyBillSearch.navigatePharmacyReprintPo}"
+                                        class="ui-button-secondary ms-3"
+                                        icon="fas fa-history"
+                                        style="font-size: 0.75rem; padding: 0.2rem 0.5rem;"/>
+                                </div>
+                            </div>
+                        </f:facet>
+
+                        <div class="row">
+                            <!-- Reprint column -->
+                            <div class="col-6 d-flex justify-content-center border border-light border-1">
+                                <h:panelGroup id="gpBillPreview" style="width: 212mm;">
+
+                                    <!-- Format 1: A4 Custom 1 (pharmacyA4.css) -->
+                                    <h:panelGroup rendered="#{configOptionController.getBooleanValueByKey('Pharmacy Purchase Order Approval Print - A4 Custom 1 Paper Format', true)}">
+                                        <h:outputStylesheet library="css" name="pharmacyA4.css"/>
+                                        <div style="width: 212mm;">
+                                            <div class="institutionName">
+                                                <h:outputText value="#{purchaseOrderNativeSqlController.printDto.institutionName}"/>
+                                            </div>
+                                            <div class="institutionContact">
+                                                <div>
+                                                    <h:outputText value="Telephone : #{purchaseOrderNativeSqlController.printDto.institutionPhone} / #{purchaseOrderNativeSqlController.printDto.departmentTelephone1}"/>
+                                                </div>
+                                                <div>
+                                                    <h:outputText value="Fax : #{purchaseOrderNativeSqlController.printDto.institutionFax}"/>
+                                                </div>
+                                                <div>
+                                                    <h:outputText value="Email : #{purchaseOrderNativeSqlController.printDto.departmentEmail}"/>
+                                                </div>
+                                            </div>
+                                            <div class="headingBill">
+                                                <h:outputText value="Purchase Order" style="text-decoration: underline;"/>
+                                                <br/>
+                                                <h:outputText value="***Reprint***"/>
+                                                <h:outputText value="***Canceled***" rendered="#{purchaseOrderNativeSqlController.printDto.cancelled}" style="font-size: 18px;"/>
+                                            </div>
+                                            <div class="row">
+                                                <div class="col-6">
+                                                    <h:panelGrid columns="3" columnClasses="labelCol,valueCol,spacerCol" styleClass="table table-borderless">
+                                                        <h:outputText value="Supplier Name"/>
+                                                        <h:outputText value=":"/>
+                                                        <h:panelGroup>
+                                                            <h:outputText value="#{purchaseOrderNativeSqlController.printDto.supplierName}"/>
+                                                            <h:outputText value=" (" rendered="#{not empty purchaseOrderNativeSqlController.printDto.supplierCode}"/>
+                                                            <h:outputText value="#{purchaseOrderNativeSqlController.printDto.supplierCode}" rendered="#{not empty purchaseOrderNativeSqlController.printDto.supplierCode}"/>
+                                                            <h:outputText value=")" rendered="#{not empty purchaseOrderNativeSqlController.printDto.supplierCode}"/>
+                                                        </h:panelGroup>
+                                                        <h:outputText value="P.O. No"/>
+                                                        <h:outputText value=":"/>
+                                                        <h:outputText value="#{purchaseOrderNativeSqlController.printDto.poNumber}"/>
+                                                        <h:outputText value="Payment Method"/>
+                                                        <h:outputText value=":"/>
+                                                        <h:outputText value="#{purchaseOrderNativeSqlController.printDto.paymentMethod}"/>
+                                                        <h:outputText value="Request Comments"/>
+                                                        <h:outputText value=":"/>
+                                                        <h:outputText value="#{purchaseOrderNativeSqlController.printDto.requestComments}"/>
+                                                    </h:panelGrid>
+                                                </div>
+                                                <div class="col-6">
+                                                    <h:panelGrid columns="3" columnClasses="labelCol,valueCol,spacerCol" styleClass="table table-borderless">
+                                                        <h:outputText value="Credit Duration" rendered="#{purchaseOrderNativeSqlController.printDto.paymentMethod eq 'Credit'}"/>
+                                                        <h:outputText value=":" rendered="#{purchaseOrderNativeSqlController.printDto.paymentMethod eq 'Credit'}"/>
+                                                        <h:outputText value="#{purchaseOrderNativeSqlController.printDto.creditDuration}" rendered="#{purchaseOrderNativeSqlController.printDto.paymentMethod eq 'Credit'}"/>
+                                                        <h:outputText value="Order Department"/>
+                                                        <h:outputText value=":"/>
+                                                        <h:outputText value="#{purchaseOrderNativeSqlController.printDto.orderDepartmentName}"/>
+                                                        <h:outputText value="P.O. Date"/>
+                                                        <h:outputText value=":"/>
+                                                        <h:outputText value="#{purchaseOrderNativeSqlController.printDto.poDate}">
+                                                            <f:convertDateTime timeZone="Asia/Colombo" pattern="#{sessionController.applicationPreference.longDateFormat}"/>
+                                                        </h:outputText>
+                                                        <h:outputText value="P.O. Time"/>
+                                                        <h:outputText value=":"/>
+                                                        <h:outputText value="#{purchaseOrderNativeSqlController.printDto.poTime}">
+                                                            <f:convertDateTime pattern="#{sessionController.applicationPreference.longTimeFormat}"/>
+                                                        </h:outputText>
+                                                        <h:outputText value="Consignment"/>
+                                                        <h:outputText value=":"/>
+                                                        <h:outputText value="#{purchaseOrderNativeSqlController.printDto.consignment ? 'Yes' : 'No'}"/>
+                                                        <h:outputText value="Approve Comments"/>
+                                                        <h:outputText value=":"/>
+                                                        <h:outputText value="#{purchaseOrderNativeSqlController.printDto.approveComments}"/>
+                                                    </h:panelGrid>
+                                                </div>
+                                            </div>
+                                            <div>
+                                                <table class="w-100" style="border-collapse: collapse; border: 1px solid black;">
+                                                    <thead>
+                                                        <tr>
+                                                            <th style="width: 30px; text-align: right; padding-right: 5px; border: 1px solid black;">No</th>
+                                                            <th style="text-align: left; min-width: 400px; border: 1px solid black;">Item Name</th>
+                                                            <th style="width: 100px; text-align: right; padding-right: 5px; border: 1px solid black;">P. Rate</th>
+                                                            <th style="width: 100px; text-align: right; padding-right: 5px; border: 1px solid black;">QTY</th>
+                                                            <th style="width: 100px; text-align: right; padding-right: 5px; border: 1px solid black;">Free QTY</th>
+                                                            <th style="width: 100px; text-align: right; padding-right: 5px; border: 1px solid black;">Total</th>
+                                                        </tr>
+                                                    </thead>
+                                                    <tbody>
+                                                        <ui:repeat value="#{purchaseOrderNativeSqlController.printDto.items}" var="lineItem" varStatus="status">
+                                                            <tr>
+                                                                <td style="width: 30px; text-align: right; padding-right: 5px; border: 1px solid black;">#{status.index + 1}</td>
+                                                                <td style="text-align: left; min-width: 400px; border: 1px solid black;">
+                                                                    <h:outputText value="#{lineItem.itemName}"/>
+                                                                    <h:outputText value="  ("/>
+                                                                    <h:outputText value="#{lineItem.itemCode}"/>
+                                                                    <h:outputText value=")"/>
+                                                                </td>
+                                                                <td style="width: 100px; text-align: right; padding-right: 5px; border: 1px solid black;">
+                                                                    <h:outputText value="#{lineItem.purchaseRate}">
+                                                                        <f:convertNumber pattern="#,##0.00"/>
+                                                                    </h:outputText>
+                                                                </td>
+                                                                <td style="width: 100px; text-align: right; padding-right: 5px; border: 1px solid black;">
+                                                                    <h:outputText value="#{lineItem.quantity}">
+                                                                        <f:convertNumber/>
+                                                                    </h:outputText>
+                                                                </td>
+                                                                <td style="width: 100px; text-align: right; padding-right: 5px; border: 1px solid black;">
+                                                                    <h:outputText value="#{lineItem.freeQuantity}">
+                                                                        <f:convertNumber/>
+                                                                    </h:outputText>
+                                                                </td>
+                                                                <td style="width: 100px; text-align: right; padding-right: 5px; border: 1px solid black; font-weight: bold;">
+                                                                    <h:outputText value="#{lineItem.lineTotal}">
+                                                                        <f:convertNumber pattern="#,###.00"/>
+                                                                    </h:outputText>
+                                                                </td>
+                                                            </tr>
+                                                        </ui:repeat>
+                                                    </tbody>
+                                                    <tfoot>
+                                                        <tr>
+                                                            <th/>
+                                                            <th colspan="4">Total</th>
+                                                            <th style="width: 100px; text-align: right; padding-right: 5px; border: 1px solid black; font-weight: bold;">
+                                                                <h:outputText value="#{purchaseOrderNativeSqlController.printDto.netTotal}">
+                                                                    <f:convertNumber pattern="#,###.00"/>
+                                                                </h:outputText>
+                                                            </th>
+                                                        </tr>
+                                                    </tfoot>
+                                                </table>
+                                            </div>
+                                            <div class="row mt-1">
+                                                <div class="col-5">
+                                                    <h:outputText value="Prepared By :  "/>
+                                                    <h:outputText value="#{purchaseOrderNativeSqlController.printDto.preparedByName}"/>
+                                                </div>
+                                                <div class="col-2"/>
+                                                <div class="col-5" style="text-align: right;">
+                                                    <h:outputText value="Prepared At :  "/>
+                                                    <h:outputText value="#{purchaseOrderNativeSqlController.printDto.preparedAt}">
+                                                        <f:convertDateTime pattern="dd/MMM/yyyy HH:mm"/>
+                                                    </h:outputText>
+                                                </div>
+                                            </div>
+                                            <div class="row">
+                                                <div class="col-5">
+                                                    <h:outputText value="Approved By :  "/>
+                                                    <h:outputText value="#{purchaseOrderNativeSqlController.printDto.approvedByName}"/>
+                                                </div>
+                                                <div class="col-2"/>
+                                                <div class="col-5" style="text-align: right;">
+                                                    <h:outputText value="Approved At :  "/>
+                                                    <h:outputText value="#{purchaseOrderNativeSqlController.printDto.approvedAt}">
+                                                        <f:convertDateTime pattern="dd/MMM/yyyy HH:mm"/>
+                                                    </h:outputText>
+                                                </div>
+                                            </div>
+                                            <div>
+                                                <p>
+                                                    <h4 style="color: #000000;">Important Note :</h4>
+                                                    <ol type="1">
+                                                        <li>Purchase order number must appear on all documents pertaining to this purchase.</li>
+                                                        <li>If unable to supply above goods within above period, 10% penalty will be claimed on the invoice value.</li>
+                                                        <li>Goods receiving time - Monday to Friday 9.00 A.M to 3.30 P.M</li>
+                                                    </ol>
+                                                    <h5 style="color: #000000;">Comment :</h5>
+                                                </p>
+                                            </div>
+                                            <div class="row">
+                                                <div class="col-5">
+                                                    <h:outputText value="Printed By :  "/>
+                                                    <h:outputText value="#{sessionController.loggedUser.name}"/>
+                                                </div>
+                                                <div class="col-2"/>
+                                                <div class="col-5" style="text-align: right;">
+                                                    <h:outputText value="Printed At :  "/>
+                                                    <h:outputText value="#{sessionController.currentDate}">
+                                                        <f:convertDateTime pattern="dd/MMM/yyyy HH:mm"/>
+                                                    </h:outputText>
+                                                </div>
+                                            </div>
+                                        </div>
+                                    </h:panelGroup>
+
+                                    <!-- Format 2: A4 Custom 2 (pharmacyA4.css) — same layout, different notes -->
+                                    <h:panelGroup rendered="#{configOptionController.getBooleanValueByKey('Pharmacy Purchase Order Approval Print - A4 Custom 2 Paper Format', false)}">
+                                        <h:outputStylesheet library="css" name="pharmacyA4.css"/>
+                                        <div style="width: 212mm;">
+                                            <div class="institutionName">
+                                                <h:outputText value="#{purchaseOrderNativeSqlController.printDto.institutionName}"/>
+                                            </div>
+                                            <div class="institutionContact">
+                                                <div>
+                                                    <h:outputText value="Telephone : #{purchaseOrderNativeSqlController.printDto.institutionPhone} / #{purchaseOrderNativeSqlController.printDto.departmentTelephone1}"/>
+                                                </div>
+                                                <div>
+                                                    <h:outputText value="Fax : #{purchaseOrderNativeSqlController.printDto.institutionFax}"/>
+                                                </div>
+                                                <div>
+                                                    <h:outputText value="Email : #{purchaseOrderNativeSqlController.printDto.departmentEmail}"/>
+                                                </div>
+                                            </div>
+                                            <div class="headingBill">
+                                                <h:outputText value="Purchase Order" style="text-decoration: underline;"/>
+                                                <br/>
+                                                <h:outputText value="***Reprint***"/>
+                                                <h:outputText value="***Canceled***" rendered="#{purchaseOrderNativeSqlController.printDto.cancelled}" style="font-size: 18px;"/>
+                                            </div>
+                                            <div class="row">
+                                                <div class="col-6">
+                                                    <h:panelGrid columns="3" columnClasses="labelCol,valueCol,spacerCol" styleClass="table table-borderless">
+                                                        <h:outputText value="Supplier Name"/>
+                                                        <h:outputText value=":"/>
+                                                        <h:panelGroup>
+                                                            <h:outputText value="#{purchaseOrderNativeSqlController.printDto.supplierName}"/>
+                                                            <h:outputText value=" (" rendered="#{not empty purchaseOrderNativeSqlController.printDto.supplierCode}"/>
+                                                            <h:outputText value="#{purchaseOrderNativeSqlController.printDto.supplierCode}" rendered="#{not empty purchaseOrderNativeSqlController.printDto.supplierCode}"/>
+                                                            <h:outputText value=")" rendered="#{not empty purchaseOrderNativeSqlController.printDto.supplierCode}"/>
+                                                        </h:panelGroup>
+                                                        <h:outputText value="P.O. No"/>
+                                                        <h:outputText value=":"/>
+                                                        <h:outputText value="#{purchaseOrderNativeSqlController.printDto.poNumber}"/>
+                                                        <h:outputText value="Payment Method"/>
+                                                        <h:outputText value=":"/>
+                                                        <h:outputText value="#{purchaseOrderNativeSqlController.printDto.paymentMethod}"/>
+                                                        <h:outputText value="Consignment"/>
+                                                        <h:outputText value=":"/>
+                                                        <h:outputText value="#{purchaseOrderNativeSqlController.printDto.consignment ? 'Yes' : 'No'}"/>
+                                                        <h:outputText value="Request Comments"/>
+                                                        <h:outputText value=":"/>
+                                                        <h:outputText value="#{purchaseOrderNativeSqlController.printDto.requestComments}"/>
+                                                    </h:panelGrid>
+                                                </div>
+                                                <div class="col-6">
+                                                    <h:panelGrid columns="3" columnClasses="labelCol,valueCol,spacerCol" styleClass="table table-borderless">
+                                                        <h:outputText value="Credit Duration" rendered="#{purchaseOrderNativeSqlController.printDto.paymentMethod eq 'Credit'}"/>
+                                                        <h:outputText value=":" rendered="#{purchaseOrderNativeSqlController.printDto.paymentMethod eq 'Credit'}"/>
+                                                        <h:outputText value="#{purchaseOrderNativeSqlController.printDto.creditDuration}" rendered="#{purchaseOrderNativeSqlController.printDto.paymentMethod eq 'Credit'}"/>
+                                                        <h:outputText value="Order Department"/>
+                                                        <h:outputText value=":"/>
+                                                        <h:outputText value="#{purchaseOrderNativeSqlController.printDto.orderDepartmentName}"/>
+                                                        <h:outputText value="P.O. Date"/>
+                                                        <h:outputText value=":"/>
+                                                        <h:outputText value="#{purchaseOrderNativeSqlController.printDto.poDate}">
+                                                            <f:convertDateTime timeZone="Asia/Colombo" pattern="#{sessionController.applicationPreference.longDateFormat}"/>
+                                                        </h:outputText>
+                                                        <h:outputText value="P.O. Time"/>
+                                                        <h:outputText value=":"/>
+                                                        <h:outputText value="#{purchaseOrderNativeSqlController.printDto.poTime}">
+                                                            <f:convertDateTime pattern="#{sessionController.applicationPreference.longTimeFormat}"/>
+                                                        </h:outputText>
+                                                        <h:outputText value="Approve Comments"/>
+                                                        <h:outputText value=":"/>
+                                                        <h:outputText value="#{purchaseOrderNativeSqlController.printDto.approveComments}"/>
+                                                    </h:panelGrid>
+                                                </div>
+                                            </div>
+                                            <div>
+                                                <table class="w-100" style="border-collapse: collapse; border: 1px solid black;">
+                                                    <thead>
+                                                        <tr>
+                                                            <th style="width: 30px; text-align: right; padding-right: 5px; border: 1px solid black;">No</th>
+                                                            <th style="text-align: left; min-width: 400px; border: 1px solid black;">Item Name</th>
+                                                            <th style="width: 100px; text-align: right; padding-right: 5px; border: 1px solid black;">P. Rate</th>
+                                                            <th style="width: 100px; text-align: right; padding-right: 5px; border: 1px solid black;">QTY</th>
+                                                            <th style="width: 100px; text-align: right; padding-right: 5px; border: 1px solid black;">Free QTY</th>
+                                                            <th style="width: 100px; text-align: right; padding-right: 5px; border: 1px solid black;">Total</th>
+                                                        </tr>
+                                                    </thead>
+                                                    <tbody>
+                                                        <ui:repeat value="#{purchaseOrderNativeSqlController.printDto.items}" var="lineItem" varStatus="status">
+                                                            <tr>
+                                                                <td style="width: 30px; text-align: right; padding-right: 5px; border: 1px solid black;">#{status.index + 1}</td>
+                                                                <td style="text-align: left; min-width: 400px; border: 1px solid black;">
+                                                                    <h:outputText value="#{lineItem.itemName}"/>
+                                                                    <h:outputText value="  ("/>
+                                                                    <h:outputText value="#{lineItem.itemCode}"/>
+                                                                    <h:outputText value=")"/>
+                                                                </td>
+                                                                <td style="width: 100px; text-align: right; padding-right: 5px; border: 1px solid black;">
+                                                                    <h:outputText value="#{lineItem.purchaseRate}">
+                                                                        <f:convertNumber pattern="#,##0.00"/>
+                                                                    </h:outputText>
+                                                                </td>
+                                                                <td style="width: 100px; text-align: right; padding-right: 5px; border: 1px solid black;">
+                                                                    <h:outputText value="#{lineItem.quantity}">
+                                                                        <f:convertNumber/>
+                                                                    </h:outputText>
+                                                                </td>
+                                                                <td style="width: 100px; text-align: right; padding-right: 5px; border: 1px solid black;">
+                                                                    <h:outputText value="#{lineItem.freeQuantity}">
+                                                                        <f:convertNumber/>
+                                                                    </h:outputText>
+                                                                </td>
+                                                                <td style="width: 100px; text-align: right; padding-right: 5px; border: 1px solid black; font-weight: bold;">
+                                                                    <h:outputText value="#{lineItem.lineTotal}">
+                                                                        <f:convertNumber pattern="#,###.00"/>
+                                                                    </h:outputText>
+                                                                </td>
+                                                            </tr>
+                                                        </ui:repeat>
+                                                    </tbody>
+                                                    <tfoot>
+                                                        <tr>
+                                                            <th/>
+                                                            <th colspan="4">Total</th>
+                                                            <th style="width: 100px; text-align: right; padding-right: 5px; border: 1px solid black; font-weight: bold;">
+                                                                <h:outputText value="#{purchaseOrderNativeSqlController.printDto.netTotal}">
+                                                                    <f:convertNumber pattern="#,###.00"/>
+                                                                </h:outputText>
+                                                            </th>
+                                                        </tr>
+                                                    </tfoot>
+                                                </table>
+                                            </div>
+                                            <div class="row mt-1">
+                                                <div class="col-5">
+                                                    <h:outputText value="Prepared By :  "/>
+                                                    <h:outputText value="#{purchaseOrderNativeSqlController.printDto.preparedByName}"/>
+                                                </div>
+                                                <div class="col-2"/>
+                                                <div class="col-5" style="text-align: right;">
+                                                    <h:outputText value="Prepared At :  "/>
+                                                    <h:outputText value="#{purchaseOrderNativeSqlController.printDto.preparedAt}">
+                                                        <f:convertDateTime pattern="dd/MMM/yyyy HH:mm"/>
+                                                    </h:outputText>
+                                                </div>
+                                            </div>
+                                            <div class="row">
+                                                <div class="col-5">
+                                                    <h:outputText value="Approved By :  "/>
+                                                    <h:outputText value="#{purchaseOrderNativeSqlController.printDto.approvedByName}"/>
+                                                </div>
+                                                <div class="col-2"/>
+                                                <div class="col-5" style="text-align: right;">
+                                                    <h:outputText value="Approved At :  "/>
+                                                    <h:outputText value="#{purchaseOrderNativeSqlController.printDto.approvedAt}">
+                                                        <f:convertDateTime pattern="dd/MMM/yyyy HH:mm"/>
+                                                    </h:outputText>
+                                                </div>
+                                            </div>
+                                            <div>
+                                                <p>
+                                                    <h4 style="color: #000000;">Important Note :</h4>
+                                                    <ol type="1">
+                                                        <li>Purchase order number must appear on all documents pertaining to this purchase.</li>
+                                                        <li>Comments:</li>
+                                                    </ol>
+                                                    <h5 style="color: #000000;">Good Receiving time - Monday to Friday 9.00 A.M to 3.30 P.M</h5>
+                                                </p>
+                                            </div>
+                                            <div class="row">
+                                                <div class="col-5">
+                                                    <h:outputText value="Printed By :  "/>
+                                                    <h:outputText value="#{sessionController.loggedUser.name}"/>
+                                                </div>
+                                                <div class="col-2"/>
+                                                <div class="col-5" style="text-align: right;">
+                                                    <h:outputText value="Printed At :  "/>
+                                                    <h:outputText value="#{sessionController.currentDate}">
+                                                        <f:convertDateTime pattern="dd/MMM/yyyy HH:mm"/>
+                                                    </h:outputText>
+                                                </div>
+                                            </div>
+                                        </div>
+                                    </h:panelGroup>
+
+                                    <!-- Format 3: Letter (pharmacyLetter.css) — site/dept header, no price column -->
+                                    <h:panelGroup rendered="#{configOptionController.getBooleanValueByKey('Pharmacy Purchase Order Approval Print - Letter Paper Format', false)}">
+                                        <h:outputStylesheet library="css" name="pharmacyLetter.css"/>
+                                        <div style="width: 212mm; height: 275mm; padding-left: 0px">
+                                            <div class="institutionName">
+                                                <h:outputText value="#{purchaseOrderNativeSqlController.printDto.orderSiteName}"/>
+                                                <br/>
+                                                <h:outputText value="#{purchaseOrderNativeSqlController.printDto.orderDepartmentName}"/>
+                                            </div>
+                                            <div class="institutionContact">
+                                                <div>
+                                                    <h:outputText value="#{purchaseOrderNativeSqlController.printDto.orderDepartmentAddress}" rendered="#{not empty purchaseOrderNativeSqlController.printDto.orderDepartmentAddress}"/>
+                                                </div>
+                                                <div>
+                                                    <h:outputText value="Telephone : " rendered="#{not empty purchaseOrderNativeSqlController.printDto.orderDepartmentTelephone1}"/>
+                                                    <h:outputText value="#{purchaseOrderNativeSqlController.printDto.orderDepartmentTelephone1}" rendered="#{not empty purchaseOrderNativeSqlController.printDto.orderDepartmentTelephone1}"/>
+                                                    <h:outputText value="/" rendered="#{not empty purchaseOrderNativeSqlController.printDto.orderDepartmentTelephone2}"/>
+                                                    <h:outputText value="#{purchaseOrderNativeSqlController.printDto.orderDepartmentTelephone2}" rendered="#{not empty purchaseOrderNativeSqlController.printDto.orderDepartmentTelephone2}"/>
+                                                </div>
+                                                <div>
+                                                    <h:outputText value="Fax :     #{purchaseOrderNativeSqlController.printDto.orderDepartmentFax}" rendered="#{not empty purchaseOrderNativeSqlController.printDto.orderDepartmentFax}"/>
+                                                </div>
+                                                <div>
+                                                    <h:outputText value="Email :  " rendered="#{not empty purchaseOrderNativeSqlController.printDto.orderInstitutionEmail}"/>
+                                                    <h:outputText value="#{purchaseOrderNativeSqlController.printDto.orderInstitutionEmail}" rendered="#{not empty purchaseOrderNativeSqlController.printDto.orderInstitutionEmail}"/>
+                                                </div>
+                                            </div>
+                                            <div class="headingBill">
+                                                <h:outputText value="Purchase Order" style="text-decoration: underline;"/>
+                                                <br/>
+                                                <h:outputText value="***Duplicate***"/>
+                                                <h:outputText value="***Cancelled***" rendered="#{purchaseOrderNativeSqlController.printDto.cancelled}" style="font-size: 18px;"/>
+                                            </div>
+                                            <div>
+                                                <table class="table table-borderless">
+                                                    <tr style="line-height: 10px">
+                                                        <td>Supplier Name</td><td>:</td>
+                                                        <td colspan="4">
+                                                            <h:outputText value="#{purchaseOrderNativeSqlController.printDto.supplierName}"/>
+                                                            <h:outputText value=" (" rendered="#{not empty purchaseOrderNativeSqlController.printDto.supplierCode}"/>
+                                                            <h:outputText value="#{purchaseOrderNativeSqlController.printDto.supplierCode}" rendered="#{not empty purchaseOrderNativeSqlController.printDto.supplierCode}"/>
+                                                            <h:outputText value=")" rendered="#{not empty purchaseOrderNativeSqlController.printDto.supplierCode}"/>
+                                                        </td>
+                                                    </tr>
+                                                    <tr style="line-height: 10px">
+                                                        <td>P.O. No</td><td>:</td>
+                                                        <td><h:outputText value="#{purchaseOrderNativeSqlController.printDto.poNumber}"/></td>
+                                                        <td>Order Department</td><td>:</td>
+                                                        <td><h:outputText value="#{purchaseOrderNativeSqlController.printDto.orderDepartmentName}"/></td>
+                                                    </tr>
+                                                    <tr style="line-height: 10px">
+                                                        <td>Consignment</td><td>:</td>
+                                                        <td><h:outputText value="#{purchaseOrderNativeSqlController.printDto.consignment ? 'Yes' : 'No'}"/></td>
+                                                        <td>P.O. Date/Time</td><td>:</td>
+                                                        <td>
+                                                            <h:outputText value="#{purchaseOrderNativeSqlController.printDto.poDate}">
+                                                                <f:convertDateTime pattern="dd/MMM/yyyy HH:mm"/>
+                                                            </h:outputText>
+                                                        </td>
+                                                    </tr>
+                                                    <tr style="line-height: 10px">
+                                                        <td>Payment Method</td><td>:</td>
+                                                        <td><h:outputText value="#{purchaseOrderNativeSqlController.printDto.paymentMethod}"/></td>
+                                                        <td><h:outputText value="Credit Duration" rendered="#{purchaseOrderNativeSqlController.printDto.paymentMethod eq 'Credit'}"/></td>
+                                                        <td><h:outputText value=":" rendered="#{purchaseOrderNativeSqlController.printDto.paymentMethod eq 'Credit'}"/></td>
+                                                        <td><h:outputText value="#{purchaseOrderNativeSqlController.printDto.creditDuration}" rendered="#{purchaseOrderNativeSqlController.printDto.paymentMethod eq 'Credit'}"/></td>
+                                                    </tr>
+                                                </table>
+                                            </div>
+                                            <div>
+                                                <table class="w-100" style="border-collapse: collapse; border: 1px solid black;">
+                                                    <thead>
+                                                        <tr>
+                                                            <th style="width: 30px; text-align: right; padding-right: 5px; border: 1px solid black;">No</th>
+                                                            <th style="text-align: left; min-width: 400px; border: 1px solid black;">Item Name</th>
+                                                            <th style="width: 100px; text-align: right; padding-right: 5px; border: 1px solid black;">P. Rate</th>
+                                                            <th style="width: 100px; text-align: right; padding-right: 5px; border: 1px solid black;">QTY</th>
+                                                            <th style="width: 100px; text-align: right; padding-right: 5px; border: 1px solid black;">Total</th>
+                                                        </tr>
+                                                    </thead>
+                                                    <tbody>
+                                                        <ui:repeat value="#{purchaseOrderNativeSqlController.printDto.items}" var="lineItem" varStatus="status">
+                                                            <tr>
+                                                                <td style="width: 30px; text-align: right; padding-right: 5px; border: 1px solid black;">#{status.index + 1}</td>
+                                                                <td style="text-align: left; min-width: 400px; border: 1px solid black;">
+                                                                    <h:outputText value="#{lineItem.itemName}"/>
+                                                                    <h:outputText value="  ("/>
+                                                                    <h:outputText value="#{lineItem.itemCode}"/>
+                                                                    <h:outputText value=")"/>
+                                                                </td>
+                                                                <td style="width: 100px; text-align: right; padding-right: 9px; border: 1px solid black;">
+                                                                    <h:outputText value="#{lineItem.purchaseRate}">
+                                                                        <f:convertNumber pattern="#,##0.00"/>
+                                                                    </h:outputText>
+                                                                </td>
+                                                                <td style="width: 100px; text-align: right; padding-right: 9px; border: 1px solid black;">
+                                                                    <h:outputText value="#{lineItem.quantity}">
+                                                                        <f:convertNumber/>
+                                                                    </h:outputText>
+                                                                </td>
+                                                                <td style="width: 100px; text-align: right; padding-right: 5px; border: 1px solid black; font-weight: bold;">
+                                                                    <h:outputText value="#{lineItem.lineTotal}">
+                                                                        <f:convertNumber pattern="#,###.00"/>
+                                                                    </h:outputText>
+                                                                </td>
+                                                            </tr>
+                                                        </ui:repeat>
+                                                    </tbody>
+                                                    <tfoot>
+                                                        <tr>
+                                                            <th/><th colspan="3">Total</th>
+                                                            <th style="width: 100px; text-align: right; padding-right: 5px; border: 1px solid black; font-weight: bold;">
+                                                                <h:outputText value="#{purchaseOrderNativeSqlController.printDto.netTotal}">
+                                                                    <f:convertNumber pattern="#,###.00"/>
+                                                                </h:outputText>
+                                                            </th>
+                                                        </tr>
+                                                    </tfoot>
+                                                </table>
+                                            </div>
+                                            <div style="font-size: 16px">
+                                                <h:outputText value="Request Comments : #{purchaseOrderNativeSqlController.printDto.requestComments}"/>
+                                            </div>
+                                            <div style="font-size: 16px">
+                                                <h:outputText value="Approve Comments : #{purchaseOrderNativeSqlController.printDto.approveComments}"/>
+                                            </div>
+                                            <div class="row mt-1">
+                                                <div class="col-5">
+                                                    <h:outputText value="Prepared By :  #{purchaseOrderNativeSqlController.printDto.preparedByName}"/>
+                                                </div>
+                                                <div class="col-2"/>
+                                                <div class="col-5" style="text-align: right;">
+                                                    <h:outputText value="Prepared At :  "/>
+                                                    <h:outputText value="#{purchaseOrderNativeSqlController.printDto.preparedAt}">
+                                                        <f:convertDateTime pattern="dd/MMM/yyyy HH:mm"/>
+                                                    </h:outputText>
+                                                </div>
+                                            </div>
+                                            <div class="row">
+                                                <div class="col-5">
+                                                    <h:outputText value="Approved By :  #{purchaseOrderNativeSqlController.printDto.approvedByName}"/>
+                                                </div>
+                                                <div class="col-2"/>
+                                                <div class="col-5" style="text-align: right;">
+                                                    <h:outputText value="Approved At :  "/>
+                                                    <h:outputText value="#{purchaseOrderNativeSqlController.printDto.approvedAt}">
+                                                        <f:convertDateTime pattern="dd/MMM/yyyy HH:mm"/>
+                                                    </h:outputText>
+                                                </div>
+                                            </div>
+                                            <div>
+                                                <h:outputText value="Important Note :" style="display:block;color:#000;font-weight:600;font-size:1.25rem;"/>
+                                                <h:outputText value="Purchase order number must appear on all documents pertaining to this purchase."/>
+                                                <h:outputText value="Goods receiving time - Monday to Friday 9.00 A.M. to 3.30 P.M." style="display:block;color:#000;font-size: 18px; font-weight: 500;"/>
+                                            </div>
+                                            <div class="row">
+                                                <div class="col-5">
+                                                    <h:outputText value="Printed By :  #{sessionController.loggedUser.name}"/>
+                                                </div>
+                                                <div class="col-2"/>
+                                                <div class="col-5" style="text-align: right;">
+                                                    <h:outputText value="Printed At :  "/>
+                                                    <h:outputText value="#{sessionController.currentDate}">
+                                                        <f:convertDateTime pattern="dd/MMM/yyyy HH:mm"/>
+                                                    </h:outputText>
+                                                </div>
+                                            </div>
+                                        </div>
+                                    </h:panelGroup>
+
+                                    <!-- Format 4: Custom 4 Letter (pharmacyLetter.css) — institution header, UOM column, no price -->
+                                    <h:panelGroup rendered="#{configOptionController.getBooleanValueByKey('Pharmacy Purchase Order Approval Print - Custom 4 Paper Format', false)}">
+                                        <h:outputStylesheet library="css" name="pharmacyLetter.css"/>
+                                        <div style="width: 212mm; height: 275mm; padding-left: 0px">
+                                            <div class="institutionName">
+                                                <h:outputText value="#{purchaseOrderNativeSqlController.printDto.orderInstitutionName}"/>
+                                            </div>
+                                            <div class="institutionContact">
+                                                <div>
+                                                    <h:outputText value="#{purchaseOrderNativeSqlController.printDto.orderDepartmentAddress}" rendered="#{not empty purchaseOrderNativeSqlController.printDto.orderDepartmentAddress}"/>
+                                                </div>
+                                                <div>
+                                                    <h:outputText value="Telephone : " rendered="#{not empty purchaseOrderNativeSqlController.printDto.orderDepartmentTelephone1}"/>
+                                                    <h:outputText value="#{purchaseOrderNativeSqlController.printDto.orderDepartmentTelephone1}" rendered="#{not empty purchaseOrderNativeSqlController.printDto.orderDepartmentTelephone1}"/>
+                                                    <h:outputText value="/" rendered="#{not empty purchaseOrderNativeSqlController.printDto.orderDepartmentTelephone2}"/>
+                                                    <h:outputText value="#{purchaseOrderNativeSqlController.printDto.orderDepartmentTelephone2}" rendered="#{not empty purchaseOrderNativeSqlController.printDto.orderDepartmentTelephone2}"/>
+                                                </div>
+                                                <div>
+                                                    <h:outputText value="Fax :     #{purchaseOrderNativeSqlController.printDto.orderDepartmentFax}" rendered="#{not empty purchaseOrderNativeSqlController.printDto.orderDepartmentFax}"/>
+                                                </div>
+                                                <div>
+                                                    <h:outputText value="Email :  " rendered="#{not empty purchaseOrderNativeSqlController.printDto.orderInstitutionEmail}"/>
+                                                    <h:outputText value="#{purchaseOrderNativeSqlController.printDto.orderInstitutionEmail}" rendered="#{not empty purchaseOrderNativeSqlController.printDto.orderInstitutionEmail}"/>
+                                                </div>
+                                            </div>
+                                            <div class="institutionName">
+                                                <h:outputText value="#{purchaseOrderNativeSqlController.printDto.orderDepartmentName}"/>
+                                            </div>
+                                            <div class="headingBill">
+                                                <h:outputText value="Purchase Order" style="text-decoration: underline;"/>
+                                                <br/>
+                                                <h:outputText value="***Duplicate***"/>
+                                                <h:outputText value="***Cancelled***" rendered="#{purchaseOrderNativeSqlController.printDto.cancelled}" style="font-size: 18px;"/>
+                                            </div>
+                                            <div>
+                                                <table class="table table-borderless">
+                                                    <tr style="line-height: 10px">
+                                                        <td>Supplier Name</td><td>:</td>
+                                                        <td colspan="4">
+                                                            <h:outputText value="#{purchaseOrderNativeSqlController.printDto.supplierName}"/>
+                                                            <h:outputText value=" (" rendered="#{not empty purchaseOrderNativeSqlController.printDto.supplierCode}"/>
+                                                            <h:outputText value="#{purchaseOrderNativeSqlController.printDto.supplierCode}" rendered="#{not empty purchaseOrderNativeSqlController.printDto.supplierCode}"/>
+                                                            <h:outputText value=")" rendered="#{not empty purchaseOrderNativeSqlController.printDto.supplierCode}"/>
+                                                        </td>
+                                                    </tr>
+                                                    <tr style="line-height: 10px">
+                                                        <td>P.O. No</td><td>:</td>
+                                                        <td><h:outputText value="#{purchaseOrderNativeSqlController.printDto.poNumber}"/></td>
+                                                        <td>Order Department</td><td>:</td>
+                                                        <td><h:outputText value="#{purchaseOrderNativeSqlController.printDto.orderDepartmentName}"/></td>
+                                                    </tr>
+                                                    <tr style="line-height: 10px">
+                                                        <td>Consignment</td><td>:</td>
+                                                        <td><h:outputText value="#{purchaseOrderNativeSqlController.printDto.consignment ? 'Yes' : 'No'}"/></td>
+                                                        <td>P.O. Date/Time</td><td>:</td>
+                                                        <td>
+                                                            <h:outputText value="#{purchaseOrderNativeSqlController.printDto.poDate}">
+                                                                <f:convertDateTime pattern="dd/MMM/yyyy HH:mm"/>
+                                                            </h:outputText>
+                                                        </td>
+                                                    </tr>
+                                                    <tr style="line-height: 10px">
+                                                        <td>Payment Method</td><td>:</td>
+                                                        <td><h:outputText value="#{purchaseOrderNativeSqlController.printDto.paymentMethod}"/></td>
+                                                        <td><h:outputText value="Credit Duration" rendered="#{purchaseOrderNativeSqlController.printDto.paymentMethod eq 'Credit'}"/></td>
+                                                        <td><h:outputText value=":" rendered="#{purchaseOrderNativeSqlController.printDto.paymentMethod eq 'Credit'}"/></td>
+                                                        <td><h:outputText value="#{purchaseOrderNativeSqlController.printDto.creditDuration} Days" rendered="#{purchaseOrderNativeSqlController.printDto.paymentMethod eq 'Credit'}"/></td>
+                                                    </tr>
+                                                </table>
+                                            </div>
+                                            <div>
+                                                <table class="w-100 mb-2" style="border-collapse: collapse; border: 1px solid black;">
+                                                    <thead>
+                                                        <tr>
+                                                            <th style="width: 30px; text-align: right; padding-right: 5px; border: 1px solid black;">No</th>
+                                                            <th style="text-align: left; min-width: 400px; border: 1px solid black;">Item Name</th>
+                                                            <th style="width: 100px; text-align: right; padding-right: 5px; border: 1px solid black;">UOM</th>
+                                                            <th style="width: 100px; text-align: right; padding-right: 5px; border: 1px solid black;">QTY</th>
+                                                        </tr>
+                                                    </thead>
+                                                    <tbody>
+                                                        <ui:repeat value="#{purchaseOrderNativeSqlController.printDto.items}" var="lineItem" varStatus="status">
+                                                            <tr>
+                                                                <td style="width: 30px; text-align: right; padding-right: 5px; border: 1px solid black;">#{status.index + 1}</td>
+                                                                <td style="text-align: left; min-width: 400px; border: 1px solid black;">
+                                                                    <h:outputText value="#{lineItem.itemName}"/>
+                                                                    <h:outputText value="  ("/>
+                                                                    <h:outputText value="#{lineItem.itemCode}"/>
+                                                                    <h:outputText value=")"/>
+                                                                </td>
+                                                                <td style="width: 100px; text-align: right; padding-right: 9px; border: 1px solid black;">
+                                                                    <h:outputText value="#{lineItem.issueUnitName}"/>
+                                                                </td>
+                                                                <td style="width: 100px; text-align: right; padding-right: 9px; border: 1px solid black;">
+                                                                    <h:outputText value="#{lineItem.quantity}">
+                                                                        <f:convertNumber/>
+                                                                    </h:outputText>
+                                                                </td>
+                                                            </tr>
+                                                        </ui:repeat>
+                                                    </tbody>
+                                                </table>
+                                            </div>
+                                            <div style="font-size: 16px">
+                                                <h:outputText value="Request Comments : #{purchaseOrderNativeSqlController.printDto.requestComments}"/>
+                                            </div>
+                                            <div style="font-size: 16px">
+                                                <h:outputText value="Approve Comments : #{purchaseOrderNativeSqlController.printDto.approveComments}"/>
+                                            </div>
+                                            <div class="row mt-1">
+                                                <div class="col-5">
+                                                    <h:outputText value="Prepared By :  #{purchaseOrderNativeSqlController.printDto.preparedByName}"/>
+                                                </div>
+                                                <div class="col-2"/>
+                                                <div class="col-5" style="text-align: right;">
+                                                    <h:outputText value="Prepared At :  "/>
+                                                    <h:outputText value="#{purchaseOrderNativeSqlController.printDto.preparedAt}">
+                                                        <f:convertDateTime pattern="dd/MMM/yyyy HH:mm"/>
+                                                    </h:outputText>
+                                                </div>
+                                            </div>
+                                            <div class="row">
+                                                <div class="col-5">
+                                                    <h:outputText value="Approved By :  #{purchaseOrderNativeSqlController.printDto.approvedByName}"/>
+                                                </div>
+                                                <div class="col-2"/>
+                                                <div class="col-5" style="text-align: right;">
+                                                    <h:outputText value="Approved At :  "/>
+                                                    <h:outputText value="#{purchaseOrderNativeSqlController.printDto.approvedAt}">
+                                                        <f:convertDateTime pattern="dd/MMM/yyyy HH:mm"/>
+                                                    </h:outputText>
+                                                </div>
+                                            </div>
+                                            <div>
+                                                <h:outputText value="Important Note :" style="display:block;color:#000;font-weight:600;font-size:1.25rem;"/>
+                                                <h:outputText value="Purchase order number must appear on all documents pertaining to this purchase."/>
+                                                <h:outputText value="Goods receiving time - Monday to Friday 9.00 A.M. to 3.30 P.M." style="display:block;color:#000;font-size: 18px; font-weight: 500;"/>
+                                            </div>
+                                            <div class="row">
+                                                <div class="col-5">
+                                                    <h:outputText value="Printed By :  #{sessionController.loggedUser.name}"/>
+                                                </div>
+                                                <div class="col-2"/>
+                                                <div class="col-5" style="text-align: right;">
+                                                    <h:outputText value="Printed At :  "/>
+                                                    <h:outputText value="#{sessionController.currentDate}">
+                                                        <f:convertDateTime pattern="dd/MMM/yyyy HH:mm"/>
+                                                    </h:outputText>
+                                                </div>
+                                            </div>
+                                        </div>
+                                    </h:panelGroup>
+
+                                </h:panelGroup>
+                            </div>
+
+                            <!-- Original print column (privilege-gated) -->
+                            <div class="col-6 d-flex justify-content-center border border-light border-1">
+                                <h:panelGroup id="gpOriginalBillPreview" style="width: 212mm;"
+                                              rendered="#{webUserController.hasPrivilege('PrintOriginalPoBillFromReprint')}">
+
+                                    <!-- Format 1 original -->
+                                    <h:panelGroup rendered="#{configOptionController.getBooleanValueByKey('Pharmacy Purchase Order Approval Print - A4 Custom 1 Paper Format', true)}">
+                                        <h:outputStylesheet library="css" name="pharmacyA4.css"/>
+                                        <div style="width: 212mm;">
+                                            <div class="institutionName">
+                                                <h:outputText value="#{purchaseOrderNativeSqlController.printDto.institutionName}"/>
+                                            </div>
+                                            <div class="institutionContact">
+                                                <div>
+                                                    <h:outputText value="Telephone : #{purchaseOrderNativeSqlController.printDto.institutionPhone} / #{purchaseOrderNativeSqlController.printDto.departmentTelephone1}"/>
+                                                </div>
+                                                <div>
+                                                    <h:outputText value="Fax : #{purchaseOrderNativeSqlController.printDto.institutionFax}"/>
+                                                </div>
+                                                <div>
+                                                    <h:outputText value="Email : #{purchaseOrderNativeSqlController.printDto.departmentEmail}"/>
+                                                </div>
+                                            </div>
+                                            <div class="headingBill">
+                                                <h:outputText value="Purchase Order" style="text-decoration: underline;"/>
+                                                <br/>
+                                                <h:outputText value="***Canceled***" rendered="#{purchaseOrderNativeSqlController.printDto.cancelled}" style="font-size: 18px;"/>
+                                            </div>
+                                            <div class="row">
+                                                <div class="col-6">
+                                                    <h:panelGrid columns="3" columnClasses="labelCol,valueCol,spacerCol" styleClass="table table-borderless">
+                                                        <h:outputText value="Supplier Name"/><h:outputText value=":"/>
+                                                        <h:panelGroup>
+                                                            <h:outputText value="#{purchaseOrderNativeSqlController.printDto.supplierName}"/>
+                                                            <h:outputText value=" (" rendered="#{not empty purchaseOrderNativeSqlController.printDto.supplierCode}"/>
+                                                            <h:outputText value="#{purchaseOrderNativeSqlController.printDto.supplierCode}" rendered="#{not empty purchaseOrderNativeSqlController.printDto.supplierCode}"/>
+                                                            <h:outputText value=")" rendered="#{not empty purchaseOrderNativeSqlController.printDto.supplierCode}"/>
+                                                        </h:panelGroup>
+                                                        <h:outputText value="P.O. No"/><h:outputText value=":"/>
+                                                        <h:outputText value="#{purchaseOrderNativeSqlController.printDto.poNumber}"/>
+                                                        <h:outputText value="Payment Method"/><h:outputText value=":"/>
+                                                        <h:outputText value="#{purchaseOrderNativeSqlController.printDto.paymentMethod}"/>
+                                                        <h:outputText value="Request Comments"/><h:outputText value=":"/>
+                                                        <h:outputText value="#{purchaseOrderNativeSqlController.printDto.requestComments}"/>
+                                                    </h:panelGrid>
+                                                </div>
+                                                <div class="col-6">
+                                                    <h:panelGrid columns="3" columnClasses="labelCol,valueCol,spacerCol" styleClass="table table-borderless">
+                                                        <h:outputText value="Credit Duration" rendered="#{purchaseOrderNativeSqlController.printDto.paymentMethod eq 'Credit'}"/>
+                                                        <h:outputText value=":" rendered="#{purchaseOrderNativeSqlController.printDto.paymentMethod eq 'Credit'}"/>
+                                                        <h:outputText value="#{purchaseOrderNativeSqlController.printDto.creditDuration}" rendered="#{purchaseOrderNativeSqlController.printDto.paymentMethod eq 'Credit'}"/>
+                                                        <h:outputText value="Order Department"/><h:outputText value=":"/>
+                                                        <h:outputText value="#{purchaseOrderNativeSqlController.printDto.orderDepartmentName}"/>
+                                                        <h:outputText value="P.O. Date"/><h:outputText value=":"/>
+                                                        <h:outputText value="#{purchaseOrderNativeSqlController.printDto.poDate}">
+                                                            <f:convertDateTime timeZone="Asia/Colombo" pattern="#{sessionController.applicationPreference.longDateFormat}"/>
+                                                        </h:outputText>
+                                                        <h:outputText value="P.O. Time"/><h:outputText value=":"/>
+                                                        <h:outputText value="#{purchaseOrderNativeSqlController.printDto.poTime}">
+                                                            <f:convertDateTime pattern="#{sessionController.applicationPreference.longTimeFormat}"/>
+                                                        </h:outputText>
+                                                        <h:outputText value="Consignment"/><h:outputText value=":"/>
+                                                        <h:outputText value="#{purchaseOrderNativeSqlController.printDto.consignment ? 'Yes' : 'No'}"/>
+                                                        <h:outputText value="Approve Comments"/><h:outputText value=":"/>
+                                                        <h:outputText value="#{purchaseOrderNativeSqlController.printDto.approveComments}"/>
+                                                    </h:panelGrid>
+                                                </div>
+                                            </div>
+                                            <div>
+                                                <table class="w-100" style="border-collapse: collapse; border: 1px solid black;">
+                                                    <thead>
+                                                        <tr>
+                                                            <th style="width: 30px; text-align: right; padding-right: 5px; border: 1px solid black;">No</th>
+                                                            <th style="text-align: left; min-width: 400px; border: 1px solid black;">Item Name</th>
+                                                            <th style="width: 100px; text-align: right; padding-right: 5px; border: 1px solid black;">P. Rate</th>
+                                                            <th style="width: 100px; text-align: right; padding-right: 5px; border: 1px solid black;">QTY</th>
+                                                            <th style="width: 100px; text-align: right; padding-right: 5px; border: 1px solid black;">Free QTY</th>
+                                                            <th style="width: 100px; text-align: right; padding-right: 5px; border: 1px solid black;">Total</th>
+                                                        </tr>
+                                                    </thead>
+                                                    <tbody>
+                                                        <ui:repeat value="#{purchaseOrderNativeSqlController.printDto.items}" var="lineItem" varStatus="status">
+                                                            <tr>
+                                                                <td style="width: 30px; text-align: right; padding-right: 5px; border: 1px solid black;">#{status.index + 1}</td>
+                                                                <td style="text-align: left; min-width: 400px; border: 1px solid black;">
+                                                                    <h:outputText value="#{lineItem.itemName}"/>
+                                                                    <h:outputText value="  ("/><h:outputText value="#{lineItem.itemCode}"/><h:outputText value=")"/>
+                                                                </td>
+                                                                <td style="width: 100px; text-align: right; padding-right: 5px; border: 1px solid black;">
+                                                                    <h:outputText value="#{lineItem.purchaseRate}"><f:convertNumber pattern="#,##0.00"/></h:outputText>
+                                                                </td>
+                                                                <td style="width: 100px; text-align: right; padding-right: 5px; border: 1px solid black;">
+                                                                    <h:outputText value="#{lineItem.quantity}"><f:convertNumber/></h:outputText>
+                                                                </td>
+                                                                <td style="width: 100px; text-align: right; padding-right: 5px; border: 1px solid black;">
+                                                                    <h:outputText value="#{lineItem.freeQuantity}"><f:convertNumber/></h:outputText>
+                                                                </td>
+                                                                <td style="width: 100px; text-align: right; padding-right: 5px; border: 1px solid black; font-weight: bold;">
+                                                                    <h:outputText value="#{lineItem.lineTotal}"><f:convertNumber pattern="#,###.00"/></h:outputText>
+                                                                </td>
+                                                            </tr>
+                                                        </ui:repeat>
+                                                    </tbody>
+                                                    <tfoot>
+                                                        <tr>
+                                                            <th/><th colspan="4">Total</th>
+                                                            <th style="width: 100px; text-align: right; padding-right: 5px; border: 1px solid black; font-weight: bold;">
+                                                                <h:outputText value="#{purchaseOrderNativeSqlController.printDto.netTotal}"><f:convertNumber pattern="#,###.00"/></h:outputText>
+                                                            </th>
+                                                        </tr>
+                                                    </tfoot>
+                                                </table>
+                                            </div>
+                                            <div class="row mt-1">
+                                                <div class="col-5"><h:outputText value="Prepared By :  #{purchaseOrderNativeSqlController.printDto.preparedByName}"/></div>
+                                                <div class="col-2"/>
+                                                <div class="col-5" style="text-align: right;">
+                                                    <h:outputText value="Prepared At :  "/>
+                                                    <h:outputText value="#{purchaseOrderNativeSqlController.printDto.preparedAt}"><f:convertDateTime pattern="dd/MMM/yyyy HH:mm"/></h:outputText>
+                                                </div>
+                                            </div>
+                                            <div class="row">
+                                                <div class="col-5"><h:outputText value="Approved By :  #{purchaseOrderNativeSqlController.printDto.approvedByName}"/></div>
+                                                <div class="col-2"/>
+                                                <div class="col-5" style="text-align: right;">
+                                                    <h:outputText value="Approved At :  "/>
+                                                    <h:outputText value="#{purchaseOrderNativeSqlController.printDto.approvedAt}"><f:convertDateTime pattern="dd/MMM/yyyy HH:mm"/></h:outputText>
+                                                </div>
+                                            </div>
+                                            <div>
+                                                <p>
+                                                    <h4 style="color: #000000;">Important Note :</h4>
+                                                    <ol type="1">
+                                                        <li>Purchase order number must appear on all documents pertaining to this purchase.</li>
+                                                        <li>If unable to supply above goods within above period, 10% penalty will be claimed on the invoice value.</li>
+                                                        <li>Goods receiving time - Monday to Friday 9.00 A.M to 3.30 P.M</li>
+                                                    </ol>
+                                                    <h5 style="color: #000000;">Comment :</h5>
+                                                </p>
+                                            </div>
+                                            <div class="row">
+                                                <div class="col-5"><h:outputText value="Printed By :  #{sessionController.loggedUser.name}"/></div>
+                                                <div class="col-2"/>
+                                                <div class="col-5" style="text-align: right;">
+                                                    <h:outputText value="Printed At :  "/>
+                                                    <h:outputText value="#{sessionController.currentDate}"><f:convertDateTime pattern="dd/MMM/yyyy HH:mm"/></h:outputText>
+                                                </div>
+                                            </div>
+                                        </div>
+                                    </h:panelGroup>
+
+                                </h:panelGroup>
+                            </div>
+                        </div>
+
+                    </p:panel>
+                </h:form>
+
+                <!-- Print config dialog -->
+                <p:dialog id="poNativeConfigDialog"
+                          header="Purchase Order Print Configuration"
+                          widgetVar="poNativeConfigDialog"
+                          modal="true"
+                          width="800"
+                          height="500"
+                          resizable="true"
+                          maximizable="true"
+                          closeOnEscape="true">
+                    <p:ajax event="open" listener="#{purchaseOrderConfigController.loadCurrentConfig}" update="poNativeConfigForm"/>
+                    <h:form id="poNativeConfigForm">
+                        <div class="row">
+                            <div class="col-md-12">
+                                <div class="card config-section">
+                                    <div class="card-header">
+                                        <h6><i class="fas fa-file-alt"/> Purchase Order Print Paper Settings</h6>
+                                    </div>
+                                    <div class="card-body">
+                                        <div class="mb-3">
+                                            <h:selectBooleanCheckbox id="a4custom1paperNative" value="#{purchaseOrderConfigController.a4custom1paper}"/>
+                                            <p:outputLabel for="a4custom1paperNative" value="A4 Paper Custom Format 1" class="ms-2"/>
+                                            <small class="form-text text-muted d-block">A4 purchase order format - Custom 1</small>
+                                        </div>
+                                        <div class="mb-3">
+                                            <h:selectBooleanCheckbox id="a4custom2paperNative" value="#{purchaseOrderConfigController.a4custom2paper}"/>
+                                            <p:outputLabel for="a4custom2paperNative" value="A4 Paper Custom Format 2" class="ms-2"/>
+                                            <small class="form-text text-muted d-block">A4 purchase order format - Custom 2</small>
+                                        </div>
+                                        <div class="mb-3">
+                                            <h:selectBooleanCheckbox id="letterPaperNative" value="#{purchaseOrderConfigController.letterPaper}"/>
+                                            <p:outputLabel for="letterPaperNative" value="Letter Paper Format" class="ms-2"/>
+                                            <small class="form-text text-muted d-block">Purchase order format - Letter Paper</small>
+                                        </div>
+                                        <div class="mb-3">
+                                            <h:selectBooleanCheckbox id="custom4paperNative" value="#{purchaseOrderConfigController.custom4paper}"/>
+                                            <p:outputLabel for="custom4paperNative" value="Custom 4 Paper Format" class="ms-2"/>
+                                            <small class="form-text text-muted d-block">Purchase order format - Custom 4 Paper</small>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                        <div class="row mt-4">
+                            <div class="col-12">
+                                <div class="card">
+                                    <div class="card-body">
+                                        <p:messages id="poNativeConfigMessages" showDetail="true" closable="true"/>
+                                        <div class="d-flex justify-content-between align-items-center">
+                                            <div class="d-flex gap-2">
+                                                <p:commandButton value="Apply &amp; Close" icon="fas fa-save"
+                                                                 class="ui-button-success" ajax="false"
+                                                                 action="#{purchaseOrderConfigController.saveConfig}"/>
+                                                <p:commandButton value="Cancel" icon="fas fa-times"
+                                                                 class="ui-button-secondary"
+                                                                 onclick="PF('poNativeConfigDialog').hide(); return false;"
+                                                                 type="button"/>
+                                            </div>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </h:form>
+                </p:dialog>
+
+            </ui:define>
+        </ui:composition>
+    </h:body>
+</html>


### PR DESCRIPTION
## Summary

- Add `PurchaseOrderPrintDto` + `PurchaseOrderItemPrintDto` flat DTOs (no JPA annotations)
- Add `PurchaseOrderNativeSqlService` — two-query pattern (header + items), all LEFT JOINs, EclipseLink-compatible `?1` positional parameters
- Add `PurchaseOrderNativeSqlController` (`@Named @SessionScoped`) with `viewByBillId()` navigation method
- Add `pharmacy_reprint_po_native.xhtml` — all 4 paper formats inlined, config dialog reuses `purchaseOrderConfigController`, Legacy View button back to old page
- Wire `PHARMACY_ORDER` and `PHARMACY_ORDER_APPROVAL` in `BillSearch` fast-path and entity-fallback switches to the native controller
- Update View Approved PO button in `pharmacy_purhcase_order_list_to_approve_dto.xhtml` to use `billSearch.navigateToViewBillByAtomicBillTypeByBillId`
- Add `developer_docs/billing/native-sql-print-page-guide.md` — 8-step developer guide for the native SQL print page pattern

## Test plan

- [ ] View PO from `pharmacy_purchase_order_list_for_recieve.xhtml` → opens native print page
- [ ] View Approved PO from `pharmacy_purhcase_order_list_to_approve_dto.xhtml` → opens native print page
- [ ] All 4 paper formats render correctly with correct data
- [ ] Bill with no `checkedBy` (null FK) shows empty string, not NPE
- [ ] Item list shows all non-retired items with correct quantities and rates
- [ ] Net total matches DB value
- [ ] Legacy View button navigates back to `pharmacy_reprint_po.xhtml`
- [ ] Cancelled POs (`PHARMACY_ORDER_CANCELLED`, `PHARMACY_ORDER_APPROVAL_CANCELLED`) still route to old entity page

Closes #20923

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Native print preview for Purchase Orders with multi-format previews (A4 variants, Letter, Custom), print-configuration dialog, and a “Legacy View” button.

* **Behavior Changes**
  * “View Approved Purchase Order” now opens the native preview (button disabled for unapproved orders).
  * Purchase Order navigation now routes active orders to the native preview while leaving cancelled/pre flows on the legacy path.

* **Documentation**
  * Added a developer guide for migrating print pages to a native-SQL, DTO-based approach.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hmislk/hmis/pull/20925?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->