### PR TITLE
refactor: align Working Time report UI with EPF report design system

### DIFF
--- a/src/main/java/com/divudi/bean/hr/HrReportController.java
+++ b/src/main/java/com/divudi/bean/hr/HrReportController.java
@@ -3104,6 +3104,9 @@ public class HrReportController implements Serializable {
 //            List<Object[]> list = fetchWorkedTime(stf);
 
             List<Object[]> list = fetchWorkedTimeByDateOnly(stf); // Added by Buddhika
+            if (list == null) {
+                list = new ArrayList<>();
+            }
 
 //            fetchWorkedTimeTemporary(stf); // For Testing
             int i = 0;
@@ -3117,6 +3120,9 @@ public class HrReportController implements Serializable {
                 Double valueExtra = (Double) obj[2] != null ? (Double) obj[2] : 0;
                 Double totalExtraDuty = (Double) obj[3] != null ? (Double) obj[3] : 0;
                 StaffShift ss = (StaffShift) obj[4] != null ? (StaffShift) obj[4] : new StaffShift();
+                if (ss.getStaff() == null || ss.getShiftDate() == null) {
+                    continue;
+                }
                 List<StaffLeave> staffLeaves = humanResourceBean.fetchStaffLeave(ss.getStaff(), ss.getShiftDate());
 //                //System.out.println("ss.getLeaveType().isFullDayLeave() = " + ss.getLeaveType().isFullDayLeave());
                 //System.out.println("staffLeaves.size() = " + staffLeaves.size());
@@ -3124,13 +3130,12 @@ public class HrReportController implements Serializable {
                     double d = 0.0;
                     for (StaffLeave sl : staffLeaves) {
                         if (sl.getLeaveType() != LeaveType.No_Pay_Half) {
-                            d += (ss.getShift().getLeaveHourHalf() * 60 * 60);
-                            //System.out.println("d = " + d);
+                            if (ss.getShift() != null) {          // add this guard
+                                d += (ss.getShift().getLeaveHourHalf() * 60 * 60);
+                            }
                         }
                     }
                     if (d > 0) {
-                        //System.out.println("d = " + d);
-                        //System.out.println("value = " + value);
                         value = d;
                     }
                 }
@@ -3288,6 +3293,9 @@ public class HrReportController implements Serializable {
                 Double valueExtra = (Double) obj[2] != null ? (Double) obj[2] : 0;
                 Double totalExtraDuty = (Double) obj[3] != null ? (Double) obj[3] : 0;
                 StaffShift ss = (StaffShift) obj[4] != null ? (StaffShift) obj[4] : new StaffShift();
+                if (ss.getStaff() == null || ss.getShiftDate() == null || ss.getShift() == null) {
+                    continue;
+                }
                 //System.out.println("ss = " + ss);
                 //System.out.println("ss.isAutoLeave() = " + ss.isAutoLeave());
                 Double value = 0.0;
@@ -3297,6 +3305,9 @@ public class HrReportController implements Serializable {
                     value = (Double) obj[1] != null ? (Double) obj[1] : 0;
                 }
                 List<StaffLeave> staffLeaves = humanResourceBean.fetchStaffLeave(ss.getStaff(), ss.getShiftDate());
+                if (staffLeaves == null) {
+                    staffLeaves = new ArrayList<>();
+                }
 //                //System.out.println("ss.getLeaveType().isFullDayLeave() = " + ss.getLeaveType().isFullDayLeave());
                 //System.out.println("staffLeaves.size() = " + staffLeaves.size());
                 //System.out.println("value = " + value);

--- a/src/main/java/com/divudi/bean/hr/HrReportController.java
+++ b/src/main/java/com/divudi/bean/hr/HrReportController.java
@@ -3284,6 +3284,9 @@ public class HrReportController implements Serializable {
 //            List<Object[]> list = fetchWorkedTime(stf);
 
             List<Object[]> list = fetchWorkedTimeByDateOnly(stf, frDate, tDate);
+            if (list == null) {
+                list = new ArrayList<>();
+            }
 
 
 //            fetchWorkedTimeTemporary(stf); // For Testing

--- a/src/main/java/com/divudi/bean/hr/HrReportController.java
+++ b/src/main/java/com/divudi/bean/hr/HrReportController.java
@@ -3124,6 +3124,9 @@ public class HrReportController implements Serializable {
                     continue;
                 }
                 List<StaffLeave> staffLeaves = humanResourceBean.fetchStaffLeave(ss.getStaff(), ss.getShiftDate());
+                if (staffLeaves == null) {
+                    staffLeaves = new ArrayList<>();
+                }
 //                //System.out.println("ss.getLeaveType().isFullDayLeave() = " + ss.getLeaveType().isFullDayLeave());
                 //System.out.println("staffLeaves.size() = " + staffLeaves.size());
                 if (staffLeaves.size() > 1) {

--- a/src/main/webapp/hr/hr_report_month_end_work_time.xhtml
+++ b/src/main/webapp/hr/hr_report_month_end_work_time.xhtml
@@ -1,217 +1,419 @@
 <?xml version='1.0' encoding='UTF-8' ?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml"
-      xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
-      xmlns:h="http://xmlns.jcp.org/jsf/html"
-      xmlns:p="http://primefaces.org/ui"
-      xmlns:f="http://xmlns.jcp.org/jsf/core"
+<!DOCTYPE html>
+<ui:composition xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
+                template="/resources/template/template.xhtml"
+                xmlns:h="http://xmlns.jcp.org/jsf/html"
+                xmlns:p="http://primefaces.org/ui"
+                xmlns:f="http://xmlns.jcp.org/jsf/core"
+                xmlns:hr="http://xmlns.jcp.org/jsf/composite/autocomplete">
 
-      xmlns:hr="http://xmlns.jcp.org/jsf/composite/autocomplete">
+    <ui:define name="content">
 
-    <h:body>
+        <h:form styleClass="mewt-form">
 
-        <ui:composition template="/resources/template/template.xhtml">
+            <h:outputStylesheet>
+                .mewt-form {
+                    padding: 2rem 1.75rem;
+                }
 
-            <ui:define name="content">
+                .page-header {
+                    margin-bottom: 1.75rem;
+                }
 
-                <h:form >
-                    <p:panel >
-                        <f:facet name="header" >
-                            <h:outputLabel value="Month End Employee Working Time + Over Time Report-By Minute" />
-                        </f:facet>
-                        <h:panelGrid columns="2" >
-                            <h:outputLabel value="From : " />
-                            <p:calendar value="#{hrReportController.fromDate}" pattern="#{sessionController.applicationPreference.longDateTimeFormat}"  />
-                            <h:outputLabel value="To : " />
-                            <p:calendar value="#{hrReportController.toDate}" pattern="#{sessionController.applicationPreference.longDateTimeFormat}"  />
-                            <h:outputLabel value="Institution : "/>
-                            <hr:institution value="#{hrReportController.reportKeyWord.institution}"/>
-                            <h:outputLabel value="Department : "/>
-                            <hr:department value="#{hrReportController.reportKeyWord.department}"/>
-                            <h:outputLabel value="Employee : "/>
-                            <hr:completeStaff value="#{hrReportController.reportKeyWord.staff}"/>
-                            <h:outputLabel value="Staff Category : "/>
-                            <hr:completeStaffCategory value="#{hrReportController.reportKeyWord.staffCategory}"/>
-                            <h:outputLabel value="Staff Designation : "/>
-                            <hr:completeDesignation value="#{hrReportController.reportKeyWord.designation}"/>
-                            <h:outputLabel value="Staff Roster : "/>
-                            <hr:completeRoster value="#{hrReportController.reportKeyWord.roster}"/>
-                        </h:panelGrid>
+                .page-title {
+                    font-size: 18px;
+                    font-weight: 600;
+                    margin: 0 0 4px 0;
+                }
 
-                        <p:commandButton ajax="false" value="Process" action="#{hrReportController.createMonthEndWorkTimeReport()}"/>
-                        <p:commandButton ajax="false" value="Process" action="#{hrReportController.createMonthEndWorkTimeReportBySalaryGenerationMethod()}"/>
+                .page-subtitle {
+                    font-size: 13px;
+                    color: #888;
+                    margin: 0;
+                }
 
-                        <p:commandButton ajax="false" value="Excel" styleClass="noPrintButton"  >
-                            <p:dataExporter type="xlsx" target="tb1" fileName="hr_report_month_end_work_time"  />
+                .controls-panel .ui-panel-content {
+                    padding: 1.5rem 1.75rem !important;
+                }
+
+                .controls-grid {
+                    display: flex;
+                    flex-direction: column;
+                    gap: 1.25rem;
+                }
+
+                .fields-grid {
+                    display: grid;
+                    grid-template-columns: repeat(2, 1fr);
+                    gap: 1rem 1.5rem;
+                }
+
+                .field-group {
+                    display: flex;
+                    flex-direction: column;
+                    gap: 6px;
+                }
+
+                .field-label {
+                    font-size: 11.5px !important;
+                    font-weight: 600 !important;
+                    text-transform: uppercase;
+                    letter-spacing: 0.05em;
+                    color: #888 !important;
+                }
+
+                .controls-actions {
+                    display: flex;
+                    gap: 10px;
+                    align-items: center;
+                    flex-wrap: wrap;
+                }
+
+                .controls-actions-secondary {
+                    display: flex;
+                    gap: 10px;
+                    align-items: center;
+                    flex-wrap: wrap;
+                    padding-top: 0.75rem;
+                    border-top: 1px solid #e8e8e8;
+                }
+
+                .btn-action {
+                    height: 36px !important;
+                    padding: 0 18px !important;
+                    font-size: 13px !important;
+                }
+
+                .report-panel {
+                    margin-top: 1.5rem;
+                }
+
+                .report-panel .ui-panel-content {
+                    padding: 0 !important;
+                }
+
+                .report-header-wrap {
+                    text-align: center;
+                    padding: 1.5rem 1.5rem 1rem;
+                    border-bottom: 1px solid #e8e8e8;
+                }
+
+                .report-title-label {
+                    font-size: 13px;
+                    color: #666;
+                    display: block;
+                    margin-bottom: 2px;
+                }
+
+                .report-meta {
+                    font-size: 13px;
+                    color: #555;
+                    margin-top: 4px;
+                }
+
+                .mewt-table .ui-datatable-tablewrapper {
+                    overflow-x: auto !important;
+                    width: 100% !important;
+                }
+
+                .mewt-table table {
+                    width: auto !important;
+                    table-layout: auto !important;
+                }
+
+                .mewt-table .ui-datatable-data td,
+                .mewt-table .ui-datatable-thead th {
+                    padding: 10px 14px !important;
+                    white-space: nowrap;
+                    font-size: 13px !important;
+                    width: auto !important;
+                }
+
+                .mewt-table .ui-datatable-thead th {
+                    font-size: 12px !important;
+                    font-weight: 600 !important;
+                    text-transform: uppercase;
+                    letter-spacing: 0.03em;
+                    color: #888 !important;
+                    background: #f9f9f9 !important;
+                    border-bottom: 1px solid #e8e8e8 !important;
+                }
+
+                .mewt-table .ui-datatable-data tr:hover td {
+                    background: #f5f7ff !important;
+                }
+
+                .mewt-table .col-text {
+                    text-align: left !important;
+                }
+
+                .mewt-table .col-num {
+                    text-align: right !important;
+                }
+
+                .mewt-table tfoot td {
+                    background: #f9f9f9 !important;
+                    font-weight: 600 !important;
+                    font-size: 13px !important;
+                    border-top: 2px solid #e0e0e0 !important;
+                    padding: 10px 14px !important;
+                }
+
+                .report-table-footer {
+                    display: flex;
+                    justify-content: flex-end;
+                    align-items: center;
+                    gap: 6px;
+                    padding: 0.85rem 1.5rem;
+                    border-top: 1px solid #e8e8e8;
+                    font-size: 12px;
+                    color: #999;
+                }
+            </h:outputStylesheet>
+
+            <div class="page-header">
+                <p class="page-title"><h:outputText value="Month End Employee Working Time + Over Time Report - By Minute" /></p>
+                <p class="page-subtitle"><h:outputText value="Filter by date range, department or employee, then process" /></p>
+            </div>
+
+            <p:panel styleClass="controls-panel">
+                <div class="controls-grid">
+
+                    <div class="fields-grid">
+                        <div class="field-group">
+                            <p:outputLabel value="From" styleClass="field-label" />
+                            <p:calendar id="fromDate"
+                                        value="#{hrReportController.fromDate}"
+                                        pattern="#{sessionController.applicationPreference.longDateTimeFormat}"
+                                        style="width: 100%;" />
+                        </div>
+
+                        <div class="field-group">
+                            <p:outputLabel value="To" styleClass="field-label" />
+                            <p:calendar id="toDate"
+                                        value="#{hrReportController.toDate}"
+                                        pattern="#{sessionController.applicationPreference.longDateTimeFormat}"
+                                        style="width: 100%;" />
+                        </div>
+
+                        <div class="field-group">
+                            <p:outputLabel value="Institution" styleClass="field-label" />
+                            <hr:institution value="#{hrReportController.reportKeyWord.institution}" />
+                        </div>
+
+                        <div class="field-group">
+                            <p:outputLabel value="Department" styleClass="field-label" />
+                            <hr:department value="#{hrReportController.reportKeyWord.department}" />
+                        </div>
+
+                        <div class="field-group">
+                            <p:outputLabel value="Employee" styleClass="field-label" />
+                            <hr:completeStaff value="#{hrReportController.reportKeyWord.staff}" />
+                        </div>
+
+                        <div class="field-group">
+                            <p:outputLabel value="Staff category" styleClass="field-label" />
+                            <hr:completeStaffCategory value="#{hrReportController.reportKeyWord.staffCategory}" />
+                        </div>
+
+                        <div class="field-group">
+                            <p:outputLabel value="Staff designation" styleClass="field-label" />
+                            <hr:completeDesignation value="#{hrReportController.reportKeyWord.designation}" />
+                        </div>
+
+                        <div class="field-group">
+                            <p:outputLabel value="Staff roster" styleClass="field-label" />
+                            <hr:completeRoster value="#{hrReportController.reportKeyWord.roster}" />
+                        </div>
+                    </div>
+
+                    <div class="controls-actions">
+                        <p:commandButton value="Process"
+                                         ajax="false"
+                                         action="#{hrReportController.createMonthEndWorkTimeReport()}"
+                                         icon="pi pi-filter"
+                                         styleClass="btn-action" />
+                        <p:commandButton value="Process (salary method)"
+                                         ajax="false"
+                                         action="#{hrReportController.createMonthEndWorkTimeReportBySalaryGenerationMethod()}"
+                                         icon="pi pi-filter"
+                                         styleClass="btn-action" />
+                    </div>
+
+                    <div class="controls-actions-secondary">
+                        <p:commandButton value="Print"
+                                         type="button"
+                                         icon="pi pi-print"
+                                         styleClass="btn-action">
+                            <p:printer target="gpBillPreview" />
                         </p:commandButton>
-                        <p:commandButton value="Print" ajax="false" action="#" >
-                            <p:printer target="gpBillPreview" ></p:printer>
+                        <p:commandButton value="Export Excel"
+                                         ajax="false"
+                                         icon="pi pi-file-excel"
+                                         styleClass="btn-action noPrintButton">
+                            <p:dataExporter type="xlsx" target="tb1"
+                                            fileName="hr_report_month_end_work_time" />
                         </p:commandButton>
-                        <p:panel id="gpBillPreview" styleClass="noBorder summeryBorder" >
-                            <p:dataTable id="tb1" value="#{hrReportController.weekDayWorks}" var="ss"  editable="true">
-                                <f:facet name="header" >
+                    </div>
 
-                                    <h:panelGroup rendered="#{hrReportController.reportKeyWord.roster ne null}">
-                                        <h:outputLabel value="#{hrReportController.reportKeyWord.roster.name} Roster" rendered="#{hrReportController.reportKeyWord.roster ne null}"/>
-                                        <br />
-                                    </h:panelGroup>
+                </div>
+            </p:panel>
 
-                                    <h:panelGroup rendered="#{hrReportController.reportKeyWord.staff ne null}">
-                                        <h:outputLabel value="Employee #{hrReportController.reportKeyWord.staff.person.name}" rendered="#{hrReportController.reportKeyWord.staff ne null}"/>
-                                        <br />
-                                    </h:panelGroup>
+            <p:panel id="gpBillPreview" styleClass="report-panel noBorder summeryBorder">
 
-                                    <h:panelGroup rendered="#{hrReportController.reportKeyWord.institution ne null}">
-                                        <h:outputLabel value="#{hrReportController.reportKeyWord.institution.name}" rendered="#{hrReportController.reportKeyWord.institution ne null}"/>
-                                        <br />
-                                    </h:panelGroup>
+                <f:facet name="header">
+                    <div class="report-header-wrap">
+                        <span class="report-title-label">
+                            <h:outputText value="Month End Employee Working Time + Over Time Report - By Minute" />
+                        </span>
+                        <p class="report-meta">
+                            <h:outputText value="#{hrReportController.fromDate}">
+                                <f:convertDateTime pattern="dd/MM/yyyy HH:mm" />
+                            </h:outputText>
+                            <h:outputText value=" — " />
+                            <h:outputText value="#{hrReportController.toDate}">
+                                <f:convertDateTime pattern="dd/MM/yyyy HH:mm" />
+                            </h:outputText>
+                        </p>
+                        <h:panelGroup rendered="#{hrReportController.reportKeyWord.roster ne null}">
+                            <p class="report-meta">
+                                <h:outputText value="Roster: " />
+                                <h:outputText value="#{hrReportController.reportKeyWord.roster.name}" />
+                            </p>
+                        </h:panelGroup>
+                        <h:panelGroup rendered="#{hrReportController.reportKeyWord.staff ne null}">
+                            <p class="report-meta">
+                                <h:outputText value="Employee: " />
+                                <h:outputText value="#{hrReportController.reportKeyWord.staff.person.name}" />
+                            </p>
+                        </h:panelGroup>
+                        <h:panelGroup rendered="#{hrReportController.reportKeyWord.institution ne null}">
+                            <p class="report-meta">
+                                <h:outputText value="#{hrReportController.reportKeyWord.institution.name}" />
+                            </p>
+                        </h:panelGroup>
+                        <h:panelGroup rendered="#{hrReportController.reportKeyWord.department ne null}">
+                            <p class="report-meta">
+                                <h:outputText value="Department: " />
+                                <h:outputText value="#{hrReportController.reportKeyWord.department.name}" />
+                            </p>
+                        </h:panelGroup>
+                        <h:panelGroup rendered="#{hrReportController.reportKeyWord.staffCategory ne null}">
+                            <p class="report-meta">
+                                <h:outputText value="Staff category: " />
+                                <h:outputText value="#{hrReportController.reportKeyWord.staffCategory.name}" />
+                            </p>
+                        </h:panelGroup>
+                        <h:panelGroup rendered="#{hrReportController.reportKeyWord.designation ne null}">
+                            <p class="report-meta">
+                                <h:outputText value="Staff designation: " />
+                                <h:outputText value="#{hrReportController.reportKeyWord.designation.name}" />
+                            </p>
+                        </h:panelGroup>
+                    </div>
+                </f:facet>
 
-                                    <h:panelGroup rendered="#{hrReportController.reportKeyWord.department ne null}">
-                                        <h:outputLabel value="#{hrReportController.reportKeyWord.department.name} Department" rendered="#{hrReportController.reportKeyWord.department ne null}"/>
-                                        <br />
-                                    </h:panelGroup>
+                <p:dataTable id="tb1"
+                             value="#{hrReportController.weekDayWorks}"
+                             var="ss"
+                             editable="true"
+                             styleClass="mewt-table">
 
-                                    <h:panelGroup rendered="#{hrReportController.reportKeyWord.staffCategory ne null}">
-                                        <h:outputLabel value="Staff Category #{hrReportController.reportKeyWord.staffCategory.name}" rendered="#{hrReportController.reportKeyWord.staffCategory ne null}"/>
-                                        <br />
-                                    </h:panelGroup>
+                    <p:column headerText="Code" styleClass="col-text">
+                        <h:outputLabel value="#{ss.staff.codeInterger}" />
+                    </p:column>
 
-                                    <h:panelGroup rendered="#{hrReportController.reportKeyWord.designation ne null}">
-                                        <h:outputLabel value="Staff Designation #{hrReportController.reportKeyWord.designation.name}" rendered="#{hrReportController.reportKeyWord.designation ne null}"/>
-                                        <br />
-                                    </h:panelGroup>
+                    <p:column headerText="Staff" styleClass="col-text">
+                        <h:outputLabel value="#{ss.staff.person.name}" />
+                    </p:column>
 
-                                    <h:outputLabel value="Month End Employee Working Time + Over Time Report-By Minute" />
-                                    <br/>
-                                    <h:outputLabel value="#{hrReportController.fromDate} - #{hrReportController.toDate}"/>
-                                </f:facet>
-                                <p:column headerText="Code">
-                                    <f:facet name="header" >
-                                        <h:outputLabel value="Code" />
-                                    </f:facet>
-                                    <h:outputLabel value="#{ss.staff.codeInterger}" />
-                                </p:column>
-                                <p:column headerText="Staff">
-                                    <f:facet name="header" >
-                                        <h:outputLabel value="Staff" />
-                                    </f:facet>
-                                    <h:outputLabel value="#{ss.staff.person.name}" />
-                                </p:column>
-                                <p:column headerText="Sun" >
-                                    <f:facet name="header" >
-                                        <h:outputLabel value="Sun" />
-                                    </f:facet>
-                                    <h:outputLabel value="#{ss.sunDay}">
-                                        <f:converter converterId="longToTime"/>
-                                    </h:outputLabel>
-                                </p:column>
-                                <p:column headerText="Mon" >
-                                    <f:facet name="header" >
-                                        <h:outputLabel value="Mon" />
-                                    </f:facet>
-                                    <h:outputLabel value="#{ss.monDay}">
-                                        <f:converter converterId="longToTime"/>
-                                    </h:outputLabel>
-                                </p:column>
-                                <p:column headerText="Tue" >
-                                    <f:facet name="header" >
-                                        <h:outputLabel value="Tue" />
-                                    </f:facet>
-                                    <h:outputLabel value="#{ss.tuesDay}">
-                                        <f:converter converterId="longToTime"/>
-                                    </h:outputLabel>
-                                </p:column>
-                                <p:column headerText="Wed">
-                                    <f:facet name="header" >
-                                        <h:outputLabel value="Wed" />
-                                    </f:facet>
-                                    <h:outputLabel value="#{ss.wednesDay}">
-                                        <f:converter converterId="longToTime"/>
-                                    </h:outputLabel>
-                                </p:column>
-                                <p:column headerText="Thur">
-                                    <f:facet name="header" >
-                                        <h:outputLabel value="Thur" />
-                                    </f:facet>
-                                    <h:outputLabel  value="#{ss.thursDay}">
-                                        <f:converter converterId="longToTime"/>
-                                    </h:outputLabel>
-                                </p:column>
-                                <p:column headerText="Fri" >
-                                    <f:facet name="header" >
-                                        <h:outputLabel value="Fri" />
-                                    </f:facet>
-                                    <h:outputLabel value="#{ss.friDay}">
-                                        <f:converter converterId="longToTime"/>
-                                    </h:outputLabel>
-                                </p:column>
-                                <p:column headerText="Sat">
-                                    <f:facet name="header" >
-                                        <h:outputLabel value="Sat" />
-                                    </f:facet>
-                                    <h:outputLabel  value="#{ss.saturDay}">
-                                        <f:converter converterId="longToTime"/>
-                                    </h:outputLabel>
-                                </p:column>
-                                <p:column headerText="Total">
-                                    <f:facet name="header" >
-                                        <h:outputLabel value="Total" />
-                                    </f:facet>
-                                    <h:outputLabel value="#{ss.total}">
-                                        <f:converter converterId="longToTime"/>
-                                    </h:outputLabel>
-                                </p:column>
-                                <p:column headerText="Over Time Hour">
-                                    <f:facet name="header" >
-                                        <h:outputLabel value="Over Time Hour" />
-                                    </f:facet>
-                                    <h:outputLabel value="#{ss.overTime}">
-                                        <f:converter converterId="longToTime"/>
-                                    </h:outputLabel>
-                                </p:column>
-                                <p:column headerText="Over Time Value">
-                                    <f:facet name="header" >
-                                        <h:outputLabel value="Over Time Value" />
-                                    </f:facet>
-                                    <h:outputLabel value="#{ss.overTime*ss.basicPerSecond*1.5}">
-                                        <f:convertNumber pattern="0.00" />
-                                    </h:outputLabel>
-                                </p:column>
-                                <p:column headerText="Extra Duty Time" rendered="false">
-                                    <f:facet name="header" >
-                                        <h:outputLabel value="Extra Duty Time" />
-                                    </f:facet>
-                                    <h:outputLabel value="#{ss.extraDuty}">
-                                        <f:converter converterId="longToTime"/>
-                                    </h:outputLabel>
-                                </p:column>
+                    <p:column headerText="Sun" styleClass="col-num">
+                        <h:outputLabel value="#{ss.sunDay / 60}">
+                            <f:convertNumber pattern="0.00" />
+                        </h:outputLabel>
+                    </p:column>
 
-                                <p:column headerText="Extra Duty Value" rendered="false">
-                                    <f:facet name="header" >
-                                        <h:outputLabel value="Extra Duty Value" />
-                                    </f:facet>
-                                    <h:outputLabel value="#{ss.extraDutyValue}">
-                                        <f:convertNumber pattern="0.00" />
-                                    </h:outputLabel>
-                                </p:column>
-                                <f:facet name="footer">
-                                    <p:outputLabel value="Print By : #{sessionController.loggedUser.webUserPerson.name} - " />
-                                    <p:outputLabel value="Print At : " />
-                                    <p:outputLabel value="#{commonFunctionsProxy.currentDateTime}" >
-                                        <f:convertDateTime pattern="yyyy MMMM dd hh:mm:ss a " />
-                                    </p:outputLabel>
-                                </f:facet>
+                    <p:column headerText="Mon" styleClass="col-num">
+                        <h:outputLabel value="#{ss.monDay / 60}">
+                            <f:convertNumber pattern="0.00" />
+                        </h:outputLabel>
+                    </p:column>
 
-                            </p:dataTable>
-                        </p:panel>
+                    <p:column headerText="Tue" styleClass="col-num">
+                        <h:outputLabel value="#{ss.tuesDay / 60}">
+                            <f:convertNumber pattern="0.00" />
+                        </h:outputLabel>
+                    </p:column>
 
+                    <p:column headerText="Wed" styleClass="col-num">
+                        <h:outputLabel value="#{ss.wednesDay / 60}">
+                            <f:convertNumber pattern="0.00" />
+                        </h:outputLabel>
+                    </p:column>
 
-                    </p:panel>
+                    <p:column headerText="Thur" styleClass="col-num">
+                        <h:outputLabel value="#{ss.thursDay / 60}">
+                            <f:convertNumber pattern="0.00" />
+                        </h:outputLabel>
+                    </p:column>
 
-                </h:form>
-            </ui:define>
+                    <p:column headerText="Fri" styleClass="col-num">
+                        <h:outputLabel value="#{ss.friDay / 60}">
+                            <f:convertNumber pattern="0.00" />
+                        </h:outputLabel>
+                    </p:column>
 
-        </ui:composition>
+                    <p:column headerText="Sat" styleClass="col-num">
+                        <h:outputLabel value="#{ss.saturDay / 60}">
+                            <f:convertNumber pattern="0.00" />
+                        </h:outputLabel>
+                    </p:column>
 
-    </h:body>
-</html>
+                    <p:column headerText="Total" styleClass="col-num">
+                        <h:outputLabel value="#{ss.total / 60}">
+                            <f:convertNumber pattern="0.00" />
+                        </h:outputLabel>
+                    </p:column>
+
+                    <p:column headerText="Over time hour" styleClass="col-num">
+                        <h:outputLabel value="#{ss.overTime / 60}">
+                            <f:convertNumber pattern="0.00" />
+                        </h:outputLabel>
+                    </p:column>
+
+                    <p:column headerText="Over time value" styleClass="col-num">
+                        <h:outputLabel value="#{ss.overTime * ss.basicPerSecond * 1.5}">
+                            <f:convertNumber pattern="0.00" />
+                        </h:outputLabel>
+                    </p:column>
+
+                    <p:column headerText="Extra duty time" styleClass="col-num" rendered="false">
+                        <h:outputLabel value="#{ss.extraDuty / 60}">
+                            <f:convertNumber pattern="0.00" />
+                        </h:outputLabel>
+                    </p:column>
+
+                    <p:column headerText="Extra duty value" styleClass="col-num" rendered="false">
+                        <h:outputLabel value="#{ss.extraDutyValue}">
+                            <f:convertNumber pattern="0.00" />
+                        </h:outputLabel>
+                    </p:column>
+
+                    <f:facet name="footer">
+                        <div class="report-table-footer">
+                            <p:outputLabel value="Print by: #{sessionController.loggedUser.webUserPerson.name}" />
+                            <span>·</span>
+                            <p:outputLabel value="#{commonFunctionsProxy.currentDateTime}">
+                                <f:convertDateTime pattern="yyyy MMMM dd hh:mm:ss a" />
+                            </p:outputLabel>
+                        </div>
+                    </f:facet>
+
+                </p:dataTable>
+
+            </p:panel>
+
+        </h:form>
+    </ui:define>
+
+</ui:composition>

--- a/src/main/webapp/hr/hr_report_month_end_work_time.xhtml
+++ b/src/main/webapp/hr/hr_report_month_end_work_time.xhtml
@@ -181,7 +181,7 @@
 
                     <div class="fields-grid">
                         <div class="field-group">
-                            <p:outputLabel value="From" styleClass="field-label" />
+                            <p:outputLabel for="fromDate" value="From" styleClass="field-label" />
                             <p:calendar id="fromDate"
                                         value="#{hrReportController.fromDate}"
                                         pattern="#{sessionController.applicationPreference.longDateTimeFormat}"
@@ -189,7 +189,7 @@
                         </div>
 
                         <div class="field-group">
-                            <p:outputLabel value="To" styleClass="field-label" />
+                            <p:outputLabel for="toDate" value="To" styleClass="field-label" />
                             <p:calendar id="toDate"
                                         value="#{hrReportController.toDate}"
                                         pattern="#{sessionController.applicationPreference.longDateTimeFormat}"

--- a/src/main/webapp/hr/hr_report_month_end_work_time_miniuts.xhtml
+++ b/src/main/webapp/hr/hr_report_month_end_work_time_miniuts.xhtml
@@ -276,7 +276,9 @@
 
                         <f:facet name="header">
                             <div class="report-header-wrap">
-                                <span class="report-title-label">Employee Working Time and Overtime Report</span>
+                                <span class="report-title-label">
+                                    <h:outputText value="Employee Working Time and Overtime Report" />
+                                </span>
 
                                 <h:panelGroup rendered="#{hrReportController.fromDate ne null}">
                                     <p class="report-meta">
@@ -296,27 +298,27 @@
                                 </h:panelGroup>
                                 <h:panelGroup rendered="#{hrReportController.reportKeyWord.department ne null}">
                                     <p class="report-meta">
-                                        Department: <h:outputText value="#{hrReportController.reportKeyWord.department.name}" />
+                                        <h:outputText value="Department: " /><h:outputText value="#{hrReportController.reportKeyWord.department.name}" />
                                     </p>
                                 </h:panelGroup>
                                 <h:panelGroup rendered="#{hrReportController.reportKeyWord.staff ne null}">
                                     <p class="report-meta">
-                                        Employee: <h:outputText value="#{hrReportController.reportKeyWord.staff.person.name}" />
+                                        <h:outputText value="Employee: " /><h:outputText value="#{hrReportController.reportKeyWord.staff.person.name}" />
                                     </p>
                                 </h:panelGroup>
                                 <h:panelGroup rendered="#{hrReportController.reportKeyWord.staffCategory ne null}">
                                     <p class="report-meta">
-                                        Staff category: <h:outputText value="#{hrReportController.reportKeyWord.staffCategory.name}" />
+                                        <h:outputText value="Staff category: " /><h:outputText value="#{hrReportController.reportKeyWord.staffCategory.name}" />
                                     </p>
                                 </h:panelGroup>
                                 <h:panelGroup rendered="#{hrReportController.reportKeyWord.designation ne null}">
                                     <p class="report-meta">
-                                        Designation: <h:outputText value="#{hrReportController.reportKeyWord.designation.name}" />
+                                        <h:outputText value="Designation: " /><h:outputText value="#{hrReportController.reportKeyWord.designation.name}" />
                                     </p>
                                 </h:panelGroup>
                                 <h:panelGroup rendered="#{hrReportController.reportKeyWord.roster ne null}">
                                     <p class="report-meta">
-                                        Roster: <h:outputText value="#{hrReportController.reportKeyWord.roster.name}" />
+                                        <h:outputText value="Roster: " /><h:outputText value="#{hrReportController.reportKeyWord.roster.name}" />
                                     </p>
                                 </h:panelGroup>
                             </div>
@@ -478,7 +480,8 @@
 
                             <f:facet name="footer">
                                 <div class="report-table-footer">
-                                    <p:outputLabel value="Print by: #{sessionController.loggedUser.webUserPerson.name}" />
+                                    <h:outputText value="Print by: " />
+                                    <h:outputText value="#{sessionController.loggedUser.webUserPerson.name}" />
                                     <span>·</span>
                                     <p:outputLabel value="#{commonFunctionsProxy.currentDateTime}">
                                         <f:convertDateTime pattern="yyyy MMMM dd hh:mm:ss a" />

--- a/src/main/webapp/hr/hr_report_month_end_work_time_miniuts.xhtml
+++ b/src/main/webapp/hr/hr_report_month_end_work_time_miniuts.xhtml
@@ -5,7 +5,6 @@
       xmlns:h="http://xmlns.jcp.org/jsf/html"
       xmlns:p="http://primefaces.org/ui"
       xmlns:f="http://xmlns.jcp.org/jsf/core"
-
       xmlns:hr="http://xmlns.jcp.org/jsf/composite/autocomplete">
 
     <h:body>
@@ -14,271 +13,480 @@
 
             <ui:define name="content">
 
-                <h:form >
-                    <p:panel >
-                        <f:facet name="header" >
-                            <h:outputLabel value="Employee Working Time and Over Time Report" />
+                <h:form styleClass="wt-report-form">
+
+                    <h:outputStylesheet>
+                        .wt-report-form {
+                            padding: 2rem 1.75rem;
+                        }
+
+                        .page-header {
+                            margin-bottom: 1.75rem;
+                        }
+
+                        .page-title {
+                            font-size: 18px;
+                            font-weight: 600;
+                            margin: 0 0 4px 0;
+                        }
+
+                        .page-subtitle {
+                            font-size: 13px;
+                            color: #888;
+                            margin: 0;
+                        }
+
+                        .controls-panel .ui-panel-content {
+                            padding: 1.5rem 1.75rem !important;
+                        }
+
+                        .controls-grid {
+                            display: flex;
+                            flex-direction: column;
+                            gap: 1.25rem;
+                        }
+
+                        .fields-grid {
+                            display: grid;
+                            grid-template-columns: repeat(2, 1fr);
+                            gap: 1rem 1.5rem;
+                        }
+
+                        .field-group {
+                            display: flex;
+                            flex-direction: column;
+                            gap: 6px;
+                        }
+
+                        .field-label {
+                            font-size: 11.5px !important;
+                            font-weight: 600 !important;
+                            text-transform: uppercase;
+                            letter-spacing: 0.05em;
+                            color: #888 !important;
+                        }
+
+                        .controls-actions {
+                            display: flex;
+                            gap: 10px;
+                            align-items: center;
+                            flex-wrap: wrap;
+                        }
+
+                        .controls-actions-secondary {
+                            display: flex;
+                            gap: 10px;
+                            align-items: center;
+                            flex-wrap: wrap;
+                            padding-top: 0.75rem;
+                            border-top: 1px solid #e8e8e8;
+                        }
+
+                        .btn-action {
+                            height: 36px !important;
+                            padding: 0 18px !important;
+                            font-size: 13px !important;
+                        }
+
+                        .btn-link-action {
+                            font-size: 12px;
+                            color: #666;
+                            text-decoration: underline;
+                            cursor: pointer;
+                        }
+
+                        .report-panel {
+                            margin-top: 1.5rem;
+                        }
+
+                        .report-panel .ui-panel-content {
+                            padding: 0 !important;
+                        }
+
+                        .report-header-wrap {
+                            text-align: center;
+                            padding: 1.5rem 1.5rem 1rem;
+                            border-bottom: 1px solid #e8e8e8;
+                        }
+
+                        .report-title-label {
+                            font-size: 13px;
+                            color: #666;
+                            display: block;
+                            margin-bottom: 2px;
+                        }
+
+                        .report-meta {
+                            font-size: 13px;
+                            color: #555;
+                            margin-top: 4px;
+                        }
+
+                        .wt-table .ui-datatable-tablewrapper {
+                            overflow-x: auto !important;
+                            width: 100% !important;
+                        }
+
+                        .wt-table table {
+                            width: auto !important;
+                            table-layout: auto !important;
+                        }
+
+                        .wt-table .ui-datatable-data td,
+                        .wt-table .ui-datatable-thead th {
+                            padding: 10px 14px !important;
+                            white-space: nowrap;
+                            font-size: 13px !important;
+                            width: auto !important;
+                        }
+
+                        .wt-table .ui-datatable-thead th {
+                            font-size: 12px !important;
+                            font-weight: 600 !important;
+                            text-transform: uppercase;
+                            letter-spacing: 0.03em;
+                            color: #888 !important;
+                            background: #f9f9f9 !important;
+                            border-bottom: 1px solid #e8e8e8 !important;
+                        }
+
+                        .wt-table .ui-datatable-data tr:hover td {
+                            background: #f5f7ff !important;
+                        }
+
+                        .wt-table .col-num {
+                            text-align: right !important;
+                        }
+
+                        .wt-table .col-text {
+                            text-align: left !important;
+                        }
+
+                        .wt-table .col-name .ui-outputlabel {
+                            font-weight: 500;
+                        }
+
+                        .wt-table tfoot td {
+                            background: #f9f9f9 !important;
+                            font-size: 12px !important;
+                            border-top: 2px solid #e0e0e0 !important;
+                            padding: 10px 14px !important;
+                            color: #999;
+                        }
+
+                        .report-table-footer {
+                            display: flex;
+                            justify-content: flex-end;
+                            align-items: center;
+                            gap: 6px;
+                            padding: 0.85rem 1.5rem;
+                            border-top: 1px solid #e8e8e8;
+                            font-size: 12px;
+                            color: #999;
+                        }
+                    </h:outputStylesheet>
+
+                    <div class="page-header">
+                        <p class="page-title"><h:outputText value="Employee Working Time and Overtime Report" /></p>
+                        <p class="page-subtitle"><h:outputText value="Filter by date range, employee, department or roster and process to generate" /></p>
+                    </div>
+
+                    <p:panel styleClass="controls-panel">
+                        <div class="controls-grid">
+
+                            <div class="fields-grid">
+                                <div class="field-group">
+                                    <p:outputLabel for="fromDate" value="From" styleClass="field-label" />
+                                    <p:calendar id="fromDate"
+                                                value="#{hrReportController.fromDate}"
+                                                pattern="#{sessionController.applicationPreference.longDateTimeFormat}"
+                                                style="width: 100%;" />
+                                </div>
+
+                                <div class="field-group">
+                                    <p:outputLabel for="toDate" value="To" styleClass="field-label" />
+                                    <p:calendar id="toDate"
+                                                value="#{hrReportController.toDate}"
+                                                pattern="#{sessionController.applicationPreference.longDateTimeFormat}"
+                                                style="width: 100%;" />
+                                </div>
+
+                                <div class="field-group">
+                                    <p:outputLabel value="Employee" styleClass="field-label" />
+                                    <hr:completeStaff value="#{hrReportController.reportKeyWord.staff}" />
+                                </div>
+
+                                <div class="field-group">
+                                    <p:outputLabel value="Institution" styleClass="field-label" />
+                                    <hr:institution value="#{hrReportController.reportKeyWord.institution}" />
+                                </div>
+
+                                <div class="field-group">
+                                    <p:outputLabel value="Department" styleClass="field-label" />
+                                    <hr:department value="#{hrReportController.reportKeyWord.department}" />
+                                </div>
+
+                                <div class="field-group">
+                                    <p:outputLabel value="Staff category" styleClass="field-label" />
+                                    <hr:completeStaffCategory value="#{hrReportController.reportKeyWord.staffCategory}" />
+                                </div>
+
+                                <div class="field-group">
+                                    <p:outputLabel value="Staff designation" styleClass="field-label" />
+                                    <hr:completeDesignation value="#{hrReportController.reportKeyWord.designation}" />
+                                </div>
+
+                                <div class="field-group">
+                                    <p:outputLabel value="Staff roster" styleClass="field-label" />
+                                    <hr:completeRoster value="#{hrReportController.reportKeyWord.roster}" />
+                                </div>
+                            </div>
+
+                            <div class="controls-actions">
+                                <p:commandButton value="Process"
+                                                 ajax="false"
+                                                 action="#{hrReportController.createMonthEndWorkTimeReport()}"
+                                                 icon="pi pi-sync"
+                                                 styleClass="btn-action" />
+                            </div>
+
+                            <div class="controls-actions-secondary">
+                                <p:commandButton value="Print"
+                                                 type="button"
+                                                 icon="pi pi-print"
+                                                 styleClass="btn-action">
+                                    <p:printer target="gpBillPreview" />
+                                </p:commandButton>
+                                <p:commandButton value="Export Excel"
+                                                 ajax="false"
+                                                 icon="pi pi-file-excel"
+                                                 styleClass="btn-action noPrintButton">
+                                    <p:dataExporter type="xlsx" target="tb1" fileName="hr_report_month_end_work_time_miniuts" />
+                                </p:commandButton>
+                                <p:commandLink ajax="false"
+                                               value="New Method"
+                                               action="#{hrReportController.createMonthEndWorkTimeReportBySalaryGenerationMethod()}"
+                                               styleClass="btn-link-action noPrintButton" />
+                            </div>
+
+                        </div>
+                    </p:panel>
+
+                    <p:panel id="gpBillPreview" styleClass="report-panel noBorder summeryBorder">
+
+                        <f:facet name="header">
+                            <div class="report-header-wrap">
+                                <span class="report-title-label">Employee Working Time and Overtime Report</span>
+
+                                <h:panelGroup rendered="#{hrReportController.fromDate ne null}">
+                                    <p class="report-meta">
+                                        <h:outputText value="#{hrReportController.fromDate}">
+                                            <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateFormat}" />
+                                        </h:outputText>
+                                        —
+                                        <h:outputText value="#{hrReportController.toDate}">
+                                            <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateFormat}" />
+                                        </h:outputText>
+                                    </p>
+                                </h:panelGroup>
+                                <h:panelGroup rendered="#{hrReportController.reportKeyWord.institution ne null}">
+                                    <p class="report-meta">
+                                        <h:outputText value="#{hrReportController.reportKeyWord.institution.name}" />
+                                    </p>
+                                </h:panelGroup>
+                                <h:panelGroup rendered="#{hrReportController.reportKeyWord.department ne null}">
+                                    <p class="report-meta">
+                                        Department: <h:outputText value="#{hrReportController.reportKeyWord.department.name}" />
+                                    </p>
+                                </h:panelGroup>
+                                <h:panelGroup rendered="#{hrReportController.reportKeyWord.staff ne null}">
+                                    <p class="report-meta">
+                                        Employee: <h:outputText value="#{hrReportController.reportKeyWord.staff.person.name}" />
+                                    </p>
+                                </h:panelGroup>
+                                <h:panelGroup rendered="#{hrReportController.reportKeyWord.staffCategory ne null}">
+                                    <p class="report-meta">
+                                        Staff category: <h:outputText value="#{hrReportController.reportKeyWord.staffCategory.name}" />
+                                    </p>
+                                </h:panelGroup>
+                                <h:panelGroup rendered="#{hrReportController.reportKeyWord.designation ne null}">
+                                    <p class="report-meta">
+                                        Designation: <h:outputText value="#{hrReportController.reportKeyWord.designation.name}" />
+                                    </p>
+                                </h:panelGroup>
+                                <h:panelGroup rendered="#{hrReportController.reportKeyWord.roster ne null}">
+                                    <p class="report-meta">
+                                        Roster: <h:outputText value="#{hrReportController.reportKeyWord.roster.name}" />
+                                    </p>
+                                </h:panelGroup>
+                            </div>
                         </f:facet>
-                        <h:panelGrid columns="2" >
-                            <h:outputLabel value="From : " />
-                            <p:calendar value="#{hrReportController.fromDate}" pattern="#{sessionController.applicationPreference.longDateTimeFormat}"  />
-                            <h:outputLabel value="To : " />
-                            <p:calendar value="#{hrReportController.toDate}" pattern="#{sessionController.applicationPreference.longDateTimeFormat}"  />
-                            <h:outputLabel value="Employee : "/>
-                            <hr:completeStaff value="#{hrReportController.reportKeyWord.staff}"/>
-                            <h:outputLabel value="Institution : "/>
-                            <hr:institution value="#{hrReportController.reportKeyWord.institution}"/>
-                            <h:outputLabel value="Department : "/>
-                            <hr:department value="#{hrReportController.reportKeyWord.department}"/>
-                            <h:outputLabel value="Staff Category : "/>
-                            <hr:completeStaffCategory value="#{hrReportController.reportKeyWord.staffCategory}"/>
-                            <h:outputLabel value="Staff Designation : "/>
-                            <hr:completeDesignation value="#{hrReportController.reportKeyWord.designation}"/>
-                            <h:outputLabel value="Staff Roster : "/>
-                            <hr:completeRoster value="#{hrReportController.reportKeyWord.roster}"/>
-                        </h:panelGrid>
 
-                        <h:panelGrid columns="4" >
-                            <p:commandButton ajax="false" value="Process" action="#{hrReportController.createMonthEndWorkTimeReport()}"/>
-                            <p:commandButton ajax="false" value="Excel" styleClass="noPrintButton"  >
-                                <p:dataExporter type="xlsx" target="tb1" fileName="hr_report_month_end_work_time_miniuts"  />
-                            </p:commandButton>
-                            <p:commandButton value="Print" ajax="false" action="#" >
-                                <p:printer target="gpBillPreview" ></p:printer>
-                            </p:commandButton>
+                        <p:dataTable id="tb1"
+                                     value="#{hrReportController.weekDayWorks}"
+                                     var="ss"
+                                     editable="true"
+                                     styleClass="wt-table">
 
-                            <p:commandLink ajax="false" value="New Method"
-                                           action="#{hrReportController.createMonthEndWorkTimeReportBySalaryGenerationMethod()}"
-                                           styleClass="tinyText" style="float: right;"/>
+                            <p:column headerText="Code" styleClass="col-text">
+                                <h:outputLabel value="#{ss.staff.codeInterger}" />
+                            </p:column>
 
-                        </h:panelGrid>
-                        <p:panel id="gpBillPreview" styleClass="noBorder summeryBorder" >
-                            <p:dataTable id="tb1" value="#{hrReportController.weekDayWorks}" var="ss"  editable="true">
-                                <f:facet name="header" >
+                            <p:column headerText="Staff" styleClass="col-text col-name" style="min-width: 180px;">
+                                <p:commandLink value="#{ss.staff.person.name}"
+                                               action="#{hrReportController.fromWeekelyOverTimeReportToStaffFingerPrintAnalysis(ss.staff)}"
+                                               ajax="false" />
+                            </p:column>
 
-                                    <h:panelGroup rendered="#{hrReportController.reportKeyWord.roster ne null}">
-                                        <h:outputLabel value="#{hrReportController.reportKeyWord.roster.name} Roster" rendered="#{hrReportController.reportKeyWord.roster ne null}"/>
-                                        <br />
-                                    </h:panelGroup>
-                                    <h:panelGroup rendered="#{hrReportController.reportKeyWord.staff ne null}">
-                                        <h:outputLabel value="Employee #{hrReportController.reportKeyWord.staff.person.name}" rendered="#{hrReportController.reportKeyWord.staff ne null}"/>
-                                        <br />
-                                    </h:panelGroup>
-
-                                    <h:panelGroup rendered="#{hrReportController.reportKeyWord.institution ne null}">
-                                        <h:outputLabel value="#{hrReportController.reportKeyWord.institution.name}" rendered="#{hrReportController.reportKeyWord.institution ne null}"/>
-                                        <br />
-                                    </h:panelGroup>
-
-                                    <h:panelGroup rendered="#{hrReportController.reportKeyWord.department ne null}">
-                                        <h:outputLabel value="#{hrReportController.reportKeyWord.department.name} Department" rendered="#{hrReportController.reportKeyWord.department ne null}"/>
-                                        <br />
-                                    </h:panelGroup>
-
-                                    <h:panelGroup rendered="#{hrReportController.reportKeyWord.staffCategory ne null}">
-                                        <h:outputLabel value="Staff Category #{hrReportController.reportKeyWord.staffCategory.name}" rendered="#{hrReportController.reportKeyWord.staffCategory ne null}"/>
-                                        <br />
-                                    </h:panelGroup>
-
-                                    <h:panelGroup rendered="#{hrReportController.reportKeyWord.designation ne null}">
-                                        <h:outputLabel value="Staff Designation #{hrReportController.reportKeyWord.designation.name}" rendered="#{hrReportController.reportKeyWord.designation ne null}"/>
-                                        <br />
-                                    </h:panelGroup>
-
-                                    <h:outputLabel value="Employee Working Time and Over Time Report " />
-                                    <h:outputLabel value="From : "/>
-                                    <h:outputLabel value="#{hrReportController.fromDate}">
-                                        <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateFormat}" ></f:convertDateTime>
-                                    </h:outputLabel>
-                                    <h:outputLabel value=" To : "/>
-                                    <h:outputLabel value="#{hrReportController.toDate}">
-                                        <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateFormat}" ></f:convertDateTime>
-                                    </h:outputLabel>
-                                </f:facet>
-                                <p:column  styleClass="shortNumericColumn">
-                                    <f:facet name="header" >
-                                        <h:outputLabel value="Code" />
-                                    </f:facet>
-                                    <h:outputLabel value="#{ss.staff.codeInterger}" />
-                                </p:column>
-                                <p:column headerText="Staff">
-                                    <f:facet name="header" >
-                                        <h:outputLabel value="Staff" />
-                                    </f:facet>
-                                    <p:commandLink value="#{ss.staff.person.name}"
-                                                   action="#{hrReportController.fromWeekelyOverTimeReportToStaffFingerPrintAnalysis(ss.staff)}" ajax="false" ></p:commandLink>
-                                </p:column>
-                                <p:column styleClass="shortNumericColumn" >
-                                    <f:facet name="header" >
-                                        <h:outputLabel value="Sun" />
-                                    </f:facet>
-                                    <h:outputLabel id="lblSun" value="#{ss.sunDay/60}">
-                                        <f:convertNumber pattern="0"/>
-                                    </h:outputLabel>
-                                    <p:tooltip for="lblSun" >
-                                        <h:outputLabel  value="#{ss.sunDay/3600}">
-                                            <f:convertNumber pattern="0.00"/>
-                                        </h:outputLabel>
-                                        <h:outputLabel value="hrs" ></h:outputLabel>
-                                    </p:tooltip>
-                                </p:column>
-                                <p:column styleClass="shortNumericColumn" >
-                                    <f:facet name="header" >
-                                        <h:outputLabel value="Mon" />
-                                    </f:facet>
-                                    <h:outputLabel id="lblMon" value="#{ss.monDay/60}">
-                                        <f:convertNumber pattern="0"/>
-                                    </h:outputLabel>
-                                    <p:tooltip for="lblMon" >
-                                        <h:outputLabel  value="#{ss.monDay/3600}">
-                                            <f:convertNumber pattern="0.00"/>
-                                        </h:outputLabel>
-                                        <h:outputLabel value="hrs" ></h:outputLabel>
-                                    </p:tooltip>
-                                </p:column>
-                                <p:column styleClass="shortNumericColumn" >
-                                    <f:facet name="header" >
-                                        <h:outputLabel value="Tue" />
-                                    </f:facet>
-                                    <h:outputLabel id="lblTue" value="#{ss.tuesDay/60}">
-                                        <f:convertNumber pattern="0"/>
-                                    </h:outputLabel>
-                                    <p:tooltip for="lblTue" >
-                                        <h:outputLabel  value="#{ss.tuesDay/3600}">
-                                            <f:convertNumber pattern="0.00"/>
-                                        </h:outputLabel>
-                                        <h:outputLabel value="hrs" ></h:outputLabel>
-                                    </p:tooltip>
-                                </p:column>
-                                <p:column styleClass="shortNumericColumn">
-                                    <f:facet name="header" >
-                                        <h:outputLabel value="Wed" />
-                                    </f:facet>
-                                    <h:outputLabel id="lblWed" value="#{ss.wednesDay/60}">
-                                        <f:convertNumber pattern="0"/>
-                                    </h:outputLabel>
-                                    <p:tooltip for="lblWed" >
-                                        <h:outputLabel  value="#{ss.wednesDay/3600}">
-                                            <f:convertNumber pattern="0.00"/>
-                                        </h:outputLabel>
-                                        <h:outputLabel value="hrs" ></h:outputLabel>
-                                    </p:tooltip>
-                                </p:column>
-                                <p:column styleClass="shortNumericColumn">
-                                    <f:facet name="header" >
-                                        <h:outputLabel value="Thur" />
-                                    </f:facet>
-                                    <h:outputLabel id="lblThu"  value="#{ss.thursDay/60}">
-                                        <f:convertNumber pattern="0"/>
-                                    </h:outputLabel>
-                                    <p:tooltip for="lblThu" >
-                                        <h:outputLabel  value="#{ss.thursDay/3600}">
-                                            <f:convertNumber pattern="0.00"/>
-                                        </h:outputLabel>
-                                        <h:outputLabel value="hrs" ></h:outputLabel>
-                                    </p:tooltip>
-                                </p:column>
-                                <p:column styleClass="shortNumericColumn" >
-                                    <f:facet name="header" >
-                                        <h:outputLabel value="Fri" />
-                                    </f:facet>
-                                    <h:outputLabel id="lblFri" value="#{ss.friDay/60}">
-                                        <f:convertNumber pattern="0"/>
-                                    </h:outputLabel>
-                                    <p:tooltip for="lblFri" >
-                                        <h:outputLabel  value="#{ss.friDay/3600}">
-                                            <f:convertNumber pattern="0.00"/>
-                                        </h:outputLabel>
-                                        <h:outputLabel value="hrs" ></h:outputLabel>
-                                    </p:tooltip>
-                                </p:column>
-                                <p:column styleClass="shortNumericColumn">
-                                    <f:facet name="header" >
-                                        <h:outputLabel value="Sat" />
-                                    </f:facet>
-                                    <h:outputLabel id="lblSat"  value="#{ss.saturDay/60}">
-                                        <f:convertNumber pattern="0"/>
-                                    </h:outputLabel>
-                                    <p:tooltip for="lblSat" >
-                                        <h:outputLabel  value="#{ss.saturDay/3600}">
-                                            <f:convertNumber pattern="0.00"/>
-                                        </h:outputLabel>
-                                        <h:outputLabel value="hrs" ></h:outputLabel>
-                                    </p:tooltip>
-                                </p:column>
-                                <p:column styleClass="shortNumericColumn">
-                                    <f:facet name="header" >
-                                        <h:outputLabel id="lblTotTitle" value="Total" />
-                                        <p:tooltip for="lblTotTitle" >
-                                            <h:outputLabel value="Total Work Time" />
-                                        </p:tooltip>
-                                    </f:facet>
-                                    <h:outputLabel id="lblTot" value="#{ss.total/60}">
-                                        <f:convertNumber pattern="0"/>
-                                    </h:outputLabel>
-                                    <p:tooltip for="lblTot" >
-                                        <h:outputLabel  value="#{ss.total/3600}">
-                                            <f:convertNumber pattern="0.00"/>
-                                        </h:outputLabel>
-                                        <h:outputLabel value="hrs" ></h:outputLabel>
-                                    </p:tooltip>
-                                </p:column>
-                                <p:column styleClass="shortNumericColumn" >
-                                    <f:facet name="header" >
-                                        <h:outputLabel value="Entitled" />
-                                    </f:facet>
-                                    <h:outputLabel id="lblEnt" value="#{ss.staff.workingTimeForOverTimePerWeek*60}">
-                                        <f:convertNumber pattern="0"/>
-                                    </h:outputLabel>
-                                    <p:tooltip for="lblEnt" >
-                                        <h:outputLabel  value="#{ss.staff.workingTimeForOverTimePerWeek}">
-                                            <f:convertNumber pattern="0.00"/>
-                                        </h:outputLabel>
-                                        <h:outputLabel value="hrs" ></h:outputLabel>
-                                    </p:tooltip>
-                                </p:column>
-
-                                <p:column styleClass="shortNumericColumn">
-                                    <f:facet name="header" >
-                                        <h:outputLabel id="lblOtTitle" value="OT" />
-                                        <p:tooltip for="lblOtTitle" >
-                                            <h:outputLabel value="Weekely Overtime (Minutes)" />
-                                        </p:tooltip>
-                                    </f:facet>
-                                    <h:outputLabel id="lblOt" value="#{ss.overTime/60}">
-                                        <f:convertNumber pattern="0"/>
-                                    </h:outputLabel>
-                                    <p:tooltip for="lblOt" >
-                                        <h:outputLabel  value="#{ss.overTime/3600}">
-                                            <f:convertNumber pattern="0.00"/>
-                                        </h:outputLabel>
-                                        <h:outputLabel value="hrs" ></h:outputLabel>
-                                    </p:tooltip>
-                                </p:column>
-
-                                <p:column styleClass="shortNumericColumn">
-                                    <f:facet name="header" >
-                                        <h:outputLabel id="lblOtValTitle" value="Value" />
-                                        <p:tooltip for="lblOtValTitle" >
-                                            <h:outputLabel value="Weekely Orvertime Value" />
-                                        </p:tooltip>
-                                    </f:facet>
-                                    <h:outputLabel value="#{ss.overTime*ss.basicPerSecond*1.5}">
+                            <p:column headerText="Sun" styleClass="col-num">
+                                <h:outputLabel id="lblSun" value="#{ss.sunDay/60}">
+                                    <f:convertNumber pattern="0" />
+                                </h:outputLabel>
+                                <p:tooltip for="lblSun">
+                                    <h:outputLabel value="#{ss.sunDay/3600}">
                                         <f:convertNumber pattern="0.00" />
                                     </h:outputLabel>
-                                </p:column>
+                                    <h:outputLabel value=" hrs" />
+                                </p:tooltip>
+                            </p:column>
 
-                                <f:facet name="footer">
-                                    <p:outputLabel value="Print By : #{sessionController.loggedUser.webUserPerson.name} - " />
-                                    <p:outputLabel value="Print At : " />
-                                    <p:outputLabel value="#{commonFunctionsProxy.currentDateTime}" >
-                                        <f:convertDateTime pattern="yyyy MMMM dd hh:mm:ss a " />
-                                    </p:outputLabel>
+                            <p:column headerText="Mon" styleClass="col-num">
+                                <h:outputLabel id="lblMon" value="#{ss.monDay/60}">
+                                    <f:convertNumber pattern="0" />
+                                </h:outputLabel>
+                                <p:tooltip for="lblMon">
+                                    <h:outputLabel value="#{ss.monDay/3600}">
+                                        <f:convertNumber pattern="0.00" />
+                                    </h:outputLabel>
+                                    <h:outputLabel value=" hrs" />
+                                </p:tooltip>
+                            </p:column>
+
+                            <p:column headerText="Tue" styleClass="col-num">
+                                <h:outputLabel id="lblTue" value="#{ss.tuesDay/60}">
+                                    <f:convertNumber pattern="0" />
+                                </h:outputLabel>
+                                <p:tooltip for="lblTue">
+                                    <h:outputLabel value="#{ss.tuesDay/3600}">
+                                        <f:convertNumber pattern="0.00" />
+                                    </h:outputLabel>
+                                    <h:outputLabel value=" hrs" />
+                                </p:tooltip>
+                            </p:column>
+
+                            <p:column headerText="Wed" styleClass="col-num">
+                                <h:outputLabel id="lblWed" value="#{ss.wednesDay/60}">
+                                    <f:convertNumber pattern="0" />
+                                </h:outputLabel>
+                                <p:tooltip for="lblWed">
+                                    <h:outputLabel value="#{ss.wednesDay/3600}">
+                                        <f:convertNumber pattern="0.00" />
+                                    </h:outputLabel>
+                                    <h:outputLabel value=" hrs" />
+                                </p:tooltip>
+                            </p:column>
+
+                            <p:column headerText="Thu" styleClass="col-num">
+                                <h:outputLabel id="lblThu" value="#{ss.thursDay/60}">
+                                    <f:convertNumber pattern="0" />
+                                </h:outputLabel>
+                                <p:tooltip for="lblThu">
+                                    <h:outputLabel value="#{ss.thursDay/3600}">
+                                        <f:convertNumber pattern="0.00" />
+                                    </h:outputLabel>
+                                    <h:outputLabel value=" hrs" />
+                                </p:tooltip>
+                            </p:column>
+
+                            <p:column headerText="Fri" styleClass="col-num">
+                                <h:outputLabel id="lblFri" value="#{ss.friDay/60}">
+                                    <f:convertNumber pattern="0" />
+                                </h:outputLabel>
+                                <p:tooltip for="lblFri">
+                                    <h:outputLabel value="#{ss.friDay/3600}">
+                                        <f:convertNumber pattern="0.00" />
+                                    </h:outputLabel>
+                                    <h:outputLabel value=" hrs" />
+                                </p:tooltip>
+                            </p:column>
+
+                            <p:column headerText="Sat" styleClass="col-num">
+                                <h:outputLabel id="lblSat" value="#{ss.saturDay/60}">
+                                    <f:convertNumber pattern="0" />
+                                </h:outputLabel>
+                                <p:tooltip for="lblSat">
+                                    <h:outputLabel value="#{ss.saturDay/3600}">
+                                        <f:convertNumber pattern="0.00" />
+                                    </h:outputLabel>
+                                    <h:outputLabel value=" hrs" />
+                                </p:tooltip>
+                            </p:column>
+
+                            <p:column headerText="Total" styleClass="col-num">
+                                <h:outputLabel id="lblTot" value="#{ss.total/60}">
+                                    <f:convertNumber pattern="0" />
+                                </h:outputLabel>
+                                <p:tooltip for="lblTot">
+                                    <h:outputLabel value="#{ss.total/3600}">
+                                        <f:convertNumber pattern="0.00" />
+                                    </h:outputLabel>
+                                    <h:outputLabel value=" hrs" />
+                                </p:tooltip>
+                            </p:column>
+
+                            <p:column headerText="Entitled" styleClass="col-num">
+                                <h:outputLabel id="lblEnt" value="#{ss.staff.workingTimeForOverTimePerWeek*60}">
+                                    <f:convertNumber pattern="0" />
+                                </h:outputLabel>
+                                <p:tooltip for="lblEnt">
+                                    <h:outputLabel value="#{ss.staff.workingTimeForOverTimePerWeek}">
+                                        <f:convertNumber pattern="0.00" />
+                                    </h:outputLabel>
+                                    <h:outputLabel value=" hrs" />
+                                </p:tooltip>
+                            </p:column>
+
+                            <p:column styleClass="col-num">
+                                <f:facet name="header">
+                                    <h:outputLabel id="lblOtTitle" value="OT" />
+                                    <p:tooltip for="lblOtTitle">
+                                        <h:outputLabel value="Weekly Overtime (Minutes)" />
+                                    </p:tooltip>
                                 </f:facet>
+                                <h:outputLabel id="lblOt" value="#{ss.overTime/60}">
+                                    <f:convertNumber pattern="0" />
+                                </h:outputLabel>
+                                <p:tooltip for="lblOt">
+                                    <h:outputLabel value="#{ss.overTime/3600}">
+                                        <f:convertNumber pattern="0.00" />
+                                    </h:outputLabel>
+                                    <h:outputLabel value=" hrs" />
+                                </p:tooltip>
+                            </p:column>
 
-                            </p:dataTable>
-                        </p:panel>
+                            <p:column styleClass="col-num">
+                                <f:facet name="header">
+                                    <h:outputLabel id="lblOtValTitle" value="Value" />
+                                    <p:tooltip for="lblOtValTitle">
+                                        <h:outputLabel value="Weekly Overtime Value" />
+                                    </p:tooltip>
+                                </f:facet>
+                                <h:outputLabel value="#{ss.overTime*ss.basicPerSecond*1.5}">
+                                    <f:convertNumber pattern="0.00" />
+                                </h:outputLabel>
+                            </p:column>
 
+                            <f:facet name="footer">
+                                <div class="report-table-footer">
+                                    <p:outputLabel value="Print by: #{sessionController.loggedUser.webUserPerson.name}" />
+                                    <span>·</span>
+                                    <p:outputLabel value="#{commonFunctionsProxy.currentDateTime}">
+                                        <f:convertDateTime pattern="yyyy MMMM dd hh:mm:ss a" />
+                                    </p:outputLabel>
+                                </div>
+                            </f:facet>
+
+                        </p:dataTable>
 
                     </p:panel>
 

--- a/src/main/webapp/hr/hr_report_month_end_work_time_miniuts_summery.xhtml
+++ b/src/main/webapp/hr/hr_report_month_end_work_time_miniuts_summery.xhtml
@@ -5,7 +5,6 @@
       xmlns:h="http://xmlns.jcp.org/jsf/html"
       xmlns:p="http://primefaces.org/ui"
       xmlns:f="http://xmlns.jcp.org/jsf/core"
-
       xmlns:hr="http://xmlns.jcp.org/jsf/composite/autocomplete">
 
     <h:body>
@@ -14,473 +13,587 @@
 
             <ui:define name="content">
 
-                <h:form >
-                    <p:panel >
-                        <f:facet name="header" >
-                            <h:outputLabel value="Employee Working Time and Over Time Report" />
-                        </f:facet>
-                        <h:panelGrid columns="2" >
-                            <h:outputLabel value="Salary Cycle : "/>
-                            <p:selectOneMenu id="advanced"
-                                             value="#{hrReportController.salaryCycle}"
-                                             var="t"
-                                             filter="true"
-                                             filterMatchMode="startsWith"  >
+                <h:form styleClass="wtm-report-form">
 
-                                <f:selectItem itemLabel="Slect Cycle"/>
-                                <f:selectItems value="#{salaryCycleController.salaryCycles}"
-                                               var="theme"
-                                               itemLabel="#{theme.name}"
-                                               itemValue="#{theme}" ></f:selectItems>
+                    <h:outputStylesheet>
+                        .wtm-report-form {
+                            padding: 2rem 1.75rem;
+                        }
 
-                                <p:column style="width:10%" headerText="Name">
-                                    <h:outputText value="#{t.name}" />
+                        .page-header {
+                            margin-bottom: 1.75rem;
+                        }
+
+                        .page-title {
+                            font-size: 18px;
+                            font-weight: 600;
+                            margin: 0 0 4px 0;
+                        }
+
+                        .page-subtitle {
+                            font-size: 13px;
+                            color: #888;
+                            margin: 0;
+                        }
+
+                        .controls-panel .ui-panel-content {
+                            padding: 1.5rem 1.75rem !important;
+                        }
+
+                        .controls-grid {
+                            display: flex;
+                            flex-direction: column;
+                            gap: 1.25rem;
+                        }
+
+                        .fields-grid {
+                            display: grid;
+                            grid-template-columns: repeat(2, 1fr);
+                            gap: 1rem 1.5rem;
+                        }
+
+                        .field-group {
+                            display: flex;
+                            flex-direction: column;
+                            gap: 6px;
+                        }
+
+                        .field-label {
+                            font-size: 11.5px !important;
+                            font-weight: 600 !important;
+                            text-transform: uppercase;
+                            letter-spacing: 0.05em;
+                            color: #888 !important;
+                        }
+
+                        .controls-actions {
+                            display: flex;
+                            gap: 10px;
+                            align-items: center;
+                            flex-wrap: wrap;
+                        }
+
+                        .controls-actions-secondary {
+                            display: flex;
+                            gap: 10px;
+                            align-items: center;
+                            flex-wrap: wrap;
+                            padding-top: 0.75rem;
+                            border-top: 1px solid #e8e8e8;
+                        }
+
+                        .btn-action {
+                            height: 36px !important;
+                            padding: 0 18px !important;
+                            font-size: 13px !important;
+                        }
+
+                        .report-panel {
+                            margin-top: 1.5rem;
+                        }
+
+                        .report-panel .ui-panel-content {
+                            padding: 0 !important;
+                        }
+
+                        .report-header-wrap {
+                            text-align: center;
+                            padding: 1.5rem 1.5rem 1rem;
+                            border-bottom: 1px solid #e8e8e8;
+                        }
+
+                        .report-title-label {
+                            font-size: 13px;
+                            color: #666;
+                            display: block;
+                            margin-bottom: 2px;
+                        }
+
+                        .report-meta {
+                            font-size: 13px;
+                            color: #555;
+                            margin-top: 4px;
+                        }
+
+                        .wt-table .ui-datatable-tablewrapper {
+                            overflow-x: auto !important;
+                            width: 100% !important;
+                        }
+
+                        .wt-table table {
+                            width: auto !important;
+                            table-layout: auto !important;
+                        }
+
+                        .wt-table .ui-datatable-data td,
+                        .wt-table .ui-datatable-thead th {
+                            padding: 10px 14px !important;
+                            white-space: nowrap;
+                            font-size: 13px !important;
+                            width: auto !important;
+                        }
+
+                        .wt-table .ui-datatable-thead th {
+                            font-size: 12px !important;
+                            font-weight: 600 !important;
+                            text-transform: uppercase;
+                            letter-spacing: 0.03em;
+                            color: #888 !important;
+                            background: #f9f9f9 !important;
+                            border-bottom: 1px solid #e8e8e8 !important;
+                        }
+
+                        .wt-table .ui-datatable-data tr:hover td {
+                            background: #f5f7ff !important;
+                        }
+
+                        .wt-table .col-num {
+                            text-align: right !important;
+                        }
+
+                        .wt-table .col-text {
+                            text-align: left !important;
+                        }
+
+                        .wt-table .col-name .ui-outputlabel {
+                            font-weight: 500;
+                        }
+
+                        .wt-table tfoot td {
+                            background: #f9f9f9 !important;
+                            font-size: 12px !important;
+                            border-top: 2px solid #e0e0e0 !important;
+                            padding: 10px 14px !important;
+                            color: #999;
+                        }
+
+                        .report-table-footer {
+                            display: flex;
+                            justify-content: flex-end;
+                            align-items: center;
+                            gap: 6px;
+                            padding: 0.85rem 1.5rem;
+                            border-top: 1px solid #e8e8e8;
+                            font-size: 12px;
+                            color: #999;
+                        }
+                    </h:outputStylesheet>
+
+                    <div class="page-header">
+                        <p class="page-title"><h:outputText value="Employee Working Time and Overtime Report" /></p>
+                        <p class="page-subtitle"><h:outputText value="Filter by salary cycle, department, employee or roster and process to generate" /></p>
+                    </div>
+
+                    <p:panel styleClass="controls-panel">
+                        <div class="controls-grid">
+
+                            <div class="fields-grid">
+                                <div class="field-group">
+                                    <p:outputLabel for="salaryCycle" value="Salary cycle" styleClass="field-label" />
+                                    <p:selectOneMenu id="salaryCycle"
+                                                     value="#{hrReportController.salaryCycle}"
+                                                     var="t"
+                                                     filter="true"
+                                                     filterMatchMode="startsWith"
+                                                     appendTo="@body"
+                                                     autoWidth="false"
+                                                     style="width: 100%;">
+                                        <f:selectItem itemLabel="Select Cycle" />
+                                        <f:selectItems value="#{salaryCycleController.salaryCycles}"
+                                                       var="theme"
+                                                       itemLabel="#{theme.name}"
+                                                       itemValue="#{theme}" />
+                                        <p:column style="width:10%" headerText="Name">
+                                            <h:outputText value="#{t.name}" />
+                                        </p:column>
+                                        <p:column headerText="Year">
+                                            <h:outputText value="#{t.salaryYear}" />
+                                        </p:column>
+                                        <p:column headerText="Month">
+                                            <h:outputText value="#{t.salaryMonth}" />
+                                        </p:column>
+                                    </p:selectOneMenu>
+                                </div>
+
+                                <div class="field-group">
+                                    <p:outputLabel value="Institution" styleClass="field-label" />
+                                    <hr:institution value="#{hrReportController.reportKeyWord.institution}" />
+                                </div>
+
+                                <div class="field-group">
+                                    <p:outputLabel value="Department" styleClass="field-label" />
+                                    <hr:department value="#{hrReportController.reportKeyWord.department}" />
+                                </div>
+
+                                <div class="field-group">
+                                    <p:outputLabel value="Employee" styleClass="field-label" />
+                                    <hr:completeStaffChannel value="#{hrReportController.reportKeyWord.staff}" />
+                                    <!--<hr:completeStaff value="#{hrReportController.reportKeyWord.staff}"/>-->
+                                </div>
+
+                                <div class="field-group">
+                                    <p:outputLabel value="Staff category" styleClass="field-label" />
+                                    <hr:completeStaffCategory value="#{hrReportController.reportKeyWord.staffCategory}" />
+                                </div>
+
+                                <div class="field-group">
+                                    <p:outputLabel value="Staff designation" styleClass="field-label" />
+                                    <hr:completeDesignation value="#{hrReportController.reportKeyWord.designation}" />
+                                </div>
+
+                                <div class="field-group">
+                                    <p:outputLabel value="Staff roster" styleClass="field-label" />
+                                    <hr:completeRoster value="#{hrReportController.reportKeyWord.roster}" />
+                                </div>
+                            </div>
+
+                            <div class="controls-actions">
+                                <p:commandButton value="Process"
+                                                 ajax="false"
+                                                 action="#{hrReportController.createMonthEndWorkTimeReportForMonth}"
+                                                 icon="pi pi-sync"
+                                                 styleClass="btn-action" />
+                            </div>
+
+                            <div class="controls-actions-secondary">
+                                <p:commandButton value="Print All"
+                                                 type="button"
+                                                 icon="pi pi-print"
+                                                 styleClass="btn-action">
+                                    <p:printer target="gpBillPreviewPrint" />
+                                </p:commandButton>
+                                <p:commandButton value="Print (Summary)"
+                                                 type="button"
+                                                 icon="pi pi-print"
+                                                 styleClass="btn-action">
+                                    <p:printer target="gpBillPreview1" />
+                                </p:commandButton>
+                                <p:commandButton value="Export Excel"
+                                                 ajax="false"
+                                                 icon="pi pi-file-excel"
+                                                 styleClass="btn-action noPrintButton">
+                                    <p:dataExporter type="xlsx" target="tb1" fileName="hr_report_month_end_work_time_miniuts_summery" />
+                                </p:commandButton>
+                            </div>
+
+                        </div>
+                    </p:panel>
+
+                    <p:panel id="gpBillPreviewPrint" styleClass="report-panel noBorder summeryBorder">
+
+                        <p:panel id="gpBillPreview1" styleClass="report-panel">
+                            <f:facet name="header">
+                                <div class="report-header-wrap">
+                                    <span class="report-title-label">Monthly Overtime Summary</span>
+                                    <h:panelGroup rendered="#{hrReportController.reportKeyWord.institution ne null}">
+                                        <p class="report-meta">
+                                            <h:outputText value="#{hrReportController.reportKeyWord.institution.name}" />
+                                        </p>
+                                    </h:panelGroup>
+                                    <h:panelGroup rendered="#{hrReportController.reportKeyWord.department ne null}">
+                                        <p class="report-meta">
+                                            Department: <h:outputText value="#{hrReportController.reportKeyWord.department.name}" />
+                                        </p>
+                                    </h:panelGroup>
+                                    <h:panelGroup rendered="#{hrReportController.reportKeyWord.staff ne null}">
+                                        <p class="report-meta">
+                                            Employee: <h:outputText value="#{hrReportController.reportKeyWord.staff.person.name}" />
+                                        </p>
+                                    </h:panelGroup>
+                                </div>
+                            </f:facet>
+
+                            <p:dataTable value="#{hrReportController.summeryForMonths}" var="ss" styleClass="wt-table">
+                                <p:column headerText="Code" styleClass="col-text">
+                                    <h:outputLabel value="#{ss.staff.codeInterger}" />
                                 </p:column>
 
-                                <p:column headerText="Year">
-                                    <h:outputText value="#{t.salaryYear}" />
+                                <p:column headerText="Staff" styleClass="col-text col-name" style="min-width: 180px;">
+                                    <h:outputLabel value="#{ss.staff.person.nameWithInitials}" />
                                 </p:column>
-                                <p:column headerText="Month">
-                                    <h:outputText value="#{t.salaryMonth}" />
+
+                                <p:column headerText="Week 1" styleClass="col-num">
+                                    <h:outputLabel id="lblw1" value="#{ss.week1/60}">
+                                        <f:convertNumber pattern="0" />
+                                    </h:outputLabel>
+                                    <p:tooltip for="lblw1">
+                                        <h:outputLabel value="#{ss.week1/3600}"><f:convertNumber pattern="0.00" /></h:outputLabel>
+                                        <h:outputLabel value=" hrs" />
+                                    </p:tooltip>
                                 </p:column>
-                            </p:selectOneMenu>
-                            <h:outputLabel value="Institution : "/>
-                            <hr:institution value="#{hrReportController.reportKeyWord.institution}"/>
-                            <h:outputLabel value="Department : "/>
-                            <hr:department value="#{hrReportController.reportKeyWord.department}"/>
-                            <h:outputLabel value="Employee : "/>
-                            <hr:completeStaffChannel value="#{hrReportController.reportKeyWord.staff}"/>
-                            <!--<hr:completeStaff value="#{hrReportController.reportKeyWord.staff}"/>-->
-                            <h:outputLabel value="Staff Category : "/>
-                            <hr:completeStaffCategory value="#{hrReportController.reportKeyWord.staffCategory}"/>
-                            <h:outputLabel value="Staff Designation : "/>
-                            <hr:completeDesignation value="#{hrReportController.reportKeyWord.designation}"/>
-                            <h:outputLabel value="Staff Roster : "/>
-                            <hr:completeRoster value="#{hrReportController.reportKeyWord.roster}"/>
-                        </h:panelGrid>
 
-                        <h:panelGrid columns="4" >
-                            <p:commandButton ajax="false" value="Process" action="#{hrReportController.createMonthEndWorkTimeReportForMonth}"/>
-                            <p:commandButton ajax="false" value="Excel" styleClass="noPrintButton"  >
-                                <p:dataExporter type="xlsx" target="tb1" fileName="hr_report_month_end_work_time_miniuts_summery"  />
-                            </p:commandButton>
-                            <p:commandButton value="Print All" ajax="false" action="#" >
-                                <p:printer target="gpBillPreviewPrint" ></p:printer>
-                            </p:commandButton>
-                            <p:commandButton value="Print(Summary)" ajax="false" action="#" >
-                                <p:printer target="gpBillPreview1" ></p:printer>
-                            </p:commandButton>
+                                <p:column headerText="Week 2" styleClass="col-num">
+                                    <h:outputLabel id="lblw2" value="#{ss.week2/60}">
+                                        <f:convertNumber pattern="0" />
+                                    </h:outputLabel>
+                                    <p:tooltip for="lblw2">
+                                        <h:outputLabel value="#{ss.week2/3600}"><f:convertNumber pattern="0.00" /></h:outputLabel>
+                                        <h:outputLabel value=" hrs" />
+                                    </p:tooltip>
+                                </p:column>
 
-                        </h:panelGrid>
-                        <p:panel id="gpBillPreviewPrint" styleClass=" noBorder summeryBorder"  >
-                            <p:panel id="gpBillPreview1" >
-                                <p:dataTable value="#{hrReportController.summeryForMonths}" var="ss">
-                                    <f:facet name="header" >
+                                <p:column headerText="Week 3" styleClass="col-num">
+                                    <h:outputLabel id="lblw3" value="#{ss.week3/60}">
+                                        <f:convertNumber pattern="0" />
+                                    </h:outputLabel>
+                                    <p:tooltip for="lblw3">
+                                        <h:outputLabel value="#{ss.week3/3600}"><f:convertNumber pattern="0.00" /></h:outputLabel>
+                                        <h:outputLabel value=" hrs" />
+                                    </p:tooltip>
+                                </p:column>
 
-                                        <h:outputLabel value="Summary" />
-                                        <h:panelGroup rendered="#{hrReportController.reportKeyWord.institution ne null}" >
-                                            <h:outputLabel value="#{hrReportController.reportKeyWord.institution.name}" />
-                                            <br/>
-                                        </h:panelGroup>
-                                        <h:panelGroup rendered="#{hrReportController.reportKeyWord.department ne null}" >
-                                            <h:outputLabel value="Department : #{hrReportController.reportKeyWord.department.name}"/>
-                                            <br/>
-                                        </h:panelGroup>
-                                        <h:panelGroup rendered="#{hrReportController.reportKeyWord.staff ne null}" >
-                                            <h:outputLabel value="Staff : #{hrReportController.reportKeyWord.staff.person.name}"/>
-                                            <br/>
-                                        </h:panelGroup>
+                                <p:column headerText="Week 4" styleClass="col-num">
+                                    <h:outputLabel id="lblw4" value="#{ss.week4/60}">
+                                        <f:convertNumber pattern="0" />
+                                    </h:outputLabel>
+                                    <p:tooltip for="lblw4">
+                                        <h:outputLabel value="#{ss.week4/3600}"><f:convertNumber pattern="0.00" /></h:outputLabel>
+                                        <h:outputLabel value=" hrs" />
+                                    </p:tooltip>
+                                </p:column>
+
+                                <p:column headerText="Week 5" styleClass="col-num">
+                                    <h:outputLabel id="lblw5" value="#{ss.week5/60}">
+                                        <f:convertNumber pattern="0" />
+                                    </h:outputLabel>
+                                    <p:tooltip for="lblw5">
+                                        <h:outputLabel value="#{ss.week5/3600}"><f:convertNumber pattern="0.00" /></h:outputLabel>
+                                        <h:outputLabel value=" hrs" />
+                                    </p:tooltip>
+                                </p:column>
+
+                                <p:column headerText="Total" styleClass="col-num">
+                                    <h:outputLabel id="lblwt" value="#{ss.total/60}">
+                                        <f:convertNumber pattern="0" />
+                                    </h:outputLabel>
+                                    <p:tooltip for="lblwt">
+                                        <h:outputLabel value="#{ss.total/3600}"><f:convertNumber pattern="0.00" /></h:outputLabel>
+                                        <h:outputLabel value=" hrs" />
+                                    </p:tooltip>
+                                </p:column>
+
+                                <p:column headerText="Entitled" styleClass="col-num">
+                                    <h:outputLabel id="lbloEnt" value="#{ss.staff.workingTimeForOverTimePerWeek*60}">
+                                        <f:convertNumber pattern="0" />
+                                    </h:outputLabel>
+                                    <p:tooltip for="lbloEnt">
+                                        <h:panelGrid columns="2">
+                                            <h:outputLabel value="#{ss.staff.workingTimeForOverTimePerWeek*60*4}"><f:convertNumber pattern="0.00" /></h:outputLabel>
+                                            <h:outputLabel value="Mins (4 Weeks)" />
+                                            <h:outputLabel value="#{ss.staff.workingTimeForOverTimePerWeek*60*5}"><f:convertNumber pattern="0.00" /></h:outputLabel>
+                                            <h:outputLabel value="Mins (5 Weeks)" />
+                                        </h:panelGrid>
+                                    </p:tooltip>
+                                </p:column>
+
+                                <p:column headerText="Over Time" styleClass="col-num">
+                                    <h:outputLabel id="lblwot" value="#{ss.overTime/60}">
+                                        <f:convertNumber pattern="0" />
+                                    </h:outputLabel>
+                                    <p:tooltip for="lblwot">
+                                        <h:outputLabel value="#{ss.overTime/3600}"><f:convertNumber pattern="0.00" /></h:outputLabel>
+                                        <h:outputLabel value=" hrs" />
+                                    </p:tooltip>
+                                </p:column>
+
+                                <p:column headerText="OT Value" styleClass="col-num">
+                                    <h:outputLabel value="#{ss.overTime*ss.basicPerSecond*1.5}">
+                                        <f:convertNumber pattern="0" />
+                                    </h:outputLabel>
+                                </p:column>
+                            </p:dataTable>
+                        </p:panel>
+
+                        <p:panel id="gpBillPreview" styleClass="report-panel">
+                            <f:facet name="header">
+                                <div class="report-header-wrap">
+                                    <span class="report-title-label">Employee Working Time and Overtime Report</span>
+                                    <h:panelGroup rendered="#{hrReportController.reportKeyWord.roster ne null}">
+                                        <p class="report-meta">
+                                            Roster: <h:outputText value="#{hrReportController.reportKeyWord.roster.name}" />
+                                        </p>
+                                    </h:panelGroup>
+                                    <h:panelGroup rendered="#{hrReportController.reportKeyWord.institution ne null}">
+                                        <p class="report-meta">
+                                            <h:outputText value="#{hrReportController.reportKeyWord.institution.name}" />
+                                        </p>
+                                    </h:panelGroup>
+                                    <h:panelGroup rendered="#{hrReportController.reportKeyWord.department ne null}">
+                                        <p class="report-meta">
+                                            Department: <h:outputText value="#{hrReportController.reportKeyWord.department.name}" />
+                                        </p>
+                                    </h:panelGroup>
+                                    <h:panelGroup rendered="#{hrReportController.reportKeyWord.staff ne null}">
+                                        <p class="report-meta">
+                                            Employee: <h:outputText value="#{hrReportController.reportKeyWord.staff.person.name}" />
+                                        </p>
+                                    </h:panelGroup>
+                                    <h:panelGroup rendered="#{hrReportController.reportKeyWord.staffCategory ne null}">
+                                        <p class="report-meta">
+                                            Staff category: <h:outputText value="#{hrReportController.reportKeyWord.staffCategory.name}" />
+                                        </p>
+                                    </h:panelGroup>
+                                    <h:panelGroup rendered="#{hrReportController.reportKeyWord.designation ne null}">
+                                        <p class="report-meta">
+                                            Designation: <h:outputText value="#{hrReportController.reportKeyWord.designation.name}" />
+                                        </p>
+                                    </h:panelGroup>
+                                    <h:panelGroup rendered="#{hrReportController.fromDate ne null}">
+                                        <p class="report-meta">
+                                            <h:outputText value="#{hrReportController.fromDate}">
+                                                <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateFormat}" />
+                                            </h:outputText>
+                                            —
+                                            <h:outputText value="#{hrReportController.toDate}">
+                                                <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateFormat}" />
+                                            </h:outputText>
+                                        </p>
+                                    </h:panelGroup>
+                                </div>
+                            </f:facet>
+
+                            <p:dataTable id="tb1" value="#{hrReportController.overTimeAllMonths}" var="o" styleClass="wt-table">
+                                <p:columnGroup type="header">
+                                    <p:row>
+                                        <p:column headerText="Code" />
+                                        <p:column headerText="Staff" />
+                                        <p:column headerText="Sun" />
+                                        <p:column headerText="Mon" />
+                                        <p:column headerText="Tue" />
+                                        <p:column headerText="Wed" />
+                                        <p:column headerText="Thu" />
+                                        <p:column headerText="Fri" />
+                                        <p:column headerText="Sat" />
+                                        <p:column headerText="Total" />
+                                        <p:column headerText="Entitled" />
+                                        <p:column headerText="OT" />
+                                        <p:column headerText="Value" />
+                                    </p:row>
+                                </p:columnGroup>
+
+                                <p:subTable value="#{o.dayWorks}" var="ss">
+                                    <f:facet name="header">
+                                        <h:outputLabel value="#{o.dateRange}" />
                                     </f:facet>
 
