### PR TITLE
fix(pharmacy): fix BHT Issue & Unit Issue reports missing historical data

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,6 +27,9 @@
 ### persistence.xml — Local JNDI Lifecycle
 17. **🚨 RESTORE LOCAL JNDI AFTER EVERY PUSH**: Immediately after every `git push`, replace the CI/CD placeholders in `persistence.xml` back to the local JNDI names — `${JDBC_DATASOURCE}` → `jdbc/coop` and `${JDBC_AUDIT_DATASOURCE}` → `jdbc/ruhunuAudit`. Leave the change **unstaged**. Do this without being asked. The developer needs local Payara to connect right away for testing.
 
+### Security — Credentials & Sensitive Data
+18. **🚨 NEVER COMMIT CREDENTIALS OR SENSITIVE DATA**: Do NOT write passwords, API keys, database usernames, IP addresses, hostnames, or SSH connection strings into any file inside the project folder — including `developer_docs/`, `tmp/`, `wiki-docs/`, migration scripts, or any other tracked or untracked file. These belong exclusively in secure storage **outside** the project directory (e.g. `C:\Credentials\`). If a doc needs to reference how to connect to a database, write a generic description and point to the external credentials file — never inline the actual values.
+
 ### Deployment
 16. **🚨 NEVER DEPLOY MANUALLY AS ROOT**: NEVER use `sudo` or root to copy WARs, run `asadmin`, or touch Payara's application/log directories directly. Root-owned files in `/opt/payara5/glassfish/domains/domain1/` (applications, generated, logs) block all future CI/CD deployments — `asadmin undeploy` and `deploy` will fail with permission errors. **All deployments MUST go through GitHub Actions CI/CD.** If a manual fix is absolutely needed, use `appuser` only. See [Deployment Recovery Guide](developer_docs/deployment/deployment-recovery-guide.md).
 

--- a/developer_docs/pharmacy/bht-unit-issue-report-backfill-guide.md
+++ b/developer_docs/pharmacy/bht-unit-issue-report-backfill-guide.md
@@ -1,0 +1,357 @@
+# BHT Issue & Unit Issue Report — Historical Data Backfill Guide
+
+**Related issue:** [#20996](https://github.com/hmislk/hmis/issues/20996)  
+**Affected reports:**
+- `/pharmacy/pharmacy_report_bht_issue_bill.xhtml` — BHT Issue Report
+- `/pharmacy/pharmacy_report_unit_issue_bill.xhtml` — Unit Issue Report
+
+---
+
+## Background
+
+After a recent update, both reports showed data for the current period but not for earlier months.
+Each report has a **different root cause**.
+
+---
+
+## Report 1 — BHT Issue Report
+
+### Root Cause
+
+`ReportsTransfer.fillDepartmentBHTIssueByBillByDTOs()` navigates
+`b.billFinanceDetails.totalPurchaseValue` as a path expression directly in the JPQL SELECT clause:
+
+```java
+"CASE WHEN b.billFinanceDetails IS NOT NULL THEN COALESCE(b.billFinanceDetails.totalPurchaseValue, 0.0) ELSE 0.0 END"
+```
+
+JPA/EclipseLink converts **any path navigation in the SELECT clause into an implicit INNER JOIN**,
+even inside a `CASE WHEN`. Bills created before `BillFinanceDetails` rows were populated have
+`BILLFINANCEDETAILS_ID = NULL` in the database, so the implicit INNER JOIN silently excludes them.
+
+New bills have `BillFinanceDetails` populated at creation time → they appear.  
+Old bills do not → they disappear.
+
+### Permanent Code Fix (included in the PR that introduced this guide — issue #20996)
+
+In `ReportsTransfer.java`, `fillDepartmentBHTIssueByBillByDTOs()`:
+
+```java
+// ADD this LEFT JOIN to the FROM clause:
+.append("LEFT JOIN b.billFinanceDetails bfd ")
+
+// REPLACE the CASE WHEN expression with:
+.append("COALESCE(bfd.totalPurchaseValue, 0.0), ")
+```
+
+### Diagnosis Query
+
+```sql
+-- How many PharmacyBhtPre bills are missing BillFinanceDetails?
+SELECT COUNT(*) AS bills_missing_bfd
+FROM bill b
+WHERE b.BILLTYPE = 'PharmacyBhtPre'
+  AND b.RETIRED   = 0
+  AND b.CREATEDAT >= '2026-03-01 00:00:00'
+  AND b.CREATEDAT <  '2026-05-26 00:00:00'   -- adjust end date as needed
+  AND b.BILLFINANCEDETAILS_ID IS NULL;
+```
+
+### Backfill — via Admin UI (preferred)
+
+Go to `/dataAdmin/admin_functions.xhtml`:
+
+1. Set the **date range** at the top of the page to the period with missing data.
+2. Click **"Correct Finance Details for Inpatient Direct Issue Bills"**.
+3. Confirm the prompt.
+4. Check `executionFeedback` — should report 0 skipped bills.
+
+This calls `DataAdministrationController.correctInpatientDirectIssueBillFinanceDetails()`, which
+covers `DIRECT_ISSUE_INWARD_MEDICINE`, `DIRECT_ISSUE_THEATRE_MEDICINE`, `DIRECT_ISSUE_STORE_INWARD`,
+and `ISSUE_MEDICINE_ON_REQUEST_INWARD`. Safe to re-run (skips bills already having a non-zero
+`totalCostValue`).
+
+### Backfill — via SQL (when UI is unavailable or for bulk historical periods)
+
+Run the following on the target database. Replace the date range as needed.
+
+**Step 1 — Check count:**
+```sql
+SELECT COUNT(*) AS bills_missing_bfd
+FROM bill b
+WHERE b.BILLTYPE = 'PharmacyBhtPre'
+  AND b.RETIRED   = 0
+  AND b.CREATEDAT >= '2026-03-01 00:00:00'
+  AND b.CREATEDAT <  '2026-05-26 00:00:00'
+  AND b.BILLFINANCEDETAILS_ID IS NULL;
+```
+
+**Step 2 — Run the stored procedure:**
+
+```sql
+DROP PROCEDURE IF EXISTS backfill_bht_bfd;
+
+DELIMITER $$
+
+CREATE PROCEDURE backfill_bht_bfd()
+BEGIN
+    DECLARE done        INT DEFAULT 0;
+    DECLARE v_bill_id   BIGINT;
+    DECLARE v_createdat DATETIME;
+    DECLARE v_total     DOUBLE;
+    DECLARE v_nettotal  DOUBLE;
+
+    DECLARE v_totalPurchase  DECIMAL(38,4) DEFAULT 0;
+    DECLARE v_totalCost      DECIMAL(38,4) DEFAULT 0;
+    DECLARE v_totalRetail    DECIMAL(38,4) DEFAULT 0;
+    DECLARE v_totalWholesale DECIMAL(38,4) DEFAULT 0;
+    DECLARE v_totalQty       DECIMAL(38,4) DEFAULT 0;
+    DECLARE v_totalFreeQty   DECIMAL(38,4) DEFAULT 0;
+    DECLARE v_new_bfd_id     BIGINT;
+
+    DECLARE cur CURSOR FOR
+        SELECT b.ID, b.CREATEDAT, b.TOTAL, b.NETTOTAL
+        FROM bill b
+        WHERE b.BILLTYPE = 'PharmacyBhtPre'
+          AND b.RETIRED   = 0
+          AND b.CREATEDAT >= '2026-03-01 00:00:00'   -- adjust as needed
+          AND b.CREATEDAT <  '2026-05-26 00:00:00'   -- adjust as needed
+          AND b.BILLFINANCEDETAILS_ID IS NULL;
+
+    DECLARE CONTINUE HANDLER FOR NOT FOUND SET done = 1;
+
+    OPEN cur;
+
+    read_loop: LOOP
+        FETCH cur INTO v_bill_id, v_createdat, v_total, v_nettotal;
+        IF done THEN LEAVE read_loop; END IF;
+
+        -- Aggregate rates from ItemBatch for this bill's items.
+        -- Values are NEGATIVE (stock going OUT to patient).
+        SELECT
+            -SUM((ABS(bi.QTY) + COALESCE(pbi.FREEQTY, 0)) * ib.PURCAHSERATE),
+            -SUM(ABS(bi.QTY)  * COALESCE(NULLIF(ib.COSTRATE, 0), ib.PURCAHSERATE)),
+            -SUM((ABS(bi.QTY) + COALESCE(pbi.FREEQTY, 0)) * ib.RETAILSALERATE),
+            -SUM((ABS(bi.QTY) + COALESCE(pbi.FREEQTY, 0)) * ib.WHOLESALERATE),
+            -SUM(ABS(bi.QTY)),
+            -SUM(COALESCE(pbi.FREEQTY, 0))
+        INTO
+            v_totalPurchase,
+            v_totalCost,
+            v_totalRetail,
+            v_totalWholesale,
+            v_totalQty,
+            v_totalFreeQty
+        FROM BillItem bi
+        JOIN PharmaceuticalBillItem pbi ON pbi.BILLITEM_ID = bi.ID
+        JOIN Stock s                    ON s.ID            = pbi.STOCK_ID
+        JOIN ItemBatch ib               ON ib.ID           = s.ITEMBATCH_ID
+        WHERE bi.BILL_ID = v_bill_id
+          AND bi.RETIRED = 0;
+
+        INSERT INTO BillFinanceDetails (
+            CREATEDAT,
+            TOTALPURCHASEVALUE,
+            TOTALCOSTVALUE,
+            TOTALRETAILSALEVALUE,
+            TOTALWHOLESALEVALUE,
+            TOTALQUANTITY,
+            TOTALFREEQUANTITY,
+            GROSSTOTAL,
+            NETTOTAL
+        ) VALUES (
+            v_createdat,
+            v_totalPurchase,
+            v_totalCost,
+            v_totalRetail,
+            v_totalWholesale,
+            v_totalQty,
+            v_totalFreeQty,
+            v_total,
+            v_nettotal
+        );
+
+        -- LAST_INSERT_ID() is reliable here — one INSERT per loop iteration,
+        -- single session, no concurrent inserts on this connection.
+        SET v_new_bfd_id = LAST_INSERT_ID();
+
+        UPDATE bill
+        SET BILLFINANCEDETAILS_ID = v_new_bfd_id
+        WHERE ID = v_bill_id;
+
+    END LOOP;
+
+    CLOSE cur;
+
+    -- Final check — should return 0
+    SELECT COUNT(*) AS still_missing
+    FROM bill
+    WHERE BILLTYPE = 'PharmacyBhtPre'
+      AND RETIRED  = 0
+      AND CREATEDAT >= '2026-03-01 00:00:00'
+      AND CREATEDAT <  '2026-05-26 00:00:00'
+      AND BILLFINANCEDETAILS_ID IS NULL;
+
+END$$
+
+DELIMITER ;
+
+CALL backfill_bht_bfd();
+
+DROP PROCEDURE IF EXISTS backfill_bht_bfd;
+```
+
+**Step 3 — Verify:**
+```sql
+SELECT
+    COUNT(*)                      AS bills_linked,
+    SUM(bfd.TOTALPURCHASEVALUE)   AS total_purchase,
+    SUM(bfd.TOTALRETAILSALEVALUE) AS total_retail,
+    MIN(b.CREATEDAT)              AS earliest,
+    MAX(b.CREATEDAT)              AS latest
+FROM bill b
+JOIN BillFinanceDetails bfd ON bfd.ID = b.BILLFINANCEDETAILS_ID
+WHERE b.BILLTYPE  = 'PharmacyBhtPre'
+  AND b.RETIRED   = 0
+  AND b.CREATEDAT >= '2026-03-01 00:00:00'
+  AND b.CREATEDAT <  '2026-05-26 00:00:00';
+```
+
+`total_purchase` and `total_retail` should be negative (stock issued out). `bills_linked` should
+match the count from Step 1.
+
+### Sign Convention
+
+| Field | Expected sign | Reason |
+|---|---|---|
+| `TOTALPURCHASEVALUE` | Negative | Stock leaving pharmacy |
+| `TOTALCOSTVALUE` | Negative | Stock leaving pharmacy |
+| `TOTALRETAILSALEVALUE` | Negative | Stock leaving pharmacy |
+| `TOTALWHOLESALEVALUE` | Negative | Stock leaving pharmacy |
+| `TOTALQUANTITY` | Negative | Quantity going out |
+| `TOTALFREEQUANTITY` | Negative | Free quantity going out |
+| `GROSSTOTAL` | Positive | From `bill.total` (bill header value) |
+| `NETTOTAL` | Positive | From `bill.netTotal` (bill header value) |
+
+---
+
+## Report 2 — Unit Issue Report
+
+### Root Cause
+
+`ReportsTransfer.fillDepartmentUnitIssueByBill()` filters on:
+```java
+BillTypeAtomic.PHARMACY_DISPOSAL_ISSUE
+BillTypeAtomic.PHARMACY_DISPOSAL_ISSUE_CANCELLED
+BillTypeAtomic.PHARMACY_DISPOSAL_ISSUE_RETURN
+```
+
+Historical bills (created before the update that introduced `PHARMACY_DISPOSAL_ISSUE`) were saved
+with `BILLTYPEATOMIC = 'PHARMACY_ISSUE'` and `BILLTYPE = 'PharmacyIssue'`. When the enum value was
+renamed/split out, no migration updated the existing rows, so those bills no longer match the query.
+
+> **Important:** Bills with `BILLTYPE = 'PharmacyTransferIssue'` also have
+> `BILLTYPEATOMIC = 'PHARMACY_ISSUE'` — these are inter-pharmacy transfers and must **not** be
+> updated. The WHERE clause must always include `BILLTYPE = 'PharmacyIssue'`.
+
+### Diagnosis Query
+
+```sql
+-- Check stale BILLTYPEATOMIC values for the affected period
+SELECT BILLTYPE, BILLTYPEATOMIC, COUNT(*) AS cnt,
+       MIN(CREATEDAT) AS earliest, MAX(CREATEDAT) AS latest
+FROM bill
+WHERE BILLTYPE IN ('PharmacyIssue', 'PharmacyDisposalIssue')
+  AND RETIRED = 0
+  AND CREATEDAT >= '2026-03-01 00:00:00'
+  AND CREATEDAT <  '2026-05-26 00:00:00'
+GROUP BY BILLTYPE, BILLTYPEATOMIC
+ORDER BY BILLTYPE, cnt DESC;
+```
+
+Rows where `BILLTYPE = 'PharmacyIssue'` and `BILLTYPEATOMIC = 'PHARMACY_ISSUE'` or
+`'PHARMACY_ISSUE_RETURN'` need to be migrated.
+
+### Migration SQL
+
+```sql
+-- Preview counts before updating
+SELECT BILLTYPEATOMIC, COUNT(*) AS cnt
+FROM bill
+WHERE BILLTYPE      = 'PharmacyIssue'
+  AND BILLTYPEATOMIC IN ('PHARMACY_ISSUE', 'PHARMACY_ISSUE_RETURN')
+  AND RETIRED       = 0
+  AND CREATEDAT >= '2026-03-01 00:00:00'   -- adjust as needed
+  AND CREATEDAT <  '2026-05-26 00:00:00'   -- adjust as needed
+GROUP BY BILLTYPEATOMIC;
+
+-- Migrate disposal issue bills
+UPDATE bill
+SET BILLTYPEATOMIC = 'PHARMACY_DISPOSAL_ISSUE'
+WHERE BILLTYPE      = 'PharmacyIssue'
+  AND BILLTYPEATOMIC = 'PHARMACY_ISSUE'
+  AND RETIRED       = 0
+  AND CREATEDAT >= '2026-03-01 00:00:00'
+  AND CREATEDAT <  '2026-05-26 00:00:00';
+
+SELECT ROW_COUNT() AS updated_disposal_issue;
+
+-- Migrate disposal issue return bills
+UPDATE bill
+SET BILLTYPEATOMIC = 'PHARMACY_DISPOSAL_ISSUE_RETURN'
+WHERE BILLTYPE      = 'PharmacyIssue'
+  AND BILLTYPEATOMIC = 'PHARMACY_ISSUE_RETURN'
+  AND RETIRED       = 0
+  AND CREATEDAT >= '2026-03-01 00:00:00'
+  AND CREATEDAT <  '2026-05-26 00:00:00';
+
+SELECT ROW_COUNT() AS updated_disposal_issue_return;
+```
+
+### Verify
+
+```sql
+SELECT BILLTYPEATOMIC, COUNT(*) AS cnt, MIN(CREATEDAT) AS earliest, MAX(CREATEDAT) AS latest
+FROM bill
+WHERE BILLTYPEATOMIC IN (
+        'PHARMACY_DISPOSAL_ISSUE',
+        'PHARMACY_DISPOSAL_ISSUE_RETURN',
+        'PHARMACY_DISPOSAL_ISSUE_CANCELLED'
+      )
+  AND RETIRED = 0
+  AND CREATEDAT >= '2026-03-01 00:00:00'
+  AND CREATEDAT <  '2026-05-26 00:00:00'
+GROUP BY BILLTYPEATOMIC;
+```
+
+The report should immediately show historical data after the UPDATE — no server restart needed.
+
+---
+
+## How to Connect to a Target Database
+
+See `developer_docs/database/mysql-developer-guide.md` for connection credentials and access
+instructions for each deployment.
+
+---
+
+## Related Files
+
+| File | Role |
+|---|---|
+| `ReportsTransfer.java` | `fillDepartmentBHTIssueByBillByDTOs()` — BHT report query (implicit join bug) |
+| `ReportsTransfer.java` | `fillDepartmentUnitIssueByBill()` — Unit issue report query (BILLTYPEATOMIC filter) |
+| `BillFinanceDetails.java` | Entity — `BILLFINANCEDETAILS_ID` FK lives on `bill` table |
+| `BillService.java` | `createBillFinancialDetailsForInpatientDirectIssueBill()` — Java equivalent of SQL backfill |
+| `DataAdministrationController.java` | `correctInpatientDirectIssueBillFinanceDetails()` — Admin UI backfill button |
+| `admin_functions.xhtml` | "Correct Finance Details for Inpatient Direct Issue Bills" button |
+| `developer_docs/pharmacy/f15-bfd-backfill-guide.md` | BFD backfill guide for F15 report (other bill types) |
+
+---
+
+## History
+
+| Date | Action | Deployment | Bills affected |
+|---|---|---|---|
+| 2026-05-25 | BFD rows inserted for `PharmacyBhtPre` bills (Mar–May 2026) | First affected site | 797 |
+| 2026-05-25 | `BILLTYPEATOMIC` migrated for `PharmacyIssue` bills (Mar–May 2026) | First affected site | 507 |

--- a/src/main/java/com/divudi/bean/pharmacy/ReportsTransfer.java
+++ b/src/main/java/com/divudi/bean/pharmacy/ReportsTransfer.java
@@ -1295,7 +1295,7 @@ public class ReportsTransfer implements Serializable {
                     .append("b.createdAt, ")
                     .append("CASE WHEN b.patientEncounter IS NOT NULL THEN COALESCE(b.patientEncounter.bhtNo, '') ELSE '' END, ")
                     .append("COALESCE(cb.deptId, ''), ")
-                    .append("CASE WHEN b.billFinanceDetails IS NOT NULL THEN COALESCE(b.billFinanceDetails.totalPurchaseValue, 0.0) ELSE 0.0 END, ")
+                    .append("COALESCE(bfd.totalPurchaseValue, 0.0), ")
                     .append("COALESCE(b.total, 0.0), ")
                     .append("COALESCE(b.margin, 0.0), ")
                     .append("COALESCE(b.discount, 0.0), ")
@@ -1303,6 +1303,7 @@ public class ReportsTransfer implements Serializable {
                     .append(") ")
                     .append("FROM Bill b ")
                     .append("LEFT JOIN b.cancelledBill cb ")
+                    .append("LEFT JOIN b.billFinanceDetails bfd ")
                     .append("WHERE b.createdAt BETWEEN :fd AND :td ")
                     .append("AND b.department=:fdept ");
 

--- a/src/main/resources/db/migrations/v2.8.0/migration-info.json
+++ b/src/main/resources/db/migrations/v2.8.0/migration-info.json
@@ -1,0 +1,14 @@
+{
+  "version": "v2.8.0",
+  "description": "Migrate stale BILLTYPEATOMIC values for pharmacy unit/disposal issue bills",
+  "issue": "#20996 — Unit Issue report missing historical data due to stale BILLTYPEATOMIC",
+  "author": "Dr M H B Ariyaratne",
+  "date": "2026-05-25",
+  "type": "data",
+  "tables_affected": ["bill"],
+  "data_changes": true,
+  "requires_downtime": false,
+  "estimated_duration_minutes": 1,
+  "note": "Updates BILLTYPEATOMIC on historical PharmacyIssue bills created before the PHARMACY_DISPOSAL_ISSUE enum value was introduced. Only touches BILLTYPE='PharmacyIssue' rows — PharmacyTransferIssue rows with the same atomic value are left unchanged. Safe to re-run (UPDATE ... WHERE ... is idempotent).",
+  "rollback": "rollback.sql"
+}

--- a/src/main/resources/db/migrations/v2.8.0/migration.sql
+++ b/src/main/resources/db/migrations/v2.8.0/migration.sql
@@ -1,0 +1,133 @@
+-- Migration v2.8.0: Migrate stale BILLTYPEATOMIC for pharmacy unit/disposal issue bills
+-- Author: Dr M H B Ariyaratne
+-- Issue: #20996
+--
+-- Background:
+--   The Unit Issue report (pharmacy_report_unit_issue_bill.xhtml) filters on
+--   BILLTYPEATOMIC IN ('PHARMACY_DISPOSAL_ISSUE', 'PHARMACY_DISPOSAL_ISSUE_CANCELLED',
+--                      'PHARMACY_DISPOSAL_ISSUE_RETURN').
+--   Bills created before the PHARMACY_DISPOSAL_ISSUE enum value was introduced were
+--   saved with BILLTYPEATOMIC = 'PHARMACY_ISSUE' / 'PHARMACY_ISSUE_RETURN' /
+--   'PHARMACY_ISSUE_CANCELLED'. This migration updates those rows so they appear
+--   in the report.
+--
+--   IMPORTANT: Bills with BILLTYPE = 'PharmacyTransferIssue' also carry
+--   BILLTYPEATOMIC = 'PHARMACY_ISSUE' — those are inter-pharmacy transfers and
+--   must NOT be updated. The WHERE clause always includes BILLTYPE = 'PharmacyIssue'.
+--
+-- Safe to re-run: UPDATE ... WHERE is idempotent.
+--
+-- UNIVERSAL: detects actual table-name case via INFORMATION_SCHEMA so this works on both
+-- case-sensitive (Linux, lower_case_table_names=0) and case-insensitive (Windows/Azure) MySQL.
+
+SELECT 'Migration v2.8.0 - Migrate stale BILLTYPEATOMIC for pharmacy unit/disposal issue bills' AS status;
+
+-- ── STEP 0: DETECT ACTUAL TABLE NAME CASE ────────────────────────────────────
+
+SET @bill_table = (
+    SELECT TABLE_NAME FROM INFORMATION_SCHEMA.TABLES
+    WHERE TABLE_SCHEMA = DATABASE() AND UPPER(TABLE_NAME) = 'BILL'
+    LIMIT 1
+);
+
+SELECT CONCAT('Bill table: ', COALESCE(@bill_table, 'NOT FOUND')) AS info;
+
+-- ── BEFORE counts ────────────────────────────────────────────────────────────
+
+SELECT 'BEFORE: stale BILLTYPEATOMIC counts' AS status;
+
+SET @before_sql = IF(@bill_table IS NULL,
+    'SELECT "SKIPPED: bill table not found" AS status',
+    CONCAT(
+        'SELECT BILLTYPEATOMIC, COUNT(*) AS cnt ',
+        'FROM ', @bill_table, ' ',
+        'WHERE BILLTYPE = ''PharmacyIssue'' ',
+        '  AND BILLTYPEATOMIC IN (''PHARMACY_ISSUE'', ''PHARMACY_ISSUE_RETURN'', ''PHARMACY_ISSUE_CANCELLED'') ',
+        '  AND RETIRED = 0 ',
+        'GROUP BY BILLTYPEATOMIC'
+    )
+);
+PREPARE stmt FROM @before_sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+-- ── STEP 1: PHARMACY_ISSUE → PHARMACY_DISPOSAL_ISSUE ─────────────────────────
+
+SELECT 'Step 1: PHARMACY_ISSUE -> PHARMACY_DISPOSAL_ISSUE' AS status;
+
+SET @sql = IF(@bill_table IS NULL,
+    'SELECT "SKIPPED: bill table not found" AS status',
+    CONCAT(
+        'UPDATE ', @bill_table, ' ',
+        'SET BILLTYPEATOMIC = ''PHARMACY_DISPOSAL_ISSUE'' ',
+        'WHERE BILLTYPE     = ''PharmacyIssue'' ',
+        '  AND BILLTYPEATOMIC = ''PHARMACY_ISSUE'' ',
+        '  AND RETIRED      = 0'
+    )
+);
+PREPARE stmt FROM @sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+SELECT ROW_COUNT() AS updated_step1;
+
+-- ── STEP 2: PHARMACY_ISSUE_RETURN → PHARMACY_DISPOSAL_ISSUE_RETURN ───────────
+
+SELECT 'Step 2: PHARMACY_ISSUE_RETURN -> PHARMACY_DISPOSAL_ISSUE_RETURN' AS status;
+
+SET @sql = IF(@bill_table IS NULL,
+    'SELECT "SKIPPED: bill table not found" AS status',
+    CONCAT(
+        'UPDATE ', @bill_table, ' ',
+        'SET BILLTYPEATOMIC = ''PHARMACY_DISPOSAL_ISSUE_RETURN'' ',
+        'WHERE BILLTYPE     = ''PharmacyIssue'' ',
+        '  AND BILLTYPEATOMIC = ''PHARMACY_ISSUE_RETURN'' ',
+        '  AND RETIRED      = 0'
+    )
+);
+PREPARE stmt FROM @sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+SELECT ROW_COUNT() AS updated_step2;
+
+-- ── STEP 3: PHARMACY_ISSUE_CANCELLED → PHARMACY_DISPOSAL_ISSUE_CANCELLED ─────
+
+SELECT 'Step 3: PHARMACY_ISSUE_CANCELLED -> PHARMACY_DISPOSAL_ISSUE_CANCELLED' AS status;
+
+SET @sql = IF(@bill_table IS NULL,
+    'SELECT "SKIPPED: bill table not found" AS status',
+    CONCAT(
+        'UPDATE ', @bill_table, ' ',
+        'SET BILLTYPEATOMIC = ''PHARMACY_DISPOSAL_ISSUE_CANCELLED'' ',
+        'WHERE BILLTYPE     = ''PharmacyIssue'' ',
+        '  AND BILLTYPEATOMIC = ''PHARMACY_ISSUE_CANCELLED'' ',
+        '  AND RETIRED      = 0'
+    )
+);
+PREPARE stmt FROM @sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+SELECT ROW_COUNT() AS updated_step3;
+
+-- ── VERIFY ───────────────────────────────────────────────────────────────────
+
+SELECT 'AFTER: remaining stale rows (should all be 0)' AS status;
+
+SET @after_sql = IF(@bill_table IS NULL,
+    'SELECT "SKIPPED: bill table not found" AS status',
+    CONCAT(
+        'SELECT BILLTYPEATOMIC, COUNT(*) AS cnt ',
+        'FROM ', @bill_table, ' ',
+        'WHERE BILLTYPE = ''PharmacyIssue'' ',
+        '  AND BILLTYPEATOMIC IN (''PHARMACY_ISSUE'', ''PHARMACY_ISSUE_RETURN'', ''PHARMACY_ISSUE_CANCELLED'') ',
+        '  AND RETIRED = 0 ',
+        'GROUP BY BILLTYPEATOMIC'
+    )
+);
+PREPARE stmt FROM @after_sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+SELECT 'Migration v2.8.0 completed' AS final_status;

--- a/src/main/resources/db/migrations/v2.8.0/rollback.sql
+++ b/src/main/resources/db/migrations/v2.8.0/rollback.sql
@@ -4,7 +4,7 @@
 -- UNIVERSAL: detects actual table-name case via INFORMATION_SCHEMA so this works on both
 -- case-sensitive (Linux, lower_case_table_names=0) and case-insensitive (Windows/Azure) MySQL.
 
-SELECT 'Rollback v2.7.0 - Reverting BILLTYPEATOMIC for pharmacy disposal issue bills' AS status;
+SELECT 'Rollback v2.8.0 - Reverting BILLTYPEATOMIC for pharmacy disposal issue bills' AS status;
 
 -- ── STEP 0: DETECT ACTUAL TABLE NAME CASE ────────────────────────────────────
 

--- a/src/main/resources/db/migrations/v2.8.0/rollback.sql
+++ b/src/main/resources/db/migrations/v2.8.0/rollback.sql
@@ -1,0 +1,73 @@
+-- Rollback v2.8.0: Revert BILLTYPEATOMIC migration for pharmacy unit/disposal issue bills
+-- WARNING: Only run if you need to undo migration v2.8.0 entirely.
+--
+-- UNIVERSAL: detects actual table-name case via INFORMATION_SCHEMA so this works on both
+-- case-sensitive (Linux, lower_case_table_names=0) and case-insensitive (Windows/Azure) MySQL.
+
+SELECT 'Rollback v2.7.0 - Reverting BILLTYPEATOMIC for pharmacy disposal issue bills' AS status;
+
+-- ── STEP 0: DETECT ACTUAL TABLE NAME CASE ────────────────────────────────────
+
+SET @bill_table = (
+    SELECT TABLE_NAME FROM INFORMATION_SCHEMA.TABLES
+    WHERE TABLE_SCHEMA = DATABASE() AND UPPER(TABLE_NAME) = 'BILL'
+    LIMIT 1
+);
+
+SELECT CONCAT('Bill table: ', COALESCE(@bill_table, 'NOT FOUND')) AS info;
+
+-- ── STEP 1: PHARMACY_DISPOSAL_ISSUE → PHARMACY_ISSUE ─────────────────────────
+
+SET @sql = IF(@bill_table IS NULL,
+    'SELECT "SKIPPED: bill table not found" AS status',
+    CONCAT(
+        'UPDATE ', @bill_table, ' ',
+        'SET BILLTYPEATOMIC = ''PHARMACY_ISSUE'' ',
+        'WHERE BILLTYPE     = ''PharmacyIssue'' ',
+        '  AND BILLTYPEATOMIC = ''PHARMACY_DISPOSAL_ISSUE'' ',
+        '  AND RETIRED      = 0'
+    )
+);
+PREPARE stmt FROM @sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+SELECT ROW_COUNT() AS reverted_step1;
+
+-- ── STEP 2: PHARMACY_DISPOSAL_ISSUE_RETURN → PHARMACY_ISSUE_RETURN ───────────
+
+SET @sql = IF(@bill_table IS NULL,
+    'SELECT "SKIPPED: bill table not found" AS status',
+    CONCAT(
+        'UPDATE ', @bill_table, ' ',
+        'SET BILLTYPEATOMIC = ''PHARMACY_ISSUE_RETURN'' ',
+        'WHERE BILLTYPE     = ''PharmacyIssue'' ',
+        '  AND BILLTYPEATOMIC = ''PHARMACY_DISPOSAL_ISSUE_RETURN'' ',
+        '  AND RETIRED      = 0'
+    )
+);
+PREPARE stmt FROM @sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+SELECT ROW_COUNT() AS reverted_step2;
+
+-- ── STEP 3: PHARMACY_DISPOSAL_ISSUE_CANCELLED → PHARMACY_ISSUE_CANCELLED ─────
+
+SET @sql = IF(@bill_table IS NULL,
+    'SELECT "SKIPPED: bill table not found" AS status',
+    CONCAT(
+        'UPDATE ', @bill_table, ' ',
+        'SET BILLTYPEATOMIC = ''PHARMACY_ISSUE_CANCELLED'' ',
+        'WHERE BILLTYPE     = ''PharmacyIssue'' ',
+        '  AND BILLTYPEATOMIC = ''PHARMACY_DISPOSAL_ISSUE_CANCELLED'' ',
+        '  AND RETIRED      = 0'
+    )
+);
+PREPARE stmt FROM @sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+SELECT ROW_COUNT() AS reverted_step3;
+
+SELECT 'Rollback v2.8.0 completed' AS final_status;


### PR DESCRIPTION
## Summary

Fixes two pharmacy reports that showed data for the current period only, with no historical data before the recent update.

Closes #20996

---

## Report 1 — BHT Issue Report (`pharmacy_report_bht_issue_bill.xhtml`)

### Root Cause
`fillDepartmentBHTIssueByBillByDTOs()` in `ReportsTransfer.java` navigated `b.billFinanceDetails.totalPurchaseValue` as a path expression in the JPQL SELECT clause:

```java
// BEFORE — implicit INNER JOIN, excludes all bills with no BFD row
"CASE WHEN b.billFinanceDetails IS NOT NULL THEN COALESCE(b.billFinanceDetails.totalPurchaseValue, 0.0) ELSE 0.0 END"
```

JPA/EclipseLink converts path navigation in SELECT into an **implicit INNER JOIN**, even inside `CASE WHEN`. Bills created before `BillFinanceDetails` was populated have `BILLFINANCEDETAILS_ID = NULL`, so they were silently excluded from the result.

### Fix
```java
// AFTER — explicit LEFT JOIN, bills without BFD still appear (purchaseValue = 0)
.append("LEFT JOIN b.billFinanceDetails bfd ")
.append("COALESCE(bfd.totalPurchaseValue, 0.0), ")
```

---

## Report 2 — Unit Issue Report (`pharmacy_report_unit_issue_bill.xhtml`)

### Root Cause
`fillDepartmentUnitIssueByBill()` filters on `BillTypeAtomic.PHARMACY_DISPOSAL_ISSUE`. Historical bills (created before the enum rename) were saved with `BILLTYPEATOMIC = 'PHARMACY_ISSUE'` and `BILLTYPE = 'PharmacyIssue'`. No migration was run when the enum value was introduced, so old bills no longer matched the query.

### Fix
Migration `v2.7.0` updates stale `BILLTYPEATOMIC` values on all deployments:
- `PHARMACY_ISSUE` → `PHARMACY_DISPOSAL_ISSUE`
- `PHARMACY_ISSUE_RETURN` → `PHARMACY_DISPOSAL_ISSUE_RETURN`
- `PHARMACY_ISSUE_CANCELLED` → `PHARMACY_DISPOSAL_ISSUE_CANCELLED`

Only `BILLTYPE = 'PharmacyIssue'` rows are touched. `PharmacyTransferIssue` rows with the same atomic value are intentionally left unchanged (they are inter-pharmacy transfers, not unit issues).

---

## Files Changed

| File | Change |
|---|---|
| `ReportsTransfer.java` | Replace implicit path join with `LEFT JOIN b.billFinanceDetails bfd` |
| `db/migrations/v2.7.0/migration.sql` | Migrate stale `BILLTYPEATOMIC` values for `PharmacyIssue` bills |
| `db/migrations/v2.7.0/rollback.sql` | Rollback script |
| `db/migrations/v2.7.0/migration-info.json` | Migration metadata |
| `developer_docs/pharmacy/bht-unit-issue-report-backfill-guide.md` | Diagnosis queries, SQL backfill procedure, sign conventions |
| `CLAUDE.md` | Rule: never commit credentials or IPs inside project folder |

---

## Data Fix (already applied at first affected site)

797 `BillFinanceDetails` rows were backfilled for `PharmacyBhtPre` bills (Mar–May 2026) via stored procedure. The migration script handles the `BILLTYPEATOMIC` rename for all other deployments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected purchase/financial totals in pharmacy transfer issue reports.

* **Database Migrations**
  * Added an idempotent data migration (with rollback) to normalize legacy bill-type values for historical pharmacy unit/disposal issue records.

* **Documentation**
  * Added a security rule prohibiting committing credentials or sensitive connection info.
  * Added a developer guide documenting diagnosis and backfill procedures for pharmacy report data recovery.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hmislk/hmis/pull/20997?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->