### PR TITLE
feat: add AutoLumo analyzer enum and MiddlewareController routing

### DIFF
--- a/src/main/java/com/divudi/core/data/lab/Analyzer.java
+++ b/src/main/java/com/divudi/core/data/lab/Analyzer.java
@@ -25,7 +25,8 @@ public enum Analyzer {
     HumaStar600("HumaStar600"),
     MaglumiX3HL7("Maglumi X3 HL7"),
     XL_200("XL 200"),
-    AIA_360("AIA 360");
+    AIA_360("AIA 360"),
+    AutoLumo("AutoLumo");
 
     private final String label;
 

--- a/src/main/java/com/divudi/ws/lims/MiddlewareController.java
+++ b/src/main/java/com/divudi/ws/lims/MiddlewareController.java
@@ -196,6 +196,7 @@ public class MiddlewareController {
                     case XL_200:
                     case AIA_360:
                     case MindrayCL1000i:
+                    case AutoLumo:
                         System.out.println("going to direct to processResultsCommon");
                         return processResultsCommon(dataBundle);
                     default:


### PR DESCRIPTION
## Summary

- Adds `AutoLumo("AutoLumo")` to the `Analyzer` enum in `Analyzer.java`
- Adds `case AutoLumo:` to the `receivePatientResults` switch in `MiddlewareController.java`, routing it to `processResultsCommon`

## Motivation

The `ccmw-autolumo` middleware (Autobio proprietary protocol) is now functional and can connect to HMIS. Without the enum value and switch case, any result push from the middleware hits the `default` branch and throws `IllegalArgumentException: Unsupported analyzer type: AutoLumo`.

This follows the same pattern as PR #20957 which added `MindrayCL1000i`.

Closes #20958

## Test plan

- [ ] Verify `Analyzer.AutoLumo` compiles and is selectable in analyzer configuration UI
- [ ] Run the `ccmw-autolumo` middleware against a test HMIS instance and confirm results are accepted via `processResultsCommon` without exception

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced support for two new lab analyzers: AIA 360 and AutoLumo. The system can now recognize and process results from these analyzer types.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hmislk/hmis/pull/20959?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->