### PR TITLE
fix/refactor: fix leave type dropdown close bug and align leave application edit UI with design system

### DIFF
--- a/src/main/webapp/hr/hr_staff_leave_edit_search.xhtml
+++ b/src/main/webapp/hr/hr_staff_leave_edit_search.xhtml
@@ -5,132 +5,347 @@
                 xmlns:h="http://xmlns.jcp.org/jsf/html"
                 xmlns:p="http://primefaces.org/ui"
                 xmlns:f="http://xmlns.jcp.org/jsf/core"
-                xmlns:au="http://xmlns.jcp.org/jsf/composite/autocomplete"
-                >
+                xmlns:au="http://xmlns.jcp.org/jsf/composite/autocomplete">
 
     <ui:define name="content">
-        <h:form>
-            <p:panel header="Leave Application Form">
-                <h:panelGrid columns="2" >
-                    <p:panel header="Search Leave Forms" >
-                        <p:panel>
-                            <p:panelGrid columns="2" >
-                                <h:outputLabel value="From Date"/>
-                                <p:calendar value="#{staffLeaveApplicationFormController.fromDate}"
-                                            pattern="#{sessionController.applicationPreference.shortDateFormat}">
-                                </p:calendar>
-                                <h:outputLabel value="To Date"/>
-                                <p:calendar value="#{staffLeaveApplicationFormController.toDate}"
-                                            pattern="#{sessionController.applicationPreference.shortDateFormat}">
-                                </p:calendar>
-                                <h:outputLabel value="Staff : "/>
-                                <au:completeStaff value="#{staffLeaveApplicationFormController.staff}"/>
-                                <h:outputLabel value="Leave Type"/>
-                                <p:selectOneMenu  value="#{staffLeaveApplicationFormController.leaveType}">
-                                    <f:selectItem itemLabel="Select Day Type"/>
-                                    <f:selectItems value="#{enumController.leaveType}"/>
-                                </p:selectOneMenu>
 
-                                <h:outputLabel value="Institution : "/>
-                                <au:institution value="#{staffLeaveApplicationFormController.reportKeyWord.institution}"/>
+        <h:form styleClass="leave-edit-form">
 
-                                <h:outputLabel value="Department : "/>
-                                <au:department value="#{staffLeaveApplicationFormController.reportKeyWord.department}"/>
+            <h:outputStylesheet>
+                .leave-edit-form {
+                    padding: 2rem 1.75rem;
+                }
 
-                                <h:outputLabel value="Staff Designation : "/>
-                                <au:completeDesignation value="#{staffLeaveApplicationFormController.reportKeyWord.designation}"/>
+                .page-header {
+                    margin-bottom: 1.75rem;
+                }
 
-                                <h:outputLabel value="Staff Roster : "/>
-                                <au:completeRoster value="#{staffLeaveApplicationFormController.reportKeyWord.roster}"/>
+                .page-title {
+                    font-size: 18px;
+                    font-weight: 600;
+                    margin: 0 0 4px 0;
+                }
 
+                .page-subtitle {
+                    font-size: 13px;
+                    color: #888;
+                    margin: 0;
+                }
 
-<!--                                <p:commandButton value="Search Approved Date" ajax="false" action="#{staffLeaveApplicationFormController.createleaveTableApprovedDate()}" />
-<p:commandButton value="Search Shift Date" ajax="false" action="#{staffLeaveApplicationFormController.createleaveTableShiftDate()}" />-->
-                            </p:panelGrid>
-                            <p:commandButton value="Search Created Date" ajax="false" action="#{staffLeaveApplicationFormController.createStaffleaveTable()}" />
-                            <p:commandButton value="Search Leave Date" ajax="false" action="#{staffLeaveApplicationFormController.createStaffleaveTablebyLeaveDate()}" />
-                            <p:commandButton value="Print" ajax="false" action="#" >
-                                <p:printer target="gpBillPreview" ></p:printer>
-                            </p:commandButton>
-                            <p:commandButton ajax="false" value="Excel" styleClass="noPrintButton"  >
-                                <p:dataExporter type="xlsx" target="tb1" fileName="hr_staff_leave_edit"  />
-                            </p:commandButton>
-                        </p:panel>
-                        <p:panel id="gpBillPreview" styleClass="noBorder summeryBorder">
-                            <p:dataTable value="#{staffLeaveApplicationFormController.staffLeaves}" var="l"
-                                         rowStyleClass="#{l.retired eq true ? 'redText':''}"
-                                         scrollable="true"
-                                         scrollHeight="300" id="tb1">
-                                <f:facet name="header">
+                .controls-panel .ui-panel-content {
+                    padding: 1.5rem 1.75rem !important;
+                }
 
