### PR TITLE
docs(pr-review): codify the no-new-top-level-comments rule + reply-under-thread + one re-review

### DIFF
--- a/.claude/skills/review-pr/SKILL.md
+++ b/.claude/skills/review-pr/SKILL.md
@@ -86,25 +86,37 @@ git push
 
 Verify CI passes before proceeding.
 
-### 8. Reply to Each Comment
+### 8. Reply to Existing Reviewer Threads
 
-> **⚠️ Only reply after you have fixed (or explicitly dismissed) the comment.** Bots cannot fix anything. Replies must describe action **taken**, not action **requested**.
+> **⚠️ Cardinal rules — read before posting anything:**
 >
-> - Valid + fixed → "Fixed in `<commit-sha>`: `<what was changed>`"
-> - Dismissed → "Dismissed because: `<specific reasoning>`"
+> 1. **Do NOT create new top-level inline comments** on the PR. Each one becomes a thread the author must manually resolve. This is noise.
+> 2. **Reply only after fixing** (or explicitly dismissing). Bots cannot fix anything — describe action taken, not requested.
+>    - Valid + fixed → "Fixed in `<commit-sha>`: `<what was changed>`"
+>    - Dismissed → "Dismissed because: `<specific reasoning>`"
+> 3. **Replies go UNDER existing reviewer threads only** (`/replies` endpoint). Never as new top-level comments.
+> 4. **Self-review items go in the commit message** (or PR description if deferred). Never as new inline comments.
+> 5. **ONE re-review request at the end**, not per item.
 >
-> Order: **discuss → fix → push → reply → re-request review**. Never reply before pushing.
+> Order: **discuss → fix → push → reply to existing threads → one re-review request**.
 
-For each comment on GitHub, post an **individual threaded reply under the parent comment** — not a new top-level comment, not a bundled review, not a general PR comment. The four options are easy to confuse:
+For each existing reviewer comment, post a threaded reply under the parent. The four endpoints are easy to confuse:
 
-| Want | Endpoint | gh command |
+| Want | Endpoint | Use? |
 |---|---|---|
-| Reply under a bot/human comment (threaded) | `POST /pulls/{pr}/comments/{id}/replies` | `gh api -X POST repos/hmislk/hmis/pulls/<PR>/comments/<COMMENT_ID>/replies -f body="..."` |
-| New standalone inline comment on a line | `POST /pulls/{pr}/comments` | `gh api -X POST repos/hmislk/hmis/pulls/<PR>/comments -f commit_id=<sha> -f path=<file> -F line=<n> -f side=RIGHT -f body="..."` |
-| Bundled review (avoid) | `POST /pulls/{pr}/reviews` | `gh api -X POST repos/.../reviews --input <json>` |
-| General PR comment (only PR-wide notes) | `POST /issues/{n}/comments` | `gh pr comment <PR> --body "..."` |
+| **Reply under existing reviewer comment (threaded)** | `POST /pulls/{pr}/comments/{id}/replies` | **YES — this is the only legitimate reply form** |
+| New standalone inline comment on a line | `POST /pulls/{pr}/comments` | NO — creates a fresh thread the author must manually resolve |
+| Bundled review | `POST /pulls/{pr}/reviews` | NO — grouping wrapper, doesn't match how bots post |
+| General PR comment (only genuine PR-wide notes) | `POST /issues/{n}/comments` | Sparingly — only for actual PR-wide announcements |
 
-**When replying to bot comments, always use the threaded reply form** so the bot can detect the conversation correctly and so the thread stays scoped to the original issue. Each individual reply maintains a clean audit trail.
+For self-review items you spot on your own PR — **don't post a new inline comment**. Fix in the next commit and reference the file:line in the commit message:
+
+```
+refactor(cashier): address self-review items
+
+- PaymentSettlementController.java:117 — add comment on shallow snapshot
+- settle_non_cash.xhtml:203 — use lastSettlementBill.institution.name
+```
 
 Find existing comment IDs to reply to:
 ```bash
@@ -112,9 +124,11 @@ gh api "repos/hmislk/hmis/pulls/<PR>/comments" \
   --jq '.[] | "\(.id) \(.user.login) \(.path):\(.line // .original_line)"'
 ```
 
