### PR TITLE
fix: resolve NPE in month-end work time report processing

### DIFF
--- a/src/main/java/com/divudi/bean/hr/HrReportController.java
+++ b/src/main/java/com/divudi/bean/hr/HrReportController.java
@@ -3104,6 +3104,9 @@ public class HrReportController implements Serializable {
 //            List<Object[]> list = fetchWorkedTime(stf);
 
             List<Object[]> list = fetchWorkedTimeByDateOnly(stf); // Added by Buddhika
+            if (list == null) {
+                list = new ArrayList<>();
+            }
 
 //            fetchWorkedTimeTemporary(stf); // For Testing
             int i = 0;
@@ -3117,6 +3120,9 @@ public class HrReportController implements Serializable {
                 Double valueExtra = (Double) obj[2] != null ? (Double) obj[2] : 0;
                 Double totalExtraDuty = (Double) obj[3] != null ? (Double) obj[3] : 0;
                 StaffShift ss = (StaffShift) obj[4] != null ? (StaffShift) obj[4] : new StaffShift();
+                if (ss.getStaff() == null || ss.getShiftDate() == null) {
+                    continue;
+                }
                 List<StaffLeave> staffLeaves = humanResourceBean.fetchStaffLeave(ss.getStaff(), ss.getShiftDate());
 //                //System.out.println("ss.getLeaveType().isFullDayLeave() = " + ss.getLeaveType().isFullDayLeave());
                 //System.out.println("staffLeaves.size() = " + staffLeaves.size());
@@ -3124,13 +3130,12 @@ public class HrReportController implements Serializable {
                     double d = 0.0;
                     for (StaffLeave sl : staffLeaves) {
                         if (sl.getLeaveType() != LeaveType.No_Pay_Half) {
-                            d += (ss.getShift().getLeaveHourHalf() * 60 * 60);
-                            //System.out.println("d = " + d);
+                            if (ss.getShift() != null) {          // add this guard
+                                d += (ss.getShift().getLeaveHourHalf() * 60 * 60);
+                            }
                         }
                     }
                     if (d > 0) {
-                        //System.out.println("d = " + d);
-                        //System.out.println("value = " + value);
                         value = d;
                     }
                 }
@@ -3288,6 +3293,9 @@ public class HrReportController implements Serializable {
                 Double valueExtra = (Double) obj[2] != null ? (Double) obj[2] : 0;
                 Double totalExtraDuty = (Double) obj[3] != null ? (Double) obj[3] : 0;
                 StaffShift ss = (StaffShift) obj[4] != null ? (StaffShift) obj[4] : new StaffShift();
+                if (ss.getStaff() == null || ss.getShiftDate() == null || ss.getShift() == null) {
+                    continue;
+                }
                 //System.out.println("ss = " + ss);
                 //System.out.println("ss.isAutoLeave() = " + ss.isAutoLeave());
                 Double value = 0.0;
@@ -3297,6 +3305,9 @@ public class HrReportController implements Serializable {
                     value = (Double) obj[1] != null ? (Double) obj[1] : 0;
                 }
                 List<StaffLeave> staffLeaves = humanResourceBean.fetchStaffLeave(ss.getStaff(), ss.getShiftDate());
+                if (staffLeaves == null) {
+                    staffLeaves = new ArrayList<>();
+                }
 //                //System.out.println("ss.getLeaveType().isFullDayLeave() = " + ss.getLeaveType().isFullDayLeave());
                 //System.out.println("staffLeaves.size() = " + staffLeaves.size());
                 //System.out.println("value = " + value);

--- a/src/main/java/com/divudi/bean/hr/HrReportController.java
+++ b/src/main/java/com/divudi/bean/hr/HrReportController.java
@@ -3124,6 +3124,9 @@ public class HrReportController implements Serializable {
                     continue;
                 }
                 List<StaffLeave> staffLeaves = humanResourceBean.fetchStaffLeave(ss.getStaff(), ss.getShiftDate());
+                if (staffLeaves == null) {
+                    staffLeaves = new ArrayList<>();
+                }
 //                //System.out.println("ss.getLeaveType().isFullDayLeave() = " + ss.getLeaveType().isFullDayLeave());
                 //System.out.println("staffLeaves.size() = " + staffLeaves.size());
                 if (staffLeaves.size() > 1) {

--- a/src/main/webapp/hr/hr_report_month_end_work_time.xhtml
+++ b/src/main/webapp/hr/hr_report_month_end_work_time.xhtml
@@ -1,217 +1,419 @@
 <?xml version='1.0' encoding='UTF-8' ?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml"
-      xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
-      xmlns:h="http://xmlns.jcp.org/jsf/html"
-      xmlns:p="http://primefaces.org/ui"
-      xmlns:f="http://xmlns.jcp.org/jsf/core"
+<!DOCTYPE html>
+<ui:composition xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
+                template="/resources/template/template.xhtml"
+                xmlns:h="http://xmlns.jcp.org/jsf/html"
+                xmlns:p="http://primefaces.org/ui"
+                xmlns:f="http://xmlns.jcp.org/jsf/core"
+                xmlns:hr="http://xmlns.jcp.org/jsf/composite/autocomplete">
 
-      xmlns:hr="http://xmlns.jcp.org/jsf/composite/autocomplete">
+    <ui:define name="content">
 
-    <h:body>
+        <h:form styleClass="mewt-form">
 
-        <ui:composition template="/resources/template/template.xhtml">
+            <h:outputStylesheet>
+                .mewt-form {
+                    padding: 2rem 1.75rem;
+                }
 
-            <ui:define name="content">
+                .page-header {
+                    margin-bottom: 1.75rem;
+                }
 
-                <h:form >
-                    <p:panel >
-                        <f:facet name="header" >
-                            <h:outputLabel value="Month End Employee Working Time + Over Time Report-By Minute" />
-                        </f:facet>
-                        <h:panelGrid columns="2" >
-                            <h:outputLabel value="From : " />
-                            <p:calendar value="#{hrReportController.fromDate}" pattern="#{sessionController.applicationPreference.longDateTimeFormat}"  />
-                            <h:outputLabel value="To : " />
-                            <p:calendar value="#{hrReportController.toDate}" pattern="#{sessionController.applicationPreference.longDateTimeFormat}"  />
-                            <h:outputLabel value="Institution : "/>
-                            <hr:institution value="#{hrReportController.reportKeyWord.institution}"/>
-                            <h:outputLabel value="Department : "/>
-                            <hr:department value="#{hrReportController.reportKeyWord.department}"/>
-                            <h:outputLabel value="Employee : "/>
-                            <hr:completeStaff value="#{hrReportController.reportKeyWord.staff}"/>
-                            <h:outputLabel value="Staff Category : "/>
-                            <hr:completeStaffCategory value="#{hrReportController.reportKeyWord.staffCategory}"/>
-                            <h:outputLabel value="Staff Designation : "/>
-                            <hr:completeDesignation value="#{hrReportController.reportKeyWord.designation}"/>
-                            <h:outputLabel value="Staff Roster : "/>
-                            <hr:completeRoster value="#{hrReportController.reportKeyWord.roster}"/>
-                        </h:panelGrid>
+                .page-title {
+                    font-size: 18px;
+                    font-weight: 600;
+                    margin: 0 0 4px 0;
+                }
 
-                        <p:commandButton ajax="false" value="Process" action="#{hrReportController.createMonthEndWorkTimeReport()}"/>
-                        <p:commandButton ajax="false" value="Process" action="#{hrReportController.createMonthEndWorkTimeReportBySalaryGenerationMethod()}"/>
+                .page-subtitle {
+                    font-size: 13px;
+                    color: #888;
+                    margin: 0;
+                }
 
-                        <p:commandButton ajax="false" value="Excel" styleClass="noPrintButton"  >
-                            <p:dataExporter type="xlsx" target="tb1" fileName="hr_report_month_end_work_time"  />
+                .controls-panel .ui-panel-content {
+                    padding: 1.5rem 1.75rem !important;
+                }
+
+                .controls-grid {
+                    display: flex;
+                    flex-direction: column;
+                    gap: 1.25rem;
+                }
+
+                .fields-grid {
+                    display: grid;
+                    grid-template-columns: repeat(2, 1fr);
+                    gap: 1rem 1.5rem;
+                }
+
+                .field-group {
+                    display: flex;
+                    flex-direction: column;
+                    gap: 6px;
+                }
+
+                .field-label {
+                    font-size: 11.5px !important;
+                    font-weight: 600 !important;
+                    text-transform: uppercase;
+                    letter-spacing: 0.05em;
+                    color: #888 !important;
+                }
+
+                .controls-actions {
+                    display: flex;
+                    gap: 10px;
+                    align-items: center;
+                    flex-wrap: wrap;
+                }
+
+                .controls-actions-secondary {
+                    display: flex;
+                    gap: 10px;
+                    align-items: center;
+                    flex-wrap: wrap;
+                    padding-top: 0.75rem;
+                    border-top: 1px solid #e8e8e8;
+                }
+
+                .btn-action {
+                    height: 36px !important;
+                    padding: 0 18px !important;
+                    font-size: 13px !important;
+                }
+
+                .report-panel {
+                    margin-top: 1.5rem;
+                }
+
+                .report-panel .ui-panel-content {
+                    padding: 0 !important;
+                }
+
+                .report-header-wrap {
+                    text-align: center;
+                    padding: 1.5rem 1.5rem 1rem;
+                    border-bottom: 1px solid #e8e8e8;
+                }
+
+                .report-title-label {
+                    font-size: 13px;
+                    color: #666;
+                    display: block;
+                    margin-bottom: 2px;
+                }
+
+                .report-meta {
+                    font-size: 13px;
+                    color: #555;
+                    margin-top: 4px;
+                }
+
+                .mewt-table .ui-datatable-tablewrapper {
+                    overflow-x: auto !important;
+                    width: 100% !important;
+                }
+
+                .mewt-table table {
+                    width: auto !important;
+                    table-layout: auto !important;
+                }
+
+                .mewt-table .ui-datatable-data td,
+                .mewt-table .ui-datatable-thead th {
+                    padding: 10px 14px !important;
+                    white-space: nowrap;
+                    font-size: 13px !important;
+                    width: auto !important;
+                }
+
+                .mewt-table .ui-datatable-thead th {
+                    font-size: 12px !important;
+                    font-weight: 600 !important;
+                    text-transform: uppercase;
+                    letter-spacing: 0.03em;
+                    color: #888 !important;
+                    background: #f9f9f9 !important;
+                    border-bottom: 1px solid #e8e8e8 !important;
+                }
+
+                .mewt-table .ui-datatable-data tr:hover td {
+                    background: #f5f7ff !important;
+                }
+
+                .mewt-table .col-text {
+                    text-align: left !important;
+                }
+
+                .mewt-table .col-num {
+                    text-align: right !important;
+                }
+
+                .mewt-table tfoot td {
+                    background: #f9f9f9 !important;
+                    font-weight: 600 !important;
+                    font-size: 13px !important;
+                    border-top: 2px solid #e0e0e0 !important;
+                    padding: 10px 14px !important;
+                }
+
+                .report-table-footer {
+                    display: flex;
+                    justify-content: flex-end;
+                    align-items: center;
+                    gap: 6px;
+                    padding: 0.85rem 1.5rem;
+                    border-top: 1px solid #e8e8e8;
+                    font-size: 12px;
+                    color: #999;
+                }
+            </h:outputStylesheet>
+
+            <div class="page-header">
+                <p class="page-title"><h:outputText value="Month End Employee Working Time + Over Time Report - By Minute" /></p>
+                <p class="page-subtitle"><h:outputText value="Filter by date range, department or employee, then process" /></p>
+            </div>
+
+            <p:panel styleClass="controls-panel">
+                <div class="controls-grid">
+
+                    <div class="fields-grid">
+                        <div class="field-group">
+                            <p:outputLabel value="From" styleClass="field-label" />
+                            <p:calendar id="fromDate"
+                                        value="#{hrReportController.fromDate}"
+                                        pattern="#{sessionController.applicationPreference.longDateTimeFormat}"
+                                        style="width: 100%;" />
+                        </div>
+
+                        <div class="field-group">
+                            <p:outputLabel value="To" styleClass="field-label" />
+                            <p:calendar id="toDate"
+                                        value="#{hrReportController.toDate}"
+                                        pattern="#{sessionController.applicationPreference.longDateTimeFormat}"
+                                        style="width: 100%;" />
+                        </div>
+
+                        <div class="field-group">
+                            <p:outputLabel value="Institution" styleClass="field-label" />
+                            <hr:institution value="#{hrReportController.reportKeyWord.institution}" />
+                        </div>
+
+                        <div class="field-group">
+                            <p:outputLabel value="Department" styleClass="field-label" />
+                            <hr:department value="#{hrReportController.reportKeyWord.department}" />
+                        </div>
+
+                        <div class="field-group">
+                            <p:outputLabel value="Employee" styleClass="field-label" />
+                            <hr:completeStaff value="#{hrReportController.reportKeyWord.staff}" />
+                        </div>
+
+                        <div class="field-group">
+                            <p:outputLabel value="Staff category" styleClass="field-label" />
+                            <hr:completeStaffCategory value="#{hrReportController.reportKeyWord.staffCategory}" />
+                        </div>
+
+                        <div class="field-group">
+                            <p:outputLabel value="Staff designation" styleClass="field-label" />
+                            <hr:completeDesignation value="#{hrReportController.reportKeyWord.designation}" />
+                        </div>
+
+                        <div class="field-group">
+                            <p:outputLabel value="Staff roster" styleClass="field-label" />
+                            <hr:completeRoster value="#{hrReportController.reportKeyWord.roster}" />
+                        </div>
+                    </div>
+
+                    <div class="controls-actions">
+                        <p:commandButton value="Process"
+                                         ajax="false"
+                                         action="#{hrReportController.createMonthEndWorkTimeReport()}"
+                                         icon="pi pi-filter"
+                                         styleClass="btn-action" />
+                        <p:commandButton value="Process (salary method)"
+                                         ajax="false"
+                                         action="#{hrReportController.createMonthEndWorkTimeReportBySalaryGenerationMethod()}"
+                                         icon="pi pi-filter"
+                                         styleClass="btn-action" />
+                    </div>
+
+                    <div class="controls-actions-secondary">
+                        <p:commandButton value="Print"
+                                         type="button"
+                                         icon="pi pi-print"
+                                         styleClass="btn-action">
+                            <p:printer target="gpBillPreview" />
                         </p:commandButton>
-                        <p:commandButton value="Print" ajax="false" action="#" >
-                            <p:printer target="gpBillPreview" ></p:printer>
+                        <p:commandButton value="Export Excel"
+                                         ajax="false"
+                                         icon="pi pi-file-excel"
+                                         styleClass="btn-action noPrintButton">
+                            <p:dataExporter type="xlsx" target="tb1"
+                                            fileName="hr_report_month_end_work_time" />
                         </p:commandButton>
-                        <p:panel id="gpBillPreview" styleClass="noBorder summeryBorder" >
-                            <p:dataTable id="tb1" value="#{hrReportController.weekDayWorks}" var="ss"  editable="true">
-                                <f:facet name="header" >
+                    </div>
 
-                                    <h:panelGroup rendered="#{hrReportController.reportKeyWord.roster ne null}">
-                                        <h:outputLabel value="#{hrReportController.reportKeyWord.roster.name} Roster" rendered="#{hrReportController.reportKeyWord.roster ne null}"/>
-                                        <br />
-                                    </h:panelGroup>
+                </div>
+            </p:panel>
 
-                                    <h:panelGroup rendered="#{hrReportController.reportKeyWord.staff ne null}">
-                                        <h:outputLabel value="Employee #{hrReportController.reportKeyWord.staff.person.name}" rendered="#{hrReportController.reportKeyWord.staff ne null}"/>
-                                        <br />
-                                    </h:panelGroup>
+            <p:panel id="gpBillPreview" styleClass="report-panel noBorder summeryBorder">
 
-                                    <h:panelGroup rendered="#{hrReportController.reportKeyWord.institution ne null}">
-                                        <h:outputLabel value="#{hrReportController.reportKeyWord.institution.name}" rendered="#{hrReportController.reportKeyWord.institution ne null}"/>
-                                        <br />
-                                    </h:panelGroup>
+                <f:facet name="header">
+                    <div class="report-header-wrap">
+                        <span class="report-title-label">
+                            <h:outputText value="Month End Employee Working Time + Over Time Report - By Minute" />
+                        </span>
+                        <p class="report-meta">
+                            <h:outputText value="#{hrReportController.fromDate}">
+                                <f:convertDateTime pattern="dd/MM/yyyy HH:mm" />
+                            </h:outputText>
+                            <h:outputText value=" — " />
+                            <h:outputText value="#{hrReportController.toDate}">
+                                <f:convertDateTime pattern="dd/MM/yyyy HH:mm" />
+                            </h:outputText>
+                        </p>
+                        <h:panelGroup rendered="#{hrReportController.reportKeyWord.roster ne null}">
+                            <p class="report-meta">
+                                <h:outputText value="Roster: " />
+                                <h:outputText value="#{hrReportController.reportKeyWord.roster.name}" />
+                            </p>
+                        </h:panelGroup>
+                        <h:panelGroup rendered="#{hrReportController.reportKeyWord.staff ne null}">
+                            <p class="report-meta">
+                                <h:outputText value="Employee: " />
+                                <h:outputText value="#{hrReportController.reportKeyWord.staff.person.name}" />
+                            </p>
+                        </h:panelGroup>
+                        <h:panelGroup rendered="#{hrReportController.reportKeyWord.institution ne null}">
+                            <p class="report-meta">
+                                <h:outputText value="#{hrReportController.reportKeyWord.institution.name}" />
+                            </p>
+                        </h:panelGroup>
+                        <h:panelGroup rendered="#{hrReportController.reportKeyWord.department ne null}">
+                            <p class="report-meta">
+                                <h:outputText value="Department: " />
+                                <h:outputText value="#{hrReportController.reportKeyWord.department.name}" />
+                            </p>
+                        </h:panelGroup>
+                        <h:panelGroup rendered="#{hrReportController.reportKeyWord.staffCategory ne null}">
+                            <p class="report-meta">
+                                <h:outputText value="Staff category: " />
+                                <h:outputText value="#{hrReportController.reportKeyWord.staffCategory.name}" />
+                            </p>
+                        </h:panelGroup>
+                        <h:panelGroup rendered="#{hrReportController.reportKeyWord.designation ne null}">
+                            <p class="report-meta">
+                                <h:outputText value="Staff designation: " />
+                                <h:outputText value="#{hrReportController.reportKeyWord.designation.name}" />
+                            </p>
+                        </h:panelGroup>
+                    </div>
+                </f:facet>
 
-                                    <h:panelGroup rendered="#{hrReportController.reportKeyWord.department ne null}">
-                                        <h:outputLabel value="#{hrReportController.reportKeyWord.department.name} Department" rendered="#{hrReportController.reportKeyWord.department ne null}"/>
-                                        <br />
-                                    </h:panelGroup>
+                <p:dataTable id="tb1"
+                             value="#{hrReportController.weekDayWorks}"
+                             var="ss"
+                             editable="true"
+                             styleClass="mewt-table">
 
-                                    <h:panelGroup rendered="#{hrReportController.reportKeyWord.staffCategory ne null}">
-                                        <h:outputLabel value="Staff Category #{hrReportController.reportKeyWord.staffCategory.name}" rendered="#{hrReportController.reportKeyWord.staffCategory ne null}"/>
-                                        <br />
-                                    </h:panelGroup>
+                    <p:column headerText="Code" styleClass="col-text">
+                        <h:outputLabel value="#{ss.staff.codeInterger}" />
+                    </p:column>
 
-                                    <h:panelGroup rendered="#{hrReportController.reportKeyWord.designation ne null}">
-                                        <h:outputLabel value="Staff Designation #{hrReportController.reportKeyWord.designation.name}" rendered="#{hrReportController.reportKeyWord.designation ne null}"/>
-                                        <br />
-                                    </h:panelGroup>
+                    <p:column headerText="Staff" styleClass="col-text">
+                        <h:outputLabel value="#{ss.staff.person.name}" />
+                    </p:column>
 
-                                    <h:outputLabel value="Month End Employee Working Time + Over Time Report-By Minute" />
-                                    <br/>
-                                    <h:outputLabel value="#{hrReportController.fromDate} - #{hrReportController.toDate}"/>
-                                </f:facet>
-                                <p:column headerText="Code">
-                                    <f:facet name="header" >
-                                        <h:outputLabel value="Code" />
-                                    </f:facet>
-                                    <h:outputLabel value="#{ss.staff.codeInterger}" />
-                                </p:column>
-                                <p:column headerText="Staff">
-                                    <f:facet name="header" >
-                                        <h:outputLabel value="Staff" />
-                                    </f:facet>
-                                    <h:outputLabel value="#{ss.staff.person.name}" />
-                                </p:column>
-                                <p:column headerText="Sun" >
-                                    <f:facet name="header" >
-                                        <h:outputLabel value="Sun" />
-                                    </f:facet>
-                                    <h:outputLabel value="#{ss.sunDay}">
-                                        <f:converter converterId="longToTime"/>
-                                    </h:outputLabel>
-                                </p:column>
-                                <p:column headerText="Mon" >
-                                    <f:facet name="header" >
-                                        <h:outputLabel value="Mon" />
-                                    </f:facet>
-                                    <h:outputLabel value="#{ss.monDay}">
-                                        <f:converter converterId="longToTime"/>
-                                    </h:outputLabel>
-                                </p:column>
-                                <p:column headerText="Tue" >
-                                    <f:facet name="header" >
-                                        <h:outputLabel value="Tue" />
-                                    </f:facet>
-                                    <h:outputLabel value="#{ss.tuesDay}">
-                                        <f:converter converterId="longToTime"/>
-                                    </h:outputLabel>
-                                </p:column>
-                                <p:column headerText="Wed">
-                                    <f:facet name="header" >
-                                        <h:outputLabel value="Wed" />
-                                    </f:facet>
-                                    <h:outputLabel value="#{ss.wednesDay}">
-                                        <f:converter converterId="longToTime"/>
-                                    </h:outputLabel>
-                                </p:column>
-                                <p:column headerText="Thur">
-                                    <f:facet name="header" >
-                                        <h:outputLabel value="Thur" />
-                                    </f:facet>
-                                    <h:outputLabel  value="#{ss.thursDay}">
-                                        <f:converter converterId="longToTime"/>
-                                    </h:outputLabel>
-                                </p:column>
-                                <p:column headerText="Fri" >
-                                    <f:facet name="header" >
-                                        <h:outputLabel value="Fri" />
-                                    </f:facet>
-                                    <h:outputLabel value="#{ss.friDay}">
-                                        <f:converter converterId="longToTime"/>
-                                    </h:outputLabel>
-                                </p:column>
-                                <p:column headerText="Sat">
-                                    <f:facet name="header" >
-                                        <h:outputLabel value="Sat" />
-                                    </f:facet>
-                                    <h:outputLabel  value="#{ss.saturDay}">
-                                        <f:converter converterId="longToTime"/>
-                                    </h:outputLabel>
-                                </p:column>
-                                <p:column headerText="Total">
-                                    <f:facet name="header" >
-                                        <h:outputLabel value="Total" />
-                                    </f:facet>
-                                    <h:outputLabel value="#{ss.total}">
-                                        <f:converter converterId="longToTime"/>
-                                    </h:outputLabel>
-                                </p:column>
-                                <p:column headerText="Over Time Hour">
-                                    <f:facet name="header" >
-                                        <h:outputLabel value="Over Time Hour" />
-                                    </f:facet>
-                                    <h:outputLabel value="#{ss.overTime}">
-                                        <f:converter converterId="longToTime"/>
-                                    </h:outputLabel>
-                                </p:column>
-                                <p:column headerText="Over Time Value">
-                                    <f:facet name="header" >
-                                        <h:outputLabel value="Over Time Value" />
-                                    </f:facet>
-                                    <h:outputLabel value="#{ss.overTime*ss.basicPerSecond*1.5}">
-                                        <f:convertNumber pattern="0.00" />
-                                    </h:outputLabel>
-                                </p:column>
-                                <p:column headerText="Extra Duty Time" rendered="false">
-                                    <f:facet name="header" >
-                                        <h:outputLabel value="Extra Duty Time" />
-                                    </f:facet>
-                                    <h:outputLabel value="#{ss.extraDuty}">
-                                        <f:converter converterId="longToTime"/>
-                                    </h:outputLabel>
-                                </p:column>
+                    <p:column headerText="Sun" styleClass="col-num">
+                        <h:outputLabel value="#{ss.sunDay / 60}">
+                            <f:convertNumber pattern="0.00" />
+                        </h:outputLabel>
+                    </p:column>
 
-                                <p:column headerText="Extra Duty Value" rendered="false">
-                                    <f:facet name="header" >
-                                        <h:outputLabel value="Extra Duty Value" />
-                                    </f:facet>
-                                    <h:outputLabel value="#{ss.extraDutyValue}">
-                                        <f:convertNumber pattern="0.00" />
-                                    </h:outputLabel>
-                                </p:column>
-                                <f:facet name="footer">
-                                    <p:outputLabel value="Print By : #{sessionController.loggedUser.webUserPerson.name} - " />
-                                    <p:outputLabel value="Print At : " />
-                                    <p:outputLabel value="#{commonFunctionsProxy.currentDateTime}" >
-                                        <f:convertDateTime pattern="yyyy MMMM dd hh:mm:ss a " />
-                                    </p:outputLabel>
-                                </f:facet>
+                    <p:column headerText="Mon" styleClass="col-num">
+                        <h:outputLabel value="#{ss.monDay / 60}">
+                            <f:convertNumber pattern="0.00" />
+                        </h:outputLabel>
+                    </p:column>
 
-                            </p:dataTable>
-                        </p:panel>
+                    <p:column headerText="Tue" styleClass="col-num">
+                        <h:outputLabel value="#{ss.tuesDay / 60}">
+                            <f:convertNumber pattern="0.00" />
+                        </h:outputLabel>
+                    </p:column>
 
+                    <p:column headerText="Wed" styleClass="col-num">
+                        <h:outputLabel value="#{ss.wednesDay / 60}">
+                            <f:convertNumber pattern="0.00" />
+                        </h:outputLabel>
+                    </p:column>
 
-                    </p:panel>
+                    <p:column headerText="Thur" styleClass="col-num">
+                        <h:outputLabel value="#{ss.thursDay / 60}">
+                            <f:convertNumber pattern="0.00" />
+                        </h:outputLabel>
+                    </p:column>
 
-                </h:form>
-            </ui:define>
+                    <p:column headerText="Fri" styleClass="col-num">
+                        <h:outputLabel value="#{ss.friDay / 60}">
+                            <f:convertNumber pattern="0.00" />
+                        </h:outputLabel>
+                    </p:column>
 
-        </ui:composition>
+                    <p:column headerText="Sat" styleClass="col-num">
+                        <h:outputLabel value="#{ss.saturDay / 60}">
+                            <f:convertNumber pattern="0.00" />
+                        </h:outputLabel>
+                    </p:column>
 
-    </h:body>
-</html>
+                    <p:column headerText="Total" styleClass="col-num">
+                        <h:outputLabel value="#{ss.total / 60}">
+                            <f:convertNumber pattern="0.00" />
+                        </h:outputLabel>
+                    </p:column>
+
+                    <p:column headerText="Over time hour" styleClass="col-num">
+                        <h:outputLabel value="#{ss.overTime / 60}">
+                            <f:convertNumber pattern="0.00" />
+                        </h:outputLabel>
+                    </p:column>
+
+                    <p:column headerText="Over time value" styleClass="col-num">
+                        <h:outputLabel value="#{ss.overTime * ss.basicPerSecond * 1.5}">
+                            <f:convertNumber pattern="0.00" />
+                        </h:outputLabel>
+                    </p:column>
+
+                    <p:column headerText="Extra duty time" styleClass="col-num" rendered="false">
+                        <h:outputLabel value="#{ss.extraDuty / 60}">
+                            <f:convertNumber pattern="0.00" />
+                        </h:outputLabel>
+                    </p:column>
+
+                    <p:column headerText="Extra duty value" styleClass="col-num" rendered="false">
+                        <h:outputLabel value="#{ss.extraDutyValue}">
+                            <f:convertNumber pattern="0.00" />
+                        </h:outputLabel>
+                    </p:column>
+
+                    <f:facet name="footer">
+                        <div class="report-table-footer">
+                            <p:outputLabel value="Print by: #{sessionController.loggedUser.webUserPerson.name}" />
+                            <span>·</span>
+                            <p:outputLabel value="#{commonFunctionsProxy.currentDateTime}">
+                                <f:convertDateTime pattern="yyyy MMMM dd hh:mm:ss a" />
+                            </p:outputLabel>
+                        </div>
+                    </f:facet>
+
+                </p:dataTable>
+
+            </p:panel>
+
+        </h:form>
+    </ui:define>
+
+</ui:composition>


### PR DESCRIPTION
## Problem

`createMonthEndWorkTimeReport()` and its overload threw a `NullPointerException`
at runtime when processing certain staff records, causing the report page to fail
on form submit.

Two root causes identified:

1. `fetchWorkedTimeByDateOnly()` returns `null` (not an empty list) when no shift
   records exist for a staff member in the date range. Iterating a null reference
   with for-each throws NPE.

2. Some `StaffShift` rows have a null `shift` association. Inside the
   `staffLeaves.size() > 1` branch, `ss.getShift().getLeaveHourHalf()` was called
   without a null check, causing NPE for those rows.

## Changes

- `createMonthEndWorkTimeReport()` — null-check `list` after
  `fetchWorkedTimeByDateOnly()`, falling back to an empty `ArrayList`
- Added `ss.getStaff() == null || ss.getShiftDate() == null` guard to skip
  incomplete shift rows early in both method variants
- Added `ss.getShift() != null` guard before accessing `leaveHourHalf` inside
  the `staffLeaves.size() > 1` block
- Null-check on `staffLeaves` return from `humanResourceBean.fetchStaffLeave()`
  in the overloaded variant, falling back to empty list
- Also includes a UI refresh of `hr_report_month_end_work_time.xhtml` — layout
  refactored to CSS grid/flex, values now displayed as decimal hours (`/ 60`)
  instead of the `longToTime` converter

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved robustness of month-end overtime calculations by handling missing data and avoiding null-related errors.

* **UI Updates**
  * Redesigned HR month-end work time report with refreshed layout, filters and responsive controls.
  * Added Print and Excel export options and clearer report headers, date range display and metadata.
  * Simplified table rendering and numeric time formatting for clearer totals and per-day values.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hmislk/hmis/pull/20927?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->