### PR TITLE
perf(pharmacy): convert sale.xhtml search composite to DTO pattern

### DIFF
--- a/developer_docs/dto/implementation-guidelines.md
+++ b/developer_docs/dto/implementation-guidelines.md
@@ -366,18 +366,86 @@ public class PurchaseOrderListDTO {
 
 **If user needs cancellation details:** Provide a "View Details" action that navigates to the full bill view where all cancellation information is available.
 
+### ✅ SOLUTION 3 (Standard): COALESCE on every nullable LEFT JOIN String — always apply this
+
+Even when LEFT JOINs are present, a `null` value flowing into a `String` DTO constructor
+parameter causes that row to be dropped in some EclipseLink versions. **Always wrap every
+LEFT JOIN String field in `COALESCE(..., '')`** to guarantee rows are never silently omitted.
+
+```java
+// ✅ CORRECT — COALESCE on every nullable LEFT JOIN String
+String sql = "SELECT new com.divudi.core.data.dto.PharmacySaleSearchDTO("
+        + "b.id, b.deptId, b.department.name, b.createdAt, "
+        + "COALESCE(creatorPerson.name, ''), "     // nullable LEFT JOIN
+        + "COALESCE(patientPerson.name, ''), "     // nullable LEFT JOIN
+        + "COALESCE(refDoctorPerson.name, ''), "   // nullable LEFT JOIN
+        + "b.paymentMethod, "
+        + "COALESCE(ps.name, ''), "               // nullable LEFT JOIN
+        + "b.total, b.discount, b.netTotal, "
+        + "b.refunded, b.cancelled) "
+        + "FROM Bill b "
+        + "LEFT JOIN b.creater creater "
+        + "LEFT JOIN creater.webUserPerson creatorPerson "
+        + "LEFT JOIN b.patient patient "
+        + "LEFT JOIN patient.person patientPerson "
+        + "LEFT JOIN b.referredBy referredBy "
+        + "LEFT JOIN referredBy.person refDoctorPerson "
+        + "LEFT JOIN b.paymentScheme ps "
+        + "WHERE ...";
+```
+
+**Rule:** Every column from a LEFT-joined table that is a `String` in the DTO constructor
+**must** be wrapped in `COALESCE(expr, '')`. Numeric and boolean fields from the root entity
+(`b.total`, `b.cancelled`) are safe without COALESCE.
+
+### Row-limit parameter pattern
+
+When exposing a DTO fetch method that should respect the user's configured row limit,
+accept `int maxResult` directly (from `searchController.getMaxResult()`) rather than a
+boolean `maxNum` flag. Pass `0` or a negative value to mean "unlimited".
+
+```java
+// ✅ Preferred — caller controls the limit
+public void fetchSaleSearchDtosFromNativeBills(int maxResult) {
+    ...
+    if (maxResult > 0) {
+        saleBillDtos = (List<PharmacySaleSearchDTO>)
+                billFacade.findLightsByJpql(sql, m, TemporalType.TIMESTAMP, maxResult);
+    } else {
+        saleBillDtos = (List<PharmacySaleSearchDTO>)
+                billFacade.findLightsByJpql(sql, m, TemporalType.TIMESTAMP);
+    }
+}
+
+// ✅ Backward-compat shim keeps old callers working
+@Deprecated
+public void fetchSaleSearchDtosFromNativeBills(boolean maxNum) {
+    fetchSaleSearchDtosFromNativeBills(maxNum ? 25 : 0);
+}
+```
+
+### No subqueries in DTO fetch methods
+
+Do **not** add JPQL subqueries (e.g. `b.id IN (SELECT bi.bill.id FROM BillItem bi WHERE ...)`)
+inside DTO constructor queries. Subqueries inside `SELECT new DTO(...)` are not supported by
+EclipseLink and subqueries in the `WHERE` clause of a constructor query degrade performance
+significantly for large tables. If item-level filtering is required, discuss an alternative
+approach before implementing.
+
 ### Best Practices Summary
 
 1. **Always use wrapper types** (`Boolean`, `Integer`, `Long`) for DTO constructor parameters
 2. **Avoid nullable relationship traversal** - accessing `b.cancelledBill.createdAt` fails silently if `cancelledBill` is null
 3. **Use LEFT JOIN with explicit aliases** if you must access nullable relationships
-4. **Use COALESCE** for nullable String fields to provide default values
+4. **Always COALESCE every LEFT JOIN String field** — wrap with `COALESCE(expr, '')` to prevent silent row drops
 5. **Test COUNT separately** to verify data exists before troubleshooting DTO construction
 6. **Add debug logging** when implementing new DTO queries to catch silent failures early
 7. **Match parameter types exactly** - don't rely on implicit conversions with `Object`
 8. **Avoid cancellation details in list DTOs** - use boolean flags, let users navigate to details for full info
 9. **Test with minimal constructor first** - if a 4-param constructor works but 11-param fails, the issue is with the additional fields
 10. **Only use persisted fields in JPQL** - derived properties like `nameWithTitle` are not valid (see below)
+11. **Accept `int maxResult` not `boolean maxNum`** - lets the caller pass `searchController.getMaxResult()` directly
+12. **No subqueries in DTO fetch methods** - discuss alternatives before adding `WHERE b.id IN (SELECT ...)`
 
 ## 🚨 CRITICAL: Derived/Calculated Properties Cannot Be Used in JPQL
 

--- a/src/main/java/com/divudi/bean/common/SearchController.java
+++ b/src/main/java/com/divudi/bean/common/SearchController.java
@@ -4665,13 +4665,21 @@ public class SearchController implements Serializable {
             JsfUtil.addErrorMessage("Please Select Bill Type");
             return;
         }
-        String jpql;
-        Map params = new HashMap();
 
         System.out.println("DEBUG: Selected billType = " + billType);
         System.out.println("DEBUG: FromDate = " + getFromDate());
         System.out.println("DEBUG: ToDate = " + getToDate());
         System.out.println("DEBUG: Current Department = " + (getSessionController().getDepartment() != null ? getSessionController().getDepartment().getId() + " - " + getSessionController().getDepartment().getName() : "NULL"));
+
+        // PharmacySale: use lightweight DTO query via PharmacyBillSearch to avoid
+        // loading full entity graphs across wide date ranges (issue #21005 / #20299).
+        if (billType == BillType.PharmacySale) {
+            pharmacyBillSearch.fetchSaleSearchDtosFromNativeBills(maxResult);
+            return;
+        }
+
+        String jpql;
+        Map params = new HashMap();
 
         // Special handling for PharmacyAdjustment - use bill type atomics instead
         if (billType == BillType.PharmacyAdjustment) {

--- a/src/main/java/com/divudi/bean/pharmacy/PharmacyBillSearch.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacyBillSearch.java
@@ -4602,9 +4602,15 @@ public class PharmacyBillSearch implements Serializable {
 
     /**
      * Fetches PHARMACY_RETAIL_SALE and PHARMACY_RETAIL_SALE_PREBILL_SETTLED_AT_CASHIER bills as DTOs.
+     * <p>
+     * Uses COALESCE on every nullable LEFT JOIN string field so that bills whose
+     * creator, patient, referredBy or paymentScheme is null are still included in
+     * the result set instead of being silently dropped by JPQL.
+     *
+     * @param maxResult the maximum number of rows to return; 0 or negative means unlimited
      */
     @SuppressWarnings("unchecked")
-    public void fetchSaleSearchDtosFromNativeBills(boolean maxNum) {
+    public void fetchSaleSearchDtosFromNativeBills(int maxResult) {
         List<com.divudi.core.data.BillTypeAtomic> btas = new ArrayList<>();
         btas.add(com.divudi.core.data.BillTypeAtomic.PHARMACY_RETAIL_SALE);
         btas.add(com.divudi.core.data.BillTypeAtomic.PHARMACY_RETAIL_SALE_PREBILL_SETTLED_AT_CASHIER);
@@ -4615,13 +4621,15 @@ public class PharmacyBillSearch implements Serializable {
         m.put("ins", sessionController.getInstitution());
         m.put("ldep", sessionController.getLoggedUser().getDepartment());
 
+        // COALESCE on every nullable LEFT JOIN string prevents rows from being
+        // silently dropped when any joined relationship is null (JPQL behaviour).
         String sql = "SELECT new com.divudi.core.data.dto.PharmacySaleSearchDTO("
                 + "b.id, b.deptId, b.department.name, b.createdAt, "
-                + "creatorPerson.name, "
-                + "patientPerson.name, "
-                + "refDoctorPerson.name, "
+                + "COALESCE(creatorPerson.name, ''), "
+                + "COALESCE(patientPerson.name, ''), "
+                + "COALESCE(refDoctorPerson.name, ''), "
                 + "b.paymentMethod, "
-                + "ps.name, "
+                + "COALESCE(ps.name, ''), "
                 + "b.total, b.discount, b.netTotal, "
                 + "b.refunded, b.cancelled) "
                 + "FROM Bill b "
@@ -4676,14 +4684,26 @@ public class PharmacyBillSearch implements Serializable {
 
         sql += " ORDER BY b.createdAt DESC";
 
-        if (maxNum) {
-            saleBillDtos = (List<PharmacySaleSearchDTO>) billFacade.findLightsByJpql(sql, m, TemporalType.TIMESTAMP, 25);
+        if (maxResult > 0) {
+            saleBillDtos = (List<PharmacySaleSearchDTO>) billFacade.findLightsByJpql(sql, m, TemporalType.TIMESTAMP, maxResult);
         } else {
             saleBillDtos = (List<PharmacySaleSearchDTO>) billFacade.findLightsByJpql(sql, m, TemporalType.TIMESTAMP);
         }
         if (saleBillDtos == null) {
             saleBillDtos = new ArrayList<>();
         }
+    }
+
+    /**
+     * @deprecated Use {@link #fetchSaleSearchDtosFromNativeBills(int)} which
+     * accepts an explicit row limit from {@code searchController.getMaxResult()}.
+     * Kept for backward compatibility with existing callers
+     * ({@code SearchController.createPharmacyRetailBills()} and
+     * {@code createPharmacyRetailAllBills()}).
+     */
+    @Deprecated
+    public void fetchSaleSearchDtosFromNativeBills(boolean maxNum) {
+        fetchSaleSearchDtosFromNativeBills(maxNum ? 25 : 0);
     }
 
 }

--- a/src/main/webapp/resources/pharmacy/search/sale.xhtml
+++ b/src/main/webapp/resources/pharmacy/search/sale.xhtml
@@ -11,113 +11,123 @@
     </cc:interface>
 
     <!-- IMPLEMENTATION -->
+    <!--
+        DTO-based sale bill search composite (issue #21005 / #20299).
+        Binds to pharmacyBillSearch.saleBillDtos (List<PharmacySaleSearchDTO>)
+        populated by SearchController.createTableByBillType() when
+        billType == PharmacySale.  Only scalar columns are fetched;
+        COALESCE prevents nullable LEFT JOINs from silently dropping rows.
+    -->
     <cc:implementation>
-        <h:panelGrid columns="4">         
+        <h:panelGrid columns="3" styleClass="mb-2">
             <h:outputLabel value="Bill No"/>
             <h:outputLabel value="Net Total"/>
-            <h:outputLabel value="Item Name"/>
-            <h:outputLabel value="Item Code"/>
-            <p:inputText autocomplete="off"  value="#{searchController.searchKeyword.billNo}" />
+            <h:outputLabel value="Patient Name"/>
+            <p:inputText autocomplete="off" value="#{searchController.searchKeyword.billNo}" />
             <p:inputText autocomplete="off" value="#{searchController.searchKeyword.netTotal}"/>
-            <p:inputText autocomplete="off" value="#{searchController.searchKeyword.itemName}"/>
-            <p:inputText autocomplete="off" value="#{searchController.searchKeyword.code}"/>
+            <p:inputText autocomplete="off" value="#{searchController.searchKeyword.patientName}"/>
         </h:panelGrid>
-        
-        <p:commandButton ajax="false" value="Download" >
-            <p:dataExporter target="tbl" type="xlsx" fileName="bill_list" ></p:dataExporter>
+
+        <p:commandButton ajax="false" value="Download" icon="fa fa-download"
+                         class="ui-button-success mb-2">
+            <p:dataExporter target="tblSale" type="xlsx" fileName="sale_bill_list"/>
         </p:commandButton>
-        
-        <p:dataTable rowIndexVar="i" id="tbl" widgetVar="tbl" value="#{searchController.bills}" var="bill"  
+
+        <p:dataTable rowIndexVar="i"
+                     id="tblSale"
+                     widgetVar="tblSale"
+                     value="#{pharmacyBillSearch.saleBillDtos}"
+                     var="dto"
                      paginator="true"
                      rows="10"
                      paginatorTemplate="{CurrentPageReport} {FirstPageLink} {PreviousPageLink} {PageLinks} {NextPageLink} {LastPageLink} {RowsPerPageDropdown}"
                      rowsPerPageTemplate="10,20,50,100"
-                     emptyMessage="No Bills Found"
-                     filteredValue="#{searchController.filteredBills}">
+                     emptyMessage="No Bills Found">
+
             <f:facet name="header">
                 <h:outputLabel value="SALE BILL SEARCH"/>
             </f:facet>
-            <p:column>
-               
-                 <p:commandButton action="pharmacy_reprint_bill_sale?faces-redirect=true" ajax="false" value="View Billed Bill">
-                    <f:setPropertyActionListener value="#{bill}" target="#{pharmacyBillSearch.bill}"/>
+
+            <!-- Actions (not exported) -->
+            <p:column headerText="Actions" exportable="false" style="white-space:nowrap;">
+                <p:commandButton
+                    ajax="false"
+                    icon="fa fa-file-invoice"
+                    styleClass="ui-button-info ui-button-sm"
+                    title="View / Manage Bill"
+                    action="#{pharmacyBillSearch.navigatePharmacyReprintRetailBill()}">
+                    <f:setPropertyActionListener value="#{dto.id}" target="#{pharmacyBillSearch.billId}"/>
                 </p:commandButton>
             </p:column>
-            
-            <p:column headerText="BILL NO" sortBy="#{bill.deptId}" filterBy="#{bill.deptId}" filterMatchMode="contains" >
-                <h:commandLink action="pharmacy_reprint_bill_sale?faces-redirect=true" value="#{bill.deptId}">
-                    <h:outputLabel  ></h:outputLabel>
-                    <f:setPropertyActionListener value="#{bill}" target="#{pharmacyBillSearch.bill}"/>
-                </h:commandLink>
-            </p:column>    
 
-            <p:column headerText="Billed At" sortBy="#{bill.createdAt}"  >
-                <h:commandLink action="pharmacy_reprint_bill_sale?faces-redirect=true" >
-                    <h:outputLabel value="#{bill.createdAt}" >
-                        <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateTimeFormat}"/>
-                    </h:outputLabel>
-                    <f:setPropertyActionListener value="#{bill}" target="#{pharmacyBillSearch.bill}"/>
-                </h:commandLink>
-                <br/>
-                <h:panelGroup rendered="#{bill.cancelled}" >
-                    <h:outputLabel style="color: red;" value="Cancelled at " />
-                    <h:outputLabel style="color: red;" rendered="#{bill.cancelled}" value="#{bill.cancelledBill.createdAt}" >
-                        <f:convertDateTime pattern="dd MMM yyyy hh mm a"/>
-                    </h:outputLabel>
-                </h:panelGroup>
-                <h:panelGroup rendered="#{bill.refunded}" >
-                    <h:outputLabel style="color: red;" value="Refunded at " />
-                    <h:outputLabel style="color: red;" rendered="#{bill.refunded}" value="#{bill.refundedBill.createdAt}" >
-                        <f:convertDateTime pattern="dd MMM yyyy hh mm a"/>
-                    </h:outputLabel>
-                </h:panelGroup>
-            </p:column>                 
-            <p:column headerText="Billed By" sortBy="#{bill.creater.webUserPerson.name}" filterBy="#{bill.creater.webUserPerson.name}" filterMatchMode="contains">
-                <h:commandLink action="pharmacy_reprint_bill_sale?faces-redirect=true" >
-                    <h:outputLabel value="#{bill.creater.webUserPerson.name}" >                                      
-                    </h:outputLabel>
-                    <f:setPropertyActionListener value="#{bill}" target="#{pharmacyBillSearch.bill}"/>
-                </h:commandLink>
-                <br/>
-                <h:panelGroup rendered="#{bill.cancelled}" >
-                    <h:outputLabel style="color: red;" value="Cancelled By " />
-                    <h:outputLabel style="color: red;" rendered="#{bill.cancelled}" value="#{bill.cancelledBill.creater.webUserPerson.name}" >                                       
-                    </h:outputLabel>
-                </h:panelGroup>
-                <h:panelGroup rendered="#{bill.refunded}" >
-                    <h:outputLabel style="color: red;" value="Refunded By " />
-                    <h:outputLabel style="color: red;" rendered="#{bill.refunded}" value="#{bill.refundedBill.creater.webUserPerson.name}" >
-
-                    </h:outputLabel>
-                </h:panelGroup>
-            </p:column>   
-            <p:column headerText="Payment Method" sortBy="#{bill.paymentMethod}" filterBy="#{bill.paymentMethod}" filterMatchMode="exact" >
-                 <f:facet name="filter">
-                        <p:selectOneMenu onchange="PF('tbl').filter()" styleClass="custom-filter">
-                            <f:selectItem itemLabel="All" itemValue="#{null}" noSelectionOption="true" />
-                            <f:selectItems value="#{enumController.paymentMethods}" />
-                        </p:selectOneMenu>
-                    </f:facet>
-                <h:commandLink action="pharmacy_reprint_bill_sale?faces-redirect=true" >
-                    <h:outputLabel value="#{bill.paymentMethod}" ></h:outputLabel>
-                    <f:setPropertyActionListener value="#{bill}" target="#{pharmacyBillSearch.bill}"/>
-                </h:commandLink>
-            </p:column>                               
-            <p:column headerText="Net Value" style="text-align: right;" sortBy="#{bill.netTotal}"  >
-                <h:commandLink action="pharmacy_reprint_bill_sale?faces-redirect=true" >
-                    <h:outputLabel value="#{bill.netTotal}" >
-                        <f:convertNumber pattern="#,##0.00"/>
-                    </h:outputLabel>
-                    <f:setPropertyActionListener value="#{bill}" target="#{pharmacyBillSearch.bill}"/>
-                </h:commandLink>
+            <p:column headerText="Bill No"
+                      sortBy="#{dto.deptId}"
+                      filterBy="#{dto.deptId}"
+                      filterMatchMode="contains">
+                <h:outputLabel value="#{dto.deptId}"/>
             </p:column>
 
-            <p:column headerText="Comments" >
-                <h:outputLabel rendered="#{bill.refundedBill ne null}" value="#{bill.refundedBill.comments}" >
+            <p:column headerText="Billed At" sortBy="#{dto.createdAt}">
+                <h:outputLabel value="#{dto.createdAt}">
+                    <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateTimeFormat}"/>
                 </h:outputLabel>
-                <h:outputLabel  rendered="#{bill.cancelledBill ne null}" value="#{bill.cancelledBill.comments}" >
+                <h:panelGroup rendered="#{dto.cancelled}">
+                    <br/>
+                    <h:outputLabel style="color:red;" value="Cancelled"/>
+                </h:panelGroup>
+                <h:panelGroup rendered="#{dto.refunded}">
+                    <br/>
+                    <h:outputLabel style="color:orange;" value="Refunded"/>
+                </h:panelGroup>
+            </p:column>
+
+            <p:column headerText="Billed By"
+                      sortBy="#{dto.creatorName}"
+                      filterBy="#{dto.creatorName}"
+                      filterMatchMode="contains">
+                <h:outputLabel value="#{dto.creatorName}"/>
+            </p:column>
+
+            <p:column headerText="Patient"
+                      sortBy="#{dto.patientName}"
+                      filterBy="#{dto.patientName}"
+                      filterMatchMode="contains">
+                <h:outputLabel value="#{dto.patientName}"/>
+            </p:column>
+
+            <p:column headerText="Payment Method"
+                      sortBy="#{dto.paymentMethod}"
+                      filterBy="#{dto.paymentMethod}"
+                      filterMatchMode="exact">
+                <f:facet name="filter">
+                    <p:selectOneMenu onchange="PF('tblSale').filter()" styleClass="custom-filter">
+                        <f:selectItem itemLabel="All" itemValue="#{null}" noSelectionOption="true"/>
+                        <f:selectItems value="#{enumController.paymentMethods}"/>
+                    </p:selectOneMenu>
+                </f:facet>
+                <h:outputLabel value="#{dto.paymentMethod}"/>
+            </p:column>
+
+            <p:column headerText="Discount Scheme"
+                      sortBy="#{dto.paymentSchemeName}"
+                      filterBy="#{dto.paymentSchemeName}"
+                      filterMatchMode="contains">
+                <h:outputLabel value="#{dto.paymentSchemeName}"/>
+            </p:column>
+
+            <p:column headerText="Net Value"
+                      style="text-align:right;"
+                      sortBy="#{dto.netTotal}">
+                <h:outputLabel value="#{dto.netTotal}">
+                    <f:convertNumber pattern="#,##0.00"/>
                 </h:outputLabel>
             </p:column>
+
+            <p:column headerText="Status" exportable="false">
+                <p:badge value="Cancelled" severity="danger"  rendered="#{dto.cancelled}"/>
+                <p:badge value="Refunded"  severity="warning" rendered="#{dto.refunded}"/>
+            </p:column>
+
         </p:dataTable>
     </cc:implementation>
 </html>


### PR DESCRIPTION
## Summary
Converts the **PharmacySale** composite panel in `pharmacy_search.xhtml` from a full `List<Bill>` entity load to a lightweight `PharmacySaleSearchDTO` JPQL constructor query. This is the first sub-task of the pharmacy bill search DTO migration (issue #20299).

## Problem
When a user selects **PharmacySale** in `pharmacy_search.xhtml` and clicks Search over a wide date range (e.g. 10 days), `createTableByBillType()` loaded full `Bill` entities via `findByJpql()`. EclipseLink then lazy-loaded `creater`, `cancelledBill`, `refundedBill`, `fromInstitution` etc. for every row — causing N+1 query storms on busy pharmacy departments.

## Changes

### `SearchController.createTableByBillType()`
- Added early-exit branch for `BillType.PharmacySale`: delegates to `pharmacyBillSearch.fetchSaleSearchDtosFromNativeBills(maxResult)` and returns immediately. No entity query is run for this bill type.

### `PharmacyBillSearch.fetchSaleSearchDtosFromNativeBills(int maxResult)`
- New `int`-based overload accepts the caller's row limit directly (from `searchController.getMaxResult()`).
- **COALESCE** applied to every nullable LEFT JOIN String field (`creatorPerson.name`, `patientPerson.name`, `refDoctorPerson.name`, `ps.name`) — prevents rows from being silently dropped by JPQL when any joined relationship is null.
- Old `boolean maxNum` overload kept as a `@Deprecated` shim for existing callers (`createPharmacyRetailBills` / `createPharmacyRetailAllBills`).

### `resources/pharmacy/search/sale.xhtml`
- Switched `value` from `#{searchController.bills}` → `#{pharmacyBillSearch.saleBillDtos}`.
- Navigation uses `f:setPropertyActionListener value="#{dto.id}" target="#{pharmacyBillSearch.billId}"` — full entity loaded on demand at view time only.
- Cancelled/refunded status shown as `p:badge` elements; canceller/refunder details available via the View action (per DTO guidelines: avoid nullable multi-hop LEFT JOINs in list queries).
- Removed item-code filter (was a subquery on BillItem — no subqueries in DTO fetch per guidelines).

### `developer_docs/dto/implementation-guidelines.md`
- Documented three new rules:
  1. **Always COALESCE every LEFT JOIN String** to prevent silent row drops
  2. **Accept `int maxResult` not `boolean maxNum`** for row-limit parameters
  3. **No subqueries in DTO fetch methods** — discuss alternatives first

## Testing
- Search `PharmacySale` over a 10-day window — should return results in seconds instead of timing out.
- Cancelled/refunded bills still visible in the list (badge shown).
- View button navigates correctly to the reprint page.
- Download (Excel) works via `p:dataExporter`.

Closes #21005
Part of #20299

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed pharmacy bill search results being dropped due to null values in certain fields.

* **New Features**
  * Redesigned pharmacy sale bill search interface with simplified search inputs and reorganized result columns for improved usability.

* **Documentation**
  * Updated implementation guidelines with best practices for handling nullable fields in search queries.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hmislk/hmis/pull/21017?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->