-                                    <h:outputLabel value="Leave Application Form"/><br/>
-                                    <h:outputLabel value="  From : "  />
-                                    <h:outputLabel  value="#{staffLeaveApplicationFormController.fromDate}" >
-                                        <f:convertDateTime pattern="dd MM yy "/>
-                                    </h:outputLabel>
-                                    <h:outputLabel/>
-                                    <h:outputLabel/>
-                                    <h:outputLabel value="  To : "/>
-                                    <h:outputLabel  value="#{staffLeaveApplicationFormController.toDate}">
-                                        <f:convertDateTime pattern="dd MM yy "/>
-                                    </h:outputLabel><br/>
-                                    <h:panelGroup rendered="#{staffLeaveApplicationFormController.reportKeyWord.institution ne null}" >
-                                        <h:outputLabel value="#{staffLeaveApplicationFormController.reportKeyWord.institution.name}" />
-                                        <br/>
-                                    </h:panelGroup>
-                                    <h:panelGroup rendered="#{staffLeaveApplicationFormController.reportKeyWord.department ne null}" >
-                                        <h:outputLabel value="Department : #{staffLeaveApplicationFormController.reportKeyWord.department.name}"/>
-                                        <br/>
-                                    </h:panelGroup>
-                                </f:facet>
+                .controls-grid {
+                    display: flex;
+                    flex-direction: column;
+                    gap: 1.25rem;
+                }
 
-                                <p:column headerText="View" >
-                                    <p:commandButton ajax="false" value="View" action="hr_staff_leave_edit" actionListener="#{staffLeaveApplicationFormController.viewStaffLeave(l)}" disabled="#{l.retired}"></p:commandButton>
-                                </p:column>
+                .fields-grid {
+                    display: grid;
+                    grid-template-columns: repeat(2, 1fr);
+                    gap: 1rem 1.5rem;
+                }
 
-                                <p:column headerText="Staff">
-                                    <f:facet name="header">
-                                        <h:outputLabel value="Staff"/>
-                                    </f:facet>
-                                    <p:outputLabel value="#{l.staff.person.nameWithTitle}" ></p:outputLabel>
-                                </p:column>
+                .field-group {
+                    display: flex;
+                    flex-direction: column;
+                    gap: 6px;
+                }
 
-                                <p:column headerText="From">
-                                    <f:facet name="header">
-                                        <h:outputLabel value="From"/>
-                                    </f:facet>
-                                    <p:outputLabel value="#{l.leaveDate}" >
-                                        <f:convertDateTime pattern="yyyy MM dd" />
-                                    </p:outputLabel>
-                                </p:column>
+                .field-label {
+                    font-size: 11.5px !important;
+                    font-weight: 600 !important;
+                    text-transform: uppercase;
+                    letter-spacing: 0.05em;
+                    color: #888 !important;
+                }
 
-                                <p:column headerText="Comment">
-                                    <f:facet name="header">
-                                        <h:outputLabel value="Comment"/>
-                                    </f:facet>
-                                    <p:outputLabel value="#{l.leaveType}" ></p:outputLabel>
-                                </p:column>
+                .controls-actions {
+                    display: flex;
+                    gap: 10px;
+                    align-items: center;
+                    flex-wrap: wrap;
+                }
 