-                                    <p:column  styleClass="shortNumericColumn">
-                                        <f:facet name="header" >
-                                            <h:outputLabel value="Code" />
-                                        </f:facet>
+                                    <p:column styleClass="col-text">
                                         <h:outputLabel value="#{ss.staff.codeInterger}" />
                                     </p:column>
 
-                                    <p:column>
-                                        <f:facet name="header" >
-                                            <h:outputLabel value="Staff" />
-                                        </f:facet>
-                                        <h:outputLabel value="#{ss.staff.person.nameWithInitials}" />
+                                    <p:column styleClass="col-text col-name" style="min-width: 180px;">
+                                        <p:outputLabel value="#{ss.staff.person.name}" />
                                     </p:column>
-                                    <p:column styleClass="shortNumericColumn" >
-                                        <f:facet name="header" >
-                                            <h:outputLabel value="Week 1" />
-                                        </f:facet>
-                                        <h:outputLabel id="lblw1" value="#{ss.week1/60}">
-                                            <f:convertNumber pattern="0"/>
-                                        </h:outputLabel>
-                                        <p:tooltip for="lblw1" >
-                                            <h:outputLabel  value="#{ss.week1/3600}">
-                                                <f:convertNumber pattern="0.00"/>
-                                            </h:outputLabel>
-                                            <h:outputLabel value="hrs" ></h:outputLabel>
+
+                                    <p:column styleClass="col-num">
+                                        <h:outputLabel id="lblSun" value="#{ss.sunDay/60}"><f:convertNumber pattern="0" /></h:outputLabel>
+                                        <p:tooltip for="lblSun">
+                                            <h:outputLabel value="#{ss.sunDay/3600}"><f:convertNumber pattern="0.00" /></h:outputLabel>
+                                            <h:outputLabel value=" hrs" />
                                         </p:tooltip>
                                     </p:column>
