### PR TITLE
feat: add AutoLumo analyzer support

### DIFF
--- a/src/main/java/com/divudi/core/data/lab/Analyzer.java
+++ b/src/main/java/com/divudi/core/data/lab/Analyzer.java
@@ -25,7 +25,8 @@ public enum Analyzer {
     HumaStar600("HumaStar600"),
     MaglumiX3HL7("Maglumi X3 HL7"),
     XL_200("XL 200"),
-    AIA_360("AIA 360");
+    AIA_360("AIA 360"),
+    AutoLumo("AutoLumo");
 
     private final String label;
 

--- a/src/main/java/com/divudi/ws/lims/MiddlewareController.java
+++ b/src/main/java/com/divudi/ws/lims/MiddlewareController.java
@@ -196,6 +196,7 @@ public class MiddlewareController {
                     case XL_200:
                     case AIA_360:
                     case MindrayCL1000i:
+                    case AutoLumo:
                         System.out.println("going to direct to processResultsCommon");
                         return processResultsCommon(dataBundle);
                     default:


### PR DESCRIPTION
## Summary
- Adds `AutoLumo` enum value to `Analyzer.java` for the Autobio AutoLumo S900 chemiluminescence analyzer
- Routes `AutoLumo` to `processResultsCommon()` in `MiddlewareController` switch statement

Hotfix port of #20959 (merged to `development`) for coop-prod deployment to enable AutoLumo middleware integration at Coop hospital.

## Test plan
- [ ] Verify middleware can push results via `/api/middleware/test_results` without `Unsupported analyzer type` error
- [ ] Verify existing analyzer integrations are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)