### PR TITLE
Add REST APIs for Machine and Analyzer Test management

### DIFF
--- a/src/main/java/com/divudi/ws/common/ApplicationConfig.java
+++ b/src/main/java/com/divudi/ws/common/ApplicationConfig.java
@@ -64,9 +64,12 @@ public class ApplicationConfig extends Application {
         resources.add(com.divudi.ws.inward.InwardRoomApi.class);
         resources.add(com.divudi.ws.inward.InwardRoomCategoryApi.class);
         resources.add(com.divudi.ws.inward.InwardRoomFacilityChargeApi.class);
+        resources.add(com.divudi.ws.lims.AnalyzerTestApi.class);
         resources.add(com.divudi.ws.lims.Lims.class);
         resources.add(com.divudi.ws.lims.LimsMiddlewareController.class);
+        resources.add(com.divudi.ws.lims.MachineApi.class);
         resources.add(com.divudi.ws.lims.MiddlewareController.class);
+        resources.add(com.divudi.ws.lims.PatientSampleApi.class);
         resources.add(com.divudi.ws.pharmacy.PharmaceuticalConfigApi.class);
         resources.add(com.divudi.ws.pharmacy.PharmaceuticalItemApi.class);
         resources.add(com.divudi.ws.pharmacy.PharmacyAdjustmentApi.class);

--- a/src/main/java/com/divudi/ws/common/CapabilityStatementResource.java
+++ b/src/main/java/com/divudi/ws/common/CapabilityStatementResource.java
@@ -169,6 +169,33 @@ public class CapabilityStatementResource {
                         "LIMS middleware integration",
                         "API Key",
                         "GET", "POST"))