-                                    <p:column styleClass="shortNumericColumn" >
-                                        <f:facet name="header" >
-                                            <h:outputLabel value="Week 2" />
-                                        </f:facet>
-                                        <h:outputLabel id="lblw2" value="#{ss.week2/60}">
-                                            <f:convertNumber pattern="0"/>
-                                        </h:outputLabel>
-                                        <p:tooltip for="lblw2" >
-                                            <h:outputLabel  value="#{ss.week2/3600}">
-                                                <f:convertNumber pattern="0.00"/>
-                                            </h:outputLabel>
-                                            <h:outputLabel value="hrs" ></h:outputLabel>
+
+                                    <p:column styleClass="col-num">
+                                        <h:outputLabel id="lblMon" value="#{ss.monDay/60}"><f:convertNumber pattern="0" /></h:outputLabel>
+                                        <p:tooltip for="lblMon">
+                                            <h:outputLabel value="#{ss.monDay/3600}"><f:convertNumber pattern="0.00" /></h:outputLabel>
+                                            <h:outputLabel value=" hrs" />
                                         </p:tooltip>
                                     </p:column>
-                                    <p:column styleClass="shortNumericColumn" >
-                                        <f:facet name="header" >
-                                            <h:outputLabel value="Week 3" />
-                                        </f:facet>
-                                        <h:outputLabel id="lblw3" value="#{ss.week3/60}">
-                                            <f:convertNumber pattern="0"/>
-                                        </h:outputLabel>
-                                        <p:tooltip for="lblw3" >
-                                            <h:outputLabel  value="#{ss.week3/3600}">
-                                                <f:convertNumber pattern="0.00"/>
-                                            </h:outputLabel>
-                                            <h:outputLabel value="hrs" ></h:outputLabel>
+
+                                    <p:column styleClass="col-num">
+                                        <h:outputLabel id="lblTue" value="#{ss.tuesDay/60}"><f:convertNumber pattern="0" /></h:outputLabel>
+                                        <p:tooltip for="lblTue">
+                                            <h:outputLabel value="#{ss.tuesDay/3600}"><f:convertNumber pattern="0.00" /></h:outputLabel>
+                                            <h:outputLabel value=" hrs" />
                                         </p:tooltip>
                                     </p:column>