-                                <p:column headerText="Creator">
-                                    <f:facet name="header">
-                                        <h:outputLabel value="Creator"/>
-                                    </f:facet>
-                                    <p:outputLabel value="#{l.creater.webUserPerson.nameWithTitle}" ></p:outputLabel>
-                                    <br></br>
-                                    <p:outputLabel value="Deleted By  #{l.retirer.webUserPerson.nameWithTitle}" rendered="#{l.retired}" style="color: blue;"/>
-                                </p:column>
-                                <f:facet name="footer">
-                                    <p:outputLabel value="Print By : #{sessionController.loggedUser.webUserPerson.name} - " />
-                                    <p:outputLabel value="Print At : " />
-                                    <p:outputLabel value="#{commonFunctionsProxy.currentDateTime}" >
-                                        <f:convertDateTime pattern="yyyy MMMM dd hh:mm:ss a " />
-                                    </p:outputLabel>
-                                </f:facet>
-                            </p:dataTable>
-                        </p:panel>
-                    </p:panel>
-                </h:panelGrid>
+                .controls-actions-secondary {
+                    display: flex;
+                    gap: 10px;
+                    align-items: center;
+                    flex-wrap: wrap;
+                    padding-top: 0.75rem;
+                    border-top: 1px solid #e8e8e8;
+                }
+
+                .btn-action {
+                    height: 36px !important;
+                    padding: 0 18px !important;
+                    font-size: 13px !important;
+                }
+
+                .report-panel {
+                    margin-top: 1.5rem;
+                }
+
+                .report-panel .ui-panel-content {
+                    padding: 0 !important;
+                }
+
+                .report-header-wrap {
+                    text-align: center;
+                    padding: 1.5rem 1.5rem 1rem;
+                    border-bottom: 1px solid #e8e8e8;
+                }
+
+                .report-title-label {
+                    font-size: 13px;
+                    color: #666;
+                    display: block;
+                    margin-bottom: 2px;
+                }
+
+                .report-meta {
+                    font-size: 13px;
+                    color: #555;
+                    margin-top: 4px;
+                }
+
+                .wt-table .ui-datatable-tablewrapper {
+                    overflow-x: auto !important;
+                    width: 100% !important;
+                }
+
+                .wt-table table {
+                    width: auto !important;
+                    table-layout: auto !important;
+                }
+
+                .wt-table .ui-datatable-data td,
+                .wt-table .ui-datatable-thead th {
+                    padding: 10px 14px !important;
+                    white-space: nowrap;
+                    font-size: 13px !important;
+                    width: auto !important;
+                }
+
+                .wt-table .ui-datatable-thead th {
+                    font-size: 12px !important;
+                    font-weight: 600 !important;
+                    text-transform: uppercase;
+                    letter-spacing: 0.03em;
+                    color: #888 !important;
+                    background: #f9f9f9 !important;
+                    border-bottom: 1px solid #e8e8e8 !important;
+                }
+
+                .wt-table .ui-datatable-data tr:hover td {
+                    background: #f5f7ff !important;
+                }
+
+                .wt-table .col-text {
+                    text-align: left !important;
+                }
+
+                .wt-table .col-name .ui-outputlabel {
+                    font-weight: 500;
+                }
+
+                .wt-table tfoot td {
+                    background: #f9f9f9 !important;
+                    font-size: 12px !important;
+                    border-top: 2px solid #e0e0e0 !important;
+                    padding: 10px 14px !important;
+                    color: #999;
+                }
+
+                .report-table-footer {
+                    display: flex;
+                    justify-content: flex-end;
+                    align-items: center;
+                    gap: 6px;
+                    padding: 0.85rem 1.5rem;
+                    border-top: 1px solid #e8e8e8;
+                    font-size: 12px;
+                    color: #999;
+                }
+            </h:outputStylesheet>
+
+            <div class="page-header">
+                <p class="page-title"><h:outputText value="Leave Application Form" /></p>
+                <p class="page-subtitle"><h:outputText value="Filter by date range, staff, leave type or department and process to generate" /></p>
+            </div>
+
+            <p:panel styleClass="controls-panel">
+                <div class="controls-grid">
+
+                    <div class="fields-grid">
+                        <div class="field-group">
+                            <p:outputLabel for="fromDate" value="From date" styleClass="field-label" />
+                            <p:calendar id="fromDate"
+                                        value="#{staffLeaveApplicationFormController.fromDate}"
+                                        pattern="#{sessionController.applicationPreference.shortDateFormat}"
+                                        style="width: 100%;" />
+                        </div>
+
+                        <div class="field-group">
+                            <p:outputLabel for="toDate" value="To date" styleClass="field-label" />
+                            <p:calendar id="toDate"
+                                        value="#{staffLeaveApplicationFormController.toDate}"
+                                        pattern="#{sessionController.applicationPreference.shortDateFormat}"
+                                        style="width: 100%;" />
+                        </div>
+
+                        <div class="field-group">
+                            <p:outputLabel value="Staff" styleClass="field-label" />
+                            <au:completeStaff value="#{staffLeaveApplicationFormController.staff}" />
+                        </div>
+
+                        <div class="field-group">
+                            <p:outputLabel for="leaveType" value="Leave type" styleClass="field-label" />
+                            <p:selectOneMenu id="leaveType"
+                                             value="#{staffLeaveApplicationFormController.leaveType}"
+                                             appendTo="@body"
+                                             autoWidth="false"
+                                             style="width: 100%;">
+                                <f:selectItem itemLabel="Select leave type" />
+                                <f:selectItems value="#{enumController.leaveType}" />
+                            </p:selectOneMenu>
+                        </div>
+
+                        <div class="field-group">
+                            <p:outputLabel value="Institution" styleClass="field-label" />
+                            <au:institution value="#{staffLeaveApplicationFormController.reportKeyWord.institution}" />
+                        </div>
+
+                        <div class="field-group">
+                            <p:outputLabel value="Department" styleClass="field-label" />
+                            <au:department value="#{staffLeaveApplicationFormController.reportKeyWord.department}" />
+                        </div>
+
+                        <div class="field-group">
+                            <p:outputLabel value="Staff designation" styleClass="field-label" />
+                            <au:completeDesignation value="#{staffLeaveApplicationFormController.reportKeyWord.designation}" />
+                        </div>
+
+                        <div class="field-group">
+                            <p:outputLabel value="Staff roster" styleClass="field-label" />
+                            <au:completeRoster value="#{staffLeaveApplicationFormController.reportKeyWord.roster}" />
+                        </div>
+                    </div>
+
+                    <div class="controls-actions">
+                        <p:commandButton value="Search Created Date"
+                                         ajax="false"
+                                         action="#{staffLeaveApplicationFormController.createStaffleaveTable()}"
+                                         icon="pi pi-search"
+                                         styleClass="btn-action" />
+                        <p:commandButton value="Search Leave Date"
+                                         ajax="false"
+                                         action="#{staffLeaveApplicationFormController.createStaffleaveTablebyLeaveDate()}"
+                                         icon="pi pi-search"
+                                         styleClass="btn-action" />
+                    </div>
+
+                    <div class="controls-actions-secondary">
+                        <p:commandButton value="Print"
+                                         type="button"
+                                         icon="pi pi-print"
+                                         styleClass="btn-action">
+                            <p:printer target="gpBillPreview" />
+                        </p:commandButton>
+                        <p:commandButton value="Export Excel"
+                                         ajax="false"
+                                         icon="pi pi-file-excel"
+                                         styleClass="btn-action noPrintButton">
+                            <p:dataExporter type="xlsx" target="tb1" fileName="hr_staff_leave_edit" />
+                        </p:commandButton>
+                    </div>
+
+                </div>
             </p:panel>