+                .add(resource("Machines (Analyzers)", "/api/machines",
+                        "CRUD for Machine (analyzer) entities. "
+                        + "GET lists active machines (supports ?query=&size=). "
+                        + "GET /{id} returns a single machine. "
+                        + "POST creates a machine (required: name; optional: code, description); returns 409 when duplicate name exists. "
+                        + "PUT /{id} updates name, code, or description. "
+                        + "DELETE /{id} soft-retires the machine.",
+                        "API Key",
+                        "GET", "POST", "PUT", "DELETE"))
+                .add(resource("Analyzer Tests", "/api/machines/{machineId}/tests",
+                        "CRUD for analyzer test Items (itemType=AnalyzerTest) linked to a Machine. "
+                        + "GET lists tests for the machine (supports ?query=&size=). "
+                        + "GET /{id} returns a single test. "
+                        + "POST creates a test (required: name, code); returns 409 when duplicate code exists for the machine. "
+                        + "PUT /{id} updates name or code. "
+                        + "DELETE /{id} soft-retires the test. "
+                        + "The code field matches analyzer output codes used by the LIMS middleware.",
+                        "API Key",
+                        "GET", "POST", "PUT", "DELETE"))
+                .add(resource("Patient Samples", "/api/patient-samples",
+                        "Search and retrieval of PatientSample records. "
+                        + "GET /search supports ?sampleId=&patientName=&fromDate=&toDate=&billNumber=&size= (dates: yyyy-MM-dd). "
+                        + "GET /{id} returns full sample detail including automation workflow fields "
+                        + "(sentToAnalyzer, receivedFromAnalyzer, sampleCollected, sampleReceivedAtLab, etc.) "
+                        + "and linked patientInvestigation, machine, test, and investigationComponent.",
+                        "API Key",
+                        "GET"))
                 .add(resource("Middleware", "/api/middleware",
                         "General middleware endpoints",
                         "API Key",

--- a/src/main/java/com/divudi/ws/lims/AnalyzerTestApi.java
+++ b/src/main/java/com/divudi/ws/lims/AnalyzerTestApi.java
@@ -1,0 +1,421 @@
+/*
+ * Open Hospital Management Information System
+ * Dr M H B Ariyaratne
+ * buddhika.ari@gmail.com
+ */
+package com.divudi.ws.lims;
+
+import com.divudi.bean.common.ApiKeyController;
+import com.divudi.core.data.ItemType;
+import com.divudi.core.entity.ApiKey;
+import com.divudi.core.entity.Item;
+import com.divudi.core.entity.WebUser;
+import com.divudi.core.entity.lab.Machine;
+import com.divudi.core.facade.ItemFacade;
+import com.divudi.core.facade.MachineFacade;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonSyntaxException;
+
+import javax.ejb.EJB;
+import javax.enterprise.context.RequestScoped;
+import javax.inject.Inject;
+import javax.servlet.http.HttpServletRequest;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.DELETE;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.PUT;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.UriInfo;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * REST API for Analyzer Test Item management (Items with itemType=AnalyzerTest linked to a Machine).
+ * Closes #20968
+ */
+@Path("machines/{machineId}/tests")
+@RequestScoped
+public class AnalyzerTestApi {
+
+    @Context
+    private HttpServletRequest requestContext;
+
+    @Context
+    private UriInfo uriInfo;
+
+    @Inject
+    private ApiKeyController apiKeyController;
+
+    @EJB
+    private ItemFacade itemFacade;
+
+    @EJB
+    private MachineFacade machineFacade;
+
+    private static final Gson gson = new GsonBuilder()
+            .setDateFormat("yyyy-MM-dd HH:mm:ss")
+            .create();
+
+    /**
+     * List analyzer tests for a machine.
+     * GET /api/machines/{machineId}/tests?query=&size=
+     */
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response list(@PathParam("machineId") Long machineId) {
+        try {
+            WebUser user = validateApiKey(requestContext.getHeader("Finance"));
+            if (user == null) {
+                return errorResponse("Not a valid key", 401);
+            }
+
+            Machine machine = machineFacade.find(machineId);
+            if (machine == null || machine.isRetired()) {
+                return errorResponse("Machine not found: " + machineId, 404);
+            }
+
+            String query = param("query");
+            int size = intParam("size", 200, 1, 1000);
+
+            StringBuilder jpql = new StringBuilder(
+                    "select i from Item i where i.retired = false"
+                    + " and i.itemType = :t and i.machine = :m");
+            Map<String, Object> params = new HashMap<>();
+            params.put("t", ItemType.AnalyzerTest);
+            params.put("m", machine);
+            if (query != null && !query.trim().isEmpty()) {
+                jpql.append(" and (upper(i.name) like :q or upper(i.code) like :q)");
+                params.put("q", "%" + query.trim().toUpperCase() + "%");
+            }
+            jpql.append(" order by i.name");
+
+            List<Item> items = itemFacade.findByJpql(jpql.toString(), params, size);
+            List<Map<String, Object>> payload = new ArrayList<>();
+            if (items != null) {
+                for (Item item : items) {
+                    payload.add(toDto(item));
+                }
+            }
+            return successResponse(payload);
+
+        } catch (IllegalArgumentException e) {
+            return errorResponse(e.getMessage(), 400);
+        } catch (Exception e) {
+            return errorResponse("An error occurred: " + e.getMessage(), 500);
+        }
+    }
+
+    /**
+     * Get an analyzer test by ID.
+     * GET /api/machines/{machineId}/tests/{id}
+     */
+    @GET
+    @Path("/{id}")
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response getById(@PathParam("machineId") Long machineId, @PathParam("id") Long id) {
+        try {
+            WebUser user = validateApiKey(requestContext.getHeader("Finance"));
+            if (user == null) {
+                return errorResponse("Not a valid key", 401);
+            }
+
+            Machine machine = machineFacade.find(machineId);
+            if (machine == null || machine.isRetired()) {
+                return errorResponse("Machine not found: " + machineId, 404);
+            }
+
+            Item item = itemFacade.find(id);
+            if (item == null || item.isRetired()) {
+                return errorResponse("Analyzer test not found: " + id, 404);
+            }
+            if (item.getMachine() == null || !item.getMachine().getId().equals(machineId)) {
+                return errorResponse("Analyzer test " + id + " does not belong to machine " + machineId, 404);
+            }
+
+            return successResponse(toDto(item));
+        } catch (Exception e) {
+            return errorResponse("An error occurred: " + e.getMessage(), 500);
+        }
+    }
+
+    /**
+     * Create an analyzer test for a machine.
+     * POST /api/machines/{machineId}/tests
+     * Body: { "name": "...", "code": "..." }
+     */
+    @POST
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response create(@PathParam("machineId") Long machineId, String requestBody) {
+        try {
+            WebUser user = validateApiKey(requestContext.getHeader("Finance"));
+            if (user == null) {
+                return errorResponse("Not a valid key", 401);
+            }
+
+            Machine machine = machineFacade.find(machineId);
+            if (machine == null || machine.isRetired()) {
+                return errorResponse("Machine not found: " + machineId, 404);
+            }
+
+            Map<?, ?> body;
+            try {
+                body = gson.fromJson(requestBody, Map.class);
+            } catch (JsonSyntaxException e) {
+                return errorResponse("Invalid JSON format: " + e.getMessage(), 400);
+            }
+            if (body == null) {
+                return errorResponse("Request body is required", 400);
+            }
+
+            String name = asString(body.get("name"));
+            if (name == null || name.trim().isEmpty()) {
+                return errorResponse("name is required", 400);
+            }
+            name = name.trim();
+
+            String code = asString(body.get("code"));
+            if (code == null || code.trim().isEmpty()) {
+                return errorResponse("code is required", 400);
+            }
+            code = code.trim();
+
+            Item existing = itemFacade.findFirstByJpql(
+                    "select i from Item i where i.retired = false"
+                    + " and i.itemType = :t and i.machine = :m and upper(i.code) = :c",
+                    Map.of("t", ItemType.AnalyzerTest, "m", machine, "c", code.toUpperCase()));
+            if (existing != null) {
+                Map<String, Object> payload = new LinkedHashMap<>();
+                payload.put("status", "already_exists");
+                payload.put("code", 409);
+                payload.put("message", "An analyzer test with this code already exists for this machine.");
+                payload.put("id", existing.getId());
+                return Response.status(409).entity(gson.toJson(payload)).build();
+            }
+
+            Item item = new Item();
+            item.setName(name);
+            item.setCode(code);
+            item.setMachine(machine);
+            item.setItemType(ItemType.AnalyzerTest);
+            item.setCreatedAt(new Date());
+            item.setCreater(user);
+            itemFacade.create(item);
+
+            return Response.status(201).entity(gson.toJson(successData(toDto(item)))).build();
+
+        } catch (IllegalArgumentException e) {
+            return errorResponse(e.getMessage(), 400);
+        } catch (Exception e) {
+            return errorResponse("An error occurred: " + e.getMessage(), 500);
+        }
+    }
+
+    /**
+     * Update an analyzer test by ID.
+     * PUT /api/machines/{machineId}/tests/{id}
+     * Body: { "name": "...", "code": "..." }
+     */
+    @PUT
+    @Path("/{id}")
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response update(@PathParam("machineId") Long machineId, @PathParam("id") Long id, String requestBody) {
+        try {
+            WebUser user = validateApiKey(requestContext.getHeader("Finance"));
+            if (user == null) {
+                return errorResponse("Not a valid key", 401);
+            }
+
+            Machine machine = machineFacade.find(machineId);
+            if (machine == null || machine.isRetired()) {
+                return errorResponse("Machine not found: " + machineId, 404);
+            }
+
+            Item item = itemFacade.find(id);
+            if (item == null || item.isRetired()) {
+                return errorResponse("Analyzer test not found: " + id, 404);
+            }
+            if (item.getMachine() == null || !item.getMachine().getId().equals(machineId)) {
+                return errorResponse("Analyzer test " + id + " does not belong to machine " + machineId, 404);
+            }
+
+            Map<?, ?> body;
+            try {
+                body = gson.fromJson(requestBody, Map.class);
+            } catch (JsonSyntaxException e) {
+                return errorResponse("Invalid JSON format: " + e.getMessage(), 400);
+            }
+            if (body == null) {
+                return errorResponse("Request body is required", 400);
+            }
+
+            if (body.containsKey("name")) {
+                String name = asString(body.get("name"));
+                if (name == null || name.trim().isEmpty()) {
+                    return errorResponse("name cannot be empty", 400);
+                }
+                item.setName(name.trim());
+            }
+            if (body.containsKey("code")) {
+                String code = asString(body.get("code"));
+                if (code == null || code.trim().isEmpty()) {
+                    return errorResponse("code cannot be empty", 400);
+                }
+                code = code.trim();
+                Item dup = itemFacade.findFirstByJpql(
+                        "select i from Item i where i.retired = false"
+                        + " and i.itemType = :t and i.machine = :m and upper(i.code) = :c and i.id <> :id",
+                        Map.of("t", ItemType.AnalyzerTest, "m", machine, "c", code.toUpperCase(), "id", id));
+                if (dup != null) {
+                    Map<String, Object> payload = new LinkedHashMap<>();
+                    payload.put("status", "already_exists");
+                    payload.put("code", 409);
+                    payload.put("message", "Another analyzer test with this code already exists for this machine.");
+                    payload.put("id", dup.getId());
+                    return Response.status(409).entity(gson.toJson(payload)).build();
+                }
+                item.setCode(code);
+            }
+
+            itemFacade.edit(item);
+            return successResponse(toDto(item));
+
+        } catch (IllegalArgumentException e) {
+            return errorResponse(e.getMessage(), 400);
+        } catch (Exception e) {
+            return errorResponse("An error occurred: " + e.getMessage(), 500);
+        }
+    }
+
+    /**
+     * Soft-retire an analyzer test by ID.
+     * DELETE /api/machines/{machineId}/tests/{id}?retireComments=reason
+     */
+    @DELETE
+    @Path("/{id}")
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response retire(@PathParam("machineId") Long machineId, @PathParam("id") Long id) {
+        try {
+            WebUser user = validateApiKey(requestContext.getHeader("Finance"));
+            if (user == null) {
+                return errorResponse("Not a valid key", 401);
+            }
+
+            Machine machine = machineFacade.find(machineId);
+            if (machine == null || machine.isRetired()) {
+                return errorResponse("Machine not found: " + machineId, 404);
+            }
+
+            Item item = itemFacade.find(id);
+            if (item == null) {
+                return errorResponse("Analyzer test not found: " + id, 404);
+            }
+            if (item.isRetired()) {
+                return errorResponse("Analyzer test is already retired: " + id, 400);
+            }
+            if (item.getMachine() == null || !item.getMachine().getId().equals(machineId)) {
+                return errorResponse("Analyzer test " + id + " does not belong to machine " + machineId, 404);
+            }
+
+            item.setRetired(true);
+            item.setRetiredAt(new Date());
+            item.setRetirer(user);
+            String retireComments = param("retireComments");
+            if (retireComments != null && !retireComments.trim().isEmpty()) {
+                item.setRetireComments(retireComments.trim());
+            }
+            itemFacade.edit(item);
+
+            Map<String, Object> resp = new LinkedHashMap<>();
+            resp.put("id", item.getId());
+            resp.put("retired", true);
+            return successResponse(resp);
+
+        } catch (Exception e) {
+            return errorResponse("An error occurred: " + e.getMessage(), 500);
+        }
+    }
+
+    // =========================================================================
+    // Helpers
+    // =========================================================================
+
+    private Map<String, Object> toDto(Item i) {
+        Map<String, Object> row = new LinkedHashMap<>();
+        row.put("id", i.getId());
+        row.put("name", i.getName());
+        row.put("code", i.getCode());
+        row.put("retired", i.isRetired());
+        if (i.getMachine() != null) {
+            Map<String, Object> m = new LinkedHashMap<>();
+            m.put("id", i.getMachine().getId());
+            m.put("name", i.getMachine().getName());
+            row.put("machine", m);
+        } else {
+            row.put("machine", null);
+        }
+        return row;
+    }
+
+    private String param(String name) {
+        return uriInfo.getQueryParameters().getFirst(name);
+    }
+
+    private int intParam(String name, int defaultValue, int min, int max) {
+        String v = param(name);
+        if (v == null || v.trim().isEmpty()) return defaultValue;
+        try {
+            int parsed = Integer.parseInt(v.trim());
+            return Math.min(Math.max(parsed, min), max);
+        } catch (NumberFormatException e) {
+            return defaultValue;
+        }
+    }
+
+    private String asString(Object o) {
+        if (o == null) return null;
+        return o.toString();
+    }
+
+    private WebUser validateApiKey(String key) {
+        if (key == null || key.trim().isEmpty()) return null;
+        ApiKey apiKey = apiKeyController.findApiKey(key);
+        if (apiKey == null || apiKey.isRetired()) return null;
+        WebUser user = apiKey.getWebUser();
+        if (user == null || user.isRetired() || !user.isActivated()) return null;
+        if (apiKey.getDateOfExpiary() == null || apiKey.getDateOfExpiary().before(new Date())) return null;
+        return user;
+    }
+
+    private Response errorResponse(String message, int code) {
+        Map<String, Object> response = new HashMap<>();
+        response.put("status", "error");
+        response.put("code", code);
+        response.put("message", message);
+        return Response.status(code).entity(gson.toJson(response)).build();
+    }
+
+    private Response successResponse(Object data) {
+        return Response.status(200).entity(gson.toJson(successData(data))).build();
+    }
+
+    private Map<String, Object> successData(Object data) {
+        Map<String, Object> response = new HashMap<>();
+        response.put("status", "success");
+        response.put("code", 200);
+        response.put("data", data);
+        return response;
+    }
+}

--- a/src/main/java/com/divudi/ws/lims/AnalyzerTestApi.java
+++ b/src/main/java/com/divudi/ws/lims/AnalyzerTestApi.java
@@ -39,6 +39,8 @@ import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 /**
  * REST API for Analyzer Test Item management (Items with itemType=AnalyzerTest linked to a Machine).
@@ -62,6 +64,8 @@ public class AnalyzerTestApi {
 
     @EJB
     private MachineFacade machineFacade;
+
+    private static final Logger logger = Logger.getLogger(AnalyzerTestApi.class.getName());
 
     private static final Gson gson = new GsonBuilder()
             .setDateFormat("yyyy-MM-dd HH:mm:ss")
@@ -110,9 +114,11 @@ public class AnalyzerTestApi {
             return successResponse(payload);
 
         } catch (IllegalArgumentException e) {
-            return errorResponse(e.getMessage(), 400);
+            logger.log(Level.WARNING, "Invalid argument in list()", e);
+            return errorResponse("Invalid request", 400);
         } catch (Exception e) {
-            return errorResponse("An error occurred: " + e.getMessage(), 500);
+            logger.log(Level.SEVERE, "Error in list()", e);
+            return errorResponse("Internal server error", 500);
         }
     }
 
@@ -136,7 +142,7 @@ public class AnalyzerTestApi {
             }
 
             Item item = itemFacade.find(id);
-            if (item == null || item.isRetired()) {
+            if (item == null || item.isRetired() || item.getItemType() != ItemType.AnalyzerTest) {
                 return errorResponse("Analyzer test not found: " + id, 404);
             }
             if (item.getMachine() == null || !item.getMachine().getId().equals(machineId)) {
@@ -145,7 +151,8 @@ public class AnalyzerTestApi {
 
             return successResponse(toDto(item));
         } catch (Exception e) {
-            return errorResponse("An error occurred: " + e.getMessage(), 500);
+            logger.log(Level.SEVERE, "Error in getById()", e);
+            return errorResponse("Internal server error", 500);
         }
     }
 
@@ -213,12 +220,14 @@ public class AnalyzerTestApi {
             item.setCreater(user);
             itemFacade.create(item);
 
-            return Response.status(201).entity(gson.toJson(successData(toDto(item)))).build();
+            return Response.status(201).entity(gson.toJson(successData(201, toDto(item)))).build();
 
         } catch (IllegalArgumentException e) {
-            return errorResponse(e.getMessage(), 400);
+            logger.log(Level.WARNING, "Invalid argument in create()", e);
+            return errorResponse("Invalid request", 400);
         } catch (Exception e) {
-            return errorResponse("An error occurred: " + e.getMessage(), 500);
+            logger.log(Level.SEVERE, "Error in create()", e);
+            return errorResponse("Internal server error", 500);
         }
     }
 
@@ -244,7 +253,7 @@ public class AnalyzerTestApi {
             }
 
             Item item = itemFacade.find(id);
-            if (item == null || item.isRetired()) {
+            if (item == null || item.isRetired() || item.getItemType() != ItemType.AnalyzerTest) {
                 return errorResponse("Analyzer test not found: " + id, 404);
             }
             if (item.getMachine() == null || !item.getMachine().getId().equals(machineId)) {
@@ -293,9 +302,11 @@ public class AnalyzerTestApi {
             return successResponse(toDto(item));
 
         } catch (IllegalArgumentException e) {
-            return errorResponse(e.getMessage(), 400);
+            logger.log(Level.WARNING, "Invalid argument in update()", e);
+            return errorResponse("Invalid request", 400);
         } catch (Exception e) {
-            return errorResponse("An error occurred: " + e.getMessage(), 500);
+            logger.log(Level.SEVERE, "Error in update()", e);
+            return errorResponse("Internal server error", 500);
         }
     }
 
@@ -319,7 +330,7 @@ public class AnalyzerTestApi {
             }
 
             Item item = itemFacade.find(id);
-            if (item == null) {
+            if (item == null || item.getItemType() != ItemType.AnalyzerTest) {
                 return errorResponse("Analyzer test not found: " + id, 404);
             }
             if (item.isRetired()) {
@@ -344,7 +355,8 @@ public class AnalyzerTestApi {
             return successResponse(resp);
 
         } catch (Exception e) {
-            return errorResponse("An error occurred: " + e.getMessage(), 500);
+            logger.log(Level.SEVERE, "Error in retire()", e);
+            return errorResponse("Internal server error", 500);
         }
     }
 
@@ -412,9 +424,13 @@ public class AnalyzerTestApi {
     }
 
     private Map<String, Object> successData(Object data) {
+        return successData(200, data);
+    }
+
+    private Map<String, Object> successData(int code, Object data) {
         Map<String, Object> response = new HashMap<>();
         response.put("status", "success");
-        response.put("code", 200);
+        response.put("code", code);
         response.put("data", data);
         return response;
     }

--- a/src/main/java/com/divudi/ws/lims/MachineApi.java
+++ b/src/main/java/com/divudi/ws/lims/MachineApi.java
@@ -36,6 +36,8 @@ import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 /**
  * REST API for Machine (Analyzer) management.
@@ -56,6 +58,8 @@ public class MachineApi {
 
     @EJB
     private MachineFacade machineFacade;
+
+    private static final Logger logger = Logger.getLogger(MachineApi.class.getName());
 
     private static final Gson gson = new GsonBuilder()
             .setDateFormat("yyyy-MM-dd HH:mm:ss")
@@ -96,9 +100,11 @@ public class MachineApi {
             return successResponse(payload);
 
         } catch (IllegalArgumentException e) {
-            return errorResponse(e.getMessage(), 400);
+            logger.log(Level.WARNING, "Invalid argument in list()", e);
+            return errorResponse("Invalid request", 400);
         } catch (Exception e) {
-            return errorResponse("An error occurred: " + e.getMessage(), 500);
+            logger.log(Level.SEVERE, "Error in list()", e);
+            return errorResponse("Internal server error", 500);
         }
     }
 
@@ -121,7 +127,8 @@ public class MachineApi {
             }
             return successResponse(toDto(machine));
         } catch (Exception e) {
-            return errorResponse("An error occurred: " + e.getMessage(), 500);
+            logger.log(Level.SEVERE, "Error in getById()", e);
+            return errorResponse("Internal server error", 500);
         }
     }
 
@@ -182,12 +189,14 @@ public class MachineApi {
             machine.setCreater(user);
             machineFacade.create(machine);
 
-            return Response.status(201).entity(gson.toJson(successData(toDto(machine)))).build();
+            return Response.status(201).entity(gson.toJson(successData(201, toDto(machine)))).build();
 
         } catch (IllegalArgumentException e) {
-            return errorResponse(e.getMessage(), 400);
+            logger.log(Level.WARNING, "Invalid argument in create()", e);
+            return errorResponse("Invalid request", 400);
         } catch (Exception e) {
-            return errorResponse("An error occurred: " + e.getMessage(), 500);
+            logger.log(Level.SEVERE, "Error in create()", e);
+            return errorResponse("Internal server error", 500);
         }
     }
 
@@ -254,9 +263,11 @@ public class MachineApi {
             return successResponse(toDto(machine));
 
         } catch (IllegalArgumentException e) {
-            return errorResponse(e.getMessage(), 400);
+            logger.log(Level.WARNING, "Invalid argument in update()", e);
+            return errorResponse("Invalid request", 400);
         } catch (Exception e) {
-            return errorResponse("An error occurred: " + e.getMessage(), 500);
+            logger.log(Level.SEVERE, "Error in update()", e);
+            return errorResponse("Internal server error", 500);
         }
     }
 
@@ -297,7 +308,8 @@ public class MachineApi {
             return successResponse(resp);
 
         } catch (Exception e) {
-            return errorResponse("An error occurred: " + e.getMessage(), 500);
+            logger.log(Level.SEVERE, "Error in retire()", e);
+            return errorResponse("Internal server error", 500);
         }
     }
 
@@ -358,9 +370,13 @@ public class MachineApi {
     }
 
     private Map<String, Object> successData(Object data) {
+        return successData(200, data);
+    }
+
+    private Map<String, Object> successData(int code, Object data) {
         Map<String, Object> response = new HashMap<>();
         response.put("status", "success");
-        response.put("code", 200);
+        response.put("code", code);
         response.put("data", data);
         return response;
     }

--- a/src/main/java/com/divudi/ws/lims/MachineApi.java
+++ b/src/main/java/com/divudi/ws/lims/MachineApi.java
@@ -1,0 +1,367 @@
+/*
+ * Open Hospital Management Information System
+ * Dr M H B Ariyaratne
+ * buddhika.ari@gmail.com
+ */
+package com.divudi.ws.lims;
+
+import com.divudi.bean.common.ApiKeyController;
+import com.divudi.core.entity.ApiKey;
+import com.divudi.core.entity.WebUser;
+import com.divudi.core.entity.lab.Machine;
+import com.divudi.core.facade.MachineFacade;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonSyntaxException;
+
+import javax.ejb.EJB;
+import javax.enterprise.context.RequestScoped;
+import javax.inject.Inject;
+import javax.servlet.http.HttpServletRequest;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.DELETE;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.PUT;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.UriInfo;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * REST API for Machine (Analyzer) management.
+ * Closes #20967
+ */
+@Path("machines")
+@RequestScoped
+public class MachineApi {
+
+    @Context
+    private HttpServletRequest requestContext;
+
+    @Context
+    private UriInfo uriInfo;
+
+    @Inject
+    private ApiKeyController apiKeyController;
+
+    @EJB
+    private MachineFacade machineFacade;
+
+    private static final Gson gson = new GsonBuilder()
+            .setDateFormat("yyyy-MM-dd HH:mm:ss")
+            .create();
+
+    /**
+     * List machines with optional name search.
+     * GET /api/machines?query=&size=
+     */
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response list() {
+        try {
+            WebUser user = validateApiKey(requestContext.getHeader("Finance"));
+            if (user == null) {
+                return errorResponse("Not a valid key", 401);
+            }
+
+            String query = param("query");
+            int size = intParam("size", 200, 1, 1000);
+
+            StringBuilder jpql = new StringBuilder(
+                    "select m from Machine m where m.retired = false");
+            Map<String, Object> params = new HashMap<>();
+            if (query != null && !query.trim().isEmpty()) {
+                jpql.append(" and upper(m.name) like :q");
+                params.put("q", "%" + query.trim().toUpperCase() + "%");
+            }
+            jpql.append(" order by m.name");
+
+            List<Machine> machines = machineFacade.findByJpql(jpql.toString(), params, size);
+            List<Map<String, Object>> payload = new ArrayList<>();
+            if (machines != null) {
+                for (Machine m : machines) {
+                    payload.add(toDto(m));
+                }
+            }
+            return successResponse(payload);
+
+        } catch (IllegalArgumentException e) {
+            return errorResponse(e.getMessage(), 400);
+        } catch (Exception e) {
+            return errorResponse("An error occurred: " + e.getMessage(), 500);
+        }
+    }
+
+    /**
+     * Get a machine by ID.
+     * GET /api/machines/{id}
+     */
+    @GET
+    @Path("/{id}")
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response getById(@PathParam("id") Long id) {
+        try {
+            WebUser user = validateApiKey(requestContext.getHeader("Finance"));
+            if (user == null) {
+                return errorResponse("Not a valid key", 401);
+            }
+            Machine machine = machineFacade.find(id);
+            if (machine == null || machine.isRetired()) {
+                return errorResponse("Machine not found: " + id, 404);
+            }
+            return successResponse(toDto(machine));
+        } catch (Exception e) {
+            return errorResponse("An error occurred: " + e.getMessage(), 500);
+        }
+    }
+
+    /**
+     * Create a new machine.
+     * POST /api/machines
+     * Body: { "name": "...", "code": "...", "description": "..." }
+     */
+    @POST
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response create(String requestBody) {
+        try {
+            WebUser user = validateApiKey(requestContext.getHeader("Finance"));
+            if (user == null) {
+                return errorResponse("Not a valid key", 401);
+            }
+
+            Map<?, ?> body;
+            try {
+                body = gson.fromJson(requestBody, Map.class);
+            } catch (JsonSyntaxException e) {
+                return errorResponse("Invalid JSON format: " + e.getMessage(), 400);
+            }
+            if (body == null) {
+                return errorResponse("Request body is required", 400);
+            }
+
+            String name = asString(body.get("name"));
+            if (name == null || name.trim().isEmpty()) {
+                return errorResponse("name is required", 400);
+            }
+            name = name.trim();
+
+            Machine existing = machineFacade.findFirstByJpql(
+                    "select m from Machine m where m.retired = false and upper(m.name) = :n",
+                    Map.of("n", name.toUpperCase()));
+            if (existing != null) {
+                Map<String, Object> payload = new LinkedHashMap<>();
+                payload.put("status", "already_exists");
+                payload.put("code", 409);
+                payload.put("message", "A machine with this name already exists.");
+                payload.put("id", existing.getId());
+                return Response.status(409).entity(gson.toJson(payload)).build();
+            }
+
+            Machine machine = new Machine();
+            machine.setName(name);
+            String code = asString(body.get("code"));
+            if (code != null && !code.trim().isEmpty()) {
+                machine.setCode(code.trim());
+            }
+            String description = asString(body.get("description"));
+            if (description != null && !description.trim().isEmpty()) {
+                machine.setDescription(description.trim());
+            }
+            machine.setCreatedAt(new Date());
+            machine.setCreater(user);
+            machineFacade.create(machine);
+
+            return Response.status(201).entity(gson.toJson(successData(toDto(machine)))).build();
+
+        } catch (IllegalArgumentException e) {
+            return errorResponse(e.getMessage(), 400);
+        } catch (Exception e) {
+            return errorResponse("An error occurred: " + e.getMessage(), 500);
+        }
+    }
+
+    /**
+     * Update a machine by ID.
+     * PUT /api/machines/{id}
+     * Body: { "name": "...", "code": "...", "description": "..." }
+     */
+    @PUT
+    @Path("/{id}")
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response update(@PathParam("id") Long id, String requestBody) {
+        try {
+            WebUser user = validateApiKey(requestContext.getHeader("Finance"));
+            if (user == null) {
+                return errorResponse("Not a valid key", 401);
+            }
+
+            Machine machine = machineFacade.find(id);
+            if (machine == null || machine.isRetired()) {
+                return errorResponse("Machine not found: " + id, 404);
+            }
+
+            Map<?, ?> body;
+            try {
+                body = gson.fromJson(requestBody, Map.class);
+            } catch (JsonSyntaxException e) {
+                return errorResponse("Invalid JSON format: " + e.getMessage(), 400);
+            }
+            if (body == null) {
+                return errorResponse("Request body is required", 400);
+            }
+
+            if (body.containsKey("name")) {
+                String name = asString(body.get("name"));
+                if (name == null || name.trim().isEmpty()) {
+                    return errorResponse("name cannot be empty", 400);
+                }
+                name = name.trim();
+                Machine dup = machineFacade.findFirstByJpql(
+                        "select m from Machine m where m.retired = false and upper(m.name) = :n and m.id <> :id",
+                        Map.of("n", name.toUpperCase(), "id", id));
+                if (dup != null) {
+                    Map<String, Object> payload = new LinkedHashMap<>();
+                    payload.put("status", "already_exists");
+                    payload.put("code", 409);
+                    payload.put("message", "Another machine with this name already exists.");
+                    payload.put("id", dup.getId());
+                    return Response.status(409).entity(gson.toJson(payload)).build();
+                }
+                machine.setName(name);
+            }
+            if (body.containsKey("code")) {
+                String code = asString(body.get("code"));
+                machine.setCode(code != null ? code.trim() : null);
+            }
+            if (body.containsKey("description")) {
+                String description = asString(body.get("description"));
+                machine.setDescription(description != null ? description.trim() : null);
+            }
+
+            machineFacade.edit(machine);
+            return successResponse(toDto(machine));
+
+        } catch (IllegalArgumentException e) {
+            return errorResponse(e.getMessage(), 400);
+        } catch (Exception e) {
+            return errorResponse("An error occurred: " + e.getMessage(), 500);
+        }
+    }
+
+    /**
+     * Soft-retire a machine by ID.
+     * DELETE /api/machines/{id}?retireComments=reason
+     */
+    @DELETE
+    @Path("/{id}")
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response retire(@PathParam("id") Long id) {
+        try {
+            WebUser user = validateApiKey(requestContext.getHeader("Finance"));
+            if (user == null) {
+                return errorResponse("Not a valid key", 401);
+            }
+
+            Machine machine = machineFacade.find(id);
+            if (machine == null) {
+                return errorResponse("Machine not found: " + id, 404);
+            }
+            if (machine.isRetired()) {
+                return errorResponse("Machine is already retired: " + id, 400);
+            }
+
+            machine.setRetired(true);
+            machine.setRetiredAt(new Date());
+            machine.setRetirer(user);
+            String retireComments = param("retireComments");
+            if (retireComments != null && !retireComments.trim().isEmpty()) {
+                machine.setRetireComments(retireComments.trim());
+            }
+            machineFacade.edit(machine);
+
+            Map<String, Object> resp = new LinkedHashMap<>();
+            resp.put("id", machine.getId());
+            resp.put("retired", true);
+            return successResponse(resp);
+
+        } catch (Exception e) {
+            return errorResponse("An error occurred: " + e.getMessage(), 500);
+        }
+    }
+
+    // =========================================================================
+    // Helpers
+    // =========================================================================
+
+    private Map<String, Object> toDto(Machine m) {
+        Map<String, Object> row = new LinkedHashMap<>();
+        row.put("id", m.getId());
+        row.put("name", m.getName());
+        row.put("code", m.getCode());
+        row.put("description", m.getDescription());
+        row.put("retired", m.isRetired());
+        return row;
+    }
+
+    private String param(String name) {
+        return uriInfo.getQueryParameters().getFirst(name);
+    }
+
+    private int intParam(String name, int defaultValue, int min, int max) {
+        String v = param(name);
+        if (v == null || v.trim().isEmpty()) return defaultValue;
+        try {
+            int parsed = Integer.parseInt(v.trim());
+            return Math.min(Math.max(parsed, min), max);
+        } catch (NumberFormatException e) {
+            return defaultValue;
+        }
+    }
+
+    private String asString(Object o) {
+        if (o == null) return null;
+        return o.toString();
+    }
+
+    private WebUser validateApiKey(String key) {
+        if (key == null || key.trim().isEmpty()) return null;
+        ApiKey apiKey = apiKeyController.findApiKey(key);
+        if (apiKey == null || apiKey.isRetired()) return null;
+        WebUser user = apiKey.getWebUser();
+        if (user == null || user.isRetired() || !user.isActivated()) return null;
+        if (apiKey.getDateOfExpiary() == null || apiKey.getDateOfExpiary().before(new Date())) return null;
+        return user;
+    }
+
+    private Response errorResponse(String message, int code) {
+        Map<String, Object> response = new HashMap<>();
+        response.put("status", "error");
+        response.put("code", code);
+        response.put("message", message);
+        return Response.status(code).entity(gson.toJson(response)).build();
+    }
+
+    private Response successResponse(Object data) {
+        return Response.status(200).entity(gson.toJson(successData(data))).build();
+    }
+
+    private Map<String, Object> successData(Object data) {
+        Map<String, Object> response = new HashMap<>();
+        response.put("status", "success");
+        response.put("code", 200);
+        response.put("data", data);
+        return response;
+    }
+}

--- a/src/main/java/com/divudi/ws/lims/PatientSampleApi.java
+++ b/src/main/java/com/divudi/ws/lims/PatientSampleApi.java
@@ -1,0 +1,309 @@
+/*
+ * Open Hospital Management Information System
+ * Dr M H B Ariyaratne
+ * buddhika.ari@gmail.com
+ */
+package com.divudi.ws.lims;
+
+import com.divudi.bean.common.ApiKeyController;
+import com.divudi.core.entity.ApiKey;
+import com.divudi.core.entity.WebUser;
+import com.divudi.core.entity.lab.PatientSample;
+import com.divudi.core.facade.PatientSampleFacade;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+
+import javax.ejb.EJB;
+import javax.enterprise.context.RequestScoped;
+import javax.inject.Inject;
+import javax.servlet.http.HttpServletRequest;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.UriInfo;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * REST API for PatientSample search and retrieval.
+ * Closes #20969
+ */
+@Path("patient-samples")
+@RequestScoped
+public class PatientSampleApi {
+
+    @Context
+    private HttpServletRequest requestContext;
+
+    @Context
+    private UriInfo uriInfo;
+
+    @Inject
+    private ApiKeyController apiKeyController;
+
+    @EJB
+    private PatientSampleFacade patientSampleFacade;
+
+    private static final Gson gson = new GsonBuilder()
+            .setDateFormat("yyyy-MM-dd HH:mm:ss")
+            .create();
+
+    /**
+     * Search patient samples.
+     * GET /api/patient-samples/search?sampleId=&patientName=&fromDate=&toDate=&billNumber=&size=
+     * Dates are accepted as yyyy-MM-dd.
+     */
+    @GET
+    @Path("/search")
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response search() {
+        try {
+            WebUser user = validateApiKey(requestContext.getHeader("Finance"));
+            if (user == null) {
+                return errorResponse("Not a valid key", 401);
+            }
+
+            String sampleIdStr = param("sampleId");
+            String patientName = param("patientName");
+            String fromDateStr = param("fromDate");
+            String toDateStr = param("toDate");
+            String billNumber = param("billNumber");
+            int size = intParam("size", 50, 1, 500);
+
+            StringBuilder jpql = new StringBuilder(
+                    "select ps from PatientSample ps where ps.retired = false");
+            Map<String, Object> params = new HashMap<>();
+
+            if (sampleIdStr != null && !sampleIdStr.trim().isEmpty()) {
+                try {
+                    Long sampleId = Long.parseLong(sampleIdStr.trim());
+                    jpql.append(" and ps.sampleId = :sid");
+                    params.put("sid", sampleId);
+                } catch (NumberFormatException e) {
+                    return errorResponse("Invalid sampleId: must be a number", 400);
+                }
+            }
+
+            if (patientName != null && !patientName.trim().isEmpty()) {
+                jpql.append(" and upper(ps.patient.person.name) like :pname");
+                params.put("pname", "%" + patientName.trim().toUpperCase() + "%");
+            }
+
+            if (billNumber != null && !billNumber.trim().isEmpty()) {
+                jpql.append(" and ps.bill.deptId = :bnum");
+                params.put("bnum", billNumber.trim());
+            }
+
+            if (fromDateStr != null && !fromDateStr.trim().isEmpty()) {
+                Date fromDate = parseDate(fromDateStr.trim());
+                if (fromDate == null) {
+                    return errorResponse("Invalid fromDate format; expected yyyy-MM-dd", 400);
+                }
+                jpql.append(" and ps.createdAt >= :fromDate");
+                params.put("fromDate", fromDate);
+            }
+
+            if (toDateStr != null && !toDateStr.trim().isEmpty()) {
+                Date toDate = parseDate(toDateStr.trim());
+                if (toDate == null) {
+                    return errorResponse("Invalid toDate format; expected yyyy-MM-dd", 400);
+                }
+                // Include the entire to-date day
+                jpql.append(" and ps.createdAt < :toDate");
+                params.put("toDate", new Date(toDate.getTime() + 86400000L));
+            }
+
+            jpql.append(" order by ps.createdAt desc");
+
+            List<PatientSample> samples = patientSampleFacade.findByJpql(jpql.toString(), params, size);
+            List<Map<String, Object>> payload = new ArrayList<>();
+            if (samples != null) {
+                for (PatientSample ps : samples) {
+                    payload.add(toDto(ps, false));
+                }
+            }
+            return successResponse(payload);
+
+        } catch (IllegalArgumentException e) {
+            return errorResponse(e.getMessage(), 400);
+        } catch (Exception e) {
+            return errorResponse("An error occurred: " + e.getMessage(), 500);
+        }
+    }
+
+    /**
+     * Get a patient sample by ID including linked investigations and automation status.
+     * GET /api/patient-samples/{id}
+     */
+    @GET
+    @Path("/{id}")
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response getById(@PathParam("id") Long id) {
+        try {
+            WebUser user = validateApiKey(requestContext.getHeader("Finance"));
+            if (user == null) {
+                return errorResponse("Not a valid key", 401);
+            }
+
+            PatientSample ps = patientSampleFacade.find(id);
+            if (ps == null || ps.isRetired()) {
+                return errorResponse("PatientSample not found: " + id, 404);
+            }
+            return successResponse(toDto(ps, true));
+
+        } catch (Exception e) {
+            return errorResponse("An error occurred: " + e.getMessage(), 500);
+        }
+    }
+
+    // =========================================================================
+    // Helpers
+    // =========================================================================
+
+    private Map<String, Object> toDto(PatientSample ps, boolean detailed) {
+        Map<String, Object> row = new LinkedHashMap<>();
+        row.put("id", ps.getId());
+        row.put("sampleId", ps.getSampleId());
+        row.put("status", ps.getStatus() != null ? ps.getStatus().name() : null);
+        row.put("createdAt", ps.getCreatedAt());
+        row.put("retired", ps.isRetired());
+        row.put("cancelled", ps.getCancelled());
+
+        if (ps.getPatient() != null) {
+            Map<String, Object> patient = new LinkedHashMap<>();
+            patient.put("id", ps.getPatient().getId());
+            patient.put("phn", ps.getPatient().getPhn());
+            if (ps.getPatient().getPerson() != null) {
+                patient.put("name", ps.getPatient().getPerson().getName());
+            }
+            row.put("patient", patient);
+        } else {
+            row.put("patient", null);
+        }
+
+        if (ps.getBill() != null) {
+            Map<String, Object> bill = new LinkedHashMap<>();
+            bill.put("id", ps.getBill().getId());
+            bill.put("billNumber", ps.getBill().getDeptId());
+            row.put("bill", bill);
+        } else {
+            row.put("bill", null);
+        }
+
+        if (ps.getMachine() != null) {
+            Map<String, Object> machine = new LinkedHashMap<>();
+            machine.put("id", ps.getMachine().getId());
+            machine.put("name", ps.getMachine().getName());
+            row.put("machine", machine);
+        } else {
+            row.put("machine", null);
+        }
+
+        if (ps.getTest() != null) {
+            Map<String, Object> test = new LinkedHashMap<>();
+            test.put("id", ps.getTest().getId());
+            test.put("name", ps.getTest().getName());
+            test.put("code", ps.getTest().getCode());
+            row.put("test", test);
+        } else {
+            row.put("test", null);
+        }
+
+        if (ps.getInvestigationComponant() != null) {
+            Map<String, Object> comp = new LinkedHashMap<>();
+            comp.put("id", ps.getInvestigationComponant().getId());
+            comp.put("name", ps.getInvestigationComponant().getName());
+            row.put("investigationComponent", comp);
+        } else {
+            row.put("investigationComponent", null);
+        }
+
+        if (detailed) {
+            row.put("sampleCollected", ps.getSampleCollected());
+            row.put("sampleCollectedAt", ps.getSampleCollectedAt());
+            row.put("sampleReceivedAtLab", ps.getSampleReceivedAtLab());
+            row.put("sampleReceivedAtLabAt", ps.getSampleReceivedAtLabAt());
+            row.put("sentToAnalyzer", ps.getSentToAnalyzer());
+            row.put("sentToAnalyzerAt", ps.getSentToAnalyzerAt());
+            row.put("receivedFromAnalyzer", ps.getReceivedFromAnalyzer());
+            row.put("receivedFromAnalyzerAt", ps.getReceivedFromAnalyzerAt());
+            row.put("sampleRejected", ps.getSampleRejected());
+            row.put("sampleRejectionComment", ps.getSampleRejectionComment());
+            row.put("readyToSentToAnalyzer", ps.getReadyTosentToAnalyzer());
+            row.put("sampleRequestType", ps.getSampleRequestType() != null ? ps.getSampleRequestType().name() : null);
+            row.put("outsourced", ps.getOutsourced());
+            if (ps.getPatientInvestigation() != null) {
+                Map<String, Object> pi = new LinkedHashMap<>();
+                pi.put("id", ps.getPatientInvestigation().getId());
+                row.put("patientInvestigation", pi);
+            } else {
+                row.put("patientInvestigation", null);
+            }
+        }
+
+        return row;
+    }
+
+    private Date parseDate(String s) {
+        try {
+            return new SimpleDateFormat("yyyy-MM-dd").parse(s);
+        } catch (ParseException e) {
+            return null;
+        }
+    }
+
+    private String param(String name) {
+        return uriInfo.getQueryParameters().getFirst(name);
+    }
+
+    private int intParam(String name, int defaultValue, int min, int max) {
+        String v = param(name);
+        if (v == null || v.trim().isEmpty()) return defaultValue;
+        try {
+            int parsed = Integer.parseInt(v.trim());
+            return Math.min(Math.max(parsed, min), max);
+        } catch (NumberFormatException e) {
+            return defaultValue;
+        }
+    }
+
+    private WebUser validateApiKey(String key) {
+        if (key == null || key.trim().isEmpty()) return null;
+        ApiKey apiKey = apiKeyController.findApiKey(key);
+        if (apiKey == null || apiKey.isRetired()) return null;
+        WebUser user = apiKey.getWebUser();
+        if (user == null || user.isRetired() || !user.isActivated()) return null;
+        if (apiKey.getDateOfExpiary() == null || apiKey.getDateOfExpiary().before(new Date())) return null;
+        return user;
+    }
+
+    private Response errorResponse(String message, int code) {
+        Map<String, Object> response = new HashMap<>();
+        response.put("status", "error");
+        response.put("code", code);
+        response.put("message", message);
+        return Response.status(code).entity(gson.toJson(response)).build();
+    }
+
+    private Response successResponse(Object data) {
+        return Response.status(200).entity(gson.toJson(successData(data))).build();
+    }
+
+    private Map<String, Object> successData(Object data) {
+        Map<String, Object> response = new HashMap<>();
+        response.put("status", "success");
+        response.put("code", 200);
+        response.put("data", data);
+        return response;
+    }
+}

--- a/src/main/java/com/divudi/ws/lims/PatientSampleApi.java
+++ b/src/main/java/com/divudi/ws/lims/PatientSampleApi.java
@@ -33,6 +33,8 @@ import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 /**
  * REST API for PatientSample search and retrieval.
@@ -53,6 +55,8 @@ public class PatientSampleApi {
 
     @EJB
     private PatientSampleFacade patientSampleFacade;
+
+    private static final Logger logger = Logger.getLogger(PatientSampleApi.class.getName());
 
     private static final Gson gson = new GsonBuilder()
             .setDateFormat("yyyy-MM-dd HH:mm:ss")
@@ -78,7 +82,7 @@ public class PatientSampleApi {
             String fromDateStr = param("fromDate");
             String toDateStr = param("toDate");
             String billNumber = param("billNumber");
-            int size = intParam("size", 50, 1, 500);
+            int size = intParam("size", 200, 1, 1000);
 
             StringBuilder jpql = new StringBuilder(
                     "select ps from PatientSample ps where ps.retired = false");
@@ -135,9 +139,11 @@ public class PatientSampleApi {
             return successResponse(payload);
 
         } catch (IllegalArgumentException e) {
-            return errorResponse(e.getMessage(), 400);
+            logger.log(Level.WARNING, "Invalid argument in search()", e);
+            return errorResponse("Invalid request", 400);
         } catch (Exception e) {
-            return errorResponse("An error occurred: " + e.getMessage(), 500);
+            logger.log(Level.SEVERE, "Error in search()", e);
+            return errorResponse("Internal server error", 500);
         }
     }
 
@@ -162,7 +168,8 @@ public class PatientSampleApi {
             return successResponse(toDto(ps, true));
 
         } catch (Exception e) {
-            return errorResponse("An error occurred: " + e.getMessage(), 500);
+            logger.log(Level.SEVERE, "Error in getById()", e);
+            return errorResponse("Internal server error", 500);
         }
     }
 
@@ -256,7 +263,9 @@ public class PatientSampleApi {
 
     private Date parseDate(String s) {
         try {
-            return new SimpleDateFormat("yyyy-MM-dd").parse(s);
+            SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd");
+            sdf.setLenient(false);
+            return sdf.parse(s);
         } catch (ParseException e) {
             return null;
         }


### PR DESCRIPTION
## Summary
Adds three new REST API endpoints for Laboratory Information Management System (LIMS) integration to support machine (analyzer) and analyzer test management, along with patient sample search and retrieval capabilities.

## Key Changes

### New REST API Classes
- **`MachineApi`** (`/api/machines`) – Full CRUD operations for Machine (analyzer) entities
  - `GET /api/machines` – List active machines with optional name search (`?query=&size=`)
  - `GET /api/machines/{id}` – Retrieve a single machine
  - `POST /api/machines` – Create a new machine (required: `name`; optional: `code`, `description`)
  - `PUT /api/machines/{id}` – Update machine properties
  - `DELETE /api/machines/{id}` – Soft-retire a machine with optional comments
  - Returns 409 Conflict when duplicate machine names are detected

- **`AnalyzerTestApi`** (`/api/machines/{machineId}/tests`) – CRUD for analyzer test Items linked to machines
  - `GET /api/machines/{machineId}/tests` – List analyzer tests for a machine with search (`?query=&size=`)
  - `GET /api/machines/{machineId}/tests/{id}` – Retrieve a single analyzer test
  - `POST /api/machines/{machineId}/tests` – Create a new analyzer test (required: `name`, `code`)
  - `PUT /api/machines/{machineId}/tests/{id}` – Update test properties
  - `DELETE /api/machines/{machineId}/tests/{id}` – Soft-retire an analyzer test
  - Validates that tests belong to the specified machine; returns 409 on duplicate codes

- **`PatientSampleApi`** (`/api/patient-samples`) – Search and retrieval for patient samples
  - `GET /api/patient-samples/search` – Search samples by ID, patient name, date range, or bill number (`?sampleId=&patientName=&fromDate=&toDate=&billNumber=&size=`)
  - `GET /api/patient-samples/{id}` – Retrieve detailed sample information including linked investigations and automation status
  - Supports date filtering in `yyyy-MM-dd` format

### Implementation Details
- All endpoints require API key authentication via the `Finance` header
- Validates API key expiry, user activation, and retirement status
- Uses JPQL for database queries with parameterized queries to prevent injection
- Implements soft-delete pattern (sets `retired` flag rather than hard deletion)
- Returns consistent JSON response format with `status`, `code`, and `data`/`message` fields
- Supports pagination via `size` parameter (default 200, max 1000)
- Handles duplicate detection with 409 Conflict responses including existing entity ID
- Includes comprehensive error handling with appropriate HTTP status codes (400, 401, 404, 409, 500)

### API Registration
- Registered all three new API classes in `ApplicationConfig`
- Updated `CapabilityStatementResource` to document the new endpoints in the FHIR Capability Statement

## Closes
- #20967 (Machine API)
- #20968 (Analyzer Test API)
- #20969 (Patient Sample API)

https://claude.ai/code/session_017Wt84NchYhMrSmmGwkjuVy

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Machine/Analyzer management endpoints for registering, listing, updating, and retiring equipment
  * Analyzer Test endpoints to manage tests scoped to a specific machine (list, get, create, update, retire)
  * Patient Sample search and retrieval endpoints with flexible filters and detailed sample views

* **Documentation**
  * API capability listings updated to include the new Machines, Analyzer Tests, and Patient Samples endpoints

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hmislk/hmis/pull/20970?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->