-                                    <p:column styleClass="shortNumericColumn" >
-                                        <f:facet name="header" >
-                                            <h:outputLabel value="Week 4" />
-                                        </f:facet>
-                                        <h:outputLabel id="lblw4" value="#{ss.week4/60}">
-                                            <f:convertNumber pattern="0"/>
-                                        </h:outputLabel>
-                                        <p:tooltip for="lblw4" >
-                                            <h:outputLabel  value="#{ss.week4/3600}">
-                                                <f:convertNumber pattern="0.00"/>
-                                            </h:outputLabel>
-                                            <h:outputLabel value="hrs" ></h:outputLabel>
+
+                                    <p:column styleClass="col-num">
+                                        <h:outputLabel id="lblWed" value="#{ss.wednesDay/60}"><f:convertNumber pattern="0" /></h:outputLabel>
+                                        <p:tooltip for="lblWed">
+                                            <h:outputLabel value="#{ss.wednesDay/3600}"><f:convertNumber pattern="0.00" /></h:outputLabel>
+                                            <h:outputLabel value=" hrs" />
                                         </p:tooltip>
                                     </p:column>
-                                    <p:column styleClass="shortNumericColumn" >
-                                        <f:facet name="header" >
-                                            <h:outputLabel value="Week 5" />
-                                        </f:facet>
-                                        <h:outputLabel id="lblw5" value="#{ss.week5/60}">
-                                            <f:convertNumber pattern="0"/>
-                                        </h:outputLabel>
-                                        <p:tooltip for="lblw5" >
-                                            <h:outputLabel  value="#{ss.week5/3600}">
-                                                <f:convertNumber pattern="0.00"/>
-                                            </h:outputLabel>
-                                            <h:outputLabel value="hrs" ></h:outputLabel>
+
+                                    <p:column styleClass="col-num">
+                                        <h:outputLabel id="lblThu" value="#{ss.thursDay/60}"><f:convertNumber pattern="0" /></h:outputLabel>
+                                        <p:tooltip for="lblThu">
+                                            <h:outputLabel value="#{ss.thursDay/3600}"><f:convertNumber pattern="0.00" /></h:outputLabel>
+                                            <h:outputLabel value=" hrs" />
                                         </p:tooltip>
                                     </p:column>
