### PR TITLE
hotfix(security): clear forced-reset flag and refresh password timestamp on every password change (#21000)

### DIFF
--- a/src/main/java/com/divudi/bean/common/SessionController.java
+++ b/src/main/java/com/divudi/bean/common/SessionController.java
@@ -1153,6 +1153,7 @@ public class SessionController implements Serializable, HttpSessionListener {
             String hashed = getSecurityController().hashAndCheck(password);
             user.setWebUserPassword(hashed);
             user.setNeedToResetPassword(false);
+            user.setLastPasswordResetAt(new Date());
             uFacade.editAndCommit(user);
             recordPasswordHistory(user, hashed);
 
@@ -1188,9 +1189,11 @@ public class SessionController implements Serializable, HttpSessionListener {
 
         String hashed = getSecurityController().hashAndCheck(newPassword);
         user.setWebUserPassword(hashed);
+        user.setNeedToResetPassword(false);
+        user.setLastPasswordResetAt(new Date());
         uFacade.editAndCommit(user);
         recordPasswordHistory(user, hashed);
-        
+
         // Purge old password history entries beyond the configured limit
         purgeOldPasswordHistory(user);
         JsfUtil.addSuccessMessage("Password changed");

--- a/src/main/java/com/divudi/bean/common/WebUserController.java
+++ b/src/main/java/com/divudi/bean/common/WebUserController.java
@@ -1312,6 +1312,8 @@ public class WebUserController implements Serializable {
         String hashedPassword;
         hashedPassword = getSecurityController().hashAndCheck(newPassword);
         current.setWebUserPassword(hashedPassword);
+        current.setNeedToResetPassword(false);
+        current.setLastPasswordResetAt(new Date());
         getFacade().editAndCommit(current);
         WebUserPasswordHistory wh = new WebUserPasswordHistory();
         wh.setWebUser(current);


### PR DESCRIPTION
## Summary

Hotfix cherry-pick of #21001 (commit `dde8a046f2`, already merged to `development`) onto `ruhunu-prod` so RH end users stop being looped back to the change-password screen after an admin resets their password.

- `WebUserController.changeCurrentUserPassword` (the admin **Change Password** page) and `SessionController.changeCurrentUserPassword` now clear `needToResetPassword` and set `lastPasswordResetAt = now()` after saving the new hash.
- `SessionController.changePassword` (user self-change) now also refreshes `lastPasswordResetAt` so a save near the expiry boundary doesn't fail the next login.

Without these writes, `SessionController.arePasswordRequirementsFulfilled()` keeps redirecting users back to the change-password panel under the tight password baseline (`Allow admin to force password change`, `Enable password expiration`) in use on `rh.carecode.org`.

Full root-cause analysis in #21000; reviewed and merged via #21001.

## Test plan

- [ ] After deploy, set Application Options on RH: `Allow admin to force password change=true`, `Enable password expiration=true` (already on in prod). Click **Reload Config**.
- [ ] As admin: open Admin → Users → Change Password for a test user → click **Force Password Reset on Next Login** → set a new password → **Change Password**.
- [ ] Log out, log in as that user → user lands on home (no change-password loop).
- [ ] As a regular user, self-change via the post-login change-password panel → log out, log in → no loop, no immediate "Password has expired".
- [ ] DB spot-check on `WEBUSER`: `needToResetPassword = 0` and `lastPasswordResetAt` ≈ now for the test user after each change.

Relates to #21000

🤖 Generated with [Claude Code](https://claude.com/claude-code)