+
+            <p:panel id="gpBillPreview" styleClass="report-panel noBorder summeryBorder">
+
+                <f:facet name="header">
+                    <div class="report-header-wrap">
+                        <span class="report-title-label">Leave Application Form</span>
+                        <h:panelGroup rendered="#{staffLeaveApplicationFormController.fromDate ne null}">
+                            <p class="report-meta">
+                                <h:outputText value="#{staffLeaveApplicationFormController.fromDate}">
+                                    <f:convertDateTime pattern="dd MM yy" />
+                                </h:outputText>
+                                —
+                                <h:outputText value="#{staffLeaveApplicationFormController.toDate}">
+                                    <f:convertDateTime pattern="dd MM yy" />
+                                </h:outputText>
+                            </p>
+                        </h:panelGroup>
+                        <h:panelGroup rendered="#{staffLeaveApplicationFormController.reportKeyWord.institution ne null}">
+                            <p class="report-meta">
+                                <h:outputText value="#{staffLeaveApplicationFormController.reportKeyWord.institution.name}" />
+                            </p>
+                        </h:panelGroup>
+                        <h:panelGroup rendered="#{staffLeaveApplicationFormController.reportKeyWord.department ne null}">
+                            <p class="report-meta">
+                                Department: <h:outputText value="#{staffLeaveApplicationFormController.reportKeyWord.department.name}" />
+                            </p>
+                        </h:panelGroup>
+                    </div>
+                </f:facet>
+
+                <p:dataTable id="tb1"
+                             value="#{staffLeaveApplicationFormController.staffLeaves}"
+                             var="l"
+                             rowStyleClass="#{l.retired eq true ? 'redText':''}"
+                             scrollable="true"
+                             scrollHeight="300"
+                             styleClass="wt-table">
+
+                    <p:column headerText="View" styleClass="col-text">
+                        <p:commandButton ajax="false"
+                                         value="View"
+                                         action="hr_staff_leave_edit"
+                                         actionListener="#{staffLeaveApplicationFormController.viewStaffLeave(l)}"
+                                         disabled="#{l.retired}" />
+                    </p:column>
+
+                    <p:column headerText="Staff" styleClass="col-text col-name" style="min-width: 180px;">
+                        <p:outputLabel value="#{l.staff.person.nameWithTitle}" />
+                    </p:column>
+
+                    <p:column headerText="From" styleClass="col-text">
+                        <p:outputLabel value="#{l.leaveDate}">
+                            <f:convertDateTime pattern="yyyy MM dd" />
+                        </p:outputLabel>
+                    </p:column>
+
+                    <p:column headerText="Comment" styleClass="col-text">
+                        <p:outputLabel value="#{l.leaveType}" />
+                    </p:column>
+
+                    <p:column headerText="Creator" styleClass="col-text">
+                        <p:outputLabel value="#{l.creater.webUserPerson.nameWithTitle}" />
+                        <br />
+                        <p:outputLabel value="Deleted By  #{l.retirer.webUserPerson.nameWithTitle}"
+                                       rendered="#{l.retired}"
+                                       style="color: blue;" />
+                    </p:column>
+
+                    <f:facet name="footer">
+                        <div class="report-table-footer">
+                            <p:outputLabel value="Print by: #{sessionController.loggedUser.webUserPerson.name}" />
+                            <span>·</span>
+                            <p:outputLabel value="#{commonFunctionsProxy.currentDateTime}">
+                                <f:convertDateTime pattern="yyyy MMMM dd hh:mm:ss a" />
+                            </p:outputLabel>
+                        </div>
+                    </f:facet>
+
+                </p:dataTable>
+
+            </p:panel>
+
         </h:form>
     </ui:define>
 


