### PR TITLE
feat(pharmacy): archive read-paths, manual archival UI, and run fix (#20729)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,6 +24,9 @@
 9. **🚨 JPQL FIRST, NATIVE SQL LAST**: Always use JPQL for database queries. Native SQL (`nativeScalarQuery`, `executeNativeSql`) is only permitted when there is a significant, demonstrated performance constraint that JPQL cannot address. Never reach for native SQL just because JPQL is harder to write.
 10. **🚨 USE `findLongByJpql` FOR COUNT QUERIES**: Always use `findLongByJpql` (not `findDoubleByJpql`) for JPQL `COUNT(...)` queries. `COUNT` returns a `Long`; using `findDoubleByJpql` causes a silent `ClassCastException` caught internally, returning `0.0` every time and making the check always pass.
 
+### persistence.xml — Local JNDI Lifecycle
+17. **🚨 RESTORE LOCAL JNDI AFTER EVERY PUSH**: Immediately after every `git push`, replace the CI/CD placeholders in `persistence.xml` back to the local JNDI names — `${JDBC_DATASOURCE}` → `jdbc/coop` and `${JDBC_AUDIT_DATASOURCE}` → `jdbc/ruhunuAudit`. Leave the change **unstaged**. Do this without being asked. The developer needs local Payara to connect right away for testing.
+
 ### Deployment
 16. **🚨 NEVER DEPLOY MANUALLY AS ROOT**: NEVER use `sudo` or root to copy WARs, run `asadmin`, or touch Payara's application/log directories directly. Root-owned files in `/opt/payara5/glassfish/domains/domain1/` (applications, generated, logs) block all future CI/CD deployments — `asadmin undeploy` and `deploy` will fail with permission errors. **All deployments MUST go through GitHub Actions CI/CD.** If a manual fix is absolutely needed, use `appuser` only. See [Deployment Recovery Guide](developer_docs/deployment/deployment-recovery-guide.md).
 

--- a/developer_docs/pharmacy/stock-history-archive-read-paths.md
+++ b/developer_docs/pharmacy/stock-history-archive-read-paths.md
@@ -1,0 +1,120 @@
+# StockHistory Archive Read Paths
+
+**Issue**: [#20729](https://github.com/hmislk/hmis/issues/20729)  
+**Branch**: `20729-stockhistory-archive-read-paths`  
+**Related**: [#20726](https://github.com/hmislk/hmis/issues/20726) (StockHistory archival), [#20978](https://github.com/hmislk/hmis/issues/20978) (REST API includeArchived — deferred)
+
+## Background
+
+Issue #20726 introduced archival of `StockHistory` rows older than the configured retention period (default 2 years) into a separate `StockHistoryArchive` table. This document audits all read paths that query `StockHistory` and records which ones were updated to optionally include archived data.
+
+MySQL partitioning was considered but ruled out: `StockHistory` has 7 foreign key constraints, and MySQL cannot partition tables with FK constraints.
+
+## Architecture: Two-Entity Strategy
+
+`StockHistoryArchive` is a JPA entity with the same schema as `StockHistory` (same columns, same FK relationships). All JPQL queries that work on `StockHistory` work identically on `StockHistoryArchive` by substituting the entity name.
+
+Two merge strategies are used depending on query type:
+
+### 1. Two-Query Merge (for JPQL date-range queries)
+Run the same JPQL against both entities, merge results in Java, sort by `createdAt`. Used by:
+- Bin card (DTO)
+- Stock ledger (DTO)
+- `fillStockHistories()` in the department stock history page
+
+### 2. Native SQL UNION (for MAX(id) subquery patterns)
+The inner `MAX(id)` subquery cannot be expressed in JPQL with two entities. A private helper `shUnionSrc(columns)` in `StockHistoryFacade` builds:
+```sql
+(SELECT <columns> FROM STOCKHISTORY UNION ALL SELECT <columns> FROM STOCKHISTORYARCHIVE)
+```
+Used by the three `calculateStockValueAt*RateOptimized` methods.
+
+### 3. ID-Based Deduplication (for closing stock reports)
+Closing stock reports compute the latest QOH per item or batch. Since STOCKHISTORY always holds records newer than STOCKHISTORYARCHIVE (archival moves old rows out), live results always take precedence. Archive rows are added only if their item/batch ID is not already present in live results.
+
+## Affected Read Paths
+
+### A. Updated — "Include Archived" Toggle Added
+
+| Report Page | Backing Bean | Method(s) Updated | Toggle Field |
+|---|---|---|---|
+| `pharmacy/bin_card_dto.xhtml` | `PharmacyErrorChecking` | `processBinCardWithDTO()` → `findBinCardDTOs(6-arg)` | `includeArchived` |
+| `reports/inventoryReports/stock_ledger_dto.xhtml` | `PharmacyReportController` | `processStockLedgerDtoReport()` | `includeArchived` |
+| `reports/inventoryReports/closing_stock_report.xhtml` | `PharmacyReportController` | `processClosingStockForItemReport()`, `processClosingStockForBatchReport()` | `includeArchived` |
+| `pharmacy/pharmacy_department_stock_history.xhtml` | `StockHistoryController` | `fillHistoryAvailableDays()`, `fillStockHistories(boolean)` | `includeArchived` |
+| Daily Stock Balance Report | `PharmacySummaryReportController` | `calculateStockValueAtRetailRate(Date, Department)` (private) | `includeArchived` |
+
+### B. Not Updated — Archive Not Required
+
+| Location | Reason |
+|---|---|
+| `DataAdministrationController.repairStockHistoryRates()` | Operates on recent data only; not a user-facing report |
+| REST API `GET /stock_history` (`StockHistoryResource`) | Deferred to issue #20978 |
+
+## Implementation Details
+
+### StockHistoryFacade
+
+**New method overloads** (3-arg, `includeArchived` flag):
+- `calculateStockValueAtRetailRateOptimized(Date, Long departmentId, boolean includeArchived)`
+- `calculateStockValueAtCostRateOptimized(Date, Long departmentId, boolean includeArchived)`
+- `calculateStockValueAtPurchaseRateOptimized(Date, Long departmentId, boolean includeArchived)`
+
+When `includeArchived=false`, each delegates to the existing 2-arg overload (no change in behavior). When `true`, the inner `MAX(id)` subquery is rewritten as a native SQL UNION query using the `shUnionSrc()` helper.
+
+**Private helper**:
+```java
+private String shUnionSrc(String columns) {
+    return "(SELECT " + columns + " FROM STOCKHISTORY UNION ALL SELECT " + columns
+           + " FROM STOCKHISTORYARCHIVE)";
+}
+```
+
+### StockHistoryController
+
+Added:
+- `@EJB StockHistoryArchiveFacade archiveFacade`
+- `boolean includeArchived = false` (with getter/setter)
+- `List<StockHistoryArchive> pharmacyStockHistoriesArchive` (read-only getter; populated when `includeArchived=true`)
+
+`fillHistoryAvailableDays()`: when `includeArchived=true`, queries archive entity for date list and merges (sorted descending).
+
+`fillStockHistories(boolean withoutZeroStock)`: when `includeArchived=true`, also queries archive entity via `archiveFacade.findByJpql(...)`, stores results in `pharmacyStockHistoriesArchive`, and adds archive stock values to controller totals.
+
+`findBinCardDTOs(6-arg)`: runs live JPQL then, if `withArchive=true`, runs same JPQL against `StockHistoryArchive` (entity name substitution), merges and sorts by `PharmacyBinCardDTO.getCreatedAt()`.
+
+### PharmacyErrorChecking
+
+Added `boolean includeArchived = false`. `processBinCardWithDTO()` passes `includeArchived` to `findBinCardDTOs(6-arg)`.
+
+### PharmacyReportController
+
+Added `boolean includeArchived = false` (with `isIncludeArchived()` / `setIncludeArchived()`).
+
+`processStockLedgerDtoReport()`: after live JPQL, when `includeArchived=true` runs archive query (entity name substitution), appends results, sorts by `StockLedgerDTO.getCreatedAt()`.
+
+`processClosingStockForItemReport()`: after live rows processed, when `includeArchived=true` runs archive JPQL, deduplicates by `row.getItem().getId()` (live takes precedence), applies same scope/consignment logic as live.
+
+`processClosingStockForBatchReport()`: same pattern, deduplicates by `row.getItemBatch().getId()`.
+
+### PharmacySummaryReportController
+
+Added `boolean includeArchived = false`. `calculateStockValueAtRetailRate(Date, Department)`: when `includeArchived=true`, immediately delegates to `stockHistoryFacade.calculateStockValueAtRetailRateOptimized(date, dept != null ? dept.getId() : null, true)` which uses the native SQL UNION path.
+
+## XHTML Changes
+
+Each report page gained a `<p:selectBooleanCheckbox>` bound to the backing bean's `includeArchived` property:
+
+- `bin_card_dto.xhtml`: checkbox before the Generate Report button
+- `stock_ledger_dto.xhtml`: checkbox above the Process button row
+- `closing_stock_report.xhtml`: checkbox below the Consignment Item checkbox (matching existing style)
+- `pharmacy_department_stock_history.xhtml`: checkbox before Display Available Days + separate `tblArchiveHistories` data table rendered when `pharmacyStockHistoriesArchive` is non-empty
+
+## Deduplication Key Reference
+
+| Report | Dedup Key | Rationale |
+|---|---|---|
+| Closing stock (item-wise) | `row.getItem().getId()` | `PharmacyRow` 18-arg constructor: first arg sets `item.id` |
+| Closing stock (batch-wise) | `row.getItemBatch().getId()` | `PharmacyRow` 24-arg constructor: 8th arg sets `itemBatch.id` |
+| Bin card / Stock ledger | No dedup — time-series rows | All rows from both tables are shown in chronological order |
+| Stock history page | No dedup — snapshot rows | Archive rows shown in separate table section |

--- a/src/main/java/com/divudi/bean/pharmacy/ItemBatchArchivalController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/ItemBatchArchivalController.java
@@ -52,7 +52,6 @@ public class ItemBatchArchivalController implements Serializable {
 
     public String navigateToArchiveItemBatch() {
         resetDefaults();
-        lastResult = null;
         candidateCount = null;
         return "/dataAdmin/archive_item_batch?faces-redirect=true";
     }
@@ -76,7 +75,6 @@ public class ItemBatchArchivalController implements Serializable {
     }
 
     public void preview() {
-        lastResult = null;
         if (!validateInputs()) {
             return;
         }

--- a/src/main/java/com/divudi/bean/pharmacy/ItemBatchArchivalController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/ItemBatchArchivalController.java
@@ -8,6 +8,7 @@ import com.divudi.bean.common.ConfigOptionApplicationController;
 import com.divudi.core.data.dto.ArchiveResult;
 import com.divudi.core.util.JsfUtil;
 import com.divudi.service.archival.ItemBatchArchivalService;
+import com.divudi.service.archival.ItemBatchArchivalTracker;
 import java.io.Serializable;
 import java.util.Calendar;
 import java.util.Date;
@@ -40,11 +41,13 @@ public class ItemBatchArchivalController implements Serializable {
     @Inject
     private ConfigOptionApplicationController configOptionController;
 
+    @Inject
+    private ItemBatchArchivalTracker tracker;
+
     private Date cutoffDate;
     private int batchSize;
     private int maxBatches;
     private boolean dryRun;
-    private ArchiveResult lastResult;
     private Long candidateCount;
 
     public String navigateToArchiveItemBatch() {
@@ -91,11 +94,19 @@ public class ItemBatchArchivalController implements Serializable {
         if (!validateInputs()) {
             return;
         }
+        if (tracker.isRunning()) {
+            JsfUtil.addErrorMessage("Archival is already in progress.");
+            return;
+        }
         try {
-            lastResult = archivalService.archive(cutoffDate, batchSize, maxBatches, dryRun);
             if (dryRun) {
-                JsfUtil.addSuccessMessage("Dry run: " + lastResult.getCandidateCount()
+                ArchiveResult result = archivalService.archive(cutoffDate, batchSize, maxBatches, true);
+                tracker.start(result.getCandidateCount(), 0);
+                tracker.finish(result);
+                JsfUtil.addSuccessMessage("Dry run: " + result.getCandidateCount()
                         + " ItemBatch row(s) would be archived");
+            } else {
+                archivalService.archiveAsync(cutoffDate, batchSize, maxBatches);
             }
         } catch (Exception ex) {
             LOGGER.log(Level.SEVERE, "ItemBatch archive run failed", ex);
@@ -135,6 +146,7 @@ public class ItemBatchArchivalController implements Serializable {
     public boolean isDryRun() { return dryRun; }
     public void setDryRun(boolean dryRun) { this.dryRun = dryRun; }
 
-    public ArchiveResult getLastResult() { return lastResult; }
+    public ArchiveResult getLastResult() { return tracker.getLastResult(); }
+    public ItemBatchArchivalTracker getTracker() { return tracker; }
     public Long getCandidateCount() { return candidateCount; }
 }

--- a/src/main/java/com/divudi/bean/pharmacy/ItemBatchArchivalController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/ItemBatchArchivalController.java
@@ -96,8 +96,6 @@ public class ItemBatchArchivalController implements Serializable {
             if (dryRun) {
                 JsfUtil.addSuccessMessage("Dry run: " + lastResult.getCandidateCount()
                         + " ItemBatch row(s) would be archived");
-            } else {
-                JsfUtil.addSuccessMessage(lastResult.getMessage());
             }
         } catch (Exception ex) {
             LOGGER.log(Level.SEVERE, "ItemBatch archive run failed", ex);

--- a/src/main/java/com/divudi/bean/pharmacy/PharmacyErrorChecking.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacyErrorChecking.java
@@ -70,6 +70,7 @@ public class PharmacyErrorChecking implements Serializable {
     double currentPurchaseValue;
     private double binCardTotalIn;
     private double binCardTotalOut;
+    private boolean includeArchived = false;
     @Named
     @Inject
     private SessionController sessionController;
@@ -134,7 +135,7 @@ public class PharmacyErrorChecking implements Serializable {
      */
     public void processBinCardWithDTO() {
         reportTimerController.trackReportExecution(() -> {
-            binCardEntries = stockHistoryController.findBinCardDTOs(fromDate, toDate, null, department, item);
+            binCardEntries = stockHistoryController.findBinCardDTOs(fromDate, toDate, null, department, item, includeArchived);
 
             if (configOptionApplicationController.getBooleanValueByKey("Pharmacy Bin Card - Hide Adjustment Bills in Bin Card", true)) {
                 List<BillType> bts = new ArrayList<>();
@@ -640,5 +641,8 @@ public class PharmacyErrorChecking implements Serializable {
     public double getBinCardNetTotal() {
         return binCardTotalIn - binCardTotalOut;
     }
+
+    public boolean isIncludeArchived() { return includeArchived; }
+    public void setIncludeArchived(boolean includeArchived) { this.includeArchived = includeArchived; }
 
 }

--- a/src/main/java/com/divudi/bean/pharmacy/PharmacySummaryReportController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacySummaryReportController.java
@@ -326,6 +326,8 @@ public class PharmacySummaryReportController implements Serializable {
 
     private List<HistoricalRecord> historicalRecords;
 
+    private boolean includeArchived = false;
+
     //transferOuts;
     //adjustments;
 // </editor-fold>
@@ -469,6 +471,9 @@ public class PharmacySummaryReportController implements Serializable {
      * @return The total stock value at retail rate, or 0.0 if calculation fails
      */
     private double calculateStockValueAtRetailRate(Date date, Department dept) {
+        if (includeArchived) {
+            return stockHistoryFacade.calculateStockValueAtRetailRateOptimized(date, dept != null ? dept.getId() : null, true);
+        }
         try {
             Map<String, Object> params = new HashMap<>();
             StringBuilder jpql = new StringBuilder();
@@ -3951,6 +3956,14 @@ public class PharmacySummaryReportController implements Serializable {
 
     public void setFloatRows(List<IncomeRow> floatRows) {
         this.floatRows = floatRows;
+    }
+
+    public boolean isIncludeArchived() {
+        return includeArchived;
+    }
+
+    public void setIncludeArchived(boolean includeArchived) {
+        this.includeArchived = includeArchived;
     }
 
     public void retireHistoricalRecord(HistoricalRecord hr) {

--- a/src/main/java/com/divudi/bean/pharmacy/StockHistoryArchivalController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/StockHistoryArchivalController.java
@@ -8,6 +8,7 @@ import com.divudi.bean.common.ConfigOptionApplicationController;
 import com.divudi.core.data.dto.ArchiveResult;
 import com.divudi.core.util.JsfUtil;
 import com.divudi.service.archival.StockHistoryArchivalService;
+import com.divudi.service.archival.StockHistoryArchivalTracker;
 import java.io.Serializable;
 import java.util.Calendar;
 import java.util.Date;
@@ -40,12 +41,14 @@ public class StockHistoryArchivalController implements Serializable {
     @Inject
     private ConfigOptionApplicationController configOptionController;
 
+    @Inject
+    private StockHistoryArchivalTracker tracker;
+
     private Date cutoffDate;
     private int retentionDays;
     private int batchSize;
     private int maxBatches;
     private boolean dryRun;
-    private ArchiveResult lastResult;
     private Long candidateCount;
 
     public String navigateToArchiveStockHistory() {
@@ -95,11 +98,19 @@ public class StockHistoryArchivalController implements Serializable {
         if (!validateInputs()) {
             return;
         }
+        if (tracker.isRunning()) {
+            JsfUtil.addErrorMessage("Archival is already in progress.");
+            return;
+        }
         try {
-            lastResult = archivalService.archive(cutoffDate, batchSize, maxBatches, dryRun);
             if (dryRun) {
-                JsfUtil.addSuccessMessage("Dry run: " + lastResult.getCandidateCount()
+                ArchiveResult result = archivalService.archive(cutoffDate, batchSize, maxBatches, true);
+                tracker.start(result.getCandidateCount(), 0);
+                tracker.finish(result);
+                JsfUtil.addSuccessMessage("Dry run: " + result.getCandidateCount()
                         + " row(s) would be archived");
+            } else {
+                archivalService.archiveAsync(cutoffDate, batchSize, maxBatches);
             }
         } catch (Exception ex) {
             LOGGER.log(Level.SEVERE, "StockHistory archive run failed", ex);
@@ -142,6 +153,7 @@ public class StockHistoryArchivalController implements Serializable {
     public boolean isDryRun() { return dryRun; }
     public void setDryRun(boolean dryRun) { this.dryRun = dryRun; }
 
-    public ArchiveResult getLastResult() { return lastResult; }
+    public ArchiveResult getLastResult() { return tracker.getLastResult(); }
+    public StockHistoryArchivalTracker getTracker() { return tracker; }
     public Long getCandidateCount() { return candidateCount; }
 }

--- a/src/main/java/com/divudi/bean/pharmacy/StockHistoryArchivalController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/StockHistoryArchivalController.java
@@ -53,7 +53,6 @@ public class StockHistoryArchivalController implements Serializable {
 
     public String navigateToArchiveStockHistory() {
         resetDefaults();
-        lastResult = null;
         candidateCount = null;
         return "/dataAdmin/archive_stock_history?faces-redirect=true";
     }

--- a/src/main/java/com/divudi/bean/pharmacy/StockHistoryArchivalController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/StockHistoryArchivalController.java
@@ -100,8 +100,6 @@ public class StockHistoryArchivalController implements Serializable {
             if (dryRun) {
                 JsfUtil.addSuccessMessage("Dry run: " + lastResult.getCandidateCount()
                         + " row(s) would be archived");
-            } else {
-                JsfUtil.addSuccessMessage(lastResult.getMessage());
             }
         } catch (Exception ex) {
             LOGGER.log(Level.SEVERE, "StockHistory archive run failed", ex);

--- a/src/main/java/com/divudi/bean/pharmacy/StockHistoryArchivalController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/StockHistoryArchivalController.java
@@ -41,6 +41,7 @@ public class StockHistoryArchivalController implements Serializable {
     private ConfigOptionApplicationController configOptionController;
 
     private Date cutoffDate;
+    private int retentionDays;
     private int batchSize;
     private int maxBatches;
     private boolean dryRun;
@@ -55,17 +56,21 @@ public class StockHistoryArchivalController implements Serializable {
     }
 
     private void resetDefaults() {
-        int retentionDays = sanitisePositive(configOptionController.getIntegerValueByKey(
+        retentionDays = sanitisePositive(configOptionController.getIntegerValueByKey(
                 "StockHistory Archive - Retention Days", 730), 730);
-        Calendar cal = Calendar.getInstance();
-        cal.add(Calendar.DATE, -retentionDays);
-        cutoffDate = cal.getTime();
+        recalculateCutoff();
 
         batchSize = sanitisePositive(configOptionController.getIntegerValueByKey(
                 "StockHistory Archive - Batch Size", 2000), 2000);
         maxBatches = sanitisePositive(configOptionController.getIntegerValueByKey(
                 "StockHistory Archive - Max Batches Per Run", 50), 50);
         dryRun = true;
+    }
+
+    public void recalculateCutoff() {
+        Calendar cal = Calendar.getInstance();
+        cal.add(Calendar.DATE, -retentionDays);
+        cutoffDate = cal.getTime();
     }
 
     private static int sanitisePositive(Integer raw, int fallback) {
@@ -126,6 +131,9 @@ public class StockHistoryArchivalController implements Serializable {
 
     public Date getCutoffDate() { return cutoffDate; }
     public void setCutoffDate(Date cutoffDate) { this.cutoffDate = cutoffDate; }
+
+    public int getRetentionDays() { return retentionDays; }
+    public void setRetentionDays(int retentionDays) { this.retentionDays = retentionDays; }
 
     public int getBatchSize() { return batchSize; }
     public void setBatchSize(int batchSize) { this.batchSize = batchSize; }

--- a/src/main/java/com/divudi/bean/pharmacy/StockHistoryController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/StockHistoryController.java
@@ -11,8 +11,12 @@ import com.divudi.core.data.HistoryType;
 import com.divudi.ejb.StockHistoryRecorder;
 import com.divudi.core.entity.Department;
 import com.divudi.core.entity.pharmacy.StockHistory;
+import com.divudi.core.entity.pharmacy.StockHistoryArchive;
 import com.divudi.core.data.dto.PharmacyBinCardDTO;
+import com.divudi.core.facade.StockHistoryArchiveFacade;
 import com.divudi.core.facade.StockHistoryFacade;
+import java.util.ArrayList;
+import java.util.Comparator;
 import com.divudi.core.util.JsfUtil;
 import com.divudi.core.entity.Item;
 import com.divudi.core.util.CommonFunctions;
@@ -44,6 +48,8 @@ public class StockHistoryController implements Serializable {
     @EJB
     private StockHistoryFacade facade;
     @EJB
+    private StockHistoryArchiveFacade archiveFacade;
+    @EJB
     StockHistoryRecorder stockHistoryRecorder;
     // </editor-fold>
     // <editor-fold defaultstate="collapsed" desc="Controllers">
@@ -63,6 +69,8 @@ public class StockHistoryController implements Serializable {
 
     private double totalStockSaleValue;
     private double totalStockPurchaseValue;
+    private boolean includeArchived = false;
+    private List<StockHistoryArchive> pharmacyStockHistoriesArchive;
 
     // </editor-fold>
     // <editor-fold defaultstate="collapsed" desc="Constructors">
@@ -126,7 +134,17 @@ public class StockHistoryController implements Serializable {
 //        }
         ////// // System.out.println("m = " + m);
         pharmacyStockHistoryDays = facade.findDateListByJpql(jpql, m, TemporalType.TIMESTAMP);
-        for (Date d : pharmacyStockHistoryDays) {
+        if (includeArchived) {
+            String archiveJpql = jpql.replace("from StockHistory s", "from StockHistoryArchive s");
+            List<Date> archiveDays = archiveFacade.findDateListByJpql(archiveJpql, m, TemporalType.TIMESTAMP);
+            List<Date> merged = new ArrayList<>(pharmacyStockHistoryDays);
+            for (Date d : archiveDays) {
+                if (!merged.contains(d)) {
+                    merged.add(d);
+                }
+            }
+            merged.sort(Comparator.reverseOrder());
+            pharmacyStockHistoryDays = merged;
         }
 
     }
@@ -165,41 +183,58 @@ public class StockHistoryController implements Serializable {
      * This method includes the stockQty and batchNo fields needed for hotfix compatibility.
      */
     public List<PharmacyBinCardDTO> findBinCardDTOs(Date fd, Date td, HistoryType ht, Department dep, Item i) {
-        StringBuilder jpql = new StringBuilder();
-        jpql.append("select new com.divudi.core.data.dto.PharmacyBinCardDTO(")
-                .append("s.id, s.pbItem.billItem.bill.id, s.createdAt, ")
-                .append("s.pbItem.billItem.bill.billType, ")
-                .append("s.pbItem.billItem.bill.billTypeAtomic, ")
-                .append("s.pbItem.billItem.item.name, ")
-                .append("s.pbItem.qty, s.pbItem.freeQty, ")
-                .append("s.pbItem.qtyPacks, s.pbItem.freeQtyPacks, ")
-                .append("s.pbItem.billItem.item.dblValue, s.itemStock, ")
-                .append("s.stockQty, s.pbItem.itemBatch.batchNo")
-                .append(") from StockHistory s ")
-                .append("where s.createdAt between :fd and :td ")
-                .append("and s.pbItem is not null ")
-                .append("and s.pbItem.billItem is not null ")
-                .append("and s.pbItem.billItem.bill is not null ")
-                .append("and s.pbItem.billItem.item is not null ")
-                .append("and s.pbItem.itemBatch is not null ");
+        return findBinCardDTOs(fd, td, ht, dep, i, false);
+    }
 
+    public List<PharmacyBinCardDTO> findBinCardDTOs(Date fd, Date td, HistoryType ht, Department dep, Item i, boolean withArchive) {
+        String baseJpql = buildBinCardJpql("StockHistory");
+        Map<String, Object> m = buildBinCardParams(fd, td, ht, dep, i);
+        String liveJpql = applyBinCardFilters(baseJpql, ht, dep, i);
+        List<PharmacyBinCardDTO> results = new ArrayList<>(
+                (List<PharmacyBinCardDTO>) facade.findLightsByJpql(liveJpql, m, TemporalType.TIMESTAMP));
+        if (withArchive) {
+            String archiveJpql = applyBinCardFilters(buildBinCardJpql("StockHistoryArchive"), ht, dep, i);
+            results.addAll((List<PharmacyBinCardDTO>) archiveFacade.findLightsByJpql(archiveJpql, m, TemporalType.TIMESTAMP));
+            results.sort(Comparator.comparing(PharmacyBinCardDTO::getCreatedAt));
+        }
+        return results;
+    }
+
+    private String buildBinCardJpql(String entity) {
+        return "select new com.divudi.core.data.dto.PharmacyBinCardDTO("
+                + "s.id, s.pbItem.billItem.bill.id, s.createdAt, "
+                + "s.pbItem.billItem.bill.billType, "
+                + "s.pbItem.billItem.bill.billTypeAtomic, "
+                + "s.pbItem.billItem.item.name, "
+                + "s.pbItem.qty, s.pbItem.freeQty, "
+                + "s.pbItem.qtyPacks, s.pbItem.freeQtyPacks, "
+                + "s.pbItem.billItem.item.dblValue, s.itemStock, "
+                + "s.stockQty, s.pbItem.itemBatch.batchNo"
+                + ") from " + entity + " s "
+                + "where s.createdAt between :fd and :td "
+                + "and s.pbItem is not null "
+                + "and s.pbItem.billItem is not null "
+                + "and s.pbItem.billItem.bill is not null "
+                + "and s.pbItem.billItem.item is not null "
+                + "and s.pbItem.itemBatch is not null ";
+    }
+
+    private Map<String, Object> buildBinCardParams(Date fd, Date td, HistoryType ht, Department dep, Item i) {
         Map<String, Object> m = new HashMap<>();
         m.put("fd", fd);
         m.put("td", td);
-        if (ht != null) {
-            jpql.append(" and s.historyType=:ht ");
-            m.put("ht", ht);
-        }
-        if (dep != null) {
-            jpql.append(" and s.department=:dep ");
-            m.put("dep", dep);
-        }
-        if (i != null) {
-            jpql.append(" and s.item=:i ");
-            m.put("i", i);
-        }
-        jpql.append(" order by s.createdAt");
-        return (List<PharmacyBinCardDTO>) facade.findLightsByJpql(jpql.toString(), m, TemporalType.TIMESTAMP);
+        if (ht != null) m.put("ht", ht);
+        if (dep != null) m.put("dep", dep);
+        if (i != null) m.put("i", i);
+        return m;
+    }
+
+    private String applyBinCardFilters(String jpql, HistoryType ht, Department dep, Item i) {
+        if (ht != null) jpql += " and s.historyType=:ht ";
+        if (dep != null) jpql += " and s.department=:dep ";
+        if (i != null) jpql += " and s.item=:i ";
+        jpql += " order by s.createdAt";
+        return jpql;
     }
 
     public void fillStockHistories(boolean withoutZeroStock) {
@@ -245,6 +280,15 @@ public class StockHistoryController implements Serializable {
         for (StockHistory psh : pharmacyStockHistories) {
             totalStockPurchaseValue += psh.getStockPurchaseValue();
             totalStockSaleValue += psh.getStockSaleValue();
+        }
+        pharmacyStockHistoriesArchive = null;
+        if (includeArchived) {
+            String archiveJpql = jpql.replace("from StockHistory s", "from StockHistoryArchive s");
+            pharmacyStockHistoriesArchive = archiveFacade.findByJpql(archiveJpql, m, TemporalType.TIMESTAMP);
+            for (StockHistoryArchive sha : pharmacyStockHistoriesArchive) {
+                totalStockPurchaseValue += sha.getStockPurchaseValue();
+                totalStockSaleValue += sha.getStockSaleValue();
+            }
         }
 
     }
@@ -360,6 +404,11 @@ public class StockHistoryController implements Serializable {
     public void setDepartmentType(DepartmentType departmentType) {
         this.departmentType = departmentType;
     }
+
+    public boolean isIncludeArchived() { return includeArchived; }
+    public void setIncludeArchived(boolean includeArchived) { this.includeArchived = includeArchived; }
+
+    public List<StockHistoryArchive> getPharmacyStockHistoriesArchive() { return pharmacyStockHistoriesArchive; }
 
     public StockHistoryFacade getFacade() {
         return facade;

--- a/src/main/java/com/divudi/bean/report/PharmacyReportController.java
+++ b/src/main/java/com/divudi/bean/report/PharmacyReportController.java
@@ -379,6 +379,7 @@ public class PharmacyReportController implements Serializable {
     private Institution toSite;
 
     private boolean consignmentItem;
+    private boolean includeArchived = false;
     private List<PharmacyRow> pharmacyRows;
     private List<BillItemDTO> billItemsDtos;
     private List<CostOfGoodSoldBillDTO> cogsBillDtos;
@@ -10647,7 +10648,13 @@ public class PharmacyReportController implements Serializable {
             }
 
             jpql.append(" ORDER BY s.id");
-            stockLedgerDtos = (List<StockLedgerDTO>) facade.findLightsByJpql(jpql.toString(), m, TemporalType.TIMESTAMP);
+            stockLedgerDtos = new java.util.ArrayList<>((List<StockLedgerDTO>) facade.findLightsByJpql(jpql.toString(), m, TemporalType.TIMESTAMP));
+            if (includeArchived) {
+                String archiveJpql = jpql.toString().replace("FROM StockHistory ", "FROM StockHistoryArchive ");
+                List<StockLedgerDTO> archiveDtos = (List<StockLedgerDTO>) facade.findLightsByJpql(archiveJpql, m, TemporalType.TIMESTAMP);
+                stockLedgerDtos.addAll(archiveDtos);
+                stockLedgerDtos.sort(java.util.Comparator.comparing(com.divudi.core.data.dto.StockLedgerDTO::getCreatedAt, java.util.Comparator.nullsLast(java.util.Comparator.naturalOrder())));
+            }
         }, InventoryReports.STOCK_LEDGER_DTO_REPORT, sessionController.getLoggedUser());
     }
 
@@ -10989,6 +10996,37 @@ public class PharmacyReportController implements Serializable {
 
             rows.add(row);
         }
+
+        if (includeArchived) {
+            String archiveJpql = jpql.toString().replace("FROM StockHistory ", "FROM StockHistoryArchive ");
+            @SuppressWarnings("unchecked")
+            List<PharmacyRow> archiveDtoRows = (List<PharmacyRow>) facade.findLightsByJpql(archiveJpql, params, TemporalType.TIMESTAMP);
+            java.util.Set<Long> liveItemIds = new java.util.HashSet<>();
+            for (PharmacyRow r : rows) {
+                if (r.getItem() != null) liveItemIds.add(r.getItem().getId());
+            }
+            for (PharmacyRow row : archiveDtoRows) {
+                if (row == null || row.getItem() == null) continue;
+                if (liveItemIds.contains(row.getItem().getId())) continue;
+                double itemQty = row.getStockQty() != null ? row.getStockQty() : 0.0;
+                if (isConsignmentItem()) { if (itemQty > 0) continue; } else { if (itemQty <= 0) continue; }
+                if (department != null) {
+                    row.setQuantity(row.getStockQty());
+                } else if (institution != null) {
+                    row.setQuantity(row.getGrossTotal());
+                    row.setPurchaseValue(row.getDiscount());
+                    row.setSaleValue(row.getNetTotal());
+                    row.setCostValue(row.getHospitalTotal());
+                } else {
+                    row.setQuantity(row.getPaidTotal());
+                    row.setPurchaseValue(row.getTax());
+                    row.setSaleValue(row.getActualTotal());
+                    row.setCostValue(row.getStaffTotal());
+                }
+                rows.add(row);
+            }
+            rows.sort(java.util.Comparator.comparing(r -> r.getItem() != null ? r.getItem().getName() : ""));
+        }
     }
 
     /**
@@ -11211,6 +11249,35 @@ public class PharmacyReportController implements Serializable {
             }
 
             rows.add(row);
+        }
+
+        if (includeArchived) {
+            String archiveJpql = jpql.toString().replace("FROM StockHistory ", "FROM StockHistoryArchive ");
+            @SuppressWarnings("unchecked")
+            List<PharmacyRow> archiveDtoRows = (List<PharmacyRow>) facade.findLightsByJpql(archiveJpql, params, TemporalType.TIMESTAMP);
+            java.util.Set<Long> liveBatchIds = new java.util.HashSet<>();
+            for (PharmacyRow r : rows) {
+                if (r.getItemBatch() != null) liveBatchIds.add(r.getItemBatch().getId());
+            }
+            for (PharmacyRow row : archiveDtoRows) {
+                if (row == null || row.getItem() == null || row.getItemBatch() == null) continue;
+                if (liveBatchIds.contains(row.getItemBatch().getId())) continue;
+                double batchQty = row.getStockQty() != null ? row.getStockQty() : 0.0;
+                if (isConsignmentItem()) { if (batchQty > 0) continue; } else { if (batchQty <= 0) continue; }
+                if (institution != null && department == null) {
+                    row.setQuantity(row.getGrossTotal());
+                    row.setPurchaseValue(row.getDiscount());
+                    row.setSaleValue(row.getNetTotal());
+                    row.setCostValue(row.getHospitalTotal());
+                } else if (department == null) {
+                    row.setQuantity(row.getPaidTotal());
+                    row.setPurchaseValue(row.getTax());
+                    row.setSaleValue(row.getActualTotal());
+                    row.setCostValue(row.getStaffTotal());
+                }
+                rows.add(row);
+            }
+            rows.sort(java.util.Comparator.comparing(r -> r.getItem() != null ? r.getItem().getName() : ""));
         }
     }
 
@@ -16407,6 +16474,14 @@ public class PharmacyReportController implements Serializable {
 
     public void setConsignmentItem(boolean consignmentItem) {
         this.consignmentItem = consignmentItem;
+    }
+
+    public boolean isIncludeArchived() {
+        return includeArchived;
+    }
+
+    public void setIncludeArchived(boolean includeArchived) {
+        this.includeArchived = includeArchived;
     }
 
     public List<StockCorrectionRow> getStockCorrectionRows() {

--- a/src/main/java/com/divudi/bean/report/PharmacyReportController.java
+++ b/src/main/java/com/divudi/bean/report/PharmacyReportController.java
@@ -11002,7 +11002,7 @@ public class PharmacyReportController implements Serializable {
             @SuppressWarnings("unchecked")
             List<PharmacyRow> archiveDtoRows = (List<PharmacyRow>) facade.findLightsByJpql(archiveJpql, params, TemporalType.TIMESTAMP);
             java.util.Set<Long> liveItemIds = new java.util.HashSet<>();
-            for (PharmacyRow r : rows) {
+            for (PharmacyRow r : dtoRows) {
                 if (r.getItem() != null) liveItemIds.add(r.getItem().getId());
             }
             for (PharmacyRow row : archiveDtoRows) {
@@ -11256,7 +11256,7 @@ public class PharmacyReportController implements Serializable {
             @SuppressWarnings("unchecked")
             List<PharmacyRow> archiveDtoRows = (List<PharmacyRow>) facade.findLightsByJpql(archiveJpql, params, TemporalType.TIMESTAMP);
             java.util.Set<Long> liveBatchIds = new java.util.HashSet<>();
-            for (PharmacyRow r : rows) {
+            for (PharmacyRow r : dtoRows) {
                 if (r.getItemBatch() != null) liveBatchIds.add(r.getItemBatch().getId());
             }
             for (PharmacyRow row : archiveDtoRows) {

--- a/src/main/java/com/divudi/core/facade/StockHistoryFacade.java
+++ b/src/main/java/com/divudi/core/facade/StockHistoryFacade.java
@@ -48,6 +48,46 @@ public class StockHistoryFacade extends AbstractFacade<StockHistory> {
      * @param departmentId The department ID for which to calculate stock value (can be null for all departments)
      * @return The total stock value at retail rate, or 0.0 if calculation fails
      */
+    private String shUnionSrc(String columns) {
+        return "(SELECT " + columns + " FROM STOCKHISTORY UNION ALL SELECT " + columns + " FROM STOCKHISTORYARCHIVE)";
+    }
+
+    public double calculateStockValueAtRetailRateOptimized(Date date, Long departmentId, boolean includeArchived) {
+        if (!includeArchived) {
+            return calculateStockValueAtRetailRateOptimized(date, departmentId);
+        }
+        try {
+            String src     = shUnionSrc("ID, DEPARTMENT_ID, ITEMBATCH_ID, STOCKQTY, RETIRED") + " sh";
+            String srcSmall = shUnionSrc("ID, DEPARTMENT_ID, ITEMBATCH_ID, RETIRED, CREATEDAT") + " combined";
+            String sql =
+                "SELECT COALESCE(SUM(latest_stock.STOCKQTY * latest_stock.retail_rate), 0.0) AS total_value " +
+                "FROM ( " +
+                "    SELECT sh.STOCKQTY, COALESCE(ib.RETAILSALERATE, 0.0) AS retail_rate " +
+                "    FROM " + src + " " +
+                "    INNER JOIN ( " +
+                "        SELECT DEPARTMENT_ID, ITEMBATCH_ID, MAX(ID) AS max_id " +
+                "        FROM " + srcSmall + " " +
+                "        WHERE RETIRED = 0 " +
+                "        AND CREATEDAT < ? " +
+                (departmentId != null ? "        AND DEPARTMENT_ID = ? " : "") +
+                "        GROUP BY DEPARTMENT_ID, ITEMBATCH_ID " +
+                "    ) AS latest ON sh.ID = latest.max_id " +
+                "    INNER JOIN ITEMBATCH ib ON sh.ITEMBATCH_ID = ib.ID " +
+                "    WHERE sh.RETIRED = 0 AND sh.STOCKQTY > 0 " +
+                ") AS latest_stock";
+            javax.persistence.Query query = getEntityManager().createNativeQuery(sql);
+            query.setParameter(1, date, TemporalType.TIMESTAMP);
+            if (departmentId != null) {
+                query.setParameter(2, departmentId);
+            }
+            Object result = query.getSingleResult();
+            return (result instanceof Number) ? ((Number) result).doubleValue() : 0.0;
+        } catch (Exception e) {
+            System.err.println("Error calculating retail rate (with archive) for date: " + date + " - " + e.getMessage());
+            return 0.0;
+        }
+    }
+
     public double calculateStockValueAtRetailRateOptimized(Date date, Long departmentId) {
         System.out.println("=== calculateStockValueAtRetailRateOptimized START ===");
         System.out.println("Input Date: " + date);
@@ -190,6 +230,44 @@ public class StockHistoryFacade extends AbstractFacade<StockHistory> {
      * @param departmentId The department ID for which to calculate stock value (can be null for all departments)
      * @return The total stock value at cost rate, or 0.0 if calculation fails
      */
+    public double calculateStockValueAtCostRateOptimized(Date date, Long departmentId, boolean includeArchived) {
+        if (!includeArchived) {
+            return calculateStockValueAtCostRateOptimized(date, departmentId);
+        }
+        try {
+            String src      = shUnionSrc("ID, DEPARTMENT_ID, ITEMBATCH_ID, STOCKQTY, RETIRED") + " sh";
+            String srcSmall = shUnionSrc("ID, DEPARTMENT_ID, ITEMBATCH_ID, RETIRED, CREATEDAT") + " combined";
+            String sql =
+                "SELECT COALESCE(SUM(latest_stock.STOCKQTY * latest_stock.cost_rate), 0.0) AS total_value " +
+                "FROM ( " +
+                "    SELECT sh.STOCKQTY, " +
+                "        CASE WHEN ib.COSTRATE IS NOT NULL AND ib.COSTRATE != 0 THEN ib.COSTRATE " +
+                "             WHEN ib.PURCAHSERATE IS NOT NULL AND ib.PURCAHSERATE != 0 THEN ib.PURCAHSERATE " +
+                "             ELSE 0.0 END AS cost_rate " +
+                "    FROM " + src + " " +
+                "    INNER JOIN ( " +
+                "        SELECT DEPARTMENT_ID, ITEMBATCH_ID, MAX(ID) AS max_id " +
+                "        FROM " + srcSmall + " " +
+                "        WHERE RETIRED = 0 AND CREATEDAT < ? " +
+                (departmentId != null ? "        AND DEPARTMENT_ID = ? " : "") +
+                "        GROUP BY DEPARTMENT_ID, ITEMBATCH_ID " +
+                "    ) AS latest ON sh.ID = latest.max_id " +
+                "    INNER JOIN ITEMBATCH ib ON sh.ITEMBATCH_ID = ib.ID " +
+                "    WHERE sh.RETIRED = 0 AND sh.STOCKQTY > 0 " +
+                ") AS latest_stock";
+            javax.persistence.Query query = getEntityManager().createNativeQuery(sql);
+            query.setParameter(1, date, TemporalType.TIMESTAMP);
+            if (departmentId != null) {
+                query.setParameter(2, departmentId);
+            }
+            Object result = query.getSingleResult();
+            return (result instanceof Number) ? ((Number) result).doubleValue() : 0.0;
+        } catch (Exception e) {
+            System.err.println("Error calculating cost rate (with archive) for date: " + date + " - " + e.getMessage());
+            return 0.0;
+        }
+    }
+
     public double calculateStockValueAtCostRateOptimized(Date date, Long departmentId) {
         System.out.println("=== calculateStockValueAtCostRateOptimized START ===");
         System.out.println("Input Date: " + date);
@@ -272,6 +350,41 @@ public class StockHistoryFacade extends AbstractFacade<StockHistory> {
      * @param departmentId The department ID (can be null for all departments)
      * @return The total stock value at purchase rate, or 0.0 if calculation fails
      */
+    public double calculateStockValueAtPurchaseRateOptimized(Date date, Long departmentId, boolean includeArchived) {
+        if (!includeArchived) {
+            return calculateStockValueAtPurchaseRateOptimized(date, departmentId);
+        }
+        try {
+            String src      = shUnionSrc("ID, DEPARTMENT_ID, ITEMBATCH_ID, STOCKQTY, RETIRED, PURCHASERATE") + " sh";
+            String srcSmall = shUnionSrc("ID, DEPARTMENT_ID, ITEMBATCH_ID, RETIRED, CREATEDAT") + " combined";
+            String sql =
+                "SELECT COALESCE(SUM(latest_stock.STOCKQTY * latest_stock.purchase_rate), 0.0) AS total_value " +
+                "FROM ( " +
+                "    SELECT sh.STOCKQTY, COALESCE(NULLIF(sh.PURCHASERATE, 0), ib.PURCAHSERATE, 0.0) AS purchase_rate " +
+                "    FROM " + src + " " +
+                "    INNER JOIN ( " +
+                "        SELECT DEPARTMENT_ID, ITEMBATCH_ID, MAX(ID) AS max_id " +
+                "        FROM " + srcSmall + " " +
+                "        WHERE RETIRED = 0 AND CREATEDAT < ? " +
+                (departmentId != null ? "        AND DEPARTMENT_ID = ? " : "") +
+                "        GROUP BY DEPARTMENT_ID, ITEMBATCH_ID " +
+                "    ) AS latest ON sh.ID = latest.max_id " +
+                "    INNER JOIN ITEMBATCH ib ON sh.ITEMBATCH_ID = ib.ID " +
+                "    WHERE sh.RETIRED = 0 AND sh.STOCKQTY > 0 " +
+                ") AS latest_stock";
+            javax.persistence.Query query = getEntityManager().createNativeQuery(sql);
+            query.setParameter(1, date, TemporalType.TIMESTAMP);
+            if (departmentId != null) {
+                query.setParameter(2, departmentId);
+            }
+            Object result = query.getSingleResult();
+            return (result instanceof Number) ? ((Number) result).doubleValue() : 0.0;
+        } catch (Exception e) {
+            System.err.println("Error calculating purchase rate (with archive) for date: " + date + " - " + e.getMessage());
+            return 0.0;
+        }
+    }
+
     public double calculateStockValueAtPurchaseRateOptimized(Date date, Long departmentId) {
         try {
             String sql =

--- a/src/main/java/com/divudi/service/archival/ArchivalBatchTx.java
+++ b/src/main/java/com/divudi/service/archival/ArchivalBatchTx.java
@@ -39,20 +39,19 @@ public class ArchivalBatchTx {
     @PersistenceContext(unitName = "hmisPU")
     private EntityManager em;
 
+    // Self-injection so doOneBatch() is invoked through the EJB proxy —
+    // mandatory for @TransactionAttribute(REQUIRES_NEW) to take effect.
+    // Calling this.doOneBatch() bypasses the proxy and ignores the annotation.
+    @EJB
+    private ArchivalBatchTx self;
+
     /**
-     * Copy the rows identified by {@code ids} from {@code sourceTable} to
-     * {@code archiveTable}, then delete them from {@code sourceTable}. All
-     * within one new transaction.
-     *
-     * Retries up to {@value #MAX_RETRIES} times on MySQL lock wait timeout
-     * (error 1205) — the competing transaction will have committed by then.
-     * Each retry opens a fresh REQUIRES_NEW transaction so the previous
-     * rolled-back state is fully discarded before we attempt again.
-     *
-     * Table/column names come from concrete archival services (compile-time
-     * constants), never from user input, so the direct string concatenation
-     * is safe from injection.
+     * Copy rows from {@code sourceTable} to {@code archiveTable} then delete
+     * them from {@code sourceTable}. Retries up to {@value #MAX_RETRIES} times
+     * on MySQL lock wait timeout (error 1205) before giving up. Each retry is a
+     * completely fresh REQUIRES_NEW transaction via the EJB proxy (self).
      */
+    @TransactionAttribute(TransactionAttributeType.NOT_SUPPORTED)
     public int copyAndDelete(String archiveTable, String sourceTable,
                              String columnList, List<Long> ids) {
         if (ids == null || ids.isEmpty()) {
@@ -61,7 +60,7 @@ public class ArchivalBatchTx {
         PersistenceException lastEx = null;
         for (int attempt = 1; attempt <= MAX_RETRIES; attempt++) {
             try {
-                return doOneBatch(archiveTable, sourceTable, columnList, ids);
+                return self.doOneBatch(archiveTable, sourceTable, columnList, ids);
             } catch (PersistenceException ex) {
                 if (!isLockTimeout(ex)) {
                     throw ex;
@@ -70,7 +69,9 @@ public class ArchivalBatchTx {
                 LOGGER.log(Level.WARNING,
                         "Archival batch lock timeout (attempt {0}/{1}), retrying in {2}ms",
                         new Object[]{attempt, MAX_RETRIES, RETRY_SLEEP_MS});
-                try { Thread.sleep(RETRY_SLEEP_MS); } catch (InterruptedException ie) {
+                try {
+                    Thread.sleep(RETRY_SLEEP_MS);
+                } catch (InterruptedException ie) {
                     Thread.currentThread().interrupt();
                     throw ex;
                 }
@@ -79,7 +80,7 @@ public class ArchivalBatchTx {
         throw lastEx;
     }
 
-    /** Single attempt — runs in its own REQUIRES_NEW transaction. */
+    /** Single transactional attempt — called via self proxy to honour REQUIRES_NEW. */
     @TransactionAttribute(TransactionAttributeType.REQUIRES_NEW)
     public int doOneBatch(String archiveTable, String sourceTable,
                           String columnList, List<Long> ids) {
@@ -109,9 +110,8 @@ public class ArchivalBatchTx {
     private static boolean isLockTimeout(PersistenceException ex) {
         Throwable cause = ex.getCause();
         while (cause != null) {
-            String msg = cause.getMessage();
-            // MySQL error 1205: Lock wait timeout exceeded
-            if (msg != null && msg.contains("Lock wait timeout exceeded")) {
+            if (cause.getMessage() != null
+                    && cause.getMessage().contains("Lock wait timeout exceeded")) {
                 return true;
             }
             cause = cause.getCause();

--- a/src/main/java/com/divudi/service/archival/ArchivalBatchTx.java
+++ b/src/main/java/com/divudi/service/archival/ArchivalBatchTx.java
@@ -11,6 +11,8 @@ import javax.ejb.TransactionAttributeType;
 import javax.persistence.EntityManager;
 import javax.persistence.PersistenceContext;
 import javax.persistence.Query;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 /**
  * Transaction-bounded executor for a single archival batch.
@@ -52,16 +54,26 @@ public class ArchivalBatchTx {
             return 0;
         }
 
+        // JPA native queries do not support binding a List to a named IN parameter;
+        // expand to individual positional placeholders (?,?,?,...) instead.
+        String placeholders = IntStream.range(0, ids.size())
+                .mapToObj(i -> "?")
+                .collect(Collectors.joining(","));
+
         String insertSql = "INSERT INTO " + archiveTable + " (" + columnList + ", ARCHIVEDAT) "
                 + "SELECT " + columnList + ", NOW() FROM " + sourceTable
-                + " WHERE ID IN (:ids)";
+                + " WHERE ID IN (" + placeholders + ")";
         Query insertQ = em.createNativeQuery(insertSql);
-        insertQ.setParameter("ids", ids);
+        for (int i = 0; i < ids.size(); i++) {
+            insertQ.setParameter(i + 1, ids.get(i));
+        }
         insertQ.executeUpdate();
 
-        String deleteSql = "DELETE FROM " + sourceTable + " WHERE ID IN (:ids)";
+        String deleteSql = "DELETE FROM " + sourceTable + " WHERE ID IN (" + placeholders + ")";
         Query deleteQ = em.createNativeQuery(deleteSql);
-        deleteQ.setParameter("ids", ids);
+        for (int i = 0; i < ids.size(); i++) {
+            deleteQ.setParameter(i + 1, ids.get(i));
+        }
         return deleteQ.executeUpdate();
     }
 }

--- a/src/main/java/com/divudi/service/archival/ArchivalBatchTx.java
+++ b/src/main/java/com/divudi/service/archival/ArchivalBatchTx.java
@@ -5,11 +5,14 @@
 package com.divudi.service.archival;
 
 import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import javax.ejb.Stateless;
 import javax.ejb.TransactionAttribute;
 import javax.ejb.TransactionAttributeType;
 import javax.persistence.EntityManager;
 import javax.persistence.PersistenceContext;
+import javax.persistence.PersistenceException;
 import javax.persistence.Query;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
@@ -28,6 +31,11 @@ import java.util.stream.IntStream;
 @Stateless
 public class ArchivalBatchTx {
 
+    private static final Logger LOGGER = Logger.getLogger(ArchivalBatchTx.class.getName());
+
+    private static final int MAX_RETRIES = 3;
+    private static final long RETRY_SLEEP_MS = 2000;
+
     @PersistenceContext(unitName = "hmisPU")
     private EntityManager em;
 
@@ -36,24 +44,45 @@ public class ArchivalBatchTx {
      * {@code archiveTable}, then delete them from {@code sourceTable}. All
      * within one new transaction.
      *
+     * Retries up to {@value #MAX_RETRIES} times on MySQL lock wait timeout
+     * (error 1205) — the competing transaction will have committed by then.
+     * Each retry opens a fresh REQUIRES_NEW transaction so the previous
+     * rolled-back state is fully discarded before we attempt again.
+     *
      * Table/column names come from concrete archival services (compile-time
      * constants), never from user input, so the direct string concatenation
      * is safe from injection.
-     *
-     * @param archiveTable   archive table name (e.g. STOCKHISTORYARCHIVE)
-     * @param sourceTable    source table name (e.g. STOCKHISTORY)
-     * @param columnList     comma-separated column list common to both tables,
-     *                       excluding ARCHIVEDAT (which is set to NOW() here)
-     * @param ids            primary-key IDs to move; must be non-null and non-empty
-     * @return number of rows deleted from the source
      */
-    @TransactionAttribute(TransactionAttributeType.REQUIRES_NEW)
     public int copyAndDelete(String archiveTable, String sourceTable,
                              String columnList, List<Long> ids) {
         if (ids == null || ids.isEmpty()) {
             return 0;
         }
+        PersistenceException lastEx = null;
+        for (int attempt = 1; attempt <= MAX_RETRIES; attempt++) {
+            try {
+                return doOneBatch(archiveTable, sourceTable, columnList, ids);
+            } catch (PersistenceException ex) {
+                if (!isLockTimeout(ex)) {
+                    throw ex;
+                }
+                lastEx = ex;
+                LOGGER.log(Level.WARNING,
+                        "Archival batch lock timeout (attempt {0}/{1}), retrying in {2}ms",
+                        new Object[]{attempt, MAX_RETRIES, RETRY_SLEEP_MS});
+                try { Thread.sleep(RETRY_SLEEP_MS); } catch (InterruptedException ie) {
+                    Thread.currentThread().interrupt();
+                    throw ex;
+                }
+            }
+        }
+        throw lastEx;
+    }
 
+    /** Single attempt — runs in its own REQUIRES_NEW transaction. */
+    @TransactionAttribute(TransactionAttributeType.REQUIRES_NEW)
+    public int doOneBatch(String archiveTable, String sourceTable,
+                          String columnList, List<Long> ids) {
         // JPA native queries do not support binding a List to a named IN parameter;
         // expand to individual positional placeholders (?,?,?,...) instead.
         String placeholders = IntStream.range(0, ids.size())
@@ -75,5 +104,18 @@ public class ArchivalBatchTx {
             deleteQ.setParameter(i + 1, ids.get(i));
         }
         return deleteQ.executeUpdate();
+    }
+
+    private static boolean isLockTimeout(PersistenceException ex) {
+        Throwable cause = ex.getCause();
+        while (cause != null) {
+            String msg = cause.getMessage();
+            // MySQL error 1205: Lock wait timeout exceeded
+            if (msg != null && msg.contains("Lock wait timeout exceeded")) {
+                return true;
+            }
+            cause = cause.getCause();
+        }
+        return false;
     }
 }

--- a/src/main/java/com/divudi/service/archival/ArchivalBatchTx.java
+++ b/src/main/java/com/divudi/service/archival/ArchivalBatchTx.java
@@ -16,6 +16,7 @@ import javax.persistence.PersistenceException;
 import javax.persistence.Query;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
+import javax.ejb.EJB;
 
 /**
  * Transaction-bounded executor for a single archival batch.

--- a/src/main/java/com/divudi/service/archival/ArchivalBatchTx.java
+++ b/src/main/java/com/divudi/service/archival/ArchivalBatchTx.java
@@ -4,6 +4,7 @@
  */
 package com.divudi.service.archival;
 
+import java.sql.SQLException;
 import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -67,14 +68,16 @@ public class ArchivalBatchTx {
                     throw ex;
                 }
                 lastEx = ex;
-                LOGGER.log(Level.WARNING,
-                        "Archival batch lock timeout (attempt {0}/{1}), retrying in {2}ms",
-                        new Object[]{attempt, MAX_RETRIES, RETRY_SLEEP_MS});
-                try {
-                    Thread.sleep(RETRY_SLEEP_MS);
-                } catch (InterruptedException ie) {
-                    Thread.currentThread().interrupt();
-                    throw ex;
+                if (attempt < MAX_RETRIES) {
+                    LOGGER.log(Level.WARNING,
+                            "Archival batch lock timeout (attempt {0}/{1}), retrying in {2}ms",
+                            new Object[]{attempt, MAX_RETRIES, RETRY_SLEEP_MS});
+                    try {
+                        Thread.sleep(RETRY_SLEEP_MS);
+                    } catch (InterruptedException ie) {
+                        Thread.currentThread().interrupt();
+                        throw ex;
+                    }
                 }
             }
         }
@@ -109,10 +112,9 @@ public class ArchivalBatchTx {
     }
 
     private static boolean isLockTimeout(PersistenceException ex) {
-        Throwable cause = ex.getCause();
+        Throwable cause = ex;
         while (cause != null) {
-            if (cause.getMessage() != null
-                    && cause.getMessage().contains("Lock wait timeout exceeded")) {
+            if (cause instanceof SQLException && ((SQLException) cause).getErrorCode() == 1205) {
                 return true;
             }
             cause = cause.getCause();

--- a/src/main/java/com/divudi/service/archival/ArchivalServiceBase.java
+++ b/src/main/java/com/divudi/service/archival/ArchivalServiceBase.java
@@ -118,16 +118,20 @@ public abstract class ArchivalServiceBase {
 
     /**
      * Run an archival pass.
-     *
-     * @param cutoff           rows with createdAt strictly before this are eligible
-     * @param batchSize        rows per transactional batch (recommended: 1000-5000)
-     * @param maxBatches       upper bound on batches in this invocation; protects
-     *                         the system from one runaway run that holds resources
-     *                         for too long. Use a sensible cap (e.g. 50 = 100k rows
-     *                         at batch size 2000) for scheduled invocations.
-     * @param dryRun           if true, only count candidates; do not move any rows
      */
     public ArchiveResult archive(Date cutoff, int batchSize, int maxBatches, boolean dryRun) {
+        return archive(cutoff, batchSize, maxBatches, dryRun, null);
+    }
+
+    /**
+     * Run an archival pass, invoking {@code onBatchMoved} with the row count
+     * after each committed batch so callers can track progress.
+     *
+     * @param onBatchMoved called with the number of rows moved after each batch;
+     *                     may be null if progress tracking is not needed
+     */
+    public ArchiveResult archive(Date cutoff, int batchSize, int maxBatches, boolean dryRun,
+                                  java.util.function.IntConsumer onBatchMoved) {
         Date startedAt = new Date();
         long candidates = countOlderThan(cutoff);
 
@@ -158,6 +162,9 @@ public abstract class ArchivalServiceBase {
             int moved = batchTx().copyAndDelete(archiveTable(), sourceTable(), columnList, ids);
             totalArchived += moved;
             batchesRun++;
+            if (onBatchMoved != null) {
+                onBatchMoved.accept(moved);
+            }
             if (ids.size() < batchSize) {
                 break;
             }

--- a/src/main/java/com/divudi/service/archival/ItemBatchArchivalService.java
+++ b/src/main/java/com/divudi/service/archival/ItemBatchArchivalService.java
@@ -9,10 +9,14 @@ import java.util.ArrayList;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import javax.ejb.Asynchronous;
 import javax.ejb.EJB;
 import javax.ejb.Stateless;
 import javax.ejb.TransactionAttribute;
 import javax.ejb.TransactionAttributeType;
+import javax.inject.Inject;
 import javax.persistence.EntityManager;
 import javax.persistence.PersistenceContext;
 import javax.persistence.Query;
@@ -46,11 +50,16 @@ public class ItemBatchArchivalService extends ArchivalServiceBase {
     @PersistenceContext(unitName = "hmisPU")
     private EntityManager em;
 
+    private static final Logger LOGGER = Logger.getLogger(ItemBatchArchivalService.class.getName());
+
     @EJB
     private ArchivalBatchTx batchTx;
 
     @EJB
     private ItemBatchArchivalBatchTx itemBatchBatchTx;
+
+    @Inject
+    private ItemBatchArchivalTracker tracker;
 
     @Override
     protected EntityManager em() {
@@ -149,15 +158,19 @@ public class ItemBatchArchivalService extends ArchivalServiceBase {
         return result.isEmpty() ? upperName : result.get(0).toString();
     }
 
-    /**
-     * Run an archival pass using the 6-step ItemBatch-specific batch executor.
-     *
-     * Overrides the base {@link ArchivalServiceBase#archive} to use
-     * {@link ItemBatchArchivalBatchTx} which handles both ItemBatch and Stock
-     * tables atomically per batch.
-     */
     @Override
     public ArchiveResult archive(Date cutoff, int batchSize, int maxBatches, boolean dryRun) {
+        return archive(cutoff, batchSize, maxBatches, dryRun, null);
+    }
+
+    /**
+     * ItemBatch-specific archival loop that uses {@link ItemBatchArchivalBatchTx}
+     * (handles ItemBatch + Stock tables atomically per batch).
+     * Invokes {@code onBatchMoved} after each committed batch for progress tracking.
+     */
+    @Override
+    public ArchiveResult archive(Date cutoff, int batchSize, int maxBatches, boolean dryRun,
+                                  java.util.function.IntConsumer onBatchMoved) {
         Date startedAt = new Date();
         long candidates = countOlderThan(cutoff);
 
@@ -203,6 +216,9 @@ public class ItemBatchArchivalService extends ArchivalServiceBase {
                     ibCols, stCols, ids);
             totalArchived += moved;
             batchesRun++;
+            if (onBatchMoved != null) {
+                onBatchMoved.accept(moved);
+            }
             if (ids.size() < batchSize) {
                 break;
             }
@@ -215,5 +231,25 @@ public class ItemBatchArchivalService extends ArchivalServiceBase {
                 + (reachedLimit ? " (batch limit reached; more rows remain)" : "");
         return new ArchiveResult(false, candidates, totalArchived, batchesRun,
                 reachedLimit, startedAt, new Date(), msg);
+    }
+
+    /**
+     * Fire-and-forget async wrapper for live archive runs.
+     */
+    @Asynchronous
+    public void archiveAsync(Date cutoff, int batchSize, int maxBatches) {
+        long candidates = countOlderThan(cutoff);
+        tracker.start(candidates, maxBatches);
+        try {
+            ArchiveResult result = archive(cutoff, batchSize, maxBatches, false,
+                    moved -> tracker.recordBatch(moved));
+            tracker.finish(result);
+        } catch (Exception ex) {
+            LOGGER.log(Level.SEVERE, "Async ItemBatch archival failed", ex);
+            ArchiveResult err = new ArchiveResult(false, tracker.getCandidates(),
+                    tracker.getArchivedSoFar(), tracker.getBatchesDone(), false,
+                    tracker.getStartedAt(), new Date(), "Error: " + ex.getMessage());
+            tracker.finish(err);
+        }
     }
 }

--- a/src/main/java/com/divudi/service/archival/ItemBatchArchivalTracker.java
+++ b/src/main/java/com/divudi/service/archival/ItemBatchArchivalTracker.java
@@ -1,0 +1,69 @@
+/*
+ * Dr M H B Ariyaratne
+ * buddhika.ari@gmail.com
+ */
+package com.divudi.service.archival;
+
+import com.divudi.core.data.dto.ArchiveResult;
+import java.io.Serializable;
+import java.util.Date;
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Named;
+
+/**
+ * Application-scoped progress tracker for the ItemBatch archival job.
+ *
+ * Lives outside the HTTP session so that a <p:poll> AJAX request can read
+ * progress while the @Asynchronous archival thread is running.
+ *
+ * Issue #20724.
+ */
+@Named
+@ApplicationScoped
+public class ItemBatchArchivalTracker implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    private volatile boolean running = false;
+    private volatile long candidates = 0;
+    private volatile long archivedSoFar = 0;
+    private volatile int batchesDone = 0;
+    private volatile int maxBatches = 0;
+    private volatile Date startedAt;
+    private volatile ArchiveResult lastResult;
+
+    public synchronized void start(long candidates, int maxBatches) {
+        this.candidates = candidates;
+        this.archivedSoFar = 0;
+        this.batchesDone = 0;
+        this.maxBatches = maxBatches;
+        this.startedAt = new Date();
+        this.lastResult = null;
+        this.running = true;
+    }
+
+    public synchronized void recordBatch(int moved) {
+        archivedSoFar += moved;
+        batchesDone++;
+    }
+
+    public synchronized void finish(ArchiveResult result) {
+        this.lastResult = result;
+        this.running = false;
+    }
+
+    public int getProgressPercent() {
+        long c = candidates;
+        long a = archivedSoFar;
+        if (c <= 0) return 0;
+        return (int) Math.min(100, (a * 100L) / c);
+    }
+
+    public boolean isRunning() { return running; }
+    public long getCandidates() { return candidates; }
+    public long getArchivedSoFar() { return archivedSoFar; }
+    public int getBatchesDone() { return batchesDone; }
+    public int getMaxBatches() { return maxBatches; }
+    public Date getStartedAt() { return startedAt; }
+    public ArchiveResult getLastResult() { return lastResult; }
+}

--- a/src/main/java/com/divudi/service/archival/StockHistoryArchivalService.java
+++ b/src/main/java/com/divudi/service/archival/StockHistoryArchivalService.java
@@ -4,10 +4,16 @@
  */
 package com.divudi.service.archival;
 
+import com.divudi.core.data.dto.ArchiveResult;
+import java.util.Date;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import javax.ejb.Asynchronous;
 import javax.ejb.EJB;
 import javax.ejb.Stateless;
 import javax.ejb.TransactionAttribute;
 import javax.ejb.TransactionAttributeType;
+import javax.inject.Inject;
 import javax.persistence.EntityManager;
 import javax.persistence.PersistenceContext;
 
@@ -32,11 +38,16 @@ import javax.persistence.PersistenceContext;
 @TransactionAttribute(TransactionAttributeType.NOT_SUPPORTED)
 public class StockHistoryArchivalService extends ArchivalServiceBase {
 
+    private static final Logger LOGGER = Logger.getLogger(StockHistoryArchivalService.class.getName());
+
     @PersistenceContext(unitName = "hmisPU")
     private EntityManager em;
 
     @EJB
     private ArchivalBatchTx batchTx;
+
+    @Inject
+    private StockHistoryArchivalTracker tracker;
 
     @Override
     protected EntityManager em() {
@@ -61,5 +72,27 @@ public class StockHistoryArchivalService extends ArchivalServiceBase {
     @Override
     protected String sourceEntityName() {
         return "StockHistory";
+    }
+
+    /**
+     * Fire-and-forget async wrapper for live archive runs.
+     * Progress is reported to {@link StockHistoryArchivalTracker} after each
+     * committed batch so the UI poll can display it without session locking.
+     */
+    @Asynchronous
+    public void archiveAsync(Date cutoff, int batchSize, int maxBatches) {
+        long candidates = countOlderThan(cutoff);
+        tracker.start(candidates, maxBatches);
+        try {
+            ArchiveResult result = archive(cutoff, batchSize, maxBatches, false,
+                    moved -> tracker.recordBatch(moved));
+            tracker.finish(result);
+        } catch (Exception ex) {
+            LOGGER.log(Level.SEVERE, "Async StockHistory archival failed", ex);
+            ArchiveResult err = new ArchiveResult(false, tracker.getCandidates(),
+                    tracker.getArchivedSoFar(), tracker.getBatchesDone(), false,
+                    tracker.getStartedAt(), new Date(), "Error: " + ex.getMessage());
+            tracker.finish(err);
+        }
     }
 }

--- a/src/main/java/com/divudi/service/archival/StockHistoryArchivalTracker.java
+++ b/src/main/java/com/divudi/service/archival/StockHistoryArchivalTracker.java
@@ -1,0 +1,71 @@
+/*
+ * Dr M H B Ariyaratne
+ * buddhika.ari@gmail.com
+ */
+package com.divudi.service.archival;
+
+import com.divudi.core.data.dto.ArchiveResult;
+import java.io.Serializable;
+import java.util.Date;
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Named;
+
+/**
+ * Application-scoped progress tracker for the StockHistory archival job.
+ *
+ * Lives outside the HTTP session so that a <p:poll> AJAX request can read
+ * progress while the @Asynchronous archival thread is running (session-scoped
+ * beans are locked to one request at a time in JSF, making polling impossible
+ * during a synchronous run).
+ *
+ * Issue #20729.
+ */
+@Named
+@ApplicationScoped
+public class StockHistoryArchivalTracker implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    private volatile boolean running = false;
+    private volatile long candidates = 0;
+    private volatile long archivedSoFar = 0;
+    private volatile int batchesDone = 0;
+    private volatile int maxBatches = 0;
+    private volatile Date startedAt;
+    private volatile ArchiveResult lastResult;
+
+    public synchronized void start(long candidates, int maxBatches) {
+        this.candidates = candidates;
+        this.archivedSoFar = 0;
+        this.batchesDone = 0;
+        this.maxBatches = maxBatches;
+        this.startedAt = new Date();
+        this.lastResult = null;
+        this.running = true;
+    }
+
+    public synchronized void recordBatch(int moved) {
+        archivedSoFar += moved;
+        batchesDone++;
+    }
+
+    public synchronized void finish(ArchiveResult result) {
+        this.lastResult = result;
+        this.running = false;
+    }
+
+    public int getProgressPercent() {
+        long c = candidates;
+        long a = archivedSoFar;
+        if (c <= 0) return 0;
+        return (int) Math.min(100, (a * 100L) / c);
+    }
+
+    public boolean isRunning() { return running; }
+    public long getCandidates() { return candidates; }
+    public long getArchivedSoFar() { return archivedSoFar; }
+    public int getBatchesDone() { return batchesDone; }
+    public int getMaxBatches() { return maxBatches; }
+    public Date getStartedAt() { return startedAt; }
+    public ArchiveResult getLastResult() { return lastResult; }
+}

--- a/src/main/resources/db/migrations/v2.7.0/migration-info.json
+++ b/src/main/resources/db/migrations/v2.7.0/migration-info.json
@@ -1,0 +1,26 @@
+{
+  "version": "v2.7.0",
+  "description": "Performance indexes for STOCKHISTORYARCHIVE (x3) — prevents full-table scans on archive queries",
+  "issue": "#20729 — StockHistory archive read paths",
+  "author": "Dr M H B Ariyaratne",
+  "date": "2026-05-23",
+  "type": "performance",
+  "tables_affected": ["stockhistoryarchive"],
+  "data_changes": false,
+  "requires_downtime": false,
+  "estimated_duration_minutes": 1,
+  "indexes_added": [
+    "stockhistoryarchive.idx_stockhistoryarchive_batch_date_retired (ITEMBATCH_ID, CREATEDAT, RETIRED)",
+    "stockhistoryarchive.idx_stockhistoryarchive_date_dept_retired (CREATEDAT, DEPARTMENT_ID, RETIRED)",
+    "stockhistoryarchive.idx_stockhistoryarchive_historytype_dept_createdat (HISTORYTYPE, DEPARTMENT_ID, CREATEDAT)"
+  ],
+  "indexes_dropped": [],
+  "performance_impact": {
+    "before": "STOCKHISTORYARCHIVE has only a single-column index on CREATEDAT (added by v2.1.18). Archive queries introduced in #20729 (bin card, stock ledger, closing stock) would full-table-scan the archive once rows accumulate.",
+    "after": "Archive queries use the same index strategies as STOCKHISTORY: batch+date range scans, dept+date range scans, historytype+dept scans.",
+    "improvement": "Archive table queries match STOCKHISTORY query plan quality once archival begins moving rows."
+  },
+  "note": "STOCKHISTORYARCHIVE is currently empty on all deployments — this migration runs instantly and will not block. These indexes are a prerequisite for the include-archived report feature introduced in #20729.",
+  "dependencies": ["v2.1.18"],
+  "rollback": "rollback.sql"
+}

--- a/src/main/resources/db/migrations/v2.7.0/migration.sql
+++ b/src/main/resources/db/migrations/v2.7.0/migration.sql
@@ -65,7 +65,9 @@ SET @sql = IF(@sha_table IS NOT NULL AND @idx1_exists = 0,
            ' (ITEMBATCH_ID, CREATEDAT, RETIRED)'),
     'SELECT "SKIPPED: idx_stockhistoryarchive_batch_date_retired already exists or table not found" AS status'
 );
-PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+PREPARE stmt FROM @sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
 
 SELECT IF(
     (SELECT COUNT(*) FROM INFORMATION_SCHEMA.STATISTICS
@@ -94,7 +96,9 @@ SET @sql = IF(@sha_table IS NOT NULL AND @idx2_exists = 0,
            ' (CREATEDAT, DEPARTMENT_ID, RETIRED)'),
     'SELECT "SKIPPED: idx_stockhistoryarchive_date_dept_retired already exists or table not found" AS status'
 );
-PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+PREPARE stmt FROM @sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
 
 SELECT IF(
     (SELECT COUNT(*) FROM INFORMATION_SCHEMA.STATISTICS
@@ -123,7 +127,9 @@ SET @sql = IF(@sha_table IS NOT NULL AND @idx3_exists = 0,
            ' (HISTORYTYPE, DEPARTMENT_ID, CREATEDAT)'),
     'SELECT "SKIPPED: idx_stockhistoryarchive_historytype_dept_createdat already exists or table not found" AS status'
 );
-PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+PREPARE stmt FROM @sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
 
 SELECT IF(
     (SELECT COUNT(*) FROM INFORMATION_SCHEMA.STATISTICS

--- a/src/main/resources/db/migrations/v2.7.0/migration.sql
+++ b/src/main/resources/db/migrations/v2.7.0/migration.sql
@@ -1,0 +1,147 @@
+-- Migration v2.7.0: Performance indexes for STOCKHISTORYARCHIVE (x3)
+-- Author: Dr M H B Ariyaratne
+-- Issue: #20729 — StockHistory archive read paths
+--
+-- Background:
+--   Migration v2.1.18 created STOCKHISTORYARCHIVE with only a single-column index
+--   on CREATEDAT. The same composite indexes that exist on STOCKHISTORY are needed
+--   here so that archive queries (bin card, stock ledger, closing stock) can use
+--   index scans instead of full table scans once archived rows accumulate.
+--
+-- Indexes added (mirrors the STOCKHISTORY composite indexes from v2.1.10 / v2.5.0):
+--   1. idx_stockhistoryarchive_batch_date_retired   (ITEMBATCH_ID, CREATEDAT, RETIRED)
+--      Used by: batch-level bin card queries, stock ledger filtered by batch
+--   2. idx_stockhistoryarchive_date_dept_retired    (CREATEDAT, DEPARTMENT_ID, RETIRED)
+--      Used by: stock value calculation at a point in time, department stock history
+--   3. idx_stockhistoryarchive_historytype_dept_createdat (HISTORYTYPE, DEPARTMENT_ID, CREATEDAT)
+--      Used by: bin card DTO report, monthly record queries
+--
+-- UNIVERSAL: detects actual table-name case via INFORMATION_SCHEMA — works on both
+-- case-sensitive (Linux, lower_case_table_names=0) and case-insensitive (Windows/Azure).
+-- All CREATE INDEX statements are guarded with existence checks — safe to re-run.
+-- Deployments that already applied this migration manually will SKIP all steps cleanly.
+
+SELECT 'Migration v2.7.0 - STOCKHISTORYARCHIVE performance indexes (x3)' AS status;
+
+-- ============================================================
+-- STEP 0: DETECT ACTUAL TABLE NAME CASE
+-- ============================================================
+
+SET @sha_table = (
+    SELECT TABLE_NAME FROM INFORMATION_SCHEMA.TABLES
+    WHERE TABLE_SCHEMA = DATABASE() AND UPPER(TABLE_NAME) = 'STOCKHISTORYARCHIVE'
+    LIMIT 1
+);
+
+SELECT CONCAT('STOCKHISTORYARCHIVE table: ', COALESCE(@sha_table, 'NOT FOUND — migration will skip')) AS info;
+
+-- ============================================================
+-- STEP 1: PRE-MIGRATION STATE
+-- ============================================================
+
+SELECT 'BEFORE: STOCKHISTORYARCHIVE indexes' AS status;
+SELECT INDEX_NAME, GROUP_CONCAT(COLUMN_NAME ORDER BY SEQ_IN_INDEX) AS columns
+FROM INFORMATION_SCHEMA.STATISTICS
+WHERE TABLE_SCHEMA = DATABASE() AND UPPER(TABLE_NAME) = 'STOCKHISTORYARCHIVE'
+GROUP BY INDEX_NAME
+ORDER BY INDEX_NAME;
+
+-- ============================================================
+-- STEP 2: idx_stockhistoryarchive_batch_date_retired
+--         (ITEMBATCH_ID, CREATEDAT, RETIRED)
+-- ============================================================
+
+SELECT 'Step 2: Creating idx_stockhistoryarchive_batch_date_retired' AS status;
+
+SET @idx1_exists = (
+    SELECT COUNT(*) FROM INFORMATION_SCHEMA.STATISTICS
+    WHERE TABLE_SCHEMA = DATABASE()
+      AND UPPER(TABLE_NAME) = 'STOCKHISTORYARCHIVE'
+      AND INDEX_NAME = 'idx_stockhistoryarchive_batch_date_retired'
+);
+
+SET @sql = IF(@sha_table IS NOT NULL AND @idx1_exists = 0,
+    CONCAT('CREATE INDEX idx_stockhistoryarchive_batch_date_retired ON ', @sha_table,
+           ' (ITEMBATCH_ID, CREATEDAT, RETIRED)'),
+    'SELECT "SKIPPED: idx_stockhistoryarchive_batch_date_retired already exists or table not found" AS status'
+);
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+SELECT IF(
+    (SELECT COUNT(*) FROM INFORMATION_SCHEMA.STATISTICS
+     WHERE TABLE_SCHEMA = DATABASE()
+       AND UPPER(TABLE_NAME) = 'STOCKHISTORYARCHIVE'
+       AND INDEX_NAME = 'idx_stockhistoryarchive_batch_date_retired') > 0,
+    'OK: idx_stockhistoryarchive_batch_date_retired present',
+    'FAILED: idx_stockhistoryarchive_batch_date_retired missing') AS verify_2;
+
+-- ============================================================
+-- STEP 3: idx_stockhistoryarchive_date_dept_retired
+--         (CREATEDAT, DEPARTMENT_ID, RETIRED)
+-- ============================================================
+
+SELECT 'Step 3: Creating idx_stockhistoryarchive_date_dept_retired' AS status;
+
+SET @idx2_exists = (
+    SELECT COUNT(*) FROM INFORMATION_SCHEMA.STATISTICS
+    WHERE TABLE_SCHEMA = DATABASE()
+      AND UPPER(TABLE_NAME) = 'STOCKHISTORYARCHIVE'
+      AND INDEX_NAME = 'idx_stockhistoryarchive_date_dept_retired'
+);
+
+SET @sql = IF(@sha_table IS NOT NULL AND @idx2_exists = 0,
+    CONCAT('CREATE INDEX idx_stockhistoryarchive_date_dept_retired ON ', @sha_table,
+           ' (CREATEDAT, DEPARTMENT_ID, RETIRED)'),
+    'SELECT "SKIPPED: idx_stockhistoryarchive_date_dept_retired already exists or table not found" AS status'
+);
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+SELECT IF(
+    (SELECT COUNT(*) FROM INFORMATION_SCHEMA.STATISTICS
+     WHERE TABLE_SCHEMA = DATABASE()
+       AND UPPER(TABLE_NAME) = 'STOCKHISTORYARCHIVE'
+       AND INDEX_NAME = 'idx_stockhistoryarchive_date_dept_retired') > 0,
+    'OK: idx_stockhistoryarchive_date_dept_retired present',
+    'FAILED: idx_stockhistoryarchive_date_dept_retired missing') AS verify_3;
+
+-- ============================================================
+-- STEP 4: idx_stockhistoryarchive_historytype_dept_createdat
+--         (HISTORYTYPE, DEPARTMENT_ID, CREATEDAT)
+-- ============================================================
+
+SELECT 'Step 4: Creating idx_stockhistoryarchive_historytype_dept_createdat' AS status;
+
+SET @idx3_exists = (
+    SELECT COUNT(*) FROM INFORMATION_SCHEMA.STATISTICS
+    WHERE TABLE_SCHEMA = DATABASE()
+      AND UPPER(TABLE_NAME) = 'STOCKHISTORYARCHIVE'
+      AND INDEX_NAME = 'idx_stockhistoryarchive_historytype_dept_createdat'
+);
+
+SET @sql = IF(@sha_table IS NOT NULL AND @idx3_exists = 0,
+    CONCAT('CREATE INDEX idx_stockhistoryarchive_historytype_dept_createdat ON ', @sha_table,
+           ' (HISTORYTYPE, DEPARTMENT_ID, CREATEDAT)'),
+    'SELECT "SKIPPED: idx_stockhistoryarchive_historytype_dept_createdat already exists or table not found" AS status'
+);
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+SELECT IF(
+    (SELECT COUNT(*) FROM INFORMATION_SCHEMA.STATISTICS
+     WHERE TABLE_SCHEMA = DATABASE()
+       AND UPPER(TABLE_NAME) = 'STOCKHISTORYARCHIVE'
+       AND INDEX_NAME = 'idx_stockhistoryarchive_historytype_dept_createdat') > 0,
+    'OK: idx_stockhistoryarchive_historytype_dept_createdat present',
+    'FAILED: idx_stockhistoryarchive_historytype_dept_createdat missing') AS verify_4;
+
+-- ============================================================
+-- STEP 5: POST-MIGRATION VERIFICATION
+-- ============================================================
+
+SELECT 'AFTER: STOCKHISTORYARCHIVE indexes' AS status;
+SELECT INDEX_NAME, GROUP_CONCAT(COLUMN_NAME ORDER BY SEQ_IN_INDEX) AS columns
+FROM INFORMATION_SCHEMA.STATISTICS
+WHERE TABLE_SCHEMA = DATABASE() AND UPPER(TABLE_NAME) = 'STOCKHISTORYARCHIVE'
+GROUP BY INDEX_NAME
+ORDER BY INDEX_NAME;
+
+SELECT 'Migration v2.7.0 completed - STOCKHISTORYARCHIVE has all 4 performance indexes' AS final_status;

--- a/src/main/resources/db/migrations/v2.7.0/rollback.sql
+++ b/src/main/resources/db/migrations/v2.7.0/rollback.sql
@@ -1,0 +1,30 @@
+-- Rollback v2.7.0: Drop STOCKHISTORYARCHIVE performance indexes
+
+SET @sha_table = (
+    SELECT TABLE_NAME FROM INFORMATION_SCHEMA.TABLES
+    WHERE TABLE_SCHEMA = DATABASE() AND UPPER(TABLE_NAME) = 'STOCKHISTORYARCHIVE'
+    LIMIT 1
+);
+
+SET @idx_exists = (SELECT COUNT(*) FROM INFORMATION_SCHEMA.STATISTICS
+    WHERE TABLE_SCHEMA = DATABASE() AND UPPER(TABLE_NAME) = 'STOCKHISTORYARCHIVE'
+      AND INDEX_NAME = 'idx_stockhistoryarchive_batch_date_retired');
+SET @sql = IF(@sha_table IS NULL OR @idx_exists = 0, 'SELECT 1',
+    CONCAT('ALTER TABLE ', @sha_table, ' DROP INDEX idx_stockhistoryarchive_batch_date_retired'));
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+SET @idx_exists = (SELECT COUNT(*) FROM INFORMATION_SCHEMA.STATISTICS
+    WHERE TABLE_SCHEMA = DATABASE() AND UPPER(TABLE_NAME) = 'STOCKHISTORYARCHIVE'
+      AND INDEX_NAME = 'idx_stockhistoryarchive_date_dept_retired');
+SET @sql = IF(@sha_table IS NULL OR @idx_exists = 0, 'SELECT 1',
+    CONCAT('ALTER TABLE ', @sha_table, ' DROP INDEX idx_stockhistoryarchive_date_dept_retired'));
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+SET @idx_exists = (SELECT COUNT(*) FROM INFORMATION_SCHEMA.STATISTICS
+    WHERE TABLE_SCHEMA = DATABASE() AND UPPER(TABLE_NAME) = 'STOCKHISTORYARCHIVE'
+      AND INDEX_NAME = 'idx_stockhistoryarchive_historytype_dept_createdat');
+SET @sql = IF(@sha_table IS NULL OR @idx_exists = 0, 'SELECT 1',
+    CONCAT('ALTER TABLE ', @sha_table, ' DROP INDEX idx_stockhistoryarchive_historytype_dept_createdat'));
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+SELECT 'Rollback v2.7.0 completed — STOCKHISTORYARCHIVE performance indexes dropped' AS status;

--- a/src/main/webapp/dataAdmin/admin_data_administration.xhtml
+++ b/src/main/webapp/dataAdmin/admin_data_administration.xhtml
@@ -150,12 +150,12 @@
                                                 styleClass="w-100 ui-button-success"
                                                 icon="fa fa-database" />
                                             <p:commandButton
-                                                value="Archive Old StockHistory"
-                                                action="#{stockHistoryArchivalController.navigateToArchiveStockHistory()}"
+                                                value="Archival"
+                                                action="admin_functions?faces-redirect=true"
                                                 ajax="false"
-                                                styleClass="w-100 ui-button-warning"
+                                                styleClass="w-100 ui-button-secondary"
                                                 icon="fa fa-archive"
-                                                rendered="#{webUserController.hasPrivilege('ArchiveOldStockHistory')}" />
+                                                rendered="#{webUserController.hasPrivilege('ArchiveOldStockHistory') or webUserController.hasPrivilege('ArchiveOldItemBatch')}" />
                                         </div>
                                     </p:tab>
 

--- a/src/main/webapp/dataAdmin/admin_functions.xhtml
+++ b/src/main/webapp/dataAdmin/admin_functions.xhtml
@@ -1107,6 +1107,65 @@
                             </table>
                         </p:tab>
 
+                        <p:tab title="Archival">
+                            <h5 class="mb-3">
+                                <i class="fa fa-archive"></i> Data Archival
+                            </h5>
+                            <div class="alert alert-info mb-3">
+                                Archival moves old records out of the live tables into separate archive tables
+                                to reduce table bloat and improve query performance. Each archival page lets you
+                                set a retention period, preview the candidate count, and run a batched move.
+                                Always run a dry-run first to confirm the candidate count before committing.
+                            </div>
+                            <table class="table table-sm table-bordered w-100">
+                                <thead class="table-light">
+                                    <tr>
+                                        <th style="width: 20%;">Name</th>
+                                        <th style="width: 55%;">Description</th>
+                                        <th style="width: 25%;">Action</th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    <tr>
+                                        <td><strong>Archive Old StockHistory Records</strong></td>
+                                        <td>
+                                            Moves StockHistory rows older than the configured retention period
+                                            (default 730 days) to STOCKHISTORYARCHIVE. Preserves original IDs.
+                                            Supports dry-run, configurable batch size, and per-run batch cap.
+                                            Reports with "Include Archived" toggle will query both tables.
+                                        </td>
+                                        <td>
+                                            <p:commandButton
+                                                value="Archive StockHistory"
+                                                icon="fa fa-archive"
+                                                ajax="false"
+                                                styleClass="ui-button-warning m-1"
+                                                action="#{stockHistoryArchivalController.navigateToArchiveStockHistory()}"
+                                                rendered="#{webUserController.hasPrivilege('ArchiveOldStockHistory')}" />
+                                        </td>
+                                    </tr>
+                                    <tr>
+                                        <td><strong>Archive Expired ItemBatch Records</strong></td>
+                                        <td>
+                                            Moves expired, zero-stock ItemBatch rows to ITEMBATCHARCHIVE to reduce
+                                            live table size. Expired batches no longer appear in stock selection
+                                            autocompletes or active reports. Archived batches remain accessible
+                                            for historical reporting.
+                                        </td>
+                                        <td>
+                                            <p:commandButton
+                                                value="Archive ItemBatch"
+                                                icon="fa fa-archive"
+                                                ajax="false"
+                                                styleClass="ui-button-warning m-1"
+                                                action="#{itemBatchArchivalController.navigateToArchiveItemBatch()}"
+                                                rendered="#{webUserController.hasPrivilege('ArchiveOldItemBatch')}" />
+                                        </td>
+                                    </tr>
+                                </tbody>
+                            </table>
+                        </p:tab>
+
                     </p:accordionPanel>
                 </h:form>
 

--- a/src/main/webapp/dataAdmin/archive_item_batch.xhtml
+++ b/src/main/webapp/dataAdmin/archive_item_batch.xhtml
@@ -12,6 +12,9 @@
         <ui:composition template="/dataAdmin/admin_data_administration.xhtml">
             <ui:define name="subcontent">
                 <h:form id="archiveForm" rendered="#{webUserController.hasPrivilege('ArchiveOldItemBatch')}">
+                    <p:poll interval="3" update="@form" globalStatus="false"
+                            active="#{itemBatchArchivalController.tracker.running}" />
+
                     <p:panel>
                         <f:facet name="header">
                             <h:outputLabel value="Archive Expired Zero-Stock ItemBatch Records" />
@@ -46,12 +49,14 @@
                                         <p:commandButton id="previewBtn" value="Preview Count" icon="fa fa-search"
                                                          class="ui-button-info m-1"
                                                          action="#{itemBatchArchivalController.preview}"
-                                                         update="archiveForm" />
+                                                         update="archiveForm"
+                                                         disabled="#{itemBatchArchivalController.tracker.running}" />
                                         <p:commandButton id="runBtn" value="Run" icon="fa fa-play"
                                                          class="ui-button-success m-1"
                                                          action="#{itemBatchArchivalController.run}"
                                                          update="archiveForm"
-                                                         onclick="return confirm('Run archive now? Non-dry-run moves ItemBatch and Stock rows out of the live tables.');" />
+                                                         disabled="#{itemBatchArchivalController.tracker.running}"
+                                                         onclick="if(#{itemBatchArchivalController.tracker.running}) return false; return confirm('Run archive now? Non-dry-run moves ItemBatch and Stock rows out of the live tables.');" />
                                     </f:facet>
                                 </p:panel>
 
@@ -66,8 +71,22 @@
                             </div>
 
                             <div class="col-md-5">
+                                <p:panel header="Archival in Progress"
+                                         rendered="#{itemBatchArchivalController.tracker.running}">
+                                    <p:progressBar value="#{itemBatchArchivalController.tracker.progressPercent}"
+                                                   displayOnly="true" labelTemplate="{value}%"
+                                                   style="margin-bottom:0.75em" />
+                                    <p:panelGrid columns="2" layout="tabular" class="w-100">
+                                        <h:outputLabel value="Rows archived" />
+                                        <h:outputText value="#{itemBatchArchivalController.tracker.archivedSoFar} / #{itemBatchArchivalController.tracker.candidates}" />
+
+                                        <h:outputLabel value="Batches done" />
+                                        <h:outputText value="#{itemBatchArchivalController.tracker.batchesDone} / #{itemBatchArchivalController.tracker.maxBatches}" />
+                                    </p:panelGrid>
+                                </p:panel>
+
                                 <p:panel header="Last Result"
-                                         rendered="#{itemBatchArchivalController.lastResult ne null}">
+                                         rendered="#{itemBatchArchivalController.lastResult ne null and not itemBatchArchivalController.tracker.running}">
                                     <p:panelGrid columns="2" layout="tabular" class="w-100">
                                         <h:outputLabel value="Mode" />
                                         <h:outputText value="#{itemBatchArchivalController.lastResult.dryRun ? 'Dry run' : 'Live run'}" />

--- a/src/main/webapp/dataAdmin/archive_stock_history.xhtml
+++ b/src/main/webapp/dataAdmin/archive_stock_history.xhtml
@@ -23,6 +23,17 @@
                             <div class="col-md-7">
                                 <p:panel header="Archive Settings">
                                     <p:panelGrid columns="2" layout="tabular" class="w-100">
+                                        <p:outputLabel for="retDays" value="Retention Period (days)" />
+                                        <h:panelGroup layout="block" styleClass="d-flex align-items-center">
+                                            <p:inputNumber id="retDays" value="#{stockHistoryArchivalController.retentionDays}"
+                                                           minValue="1" maxValue="36500" decimalPlaces="0" thousandSeparator=""
+                                                           inputStyleClass="w-100" style="flex:1" />
+                                            <p:commandButton value="Apply" icon="fa fa-sync" class="ui-button-secondary mx-1"
+                                                             action="#{stockHistoryArchivalController.recalculateCutoff}"
+                                                             update="cutoff messages" process="retDays"
+                                                             title="Recalculate cutoff date from retention days" />
+                                        </h:panelGroup>
+
                                         <p:outputLabel for="cutoff" value="Cutoff Date (archive rows created before this)" />
                                         <p:calendar id="cutoff" value="#{stockHistoryArchivalController.cutoffDate}"
                                                     pattern="#{sessionController.applicationPreference.longDateTimeFormat}"

--- a/src/main/webapp/dataAdmin/archive_stock_history.xhtml
+++ b/src/main/webapp/dataAdmin/archive_stock_history.xhtml
@@ -12,6 +12,9 @@
         <ui:composition template="/dataAdmin/admin_data_administration.xhtml">
             <ui:define name="subcontent">
                 <h:form id="archiveForm" rendered="#{webUserController.hasPrivilege('ArchiveOldStockHistory')}">
+                    <p:poll interval="3" update="@form" globalStatus="false"
+                            active="#{stockHistoryArchivalController.tracker.running}" />
+
                     <p:panel>
                         <f:facet name="header">
                             <h:outputLabel value="Archive Old StockHistory Records" />
@@ -57,19 +60,35 @@
                                         <p:commandButton id="previewBtn" value="Preview Count" icon="fa fa-search"
                                                          class="ui-button-info m-1"
                                                          action="#{stockHistoryArchivalController.preview}"
-                                                         update="archiveForm" />
+                                                         update="archiveForm"
+                                                         disabled="#{stockHistoryArchivalController.tracker.running}" />
                                         <p:commandButton id="runBtn" value="Run" icon="fa fa-play"
                                                          class="ui-button-success m-1"
                                                          action="#{stockHistoryArchivalController.run}"
                                                          update="archiveForm"
-                                                         onclick="return confirm('Run archive now? Non-dry-run moves rows out of STOCKHISTORY.');" />
+                                                         disabled="#{stockHistoryArchivalController.tracker.running}"
+                                                         onclick="if(#{stockHistoryArchivalController.tracker.running}) return false; return confirm('Run archive now? Non-dry-run moves rows out of STOCKHISTORY.');" />
                                     </f:facet>
                                 </p:panel>
                             </div>
 
                             <div class="col-md-5">
+                                <p:panel header="Archival in Progress"
+                                         rendered="#{stockHistoryArchivalController.tracker.running}">
+                                    <p:progressBar value="#{stockHistoryArchivalController.tracker.progressPercent}"
+                                                   displayOnly="true" labelTemplate="{value}%"
+                                                   style="margin-bottom:0.75em" />
+                                    <p:panelGrid columns="2" layout="tabular" class="w-100">
+                                        <h:outputLabel value="Rows archived" />
+                                        <h:outputText value="#{stockHistoryArchivalController.tracker.archivedSoFar} / #{stockHistoryArchivalController.tracker.candidates}" />
+
+                                        <h:outputLabel value="Batches done" />
+                                        <h:outputText value="#{stockHistoryArchivalController.tracker.batchesDone} / #{stockHistoryArchivalController.tracker.maxBatches}" />
+                                    </p:panelGrid>
+                                </p:panel>
+
                                 <p:panel header="Last Result"
-                                         rendered="#{stockHistoryArchivalController.lastResult ne null}">
+                                         rendered="#{stockHistoryArchivalController.lastResult ne null and not stockHistoryArchivalController.tracker.running}">
                                     <p:panelGrid columns="2" layout="tabular" class="w-100">
                                         <h:outputLabel value="Mode" />
                                         <h:outputText value="#{stockHistoryArchivalController.lastResult.dryRun ? 'Dry run' : 'Live run'}" />

--- a/src/main/webapp/dataAdmin/archive_stock_history.xhtml
+++ b/src/main/webapp/dataAdmin/archive_stock_history.xhtml
@@ -30,7 +30,7 @@
                                                            inputStyleClass="w-100" style="flex:1" />
                                             <p:commandButton value="Apply" icon="fa fa-sync" class="ui-button-secondary mx-1"
                                                              action="#{stockHistoryArchivalController.recalculateCutoff}"
-                                                             update="cutoff messages" process="retDays"
+                                                             update="cutoff messages" process="@form"
                                                              title="Recalculate cutoff date from retention days" />
                                         </h:panelGroup>
 

--- a/src/main/webapp/pharmacy/bin_card_dto.xhtml
+++ b/src/main/webapp/pharmacy/bin_card_dto.xhtml
@@ -74,9 +74,13 @@
                         </p:column>
                     </p:autoComplete>
                     <p:spacer width="10" ></p:spacer>
-                    <p:commandButton 
-                        class="m-1 ui-button-warning" 
-                        ajax="false" 
+                    <p:selectBooleanCheckbox id="includeArchived"
+                                             value="#{pharmacyErrorChecking.includeArchived}"/>
+                    <p:outputLabel for="includeArchived" value="Include Archived" class="m-1"/>
+                    <p:spacer width="10" ></p:spacer>
+                    <p:commandButton
+                        class="m-1 ui-button-warning"
+                        ajax="false"
                         icon="fas fa-arrows-rotate"
                         value="Generate Report"
                         action="#{pharmacyErrorChecking.processBinCardWithDTO()}" >

--- a/src/main/webapp/pharmacy/pharmacy_department_stock_history.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_department_stock_history.xhtml
@@ -41,10 +41,15 @@
 
 
                                 </h:panelGrid>
+                                <div class="my-2 d-flex align-items-center">
+                                    <p:selectBooleanCheckbox id="includeArchived"
+                                                             value="#{stockHistoryController.includeArchived}"/>
+                                    <p:outputLabel for="includeArchived" value="Include Archived" class="mx-2"/>
+                                </div>
                                 <div class="my-2">
-                                    <p:commandButton ajax="false" 
+                                    <p:commandButton ajax="false"
                                                      class="ui-button-warning"
-                                                     action="#{stockHistoryController.fillHistoryAvailableDays()}" 
+                                                     action="#{stockHistoryController.fillHistoryAvailableDays()}"
                                                      value="Display Available Days"  ></p:commandButton>
                                     <p:commandButton ajax="false" 
                                                      class="ui-button-warning mx-1"
@@ -169,6 +174,72 @@
                                             <f:convertNumber pattern="#,###,##0.00" />
                                         </p:outputLabel>
                                     </f:facet>
+                                </p:column>
+                            </p:dataTable>
+                        </p:panel>
+
+                        <p:panel styleClass="noBorder summeryBorder" class="my-2"
+                                 rendered="#{not empty stockHistoryController.pharmacyStockHistoriesArchive}">
+                            <f:facet name="header">
+                                <p:outputLabel value="Archived Stock History Records" style="font-weight:bold;"/>
+                            </f:facet>
+                            <p:dataTable id="tblArchiveHistories"
+                                         value="#{stockHistoryController.pharmacyStockHistoriesArchive}"
+                                         rowKey="#{archItem.id}"
+                                         rowIndexVar="ai"
+                                         var="archItem">
+                                <p:column style="width: 40px;">
+                                    <f:facet name="header">No</f:facet>
+                                    <p:outputLabel value="#{ai + 1}"/>
+                                </p:column>
+                                <p:column rendered="#{stockHistoryController.department eq null}"
+                                          sortBy="#{archItem.department.name}"
+                                          filterBy="#{archItem.department.name}"
+                                          filterMatchMode="contains">
+                                    <f:facet name="header">
+                                        <p:outputLabel value="Department"/>
+                                    </f:facet>
+                                    <p:outputLabel value="#{archItem.department.name}"/>
+                                </p:column>
+                                <p:column sortBy="#{archItem.item.name}"
+                                          filterBy="#{archItem.item.name}"
+                                          filterMatchMode="contains">
+                                    <f:facet name="header">
+                                        <p:outputLabel value="Item"/>
+                                    </f:facet>
+                                    <p:outputLabel value="#{archItem.item.name}"/>
+                                </p:column>
+                                <p:column style="text-align: right;" styleClass="averageNumericColumn">
+                                    <f:facet name="header">
+                                        <p:outputLabel value="Stock"/>
+                                    </f:facet>
+                                    <p:outputLabel value="#{archItem.stockQty}"/>
+                                </p:column>
+                                <p:column style="text-align: right;" styleClass="averageNumericColumn">
+                                    <f:facet name="header">
+                                        <p:outputLabel value="Purchase Value"/>
+                                    </f:facet>
+                                    <p:outputLabel value="#{archItem.stockPurchaseValue}" rendered="#{archItem.stockPurchaseValue ne 0.0}">
+                                        <f:convertNumber pattern="#,###,##0.00"/>
+                                    </p:outputLabel>
+                                    <p:outputLabel value="Not Recorded." rendered="#{archItem.stockPurchaseValue eq 0.0}"/>
+                                </p:column>
+                                <p:column style="text-align: right;" styleClass="averageNumericColumn">
+                                    <f:facet name="header">
+                                        <p:outputLabel value="Retail Sale Value"/>
+                                    </f:facet>
+                                    <p:outputLabel value="#{archItem.stockSaleValue}" rendered="#{archItem.stockSaleValue ne 0.0}">
+                                        <f:convertNumber pattern="#,###,##0.00"/>
+                                    </p:outputLabel>
+                                    <p:outputLabel value="Not Recorded." rendered="#{archItem.stockSaleValue eq 0.0}"/>
+                                </p:column>
+                                <p:column style="text-align: right;" styleClass="averageNumericColumn">
+                                    <f:facet name="header">
+                                        <p:outputLabel value="Archived At"/>
+                                    </f:facet>
+                                    <p:outputLabel value="#{archItem.archivedAt}">
+                                        <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateTimeFormat}"/>
+                                    </p:outputLabel>
                                 </p:column>
                             </p:dataTable>
                         </p:panel>

--- a/src/main/webapp/reports/inventoryReports/closing_stock_report.xhtml
+++ b/src/main/webapp/reports/inventoryReports/closing_stock_report.xhtml
@@ -264,6 +264,14 @@
                             <p:selectBooleanCheckbox id="consignmentItem"
                                                      value="#{pharmacyReportController.consignmentItem}"
                                                      itemLabel="Yes"/>
+
+                            <h:panelGroup layout="block" styleClass="form-group">
+                                <h:outputText styleClass="fa fa-archive mr-2"/>
+                                <p:outputLabel value="Include Archived" for="includeArchived" class="m-3"/>
+                            </h:panelGroup>
+                            <p:selectBooleanCheckbox id="includeArchived"
+                                                     value="#{pharmacyReportController.includeArchived}"
+                                                     itemLabel="Yes"/>
                         </h:panelGrid>
 
                         <div class="d-flex align-items-center">

--- a/src/main/webapp/reports/inventoryReports/stock_ledger_dto.xhtml
+++ b/src/main/webapp/reports/inventoryReports/stock_ledger_dto.xhtml
@@ -292,7 +292,13 @@
                             </h:panelGroup>
                         </h:panelGrid>
 
-                        <div class="d-flex align-items-center mt-5">
+                        <div class="d-flex align-items-center mt-3">
+                            <p:selectBooleanCheckbox id="includeArchived"
+                                                     value="#{pharmacyReportController.includeArchived}"/>
+                            <p:outputLabel for="includeArchived" value="Include Archived" class="mx-2"/>
+                        </div>
+
+                        <div class="d-flex align-items-center mt-3">
                             <p:commandButton
                                 class="ui-button-warning mx-1"
                                 icon="fas fa-cogs"


### PR DESCRIPTION
## Summary

- **Archive read paths**: StockHistory and ItemBatch reports gain an **Include Archived** checkbox that merges results from the live table and the archive table. Deduplication builds from the full unfiltered live query set so zero-stock items with a live latest record are never re-surfaced from archive (#20729 Codex P1 fix).
- **Manual archival UI**: Admin pages for StockHistory (`/dataAdmin/archive_stock_history`) and ItemBatch (`/dataAdmin/archive_item_batch`) allow authorised users to set retention period, batch size, max batches, and dry-run before executing.
- **Async execution with live progress monitor**: Clicking Run fires an `@Asynchronous` EJB method and returns immediately. A `<p:poll>` updates a progress bar every 3 seconds showing rows archived / candidates and batches done. Buttons are disabled while running.
- **Lock-timeout retry**: `ArchivalBatchTx.copyAndDelete()` retries up to 3 times (2 s sleep) on MySQL error 1205 (lock wait timeout). Self-injection (`@EJB ArchivalBatchTx self`) ensures each retry opens a genuine `REQUIRES_NEW` transaction through the EJB proxy — direct `this.doOneBatch()` would bypass the proxy and silently ignore the annotation.
- **Database migration v2.7.0**: Three composite indexes on `STOCKHISTORYARCHIVE` matching archive-inclusive report query patterns. Script is idempotent and case-insensitive (INFORMATION_SCHEMA detection).
- **Admin functions tab**: Archival tab added to the admin functions page with links to both archive pages.
- **Wiki**: `Pharmacy-StockHistory-Archival.md` published covering navigation, settings, step-by-step usage, result panel fields, migration, maintenance schedule, and troubleshooting.

## Test plan

- [ ] Run dry run on StockHistory archive page — preview count shown, no rows moved
- [ ] Run live archive — progress bar updates every 3 seconds, Last Result panel shown on completion
- [ ] Re-run when batch limit reached — continues from where it left off
- [ ] Run while pharmacy is active — lock timeouts retry and succeed (check `server.log` for WARNING lines)
- [ ] Enable Include Archived on Closing Stock / Stock Ledger / Bin Card / Dept Stock History reports — archived rows merge correctly, zero-stock items with live records not duplicated
- [ ] Dry run on ItemBatch archive page
- [ ] Run v2.7.0 migration SQL — all 3 indexes created, idempotent on re-run

Closes #20729

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added "Include Archived" toggles across pharmacy reports, bin cards, and stock history pages to optionally display archived records alongside live data
  * Enhanced archival interface with real-time progress tracking, improved run controls, and periodic UI updates during archival operations

* **Bug Fixes**
  * Improved retry logic for database lock timeout handling during batch archival operations

* **Performance**
  * Added performance indexes on archived stock tables to optimize archived record queries

* **Documentation**
  * Added developer documentation describing archived stock history implementation and read paths

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hmislk/hmis/pull/20985?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->