### PR TITLE
docs(pr-review): warn that 'please resolve' triggers CodeRabbit Chat auto-PRs

### DIFF
--- a/.claude/skills/review-pr/SKILL.md
+++ b/.claude/skills/review-pr/SKILL.md
@@ -94,6 +94,8 @@ Verify CI passes before proceeding.
 > 2. **Reply only after fixing** (or explicitly dismissing). Bots cannot fix anything — describe action taken, not requested.
 >    - Valid + fixed → "Fixed in `<commit-sha>`: `<what was changed>`"
 >    - Dismissed → "Dismissed because: `<specific reasoning>`"
+>
+>    **⚠️ "Please resolve" wording on a CodeRabbit thread triggers CodeRabbit Chat** — it opens a NEW PR (`📝 CodeRabbit Chat: Implement requested code changes`, branch `coderabbitai/chat/<sha>`) attempting the fix against a stale snapshot. Often duplicates work the author has already done and has shipped unsafe diffs (e.g. deleted a `params.put(...)` line on PR #20979). If you accidentally trigger one: **close it, delete the branch.**
 > 3. **Replies go UNDER existing reviewer threads only** (`/replies` endpoint). Never as new top-level comments.
 > 4. **Self-review items go in the commit message** (or PR description if deferred). Never as new inline comments.
 > 5. **ONE re-review request at the end**, not per item.

--- a/.claude/skills/review-pr/SKILL.md
+++ b/.claude/skills/review-pr/SKILL.md
@@ -95,7 +95,7 @@ Verify CI passes before proceeding.
 >    - Valid + fixed → "Fixed in `<commit-sha>`: `<what was changed>`"
 >    - Dismissed → "Dismissed because: `<specific reasoning>`"
 >
->    **⚠️ "Please resolve" wording on a CodeRabbit thread triggers CodeRabbit Chat** — it opens a NEW PR (`📝 CodeRabbit Chat: Implement requested code changes`, branch `coderabbitai/chat/<sha>`) attempting the fix against a stale snapshot. Often duplicates work the author has already done and has shipped unsafe diffs (e.g. deleted a `params.put(...)` line on PR #20979). If you accidentally trigger one: **close it, delete the branch.**
+>    **⚠️ "Please resolve" wording on a CodeRabbit thread triggers CodeRabbit Chat** — it opens a NEW PR (`📝 CodeRabbit Chat: Implement requested code changes`, branch `coderabbitai/chat/<sha>`) attempting the fix against a stale snapshot. These auto-PRs often duplicate work the author has already done and have shipped unsafe diffs (e.g. deleted a `params.put(...)` line on PR #20979). If you accidentally trigger one: **close it, delete the branch.**
 > 3. **Replies go UNDER existing reviewer threads only** (`/replies` endpoint). Never as new top-level comments.
 > 4. **Self-review items go in the commit message** (or PR description if deferred). Never as new inline comments.
 > 5. **ONE re-review request at the end**, not per item.

--- a/.codex/skills/review-pr/SKILL.md
+++ b/.codex/skills/review-pr/SKILL.md
@@ -40,6 +40,7 @@ Use this skill when working a PR review loop on HMIS: collect review comments, v
 2. **Reply only after fixing** (or explicitly dismissing). Bots cannot fix anything — describe action taken, not requested.
    - Valid + fixed → "Fixed in `<commit-sha>`: `<what was changed>`"
    - Dismissed → "Dismissed because: `<specific reasoning>`"
+   - **⚠️ "Please resolve" wording on a CodeRabbit thread triggers CodeRabbit Chat**, which opens a NEW PR attempting the fix against a stale snapshot. Has shipped unsafe diffs in the past (PR #20979). If accidentally triggered: close the PR, delete the `coderabbitai/chat/<sha>` branch.
 3. **Replies go UNDER existing reviewer threads only** — use `POST /pulls/{pr}/comments/{id}/replies`. Never as new top-level comments.
 4. **Self-review items go in the commit message** (or PR description if deferred). Never as new inline comments. Reference file:line in the commit message so reviewers can find the change in the diff.
 5. **ONE re-review request at the end** — click "Re-request review" once after all fixes are pushed and all existing threads have replies. Not per item.

--- a/.codex/skills/review-pr/SKILL.md
+++ b/.codex/skills/review-pr/SKILL.md
@@ -40,7 +40,7 @@ Use this skill when working a PR review loop on HMIS: collect review comments, v
 2. **Reply only after fixing** (or explicitly dismissing). Bots cannot fix anything — describe action taken, not requested.
    - Valid + fixed → "Fixed in `<commit-sha>`: `<what was changed>`"
    - Dismissed → "Dismissed because: `<specific reasoning>`"
-   - **⚠️ "Please resolve" wording on a CodeRabbit thread triggers CodeRabbit Chat**, which opens a NEW PR attempting the fix against a stale snapshot. Has shipped unsafe diffs in the past (PR #20979). If accidentally triggered: close the PR, delete the `coderabbitai/chat/<sha>` branch.
+   - **⚠️ "Please resolve" wording on a CodeRabbit thread triggers CodeRabbit Chat**, which opens a NEW PR attempting the fix against a stale snapshot. These auto-PRs have shipped unsafe diffs in the past (PR #20979). If accidentally triggered: close the PR, delete the `coderabbitai/chat/<sha>` branch.
 3. **Replies go UNDER existing reviewer threads only** — use `POST /pulls/{pr}/comments/{id}/replies`. Never as new top-level comments.
 4. **Self-review items go in the commit message** (or PR description if deferred). Never as new inline comments. Reference file:line in the commit message so reviewers can find the change in the diff.
 5. **ONE re-review request at the end** — click "Re-request review" once after all fixes are pushed and all existing threads have replies. Not per item.

--- a/developer_docs/git/pr-review-workflow.md
+++ b/developer_docs/git/pr-review-workflow.md
@@ -112,6 +112,8 @@ git branch -d <branch-name>
 >    - **Valid + fixed** → "Fixed in `<commit-sha>`: `<what was changed>`"
 >    - **Dismissed** → "Dismissed because: `<specific reasoning>`"
 >
+>    **⚠️ CodeRabbit Chat consequence:** wording like "please resolve", "please address", "please add X" on a CodeRabbit thread is interpreted as a Chat command. CodeRabbit will then **open a NEW PR** (named `📝 CodeRabbit Chat: Implement requested code changes` on branch `coderabbitai/chat/<sha>`) attempting the fix. That auto-PR is generated against a snapshot of the diff that may already be stale, often duplicates or conflicts with work the author has done, and has produced unsafe diffs (e.g. deleting a `params.put(...)` line on PR #20979). If you accidentally trigger one: **close it without merging** and delete the `coderabbitai/chat/<sha>` branch.
+>
 > 3. **Replies go UNDER existing reviewer threads** (`POST /pulls/{pr}/comments/{id}/replies`) — never as new top-level comments. The reply stays in the parent's thread and the bot/reviewer can resolve their own thread on detection.
 >
 > 4. **Self-review items go in the commit message and/or PR description**, NOT as new top-level inline comments. If you spot something while reviewing your own PR, fix it (or document the decision to defer) in the commit message and update the PR description checklist. Don't sprinkle review items as new inline comments — that creates manual-resolve noise.


### PR DESCRIPTION
## Summary

Small follow-up to PR #20980. Captures a concrete consequence we hit today:

My "please resolve" / "please address" replies under CodeRabbit threads on PR #20977 caused **CodeRabbit Chat** to interpret them as commands and **open a new PR (#20979)** attempting the fixes on its own \`coderabbitai/chat/<sha>\` branch.

That auto-PR was:
- **Stale** — the \`actor != null\` guard was already in \`development\` via my own commit \`322f86247f\`
- **Unsafe** — its diff deleted \`params.put("b", settlementBill);\` from \`cancelSettlement\`, which would have left the JPQL parameter \`:b\` unbound

PR #20979 has been closed and the \`coderabbitai/chat/1984d15\` branch deleted.

## Changes

Adds a one-paragraph warning to all three review-pr surfaces:
- \`developer_docs/git/pr-review-workflow.md\` — under cardinal rule #2
- \`.claude/skills/review-pr/SKILL.md\` — under cardinal rule #2
- \`.codex/skills/review-pr/SKILL.md\` — under cardinal rule #2

The warning explains:
1. "Please resolve" / "please address" wording on a CodeRabbit thread triggers CodeRabbit Chat
2. CodeRabbit then opens a new PR with the proposed fix against a stale snapshot
3. These auto-PRs have shipped unsafe diffs in the past
4. Recovery: close the PR, delete the \`coderabbitai/chat/<sha>\` branch

## Test plan

- [ ] Doc-only changes — no code, no compile needed
- [ ] All three files consistent (warning under rule #2 in each)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Documentation
* Added warnings to the PR review workflow about CodeRabbit Chat being triggered by request-like review wording (e.g., “please resolve”), which can open an automatic PR on a chat branch.
* Added instructions to close any auto-generated PR and delete the associated chat branch if triggered.
* Documentation updates applied across multiple workflow and guidance pages.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hmislk/hmis/pull/20986?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->