-                                    <p:column styleClass="shortNumericColumn" >
-                                        <f:facet name="header" >
-                                            <h:outputLabel value="Total" />
-                                        </f:facet>
-                                        <h:outputLabel id="lblwt" value="#{ss.total/60}">
-                                            <f:convertNumber pattern="0"/>
-                                        </h:outputLabel>
-                                        <p:tooltip for="lblwt" >
-                                            <h:outputLabel  value="#{ss.total/3600}">
-                                                <f:convertNumber pattern="0.00"/>
-                                            </h:outputLabel>
-                                            <h:outputLabel value="hrs" ></h:outputLabel>
+
+                                    <p:column styleClass="col-num">
+                                        <h:outputLabel id="lblFri" value="#{ss.friDay/60}"><f:convertNumber pattern="0" /></h:outputLabel>
+                                        <p:tooltip for="lblFri">
+                                            <h:outputLabel value="#{ss.friDay/3600}"><f:convertNumber pattern="0.00" /></h:outputLabel>
+                                            <h:outputLabel value=" hrs" />
                                         </p:tooltip>
                                     </p:column>
-                                    <p:column styleClass="shortNumericColumn" >
-                                        <f:facet name="header" >
-                                            <h:outputLabel value="Entitled" />
-                                        </f:facet>
-                                        <h:outputLabel id="lbloEnt" value="#{ss.staff.workingTimeForOverTimePerWeek*60}">
-                                            <f:convertNumber pattern="0"/>
-                                        </h:outputLabel>
-                                        <p:tooltip for="lbloEnt" >
-                                            <h:panelGrid columns="2">
-                                                <h:outputLabel  value="#{ss.staff.workingTimeForOverTimePerWeek*60*4}">
-                                                    <f:convertNumber pattern="0.00"/>
-                                                </h:outputLabel>
-                                                <h:outputLabel value="Mins(4 Weeks)" ></h:outputLabel>
-                                                <h:outputLabel  value="#{ss.staff.workingTimeForOverTimePerWeek*60*5}">
-                                                    <f:convertNumber pattern="0.00"/>
-                                                </h:outputLabel>
-                                                <h:outputLabel value="Mins(5 Weeks)" ></h:outputLabel>
-                                            </h:panelGrid>
+
+                                    <p:column styleClass="col-num">
+                                        <h:outputLabel id="lblSat" value="#{ss.saturDay/60}"><f:convertNumber pattern="0" /></h:outputLabel>
+                                        <p:tooltip for="lblSat">
+                                            <h:outputLabel value="#{ss.saturDay/3600}"><f:convertNumber pattern="0.00" /></h:outputLabel>
+                                            <h:outputLabel value=" hrs" />
                                         </p:tooltip>
                                     </p:column>