### PR DESCRIPTION
## Summary

Fixes the leave type dropdown close bug and aligns
`hr_staff_leave_edit.xhtml` with the established HR report design system.

## Changes

### Bug fix
- Added `appendTo="@body"` to `p:selectOneMenu#leaveType` — same
  immediate-close bug present across other pages

### UI changes
- Removed triple nested `p:panel` / `h:panelGrid` / `p:panel` /
  `p:panel` wrapper chain; replaced with flat `fields-grid` CSS grid
- Replaced inline button mix with `controls-actions` (two Search buttons)
  + `controls-actions-secondary` (Print, Export) flex rows; added icons
- Removed `action="#"` no-op from Print button; `type="button"` retained
- Moved report header out of `p:dataTable` facet into `report-header-wrap`
  div on the outer panel
- Added `wt-table` styleClass with consistent header, cell, hover, and
  footer styles
- Removed all redundant `<f:facet name="header">` blocks from columns
  that already had `headerText` set
- Table footer changed to `report-table-footer` flex row with separator dot
- Removed commented-out `Search Approved Date` and `Search Shift Date`
  button blocks (dead XML comments)

## What was intentionally left unchanged
- All `#{...}` EL bindings and action methods
  (`staffLeaveApplicationFormController`)
- `rowStyleClass="#{l.retired eq true ? 'redText':''}"` preserved
- `scrollable="true" scrollHeight="300"` on `p:dataTable` preserved
- View button `action="hr_staff_leave_edit"` and `actionListener`
  preserved exactly
- Creator column conditional "Deleted By" label and
  `style="color: blue;"` preserved
- `Comment` column binding `#{l.leaveType}` left as found
- `p:dataExporter` `target` and `fileName`
- `p:printer` `target` attribute
- `noBorder summeryBorder` styleClasses on the report panel
- `noPrintButton` styleClass on Export button