-Reply content:
-- Valid + fixed: describe what was changed
-- Dismissed: explain why (with reasoning)
+Post a threaded reply:
+```bash
+gh api -X POST "repos/hmislk/hmis/pulls/<PR>/comments/<COMMENT_ID>/replies" \
+  -f body="Fixed in <commit-sha>: <what was changed>."
+```
 
 Do NOT resolve other reviewers' conversations. CodeRabbit auto-resolves on detection.
 

--- a/.claude/skills/review-pr/SKILL.md
+++ b/.claude/skills/review-pr/SKILL.md
@@ -88,6 +88,13 @@ Verify CI passes before proceeding.
 
 ### 8. Reply to Each Comment
 
+> **⚠️ Only reply after you have fixed (or explicitly dismissed) the comment.** Bots cannot fix anything. Replies must describe action **taken**, not action **requested**.
+>
+> - Valid + fixed → "Fixed in `<commit-sha>`: `<what was changed>`"
+> - Dismissed → "Dismissed because: `<specific reasoning>`"
+>
+> Order: **discuss → fix → push → reply → re-request review**. Never reply before pushing.
+
 For each comment on GitHub, post an **individual threaded reply under the parent comment** — not a new top-level comment, not a bundled review, not a general PR comment. The four options are easy to confuse:
 
 | Want | Endpoint | gh command |

--- a/.claude/skills/review-pr/SKILL.md
+++ b/.claude/skills/review-pr/SKILL.md
@@ -88,11 +88,30 @@ Verify CI passes before proceeding.
 
 ### 8. Reply to Each Comment
 
-For each comment on GitHub, post an individual reply:
+For each comment on GitHub, post an **individual threaded reply under the parent comment** — not a new top-level comment, not a bundled review, not a general PR comment. The four options are easy to confuse:
+
+| Want | Endpoint | gh command |
+|---|---|---|
+| Reply under a bot/human comment (threaded) | `POST /pulls/{pr}/comments/{id}/replies` | `gh api -X POST repos/hmislk/hmis/pulls/<PR>/comments/<COMMENT_ID>/replies -f body="..."` |
+| New standalone inline comment on a line | `POST /pulls/{pr}/comments` | `gh api -X POST repos/hmislk/hmis/pulls/<PR>/comments -f commit_id=<sha> -f path=<file> -F line=<n> -f side=RIGHT -f body="..."` |
+| Bundled review (avoid) | `POST /pulls/{pr}/reviews` | `gh api -X POST repos/.../reviews --input <json>` |
+| General PR comment (only PR-wide notes) | `POST /issues/{n}/comments` | `gh pr comment <PR> --body "..."` |
+
+**When replying to bot comments, always use the threaded reply form** so the bot can detect the conversation correctly and so the thread stays scoped to the original issue. Each individual reply maintains a clean audit trail.
+
+Find existing comment IDs to reply to:
+```bash
+gh api "repos/hmislk/hmis/pulls/<PR>/comments" \
+  --jq '.[] | "\(.id) \(.user.login) \(.path):\(.line // .original_line)"'
+```
+
+Reply content:
 - Valid + fixed: describe what was changed
 - Dismissed: explain why (with reasoning)
 
 Do NOT resolve other reviewers' conversations. CodeRabbit auto-resolves on detection.