-                                    <p:column styleClass="shortNumericColumn" >
-                                        <f:facet name="header" >
-                                            <h:outputLabel value="Over Time" />
+
+                                    <p:column styleClass="col-num">
+                                        <f:facet name="header">
+                                            <h:outputLabel id="lblTotTitle" value="Total" />
+                                            <p:tooltip for="lblTotTitle"><h:outputLabel value="Total Work Time" /></p:tooltip>
                                         </f:facet>
-                                        <h:outputLabel id="lblwot" value="#{ss.overTime/60}">
-                                            <f:convertNumber pattern="0"/>
-                                        </h:outputLabel>
-                                        <p:tooltip for="lblwot" >
-                                            <h:outputLabel  value="#{ss.overTime/3600}">
-                                                <f:convertNumber pattern="0.00"/>
-                                            </h:outputLabel>
-                                            <h:outputLabel value="hrs" ></h:outputLabel>
+                                        <h:outputLabel id="lblTot" value="#{ss.total/60}"><f:convertNumber pattern="0" /></h:outputLabel>
+                                        <p:tooltip for="lblTot">
+                                            <h:outputLabel value="#{ss.total/3600}"><f:convertNumber pattern="0.00" /></h:outputLabel>
+                                            <h:outputLabel value=" hrs" />
                                         </p:tooltip>
                                     </p:column>
