### PR TITLE
fix(pharmacy): add lock-timeout retry to ItemBatch archival and move nav to Data tab

### DIFF
--- a/src/main/java/com/divudi/service/archival/ArchivalServiceBase.java
+++ b/src/main/java/com/divudi/service/archival/ArchivalServiceBase.java
@@ -5,10 +5,12 @@
 package com.divudi.service.archival;
 
 import com.divudi.core.data.dto.ArchiveResult;
+import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 import javax.persistence.EntityManager;
+import javax.persistence.PersistenceException;
 import javax.persistence.Query;
 
 /**
@@ -33,6 +35,21 @@ import javax.persistence.Query;
  * Issue #20726.
  */
 public abstract class ArchivalServiceBase {
+
+    /**
+     * Returns true when {@code ex} (or any cause in its chain) is a MySQL
+     * lock wait timeout (error 1205). Used by subclass retry logic.
+     */
+    protected static boolean isLockTimeout(PersistenceException ex) {
+        Throwable cause = ex;
+        while (cause != null) {
+            if (cause instanceof SQLException && ((SQLException) cause).getErrorCode() == 1205) {
+                return true;
+            }
+            cause = cause.getCause();
+        }
+        return false;
+    }
 
     protected abstract EntityManager em();
 

--- a/src/main/java/com/divudi/service/archival/ItemBatchArchivalService.java
+++ b/src/main/java/com/divudi/service/archival/ItemBatchArchivalService.java
@@ -7,7 +7,6 @@ package com.divudi.service.archival;
 import com.divudi.core.data.dto.ArchiveResult;
 import java.util.ArrayList;
 import java.util.Date;
-import java.util.HashMap;
 import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -19,6 +18,7 @@ import javax.ejb.TransactionAttributeType;
 import javax.inject.Inject;
 import javax.persistence.EntityManager;
 import javax.persistence.PersistenceContext;
+import javax.persistence.PersistenceException;
 import javax.persistence.Query;
 
 /**
@@ -46,6 +46,9 @@ import javax.persistence.Query;
 @Stateless
 @TransactionAttribute(TransactionAttributeType.NOT_SUPPORTED)
 public class ItemBatchArchivalService extends ArchivalServiceBase {
+
+    private static final int MAX_RETRIES = 3;
+    private static final long RETRY_SLEEP_MS = 2000;
 
     @PersistenceContext(unitName = "hmisPU")
     private EntityManager em;
@@ -211,7 +214,7 @@ public class ItemBatchArchivalService extends ArchivalServiceBase {
             if (ids.isEmpty()) {
                 break;
             }
-            int moved = itemBatchBatchTx.archiveBatch(
+            int moved = archiveBatchWithRetry(
                     ibTable, ibArchive, stTable, stArchive, pbiTable,
                     ibCols, stCols, ids);
             totalArchived += moved;
@@ -231,6 +234,42 @@ public class ItemBatchArchivalService extends ArchivalServiceBase {
                 + (reachedLimit ? " (batch limit reached; more rows remain)" : "");
         return new ArchiveResult(false, candidates, totalArchived, batchesRun,
                 reachedLimit, startedAt, new Date(), msg);
+    }
+
+    /**
+     * Calls {@link ItemBatchArchivalBatchTx#archiveBatch} and retries up to
+     * {@value #MAX_RETRIES} times on MySQL lock wait timeout (error 1205).
+     * Since {@code ItemBatchArchivalService} runs NOT_SUPPORTED, each retry
+     * goes through the EJB proxy so {@code REQUIRES_NEW} is honoured afresh.
+     */
+    private int archiveBatchWithRetry(String ibTable, String ibArchive,
+            String stTable, String stArchive, String pbiTable,
+            String ibCols, String stCols, List<Long> ids) {
+        PersistenceException lastEx = null;
+        for (int attempt = 1; attempt <= MAX_RETRIES; attempt++) {
+            try {
+                return itemBatchBatchTx.archiveBatch(
+                        ibTable, ibArchive, stTable, stArchive, pbiTable,
+                        ibCols, stCols, ids);
+            } catch (PersistenceException ex) {
+                if (!isLockTimeout(ex)) {
+                    throw ex;
+                }
+                lastEx = ex;
+                if (attempt < MAX_RETRIES) {
+                    LOGGER.log(Level.WARNING,
+                            "ItemBatch archival batch lock timeout (attempt {0}/{1}), retrying in {2}ms",
+                            new Object[]{attempt, MAX_RETRIES, RETRY_SLEEP_MS});
+                    try {
+                        Thread.sleep(RETRY_SLEEP_MS);
+                    } catch (InterruptedException ie) {
+                        Thread.currentThread().interrupt();
+                        throw ex;
+                    }
+                }
+            }
+        }
+        throw lastEx;
     }
 
     /**

--- a/src/main/webapp/dataAdmin/admin_data_administration.xhtml
+++ b/src/main/webapp/dataAdmin/admin_data_administration.xhtml
@@ -138,6 +138,20 @@
                                     <p:tab title="Data" disabled="false">
                                         <div class="d-grid gap-2">
                                             <p:commandButton
+                                                value="Archive StockHistory"
+                                                action="#{stockHistoryArchivalController.navigateToArchiveStockHistory()}"
+                                                ajax="false"
+                                                styleClass="w-100 ui-button-warning"
+                                                icon="fa fa-archive"
+                                                rendered="#{webUserController.hasPrivilege('ArchiveOldStockHistory')}" />
+                                            <p:commandButton
+                                                value="Archive ItemBatch"
+                                                action="#{itemBatchArchivalController.navigateToArchiveItemBatch()}"
+                                                ajax="false"
+                                                styleClass="w-100 ui-button-warning"
+                                                icon="fa fa-archive"
+                                                rendered="#{webUserController.hasPrivilege('ArchiveOldItemBatch')}" />
+                                            <p:commandButton
                                                 value="Generate Historical Record"
                                                 action="#{historicalRecordController.navigateToHistoricalRecordGenerate()}"
                                                 ajax="false"
@@ -149,13 +163,6 @@
                                                 ajax="false"
                                                 styleClass="w-100 ui-button-success"
                                                 icon="fa fa-database" />
-                                            <p:commandButton
-                                                value="Archival"
-                                                action="admin_functions?faces-redirect=true"
-                                                ajax="false"
-                                                styleClass="w-100 ui-button-secondary"
-                                                icon="fa fa-archive"
-                                                rendered="#{webUserController.hasPrivilege('ArchiveOldStockHistory') or webUserController.hasPrivilege('ArchiveOldItemBatch')}" />
                                         </div>
                                     </p:tab>
 

--- a/src/main/webapp/dataAdmin/admin_functions.xhtml
+++ b/src/main/webapp/dataAdmin/admin_functions.xhtml
@@ -1107,65 +1107,6 @@
                             </table>
                         </p:tab>
 
-                        <p:tab title="Archival">
-                            <h5 class="mb-3">
-                                <i class="fa fa-archive"></i> Data Archival
-                            </h5>
-                            <div class="alert alert-info mb-3">
-                                Archival moves old records out of the live tables into separate archive tables
-                                to reduce table bloat and improve query performance. Each archival page lets you
-                                set a retention period, preview the candidate count, and run a batched move.
-                                Always run a dry-run first to confirm the candidate count before committing.
-                            </div>
-                            <table class="table table-sm table-bordered w-100">
-                                <thead class="table-light">
-                                    <tr>
-                                        <th style="width: 20%;">Name</th>
-                                        <th style="width: 55%;">Description</th>
-                                        <th style="width: 25%;">Action</th>
-                                    </tr>
-                                </thead>
-                                <tbody>
-                                    <tr>
-                                        <td><strong>Archive Old StockHistory Records</strong></td>
-                                        <td>
-                                            Moves StockHistory rows older than the configured retention period
-                                            (default 730 days) to STOCKHISTORYARCHIVE. Preserves original IDs.
-                                            Supports dry-run, configurable batch size, and per-run batch cap.
-                                            Reports with "Include Archived" toggle will query both tables.
-                                        </td>
-                                        <td>
-                                            <p:commandButton
-                                                value="Archive StockHistory"
-                                                icon="fa fa-archive"
-                                                ajax="false"
-                                                styleClass="ui-button-warning m-1"
-                                                action="#{stockHistoryArchivalController.navigateToArchiveStockHistory()}"
-                                                rendered="#{webUserController.hasPrivilege('ArchiveOldStockHistory')}" />
-                                        </td>
-                                    </tr>
-                                    <tr>
-                                        <td><strong>Archive Expired ItemBatch Records</strong></td>
-                                        <td>
-                                            Moves expired, zero-stock ItemBatch rows to ITEMBATCHARCHIVE to reduce
-                                            live table size. Expired batches no longer appear in stock selection
-                                            autocompletes or active reports. Archived batches remain accessible
-                                            for historical reporting.
-                                        </td>
-                                        <td>
-                                            <p:commandButton
-                                                value="Archive ItemBatch"
-                                                icon="fa fa-archive"
-                                                ajax="false"
-                                                styleClass="ui-button-warning m-1"
-                                                action="#{itemBatchArchivalController.navigateToArchiveItemBatch()}"
-                                                rendered="#{webUserController.hasPrivilege('ArchiveOldItemBatch')}" />
-                                        </td>
-                                    </tr>
-                                </tbody>
-                            </table>
-                        </p:tab>
-
                     </p:accordionPanel>
                 </h:form>
 


### PR DESCRIPTION
## Summary

Follow-up to #20724 (ItemBatch archival) and #20985 (StockHistory archival improvements).

- **Lock-timeout retry for ItemBatch batches** — `ItemBatchArchivalBatchTx.archiveBatch()` is called directly from `ItemBatchArchivalService` with no retry, meaning a MySQL lock wait timeout (error 1205) from concurrent pharmacy transactions would silently skip or abort a batch. This PR adds `archiveBatchWithRetry()` with the same 3-attempt / 2 s backoff pattern already present in `ArchivalBatchTx` for StockHistory. `isLockTimeout()` is promoted to `ArchivalServiceBase` (protected static) so both services share the detection logic.
- **Navigation moved to Data tab sidebar** — The archival pages were reachable only via the "Archival" tab buried inside `admin_functions.xhtml`. Users with `ArchiveOldStockHistory` or `ArchiveOldItemBatch` privilege now see direct "Archive StockHistory" / "Archive ItemBatch" buttons at the top of the Data tab in the main `admin_data_administration.xhtml` sidebar, navigating straight to the dedicated archival pages. The "Archival" tab in `admin_functions.xhtml` is removed.

## Changes

| File | Change |
|---|---|
| `ArchivalServiceBase.java` | Add `protected static isLockTimeout()` (walks cause chain for MySQL error 1205) |
| `ItemBatchArchivalService.java` | Add `MAX_RETRIES`, `RETRY_SLEEP_MS` constants + `archiveBatchWithRetry()` helper; use it in the batch loop |
| `admin_data_administration.xhtml` | Replace "Archival" link with two privilege-guarded direct buttons at top of Data tab |
| `admin_functions.xhtml` | Remove "Archival" tab |

## Test plan

- [ ] Navigate to Data tab in `admin_data_administration.xhtml` — confirm "Archive StockHistory" and "Archive ItemBatch" buttons appear (for users with the respective privileges) at the top of the tab
- [ ] Click each button — confirm it navigates to the correct dedicated archival page
- [ ] Confirm the "Archival" tab is no longer visible in `admin_functions.xhtml`
- [ ] Run ItemBatch archive with concurrent pharmacy activity — confirm lock timeouts are retried (check server log for "lock timeout (attempt X/3), retrying" warning) rather than failing the batch

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced batch archival operations with automatic retry handling for improved reliability.

* **UI Updates**
  * Replaced the single archival button with dedicated "Archive StockHistory" and "Archive ItemBatch" actions for clearer operation selection.
  * Reorganized archive operations, removing the archival tab from admin functions and making actions directly accessible from the Data tab.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hmislk/hmis/pull/20999?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->