### PR TITLE
hotfix(lims): skip wrong-component rows when writing analyzer results (#20981)

### DIFF
--- a/src/main/java/com/divudi/ws/lims/LimsMiddlewareController.java
+++ b/src/main/java/com/divudi/ws/lims/LimsMiddlewareController.java
@@ -1208,26 +1208,9 @@ public class LimsMiddlewareController {
                                     temFlag = true;
                                     valueToSave = true;
                                 } else {
-                                    // // System.out.println("3 result = " + result);
-                                    priv.setStrValue(result);
-
-                                    Double dbl = 0d;
-                                    try {
-                                        dbl = Double.parseDouble(result);
-                                        // // System.out.println("3 dbl = " + dbl);
-                                    } catch (Exception e) {
-                                    }
-                                    priv.setDoubleValue(dbl);
-                                    // // System.out.println("3 priv.getDoubleValue() = " + priv.getDoubleValue());
-                                    if (priv.getId() == null) {
-                                        // // System.out.println("3 new priv created = " + dbl);
-                                        patientReportItemValueFacade.create(priv);
-                                    } else {
-                                        // // System.out.println("3 new priv Updates = " + dbl);
-                                        patientReportItemValueFacade.edit(priv);
-                                    }
-                                    temFlag = true;
-                                    valueToSave = true;
+                                    // Both ps.investigationComponant and priv.sampleComponent are set
+                                    // but they don't match — this row belongs to a different time point.
+                                    // Skip it; the correct row will be handled in a later iteration.
                                 }
                             }
 


### PR DESCRIPTION
## Summary

Hotfix cherry-picked from PR #20982 (merged to `development`).

- Analyzer results for multi-sample investigations (BSP, OGTT) were overwriting earlier time-point values instead of placing each result in its correct slot
- Root cause: the `else` branch in `addResultToReport()` wrote unconditionally to any `PatientReportItemValue` whose test code matched, even when `priv.sampleComponent` and `ps.investigationComponant` were both set but belonged to **different** time points
- Fix: `else` branch is now a no-op — mismatched component rows are skipped; the correct row is handled in the next iteration

## Test plan

- [x] Tested all scenarios on local instance against coop data — confirmed working by developer before requesting hotfix

## Safety

Single-component tests (`ps.investigationComponant == null`) are unaffected — they always take Branch 1.

Fixes #20981

🤖 Generated with [Claude Code](https://claude.com/claude-code)