### PR TITLE
fix(lims): skip wrong-component rows when writing analyzer results (#20981)

### DIFF
--- a/src/main/java/com/divudi/ws/lims/LimsMiddlewareController.java
+++ b/src/main/java/com/divudi/ws/lims/LimsMiddlewareController.java
@@ -1208,26 +1208,9 @@ public class LimsMiddlewareController {
                                     temFlag = true;
                                     valueToSave = true;
                                 } else {
-                                    // // System.out.println("3 result = " + result);
-                                    priv.setStrValue(result);
-
-                                    Double dbl = 0d;
-                                    try {
-                                        dbl = Double.parseDouble(result);
-                                        // // System.out.println("3 dbl = " + dbl);
-                                    } catch (Exception e) {
-                                    }
-                                    priv.setDoubleValue(dbl);
-                                    // // System.out.println("3 priv.getDoubleValue() = " + priv.getDoubleValue());
-                                    if (priv.getId() == null) {
-                                        // // System.out.println("3 new priv created = " + dbl);
-                                        patientReportItemValueFacade.create(priv);
-                                    } else {
-                                        // // System.out.println("3 new priv Updates = " + dbl);
-                                        patientReportItemValueFacade.edit(priv);
-                                    }
-                                    temFlag = true;
-                                    valueToSave = true;
+                                    // Both ps.investigationComponant and priv.sampleComponent are set
+                                    // but they don't match — this row belongs to a different time point.
+                                    // Skip it; the correct row will be handled in a later iteration.
                                 }
                             }
 


### PR DESCRIPTION
## Summary

- In `LimsMiddlewareController.addResultToReport()`, the `else` branch of the component-matching fallback was unconditionally writing the incoming analyzer value to every `PatientReportItemValue` whose test code matched, even when `priv.sampleComponent` and `ps.investigationComponant` were both set but pointed to **different** time points
- This caused each new result for a multi-sample investigation (BSP, OGTT) to overwrite all previously written component values instead of filling only its own slot
- Fix: the `else` branch is now a no-op — when both sides are non-null and don't match, the row is skipped and the correct matching row is handled in a later iteration

## Root cause (confirmed from production data)

Coop DB `patientreport` 9577263 (BLOOD SUGAR PROFILES 3-sample, pi 9562840) showed BSP/PL value `117.2` written into the BSP/PB row — both rows ended up with the same value. The BSP/PD row was untouched (result not yet received).

The three write paths in the fallback block:
| Branch | Condition | Behaviour |
|--------|-----------|-----------|
| 1 | Either side null | Write (correct — single-component tests) |
| 2 | Both set, components **match** | Write (correct) |
| **3 (else)** | Both set, components **don't match** | **Was writing — now skipped** |

## Safety for single-component tests

`ps.investigationComponant` is `null` for all single-component investigations (FBS, FBC, etc.) — they always hit Branch 1 and are completely unaffected by this change.

## Test plan

- [ ] Send analyzer results for a multi-sample investigation (BSP or OGTT) — verify each time point receives only its own value
- [ ] Send analyzer results for a single-component test (FBS) — verify value is still written correctly
- [ ] Verify re-sending a result for the same sample updates the correct row without touching other components

Closes #20981

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where laboratory results could be incorrectly saved to mismatched entries, ensuring results are only persisted when the required components properly align.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hmislk/hmis/pull/20982?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->