### PR TITLE
fix(security): clear forced-reset flag and refresh password timestamp on every password change (#21000)

### DIFF
--- a/src/main/java/com/divudi/bean/common/SessionController.java
+++ b/src/main/java/com/divudi/bean/common/SessionController.java
@@ -1153,6 +1153,7 @@ public class SessionController implements Serializable, HttpSessionListener {
             String hashed = getSecurityController().hashAndCheck(password);
             user.setWebUserPassword(hashed);
             user.setNeedToResetPassword(false);
+            user.setLastPasswordResetAt(new Date());
             uFacade.editAndCommit(user);
             recordPasswordHistory(user, hashed);
 
@@ -1188,9 +1189,11 @@ public class SessionController implements Serializable, HttpSessionListener {
 
         String hashed = getSecurityController().hashAndCheck(newPassword);
         user.setWebUserPassword(hashed);
+        user.setNeedToResetPassword(false);
+        user.setLastPasswordResetAt(new Date());
         uFacade.editAndCommit(user);
         recordPasswordHistory(user, hashed);
-        
+
         // Purge old password history entries beyond the configured limit
         purgeOldPasswordHistory(user);
         JsfUtil.addSuccessMessage("Password changed");

--- a/src/main/java/com/divudi/bean/common/WebUserController.java
+++ b/src/main/java/com/divudi/bean/common/WebUserController.java
@@ -1340,6 +1340,8 @@ public class WebUserController implements Serializable {
         String hashedPassword;
         hashedPassword = getSecurityController().hashAndCheck(newPassword);
         current.setWebUserPassword(hashedPassword);
+        current.setNeedToResetPassword(false);
+        current.setLastPasswordResetAt(new Date());
         getFacade().editAndCommit(current);
         WebUserPasswordHistory wh = new WebUserPasswordHistory();
         wh.setWebUser(current);


### PR DESCRIPTION
## Summary

- `WebUserController.changeCurrentUserPassword` (the admin **Change Password** page) and `SessionController.changeCurrentUserPassword` now clear `needToResetPassword` and set `lastPasswordResetAt = now()` after saving the new hash.
- `SessionController.changePassword` (user self-change, which already cleared the flag) now also refreshes `lastPasswordResetAt` so a save near the expiry boundary doesn't fail the next login.

Without these two writes, `SessionController.arePasswordRequirementsFulfilled()` keeps re-routing the user to the change-password panel — exactly the loop QA is hitting on `rh.carecode.org` where the tight password baseline (`Allow admin to force password change`, `Enable password expiration`) is enforced. Full root-cause analysis is in #21000.

## Test plan

- [ ] In Application Options enable `Allow admin to force password change` and `Enable password expiration` (already on in RH production).
- [ ] As admin: open Admin → Users → Change Password for test user → click **Force Password Reset on Next Login** → set a new password → **Change Password**.
- [ ] Log out, log in as test user → user lands on their normal home page (no change-password loop).
- [ ] As a regular user, change own password via the post-login change-password panel → log out, log back in → no loop, no immediate "Password has expired".
- [ ] DB check: after each change, `WEBUSER.needToResetPassword = 0` and `lastPasswordResetAt` matches the moment of change.

Closes #21000

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced password reset handling by properly recording the timestamp when passwords are changed, ensuring the system accurately tracks password reset history and clears the password reset requirement flag after successful completion.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hmislk/hmis/pull/21001?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->