-                                    <p:column styleClass="shortNumericColumn" >
-                                        <f:facet name="header" >
-                                            <h:outputLabel value="OT Value" />
+
+                                    <p:column styleClass="col-num">
+                                        <h:outputLabel id="lblEnt" value="#{ss.staff.workingTimeForOverTimePerWeek*60}"><f:convertNumber pattern="0" /></h:outputLabel>
+                                        <p:tooltip for="lblEnt">
+                                            <h:outputLabel value="#{ss.staff.workingTimeForOverTimePerWeek}"><f:convertNumber pattern="0.00" /></h:outputLabel>
+                                            <h:outputLabel value=" hrs" />
+                                        </p:tooltip>
+                                    </p:column>
+
+                                    <p:column styleClass="col-num">
+                                        <f:facet name="header">
+                                            <h:outputLabel id="lblOtTitle" value="OT" />
+                                            <p:tooltip for="lblOtTitle"><h:outputLabel value="Weekly Overtime (Minutes)" /></p:tooltip>
+                                        </f:facet>
+                                        <h:outputLabel id="lblOt" value="#{ss.overTime/60}"><f:convertNumber pattern="0" /></h:outputLabel>
+                                        <p:tooltip for="lblOt">
+                                            <h:outputLabel value="#{ss.overTime/3600}"><f:convertNumber pattern="0.00" /></h:outputLabel>
+                                            <h:outputLabel value=" hrs" />
+                                        </p:tooltip>
+                                    </p:column>
+
+                                    <p:column styleClass="col-num">
+                                        <f:facet name="header">
+                                            <h:outputLabel id="lblOtValTitle" value="Value" />
+                                            <p:tooltip for="lblOtValTitle"><h:outputLabel value="Weekly Overtime Value" /></p:tooltip>
                                         </f:facet>
                                         <h:outputLabel value="#{ss.overTime*ss.basicPerSecond*1.5}">
-                                            <f:convertNumber pattern="0"/>
+                                            <f:convertNumber pattern="0" />
                                         </h:outputLabel>
                                     </p:column>
-                                </p:dataTable>
-                            </p:panel>
-                            <p:panel id="gpBillPreview" >
-                                <p:dataTable value="#{hrReportController.overTimeAllMonths}" var="o">
-                                    <f:facet name="header" >
+                                </p:subTable>
 