+
+Full API recipes and cleanup commands: see [Posting PR Comments via gh CLI](../../developer_docs/git/pr-review-workflow.md#posting-pr-comments-via-gh-cli).
 
 ### 9. Re-Request Review
 

--- a/.claude/skills/review-pr/SKILL.md
+++ b/.claude/skills/review-pr/SKILL.md
@@ -111,7 +111,7 @@ For each existing reviewer comment, post a threaded reply under the parent. The 
 
 For self-review items you spot on your own PR — **don't post a new inline comment**. Fix in the next commit and reference the file:line in the commit message:
 
-```
+```text
 refactor(cashier): address self-review items
 
 - PaymentSettlementController.java:117 — add comment on shallow snapshot
@@ -132,7 +132,7 @@ gh api -X POST "repos/hmislk/hmis/pulls/<PR>/comments/<COMMENT_ID>/replies" \
 
 Do NOT resolve other reviewers' conversations. CodeRabbit auto-resolves on detection.
 
-Full API recipes and cleanup commands: see [Posting PR Comments via gh CLI](../../developer_docs/git/pr-review-workflow.md#posting-pr-comments-via-gh-cli).
+Full API recipes and cleanup commands: see [Posting PR Comments via gh CLI](../../../developer_docs/git/pr-review-workflow.md#posting-pr-comments-via-gh-cli).
 
 ### 9. Re-Request Review
 

--- a/.codex/skills/review-pr/SKILL.md
+++ b/.codex/skills/review-pr/SKILL.md
@@ -32,10 +32,38 @@ Use this skill when working a PR review loop on HMIS: collect review comments, v
    - Verify `persistence.xml` placeholders remain `${JDBC_DATASOURCE}` and `${JDBC_AUDIT_DATASOURCE}`.
    - For JSF/XHTML fixes, keep standard `<!DOCTYPE html>` and use `h:outputText` for static ERP labels.
 
-6. Push, reply, and re-request review.
-   - Push only after the fix is ready.
-   - Reply to each reviewer thread individually with what changed or why the comment was dismissed.
-   - Ask for another review pass after the push.
+6. Push, reply, and re-request review — by the cardinal rules below.
+
+## Cardinal Rules for Posting on a PR
+
+1. **Do NOT create new top-level inline comments** on the PR. Each one becomes a thread the author must manually resolve. Self-review noise is the most common offender.
+2. **Reply only after fixing** (or explicitly dismissing). Bots cannot fix anything — describe action taken, not requested.
+   - Valid + fixed → "Fixed in `<commit-sha>`: `<what was changed>`"
+   - Dismissed → "Dismissed because: `<specific reasoning>`"
+3. **Replies go UNDER existing reviewer threads only** — use `POST /pulls/{pr}/comments/{id}/replies`. Never as new top-level comments.
+4. **Self-review items go in the commit message** (or PR description if deferred). Never as new inline comments. Reference file:line in the commit message so reviewers can find the change in the diff.
+5. **ONE re-review request at the end** — click "Re-request review" once after all fixes are pushed and all existing threads have replies. Not per item.
+
+Order: **discuss → fix → push → reply to existing threads → one re-review request**.
+
+## Endpoint Cheat Sheet
+
+| Want | Endpoint | Use? |
+|---|---|---|
+| Reply under existing reviewer comment | `POST /pulls/{pr}/comments/{id}/replies` | YES |
+| New standalone inline comment | `POST /pulls/{pr}/comments` | NO — creates a fresh thread |
+| Bundled review wrapper | `POST /pulls/{pr}/reviews` | NO |
+| General PR comment | `POST /issues/{n}/comments` | Sparingly, only for actual PR-wide notes |
+
+```bash
+# List existing comments to find a parent ID
+gh api "repos/hmislk/hmis/pulls/<PR>/comments" \
+  --jq '.[] | "\(.id) \(.user.login) \(.path):\(.line // .original_line)"'
+
+# Post a threaded reply (the only legitimate reply form)
+gh api -X POST "repos/hmislk/hmis/pulls/<PR>/comments/<COMMENT_ID>/replies" \
+  -f body="Fixed in <commit-sha>: <what was changed>."
+```
 
 ## Common Review Patterns
 

--- a/developer_docs/git/pr-review-workflow.md
+++ b/developer_docs/git/pr-review-workflow.md
@@ -104,14 +104,21 @@ git branch -d <branch-name>
 
 ## Posting PR Comments via gh CLI
 
-> **⚠️ Reply only after you have fixed (or explicitly dismissed) the comment.**
+> **⚠️ THE CARDINAL RULES**
 >
-> Bots (CodeRabbit, Codex) **cannot fix anything** — they only identify issues. Replying "please resolve" / "please address" / "please add the null guard" treats the bot as if it were an assignee, which it is not. Every reply you post under a reviewer's comment must describe action **taken**:
+> 1. **Do NOT create new top-level inline comments** on a PR. Every new top-level inline comment becomes its own discussion thread that the PR author must manually resolve. Filing 7 self-review items as new top-level inline comments creates 7 chores for the author. This is noise, not review.
 >
-> - **Valid + fixed** → "Fixed in `<commit-sha>`: `<what was changed>`"
-> - **Dismissed** → "Dismissed because: `<specific reasoning>`"
+> 2. **Reply only after you have fixed (or explicitly dismissed) the comment.** Bots (CodeRabbit, Codex) **cannot fix anything** — they only identify issues. Replying "please resolve" / "please address" / "please add the null guard" treats the bot as if it were an assignee, which it is not. Reply content must describe action **taken**, not action **requested**:
+>    - **Valid + fixed** → "Fixed in `<commit-sha>`: `<what was changed>`"
+>    - **Dismissed** → "Dismissed because: `<specific reasoning>`"
 >
-> The sequence is always: **discuss → fix → push → reply → re-request review**. Never reply before pushing the fix. Same rule applies to your own standalone review items — once filed, *you* (or the PR author) must do the work, not the bot.
+> 3. **Replies go UNDER existing reviewer threads** (`POST /pulls/{pr}/comments/{id}/replies`) — never as new top-level comments. The reply stays in the parent's thread and the bot/reviewer can resolve their own thread on detection.
+>
+> 4. **Self-review items go in the commit message and/or PR description**, NOT as new top-level inline comments. If you spot something while reviewing your own PR, fix it (or document the decision to defer) in the commit message and update the PR description checklist. Don't sprinkle review items as new inline comments — that creates manual-resolve noise.
+>
+> 5. **ONE re-review request at the end**, not one per item. After all fixes are pushed and all existing reviewer threads have been replied to, click **"Re-request review"** (or post a single summary comment if no human reviewer is assigned). Do not nag reviewers per-item.
+>
+> The sequence is always: **discuss → fix → push → reply to existing threads → one re-review request**. Never reply before pushing the fix. Never file new top-level inline comments as a substitute for a commit-message note.
 
 Four different ways exist to post comments on a PR. Picking the wrong one is the most common mistake. Each behaves differently in the GitHub UI:
 
@@ -124,29 +131,28 @@ Four different ways exist to post comments on a PR. Picking the wrong one is the
 
 ### When to use which
 
-- **Replying to a bot comment** (CodeRabbit / Codex / human reviewer) → always use the `/replies` endpoint. The reply stays in the parent's thread and the bot can detect the conversation correctly.
-- **Filing a new review item on a specific line** → use `POST /pulls/{pr}/comments` directly. This produces an individual standalone inline comment, the same shape as CodeRabbit/Codex post. Each one is its own resolvable thread.
-- **A PR-wide observation** (e.g. "this PR needs a Linear ticket") → `gh pr comment` is acceptable, but prefer inline if it can be tied to a line.
-- **Avoid** `POST /pulls/{pr}/reviews` with bundled `comments[]` unless you're submitting a formal review pass — it groups all comments under one "review" wrapper, which makes them harder to resolve individually and does not match how bots post.
+- **Replying to a bot/human reviewer comment** → use the `/replies` endpoint. The reply stays in the parent thread, the bot/reviewer can auto-resolve their own thread on detection, and the author does NOT have to manually resolve it. **This is the only acceptable place to post a reply on a PR review.**
+- **A new review item from your own self-review** → do **NOT** post it as a new top-level inline comment. Put it in the **commit message** that fixes it (preferred) or note it in the **PR description** if it's being deferred. Creating new top-level threads forces the author to manually resolve each one, which is noise. This was the wrong move on PR #20977 and PR #20983 — both required cleanup.
+- **A genuinely PR-wide announcement** (e.g. "merge blocked pending Linear ticket") → `gh pr comment` is acceptable for actual PR-wide observations only, and used sparingly.
+- **Avoid** `POST /pulls/{pr}/reviews` with bundled `comments[]`. It groups comments under one "review" wrapper that doesn't match how bots post, and on your own PR you cannot even use `event: REQUEST_CHANGES`.
+
+### How to handle self-review items (the right way)
+
+If you spot a problem in your own PR after pushing:
+
+1. **Fix it** in the next commit on the same branch.
+2. **Reference the file:line in the commit message** so reviewers can find the change in the diff:
+   ```
+   refactor(cashier): address self-review items
+   
+   - PaymentSettlementController.java:117 — add comment on shallow snapshot
+   - settle_non_cash.xhtml:203 — use lastSettlementBill.institution.name
+   - PaymentSettlementController.java:150 — drop redundant state reset
+   ```
+3. **Push.** Reviewers see the new commit in the PR diff. No new threads created. No manual resolves needed.
+4. If you're deferring an item rather than fixing it, **add a line to the PR description** explaining the decision — do not file an inline comment.
 
 ### Practical recipes
-
-**Standalone inline comment on a specific line:**
-```bash
-SHA=$(git rev-parse HEAD)
-gh api -X POST "repos/hmislk/hmis/pulls/<PR>/comments" \
-  -f commit_id="$SHA" \
-  -f path="src/main/java/.../Foo.java" \
-  -F line=42 \
-  -f side="RIGHT" \
-  -f body="Body text here."
-```
-
-**Threaded reply under an existing comment (id from `/comments` list):**
-```bash
-gh api -X POST "repos/hmislk/hmis/pulls/<PR>/comments/<COMMENT_ID>/replies" \
-  -f body="Please resolve — <action>."
-```
 
 **List existing inline comments with IDs (find a parent to reply to):**
 ```bash
@@ -154,9 +160,17 @@ gh api "repos/hmislk/hmis/pulls/<PR>/comments" \
   --jq '.[] | "\(.id) \(.user.login) \(.path):\(.line // .original_line)"'
 ```
 
-**Cannot do** `event: REQUEST_CHANGES` on your own PR. Use `event: COMMENT` instead, or post standalone comments without a review wrapper.
+**Threaded reply under an existing comment** (this is the only legitimate reply form):
+```bash
+gh api -X POST "repos/hmislk/hmis/pulls/<PR>/comments/<COMMENT_ID>/replies" \
+  -f body="Fixed in <commit-sha>: <what was changed>."
+```
 
-### Cleanup
+> **Do not** post new top-level inline comments (`POST /pulls/{pr}/comments`) on your own PR — those create new threads that the author must manually resolve. Use a follow-up commit instead.
+
+**Cannot do** `event: REQUEST_CHANGES` on your own PR. Use `event: COMMENT` if you must use the reviews endpoint, but prefer threaded replies to existing reviewer comments and a single follow-up commit for your own findings.
+
+### Cleanup (when you've already made the mistake)
 
 - Delete an inline comment: `gh api -X DELETE repos/<o>/<r>/pulls/comments/<id>`
 - Delete a general PR comment: `gh api -X DELETE repos/<o>/<r>/issues/comments/<id>`
@@ -165,6 +179,7 @@ gh api "repos/hmislk/hmis/pulls/<PR>/comments" \
 ## Notes
 
 - All PRs target `development`, never `master`
-- "Re-request review" is distinct from just pushing — always click it
-- Replying to each comment individually maintains a clean audit trail
+- "Re-request review" is distinct from just pushing — always click it once, at the end
+- Replying ONLY UNDER existing reviewer threads maintains a clean audit trail without creating new manual-resolve chores
+- Self-review items go in commit messages, not as new inline comments
 - The `/review-pr` skill automates the investigation and fix steps of this workflow

--- a/developer_docs/git/pr-review-workflow.md
+++ b/developer_docs/git/pr-review-workflow.md
@@ -82,6 +82,8 @@ Then on GitHub, reply to **each reviewer comment individually** with:
 
 Do **not** resolve other reviewers' conversations yourself. CodeRabbit auto-resolves when it detects the fix. For human reviewers, let them resolve.
 
+See [§ Posting PR Comments via gh CLI](#posting-pr-comments-via-gh-cli) below for the correct API endpoints — using the wrong one bundles comments under a review wrapper or posts them as general PR comments that aren't tied to a line.
+
 ### 7. Re-Request Review
 
 After pushing fixes, click **"Re-request review"** on the PR page to notify reviewers. Do not wait for them to notice the new push.
@@ -99,6 +101,57 @@ Check that CI is green after pushing before replying to comments. A fix that bre
 ```bash
 git branch -d <branch-name>
 ```
+
+## Posting PR Comments via gh CLI
+
+Four different ways exist to post comments on a PR. Picking the wrong one is the most common mistake. Each behaves differently in the GitHub UI:
+
+| What you want | Endpoint | gh / API command | Visible as |
+|---|---|---|---|
+| Reply UNDER an existing inline comment (threaded) | `POST /pulls/{pr}/comments/{id}/replies` | `gh api -X POST repos/<o>/<r>/pulls/<pr>/comments/<id>/replies -f body="..."` | Nested reply in the thread |
+| Standalone inline comment on a specific line | `POST /pulls/{pr}/comments` | `gh api -X POST repos/<o>/<r>/pulls/<pr>/comments -f commit_id=<sha> -f path=<file> -F line=<n> -f side=RIGHT -f body="..."` | Top-level inline comment (same shape as CodeRabbit/Codex) |
+| Multiple inline comments grouped under a "review" | `POST /pulls/{pr}/reviews` with `comments[]` | `gh pr review` or `gh api -X POST repos/<o>/<r>/pulls/<pr>/reviews --input <json>` | All grouped under a single review wrapper — NOT what bots do |
+| General PR-level comment (conversation tab) | `POST /issues/{n}/comments` | `gh pr comment <pr> --body "..."` | NOT tied to a line; lands in the Conversation tab |
+
+### When to use which
+
+- **Replying to a bot comment** (CodeRabbit / Codex / human reviewer) → always use the `/replies` endpoint. The reply stays in the parent's thread and the bot can detect the conversation correctly.
+- **Filing a new review item on a specific line** → use `POST /pulls/{pr}/comments` directly. This produces an individual standalone inline comment, the same shape as CodeRabbit/Codex post. Each one is its own resolvable thread.
+- **A PR-wide observation** (e.g. "this PR needs a Linear ticket") → `gh pr comment` is acceptable, but prefer inline if it can be tied to a line.
+- **Avoid** `POST /pulls/{pr}/reviews` with bundled `comments[]` unless you're submitting a formal review pass — it groups all comments under one "review" wrapper, which makes them harder to resolve individually and does not match how bots post.
+
+### Practical recipes
+
+**Standalone inline comment on a specific line:**
+```bash
+SHA=$(git rev-parse HEAD)
+gh api -X POST "repos/hmislk/hmis/pulls/<PR>/comments" \
+  -f commit_id="$SHA" \
+  -f path="src/main/java/.../Foo.java" \
+  -F line=42 \
+  -f side="RIGHT" \
+  -f body="Body text here."
+```
+
+**Threaded reply under an existing comment (id from `/comments` list):**
+```bash
+gh api -X POST "repos/hmislk/hmis/pulls/<PR>/comments/<COMMENT_ID>/replies" \
+  -f body="Please resolve — <action>."
+```
+
+**List existing inline comments with IDs (find a parent to reply to):**
+```bash
+gh api "repos/hmislk/hmis/pulls/<PR>/comments" \
+  --jq '.[] | "\(.id) \(.user.login) \(.path):\(.line // .original_line)"'
+```
+
+**Cannot do** `event: REQUEST_CHANGES` on your own PR. Use `event: COMMENT` instead, or post standalone comments without a review wrapper.
+
+### Cleanup
+
+- Delete an inline comment: `gh api -X DELETE repos/<o>/<r>/pulls/comments/<id>`
+- Delete a general PR comment: `gh api -X DELETE repos/<o>/<r>/issues/comments/<id>`
+- A review wrapper itself can be dismissed but its comments persist — delete each comment individually if you need to remove them.
 
 ## Notes
 

--- a/developer_docs/git/pr-review-workflow.md
+++ b/developer_docs/git/pr-review-workflow.md
@@ -104,6 +104,15 @@ git branch -d <branch-name>
 
 ## Posting PR Comments via gh CLI
 
+> **⚠️ Reply only after you have fixed (or explicitly dismissed) the comment.**
+>
+> Bots (CodeRabbit, Codex) **cannot fix anything** — they only identify issues. Replying "please resolve" / "please address" / "please add the null guard" treats the bot as if it were an assignee, which it is not. Every reply you post under a reviewer's comment must describe action **taken**:
+>
+> - **Valid + fixed** → "Fixed in `<commit-sha>`: `<what was changed>`"
+> - **Dismissed** → "Dismissed because: `<specific reasoning>`"
+>
+> The sequence is always: **discuss → fix → push → reply → re-request review**. Never reply before pushing the fix. Same rule applies to your own standalone review items — once filed, *you* (or the PR author) must do the work, not the bot.
+
 Four different ways exist to post comments on a PR. Picking the wrong one is the most common mistake. Each behaves differently in the GitHub UI:
 
 | What you want | Endpoint | gh / API command | Visible as |

--- a/developer_docs/git/pr-review-workflow.md
+++ b/developer_docs/git/pr-review-workflow.md
@@ -142,7 +142,7 @@ If you spot a problem in your own PR after pushing:
 
 1. **Fix it** in the next commit on the same branch.
 2. **Reference the file:line in the commit message** so reviewers can find the change in the diff:
-   ```
+   ```text
    refactor(cashier): address self-review items
    
    - PaymentSettlementController.java:117 — add comment on shallow snapshot


### PR DESCRIPTION
## Summary

Adds the **cardinal rules for posting comments on a PR** to `developer_docs/git/pr-review-workflow.md`, `.claude/skills/review-pr/SKILL.md`, and `.codex/skills/review-pr/SKILL.md` — captured from two real cleanup cycles on PR #20977 and PR #20983.

The previous workflow doc only said "reply to each comment individually". It did not say:

1. **Don't create new top-level inline comments** — they create new threads that the author must manually resolve. Filing 7 self-review items as new inline comments creates 7 chores. Noise, not review.
2. **Self-review items go in the commit message** (or PR description if deferred). Reference file:line in the commit body so reviewers can spot the change in the diff.
3. **Replies go UNDER existing reviewer threads only** (`POST /pulls/{pr}/comments/{id}/replies`). Never as new top-level comments.
4. **Bots can't fix anything** — replies must describe action *taken*, not *requested*. "Please resolve" / "please address" is wrong.
5. **ONE re-review request at the end**, not one per item.

Order is always: **discuss → fix → push → reply to existing threads → one re-review request**.

Also:
- Adds the endpoint cheat sheet (`/replies` vs `/pulls/{pr}/comments` vs `/reviews` vs `/issues/{n}/comments`)
- Adds practical recipes for listing comment IDs and posting threaded replies
- Removes the previous "standalone inline comment recipe" since it was actively encouraging the wrong workflow
- Mirrors all of this to the `.codex/skills/review-pr/SKILL.md` mirror, which previously had no coverage of this at all

## Test plan

- [ ] Doc-only changes — no code, no compile needed
- [ ] Anchor links from the `/review-pr` skill resolve to the right section
- [ ] Examples are accurate against the current GitHub REST API
- [ ] `.codex` mirror has the same cardinal rules as `.claude`

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated PR review workflow to require a strict discuss → fix → push → reply → re-request-review sequence; replies allowed only after a comment is fixed or explicitly dismissed and must describe the action taken.
  * Clarified when to use threaded replies vs standalone, grouped, or PR-level comments.
  * Added practical guidance for posting, locating, and cleaning up PR comments via supported tooling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hmislk/hmis/pull/20980?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->