### PR TITLE
fix: load bill from billId in navigatePharmacyReprintRetailBill

### DIFF
--- a/src/main/java/com/divudi/bean/pharmacy/PharmacyBillSearch.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacyBillSearch.java
@@ -321,6 +321,9 @@ public class PharmacyBillSearch implements Serializable {
     }
 
     public String navigatePharmacyReprintRetailBill() {
+        if (bill == null && billId != null) {
+            bill = billService.reloadBill(billId);
+        }
         if (bill == null) {
             JsfUtil.addErrorMessage("No Bill Selected");
             return null;


### PR DESCRIPTION
## Summary
- `navigatePharmacyReprintRetailBill()` guarded on `bill == null` but the DTO table only ever set `billId` via `f:setPropertyActionListener`, so `bill` was always null
- Added a fallback: when `bill == null && billId != null`, load the bill via `billService.reloadBill(billId)` before the null check
- Every Manage Sale Bill button click in the pharmacy sale search DTO table now navigates correctly

## Test plan
- [ ] Go to Pharmacy → Search Sale Bill
- [ ] Run a search and confirm DTO results appear
- [ ] Click **Manage Sale Bill** on any row — should navigate to reprint/manage page without error
- [ ] Confirm "No Bill Selected" error no longer appears

Closes #20652

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced the pharmacy bill reprint process to better handle bill retrieval scenarios, ensuring proper navigation to the retail sale reprint page when appropriate bill data is available.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hmislk/hmis/pull/20974?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->