-                                        <h:panelGroup rendered="#{hrReportController.reportKeyWord.roster ne null}">
-                                            <h:outputLabel value="#{hrReportController.reportKeyWord.roster.name} Roster" rendered="#{hrReportController.reportKeyWord.roster ne null}"/>
-                                            <br />
-                                        </h:panelGroup>
-
-                                        <h:panelGroup rendered="#{hrReportController.reportKeyWord.staff ne null}">
-                                            <h:outputLabel value="Employee #{hrReportController.reportKeyWord.staff.person.name}" rendered="#{hrReportController.reportKeyWord.staff ne null}"/>
-                                            <br />
-                                        </h:panelGroup>
-
-                                        <h:panelGroup rendered="#{hrReportController.reportKeyWord.institution ne null}">
-                                            <h:outputLabel value="#{hrReportController.reportKeyWord.institution.name}" rendered="#{hrReportController.reportKeyWord.institution ne null}"/>
-                                            <br />
-                                        </h:panelGroup>
-
-                                        <h:panelGroup rendered="#{hrReportController.reportKeyWord.department ne null}">
-                                            <h:outputLabel value="#{hrReportController.reportKeyWord.department.name} Department" rendered="#{hrReportController.reportKeyWord.department ne null}"/>
-                                            <br />
-                                        </h:panelGroup>
-
-                                        <h:panelGroup rendered="#{hrReportController.reportKeyWord.staffCategory ne null}">
-                                            <h:outputLabel value="Staff Category #{hrReportController.reportKeyWord.staffCategory.name}" rendered="#{hrReportController.reportKeyWord.staffCategory ne null}"/>
-                                            <br />
-                                        </h:panelGroup>
-
-                                        <h:panelGroup rendered="#{hrReportController.reportKeyWord.designation ne null}">
-                                            <h:outputLabel value="Staff Designation #{hrReportController.reportKeyWord.designation.name}" rendered="#{hrReportController.reportKeyWord.designation ne null}"/>
-                                            <br />
-                                        </h:panelGroup>
-
-                                        <h:outputLabel value="Employee Working Time and Over Time Report " />
-                                        <h:outputLabel value="From : "/>
-                                        <h:outputLabel value="#{hrReportController.fromDate}">
-                                            <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateFormat}" ></f:convertDateTime>
-                                        </h:outputLabel>
-                                        <h:outputLabel value=" To : "/>
-                                        <h:outputLabel value="#{hrReportController.toDate}">
-                                            <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateFormat}" ></f:convertDateTime>
-                                        </h:outputLabel>
-                                    </f:facet>
-                                    <p:columnGroup type="header" >
-                                        <p:row>
-                                            <p:column headerText="Code"/>
-                                            <p:column headerText="Staff"/>
-                                            <p:column headerText="Sun"/>
-                                            <p:column headerText="Mon"/>
-                                            <p:column headerText="Tue"/>
-                                            <p:column headerText="Wed"/>
-                                            <p:column headerText="Thur"/>
-                                            <p:column headerText="Fri"/>
-                                            <p:column headerText="Sat"/>
-                                            <p:column headerText="Total"/>
-                                            <p:column headerText="Entitled"/>
-                                            <p:column headerText="OT"/>
-                                            <p:column headerText="Value"/>
-                                        </p:row>
-                                    </p:columnGroup>
-                                    <p:subTable value="#{o.dayWorks}" var="ss">
-                                        <f:facet name="header" >
-                                            <h:outputLabel value="#{o.dateRange}" />
-                                        </f:facet>
-                                        <p:column  styleClass="shortNumericColumn">
-                                            <f:facet name="header" >
-                                                <h:outputLabel value="Code" />
-                                            </f:facet>
-                                            <h:outputLabel value="#{ss.staff.codeInterger}" />
-                                        </p:column>
-                                        <p:column headerText="Staff">
-                                            <f:facet name="header" >
-                                                <h:outputLabel value="Staff" />
-                                            </f:facet>
-                                            <p:outputLabel value="#{ss.staff.person.name}" />
-                                        </p:column>
-                                        <p:column styleClass="shortNumericColumn" >
-                                            <f:facet name="header" >
-                                                <h:outputLabel value="Sun" />
-                                            </f:facet>
-                                            <h:outputLabel id="lblSun" value="#{ss.sunDay/60}">
-                                                <f:convertNumber pattern="0"/>
-                                            </h:outputLabel>
-                                            <p:tooltip for="lblSun" >
-                                                <h:outputLabel  value="#{ss.sunDay/3600}">
-                                                    <f:convertNumber pattern="0.00"/>
-                                                </h:outputLabel>
-                                                <h:outputLabel value="hrs" ></h:outputLabel>
-                                            </p:tooltip>
-                                        </p:column>
-                                        <p:column styleClass="shortNumericColumn" >
-                                            <f:facet name="header" >
-                                                <h:outputLabel value="Mon" />
-                                            </f:facet>
-                                            <h:outputLabel id="lblMon" value="#{ss.monDay/60}">
-                                                <f:convertNumber pattern="0"/>
-                                            </h:outputLabel>
-                                            <p:tooltip for="lblMon" >
-                                                <h:outputLabel  value="#{ss.monDay/3600}">
-                                                    <f:convertNumber pattern="0.00"/>
-                                                </h:outputLabel>
-                                                <h:outputLabel value="hrs" ></h:outputLabel>
-                                            </p:tooltip>
-                                        </p:column>
-                                        <p:column styleClass="shortNumericColumn" >
-                                            <f:facet name="header" >
-                                                <h:outputLabel value="Tue" />
-                                            </f:facet>
-                                            <h:outputLabel id="lblTue" value="#{ss.tuesDay/60}">
-                                                <f:convertNumber pattern="0"/>
-                                            </h:outputLabel>
-                                            <p:tooltip for="lblTue" >
-                                                <h:outputLabel  value="#{ss.tuesDay/3600}">
-                                                    <f:convertNumber pattern="0.00"/>
-                                                </h:outputLabel>
-                                                <h:outputLabel value="hrs" ></h:outputLabel>
-                                            </p:tooltip>
-                                        </p:column>
-                                        <p:column styleClass="shortNumericColumn">
-                                            <f:facet name="header" >
-                                                <h:outputLabel value="Wed" />
-                                            </f:facet>
-                                            <h:outputLabel id="lblWed" value="#{ss.wednesDay/60}">
-                                                <f:convertNumber pattern="0"/>
-                                            </h:outputLabel>
-                                            <p:tooltip for="lblWed" >
-                                                <h:outputLabel  value="#{ss.wednesDay/3600}">
-                                                    <f:convertNumber pattern="0.00"/>
-                                                </h:outputLabel>
-                                                <h:outputLabel value="hrs" ></h:outputLabel>
-                                            </p:tooltip>
-                                        </p:column>
-                                        <p:column styleClass="shortNumericColumn">
-                                            <f:facet name="header" >
-                                                <h:outputLabel value="Thur" />
-                                            </f:facet>
-                                            <h:outputLabel id="lblThu"  value="#{ss.thursDay/60}">
-                                                <f:convertNumber pattern="0"/>
-                                            </h:outputLabel>
-                                            <p:tooltip for="lblThu" >
-                                                <h:outputLabel  value="#{ss.thursDay/3600}">
-                                                    <f:convertNumber pattern="0.00"/>
-                                                </h:outputLabel>
-                                                <h:outputLabel value="hrs" ></h:outputLabel>
-                                            </p:tooltip>
-                                        </p:column>
-                                        <p:column styleClass="shortNumericColumn" >
-                                            <f:facet name="header" >
-                                                <h:outputLabel value="Fri" />
-                                            </f:facet>
-                                            <h:outputLabel id="lblFri" value="#{ss.friDay/60}">
-                                                <f:convertNumber pattern="0"/>
-                                            </h:outputLabel>
-                                            <p:tooltip for="lblFri" >
-                                                <h:outputLabel  value="#{ss.friDay/3600}">
-                                                    <f:convertNumber pattern="0.00"/>
-                                                </h:outputLabel>
-                                                <h:outputLabel value="hrs" ></h:outputLabel>
-                                            </p:tooltip>
-                                        </p:column>
-                                        <p:column styleClass="shortNumericColumn">
-                                            <f:facet name="header" >
-                                                <h:outputLabel value="Sat" />
-                                            </f:facet>
-                                            <h:outputLabel id="lblSat"  value="#{ss.saturDay/60}">
-                                                <f:convertNumber pattern="0"/>
-                                            </h:outputLabel>
-                                            <p:tooltip for="lblSat" >
-                                                <h:outputLabel  value="#{ss.saturDay/3600}">
-                                                    <f:convertNumber pattern="0.00"/>
-                                                </h:outputLabel>
-                                                <h:outputLabel value="hrs" ></h:outputLabel>
-                                            </p:tooltip>
-                                        </p:column>
-                                        <p:column styleClass="shortNumericColumn">
-                                            <f:facet name="header" >
-                                                <h:outputLabel id="lblTotTitle" value="Total" />
-                                                <p:tooltip for="lblTotTitle" >
-                                                    <h:outputLabel value="Total Work Time" />
-                                                </p:tooltip>
-                                            </f:facet>
-                                            <h:outputLabel id="lblTot" value="#{ss.total/60}">
-                                                <f:convertNumber pattern="0"/>
-                                            </h:outputLabel>
-                                            <p:tooltip for="lblTot" >
-                                                <h:outputLabel  value="#{ss.total/3600}">
-                                                    <f:convertNumber pattern="0.00"/>
-                                                </h:outputLabel>
-                                                <h:outputLabel value="hrs" ></h:outputLabel>
-                                            </p:tooltip>
-                                        </p:column>
-                                        <p:column styleClass="shortNumericColumn" >
-                                            <f:facet name="header" >
-                                                <h:outputLabel value="Entitled" />
-                                            </f:facet>
-                                            <h:outputLabel id="lblEnt" value="#{ss.staff.workingTimeForOverTimePerWeek*60}">
-                                                <f:convertNumber pattern="0"/>
-                                            </h:outputLabel>
-                                            <p:tooltip for="lblEnt" >
-                                                <h:outputLabel  value="#{ss.staff.workingTimeForOverTimePerWeek}">
-                                                    <f:convertNumber pattern="0.00"/>
-                                                </h:outputLabel>
-                                                <h:outputLabel value="hrs" ></h:outputLabel>
-                                            </p:tooltip>
-                                        </p:column>
-
-                                        <p:column styleClass="shortNumericColumn">
-                                            <f:facet name="header" >
-                                                <h:outputLabel id="lblOtTitle" value="OT" />
-                                                <p:tooltip for="lblOtTitle" >
-                                                    <h:outputLabel value="Weekely Overtime (Minutes)" />
-                                                </p:tooltip>
-                                            </f:facet>
-                                            <h:outputLabel id="lblOt" value="#{ss.overTime/60}">
-                                                <f:convertNumber pattern="0"/>
-                                            </h:outputLabel>
-                                            <p:tooltip for="lblOt" >
-                                                <h:outputLabel  value="#{ss.overTime/3600}">
-                                                    <f:convertNumber pattern="0.00"/>
-                                                </h:outputLabel>
-                                                <h:outputLabel value="hrs" ></h:outputLabel>
-                                            </p:tooltip>
-                                        </p:column>
-
-                                        <p:column styleClass="shortNumericColumn">
-                                            <f:facet name="header" >
-                                                <h:outputLabel id="lblOtValTitle" value="Value" />
-                                                <p:tooltip for="lblOtValTitle" >
-                                                    <h:outputLabel value="Weekely Orvertime Value" />
-                                                </p:tooltip>
-                                            </f:facet>
-                                            <h:outputLabel value="#{ss.overTime*ss.basicPerSecond*1.5}">
-                                                <f:convertNumber pattern="0" />
-                                            </h:outputLabel>
-                                        </p:column>
-                                    </p:subTable>
-                                    <f:facet name="footer">
-                                        <p:outputLabel value="Print By : #{sessionController.loggedUser.webUserPerson.name} - " />
-                                        <p:outputLabel value="Print At : " />
-                                        <p:outputLabel value="#{commonFunctionsProxy.currentDateTime}" >
-                                            <f:convertDateTime pattern="yyyy MMMM dd hh:mm:ss a " />
+                                <f:facet name="footer">
+                                    <div class="report-table-footer">
+                                        <p:outputLabel value="Print by: #{sessionController.loggedUser.webUserPerson.name}" />
+                                        <span>·</span>
+                                        <p:outputLabel value="#{commonFunctionsProxy.currentDateTime}">
+                                            <f:convertDateTime pattern="yyyy MMMM dd hh:mm:ss a" />
                                         </p:outputLabel>
-                                    </f:facet>
-                                </p:dataTable>
-                            </p:panel>
+                                    </div>
+                                </f:facet>
+                            </p:dataTable>
                         </p:panel>
-
 
                     </p:panel>
 


### PR DESCRIPTION
**# refactor: align Working Time report UI with EPF report design system

## Summary

Applies the same layout patterns already established in `hrEpfReport.xhtml` to `hrWorkTimeReport.xhtml`. No backend bindings, action methods, or component logic were changed.

---

## Changes

### Layout & structure
- Replaced outer `h:panelGrid columns="2"` filter area with CSS grid (`fields-grid` / `field-group`) matching the EPF report
- Replaced `h:panelGrid columns="4"` button row with `controls-actions` + `controls-actions-secondary` flex rows
- Moved **Process** to the primary action row; **Print**, **Export Excel**, and **New Method** to the secondary row
- Wrapped everything in a `controls-panel` / `controls-grid` container, consistent with EPF report

### Report header
- Removed `<f:facet name="header">` label-dump from inside `p:dataTable`
- Added a `report-header-wrap` div inside the panel's `header` facet, matching EPF report structure
- Filter context labels (date range, institution, department, employee, category, designation, roster) now render conditionally in the same style as EPF

### Table
- Added `wt-table` styleClass (mirrors `epf-table`) with consistent header, cell padding, hover, and footer styles
- Replaced `shortNumericColumn` with `col-num` / `col-text` classes
- Columns with `headerText` set via the attribute (no inner `<f:facet name="header">`) where no tooltip on the header is needed; kept `<f:facet name="header">` only for **OT** and **Value** columns that require `p:tooltip`
- Table footer changed from inline label concatenation to `report-table-footer` flex row with separator dot, matching EPF report

### Cosmetic / typo fixes
- "Weekely" → "Weekly" (two occurrences in tooltip labels)
- "Orvertime" → "Overtime" (tooltip label)
- `p:commandButton value="Print"` — removed `action="#"` (was a no-op placeholder); `type="button"` retained
- Added `for` attributes to `p:outputLabel` elements where a matching input `id` was added (`fromDate`, `toDate`)

---

## What was intentionally left unchanged
- All `#{...}` EL expressions — bean names, properties, action methods
- `p:dataExporter` `target` and `fileName` attributes
- `p:printer` `target` attribute
- `p:commandLink` drill-down inside the table (`fromWeekelyOverTimeReportToStaffFingerPrintAnalysis`)
- All `p:tooltip` `for` / value bindings
- `editable="true"` on `p:dataTable`
- `ui:composition` / `h:body` wrapper structure
- `noBorder summeryBorder` styleClasses on `p:panel#gpBillPreview`
- `noPrintButton` styleClass on export/secondary actions
**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Excel export and enhanced print options (summary and full); added “New Method” action for alternate report generation.

* **Style**
  * Redesigned responsive report layout, refined filter form and controls, and improved table presentation (day-by-day, minute→hour display, totals, OT minutes and OT value).
  * Enhanced header showing date range and selected filters; cleaner footer with “Print by” and timestamp.

* **Bug Fixes**
  * More robust report generation to avoid errors when data is missing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hmislk/hmis/pull/20931?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->