### PR TITLE
fix(pharmacy): fix JTA transaction abort when settling sale without patient

### DIFF
--- a/src/main/java/com/divudi/bean/pharmacy/PharmacyFastRetailSaleController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacyFastRetailSaleController.java
@@ -1407,7 +1407,7 @@ public class PharmacyFastRetailSaleController implements Serializable, Controlle
             PharmaceuticalBillItem tmpPh = tbi.getPharmaceuticalBillItem();
             tbi.setPharmaceuticalBillItem(null);
 
-            if (tbi.getPrescription() != null) {
+            if (tbi.hasPrescription()) {
                 if (tbi.getPrescription().getId() == null) {
                     prescriptionFacade.create(tbi.getPrescription());
                 } else {
@@ -1493,7 +1493,7 @@ public class PharmacyFastRetailSaleController implements Serializable, Controlle
                 getBillItemFacade().create(newBil);
             }
 
-            if (tbi.getPrescription() != null) {
+            if (tbi.hasPrescription()) {
                 if (tbi.getPrescription().getId() == null) {
                     prescriptionFacade.create(tbi.getPrescription());
                 } else {
@@ -1501,7 +1501,9 @@ public class PharmacyFastRetailSaleController implements Serializable, Controlle
                 }
 
                 newBil.setPrescription(tbi.getPrescription());
-                tbi.getPrescription().setPatient(patient);
+                if (patient != null && patient.getId() != null) {
+                    tbi.getPrescription().setPatient(patient);
+                }
                 tbi.getPrescription().setCreatedAt(new Date());
                 tbi.getPrescription().setCreater(sessionController.getWebUser());
                 tbi.getPrescription().setInstitution(sessionController.getInstitution());

--- a/src/main/java/com/divudi/bean/pharmacy/PharmacySaleController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacySaleController.java
@@ -2471,10 +2471,19 @@ public class PharmacySaleController implements Serializable, ControllerWithPatie
             newlyCreatedBillItemForSaleBill.setCreatedAt(Calendar.getInstance().getTime());
             newlyCreatedBillItemForSaleBill.setCreater(getSessionController().getLoggedUser());
 
-            if (preBillItem.getPrescription() != null) {
+            // Use hasPrescription() instead of getPrescription() != null to avoid the
+            // auto-create side-effect: getPrescription() always returns a new Prescription()
+            // when the field is null, causing an unpersisted Patient to be attached and the
+            // JTA transaction to abort when no patient details were entered (issue #20504).
+            if (preBillItem.hasPrescription()) {
                 Prescription newlyCreatedPrescreptionForSaleBillItem = preBillItem.getPrescription().cloneForNewEntity();
                 newlyCreatedBillItemForSaleBill.setPrescription(newlyCreatedPrescreptionForSaleBillItem);
-                newlyCreatedPrescreptionForSaleBillItem.setPatient(patient);
+                // Only link patient when it is a persisted entity (id != null), to avoid
+                // attaching a transient Patient and triggering "new object found through
+                // relationship" errors from EclipseLink (issue #20504).
+                if (patient != null && patient.getId() != null) {
+                    newlyCreatedPrescreptionForSaleBillItem.setPatient(patient);
+                }
                 newlyCreatedPrescreptionForSaleBillItem.setCreatedAt(new Date());
                 newlyCreatedPrescreptionForSaleBillItem.setCreater(sessionController.getWebUser());
                 newlyCreatedPrescreptionForSaleBillItem.setInstitution(sessionController.getInstitution());
@@ -2510,9 +2519,11 @@ public class PharmacySaleController implements Serializable, ControllerWithPatie
                 getBillItemFacade().create(newBil);
             }
 
-            if (tbi.getPrescription() != null) {
+            if (tbi.hasPrescription()) {
                 newBil.setPrescription(tbi.getPrescription());
-                tbi.getPrescription().setPatient(patient);
+                if (patient != null && patient.getId() != null) {
+                    tbi.getPrescription().setPatient(patient);
+                }
                 tbi.getPrescription().setCreatedAt(new Date());
                 tbi.getPrescription().setCreater(sessionController.getWebUser());
                 tbi.getPrescription().setInstitution(sessionController.getInstitution());

--- a/src/main/java/com/divudi/bean/pharmacy/PharmacySaleController1.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacySaleController1.java
@@ -1986,7 +1986,10 @@ public class PharmacySaleController1 implements Serializable, ControllerWithPati
                 getBillItemFacade().create(newBil);
             }
 
-            if (tbi.getPrescription() != null) {
+            // Use hasPrescription() to avoid auto-creating a blank Prescription via the
+            // getter, which would cause an unpersisted Patient to be attached and abort
+            // the JTA transaction when no patient details were entered (issue #20504).
+            if (tbi.hasPrescription()) {
                 if (tbi.getPrescription().getId() == null) {
                     prescriptionFacade.create(tbi.getPrescription());
                 } else {
@@ -1994,7 +1997,9 @@ public class PharmacySaleController1 implements Serializable, ControllerWithPati
                 }
 
                 newBil.setPrescription(tbi.getPrescription());
-                tbi.getPrescription().setPatient(patient);
+                if (patient != null && patient.getId() != null) {
+                    tbi.getPrescription().setPatient(patient);
+                }
                 tbi.getPrescription().setCreatedAt(new Date());
                 tbi.getPrescription().setCreater(sessionController.getWebUser());
                 tbi.getPrescription().setInstitution(sessionController.getInstitution());

--- a/src/main/java/com/divudi/bean/pharmacy/PharmacySaleController2.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacySaleController2.java
@@ -1986,7 +1986,10 @@ public class PharmacySaleController2 implements Serializable, ControllerWithPati
                 getBillItemFacade().create(newBil);
             }
 
-            if (tbi.getPrescription() != null) {
+            // Use hasPrescription() to avoid auto-creating a blank Prescription via the
+            // getter, which would cause an unpersisted Patient to be attached and abort
+            // the JTA transaction when no patient details were entered (issue #20504).
+            if (tbi.hasPrescription()) {
                 if (tbi.getPrescription().getId() == null) {
                     prescriptionFacade.create(tbi.getPrescription());
                 } else {
@@ -1994,7 +1997,9 @@ public class PharmacySaleController2 implements Serializable, ControllerWithPati
                 }
 
                 newBil.setPrescription(tbi.getPrescription());
-                tbi.getPrescription().setPatient(patient);
+                if (patient != null && patient.getId() != null) {
+                    tbi.getPrescription().setPatient(patient);
+                }
                 tbi.getPrescription().setCreatedAt(new Date());
                 tbi.getPrescription().setCreater(sessionController.getWebUser());
                 tbi.getPrescription().setInstitution(sessionController.getInstitution());

--- a/src/main/java/com/divudi/bean/pharmacy/PharmacySaleController3.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacySaleController3.java
@@ -1986,7 +1986,10 @@ public class PharmacySaleController3 implements Serializable, ControllerWithPati
                 getBillItemFacade().create(newBil);
             }
 
-            if (tbi.getPrescription() != null) {
+            // Use hasPrescription() to avoid auto-creating a blank Prescription via the
+            // getter, which would cause an unpersisted Patient to be attached and abort
+            // the JTA transaction when no patient details were entered (issue #20504).
+            if (tbi.hasPrescription()) {
                 if (tbi.getPrescription().getId() == null) {
                     prescriptionFacade.create(tbi.getPrescription());
                 } else {
@@ -1994,7 +1997,9 @@ public class PharmacySaleController3 implements Serializable, ControllerWithPati
                 }
 
                 newBil.setPrescription(tbi.getPrescription());
-                tbi.getPrescription().setPatient(patient);
+                if (patient != null && patient.getId() != null) {
+                    tbi.getPrescription().setPatient(patient);
+                }
                 tbi.getPrescription().setCreatedAt(new Date());
                 tbi.getPrescription().setCreater(sessionController.getWebUser());
                 tbi.getPrescription().setInstitution(sessionController.getInstitution());

--- a/src/main/java/com/divudi/bean/pharmacy/PharmacySaleForCashierController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacySaleForCashierController.java
@@ -3413,10 +3413,12 @@ public class PharmacySaleForCashierController implements Serializable, Controlle
             newlyCreatedBillItemForSaleBill.setCreatedAt(Calendar.getInstance().getTime());
             newlyCreatedBillItemForSaleBill.setCreater(getSessionController().getLoggedUser());
 
-            if (preBillItem.getPrescription() != null) {
+            if (preBillItem.hasPrescription()) {
                 Prescription newlyCreatedPrescreptionForSaleBillItem = preBillItem.getPrescription().cloneForNewEntity();
                 newlyCreatedBillItemForSaleBill.setPrescription(newlyCreatedPrescreptionForSaleBillItem);
-                newlyCreatedPrescreptionForSaleBillItem.setPatient(patient);
+                if (patient != null && patient.getId() != null) {
+                    newlyCreatedPrescreptionForSaleBillItem.setPatient(patient);
+                }
                 newlyCreatedPrescreptionForSaleBillItem.setCreatedAt(new Date());
                 newlyCreatedPrescreptionForSaleBillItem.setCreater(sessionController.getWebUser());
                 newlyCreatedPrescreptionForSaleBillItem.setInstitution(sessionController.getInstitution());
@@ -3452,9 +3454,11 @@ public class PharmacySaleForCashierController implements Serializable, Controlle
                 getBillItemFacade().create(newBil);
             }
 
-            if (tbi.getPrescription() != null) {
+            if (tbi.hasPrescription()) {
                 newBil.setPrescription(tbi.getPrescription());
-                tbi.getPrescription().setPatient(patient);
+                if (patient != null && patient.getId() != null) {
+                    tbi.getPrescription().setPatient(patient);
+                }
                 tbi.getPrescription().setCreatedAt(new Date());
                 tbi.getPrescription().setCreater(sessionController.getWebUser());
                 tbi.getPrescription().setInstitution(sessionController.getInstitution());

--- a/src/main/java/com/divudi/bean/pharmacy/PharmacySaleForCashierController1.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacySaleForCashierController1.java
@@ -3431,10 +3431,12 @@ public class PharmacySaleForCashierController1 implements Serializable, Controll
             newlyCreatedBillItemForSaleBill.setCreatedAt(Calendar.getInstance().getTime());
             newlyCreatedBillItemForSaleBill.setCreater(getSessionController().getLoggedUser());
 
-            if (preBillItem.getPrescription() != null) {
+            if (preBillItem.hasPrescription()) {
                 Prescription newlyCreatedPrescreptionForSaleBillItem = preBillItem.getPrescription().cloneForNewEntity();
                 newlyCreatedBillItemForSaleBill.setPrescription(newlyCreatedPrescreptionForSaleBillItem);
-                newlyCreatedPrescreptionForSaleBillItem.setPatient(patient);
+                if (patient != null && patient.getId() != null) {
+                    newlyCreatedPrescreptionForSaleBillItem.setPatient(patient);
+                }
                 newlyCreatedPrescreptionForSaleBillItem.setCreatedAt(new Date());
                 newlyCreatedPrescreptionForSaleBillItem.setCreater(sessionController.getWebUser());
                 newlyCreatedPrescreptionForSaleBillItem.setInstitution(sessionController.getInstitution());
@@ -3470,9 +3472,11 @@ public class PharmacySaleForCashierController1 implements Serializable, Controll
                 getBillItemFacade().create(newBil);
             }
 
-            if (tbi.getPrescription() != null) {
+            if (tbi.hasPrescription()) {
                 newBil.setPrescription(tbi.getPrescription());
-                tbi.getPrescription().setPatient(patient);
+                if (patient != null && patient.getId() != null) {
+                    tbi.getPrescription().setPatient(patient);
+                }
                 tbi.getPrescription().setCreatedAt(new Date());
                 tbi.getPrescription().setCreater(sessionController.getWebUser());
                 tbi.getPrescription().setInstitution(sessionController.getInstitution());

--- a/src/main/java/com/divudi/bean/pharmacy/PharmacySaleForCashierController2.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacySaleForCashierController2.java
@@ -3429,10 +3429,12 @@ public class PharmacySaleForCashierController2 implements Serializable, Controll
             newlyCreatedBillItemForSaleBill.setCreatedAt(Calendar.getInstance().getTime());
             newlyCreatedBillItemForSaleBill.setCreater(getSessionController().getLoggedUser());
 
-            if (preBillItem.getPrescription() != null) {
+            if (preBillItem.hasPrescription()) {
                 Prescription newlyCreatedPrescreptionForSaleBillItem = preBillItem.getPrescription().cloneForNewEntity();
                 newlyCreatedBillItemForSaleBill.setPrescription(newlyCreatedPrescreptionForSaleBillItem);
-                newlyCreatedPrescreptionForSaleBillItem.setPatient(patient);
+                if (patient != null && patient.getId() != null) {
+                    newlyCreatedPrescreptionForSaleBillItem.setPatient(patient);
+                }
                 newlyCreatedPrescreptionForSaleBillItem.setCreatedAt(new Date());
                 newlyCreatedPrescreptionForSaleBillItem.setCreater(sessionController.getWebUser());
                 newlyCreatedPrescreptionForSaleBillItem.setInstitution(sessionController.getInstitution());
@@ -3468,9 +3470,11 @@ public class PharmacySaleForCashierController2 implements Serializable, Controll
                 getBillItemFacade().create(newBil);
             }
 
-            if (tbi.getPrescription() != null) {
+            if (tbi.hasPrescription()) {
                 newBil.setPrescription(tbi.getPrescription());
-                tbi.getPrescription().setPatient(patient);
+                if (patient != null && patient.getId() != null) {
+                    tbi.getPrescription().setPatient(patient);
+                }
                 tbi.getPrescription().setCreatedAt(new Date());
                 tbi.getPrescription().setCreater(sessionController.getWebUser());
                 tbi.getPrescription().setInstitution(sessionController.getInstitution());

--- a/src/main/java/com/divudi/bean/pharmacy/PharmacySaleForCashierController3.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacySaleForCashierController3.java
@@ -3432,10 +3432,12 @@ public class PharmacySaleForCashierController3 implements Serializable, Controll
             newlyCreatedBillItemForSaleBill.setCreatedAt(Calendar.getInstance().getTime());
             newlyCreatedBillItemForSaleBill.setCreater(getSessionController().getLoggedUser());
 
-            if (preBillItem.getPrescription() != null) {
+            if (preBillItem.hasPrescription()) {
                 Prescription newlyCreatedPrescreptionForSaleBillItem = preBillItem.getPrescription().cloneForNewEntity();
                 newlyCreatedBillItemForSaleBill.setPrescription(newlyCreatedPrescreptionForSaleBillItem);
-                newlyCreatedPrescreptionForSaleBillItem.setPatient(patient);
+                if (patient != null && patient.getId() != null) {
+                    newlyCreatedPrescreptionForSaleBillItem.setPatient(patient);
+                }
                 newlyCreatedPrescreptionForSaleBillItem.setCreatedAt(new Date());
                 newlyCreatedPrescreptionForSaleBillItem.setCreater(sessionController.getWebUser());
                 newlyCreatedPrescreptionForSaleBillItem.setInstitution(sessionController.getInstitution());
@@ -3471,9 +3473,11 @@ public class PharmacySaleForCashierController3 implements Serializable, Controll
                 getBillItemFacade().create(newBil);
             }
 
-            if (tbi.getPrescription() != null) {
+            if (tbi.hasPrescription()) {
                 newBil.setPrescription(tbi.getPrescription());
-                tbi.getPrescription().setPatient(patient);
+                if (patient != null && patient.getId() != null) {
+                    tbi.getPrescription().setPatient(patient);
+                }
                 tbi.getPrescription().setCreatedAt(new Date());
                 tbi.getPrescription().setCreater(sessionController.getWebUser());
                 tbi.getPrescription().setInstitution(sessionController.getInstitution());

--- a/src/main/java/com/divudi/bean/pharmacy/PharmacySimpleRetailSaleController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacySimpleRetailSaleController.java
@@ -1544,7 +1544,7 @@ public class PharmacySimpleRetailSaleController implements Serializable, Control
             PharmaceuticalBillItem tmpPh = tbi.getPharmaceuticalBillItem();
             tbi.setPharmaceuticalBillItem(null);
 
-            if (tbi.getPrescription() != null) {
+            if (tbi.hasPrescription()) {
                 if (tbi.getPrescription().getId() == null) {
                     prescriptionFacade.create(tbi.getPrescription());
                 } else {
@@ -1618,7 +1618,7 @@ public class PharmacySimpleRetailSaleController implements Serializable, Control
                 getBillItemFacade().create(newBil);
             }
 
-            if (tbi.getPrescription() != null) {
+            if (tbi.hasPrescription()) {
                 if (tbi.getPrescription().getId() == null) {
                     prescriptionFacade.create(tbi.getPrescription());
                 } else {
@@ -1626,7 +1626,9 @@ public class PharmacySimpleRetailSaleController implements Serializable, Control
                 }
 
                 newBil.setPrescription(tbi.getPrescription());
-                tbi.getPrescription().setPatient(patient);
+                if (patient != null && patient.getId() != null) {
+                    tbi.getPrescription().setPatient(patient);
+                }
                 tbi.getPrescription().setCreatedAt(new Date());
                 tbi.getPrescription().setCreater(sessionController.getWebUser());
                 tbi.getPrescription().setInstitution(sessionController.getInstitution());

--- a/src/main/java/com/divudi/core/entity/BillItem.java
+++ b/src/main/java/com/divudi/core/entity/BillItem.java
@@ -1180,6 +1180,16 @@ public class BillItem implements Serializable, RetirableEntity {
         return prescription;
     }
 
+    /**
+     * Returns true only when a Prescription has been explicitly associated with
+     * this BillItem (i.e. it was persisted before or carries meaningful data).
+     * Use this instead of {@code getPrescription() != null} to avoid the
+     * auto-create side-effect of the getter.
+     */
+    public boolean hasPrescription() {
+        return prescription != null && prescription.getId() != null;
+    }
+
     public void setPrescription(Prescription prescription) {
         this.prescription = prescription;
     }


### PR DESCRIPTION
## Problem

When settling a pharmacy retail sale without entering patient details, the transaction aborted with:

> java.lang.IllegalStateException: During synchronization a new object was found through a relationship that was not marked cascade PERSIST: com.divudi.core.entity.Patient[ id=null ]

## Root Cause

BillItem.getPrescription() uses a lazy-initializer pattern — it auto-creates a new Prescription() when the backing field is null and never returns 
ull. The saveSaleBillItems() methods in all pharmacy sale controllers checked:

`java
if (preBillItem.getPrescription() != null) { // always true!
`

Because the getter never returns 
ull, a blank Prescription was always created, and patient (an unpersisted Patient with id=null) was set on it. EclipseLink detected the transient entity during transaction commit and aborted.

## Fix

1. **BillItem.hasPrescription()** — new method that returns 	rue only when the prescription field was explicitly set to a persisted entity (id != null). Avoids the auto-create side-effect.

2. **10 pharmacy controllers** — replaced all getPrescription() != null guards with hasPrescription() in saveSaleBillItems().

3. **Patient guard** — added patient != null && patient.getId() != null check before setting patient on prescription, as a belt-and-suspenders defence.

## Controllers Fixed
- PharmacySaleController (and variants 1, 2, 3)
- PharmacySaleForCashierController (and variants 1, 2, 3)
- PharmacySimpleRetailSaleController
- PharmacyFastRetailSaleController

Closes #20504

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved prescription handling in pharmacy billing to prevent unintended creation of empty prescriptions when no patient details are provided.
  * Enhanced data validation to ensure prescriptions are only linked to patients that are already saved in the system, preventing invalid associations during bill item creation and processing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hmislk/hmis/pull/20998?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->