### PR TITLE
fix: include cashier-settled bills in native pharmacy sale search

### DIFF
--- a/src/main/java/com/divudi/bean/pharmacy/PharmacyBillSearch.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacyBillSearch.java
@@ -4601,12 +4601,15 @@ public class PharmacyBillSearch implements Serializable {
     }
 
     /**
-     * Fetches native PHARMACY_RETAIL_SALE bills (not linked to a PreBill) as DTOs.
+     * Fetches PHARMACY_RETAIL_SALE and PHARMACY_RETAIL_SALE_PREBILL_SETTLED_AT_CASHIER bills as DTOs.
      */
     @SuppressWarnings("unchecked")
     public void fetchSaleSearchDtosFromNativeBills(boolean maxNum) {
+        List<com.divudi.core.data.BillTypeAtomic> btas = new ArrayList<>();
+        btas.add(com.divudi.core.data.BillTypeAtomic.PHARMACY_RETAIL_SALE);
+        btas.add(com.divudi.core.data.BillTypeAtomic.PHARMACY_RETAIL_SALE_PREBILL_SETTLED_AT_CASHIER);
         Map<String, Object> m = new HashMap<>();
-        m.put("bta", com.divudi.core.data.BillTypeAtomic.PHARMACY_RETAIL_SALE);
+        m.put("btas", btas);
         m.put("fd", searchController.getFromDate());
         m.put("td", searchController.getToDate());
         m.put("ins", sessionController.getInstitution());
@@ -4629,7 +4632,7 @@ public class PharmacyBillSearch implements Serializable {
                 + "LEFT JOIN b.referredBy referredBy "
                 + "LEFT JOIN referredBy.person refDoctorPerson "
                 + "LEFT JOIN b.paymentScheme ps "
-                + "WHERE b.billTypeAtomic = :bta "
+                + "WHERE b.billTypeAtomic IN :btas "
                 + "AND b.createdAt BETWEEN :fd AND :td "
                 + "AND b.institution = :ins "
                 + "AND b.department = :ldep";


### PR DESCRIPTION
## Summary
- `fetchSaleSearchDtosFromNativeBills` in `PharmacyBillSearch` was filtering on `PHARMACY_RETAIL_SALE` only, silently omitting bills settled via the cashier pre-bill flow (`PHARMACY_RETAIL_SALE_PREBILL_SETTLED_AT_CASHIER`)
- Changed the single-value `=` filter to an `IN` clause covering both atomic types
- Consistent with the pattern used in `BillService`, `ReportController`, and `PharmacyReportController`

## Test plan
- [ ] Search pharmacy retail sale bills on a deployment using the cashier-settlement flow — cashier-settled bills now appear in results
- [ ] Direct sale bills continue to appear as before
- [ ] Filters (patient name, bill no, net total, payment method) work for both bill types

Closes #20650

🤖 Generated with [Claude Code](https://claude.com/claude-code)